### PR TITLE
fix(desktop): preserve grid drag state

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/grid/useGridDrag.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/grid/useGridDrag.test.tsx
@@ -1,0 +1,63 @@
+import type {
+  GridDefinition,
+  GridPlacement,
+} from "@posthog/core/canvas/gridLayoutSchemas";
+import { act, renderHook } from "@testing-library/react";
+import type { RefObject } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useGridDrag } from "./useGridDrag";
+
+const GRID: GridDefinition = { columns: 6, rowHeight: 96, gap: 8 };
+const PLACEMENT: GridPlacement = {
+  id: "widget",
+  status: "live",
+  x: 0,
+  y: 0,
+  w: 1,
+  h: 1,
+};
+
+function pointer(clientX: number, clientY: number): React.PointerEvent {
+  return {
+    button: 0,
+    clientX,
+    clientY,
+    pointerId: 1,
+    stopPropagation: vi.fn(),
+  } as unknown as React.PointerEvent;
+}
+
+describe("useGridDrag", () => {
+  it("commits a move when pointer events arrive before React rerenders", () => {
+    const onComplete = vi.fn();
+    const surface = document.createElement("div");
+    vi.spyOn(surface, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 600,
+    } as DOMRect);
+    surface.setPointerCapture = vi.fn();
+    const surfaceRef = { current: surface } as RefObject<HTMLDivElement | null>;
+    const { result } = renderHook(() =>
+      useGridDrag({
+        surfaceRef,
+        grid: GRID,
+        interactive: true,
+        onComplete,
+      }),
+    );
+
+    act(() => {
+      result.current.startMove(PLACEMENT)(pointer(50, 50));
+      result.current.onPointerMove(pointer(250, 50));
+      result.current.onPointerUp();
+    });
+
+    expect(onComplete).toHaveBeenCalledWith({
+      kind: "move",
+      placementId: "widget",
+      origin: PLACEMENT,
+      rect: { x: 2, y: 0, w: 1, h: 1 },
+    });
+  });
+});

--- a/products/desktop/packages/ui/src/features/canvas/grid/useGridDrag.ts
+++ b/products/desktop/packages/ui/src/features/canvas/grid/useGridDrag.ts
@@ -2,7 +2,7 @@ import type {
   GridDefinition,
   GridPlacement,
 } from "@posthog/core/canvas/gridLayoutSchemas";
