### PR TITLE
feat(insights): add performed event breakdown button

### DIFF
--- a/frontend/src/scenes/insights/filters/BreakdownFilter/PerformedBreakdownButton.test.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/PerformedBreakdownButton.test.ts
@@ -1,0 +1,16 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { performedBreakdownHogQL } from './PerformedBreakdownButton'
+
+describe('performedBreakdownHogQL', () => {
+    it.each([
+        ['escapes quotes in event names', "sign'up", TaxonomicFilterGroupType.Events, "sign'up", "event = 'sign\\'up'"],
+        ['matches actions by id', 42, TaxonomicFilterGroupType.Actions, 'My action', 'matchesAction(42)'],
+    ])('%s', (_name, value, groupType, label, expectedMatch) => {
+        const expr = performedBreakdownHogQL(value, groupType, label)
+        expect(expr).toBe(
+            `if(person_id IN (SELECT person_id FROM events WHERE ${expectedMatch} AND timestamp > now() - INTERVAL 30 DAY), ` +
+                `'Did perform', 'Did not perform') -- Performed ${label}`
+        )
+    })
+})

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/PerformedBreakdownButton.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/PerformedBreakdownButton.tsx
@@ -1,0 +1,66 @@
+import { useActions, useValues } from 'kea'
+import { ReactElement } from 'react'
+
+import { IconPlusSmall } from '@posthog/icons'
+
+import { TaxonomicFilterGroup, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { TaxonomicPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import { FEATURE_FLAGS } from 'lib/constants'
+
+import { hogql } from '~/queries/utils'
+
+import { taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
+
+/** A HogQL breakdown splitting people into those who performed the event or action in the
+ * last 30 days and those who didn't. The trailing comment is the tag's display label. */
+export function performedBreakdownHogQL(
+    value: string | number,
+    groupType: TaxonomicFilterGroupType,
+    name: string
+): string {
+    const match =
+        groupType === TaxonomicFilterGroupType.Actions
+            ? hogql`matchesAction(${Number(value)})`
+            : hogql`event = ${String(value)}`
+    return (
+        `if(person_id IN (SELECT person_id FROM events WHERE ${match} AND timestamp > now() - INTERVAL 30 DAY), ` +
+        `'Did perform', 'Did not perform') -- Performed ${name}`
+    )
+}
+
+interface PerformedBreakdownButtonProps {
+    disabledReason?: ReactElement | string
+    size?: 'small' | 'medium'
+}
+
+export function PerformedBreakdownButton({ disabledReason, size }: PerformedBreakdownButtonProps): JSX.Element | null {
+    const { addBreakdown } = useActions(taxonomicBreakdownFilterLogic)
+    const { featureFlags, hasDataWarehouseSeries } = useValues(taxonomicBreakdownFilterLogic)
+
+    // A performed breakdown compiles to a person_id subquery over the events table, which a warehouse series has no key for
+    if (!featureFlags[FEATURE_FLAGS.BEHAVIORAL_PROPERTY_FILTER] || hasDataWarehouseSeries) {
+        return null
+    }
+
+    return (
+        <TaxonomicPopover
+            groupType={TaxonomicFilterGroupType.Events}
+            groupTypes={[TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]}
+            value={null}
+            onChange={(value, groupType, item) =>
+                value != null &&
+                addBreakdown(performedBreakdownHogQL(value, groupType, item?.name || String(value)), {
+                    type: TaxonomicFilterGroupType.HogQLExpression,
+                } as TaxonomicFilterGroup)
+            }
+            type="secondary"
+            placeholder="Performed"
+            placeholderClass=""
+            icon={<IconPlusSmall />}
+            sideIcon={null}
+            size={size}
+            disabledReason={disabledReason}
+            data-attr="add-performed-breakdown-button"
+        />
+    )
+}

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.test.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.test.tsx
@@ -97,6 +97,26 @@ describe('TaxonomicBreakdownFilter', () => {
         })
     })
 
+    describe('performed breakdown button', () => {
+        it('renders only when the behavioral property filter flag is on', async () => {
+            renderInsightPage({
+                query: buildTrendsQuery(),
+                featureFlags: { 'behavioral-property-filter': true },
+            })
+            await waitForBreakdownButton()
+            expect(screen.getByTestId('add-performed-breakdown-button')).toBeInTheDocument()
+        })
+
+        it('stays hidden when the flag is off', async () => {
+            renderInsightPage({
+                query: buildTrendsQuery(),
+                featureFlags: { 'behavioral-property-filter': false },
+            })
+            await waitForBreakdownButton()
+            expect(screen.queryByTestId('add-performed-breakdown-button')).not.toBeInTheDocument()
+        })
+    })
+
     describe('at the funnel cohort cap', () => {
         it('surfaces the funnel cohort explanation and the cohort-anchored docs link', async () => {
             renderInsightPage({

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter.tsx
@@ -16,6 +16,7 @@ import { ChartDisplayType, InsightLogicProps } from '~/types'
 
 import { EditableBreakdownTag } from './BreakdownTag'
 import { GlobalBreakdownOptionsMenu } from './GlobalBreakdownOptionsMenu'
+import { PerformedBreakdownButton } from './PerformedBreakdownButton'
 import { TaxonomicBreakdownButton } from './TaxonomicBreakdownButton'
 import { TaxonomicBreakdownFilterLogicProps, taxonomicBreakdownFilterLogic } from './taxonomicBreakdownFilterLogic'
 
@@ -163,6 +164,7 @@ export function TaxonomicBreakdownFilter({
                     disabledReasonInteractive={!!composedDisabledReason}
                     size={size}
                 />
+                <PerformedBreakdownButton disabledReason={composedDisabledReason} size={size} />
             </div>
             {showInlineOptions && isMultipleBreakdownsEnabled && hasGlobalBreakdownOptions && (
                 <div className="mt-2 border-t pt-2">


### PR DESCRIPTION
## Problem

Users can filter a series by "Performed event" (the flag-gated behavioral filter), but they can't split a series by it. Comparing how people who did an action behave against people who didn't takes two insights or hand-written SQL.

## Changes

- The breakdown section of the insight editor gets a "Performed" button next to "+ Breakdown". Picking an event or action splits every series into "Did perform" and "Did not perform" (over the last 30 days).
- The button only shows when the `behavioral-property-filter` flag is on, and hides for data warehouse series (they have no `person_id` to join on), matching the existing performed buttons.
- Under the hood it emits a HogQL breakdown: `if(person_id IN (SELECT person_id FROM events WHERE event = '<x>' AND timestamp > now() - INTERVAL 30 DAY), 'Did perform', 'Did not perform') -- Performed <x>`. The trailing comment is what the breakdown tag displays, and clicking the tag opens the SQL for editing.
- Reusing the HogQL breakdown type means no schema or backend changes: trends multi-breakdowns, funnels, persons modal, and dashboards all work through the existing paths.

![performed breakdown applied](https://raw.githubusercontent.com/PostHog/pr-assets/bf8e5031539e2ea11a683d66bbb790ce38f29cca/2026/08/44d51f35-b229-4470-a69d-bc56ec1ec915.png)

## How did you test this code?

- Jest: `performedBreakdownHogQL` unit test catches broken quote escaping in event names and wrong action matching; two `TaxonomicBreakdownFilter` render tests catch the button rendering without the flag or disappearing with it.
- Local dev stack: applied the breakdown on a trends insight via the UI (screenshot above; tag renders "Performed $pageview") and ran the resulting `TrendsQuery` against ClickHouse, which returned a "Did perform" series.
- Not checked manually: funnels and the persons modal; both go through the existing `hogql` breakdown paths this change doesn't touch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - the button is behind the `behavioral-property-filter` flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with pi (PostHog cloud task). Skills invoked: /writing-ui-components, /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.
- Considered a first-class `behavioral` breakdown type (schema + backend + actors query changes); chose to generate a HogQL breakdown instead since it works today across trends/funnels/actors with zero backend surface, and the labeled tag keeps the UX. A dedicated type can follow if the feature sticks.
- The 30-day window mirrors the behavioral filter's default; it's baked into the generated SQL and editable from the tag.
