### PR TITLE
chore(mcp-analytics): widen the intent corpus and hold back unsupported claims

### DIFF
--- a/products/mcp_analytics/backend/intent_clustering.py
+++ b/products/mcp_analytics/backend/intent_clustering.py
@@ -26,6 +26,7 @@ where a ``$mcp_tools_list`` catalog was observed, how often agents discover the
 tool when it is advertised.
 """
 
+import re
 import math
 import asyncio
 import hashlib
@@ -71,6 +72,10 @@ MAX_SAMPLE_INTENTS_PER_CLUSTER = 3
 MAX_DESCRIPTION_LENGTH = 512
 # Below this many advertised sessions a discovery rate is noise, so it stays null.
 MIN_ADVERTISED_SESSIONS = 5
+# A cluster holding one intent has no competition to report: its tool spread is one
+# agent's call sequence. Naming a runner-up there presents a sequence as a routing
+# conflict, so `top_competitor` stays null until a cluster groups intents.
+MIN_INTENTS_FOR_COMPETITOR = 2
 # Payload bounds for the snapshot blob. Only the two top-level caps report what they
 # dropped (`dropped_tools`, `dropped_overlap_pairs` in computed_with); the per-cluster
 # caps below truncate silently, so `computed_with` is not a completeness check for them.
@@ -679,6 +684,32 @@ def fetch_tool_descriptions(
     }
 
 
+# A run id stamped into an otherwise fixed template makes one recurring goal
+# arrive as one distinct intent per run. Each variant carries too few calls to
+# clear the top-N cut, so the calls drop out of clustering entirely rather than
+# grouping under the goal they belong to. Folding the id back in lifts the whole
+# family above the cut as a single intent.
+_INTENT_RUN_ID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE)
+# Agents end the same sentence with and without a period, which splits an intent
+# in two for a character no reader would notice.
+_INTENT_TRAILING_PUNCTUATION = re.compile(r"[.!?:;,]+$")
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+
+def normalize_intent_text(text: str) -> str:
+    """Fold the spellings of one intent onto a single key before it is counted.
+
+    Deliberately narrow. Every rule is a chance to merge two goals that differ for
+    a reason, so each one here was measured against a real corpus and the rules
+    that merged only a handful of calls were dropped rather than kept for
+    tidiness. Case is left alone: the surviving text becomes the cluster label,
+    and folding case buys little next to the two rules below.
+    """
+    text = _INTENT_RUN_ID.sub("<id>", text)
+    text = _WHITESPACE_RUN.sub(" ", text).strip()
+    return _INTENT_TRAILING_PUNCTUATION.sub("", text).strip()
+
+
 def build_call_corpus(
     rows: list[tuple[str, str, str, bool]],
     top_n: int = DEFAULT_TOP_N_INTENTS,
@@ -707,7 +738,9 @@ def build_call_corpus(
         # constant. It is not an intent, and clustering it forms a pseudo-cluster.
         if text == NO_INTENT_RECORDED_FALLBACK:
             text = ""
-        text = text[:MAX_INTENT_TEXT_LENGTH]
+        # Clip before normalizing so the regex work stays bounded by the same
+        # limit the SQL applies.
+        text = normalize_intent_text(text[:MAX_INTENT_TEXT_LENGTH])
 
         intent_text: str | None
         if text:
@@ -1127,9 +1160,13 @@ def compute_tool_pivot(
             weighted_entropy[tool] += entry["count"] * cluster["routing_entropy"]
             if not in_snapshot:
                 continue
-            competitor = next(
-                ({"tool": other["tool"], "pct": other["pct"]} for other in distribution if other["tool"] != tool),
-                None,
+            competitor = (
+                next(
+                    ({"tool": other["tool"], "pct": other["pct"]} for other in distribution if other["tool"] != tool),
+                    None,
+                )
+                if cluster.get("intent_count", 0) >= MIN_INTENTS_FOR_COMPETITOR
+                else None
             )
             per_tool_clusters[tool].append(
                 {

--- a/products/mcp_analytics/backend/tests/test_intent_clustering.py
+++ b/products/mcp_analytics/backend/tests/test_intent_clustering.py
@@ -61,6 +61,7 @@ from products.mcp_analytics.backend.intent_clustering import (
     fetch_session_calls,
     fetch_tool_descriptions,
     fetch_window_stats,
+    normalize_intent_text,
     sample_corpus_sessions,
     top_corpus_tools,
 )
@@ -421,7 +422,72 @@ class TestBuildSnapshot:
 # build_call_corpus --------------------------------------------------------
 
 
+class TestNormalizeIntentText:
+    @parameterized.expand(
+        [
+            ("a run id", "Signals scout run 01a01cae-fdd4-772e-b35c-07d69a095632", "Signals scout run <id>"),
+            ("an uppercase run id", "run 01A01CAE-FDD4-772E-B35C-07D69A095632", "run <id>"),
+            (
+                "two ids in one intent",
+                "copy 01a01cae-fdd4-772e-b35c-07d69a095632 to 7f2e1b90-aaaa-4bcd-8123-0f9e2d3c4b5a",
+                "copy <id> to <id>",
+            ),
+            ("a trailing period", "Read tool schema before use.", "Read tool schema before use"),
+            ("trailing punctuation after an id", "scout run 01a01cae-fdd4-772e-b35c-07d69a095632.", "scout run <id>"),
+            (
+                "the whitespace a replacement leaves",
+                "run   01a01cae-fdd4-772e-b35c-07d69a095632   again",
+                "run <id> again",
+            ),
+        ]
+    )
+    def test_folds_the_spellings_of_one_intent_together(self, _name: str, raw: str, expected: str) -> None:
+        assert normalize_intent_text(raw) == expected
+
+    @parameterized.expand(
+        [
+            ("case, which becomes the cluster label", "Read Tool Schema Before Use"),
+            ("short numbers that carry meaning", "count errors over the last 7 days"),
+            ("a long number that is not a run id", "window starting 1755763299000"),
+            ("a date, since two dates are two questions", "audit for 2026-08-20"),
+            ("mid-sentence punctuation", "check flags, then read logs"),
+            ("no identifiers at all", "find the slowest endpoints"),
+        ]
+    )
+    def test_leaves_text_alone_when_folding_it_would_merge_real_differences(self, _name: str, raw: str) -> None:
+        # Every rule here can merge two goals that differ for a reason, so the set
+        # stays at the rules that measurably earned their place on a real corpus.
+        assert normalize_intent_text(raw) == raw
+
+
 class TestBuildCallCorpus:
+    def test_collapses_intent_variants_that_differ_only_by_a_run_id(self) -> None:
+        # A recurring job stamps its run id into a fixed template, so one goal
+        # arrives as N intents. Each variant carries too few calls to clear the
+        # top-N cut, so the calls left clustering entirely instead of grouping.
+        rows = [
+            ("s1", "query_logs", "scout run 01a01cae-fdd4-772e-b35c-07d69a095632", False),
+            ("s2", "query_logs", "scout run 7f2e1b90-aaaa-4bcd-8123-0f9e2d3c4b5a", False),
+            ("s3", "query_logs", "scout run 3c9d5e21-bbbb-4aef-9012-1a2b3c4d5e6f", False),
+        ]
+
+        records, _, _ = build_call_corpus(rows)
+
+        assert [r.intent_text for r in records] == ["scout run <id>"]
+        assert records[0].frequency == 3
+        assert records[0].session_count == 3
+
+    def test_keeps_distinct_goals_apart_when_only_their_run_ids_match(self) -> None:
+        run_id = "01a01cae-fdd4-772e-b35c-07d69a095632"
+        rows = [
+            ("s1", "query_logs", f"read logs for {run_id}", False),
+            ("s2", "query_apm_spans", f"read spans for {run_id}", False),
+        ]
+
+        records, _, _ = build_call_corpus(rows)
+
+        assert sorted(r.intent_text for r in records) == ["read logs for <id>", "read spans for <id>"]
+
     def test_attributes_tool_counts_to_the_calls_own_intent(self) -> None:
         # The v1 pipeline smeared the session's first intent across every call in
         # the session, so tools used for a later intent were mis-credited.
@@ -803,6 +869,7 @@ def _cluster_fixture() -> list[dict[str, Any]]:
             "id": 0,
             "label": "check flags",
             "call_count": 10,
+            "intent_count": 4,
             "routing_entropy": 0.5,
             "tool_distribution": [
                 {"tool": "t1", "count": 6, "pct": 60.0, "errors": 1, "error_rate_pct": 16.7},
@@ -813,6 +880,7 @@ def _cluster_fixture() -> list[dict[str, Any]]:
             "id": 1,
             "label": "run queries",
             "call_count": 4,
+            "intent_count": 2,
             "routing_entropy": 0.0,
             "tool_distribution": [
                 {"tool": "t1", "count": 4, "pct": 100.0, "errors": 0, "error_rate_pct": 0.0},
@@ -851,6 +919,26 @@ class TestComputeToolPivot:
         assert t2["clusters"][0]["rank"] == 2
         assert t2["clusters"][0]["top_competitor"] == {"tool": "t1", "pct": 60.0}
         assert by_tool["t1"]["clusters"][1]["top_competitor"] is None
+
+    def test_withholds_a_competitor_from_a_cluster_holding_one_intent(self) -> None:
+        # One intent's tool spread is one agent's sequence, not two tools competing
+        # for a goal. Naming a competitor there reads as a routing conflict that
+        # the sample cannot show.
+        clusters = _cluster_fixture()
+        clusters[0]["intent_count"] = 1
+
+        pivot, _ = compute_tool_pivot(
+            clusters,
+            calls_by_session={"s1": [_attributed_call("s1", "t1"), _attributed_call("s1", "t2")]},
+            advertised_by_session={},
+            tool_descriptions={},
+            description_fit={},
+        )
+
+        by_tool = {t["tool"]: t for t in pivot}
+        assert by_tool["t1"]["clusters"][0]["top_competitor"] is None
+        # Capture share still stands: it is a count, not an inference about routing.
+        assert by_tool["t1"]["clusters"][0]["capture_pct"] == pytest.approx(60.0)
 
     def test_advertised_denominator_ignores_sessions_absent_from_the_corpus(self) -> None:
         # The row cap can drop whole sessions after their ids were sampled. Leaving

--- a/products/mcp_analytics/frontend/clustering/ClusteringCoverageBanner.tsx
+++ b/products/mcp_analytics/frontend/clustering/ClusteringCoverageBanner.tsx
@@ -18,8 +18,14 @@ export function ClusteringCoverageBanner(): JSX.Element | null {
 
     const parts: string[] = []
     if (meta.window_sessions !== null && meta.window_sessions !== undefined) {
+        // The share is what makes the two counts readable at a glance. "1,548 of
+        // 468,042" is easy to skim past; "0.3% of them" is not.
+        const share =
+            meta.session_coverage_pct !== null && meta.session_coverage_pct !== undefined
+                ? ` (${meta.session_coverage_pct < 1 ? meta.session_coverage_pct.toFixed(1) : meta.session_coverage_pct.toFixed(0)}% of them)`
+                : ''
         parts.push(
-            `Based on ${humanFriendlyNumber(meta.sampled_sessions)} sampled sessions out of ${humanFriendlyNumber(meta.window_sessions)} in the window`
+            `Based on ${humanFriendlyNumber(meta.sampled_sessions)} sampled sessions out of ${humanFriendlyNumber(meta.window_sessions)} in the window${share}`
         )
     } else {
         parts.push(`Based on ${humanFriendlyNumber(meta.sampled_sessions)} sampled sessions`)

--- a/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
+++ b/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
@@ -194,7 +194,8 @@ function IntentsView(): JSX.Element {
 }
 
 export function MCPAnalyticsClustering(): JSX.Element {
-    const { snapshot, hasSnapshot, isComputing, snapshotLoading, viewMode } = useValues(mcpClusteringLogic)
+    const { snapshot, hasSnapshot, isComputing, snapshotLoading, viewMode, lowSampleWarning } =
+        useValues(mcpClusteringLogic)
     const { recompute } = useActions(mcpClusteringLogic)
 
     if (snapshot.status === 'error') {
@@ -223,6 +224,10 @@ export function MCPAnalyticsClustering(): JSX.Element {
     return (
         <div className="flex flex-col gap-4" data-quill>
             <StatusRow />
+            {/* The coverage line in the status row states the same sample, but at the
+                size of a timestamp. A thin sample changes how every number below it
+                should be read, so it gets its own banner. */}
+            {lowSampleWarning && <LemonBanner type="warning">{lowSampleWarning}</LemonBanner>}
             <div className="flex flex-wrap items-center gap-3">
                 <ViewToggle />
                 <CategoryScope />

--- a/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.test.ts
+++ b/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.test.ts
@@ -10,15 +10,18 @@ import { mcpAnalyticsIntentClustersRetrieve } from '../generated/api'
 import type {
     MCPIntentClusterApi,
     MCPIntentClusterSnapshotApi,
+    MCPIntentClusterSnapshotMetaApi,
     MCPIntentClusterToolEntryApi,
     MCPToolPivotApi,
     MCPToolPivotClusterEntryApi,
 } from '../generated/api.schemas'
 import {
+    LOW_SESSION_COVERAGE_PCT,
     type ClusterFilter,
     type RouteShape,
     clusterCategories,
     fitDomain,
+    lowSampleCaveat,
     mcpClusteringLogic,
     routeShape,
     routingSegments,
@@ -756,5 +759,30 @@ describe('mcpClusteringLogic helpers', () => {
         const [low, high] = fitDomain(fits)
 
         expect(high - low).toBeGreaterThan(0)
+    })
+
+    // The snapshot has always reported its own coverage, but nothing rendered it, so
+    // a run over a fraction of a percent of sessions read exactly like a census.
+    describe('lowSampleCaveat', () => {
+        const meta = (session_coverage_pct: number | null): MCPIntentClusterSnapshotMetaApi =>
+            ({ ...SNAPSHOT.computed_with, session_coverage_pct }) as MCPIntentClusterSnapshotMetaApi
+
+        it('names the coverage when the run sampled a sliver of the window', () => {
+            expect(lowSampleCaveat(meta(0.3))).toContain('0.3%')
+        })
+
+        it.each([
+            ['coverage clears the bar', LOW_SESSION_COVERAGE_PCT + 0.1],
+            ['coverage sits exactly on the bar', LOW_SESSION_COVERAGE_PCT],
+        ])('stays quiet when %s', (_name, pct) => {
+            expect(lowSampleCaveat(meta(pct))).toBeNull()
+        })
+
+        it.each([
+            ['the snapshot predates coverage metadata', null],
+            ['there is no metadata at all', undefined],
+        ])('stays quiet when %s rather than implying full coverage', (_name, value) => {
+            expect(lowSampleCaveat(value === null ? meta(null) : undefined)).toBeNull()
+        })
     })
 })

--- a/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.ts
+++ b/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.ts
@@ -14,6 +14,7 @@ import { mcpAnalyticsIntentClustersRecompute, mcpAnalyticsIntentClustersRetrieve
 import type {
     MCPIntentClusterApi,
     MCPIntentClusterSnapshotApi,
+    MCPIntentClusterSnapshotMetaApi,
     MCPToolOverlapApi,
     MCPToolPivotApi,
     MCPToolPivotClusterEntryApi,
@@ -210,6 +211,28 @@ export function fitDomain(fits: number[]): [number, number] {
     return [Math.max(-1, low - pad), Math.min(1, high + pad)]
 }
 
+/**
+ * Session coverage under this reads as a sliver of the window rather than a view
+ * of it. Clustering has always sampled and always reported how much, but nothing
+ * rendered the figure, so a run over a fraction of a percent looked like a census.
+ */
+export const LOW_SESSION_COVERAGE_PCT = 5
+
+export function lowSampleCaveat(meta: MCPIntentClusterSnapshotMetaApi | null | undefined): string | null {
+    const coverage = meta?.session_coverage_pct
+    // Null coverage means the snapshot never measured it. Saying nothing is right;
+    // warning would invent a problem, and a silent pass would imply a full window.
+    if (coverage === null || coverage === undefined || coverage >= LOW_SESSION_COVERAGE_PCT) {
+        return null
+    }
+    return `This run clustered ${formatCoverage(coverage)}% of the sessions in the window. Every count and percentage here describes that sample, so read small clusters and per-tool rates as directional.`
+}
+
+/** Keeps a sub-1% coverage figure from rounding to a flat "0%". */
+function formatCoverage(pct: number): string {
+    return pct >= 1 ? pct.toFixed(0) : pct.toFixed(1)
+}
+
 function median(values: number[]): number | null {
     if (values.length === 0) {
         return null
@@ -237,6 +260,7 @@ export interface mcpClusteringLogicValues {
     hasSnapshot: boolean
     hasToolPivot: boolean
     isComputing: boolean
+    lowSampleWarning: string | null
     routeShapeCounts: RouteShapeCounts
     scatterPoints: ScatterPoint[]
     scopedClusters: MCPIntentClusterApi[]
@@ -391,6 +415,7 @@ export interface mcpClusteringLogicMeta {
         routeShapeCounts: (searchedClusters: MCPIntentClusterApi[]) => RouteShapeCounts
         isComputing: (snapshot: MCPIntentClusterSnapshotApi) => boolean
         hasSnapshot: (snapshot: MCPIntentClusterSnapshotApi) => boolean
+        lowSampleWarning: (snapshot: MCPIntentClusterSnapshotApi) => string | null
     }
 }
 
@@ -778,6 +803,10 @@ export const mcpClusteringLogic = kea<mcpClusteringLogicType>([
             (s) => [s.snapshot],
             (snapshot: MCPIntentClusterSnapshotApi): boolean =>
                 snapshot.last_computed_at !== null || snapshot.clusters.length > 0,
+        ],
+        lowSampleWarning: [
+            (s) => [s.snapshot],
+            (snapshot: MCPIntentClusterSnapshotApi): string | null => lowSampleCaveat(snapshot.computed_with),
         ],
     }),
     listeners(({ actions, values, cache }) => ({


### PR DESCRIPTION
## Problem

Someone reading the intent clustering tab cannot tell how much of their traffic it saw, and some of its numbers claim more than the sample supports. Three separate causes:

- **Most calls never reach clustering.** The run embeds the top 1000 intents by call volume. A recurring job stamps its run id into a fixed template, so one goal arrives as one distinct intent per run. Each variant is too small to clear the cut, so the whole family drops out instead of grouping under the goal it belongs to. On a real 7-day corpus the top-1000 cut covered about a tenth of intent-bearing calls.
- **A cluster of one intent still names a "top competitor".** That runner-up is the second tool in one agent's call sequence. It reads as two tools competing for a goal, which one intent cannot show.
- **The sample size is invisible.** The snapshot has always computed `session_coverage_pct` and the API has always returned it. Nothing rendered it. A run over a fraction of a percent of sessions looked exactly like a run over all of them.

## Changes

- Clustering now covers **32.5% more calls** at the same 1000-intent budget, because run-id variants of one goal fold together and clear the cut as a family. Measured end to end against a real 7-day corpus.
- Intents that differ only by a trailing period stop counting as two goals.
- A cluster holding a single intent shows no top competitor. Its capture share still shows, because that is a count rather than an inference about routing.
- The status row now states the sampled share, so "1,548 sampled sessions out of 468,042" reads as "0.3% of them".
- A run that covers a sliver of the window opens with a warning naming the figure, instead of leaving it to a line set at the size of a timestamp.

Cluster labels can now end in `<id>` where a run id was folded out. That is deliberate: it keeps the template readable, and it makes an intent that was only ever an identifier visible as one.

`normalize_intent_text` stays deliberately narrow. Every rule can merge two goals that differ for a reason, so each was measured on its own and the ones that earned nothing were dropped:

| Rule | Extra calls covered | Kept |
|---|---|---|
| Run id (UUID) | +31.3% | Yes |
| Trailing punctuation | +4.1% | Yes |
| Lowercasing | +3.8% | No, it degrades the cluster label for a fraction of the gain |
| Long hex runs | +4 calls | No |
| Long digit runs | +9 calls | No |
| Dates and timestamps | +12 calls | No |

The last three moved about 25 calls out of 880,000 while carrying real over-normalization risk, so two dates would have become one goal for no measurable benefit.

Nothing about the sampling strategy or the distance threshold changes here. This widens what the existing budget reaches and stops the page implying more than it measured.

<details>
<summary>Screenshots</summary>

Not captured. Rendering the tab needs a seeded snapshot and the `mcp-analytics` flag, and the frontend build was not runnable in this sandbox. The exact strings a person sees, using the real snapshot's numbers, are in the testing section below.
</details>

## How did you test this code?

Written test-first: the new cases failed before the change landed. The rewrite after measurement was also test-first.

Backend, in `test_intent_clustering.py`. The regressions each group catches, none of which an existing test covered:

- `TestNormalizeIntentText` — a run id or trailing period silently splitting one goal in two, and the mirror failure of over-normalizing: case, dates, long numbers and mid-sentence punctuation each have a case asserting they survive.
- `TestBuildCallCorpus` — normalization not being applied where the top-N cut happens, so variants stay split. A second case holds two goals apart when only their run ids match.
- `TestComputeToolPivot` — a one-intent cluster naming a competitor again.

Frontend, in `mcpClusteringLogic.test.ts`: `lowSampleCaveat` losing the coverage figure, firing at healthy coverage, and the boundary case where coverage is absent, which must stay silent rather than imply a full window.

Run locally: all 361 `products/mcp_analytics` backend tests, including the 14 ClickHouse and Postgres backed ones after starting those containers, and all 263 `products/mcp_analytics` frontend tests. `ruff check`, `ruff format`, `oxlint` and `oxfmt` are clean.

Not run: the full frontend `tsgo --noEmit`. It was OOM-killed twice with 12 GB free, so it needs more memory than this sandbox has. A scoped `tsc --noEmit` over the changed modules reports nothing. CI covers the real check.

The coverage numbers come from running the shipped normalizer against production intent data, not from a fixture. The Python function's output was compared against the same normalization expressed in SQL over the full 7-day corpus, and they agree on every real intent checked.

<details>
<summary>The copy a person sees, with the real snapshot's numbers</summary>

```
STATUS ROW (was): · Based on 1,548 sampled sessions out of 468,042 in the window.
STATUS ROW (now): · Based on 1,548 sampled sessions out of 468,042 in the window (0.3% of them).

WARNING BANNER (new):
  This run clustered 0.3% of the sessions in the window. Every count and percentage
  here describes that sample, so read small clusters and per-tool rates as directional.

At healthy coverage (10%): null
```
</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 4.5), starting from a question about whether the clustering tab gives a representative read for a specific product area.

The first implementation was wrong and measurement caught it. The plan was to strip every volatile identifier: UUIDs, long hex, long digit runs, ISO timestamps and dates. A first check of distinct intents inside the already-cut top 1000 then suggested identifier stripping collapsed nothing at all, which pointed at casing and punctuation instead. Both readings were artifacts of measuring after the cut. Measuring the metric that matters, the share of calls the corpus covers with normalization applied before the cut, showed run ids carrying almost the whole gain and the other four identifier rules moving about 25 calls between them. Those four were deleted and lowercasing was rejected on the label cost. Every number in the table above came out of that pass.

Skills invoked: `/debugging-mcp-analytics`, `/writing-tests`, `/writing-pr-descriptions`, `/writing-user-facing-copy`.

Behavior change worth flagging for review: existing snapshots keep their current numbers until the next run, and the first run after this merges intents that were previously counted separately. Cluster intent counts and the cluster total will move. That is the fix working, not drift.

A companion PR fixes a validation error message in the MCP server that this same investigation surfaced.