-import { type RefObject, useState } from "react";
+import { type RefObject, useRef, useState } from "react";
 import {
   cellFromPoint,
   clampRect,
@@ -48,6 +48,14 @@ export function useGridDrag({
   onComplete: (outcome: GridDragOutcome) => void;
 }) {
   const [drag, setDrag] = useState<GridDragState | null>(null);
+  // Pointer events can arrive before React commits the state update from the
+  // preceding event. Keep the active gesture in a ref so a press, immediate
+  // move, and release still uses the same drag state.
+  const dragRef = useRef<GridDragState | null>(null);
+  const setActiveDrag = (next: GridDragState | null) => {
+    dragRef.current = next;
+    setDrag(next);
+  };
   // The empty cell under a resting pointer, so the surface can show where a
   // click would put a box. Only the surface itself reports one: a tile handles
   // its own presses, and hovering it is not an offer to draw.
@@ -69,7 +77,11 @@ export function useGridDrag({
     const anchor = cellAt(event);
     capture(event);
     setHover(null);
-    setDrag({ kind: "draw", anchor, rect: rectFromCells(anchor, anchor) });
+    setActiveDrag({
+      kind: "draw",
+      anchor,
+      rect: rectFromCells(anchor, anchor),
+    });
   };
 
   const startMove =
@@ -78,7 +90,7 @@ export function useGridDrag({
       event.stopPropagation();
       capture(event);
       setHover(null);
-      setDrag({
+      setActiveDrag({
         kind: "move",
         placementId: placement.id,
         grabbed: cellAt(event),
@@ -98,7 +110,7 @@ export function useGridDrag({
       event.stopPropagation();
       capture(event);
       setHover(null);
-      setDrag({
+      setActiveDrag({
         kind: "resize",
         placementId: placement.id,
         origin: placement,
@@ -112,7 +124,8 @@ export function useGridDrag({
     };
 
   const onPointerMove = (event: React.PointerEvent) => {
-    if (!drag) {
+    const activeDrag = dragRef.current;
+    if (!activeDrag) {
       const cell =
         interactive && event.target === surfaceRef.current
           ? cellAt(event)
@@ -124,42 +137,49 @@ export function useGridDrag({
       return;
     }
     const cell = cellAt(event);
-    if (drag.kind === "draw") {
-      setDrag({ ...drag, rect: rectFromCells(drag.anchor, cell) });
-    } else if (drag.kind === "move") {
+    if (activeDrag.kind === "draw") {
+      setActiveDrag({
+        ...activeDrag,
+        rect: rectFromCells(activeDrag.anchor, cell),
+      });
+    } else if (activeDrag.kind === "move") {
       const rect = clampRect(
         {
-          ...drag.origin,
-          x: drag.origin.x + (cell.col - drag.grabbed.col),
-          y: drag.origin.y + (cell.row - drag.grabbed.row),
+          ...activeDrag.origin,
+          x: activeDrag.origin.x + (cell.col - activeDrag.grabbed.col),
+          y: activeDrag.origin.y + (cell.row - activeDrag.grabbed.row),
         },
         grid.columns,
       );
-      setDrag({ ...drag, rect });
+      setActiveDrag({ ...activeDrag, rect });
     } else {
       const rect = clampRect(
         {
-          ...drag.origin,
-          w: cell.col - drag.origin.x + 1,
-          h: cell.row - drag.origin.y + 1,
+          ...activeDrag.origin,
+          w: cell.col - activeDrag.origin.x + 1,
+          h: cell.row - activeDrag.origin.y + 1,
         },
         grid.columns,
       );
-      setDrag({ ...drag, rect });
+      setActiveDrag({ ...activeDrag, rect });
     }
   };
 
   const onPointerUp = () => {
-    if (!drag) return;
-    setDrag(null);
+    const activeDrag = dragRef.current;
+    if (!activeDrag) return;
+    setActiveDrag(null);
     onComplete({
-      kind: drag.kind,
+      kind: activeDrag.kind,
       // Move/resize rects are clamped on every pointer move; only a drawn
       // rect still needs it.
       rect:
-        drag.kind === "draw" ? clampRect(drag.rect, grid.columns) : drag.rect,
-      placementId: drag.kind === "draw" ? undefined : drag.placementId,
-      origin: drag.kind === "draw" ? undefined : drag.origin,
+        activeDrag.kind === "draw"
+          ? clampRect(activeDrag.rect, grid.columns)
+          : activeDrag.rect,
+      placementId:
+        activeDrag.kind === "draw" ? undefined : activeDrag.placementId,
+      origin: activeDrag.kind === "draw" ? undefined : activeDrag.origin,
     });
   };
 
@@ -169,7 +189,7 @@ export function useGridDrag({
   // tracks the cursor with no button held and persists an unmade edit on the
   // next click.
   const onPointerCancel = () => {
-    setDrag(null);
+    setActiveDrag(null);
   };
 
   const onPointerLeave = () => {


### PR DESCRIPTION
## Problem

Canvas editors can release a drag before React applies its preceding pointer-state update. Component and insight cards then stay in place.

## Changes

- Grid card grippers now retain their active drag state across rapid pointer events.
- The change is mechanical; it does not alter the canvas static appearance.
- Screenshot omitted because the fix only changes drag interaction.

## How did you test this code?

- Added a focused hook test for a move that starts, moves, and ends before React rerenders.
- Ran the focused UI test, Biome check, and UI typecheck.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fixes an existing canvas interaction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used `/posthog-desktop`, `/composing-grid-canvases`, `/writing-tests`, and `/writing-pr-descriptions` to diagnose and test the grid drag-state fix.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*