### PR TITLE
feat(desktop): add proactive agent feedback guidance

### DIFF
--- a/products/desktop/packages/agent/README.md
+++ b/products/desktop/packages/agent/README.md
@@ -74,6 +74,12 @@ In cloud background mode, permissions are always auto-approved. In interactive m
 
 Cloud provisioning can pass `--posthogExecPermissionRegex <regex>` to require one-time client approval for matching PostHog MCP `exec` sub-tools in every interactive cloud Claude and Codex permission mode. Non-matching sub-tools never prompt. Locally, hands-off modes stay hands-off: Claude `auto` and `bypassPermissions`, and Codex `auto` and `full-access`, auto-approve matching sub-tools; other local modes prompt. Matching is case-insensitive against the delegated name in `call [--json] <sub-tool> ...`. These prompts offer Claude users an always-allow choice remembered in local repository settings; Codex approvals remain one-time. An invalid or empty regex is logged and falls back to the default. Background runs keep their existing auto-approval behavior. The default is `(^|-)(partial-update|update|patch|delete|destroy)(-|$)`.
 
+### Agent feedback
+
+Shared agent guidance tells every runtime to report concrete PostHog product, tool, capability, and instruction friction through the PostHog MCP `agent-feedback` capability. This includes an expected tool being unavailable. Agents report the exact surface and task impact without secrets or sensitive task content, then continue the user's work.
+
+The MCP server captures these reports as structured `mcp feedback submitted` events. Its standard MCP context identifies PostHog Code consumers, so downstream Signals scouts can aggregate recurring themes without a second Desktop telemetry path. If the feedback capability is unavailable, the agent surfaces that failure to the user instead of silently dropping it.
+
 ## ACP connection layer
 
 `createAcpConnection()` in `src/adapters/acp-connection.ts` is the heart of the package. It's a factory that returns a `{ clientStreams, cleanup }` object — a pair of ndJson `ReadableStream`/`WritableStream` that the caller uses to speak ACP.

--- a/products/desktop/packages/agent/src/pi/task-system-prompt-extension.test.ts
+++ b/products/desktop/packages/agent/src/pi/task-system-prompt-extension.test.ts
@@ -3,6 +3,7 @@ import type {
   SessionEntry,
   SessionManager,
 } from "@earendil-works/pi-coding-agent";
+import { AGENT_FEEDBACK_PROMPT } from "@posthog/shared/product-engineer-prompt";
 import { describe, expect, it, vi } from "vitest";
 import { buildTaskSystemPrompt, type TaskContext } from "./task-system-prompt";
 import {
@@ -75,7 +76,7 @@ describe("Pi task system prompt", () => {
     expect(appendCustomEntry).not.toHaveBeenCalled();
   });
 
-  it("renders and appends the task prompt before each agent run", () => {
+  it("appends task and feedback guidance before each agent run", () => {
     const handlers = new Map<string, unknown>();
     createPiTaskSystemPromptExtension(taskContext).factory({
       on: (event: string, handler: unknown) => handlers.set(event, handler),
@@ -85,7 +86,7 @@ describe("Pi task system prompt", () => {
     }) => { systemPrompt: string };
 
     expect(beforeAgentStart({ systemPrompt: "Pi instructions" })).toEqual({
-      systemPrompt: `Pi instructions\n\n${buildTaskSystemPrompt(taskContext)}`,
+      systemPrompt: `Pi instructions\n\n${buildTaskSystemPrompt(taskContext)}\n\n${AGENT_FEEDBACK_PROMPT}`,
     });
   });
 });

--- a/products/desktop/packages/agent/src/pi/task-system-prompt-extension.ts
+++ b/products/desktop/packages/agent/src/pi/task-system-prompt-extension.ts
@@ -4,6 +4,7 @@ import type {
   SessionEntry,
   SessionManager,
 } from "@earendil-works/pi-coding-agent";
+import { appendAgentFeedbackPrompt } from "@posthog/shared/product-engineer-prompt";
 import { buildTaskSystemPrompt, type TaskContext } from "./task-system-prompt";
 
 export const POSTHOG_PI_TASK_CONTEXT_ENTRY_TYPE = "posthog.pi.task-context";
@@ -100,7 +101,9 @@ export function createPiTaskSystemPromptExtension(
         return;
       }
       pi.on("before_agent_start", (event) => ({
-        systemPrompt: `${event.systemPrompt}\n\n${buildTaskSystemPrompt(context)}`,
+        systemPrompt: appendAgentFeedbackPrompt(
+          `${event.systemPrompt}\n\n${buildTaskSystemPrompt(context)}`,
+        ),
       }));
     },
   };

--- a/products/desktop/packages/shared/src/product-engineer-prompt.test.ts
+++ b/products/desktop/packages/shared/src/product-engineer-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  appendAgentFeedbackPrompt,
   PRODUCT_ENGINEER_PROMPT,
   prependProductEngineerPrompt,
 } from "./product-engineer-prompt";
