### PR TITLE
feat(inbox): start triage mode with review and merge reports

### DIFF
--- a/products/signals/frontend/inbox/InboxScene.stories.tsx
+++ b/products/signals/frontend/inbox/InboxScene.stories.tsx
@@ -40,10 +40,16 @@ function routeTo(pathname: string, searchParams: Record<string, string> = {}): D
 
 const sceneMocks = mswDecorator({
     get: {
-        '/api/projects/:id/signals/reports': () => [
-            200,
-            { results: allReports, count: allReports.length, next: null, previous: null },
-        ],
+        // Split by the pull request filter so triage mode (which loads both lists) doesn't see every
+        // report twice; the list sections read the same split.
+        '/api/projects/:id/signals/reports': ({ request }) => {
+            const hasPr = new URL(request.url).searchParams.get('has_implementation_pr')
+            const results =
+                hasPr === null
+                    ? allReports
+                    : allReports.filter((report) => !!report.implementation_pr_url === (hasPr === 'true'))
+            return [200, { results, count: results.length, next: null, previous: null }]
+        },
         '/api/projects/:id/signals/reports/available_reviewers': () => [200, mockReviewers],
         '/api/projects/:id/signals/reports/:reportId': (req) => {
             const report = allReports.find((candidate) => candidate.id === req.params.reportId)
@@ -91,7 +97,7 @@ type Story = StoryObj
 
 export const Inbox: Story = {}
 
-// Triage mode over the Needs-a-decision queue: one report at a time, keyboard-driven.
+// Triage mode: Review and merge first, then Needs a PR, one report at a time, keyboard-driven.
 export const Triage: Story = {
     decorators: [routeTo(urls.inboxTriage())],
 }

--- a/products/signals/frontend/inbox/components/detail/ReportDetail.tsx
+++ b/products/signals/frontend/inbox/components/detail/ReportDetail.tsx
@@ -27,6 +27,7 @@ import {
     displayConventionalCommitTitle,
     parseConventionalCommitTitle,
     parsePrUrlParts,
+    prFilesUrl,
     safeHttpUrl,
 } from '../../utils/reportPresentation'
 import { parseReportSummary } from '../../utils/reportSummary'
@@ -537,11 +538,6 @@ export function InboxDetailFrame({
             {overviewBody}
         </div>
     )
-}
-
-/** Point a PR URL at its diff/files tab, without double-appending if it's already there. */
-function prFilesUrl(prUrl: string): string {
-    return prUrl.replace(/\/+$/, '').replace(/(\/files)?$/, '/files')
 }
 
 /** The "Open in GitHub" button, shared by the page header and the summary's pull request note. */

--- a/products/signals/frontend/inbox/components/tabs/ReportsTab.tsx
+++ b/products/signals/frontend/inbox/components/tabs/ReportsTab.tsx
@@ -216,7 +216,7 @@ export function ReportsTab(): JSX.Element {
                         size="small"
                         to={urls.inboxTriage()}
                         sideIcon={<KeyboardShortcut t />}
-                        tooltip="Go through the reports that need a pull request one at a time"
+                        tooltip="Go through pull requests to review, then reports that need one, one at a time"
                         data-attr="inbox-triage-mode"
                     >
                         Triage mode

--- a/products/signals/frontend/inbox/components/triage/InboxTriageView.tsx
+++ b/products/signals/frontend/inbox/components/triage/InboxTriageView.tsx
@@ -12,9 +12,9 @@ import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { cn } from 'lib/utils/css-classes'
 import { urls } from 'scenes/urls'
 
-import { captureInboxPanelViewed } from '../../inboxAnalytics'
+import { captureInboxPanelViewed, captureInboxReportAction } from '../../inboxAnalytics'
 import { inboxTriageLogic } from '../../logics/inboxTriageLogic'
-import { SignalReport } from '../../types'
+import { INBOX_REPORT_SECTION_LABEL, SignalReport } from '../../types'
 import {
     deriveHeadline,
     displayConventionalCommitTitle,
@@ -95,7 +95,8 @@ function HintBarItem({ shortcut, label }: { shortcut: JSX.Element; label: string
 }
 
 function TriageCard({ report, expanded }: { report: SignalReport; expanded: boolean }): JSX.Element {
-    const { canCreatePr, isCreatingPr, aiConsentDisabledReason, currentReportUrl } = useValues(inboxTriageLogic)
+    const { canCreatePr, isCreatingPr, aiConsentDisabledReason, currentReportUrl, currentPrUrl } =
+        useValues(inboxTriageLogic)
     const { archiveCurrent, createPrForCurrent, openCurrent, toggleExpanded } = useActions(inboxTriageLogic)
 
     const conventionalTitle = parseConventionalCommitTitle(report.title)
@@ -197,7 +198,24 @@ function TriageCard({ report, expanded }: { report: SignalReport; expanded: bool
                 >
                     Archive
                 </LemonButton>
-                {canCreatePr && (
+                {currentPrUrl ? (
+                    // Merging happens on GitHub, so for a report with a pull request open the primary
+                    // action hands the reader to the PR's diff.
+                    <LemonButton
+                        type="primary"
+                        size="small"
+                        icon={<IconPullRequest />}
+                        sideIcon={<KeyboardShortcut g />}
+                        to={currentPrUrl}
+                        targetBlank
+                        onClick={() =>
+                            captureInboxReportAction({ report, actionType: 'open_pr', surface: 'triage_mode' })
+                        }
+                        data-attr="inbox-triage-open-pr"
+                    >
+                        Open in GitHub
+                    </LemonButton>
+                ) : canCreatePr ? (
                     <LemonButton
                         type="primary"
                         size="small"
@@ -210,7 +228,7 @@ function TriageCard({ report, expanded }: { report: SignalReport; expanded: bool
                     >
                         Create PR
                     </LemonButton>
-                )}
+                ) : null}
                 <div className="flex-1" />
                 <LemonButton
                     type="tertiary"
@@ -251,9 +269,18 @@ export function InboxTriageView(): JSX.Element {
         nextReport,
         expanded,
         counter,
+        currentSectionKey,
     } = useValues(inboxTriageLogic)
-    const { navigate, toggleExpanded, setExpanded, archiveCurrent, createPrForCurrent, openCurrent, ensureLoaded } =
-        useActions(inboxTriageLogic)
+    const {
+        navigate,
+        toggleExpanded,
+        setExpanded,
+        archiveCurrent,
+        createPrForCurrent,
+        openPrForCurrent,
+        openCurrent,
+        ensureLoaded,
+    } = useActions(inboxTriageLogic)
 
     useKeyboardHotkeys(
         {
@@ -280,6 +307,7 @@ export function InboxTriageView(): JSX.Element {
             o: { action: outsideDialogs(() => openCurrent()) },
             a: { action: outsideDialogs(() => archiveCurrent()) },
             c: { action: outsideDialogs(() => createPrForCurrent()) },
+            g: { action: outsideDialogs(() => openPrForCurrent()) },
             escape: {
                 // Escape peels back one layer: the expanded summary, then triage mode itself.
                 action: outsideDialogs(() => {
@@ -291,7 +319,16 @@ export function InboxTriageView(): JSX.Element {
                 }),
             },
         },
-        [expanded, navigate, toggleExpanded, setExpanded, archiveCurrent, createPrForCurrent, openCurrent]
+        [
+            expanded,
+            navigate,
+            toggleExpanded,
+            setExpanded,
+            archiveCurrent,
+            createPrForCurrent,
+            openPrForCurrent,
+            openCurrent,
+        ]
     )
 
     // Once per open, when the queue has settled, so the panel shows up next to the other
@@ -320,8 +357,11 @@ export function InboxTriageView(): JSX.Element {
                 >
                     Reports
                 </LemonButton>
-                <Tooltip title="Your place in the reports that need a pull request">
-                    <span className="text-xs text-tertiary tabular-nums">{counter}</span>
+                <Tooltip title="Your place in the queue: pull requests to review first, then reports that need one">
+                    <span className="flex items-center gap-2 text-xs text-tertiary">
+                        {currentSectionKey && <span>{INBOX_REPORT_SECTION_LABEL[currentSectionKey]}</span>}
+                        <span className="tabular-nums">{counter}</span>
+                    </span>
                 </Tooltip>
             </div>
 
@@ -383,6 +423,7 @@ export function InboxTriageView(): JSX.Element {
                 <HintBarItem shortcut={<KeyboardShortcut arrowdown />} label="next" />
                 <HintBarItem shortcut={<KeyboardShortcut arrowup />} label="previous" />
                 <HintBarItem shortcut={<KeyboardShortcut command enter />} label="open report" />
+                <HintBarItem shortcut={<KeyboardShortcut g />} label="open in GitHub" />
                 <HintBarItem shortcut={<KeyboardShortcut escape />} label="back" />
             </footer>
         </div>

--- a/products/signals/frontend/inbox/logics/inboxTriageLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/inboxTriageLogic.test.ts
@@ -16,7 +16,7 @@ const REPORTS_URL = '/api/projects/:team_id/signals/reports/'
 // Matches the list logic's server page size, so a spot past it needs a second page.
 const PAGE_SIZE = 50
 
-function makeReport(id: string): SignalReport {
+function makeReport(id: string, extra: Partial<SignalReport> = {}): SignalReport {
     return {
         id,
         title: `Report ${id}`,
@@ -31,8 +31,13 @@ function makeReport(id: string): SignalReport {
         source_products: ['error_tracking'],
         created_at: '2026-06-11T10:00:00Z',
         updated_at: '2026-06-11T10:00:00Z',
+        ...extra,
     } satisfies SignalReport
 }
+
+const REVIEW_REPORTS = Array.from({ length: 2 }, (_, i) =>
+    makeReport(`pr-${i}`, { implementation_pr_url: `https://github.com/example/app/pull/${i + 1}` })
+)
 
 const FIRST_PAGE = Array.from({ length: PAGE_SIZE }, (_, i) => makeReport(`r-${i}`))
 const SECOND_PAGE = Array.from({ length: 10 }, (_, i) => makeReport(`r-${PAGE_SIZE + i}`))
@@ -48,6 +53,11 @@ describe('inboxTriageLogic', () => {
                 '/api/projects/:team_id/signals/reports/available_reviewers': {},
                 [REPORTS_URL]: ({ request }) => {
                     const { searchParams } = new URL(request.url)
+                    // The Review-and-merge list stays empty unless a test overrides it, so the
+                    // Needs-a-PR queue keeps its indexes.
+                    if (searchParams.get('has_implementation_pr') === 'true') {
+                        return [200, { count: 0, next: null, previous: null, results: [] }]
+                    }
                     const offset = searchParams.get('offset')
                     if (searchParams.get('limit') !== '1') {
                         requestedOffsets.push(offset)
@@ -125,6 +135,9 @@ describe('inboxTriageLogic', () => {
                 '/api/projects/:team_id/signals/reports/available_reviewers': {},
                 [REPORTS_URL]: ({ request }) => {
                     const { searchParams } = new URL(request.url)
+                    if (searchParams.get('has_implementation_pr') === 'true') {
+                        return [200, { count: 0, next: null, previous: null, results: [] }]
+                    }
                     if (searchParams.get('limit') === '1') {
                         return [
                             200,
@@ -170,6 +183,68 @@ describe('inboxTriageLogic', () => {
 
         expect(logic.values.isLoaded).toBe(false)
         expect(logic.values.reportsLoadFailed).toBe(true)
+    })
+
+    describe('with pull requests to review', () => {
+        let stateCalls: { reportId: string; state: string }[]
+
+        beforeEach(() => {
+            stateCalls = []
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/signals/reports/available_reviewers': {},
+                    [REPORTS_URL]: ({ request }) => {
+                        const { searchParams } = new URL(request.url)
+                        const forReview = searchParams.get('has_implementation_pr') === 'true'
+                        const results = forReview
+                            ? REVIEW_REPORTS
+                            : FIRST_PAGE.slice(0, 3).map((report) => ({
+                                  ...report,
+                                  actionability: 'immediately_actionable' as const,
+                              }))
+                        return [200, { count: results.length, next: null, previous: null, results }]
+                    },
+                },
+                post: {
+                    '/api/projects/:team_id/signals/reports/:reportId/state': async ({ request, params }) => {
+                        const body = (await request.json()) as { state: string }
+                        stateCalls.push({ reportId: String(params.reportId), state: body.state })
+                        return [200, {}]
+                    },
+                },
+            })
+        })
+
+        it('walks the pull requests to review before the reports that need one', async () => {
+            await mountAt({})
+
+            expect(logic.values.reports.map((report) => report.id)).toEqual(['pr-0', 'pr-1', 'r-0', 'r-1', 'r-2'])
+            expect(logic.values.currentSectionKey).toBe('monitoring')
+            expect(logic.values.currentPrUrl).toBe('https://github.com/example/app/pull/1/files')
+            expect(logic.values.canCreatePr).toBe(false)
+
+            logic.actions.navigate(2)
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.currentReport?.id).toBe('r-0')
+            expect(logic.values.currentSectionKey).toBe('needs-decision')
+            expect(logic.values.currentPrUrl).toBeNull()
+            expect(logic.values.canCreatePr).toBe(true)
+        })
+
+        // Archiving must hit the list that owns the row, or the row lingers in the queue and the
+        // spot never moves on.
+        it('archives a pull request through its own list and moves to the next spot', async () => {
+            await mountAt({})
+
+            logic.actions.reviewArchiveReport('pr-0', 'already_fixed', '')
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.reports.map((report) => report.id)).toEqual(['pr-1', 'r-0', 'r-1', 'r-2'])
+            expect(logic.values.currentReport?.id).toBe('pr-1')
+            expect(router.values.searchParams).toEqual({ report: 'pr-1', at: 0 })
+            expect(stateCalls).toEqual([{ reportId: 'pr-0', state: 'suppressed' }])
+        })
     })
 
     it('keeps the URL on the current spot and hands it to the report page as the way back', async () => {

--- a/products/signals/frontend/inbox/logics/inboxTriageLogic.ts
+++ b/products/signals/frontend/inbox/logics/inboxTriageLogic.ts
@@ -9,14 +9,21 @@ import { captureInboxReportAction } from '../inboxAnalytics'
 import { inboxSceneLogic } from '../inboxSceneLogic'
 import { inboxTaskKickoffLogic } from '../inboxTaskKickoffLogic'
 import { INBOX_PRIMARY_REPORT_SECTION_KEY, InboxReportSectionKey, SignalReport } from '../types'
-import { displayConventionalCommitTitle } from '../utils/reportPresentation'
+import { displayConventionalCommitTitle, prFilesUrl, safeHttpUrl } from '../utils/reportPresentation'
 import { INBOX_REPORT_SECTION_LIST_PARAMS, reportListLogic } from './reportListLogic'
 
 /**
- * Triage mode triages the Needs-a-PR queue, sharing that section's loaded pages, filters, and
- * scope. It walks every loaded report, not just the rows the section has expanded to show.
+ * Triage mode walks two queues back to back, sharing each section's loaded pages, filters, and
+ * scope: first Review and merge (reports with a pull request open), then Needs a PR. It walks every
+ * loaded report, not just the rows the sections have expanded to show.
  */
+export const TRIAGE_REVIEW_SECTION_KEY: InboxReportSectionKey = 'monitoring'
 export const TRIAGE_SECTION_KEY: InboxReportSectionKey = INBOX_PRIMARY_REPORT_SECTION_KEY
+
+const REVIEW_LIST_PROPS = {
+    sectionKey: TRIAGE_REVIEW_SECTION_KEY,
+    listParams: INBOX_REPORT_SECTION_LIST_PARAMS[TRIAGE_REVIEW_SECTION_KEY],
+}
 
 const TRIAGE_LIST_PROPS = {
     sectionKey: TRIAGE_SECTION_KEY,
@@ -35,20 +42,32 @@ function clampIndex(index: number, length: number): number {
 export interface inboxTriageLogicValues {
     aiConsentDisabledReason: string | null // inboxTaskKickoffLogic
     isCreatingPr: boolean // inboxTaskKickoffLogic
-    hasMore: boolean // reportListLogic
-    isLoaded: boolean // reportListLogic
-    reports: SignalReport[] // reportListLogic
-    reportsLoadFailed: boolean // reportListLogic
-    reportsResponseLoading: boolean // reportListLogic
+    reviewHasMore: boolean // reportListLogic
+    reviewIsLoaded: boolean // reportListLogic
+    reviewReports: SignalReport[] // reportListLogic
+    reviewReportsLoadFailed: boolean // reportListLogic
+    reviewReportsResponseLoading: boolean // reportListLogic
+    prHasMore: boolean // reportListLogic
+    prIsLoaded: boolean // reportListLogic
+    prReports: SignalReport[] // reportListLogic
+    prReportsLoadFailed: boolean // reportListLogic
+    prReportsResponseLoading: boolean // reportListLogic
     canCreatePr: boolean
     counter: string
     currentIndex: number
+    currentPrUrl: string | null
     currentReport: SignalReport | null
     currentReportUrl: string | null
+    currentSectionKey: InboxReportSectionKey | null
     expanded: boolean
+    hasMore: boolean
+    isLoaded: boolean
     isRestoringPosition: boolean
     nextReport: SignalReport | null
     previousReport: SignalReport | null
+    reports: SignalReport[]
+    reportsLoadFailed: boolean
+    reportsResponseLoading: boolean
     requestedIndex: number
     requestedReportId: string | null
     requestedReportIndex: number
@@ -68,7 +87,7 @@ export interface inboxTriageLogicActions {
     createPrFromReport: (report: SignalReport) => {
         report: SignalReport
     } // inboxTaskKickoffLogic
-    archiveReport: (
+    reviewArchiveReport: (
         reportId: string,
         reason:
             | 'already_fixed'
@@ -89,40 +108,94 @@ export interface inboxTriageLogicActions {
             | 'wontfix_irrelevant'
         reportId: string
     } // reportListLogic
-    ensureLoaded: () => {
+    reviewEnsureLoaded: () => {
         value: true
     } // reportListLogic
-    loadMore: () => {
+    reviewLoadMore: () => {
         value: true
     } // reportListLogic
-    loadMoreReportsFailure: (
+    reviewLoadMoreReportsFailure: (
         error: string,
         errorObject?: any
     ) => {
         error: string
         errorObject?: any
     } // reportListLogic
-    loadMoreReportsSuccess: (
+    reviewLoadMoreReportsSuccess: (
         reportsResponse: import('./reportListLogic').ReportListResponse,
         payload?: any
     ) => {
         payload?: any
         reportsResponse: import('./reportListLogic').ReportListResponse
     } // reportListLogic
-    loadReportsSuccess: (
+    reviewLoadReportsSuccess: (
         reportsResponse: import('./reportListLogic').ReportListResponse,
         payload?: any
     ) => {
         payload?: any
         reportsResponse: import('./reportListLogic').ReportListResponse
     } // reportListLogic
-    removeReport: (reportId: string) => {
+    reviewRemoveReport: (reportId: string) => {
+        reportId: string
+    } // reportListLogic
+    prArchiveReport: (
+        reportId: string,
+        reason:
+            | 'already_fixed'
+            | 'analysis_wrong'
+            | 'other'
+            | 'report_unclear'
+            | 'wontfix_intentional'
+            | 'wontfix_irrelevant',
+        note: string
+    ) => {
+        note: string
+        reason:
+            | 'already_fixed'
+            | 'analysis_wrong'
+            | 'other'
+            | 'report_unclear'
+            | 'wontfix_intentional'
+            | 'wontfix_irrelevant'
+        reportId: string
+    } // reportListLogic
+    prEnsureLoaded: () => {
+        value: true
+    } // reportListLogic
+    prLoadMore: () => {
+        value: true
+    } // reportListLogic
+    prLoadMoreReportsFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    } // reportListLogic
+    prLoadMoreReportsSuccess: (
+        reportsResponse: import('./reportListLogic').ReportListResponse,
+        payload?: any
+    ) => {
+        payload?: any
+        reportsResponse: import('./reportListLogic').ReportListResponse
+    } // reportListLogic
+    prLoadReportsSuccess: (
+        reportsResponse: import('./reportListLogic').ReportListResponse,
+        payload?: any
+    ) => {
+        payload?: any
+        reportsResponse: import('./reportListLogic').ReportListResponse
+    } // reportListLogic
+    prRemoveReport: (reportId: string) => {
         reportId: string
     } // reportListLogic
     archiveCurrent: () => {
         value: true
     }
     createPrForCurrent: () => {
+        value: true
+    }
+    ensureLoaded: () => {
         value: true
     }
     focusReport: (
@@ -132,10 +205,16 @@ export interface inboxTriageLogicActions {
         index: number
         reportId: string | null
     }
+    loadMore: () => {
+        value: true
+    }
     navigate: (delta: number) => {
         delta: number
     }
     openCurrent: () => {
+        value: true
+    }
+    openPrForCurrent: () => {
         value: true
     }
     setExpanded: (expanded: boolean) => {
@@ -152,6 +231,11 @@ export interface inboxTriageLogicActions {
 // Generated by kea-typegen. Update if you're an agent, ignore if you're human.
 export interface inboxTriageLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
+        reports: (reviewReports: SignalReport[], prReports: SignalReport[]) => SignalReport[]
+        hasMore: (reviewHasMore: boolean, prHasMore: boolean) => boolean
+        isLoaded: (reviewIsLoaded: boolean, prIsLoaded: boolean) => boolean
+        reportsLoadFailed: (reviewReportsLoadFailed: boolean, prReportsLoadFailed: boolean) => boolean
+        reportsResponseLoading: (reviewReportsResponseLoading: boolean, prReportsResponseLoading: boolean) => boolean
         requestedReportIndex: (requestedReportId: string | null, reports: SignalReport[]) => number
         currentIndex: (requestedReportIndex: number, requestedIndex: number, reports: SignalReport[]) => number
         isRestoringPosition: (
@@ -162,10 +246,16 @@ export interface inboxTriageLogicMeta {
             restoreFailed: boolean
         ) => boolean
         currentReport: (reports: SignalReport[], currentIndex: number) => SignalReport | null
+        currentSectionKey: (
+            currentReport: SignalReport | null,
+            currentIndex: number,
+            reviewReports: SignalReport[]
+        ) => InboxReportSectionKey | null
         previousReport: (reports: SignalReport[], currentIndex: number) => SignalReport | null
         nextReport: (reports: SignalReport[], currentIndex: number) => SignalReport | null
         counter: (reports: SignalReport[], currentIndex: number, hasMore: boolean) => string
         canCreatePr: (currentReport: SignalReport | null) => boolean
+        currentPrUrl: (currentReport: SignalReport | null) => string | null
         returnUrl: (currentReport: SignalReport | null, currentIndex: number) => string
         currentReportUrl: (currentReport: SignalReport | null, returnUrl: string) => string | null
     }
@@ -179,30 +269,55 @@ export type inboxTriageLogicType = MakeLogicType<
 >
 
 /**
- * Triage mode: one report at a time from the Needs-a-decision queue, driven from the keyboard. The
- * queue is the landing view's own `reportListLogic` (same pages, filters, and reviewer scope), so
- * archiving here drops the row from the list too and the next report slides into place.
+ * Triage mode: one report at a time, driven from the keyboard. The queue is Review and merge
+ * followed by Needs a PR, each backed by the landing view's own `reportListLogic` (same pages,
+ * filters, and reviewer scope), so archiving here drops the row from that list too and the next
+ * report slides into place. Paging drains the review list before the first Needs-a-PR page loads.
  */
 export const inboxTriageLogic = kea<inboxTriageLogicType>([
     path(['scenes', 'inbox', 'logics', 'inboxTriageLogic']),
 
     connect(() => ({
         values: [
+            reportListLogic(REVIEW_LIST_PROPS),
+            [
+                'reports as reviewReports',
+                'hasMore as reviewHasMore',
+                'isLoaded as reviewIsLoaded',
+                'reportsResponseLoading as reviewReportsResponseLoading',
+                'reportsLoadFailed as reviewReportsLoadFailed',
+            ],
             reportListLogic(TRIAGE_LIST_PROPS),
-            ['reports', 'hasMore', 'isLoaded', 'reportsResponseLoading', 'reportsLoadFailed'],
+            [
+                'reports as prReports',
+                'hasMore as prHasMore',
+                'isLoaded as prIsLoaded',
+                'reportsResponseLoading as prReportsResponseLoading',
+                'reportsLoadFailed as prReportsLoadFailed',
+            ],
             inboxTaskKickoffLogic,
             ['isCreatingPr', 'aiConsentDisabledReason'],
         ],
         actions: [
+            reportListLogic(REVIEW_LIST_PROPS),
+            [
+                'ensureLoaded as reviewEnsureLoaded',
+                'loadMore as reviewLoadMore',
+                'archiveReport as reviewArchiveReport',
+                'removeReport as reviewRemoveReport',
+                'loadReportsSuccess as reviewLoadReportsSuccess',
+                'loadMoreReportsSuccess as reviewLoadMoreReportsSuccess',
+                'loadMoreReportsFailure as reviewLoadMoreReportsFailure',
+            ],
             reportListLogic(TRIAGE_LIST_PROPS),
             [
-                'ensureLoaded',
-                'loadMore',
-                'archiveReport',
-                'removeReport',
-                'loadReportsSuccess',
-                'loadMoreReportsSuccess',
-                'loadMoreReportsFailure',
+                'ensureLoaded as prEnsureLoaded',
+                'loadMore as prLoadMore',
+                'archiveReport as prArchiveReport',
+                'removeReport as prRemoveReport',
+                'loadReportsSuccess as prLoadReportsSuccess',
+                'loadMoreReportsSuccess as prLoadMoreReportsSuccess',
+                'loadMoreReportsFailure as prLoadMoreReportsFailure',
             ],
             inboxTaskKickoffLogic,
             ['createPrFromReport'],
@@ -212,6 +327,8 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
     })),
 
     actions({
+        ensureLoaded: true,
+        loadMore: true,
         navigate: (delta: number) => ({ delta }),
         setIndex: (index: number) => ({ index }),
         // Restore a spot carried in the triage URL: the report the user was on, and where it sat.
@@ -220,6 +337,7 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
         setExpanded: (expanded: boolean) => ({ expanded }),
         archiveCurrent: true,
         createPrForCurrent: true,
+        openPrForCurrent: true,
         openCurrent: true,
     }),
 
@@ -257,14 +375,43 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
             false,
             {
                 focusReport: () => false,
-                loadReportsSuccess: () => false,
-                loadMoreReportsSuccess: () => false,
-                loadMoreReportsFailure: () => true,
+                reviewLoadReportsSuccess: () => false,
+                reviewLoadMoreReportsSuccess: () => false,
+                reviewLoadMoreReportsFailure: () => true,
+                prLoadReportsSuccess: () => false,
+                prLoadMoreReportsSuccess: () => false,
+                prLoadMoreReportsFailure: () => true,
             },
         ],
     }),
 
     selectors({
+        // The review queue comes first; Needs-a-PR rows start where it ends.
+        reports: [
+            (s) => [s.reviewReports, s.prReports],
+            (reviewReports: SignalReport[], prReports: SignalReport[]): SignalReport[] => [
+                ...reviewReports,
+                ...prReports,
+            ],
+        ],
+        hasMore: [
+            (s) => [s.reviewHasMore, s.prHasMore],
+            (reviewHasMore: boolean, prHasMore: boolean): boolean => reviewHasMore || prHasMore,
+        ],
+        isLoaded: [
+            (s) => [s.reviewIsLoaded, s.prIsLoaded],
+            (reviewIsLoaded: boolean, prIsLoaded: boolean): boolean => reviewIsLoaded && prIsLoaded,
+        ],
+        reportsLoadFailed: [
+            (s) => [s.reviewReportsLoadFailed, s.prReportsLoadFailed],
+            (reviewReportsLoadFailed: boolean, prReportsLoadFailed: boolean): boolean =>
+                reviewReportsLoadFailed || prReportsLoadFailed,
+        ],
+        reportsResponseLoading: [
+            (s) => [s.reviewReportsResponseLoading, s.prReportsResponseLoading],
+            (reviewReportsResponseLoading: boolean, prReportsResponseLoading: boolean): boolean =>
+                reviewReportsResponseLoading || prReportsResponseLoading,
+        ],
         requestedReportIndex: [
             (s) => [s.requestedReportId, s.reports],
             (requestedReportId: string | null, reports: SignalReport[]): number =>
@@ -291,6 +438,21 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
             (s) => [s.reports, s.currentIndex],
             (reports: SignalReport[], currentIndex: number): SignalReport | null => reports[currentIndex] ?? null,
         ],
+        // Which list owns the current report, so archiving hits the right list and the card shows
+        // that list's actions.
+        currentSectionKey: [
+            (s) => [s.currentReport, s.currentIndex, s.reviewReports],
+            (
+                currentReport: SignalReport | null,
+                currentIndex: number,
+                reviewReports: SignalReport[]
+            ): InboxReportSectionKey | null =>
+                currentReport === null
+                    ? null
+                    : currentIndex < reviewReports.length
+                      ? TRIAGE_REVIEW_SECTION_KEY
+                      : TRIAGE_SECTION_KEY,
+        ],
         previousReport: [
             (s) => [s.reports, s.currentIndex],
             (reports: SignalReport[], currentIndex: number): SignalReport | null =>
@@ -310,6 +472,14 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
             (s) => [s.currentReport],
             (currentReport: SignalReport | null): boolean =>
                 currentReport !== null && canCreateImplementationPr(currentReport),
+        ],
+        // The current report's pull request, pointed at its files tab, so review starts on the diff.
+        currentPrUrl: [
+            (s) => [s.currentReport],
+            (currentReport: SignalReport | null): string | null => {
+                const prUrl = safeHttpUrl(currentReport?.implementation_pr_url)
+                return prUrl ? prFilesUrl(prUrl) : null
+            },
         ],
         // The triage URL for the current spot; what a report opened from here returns to.
         returnUrl: [
@@ -336,8 +506,22 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
             }
         }
         return {
-            loadReportsSuccess: loadTowardRequestedSpot,
-            loadMoreReportsSuccess: loadTowardRequestedSpot,
+            ensureLoaded: () => {
+                actions.reviewEnsureLoaded()
+                actions.prEnsureLoaded()
+            },
+            // Drain the review list first so its rows never land in the middle of the Needs-a-PR run.
+            loadMore: () => {
+                if (values.reviewHasMore) {
+                    actions.reviewLoadMore()
+                } else if (values.prHasMore) {
+                    actions.prLoadMore()
+                }
+            },
+            reviewLoadReportsSuccess: loadTowardRequestedSpot,
+            reviewLoadMoreReportsSuccess: loadTowardRequestedSpot,
+            prLoadReportsSuccess: loadTowardRequestedSpot,
+            prLoadMoreReportsSuccess: loadTowardRequestedSpot,
             navigate: ({ delta }) => {
                 actions.setIndex(clampIndex(values.currentIndex + delta, values.reports.length))
                 if (
@@ -350,7 +534,8 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
             },
             archiveCurrent: () => {
                 const report = values.currentReport
-                if (!report) {
+                const sectionKey = values.currentSectionKey
+                if (!report || !sectionKey) {
                     return
                 }
                 openDismissReportDialog({
@@ -364,8 +549,12 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
                             surface: 'triage_mode',
                             extra: { dismissal_reason: reason, ...(note ? { dismissal_note: note } : {}) },
                         })
-                        // The list logic drops the row optimistically, so the next report takes this index.
-                        actions.archiveReport(report.id, reason, note)
+                        // The owning list drops the row optimistically, so the next report takes this index.
+                        if (sectionKey === TRIAGE_REVIEW_SECTION_KEY) {
+                            actions.reviewArchiveReport(report.id, reason, note)
+                        } else {
+                            actions.prArchiveReport(report.id, reason, note)
+                        }
                     },
                 })
             },
@@ -377,6 +566,15 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
                 captureInboxReportAction({ report, actionType: 'create_pr', surface: 'triage_mode' })
                 actions.createPrFromReport(report)
             },
+            openPrForCurrent: () => {
+                const report = values.currentReport
+                const prUrl = values.currentPrUrl
+                if (!report || !prUrl) {
+                    return
+                }
+                captureInboxReportAction({ report, actionType: 'open_pr', surface: 'triage_mode' })
+                window.open(prUrl, '_blank', 'noopener')
+            },
             openCurrent: () => {
                 const report = values.currentReport
                 if (report) {
@@ -387,7 +585,7 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
     }),
 
     // The URL follows the current spot (replaced, not pushed, so the browser's back button leaves
-    // triage in one step). Archiving moves the spot too, once the row is gone from the list.
+    // triage in one step). Archiving moves the spot too, once the row is gone from its list.
     actionToUrl(({ values }) => {
         const positionUrl = (): [string, Record<string, unknown>, Record<string, unknown>, { replace: boolean }] => {
             // Other params (the list scope, for one) stay; only the spot is rewritten.
@@ -401,7 +599,8 @@ export const inboxTriageLogic = kea<inboxTriageLogicType>([
         }
         return {
             setIndex: positionUrl,
-            removeReport: positionUrl,
+            reviewRemoveReport: positionUrl,
+            prRemoveReport: positionUrl,
         }
     }),
 

--- a/products/signals/frontend/inbox/utils/reportPresentation.ts
+++ b/products/signals/frontend/inbox/utils/reportPresentation.ts
@@ -119,3 +119,8 @@ export function parsePrUrlParts(prUrl: string): ParsedPrUrlParts | null {
 export function parsePrRepoSlug(prUrl: string): string | null {
     return parsePrUrlParts(prUrl)?.repoSlug ?? null
 }
+
+/** Point a PR URL at its diff/files tab, without double-appending if it's already there. */
+export function prFilesUrl(prUrl: string): string {
+    return prUrl.replace(/\/+$/, '').replace(/(\/files)?$/, '/files')
+}


### PR DESCRIPTION
## Problem

Triage mode skips the reports that already have a pull request open. A user who presses the Triage mode button only sees the Needs a PR queue, so the pull requests that wait for review and merge stay in the list behind them.

The pull requests are the closest to done, so they are the first thing to decide on.

## Changes

- Triage mode now starts with the Review and merge reports, then continues into the Needs a PR reports. The counter shows the section name next to the position, for example "Review and merge 1 / 17".
- A report with a pull request shows "Open in GitHub" as the primary action. It opens the files tab of the pull request in a new tab. PostHog cannot merge the pull request itself, so the review happens on GitHub. The shortcut is `G`, and the hint bar lists it.
- A report without a pull request keeps the "Create PR" primary action and the `C` shortcut.
- Archive stays on both kinds of report. It removes the row from the list that owns the report, so the next report slides into place.
- The Triage mode button tooltip and the counter tooltip describe the new queue order.

| Review and merge report | Needs a PR report |
| --- | --- |
| ![triage-review](https://raw.githubusercontent.com/PostHog/pr-assets/ff17427901c56146219b9bd26549b86b9d41ef36/2026/08/9cc25de6-edb3-4eaf-8339-54d3a0216418.png) | ![triage-needs-pr](https://raw.githubusercontent.com/PostHog/pr-assets/ad97f726408ba07815ac86309573287503be94ef/2026/08/0dba987e-6ec5-45a4-8992-444ee16f2c58.png) |

Mechanical: `inboxTriageLogic` connects to the `monitoring` and `needs-decision` list logics under aliases and joins their rows. Paging drains the review list before it loads the next Needs a PR page. `prFilesUrl` moved from `ReportDetail` to the shared `reportPresentation` utils. The Inbox story mock now filters by `has_implementation_pr`, so triage does not show each report twice.

## How did you test this code?

- Two new cases in `inboxTriageLogic.test.ts`: the queue lists the review reports before the Needs a PR reports and switches the section and primary action at the boundary, and an archive on a review report goes through its own list and moves the spot on.
- Ran the triage logic, triage view, and report list Jest suites locally.
- Screenshots come from the `Scenes-App/Inbox/Scene/Triage` story in Storybook.
- Not checked: the running app with real reports. The local dev stack was not reachable from the browser in this session.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Triage mode has no doc page yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) wrote the change in [this session](https://claude.ai/code/session_01TyzRevwUkKsSawQJuCwGEB). Skills invoked: `/writing-pr-descriptions`. Tools: Bash, Storybook, Playwright for the screenshots, `hogli pr:upload-image`.

Decisions: the queue keeps one combined index so the URL and the back link keep their shape. The primary action reads the report's pull request URL, not the section, so a report that gets a pull request while the user stays in triage shows the correct button. `kea-typegen` crashed in the local environment, so the type interfaces were written by hand in the same format.

https://claude.ai/code/session_01TyzRevwUkKsSawQJuCwGEB
