### PR TITLE
chore(experiments): experiments scene product migration velocity stats

### DIFF
--- a/products/experiments/frontend/components/ExperimentVelocityStats.tsx
+++ b/products/experiments/frontend/components/ExperimentVelocityStats.tsx
@@ -5,7 +5,7 @@ import { Tooltip } from '@posthog/lemon-ui'
 
 import { IconTrendingDown } from 'lib/lemon-ui/icons'
 
-import { experimentsLogic } from '../../../../products/experiments/frontend/scenes/experimentsLogic'
+import { experimentsLogic } from 'products/experiments/frontend/scenes/experimentsLogic'
 
 export function ExperimentVelocityStats(): JSX.Element | null {
     const { experimentsStats, experimentsStatsLoading } = useValues(experimentsLogic)

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -35,7 +35,6 @@ import {
     confirmDeleteExperiment,
 } from 'scenes/experiments/experimentActions'
 import { getExperimentStatus } from 'scenes/experiments/experimentStatus'
-import { ExperimentVelocityStats } from 'scenes/experiments/ExperimentVelocityStats'
 import MaxTool from 'scenes/max/MaxTool'
 import { useMaxTool } from 'scenes/max/useMaxTool'
 import { organizationLogic } from 'scenes/organizationLogic'
@@ -57,6 +56,7 @@ import {
     ExperimentsTabs,
 } from '~/types'
 
+import { ExperimentVelocityStats } from 'products/experiments/frontend/components/ExperimentVelocityStats'
 import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
 /**


### PR DESCRIPTION
## Problem

`ExperimentVelocityStats` still lives under `frontend/src/scenes/experiments`. It belongs in the experiments product folder.

## Changes

Mechanical move of `ExperimentVelocityStats` to `products/experiments/frontend/components`. All importers now use the `products/` path. No behavior change.

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend typescript:check
```

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments products/experiments/frontend
```

![cat-type-small](https://github.com/user-attachments/assets/bfbfd9e1-66f3-4aff-b6f7-800194b8a973)

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /stacking-prs (local)
- /writing-ui-components (local)
- /writing-pull-requests (local)

Relevant decisions:

- Each file moves in its own stacked PR, so review stays small and mechanical.
- Components go to `products/experiments/frontend/components`; helper modules go to the frontend root. No `../` imports.