@@ -23,7 +24,16 @@ describe("prependProductEngineerPrompt", () => {
 
   it("does not duplicate guidance when a session rebuilds its prompt", () => {
     const firstPrompt = prependProductEngineerPrompt(UPSTREAM_PROMPT);
+    const feedbackPrompt = appendAgentFeedbackPrompt(UPSTREAM_PROMPT);
 
     expect(prependProductEngineerPrompt(firstPrompt)).toBe(firstPrompt);
+    expect(appendAgentFeedbackPrompt(feedbackPrompt)).toBe(feedbackPrompt);
+  });
+
+  it("keeps agent feedback actionable and privacy safe", () => {
+    expect(PRODUCT_ENGINEER_PROMPT).toContain("agent-feedback");
+    expect(PRODUCT_ENGINEER_PROMPT).toContain("whether it blocked the task");
+    expect(PRODUCT_ENGINEER_PROMPT).toContain("Never include secrets");
+    expect(PRODUCT_ENGINEER_PROMPT).toContain("continue the user's task");
   });
 });

--- a/products/desktop/packages/shared/src/product-engineer-prompt.ts
+++ b/products/desktop/packages/shared/src/product-engineer-prompt.ts
@@ -1,3 +1,7 @@
+export const AGENT_FEEDBACK_PROMPT = `## Agent feedback
+
+When PostHog itself causes concrete friction — a product surface, MCP tool, agent capability, or instruction is broken, confusing, slow, missing, or needs an avoidable workaround — submit concise feedback through the PostHog MCP \`agent-feedback\` capability. Include the exact surface, tool, or error; whether it blocked the task; and a suggested improvement when known. Never include secrets, customer data, or sensitive task content. If the feedback capability itself is unavailable, tell the user what could not be sent. Feedback is a side report: continue the user's task.`;
+
 export const PRODUCT_ENGINEER_PROMPT = `Operate as an expert product engineer. Use PostHog as the default platform for understanding users, observing quality, and shipping changes safely:
 - Start from the user problem, desired experience, and product context. Understand why the work matters before deciding what to build.
 - Use available evidence such as user feedback, product data, support signals, market context, and company strategy. Ask for missing context when it would change the decision.
@@ -32,7 +36,18 @@ Use PostHog throughout the product loop:
 - Use PostHog feature flags for uncertain or risky rollouts. Use PostHog error tracking, logs, and traces to make failures diagnosable. Use PostHog AI Observability for AI model calls.
 - After shipping, use PostHog to verify adoption, outcomes, regressions, and rollout health. Let observed behavior drive the next iteration.
 
+${AGENT_FEEDBACK_PROMPT}
+
 Prefer customer impact and product quality over technical novelty. Treat code as one tool for creating useful, measurable outcomes.`;
+
+export function appendAgentFeedbackPrompt(prompt: string): string {
+  if (prompt.includes(AGENT_FEEDBACK_PROMPT)) {
+    return prompt;
+  }
+  return prompt
+    ? `${prompt}\n\n${AGENT_FEEDBACK_PROMPT}`
+    : AGENT_FEEDBACK_PROMPT;
+}
 
 export function prependProductEngineerPrompt(prompt: string): string {
   if (prompt.includes(PRODUCT_ENGINEER_PROMPT)) {


### PR DESCRIPTION
## Problem

Desktop agents can encounter broken, missing, confusing, or slow PostHog capabilities without consistently reporting that friction.

**Why:** Product teams need actionable agent feedback in PostHog so recurring problems can reach Signals and guide improvements.

## Changes

- Desktop agents now report concrete PostHog friction through the existing `agent-feedback` MCP capability, then continue the user's task.
- Pi receives the same shared guidance as the other agent runtimes.
- The existing structured MCP event remains the sole telemetry path for downstream Signals aggregation.

## How did you test this code?

- Targeted Vitest suites cover prompt inclusion, privacy wording, task continuity, and idempotence.
- The full Desktop typecheck and lint complete successfully.
- The repository preflight wrapper was unavailable because this environment lacks `hogli` and `flox`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The agent package README documents the MCP event path, Signals aggregation, and unavailable-feedback behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop's Codex agent authored this change with PostHog MCP, shell, and GitHub CLI tooling.

Skills invoked: `/posthog-desktop`, `/querying-posthog-data`, `/authoring-scouts`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The design reuses existing structured MCP feedback instead of introducing a second Desktop telemetry client or local tool.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
