### PR TITLE
chore(experiments): experiments scene product migration duplicate modal

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/PageHeader.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/PageHeader.tsx
@@ -17,8 +17,8 @@ import { ScenePanel, ScenePanelActionsSection } from '~/layout/scenes/SceneLayou
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { CopyExperimentToProjectModal } from 'products/experiments/frontend/components/CopyExperimentToProjectModal'
+import { DuplicateExperimentModal } from 'products/experiments/frontend/components/DuplicateExperimentModal'
 
-import { DuplicateExperimentModal } from '../DuplicateExperimentModal'
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
 import { ExperimentActionsMenu } from './ExperimentActionsMenu'

--- a/products/experiments/frontend/components/DuplicateExperimentModal.tsx
+++ b/products/experiments/frontend/components/DuplicateExperimentModal.tsx
@@ -4,13 +4,12 @@ import { useState } from 'react'
 import { LemonInput, LemonModal } from '@posthog/lemon-ui'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { ExperimentFlagKeyInput } from 'scenes/experiments/ExperimentFlagKeyInput'
 import { slugifyFeatureFlagKey } from 'scenes/feature-flags/featureFlagLogic'
 
 import { Experiment } from '~/types'
 
 import { experimentsLogic } from 'products/experiments/frontend/scenes/experimentsLogic'
-
-import { ExperimentFlagKeyInput } from './ExperimentFlagKeyInput'
 
 interface DuplicateExperimentModalProps {
     isOpen: boolean

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -27,7 +27,6 @@ import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { pluralize } from 'lib/utils/strings'
 import stringWithWBR from 'lib/utils/stringWithWBR'
 import { CONCLUSION_DISPLAY_CONFIG } from 'scenes/experiments/constants'
-import { DuplicateExperimentModal } from 'scenes/experiments/DuplicateExperimentModal'
 import {
     canArchiveExperiment,
     confirmArchiveExperiment,
@@ -56,6 +55,7 @@ import {
 } from '~/types'
 
 import { CopyExperimentToProjectModal } from 'products/experiments/frontend/components/CopyExperimentToProjectModal'
+import { DuplicateExperimentModal } from 'products/experiments/frontend/components/DuplicateExperimentModal'
 import { ExperimentVelocityStats } from 'products/experiments/frontend/components/ExperimentVelocityStats'
 import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'


### PR DESCRIPTION
## Problem

`DuplicateExperimentModal` still lives under `frontend/src/scenes/experiments`. It belongs in the experiments product folder.

## Changes

Mechanical move of `DuplicateExperimentModal` to `products/experiments/frontend/components`. All importers now use the `products/` path. No behavior change.

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend typescript:check
```

```bash
pnpm --filter=@posthog/frontend jest frontend/src/scenes/experiments products/experiments/frontend
```

![cat-type-small](https://github.com/user-attachments/assets/19c2cb78-30d3-4313-8c2a-ef283ee54dab)

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /stacking-prs (local)
- /writing-ui-components (local)
- /writing-pull-requests (local)

Relevant decisions:

- Each file moves in its own stacked PR, so review stays small and mechanical.
- Components go to `products/experiments/frontend/components`; helper modules go to the frontend root. No `../` imports.