### PR TITLE
feat(error_tracking): emit internal events on manual issue transitions

### DIFF
--- a/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
+++ b/frontend/src/lib/components/ActivityLog/humanizeActivity.tsx
@@ -6,7 +6,7 @@ import { ActivityScope, InsightShortId, PersonType, UserBasicType } from '~/type
 
 export interface ActivityChange {
     type: ActivityScope
-    action: 'changed' | 'created' | 'deleted' | 'exported' | 'split' | 'copied'
+    action: 'changed' | 'created' | 'deleted' | 'exported' | 'split' | 'merged' | 'copied'
     field?: string
     before?: string | number | any[] | Record<string, any> | boolean | null
     after?: string | number | any[] | Record<string, any> | boolean | null

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -40,6 +40,22 @@ export const getProductEventFilterOptions = (contextId: HogFunctionConfiguration
                     label: 'Error tracking issue spiking',
                     value: '$error_tracking_issue_spiking',
                 },
+                {
+                    label: 'Error tracking issue resolved',
+                    value: '$error_tracking_issue_resolved',
+                },
+                {
+                    label: 'Error tracking issue suppressed',
+                    value: '$error_tracking_issue_suppressed',
+                },
+                {
+                    label: 'Error tracking issue assigned',
+                    value: '$error_tracking_issue_assigned',
+                },
+                {
+                    label: 'Error tracking issue merged',
+                    value: '$error_tracking_issue_merged',
+                },
             ]
         case 'insight-alerts':
             return [

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -53,8 +53,16 @@ export const getProductEventFilterOptions = (contextId: HogFunctionConfiguration
                     value: '$error_tracking_issue_assigned',
                 },
                 {
+                    label: 'Error tracking issue unassigned',
+                    value: '$error_tracking_issue_unassigned',
+                },
+                {
                     label: 'Error tracking issue merged',
                     value: '$error_tracking_issue_merged',
+                },
+                {
+                    label: 'Error tracking issue split',
+                    value: '$error_tracking_issue_split',
                 },
             ]
         case 'insight-alerts':

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -1709,6 +1709,10 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
         case '$error_tracking_issue_created':
         case '$error_tracking_issue_reopened':
         case '$error_tracking_issue_spiking':
+        case '$error_tracking_issue_resolved':
+        case '$error_tracking_issue_suppressed':
+        case '$error_tracking_issue_assigned':
+        case '$error_tracking_issue_merged':
             return 'error-tracking'
         case '$insight_alert_firing':
             return 'insight-alerts'

--- a/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
+++ b/frontend/src/scenes/hog-functions/sub-templates/sub-templates.ts
@@ -1712,7 +1712,9 @@ export const eventToHogFunctionContextId = (event: string | undefined): HogFunct
         case '$error_tracking_issue_resolved':
         case '$error_tracking_issue_suppressed':
         case '$error_tracking_issue_assigned':
+        case '$error_tracking_issue_unassigned':
         case '$error_tracking_issue_merged':
+        case '$error_tracking_issue_split':
             return 'error-tracking'
         case '$insight_alert_firing':
             return 'insight-alerts'

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4012,17 +4012,33 @@
             "ignored_in_assistant": true,
             "label": "Element viewed"
         },
+        "$error_tracking_issue_assigned": {
+            "description": "Fires when an error tracking issue is assigned to a user or role.",
+            "label": "Error tracking issue assigned"
+        },
         "$error_tracking_issue_created": {
             "description": "Fires when a new error tracking issue is created from an incoming exception.",
             "label": "Error tracking issue created"
+        },
+        "$error_tracking_issue_merged": {
+            "description": "Fires when error tracking issues are merged into another issue.",
+            "label": "Error tracking issue merged"
         },
         "$error_tracking_issue_reopened": {
             "description": "Fires when a previously resolved error tracking issue is seen again and reopened.",
             "label": "Error tracking issue reopened"
         },
+        "$error_tracking_issue_resolved": {
+            "description": "Fires when an error tracking issue is marked as resolved.",
+            "label": "Error tracking issue resolved"
+        },
         "$error_tracking_issue_spiking": {
             "description": "Fires when an error tracking issue's volume spikes above its expected rate.",
             "label": "Error tracking issue spiking"
+        },
+        "$error_tracking_issue_suppressed": {
+            "description": "Fires when an error tracking issue is marked as suppressed.",
+            "label": "Error tracking issue suppressed"
         },
         "$exception": {
             "description": "An unexpected error or unhandled exception in your application.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -4036,9 +4036,17 @@
             "description": "Fires when an error tracking issue's volume spikes above its expected rate.",
             "label": "Error tracking issue spiking"
         },
+        "$error_tracking_issue_split": {
+            "description": "Fires when fingerprints are split out of an error tracking issue into new issues.",
+            "label": "Error tracking issue split"
+        },
         "$error_tracking_issue_suppressed": {
             "description": "Fires when an error tracking issue is marked as suppressed.",
             "label": "Error tracking issue suppressed"
+        },
+        "$error_tracking_issue_unassigned": {
+            "description": "Fires when an error tracking issue's assignee is removed.",
+            "label": "Error tracking issue unassigned"
         },
         "$exception": {
             "description": "An unexpected error or unhandled exception in your application.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -469,6 +469,22 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Error tracking issue spiking",
             "description": "Fires when an error tracking issue's volume spikes above its expected rate.",
         },
+        "$error_tracking_issue_resolved": {
+            "label": "Error tracking issue resolved",
+            "description": "Fires when an error tracking issue is marked as resolved.",
+        },
+        "$error_tracking_issue_suppressed": {
+            "label": "Error tracking issue suppressed",
+            "description": "Fires when an error tracking issue is marked as suppressed.",
+        },
+        "$error_tracking_issue_assigned": {
+            "label": "Error tracking issue assigned",
+            "description": "Fires when an error tracking issue is assigned to a user or role.",
+        },
+        "$error_tracking_issue_merged": {
+            "label": "Error tracking issue merged",
+            "description": "Fires when error tracking issues are merged into another issue.",
+        },
         "$conversation_message_sent": {
             "label": "Conversation message sent",
             "description": "Fires when a message is sent in a support conversation.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -481,9 +481,17 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Error tracking issue assigned",
             "description": "Fires when an error tracking issue is assigned to a user or role.",
         },
+        "$error_tracking_issue_unassigned": {
+            "label": "Error tracking issue unassigned",
+            "description": "Fires when an error tracking issue's assignee is removed.",
+        },
         "$error_tracking_issue_merged": {
             "label": "Error tracking issue merged",
             "description": "Fires when error tracking issues are merged into another issue.",
+        },
+        "$error_tracking_issue_split": {
+            "label": "Error tracking issue split",
+            "description": "Fires when fingerprints are split out of an error tracking issue into new issues.",
         },
         "$conversation_message_sent": {
             "label": "Conversation message sent",

--- a/products/error_tracking/backend/facade/issues.py
+++ b/products/error_tracking/backend/facade/issues.py
@@ -8,6 +8,8 @@ django.setup() path of the read-oriented main facade.
 from typing import Any
 from uuid import UUID
 
+from posthog.models.user import User
+
 from ..logic import issue_mutations as _mutations
 from ..models import ErrorTrackingIssueMergeResult
 from . import api, contracts
@@ -25,13 +27,13 @@ def update_issue(
 
 
 def merge_issues(
-    team_id: int, issue_id: UUID, source_ids: list[str], *, user: Any, was_impersonated: bool
+    team_id: int, issue_id: UUID, source_ids: list[str], *, user: User, was_impersonated: bool
 ) -> ErrorTrackingIssueMergeResult:
     return _mutations.merge_issues(team_id, issue_id, source_ids, user=user, was_impersonated=was_impersonated)
 
 
 def split_issue(
-    team_id: int, issue_id: UUID, fingerprints: list[dict], *, user: Any, was_impersonated: bool
+    team_id: int, issue_id: UUID, fingerprints: list[dict], *, user: User, was_impersonated: bool
 ) -> list[UUID]:
     return _mutations.split_issue(team_id, issue_id, fingerprints, user=user, was_impersonated=was_impersonated)
 

--- a/products/error_tracking/backend/facade/issues.py
+++ b/products/error_tracking/backend/facade/issues.py
@@ -24,12 +24,16 @@ def update_issue(
     return api._to_issue(issue)
 
 
-def merge_issues(team_id: int, issue_id: UUID, source_ids: list[str]) -> ErrorTrackingIssueMergeResult:
-    return _mutations.merge_issues(team_id, issue_id, source_ids)
+def merge_issues(
+    team_id: int, issue_id: UUID, source_ids: list[str], *, user: Any, was_impersonated: bool
+) -> ErrorTrackingIssueMergeResult:
+    return _mutations.merge_issues(team_id, issue_id, source_ids, user=user, was_impersonated=was_impersonated)
 
 
-def split_issue(team_id: int, issue_id: UUID, fingerprints: list[dict]) -> list[UUID]:
-    return _mutations.split_issue(team_id, issue_id, fingerprints)
+def split_issue(
+    team_id: int, issue_id: UUID, fingerprints: list[dict], *, user: Any, was_impersonated: bool
+) -> list[UUID]:
+    return _mutations.split_issue(team_id, issue_id, fingerprints, user=user, was_impersonated=was_impersonated)
 
 
 def set_issue_cohort(team_id: int, issue_id: UUID, cohort_id: int) -> None:

--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -19,6 +19,14 @@ from posthog.tasks.email import send_error_tracking_issue_assigned
 from products.access_control.backend.models.role import Role
 from products.cohorts.backend.models.cohort import Cohort
 from products.error_tracking.backend.logic import ErrorTrackingIssueNotFoundError, get_issue
+from products.error_tracking.backend.logic.lifecycle_events import (
+    ISSUE_ASSIGNED_EVENT,
+    ISSUE_MERGED_EVENT,
+    STATUS_CHANGE_EVENTS,
+    assignee_property,
+    produce_issue_lifecycle_event_on_commit,
+    status_label,
+)
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
@@ -143,20 +151,83 @@ def update_issue(
     if state_updated:
         sync_issues_to_clickhouse(issue_ids=[issue.id], team_id=team_id)
 
+    if status_updated and status_after in STATUS_CHANGE_EVENTS:
+        produce_issue_lifecycle_event_on_commit(
+            event=STATUS_CHANGE_EVENTS[status_after],
+            issue=issue,
+            user=user,
+            extra_properties={"previous_status": status_label(status_before)},
+        )
+
     return issue
 
 
-def merge_issues(team_id: int, issue_id: UUID, source_ids: list[str]) -> ErrorTrackingIssueMergeResult:
-    issue = _get_issue(team_id, issue_id)
+def merge_issues(
+    team_id: int, issue_id: UUID, source_ids: list[str], *, user: User, was_impersonated: bool
+) -> ErrorTrackingIssueMergeResult:
+    issue = _get_issue(team_id, issue_id, select_related=("team__organization",))
     # Make sure we don't delete the issue being merged into (defensive of frontend bugs)
     ids = [x for x in source_ids if x != str(issue.id)]
-    return issue.merge(issue_ids=ids)
+    result = issue.merge(issue_ids=ids)
+
+    if result == ErrorTrackingIssueMergeResult.MERGED:
+        log_activity(
+            organization_id=issue.team.organization_id,
+            team_id=team_id,
+            user=user,
+            was_impersonated=was_impersonated,
+            item_id=str(issue.id),
+            scope="ErrorTrackingIssue",
+            activity="merged",
+            detail=Detail(
+                name=issue.name,
+                changes=[
+                    Change(type="ErrorTrackingIssue", field="merged_issue_ids", after=ids, action="merged"),
+                ],
+            ),
+        )
+        # `ids` are the requested sources; a source that vanished mid-merge may still be
+        # listed here, which is harmless for consumers reacting to merged-away issues.
+        produce_issue_lifecycle_event_on_commit(
+            event=ISSUE_MERGED_EVENT,
+            issue=issue,
+            user=user,
+            extra_properties={"merged_issue_ids": ids},
+        )
+
+    return result
 
 
-def split_issue(team_id: int, issue_id: UUID, fingerprints: list[dict]) -> list[UUID]:
-    issue = _get_issue(team_id, issue_id)
+def split_issue(
+    team_id: int, issue_id: UUID, fingerprints: list[dict], *, user: User, was_impersonated: bool
+) -> list[UUID]:
+    issue = _get_issue(team_id, issue_id, select_related=("team__organization",))
     new_issues = issue.split(fingerprints=fingerprints)
-    return [new_issue.id for new_issue in new_issues]
+    new_issue_ids = [new_issue.id for new_issue in new_issues]
+
+    if new_issues:
+        log_activity(
+            organization_id=issue.team.organization_id,
+            team_id=team_id,
+            user=user,
+            was_impersonated=was_impersonated,
+            item_id=str(issue.id),
+            scope="ErrorTrackingIssue",
+            activity="split",
+            detail=Detail(
+                name=issue.name,
+                changes=[
+                    Change(
+                        type="ErrorTrackingIssue",
+                        field="split_issue_ids",
+                        after=[str(new_issue_id) for new_issue_id in new_issue_ids],
+                        action="split",
+                    ),
+                ],
+            ),
+        )
+
+    return new_issue_ids
 
 
 def set_issue_cohort(team_id: int, issue_id: UUID, cohort_id: int) -> None:
@@ -227,6 +298,14 @@ def bulk_update_issues(
                         ],
                     ),
                 )
+                if new_status in STATUS_CHANGE_EVENTS:
+                    produce_issue_lifecycle_event_on_commit(
+                        event=STATUS_CHANGE_EVENTS[new_status],
+                        issue=issue,
+                        user=user,
+                        status=new_status,
+                        extra_properties={"previous_status": status_label(issue.status)},
+                    )
             if changed_issue_ids:
                 ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=changed_issue_ids).update(
                     status=new_status, state_updated_at=timezone.now()
@@ -291,6 +370,13 @@ def _assign_one(
             assignment=assignment_after,
             assignee=assignee,
             assigner=user,
+        )
+
+        produce_issue_lifecycle_event_on_commit(
+            event=ISSUE_ASSIGNED_EVENT,
+            issue=issue,
+            user=user,
+            extra_properties={"assignee": assignee_property(assignee)},
         )
     else:
         if assignment_before is None:

--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -150,16 +150,18 @@ def update_issue(
                 detail=Detail(name=issue.name, changes=changes),
             )
 
+        if status_updated and status_after in STATUS_CHANGE_EVENTS:
+            # Register inside the transaction: a ClickHouse sync failure after commit
+            # must not drop the event, since a retry sees no transition and emits nothing.
+            produce_issue_lifecycle_event_on_commit(
+                event=STATUS_CHANGE_EVENTS[status_after],
+                issue=issue,
+                user=user,
+                extra_properties={"previous_status": status_label(status_before)},
+            )
+
     if state_updated:
         sync_issues_to_clickhouse(issue_ids=[issue.id], team_id=team_id)
-
-    if status_updated and status_after in STATUS_CHANGE_EVENTS:
-        produce_issue_lifecycle_event_on_commit(
-            event=STATUS_CHANGE_EVENTS[status_after],
-            issue=issue,
-            user=user,
-            extra_properties={"previous_status": status_label(status_before)},
-        )
 
     return issue
 

--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -22,8 +22,11 @@ from products.error_tracking.backend.logic import ErrorTrackingIssueNotFoundErro
 from products.error_tracking.backend.logic.lifecycle_events import (
     ISSUE_ASSIGNED_EVENT,
     ISSUE_MERGED_EVENT,
+    ISSUE_SPLIT_EVENT,
+    ISSUE_UNASSIGNED_EVENT,
     STATUS_CHANGE_EVENTS,
     assignee_property,
+    issue_fingerprint_for_links,
     produce_issue_lifecycle_event_on_commit,
     status_label,
 )
@@ -168,6 +171,10 @@ def merge_issues(
     issue = _get_issue(team_id, issue_id, select_related=("team__organization",))
     # Make sure we don't delete the issue being merged into (defensive of frontend bugs)
     ids = [x for x in source_ids if x != str(issue.id)]
+    # Snapshot before the merge moves source fingerprints onto this issue: a link
+    # built from a merged-in fingerprint would retarget if that fingerprint is
+    # later split back out.
+    fingerprint_before_merge = issue_fingerprint_for_links(issue)
     result = issue.merge(issue_ids=ids)
 
     if result == ErrorTrackingIssueMergeResult.MERGED:
@@ -192,6 +199,7 @@ def merge_issues(
             event=ISSUE_MERGED_EVENT,
             issue=issue,
             user=user,
+            fingerprint=fingerprint_before_merge,
             extra_properties={"merged_issue_ids": ids},
         )
 
@@ -225,6 +233,12 @@ def split_issue(
                     ),
                 ],
             ),
+        )
+        produce_issue_lifecycle_event_on_commit(
+            event=ISSUE_SPLIT_EVENT,
+            issue=issue,
+            user=user,
+            extra_properties={"split_issue_ids": [str(new_issue_id) for new_issue_id in new_issue_ids]},
         )
 
     return new_issue_ids
@@ -383,6 +397,16 @@ def _assign_one(
             return False
         assignment_before.delete()
         serialized_assignment_after = None
+
+        extra_properties = None
+        if serialized_assignment_before and serialized_assignment_before.get("id") is not None:
+            extra_properties = {"previous_assignee": assignee_property(serialized_assignment_before)}
+        produce_issue_lifecycle_event_on_commit(
+            event=ISSUE_UNASSIGNED_EVENT,
+            issue=issue,
+            user=user,
+            extra_properties=extra_properties,
+        )
 
     log_activity(
         organization_id=organization.id,

--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -175,9 +175,10 @@ def merge_issues(
     # built from a merged-in fingerprint would retarget if that fingerprint is
     # later split back out.
     fingerprint_before_merge = issue_fingerprint_for_links(issue)
-    result = issue.merge(issue_ids=ids)
+    result, merged_issue_ids = issue.merge(issue_ids=ids)
 
     if result == ErrorTrackingIssueMergeResult.MERGED:
+        merged_id_strings = [str(merged_issue_id) for merged_issue_id in merged_issue_ids]
         log_activity(
             organization_id=issue.team.organization_id,
             team_id=team_id,
@@ -189,18 +190,18 @@ def merge_issues(
             detail=Detail(
                 name=issue.name,
                 changes=[
-                    Change(type="ErrorTrackingIssue", field="merged_issue_ids", after=ids, action="merged"),
+                    Change(
+                        type="ErrorTrackingIssue", field="merged_issue_ids", after=merged_id_strings, action="merged"
+                    ),
                 ],
             ),
         )
-        # `ids` are the requested sources; a source that vanished mid-merge may still be
-        # listed here, which is harmless for consumers reacting to merged-away issues.
         produce_issue_lifecycle_event_on_commit(
             event=ISSUE_MERGED_EVENT,
             issue=issue,
             user=user,
             fingerprint=fingerprint_before_merge,
-            extra_properties={"merged_issue_ids": ids},
+            extra_properties={"merged_issue_ids": merged_id_strings},
         )
 
     return result

--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -26,7 +26,6 @@ from products.error_tracking.backend.logic.lifecycle_events import (
     ISSUE_UNASSIGNED_EVENT,
     STATUS_CHANGE_EVENTS,
     assignee_property,
-    issue_fingerprint_for_links,
     produce_issue_lifecycle_event_on_commit,
     status_label,
 )
@@ -171,10 +170,6 @@ def merge_issues(
     issue = _get_issue(team_id, issue_id, select_related=("team__organization",))
     # Make sure we don't delete the issue being merged into (defensive of frontend bugs)
     ids = [x for x in source_ids if x != str(issue.id)]
-    # Snapshot before the merge moves source fingerprints onto this issue: a link
-    # built from a merged-in fingerprint would retarget if that fingerprint is
-    # later split back out.
-    fingerprint_before_merge = issue_fingerprint_for_links(issue)
     result, merged_issue_ids = issue.merge(issue_ids=ids)
 
     if result == ErrorTrackingIssueMergeResult.MERGED:
@@ -200,7 +195,6 @@ def merge_issues(
             event=ISSUE_MERGED_EVENT,
             issue=issue,
             user=user,
-            fingerprint=fingerprint_before_merge,
             extra_properties={"merged_issue_ids": merged_id_strings},
         )
 

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -10,7 +10,6 @@ import json
 from typing import Any, Optional
 
 from django.db import transaction
-from django.utils import timezone
 
 import structlog
 
@@ -65,10 +64,11 @@ def produce_issue_lifecycle_event_on_commit(
     # Snapshot everything now: the issue row may be mutated again (or deleted, for
     # merge sources) before the surrounding transaction commits.
     team_id = issue.team_id
-    # Destination message templates deep-link issues via `fingerprint` plus
-    # `exception_timestamp` (see the error tracking sub-templates). Manual
-    # transitions have no triggering exception, so any of the issue's
-    # fingerprints and the transition time keep those links working.
+    # Destination message templates deep-link issues via `fingerprint` (see the
+    # error tracking sub-templates). Manual transitions have no triggering
+    # exception, so any of the issue's fingerprints keeps those links working;
+    # `exception_timestamp` stays absent so the issue scene falls back to the
+    # issue's latest exception instead of an empty window around the mutation.
     fingerprint = (
         ErrorTrackingIssueFingerprintV2.objects.filter(team_id=team_id, issue_id=issue.id)
         .values_list("fingerprint", flat=True)
@@ -78,7 +78,6 @@ def produce_issue_lifecycle_event_on_commit(
         "name": issue.name,
         "description": issue.description,
         "status": status_label(status if status is not None else issue.status),
-        "exception_timestamp": timezone.now().isoformat(),
         **({"fingerprint": fingerprint} if fingerprint is not None else {}),
         **(extra_properties or {}),
     }

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -69,15 +69,13 @@ def _current_assignee_property(issue: ErrorTrackingIssue) -> Optional[str]:
     return None
 
 
-def issue_fingerprint_for_links(issue: ErrorTrackingIssue) -> Optional[str]:
-    # Deterministic anchor: prefer the issue's own founding fingerprint. `version`
-    # counts reassignments (merge/split bump it; cymbal inserts at 0), so a
-    # version-0 row was born attached to this issue and cannot be a merged-in
-    # fingerprint that a later split would point at another issue. Callers whose
-    # mutation moves fingerprints (merge) must still snapshot this before mutating.
+def _issue_fingerprint_for_links(issue: ErrorTrackingIssue) -> Optional[str]:
+    # Legacy destination templates deep-link issues through the fingerprint
+    # redirect page, which resolves to the fingerprint's current owner. Any
+    # attached fingerprint works; the ordering only keeps the pick deterministic.
     return (
         ErrorTrackingIssueFingerprintV2.objects.filter(team_id=issue.team_id, issue_id=issue.id)
-        .order_by("version", "first_seen", "id")
+        .order_by("first_seen", "id")
         .values_list("fingerprint", flat=True)
         .first()
     )
@@ -89,19 +87,15 @@ def produce_issue_lifecycle_event_on_commit(
     issue: ErrorTrackingIssue,
     user: Optional[User],
     status: Optional[str] = None,
-    fingerprint: Optional[str] = None,
     extra_properties: Optional[dict[str, Any]] = None,
 ) -> None:
     # Snapshot everything now: the issue row may be mutated again (or deleted, for
     # merge sources) before the surrounding transaction commits.
     team_id = issue.team_id
-    # Destination message templates deep-link issues via `fingerprint` (see the
-    # error tracking sub-templates). Manual transitions have no triggering
-    # exception, so one of the issue's own fingerprints keeps those links working;
-    # `exception_timestamp` stays absent so the issue scene falls back to the
-    # issue's latest exception instead of an empty window around the mutation.
-    if fingerprint is None:
-        fingerprint = issue_fingerprint_for_links(issue)
+    # `exception_timestamp` stays absent on manual transitions so the issue scene
+    # falls back to the issue's latest exception instead of an empty window around
+    # the mutation.
+    fingerprint = _issue_fingerprint_for_links(issue)
     current_assignee = _current_assignee_property(issue)
     # Same issue-property set the ingestion-driven producer emits (see
     # produce_issue_lifecycle_internal_event), so destination property filters

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -10,6 +10,7 @@ import json
 from typing import Any, Optional
 
 from django.db import transaction
+from django.utils import timezone
 
 import structlog
 
@@ -17,7 +18,7 @@ from posthog.api.shared import UserBasicSerializer
 from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
 from posthog.models.user import User
 
-from products.error_tracking.backend.models import ErrorTrackingIssue
+from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingIssueFingerprintV2
 
 logger = structlog.get_logger(__name__)
 
@@ -26,7 +27,7 @@ ISSUE_SUPPRESSED_EVENT = "$error_tracking_issue_suppressed"
 ISSUE_ASSIGNED_EVENT = "$error_tracking_issue_assigned"
 ISSUE_MERGED_EVENT = "$error_tracking_issue_merged"
 # Cymbal emits this same event when an ingested exception reopens an issue; manual
-# reopens reuse it (without exception props) so reopened alerts cover both paths.
+# reopens reuse it so reopened alerts cover both paths.
 ISSUE_REOPENED_EVENT = "$error_tracking_issue_reopened"
 
 STATUS_CHANGE_EVENTS: dict[str, str] = {
@@ -64,10 +65,21 @@ def produce_issue_lifecycle_event_on_commit(
     # Snapshot everything now: the issue row may be mutated again (or deleted, for
     # merge sources) before the surrounding transaction commits.
     team_id = issue.team_id
+    # Destination message templates deep-link issues via `fingerprint` plus
+    # `exception_timestamp` (see the error tracking sub-templates). Manual
+    # transitions have no triggering exception, so any of the issue's
+    # fingerprints and the transition time keep those links working.
+    fingerprint = (
+        ErrorTrackingIssueFingerprintV2.objects.filter(team_id=team_id, issue_id=issue.id)
+        .values_list("fingerprint", flat=True)
+        .first()
+    )
     properties: dict[str, Any] = {
         "name": issue.name,
         "description": issue.description,
         "status": status_label(status if status is not None else issue.status),
+        "exception_timestamp": timezone.now().isoformat(),
+        **({"fingerprint": fingerprint} if fingerprint is not None else {}),
         **(extra_properties or {}),
     }
     internal_event = InternalEventEvent(event=event, distinct_id=str(issue.id), properties=properties)

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -13,11 +13,14 @@ from django.db import transaction
 
 import structlog
 
-from posthog.api.shared import UserBasicSerializer
 from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
 from posthog.models.user import User
 
-from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingIssueFingerprintV2
+from products.error_tracking.backend.models import (
+    ErrorTrackingIssue,
+    ErrorTrackingIssueAssignment,
+    ErrorTrackingIssueFingerprintV2,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -55,6 +58,17 @@ def assignee_property(assignee: dict[str, Any]) -> str:
     return json.dumps({"type": assignee["type"], "id": assignee_id}, separators=(",", ":"))
 
 
+def _current_assignee_property(issue: ErrorTrackingIssue) -> Optional[str]:
+    assignment = ErrorTrackingIssueAssignment.objects.filter(issue_id=issue.id).values("user_id", "role_id").first()
+    if assignment is None:
+        return None
+    if assignment["user_id"] is not None:
+        return assignee_property({"type": "user", "id": assignment["user_id"]})
+    if assignment["role_id"] is not None:
+        return assignee_property({"type": "role", "id": assignment["role_id"]})
+    return None
+
+
 def issue_fingerprint_for_links(issue: ErrorTrackingIssue) -> Optional[str]:
     # Deterministic: always the issue's longest-held fingerprint, so persisted
     # links keep resolving to this issue as long as possible. Callers whose
@@ -86,19 +100,37 @@ def produce_issue_lifecycle_event_on_commit(
     # issue's latest exception instead of an empty window around the mutation.
     if fingerprint is None:
         fingerprint = issue_fingerprint_for_links(issue)
+    current_assignee = _current_assignee_property(issue)
+    # Same issue-property set the ingestion-driven producer emits (see
+    # produce_issue_lifecycle_internal_event), so destination property filters
+    # match both paths.
     properties: dict[str, Any] = {
         "name": issue.name,
         "description": issue.description,
+        "issue_description": issue.description,
+        "first_seen": issue.created_at.isoformat(),
+        "severity": issue.severity,
         "status": status_label(status if status is not None else issue.status),
         **({"fingerprint": fingerprint} if fingerprint is not None else {}),
+        **({"assignee": current_assignee} if current_assignee is not None else {}),
         **(extra_properties or {}),
     }
     internal_event = InternalEventEvent(event=event, distinct_id=str(issue.id), properties=properties)
 
     person = None
     if user is not None:
-        user_data = UserBasicSerializer(user).data
-        person = InternalEventPerson(id=str(user_data["id"]), properties=dict(user_data))
+        # Deliberately a minimal actor subset: person reaches customer-configured
+        # destinations verbatim (the default webhook body sends `{person}`), so no
+        # full user serializer here.
+        person = InternalEventPerson(
+            id=str(user.id),
+            properties={
+                "id": str(user.id),
+                "distinct_id": user.distinct_id,
+                "email": user.email,
+                "first_name": user.first_name,
+            },
+        )
 
     def _produce() -> None:
         try:

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -1,0 +1,88 @@
+"""CDP internal events for user-driven issue lifecycle transitions.
+
+Ingestion-driven transitions (created, reopened, spiking) are emitted by cymbal's
+notifications worker (rust/cymbal/src/modes/notifications). These helpers cover the
+transitions that happen in Django so destinations subscribed to issue lifecycle
+events see the full picture.
+"""
+
+import json
+from typing import Any, Optional
+
+from django.db import transaction
+
+import structlog
+
+from posthog.api.shared import UserBasicSerializer
+from posthog.cdp.internal_events import InternalEventEvent, InternalEventPerson, produce_internal_event
+from posthog.models.user import User
+
+from products.error_tracking.backend.models import ErrorTrackingIssue
+
+logger = structlog.get_logger(__name__)
+
+ISSUE_RESOLVED_EVENT = "$error_tracking_issue_resolved"
+ISSUE_SUPPRESSED_EVENT = "$error_tracking_issue_suppressed"
+ISSUE_ASSIGNED_EVENT = "$error_tracking_issue_assigned"
+ISSUE_MERGED_EVENT = "$error_tracking_issue_merged"
+# Cymbal emits this same event when an ingested exception reopens an issue; manual
+# reopens reuse it (without exception props) so reopened alerts cover both paths.
+ISSUE_REOPENED_EVENT = "$error_tracking_issue_reopened"
+
+STATUS_CHANGE_EVENTS: dict[str, str] = {
+    ErrorTrackingIssue.Status.ACTIVE: ISSUE_REOPENED_EVENT,
+    ErrorTrackingIssue.Status.RESOLVED: ISSUE_RESOLVED_EVENT,
+    ErrorTrackingIssue.Status.SUPPRESSED: ISSUE_SUPPRESSED_EVENT,
+}
+
+
+def status_label(status: str) -> str:
+    # Cymbal emits display-cased status values ("Active", "Resolved") on the
+    # ingestion-driven events; keep the same shape here so filters match both.
+    try:
+        return str(ErrorTrackingIssue.Status(status).label)
+    except ValueError:
+        return status
+
+
+def assignee_property(assignee: dict[str, Any]) -> str:
+    # Wire-compatible with cymbal's `Assignee` serialization on created/reopened events
+    # (compact serde JSON, adjacently tagged, numeric user ids and string role ids), so
+    # exact-match filters on the assignee property behave the same across all events.
+    assignee_id = int(assignee["id"]) if assignee["type"] == "user" else str(assignee["id"])
+    return json.dumps({"type": assignee["type"], "id": assignee_id}, separators=(",", ":"))
+
+
+def produce_issue_lifecycle_event_on_commit(
+    *,
+    event: str,
+    issue: ErrorTrackingIssue,
+    user: Optional[User],
+    status: Optional[str] = None,
+    extra_properties: Optional[dict[str, Any]] = None,
+) -> None:
+    # Snapshot everything now: the issue row may be mutated again (or deleted, for
+    # merge sources) before the surrounding transaction commits.
+    team_id = issue.team_id
+    properties: dict[str, Any] = {
+        "name": issue.name,
+        "description": issue.description,
+        "status": status_label(status if status is not None else issue.status),
+        **(extra_properties or {}),
+    }
+    internal_event = InternalEventEvent(event=event, distinct_id=str(issue.id), properties=properties)
+
+    person = None
+    if user is not None:
+        user_data = UserBasicSerializer(user).data
+        person = InternalEventPerson(id=str(user_data["id"]), properties=dict(user_data))
+
+    def _produce() -> None:
+        try:
+            produce_internal_event(team_id=team_id, event=internal_event, person=person)
+        except Exception:
+            # Already logged by produce_internal_event; alert emission must never
+            # fail the mutation that triggered it.
+            pass
+
+    transaction.on_commit(_produce)

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -70,12 +70,14 @@ def _current_assignee_property(issue: ErrorTrackingIssue) -> Optional[str]:
 
 
 def issue_fingerprint_for_links(issue: ErrorTrackingIssue) -> Optional[str]:
-    # Deterministic: always the issue's longest-held fingerprint, so persisted
-    # links keep resolving to this issue as long as possible. Callers whose
-    # mutation moves fingerprints (merge) must snapshot this before mutating.
+    # Deterministic anchor: prefer the issue's own founding fingerprint. `version`
+    # counts reassignments (merge/split bump it; cymbal inserts at 0), so a
+    # version-0 row was born attached to this issue and cannot be a merged-in
+    # fingerprint that a later split would point at another issue. Callers whose
+    # mutation moves fingerprints (merge) must still snapshot this before mutating.
     return (
         ErrorTrackingIssueFingerprintV2.objects.filter(team_id=issue.team_id, issue_id=issue.id)
-        .order_by("first_seen", "id")
+        .order_by("version", "first_seen", "id")
         .values_list("fingerprint", flat=True)
         .first()
     )

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -59,13 +59,13 @@ def assignee_property(assignee: dict[str, Any]) -> str:
 
 
 def _current_assignee_property(issue: ErrorTrackingIssue) -> Optional[str]:
-    assignment = ErrorTrackingIssueAssignment.objects.filter(issue_id=issue.id).values("user_id", "role_id").first()
+    assignment = ErrorTrackingIssueAssignment.objects.filter(issue_id=issue.id).only("user_id", "role_id").first()
     if assignment is None:
         return None
-    if assignment["user_id"] is not None:
-        return assignee_property({"type": "user", "id": assignment["user_id"]})
-    if assignment["role_id"] is not None:
-        return assignee_property({"type": "role", "id": assignment["role_id"]})
+    if assignment.user_id:
+        return assignee_property({"type": "user", "id": assignment.user_id})
+    if assignment.role_id:
+        return assignee_property({"type": "role", "id": assignment.role_id})
     return None
 
 

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -24,7 +24,9 @@ logger = structlog.get_logger(__name__)
 ISSUE_RESOLVED_EVENT = "$error_tracking_issue_resolved"
 ISSUE_SUPPRESSED_EVENT = "$error_tracking_issue_suppressed"
 ISSUE_ASSIGNED_EVENT = "$error_tracking_issue_assigned"
+ISSUE_UNASSIGNED_EVENT = "$error_tracking_issue_unassigned"
 ISSUE_MERGED_EVENT = "$error_tracking_issue_merged"
+ISSUE_SPLIT_EVENT = "$error_tracking_issue_split"
 # Cymbal emits this same event when an ingested exception reopens an issue; manual
 # reopens reuse it so reopened alerts cover both paths.
 ISSUE_REOPENED_EVENT = "$error_tracking_issue_reopened"
@@ -53,12 +55,25 @@ def assignee_property(assignee: dict[str, Any]) -> str:
     return json.dumps({"type": assignee["type"], "id": assignee_id}, separators=(",", ":"))
 
 
+def issue_fingerprint_for_links(issue: ErrorTrackingIssue) -> Optional[str]:
+    # Deterministic: always the issue's longest-held fingerprint, so persisted
+    # links keep resolving to this issue as long as possible. Callers whose
+    # mutation moves fingerprints (merge) must snapshot this before mutating.
+    return (
+        ErrorTrackingIssueFingerprintV2.objects.filter(team_id=issue.team_id, issue_id=issue.id)
+        .order_by("first_seen", "id")
+        .values_list("fingerprint", flat=True)
+        .first()
+    )
+
+
 def produce_issue_lifecycle_event_on_commit(
     *,
     event: str,
     issue: ErrorTrackingIssue,
     user: Optional[User],
     status: Optional[str] = None,
+    fingerprint: Optional[str] = None,
     extra_properties: Optional[dict[str, Any]] = None,
 ) -> None:
     # Snapshot everything now: the issue row may be mutated again (or deleted, for
@@ -66,14 +81,11 @@ def produce_issue_lifecycle_event_on_commit(
     team_id = issue.team_id
     # Destination message templates deep-link issues via `fingerprint` (see the
     # error tracking sub-templates). Manual transitions have no triggering
-    # exception, so any of the issue's fingerprints keeps those links working;
+    # exception, so one of the issue's own fingerprints keeps those links working;
     # `exception_timestamp` stays absent so the issue scene falls back to the
     # issue's latest exception instead of an empty window around the mutation.
-    fingerprint = (
-        ErrorTrackingIssueFingerprintV2.objects.filter(team_id=team_id, issue_id=issue.id)
-        .values_list("fingerprint", flat=True)
-        .first()
-    )
+    if fingerprint is None:
+        fingerprint = issue_fingerprint_for_links(issue)
     properties: dict[str, Any] = {
         "name": issue.name,
         "description": issue.description,

--- a/products/error_tracking/backend/logic/lifecycle_events.py
+++ b/products/error_tracking/backend/logic/lifecycle_events.py
@@ -70,9 +70,11 @@ def _current_assignee_property(issue: ErrorTrackingIssue) -> Optional[str]:
 
 
 def _issue_fingerprint_for_links(issue: ErrorTrackingIssue) -> Optional[str]:
-    # Legacy destination templates deep-link issues through the fingerprint
-    # redirect page, which resolves to the fingerprint's current owner. Any
-    # attached fingerprint works; the ordering only keeps the pick deterministic.
+    # Existing Error Tracking destination templates expect `fingerprint`. Manual
+    # transitions have no triggering exception, so include one currently attached
+    # fingerprint for compatibility. Fingerprint routes follow current ownership
+    # after merges/splits; `distinct_id` identifies the issue that emitted the
+    # event. The ordering only keeps the pick deterministic.
     return (
         ErrorTrackingIssueFingerprintV2.objects.filter(team_id=issue.team_id, issue_id=issue.id)
         .order_by("first_seen", "id")

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -91,25 +91,31 @@ class ErrorTrackingIssue(UUIDTModel):
 
     def merge(
         self, issue_ids: Sequence[str | UUID], expected_fingerprint_issue_ids: dict[str, UUID] | None = None
-    ) -> ErrorTrackingIssueMergeResult:
+    ) -> "tuple[ErrorTrackingIssueMergeResult, list[UUID]]":
+        """Merge source issues into this issue.
+
+        Returns the outcome plus the source issue ids that were actually merged:
+        requested sources that already disappeared are dropped by the lock step,
+        so callers must not report the requested list as merged.
+        """
         team_id = self.team_id
         target_issue_id = self.id
         source_issue_ids = _normalize_source_issue_ids(issue_ids=issue_ids, target_issue_id=target_issue_id)
         if not source_issue_ids:
-            return ErrorTrackingIssueMergeResult.NO_SOURCE_ISSUES
+            return ErrorTrackingIssueMergeResult.NO_SOURCE_ISSUES, []
 
         with transaction.atomic():
             existing_source_issue_ids = _lock_merge_issues(
                 team_id=team_id, target_issue_id=target_issue_id, source_issue_ids=source_issue_ids
             )
             if existing_source_issue_ids is None:
-                return ErrorTrackingIssueMergeResult.STALE_ISSUES
+                return ErrorTrackingIssueMergeResult.STALE_ISSUES, []
             if not existing_source_issue_ids:
-                return ErrorTrackingIssueMergeResult.NO_SOURCE_ISSUES
+                return ErrorTrackingIssueMergeResult.NO_SOURCE_ISSUES, []
             if expected_fingerprint_issue_ids is not None and not _lock_expected_fingerprint_issue_ids(
                 team_id=team_id, expected_fingerprint_issue_ids=expected_fingerprint_issue_ids
             ):
-                return ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS
+                return ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS, []
 
             locked_source_fingerprints = list(
                 ErrorTrackingIssueFingerprintV2.objects.select_for_update()
@@ -141,7 +147,7 @@ class ErrorTrackingIssue(UUIDTModel):
             _sync_error_tracking_issue_changes_on_commit(
                 team_id=team_id, issue_ids=[target_issue_id], overrides=overrides
             )
-            return ErrorTrackingIssueMergeResult.MERGED
+            return ErrorTrackingIssueMergeResult.MERGED, existing_source_issue_ids
 
     def split(self, fingerprints: list[dict]) -> list["ErrorTrackingIssue"]:
         team_id = self.team_id

--- a/products/error_tracking/backend/presentation/views/issues.py
+++ b/products/error_tracking/backend/presentation/views/issues.py
@@ -1,3 +1,4 @@
+from typing import cast
 from uuid import UUID
 
 from django.http import JsonResponse
@@ -17,6 +18,7 @@ from posthog.api.utils import action
 from posthog.helpers.impersonation import is_impersonated
 from posthog.models.activity_logging.activity_log import load_activity
 from posthog.models.activity_logging.activity_page import activity_page_response
+from posthog.models.user import User
 
 from products.error_tracking.backend.facade import (
     api as facade_api,
@@ -277,7 +279,7 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
                 self.team.id,
                 UUID(str(pk)),
                 ids,
-                user=request.user,
+                user=cast(User, request.user),
                 was_impersonated=is_impersonated(request),
             )
         except IssueNotFoundError:
@@ -300,7 +302,7 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
                 self.team.id,
                 UUID(str(pk)),
                 fingerprints,
-                user=request.user,
+                user=cast(User, request.user),
                 was_impersonated=is_impersonated(request),
             )
         except IssueNotFoundError:

--- a/products/error_tracking/backend/presentation/views/issues.py
+++ b/products/error_tracking/backend/presentation/views/issues.py
@@ -273,7 +273,13 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
     def merge(self, request: ValidatedRequest, *args: object, pk: object = None, **kwargs: object) -> Response:
         ids = [str(issue_id) for issue_id in request.validated_data["ids"]]
         try:
-            merge_result = issues_facade.merge_issues(self.team.id, UUID(str(pk)), ids)
+            merge_result = issues_facade.merge_issues(
+                self.team.id,
+                UUID(str(pk)),
+                ids,
+                user=request.user,
+                was_impersonated=is_impersonated(request),
+            )
         except IssueNotFoundError:
             raise NotFound("Issue not found")
         if merge_result == issues_facade.ErrorTrackingIssueMergeResult.STALE_ISSUES:
@@ -290,7 +296,13 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
     def split(self, request: ValidatedRequest, *args: object, pk: object = None, **kwargs: object) -> Response:
         fingerprints = request.validated_data["fingerprints"]
         try:
-            new_issue_ids = issues_facade.split_issue(self.team.id, UUID(str(pk)), fingerprints)
+            new_issue_ids = issues_facade.split_issue(
+                self.team.id,
+                UUID(str(pk)),
+                fingerprints,
+                user=request.user,
+                was_impersonated=is_impersonated(request),
+            )
         except IssueNotFoundError:
             raise NotFound("Issue not found")
         return Response({"success": True, "new_issue_ids": [str(i) for i in new_issue_ids]})

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -235,7 +235,7 @@ def _merge_fingerprint_into_closest_issue(
 
         source_issue_id = source_fingerprint.issue_id
         target_issue_id = target_fingerprint.issue_id
-        merge_result = target_fingerprint.issue.merge(
+        merge_result, _merged_issue_ids = target_fingerprint.issue.merge(
             issue_ids=[source_issue_id],
             expected_fingerprint_issue_ids={
                 fingerprint: source_issue_id,

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
@@ -227,7 +227,7 @@ class TestFingerprintEmbeddingResultActivity:
         target_issue_id = uuid.uuid4()
         source_fingerprint = MagicMock(issue_id=source_issue_id, fingerprint="test-fingerprint")
         target_issue = MagicMock()
-        target_issue.merge.return_value = ErrorTrackingIssueMergeResult.MERGED
+        target_issue.merge.return_value = (ErrorTrackingIssueMergeResult.MERGED, [])
         target_fingerprint = MagicMock(issue_id=target_issue_id, issue=target_issue, fingerprint="fingerprint-1")
         team = MagicMock(id=2, uuid=uuid.uuid4())
         fingerprint_query = MagicMock()
@@ -281,7 +281,7 @@ class TestFingerprintEmbeddingResultActivity:
         source_fingerprint = MagicMock(issue_id=source_issue_id, fingerprint="test-fingerprint")
         same_issue_fingerprint = MagicMock(issue_id=source_issue_id, fingerprint="same-issue")
         target_issue = MagicMock()
-        target_issue.merge.return_value = ErrorTrackingIssueMergeResult.MERGED
+        target_issue.merge.return_value = (ErrorTrackingIssueMergeResult.MERGED, [])
         target_fingerprint = MagicMock(issue_id=target_issue_id, issue=target_issue, fingerprint="valid-target")
         fingerprint_query = MagicMock()
         fingerprint_query.select_related.return_value.order_by.return_value = [
@@ -390,7 +390,7 @@ class TestFingerprintEmbeddingResultActivity:
         target_issue_id = uuid.uuid4()
         source_fingerprint = MagicMock(issue_id=source_issue_id, fingerprint="test-fingerprint")
         target_issue = MagicMock()
-        target_issue.merge.return_value = ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS
+        target_issue.merge.return_value = (ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS, [])
         target_fingerprint = MagicMock(issue_id=target_issue_id, issue=target_issue, fingerprint="fingerprint-1")
         team = MagicMock(id=2, uuid=uuid.uuid4())
         fingerprint_query = MagicMock()

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -68,7 +68,7 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         assert latest_issue_state_watermark(self.team.id) == source_stamp
 
         with freeze_time("2022-01-10T12:05:00"):
-            assert target.merge(issue_ids=[source.id]) == ErrorTrackingIssueMergeResult.MERGED
+            assert target.merge(issue_ids=[source.id])[0] == ErrorTrackingIssueMergeResult.MERGED
 
         target.refresh_from_db()
         assert target.state_updated_at == datetime(2022, 1, 10, 12, 5, tzinfo=UTC)
@@ -111,7 +111,10 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         stale_issue_id = self.create_issue(["fingerprint_three"]).id
         ErrorTrackingIssue.objects.filter(id=stale_issue_id).delete()
 
-        assert issue_two.merge(issue_ids=[issue_one.id, stale_issue_id]) == ErrorTrackingIssueMergeResult.MERGED
+        assert issue_two.merge(issue_ids=[issue_one.id, stale_issue_id]) == (
+            ErrorTrackingIssueMergeResult.MERGED,
+            [issue_one.id],
+        )
 
         # The still-present source is merged into the target even though a sibling source was stale
         assert not ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
@@ -123,7 +126,7 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         stale_issue_id = self.create_issue(["fingerprint_three"]).id
         ErrorTrackingIssue.objects.filter(id=stale_issue_id).delete()
 
-        assert issue_two.merge(issue_ids=[stale_issue_id]) == ErrorTrackingIssueMergeResult.NO_SOURCE_ISSUES
+        assert issue_two.merge(issue_ids=[stale_issue_id]) == (ErrorTrackingIssueMergeResult.NO_SOURCE_ISSUES, [])
 
         assert ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=issue_two.id).count() == 1
 
@@ -132,7 +135,7 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         issue_two = self.create_issue(["fingerprint_two"])
         ErrorTrackingIssue.objects.filter(id=issue_two.id).delete()
 
-        assert issue_two.merge(issue_ids=[issue_one.id]) == ErrorTrackingIssueMergeResult.STALE_ISSUES
+        assert issue_two.merge(issue_ids=[issue_one.id]) == (ErrorTrackingIssueMergeResult.STALE_ISSUES, [])
 
         # The source is left untouched when the target the frontend picked is gone
         assert ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
@@ -143,16 +146,13 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         issue_two = self.create_issue(["fingerprint_two"])
         issue_three = self.create_issue(["fingerprint_three"])
 
-        assert (
-            issue_two.merge(
-                issue_ids=[issue_one.id],
-                expected_fingerprint_issue_ids={
-                    "fingerprint_one": issue_three.id,
-                    "fingerprint_two": issue_two.id,
-                },
-            )
-            == ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS
-        )
+        assert issue_two.merge(
+            issue_ids=[issue_one.id],
+            expected_fingerprint_issue_ids={
+                "fingerprint_one": issue_three.id,
+                "fingerprint_two": issue_two.id,
+            },
+        ) == (ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS, [])
 
         assert ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
         assert ErrorTrackingIssueFingerprintV2.objects.get(fingerprint="fingerprint_one").issue_id == issue_one.id
@@ -167,7 +167,7 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
             patch("products.error_tracking.backend.models.sync_issues_to_clickhouse") as sync_issues_to_clickhouse,
             self.captureOnCommitCallbacks(execute=True),
         ):
-            assert issue_two.merge(issue_ids=[issue_one.id]) == ErrorTrackingIssueMergeResult.MERGED
+            assert issue_two.merge(issue_ids=[issue_one.id])[0] == ErrorTrackingIssueMergeResult.MERGED
 
         sync_issues_to_clickhouse.assert_called_once_with(issue_ids=[issue_two.id], team_id=self.team.id)
 
@@ -418,7 +418,7 @@ class TestErrorTrackingMergeConcurrency(ErrorTrackingIssueTestMixin, NonAtomicBa
                 cursor.execute("SET lock_timeout = '10s'")
                 cursor.execute("SET statement_timeout = '15s'")
             start_barrier.wait(timeout=5)
-            return ErrorTrackingIssue.objects.get(id=target_issue_id).merge(issue_ids=source_issue_ids)
+            return ErrorTrackingIssue.objects.get(id=target_issue_id).merge(issue_ids=source_issue_ids)[0]
         finally:
             close_old_connections()
 

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -503,7 +503,7 @@ class TestErrorTracking(APIBaseTest):
     def test_issue_status_update_produces_lifecycle_internal_event(
         self, initial_status, new_status, event_name, status_prop, previous_prop
     ):
-        issue = self.create_issue()
+        issue = self.create_issue(fingerprints=["lifecycle_fingerprint"])
         ErrorTrackingIssue.objects.filter(id=issue.id).update(status=initial_status)
 
         with (
@@ -524,6 +524,9 @@ class TestErrorTracking(APIBaseTest):
         assert event.distinct_id == str(issue.id)
         assert event.properties["status"] == status_prop
         assert event.properties["previous_status"] == previous_prop
+        # Destination templates deep-link issues from these two properties.
+        assert event.properties["fingerprint"] == "lifecycle_fingerprint"
+        assert event.properties["exception_timestamp"] is not None
         assert kwargs["person"].id == str(self.user.id)
 
     def test_issue_update_without_status_transition_produces_no_lifecycle_event(self):

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -538,6 +538,30 @@ class TestErrorTracking(APIBaseTest):
         # The person block reaches customer webhooks verbatim: minimal actor only.
         assert set(person.properties.keys()) == {"id", "distinct_id", "email", "first_name"}
 
+    def test_issue_status_lifecycle_event_survives_clickhouse_sync_failure(self):
+        issue = self.create_issue(fingerprints=["lifecycle_fingerprint"])
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            patch(
+                "products.error_tracking.backend.logic.issue_mutations.sync_issues_to_clickhouse",
+                side_effect=Exception("clickhouse down"),
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}",
+                data={"status": "resolved"},
+            )
+
+        assert response.status_code == 500
+        # The status committed, so a retry sees no transition: the event must
+        # already have been registered when the sync failed.
+        mock_produce.assert_called_once()
+        assert mock_produce.call_args.kwargs["event"].event == "$error_tracking_issue_resolved"
+        issue.refresh_from_db()
+        assert issue.status == ErrorTrackingIssue.Status.RESOLVED
+
     def test_issue_update_without_status_transition_produces_no_lifecycle_event(self):
         issue = self.create_issue()
 

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1,4 +1,5 @@
 import os
+import json
 from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
@@ -16,6 +17,7 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Team, User
+from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.integration import Integration
 from posthog.models.utils import uuid7
 from posthog.settings import (
@@ -489,6 +491,152 @@ class TestErrorTracking(APIBaseTest):
         )
 
         assert response.status_code == 404
+
+    @parameterized.expand(
+        [
+            ("active", "resolved", "$error_tracking_issue_resolved", "Resolved", "Active"),
+            ("active", "suppressed", "$error_tracking_issue_suppressed", "Suppressed", "Active"),
+            ("resolved", "active", "$error_tracking_issue_reopened", "Active", "Resolved"),
+            ("suppressed", "active", "$error_tracking_issue_reopened", "Active", "Suppressed"),
+        ]
+    )
+    def test_issue_status_update_produces_lifecycle_internal_event(
+        self, initial_status, new_status, event_name, status_prop, previous_prop
+    ):
+        issue = self.create_issue()
+        ErrorTrackingIssue.objects.filter(id=issue.id).update(status=initial_status)
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}",
+                data={"status": new_status},
+            )
+
+        assert response.status_code == 200, response.json()
+        mock_produce.assert_called_once()
+        kwargs = mock_produce.call_args.kwargs
+        assert kwargs["team_id"] == self.team.id
+        event = kwargs["event"]
+        assert event.event == event_name
+        assert event.distinct_id == str(issue.id)
+        assert event.properties["status"] == status_prop
+        assert event.properties["previous_status"] == previous_prop
+        assert kwargs["person"].id == str(self.user.id)
+
+    def test_issue_update_without_status_transition_produces_no_lifecycle_event(self):
+        issue = self.create_issue()
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}",
+                data={"name": "Renamed issue"},
+            )
+
+        assert response.status_code == 200, response.json()
+        mock_produce.assert_not_called()
+
+    def test_issue_bulk_set_status_produces_lifecycle_events_only_for_transitions(self):
+        active_issue = self.create_issue()
+        resolved_issue = self.create_issue()
+        ErrorTrackingIssue.objects.filter(id=resolved_issue.id).update(status=ErrorTrackingIssue.Status.RESOLVED)
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/issues/bulk",
+                data={"ids": [active_issue.id, resolved_issue.id], "action": "set_status", "status": "resolved"},
+            )
+
+        assert response.status_code == 200, response.json()
+        mock_produce.assert_called_once()
+        event = mock_produce.call_args.kwargs["event"]
+        assert event.event == "$error_tracking_issue_resolved"
+        assert event.distinct_id == str(active_issue.id)
+        assert event.properties["status"] == "Resolved"
+        assert event.properties["previous_status"] == "Active"
+
+    def test_issue_assign_produces_lifecycle_internal_event(self):
+        issue = self.create_issue()
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
+                data={"assignee": {"id": self.user.id, "type": "user"}},
+            )
+
+        assert response.status_code == 200, response.json()
+        mock_produce.assert_called_once()
+        event = mock_produce.call_args.kwargs["event"]
+        assert event.event == "$error_tracking_issue_assigned"
+        assert event.distinct_id == str(issue.id)
+        # Byte-identical to cymbal's compact serde output so exact-match filters work.
+        assert event.properties["assignee"] == f'{{"type":"user","id":{self.user.id}}}'
+        assert json.loads(event.properties["assignee"]) == {"type": "user", "id": self.user.id}
+
+    def test_issue_merge_produces_lifecycle_event_and_activity_log(self):
+        issue_one = self.create_issue(fingerprints=["fingerprint_one"])
+        issue_two = self.create_issue(fingerprints=["fingerprint_two"])
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue_one.id}/merge",
+                data={"ids": [issue_two.id]},
+            )
+
+        assert response.status_code == 200, response.json()
+        mock_produce.assert_called_once()
+        event = mock_produce.call_args.kwargs["event"]
+        assert event.event == "$error_tracking_issue_merged"
+        assert event.distinct_id == str(issue_one.id)
+        assert event.properties["merged_issue_ids"] == [str(issue_two.id)]
+
+        activity = ActivityLog.objects.get(scope="ErrorTrackingIssue", activity="merged")
+        assert activity.item_id == str(issue_one.id)
+        assert activity.detail["changes"][0]["after"] == [str(issue_two.id)]
+
+    def test_issue_merge_without_effect_logs_no_activity(self):
+        issue = self.create_issue(fingerprints=["fingerprint_one"])
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/merge",
+                data={"ids": [issue.id]},
+            )
+
+        assert response.status_code == 200, response.json()
+        mock_produce.assert_not_called()
+        assert not ActivityLog.objects.filter(scope="ErrorTrackingIssue", activity="merged").exists()
+
+    def test_issue_split_logs_activity(self):
+        issue = self.create_issue(fingerprints=["fingerprint_one", "fingerprint_two"])
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/split",
+            data={"fingerprints": [{"fingerprint": "fingerprint_two", "name": "Split issue"}]},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.json()
+        activity = ActivityLog.objects.get(scope="ErrorTrackingIssue", activity="split")
+        assert activity.item_id == str(issue.id)
+        assert activity.detail["changes"][0]["after"] == response.json()["new_issue_ids"]
 
     def test_can_start_symbol_set_upload(self) -> None:
         chunk_id = uuid7()

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -524,9 +524,10 @@ class TestErrorTracking(APIBaseTest):
         assert event.distinct_id == str(issue.id)
         assert event.properties["status"] == status_prop
         assert event.properties["previous_status"] == previous_prop
-        # Destination templates deep-link issues from these two properties.
+        # Destination templates deep-link issues from the fingerprint; no
+        # exception_timestamp, so the issue scene falls back to the latest event.
         assert event.properties["fingerprint"] == "lifecycle_fingerprint"
-        assert event.properties["exception_timestamp"] is not None
+        assert "exception_timestamp" not in event.properties
         assert kwargs["person"].id == str(self.user.id)
 
     def test_issue_update_without_status_transition_produces_no_lifecycle_event(self):

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -588,9 +588,39 @@ class TestErrorTracking(APIBaseTest):
         assert event.properties["assignee"] == f'{{"type":"user","id":{self.user.id}}}'
         assert json.loads(event.properties["assignee"]) == {"type": "user", "id": self.user.id}
 
+    def test_issue_unassign_produces_lifecycle_internal_event(self):
+        issue = self.create_issue()
+        self.client.patch(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
+            data={"assignee": {"id": self.user.id, "type": "user"}},
+        )
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
+                data={"assignee": None},
+                format="json",
+            )
+
+        assert response.status_code == 200, response.json()
+        mock_produce.assert_called_once()
+        event = mock_produce.call_args.kwargs["event"]
+        assert event.event == "$error_tracking_issue_unassigned"
+        assert event.distinct_id == str(issue.id)
+        assert event.properties["previous_assignee"] == f'{{"type":"user","id":{self.user.id}}}'
+
     def test_issue_merge_produces_lifecycle_event_and_activity_log(self):
         issue_one = self.create_issue(fingerprints=["fingerprint_one"])
         issue_two = self.create_issue(fingerprints=["fingerprint_two"])
+        # The source's fingerprint is older, so after the merge it would sort first;
+        # the event must still carry one of the target's own pre-merge fingerprints,
+        # or a later split of the merged-in fingerprint retargets persisted links.
+        ErrorTrackingIssueFingerprintV2.objects.filter(issue=issue_two).update(
+            first_seen=timezone.now() - timedelta(days=1)
+        )
 
         with (
             patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
@@ -607,9 +637,11 @@ class TestErrorTracking(APIBaseTest):
         assert event.event == "$error_tracking_issue_merged"
         assert event.distinct_id == str(issue_one.id)
         assert event.properties["merged_issue_ids"] == [str(issue_two.id)]
+        assert event.properties["fingerprint"] == "fingerprint_one"
 
         activity = ActivityLog.objects.get(scope="ErrorTrackingIssue", activity="merged")
         assert activity.item_id == str(issue_one.id)
+        assert activity.detail is not None
         assert activity.detail["changes"][0]["after"] == [str(issue_two.id)]
 
     def test_issue_merge_without_effect_logs_no_activity(self):
@@ -628,18 +660,31 @@ class TestErrorTracking(APIBaseTest):
         mock_produce.assert_not_called()
         assert not ActivityLog.objects.filter(scope="ErrorTrackingIssue", activity="merged").exists()
 
-    def test_issue_split_logs_activity(self):
+    def test_issue_split_produces_lifecycle_event_and_activity_log(self):
         issue = self.create_issue(fingerprints=["fingerprint_one", "fingerprint_two"])
 
-        response = self.client.post(
-            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/split",
-            data={"fingerprints": [{"fingerprint": "fingerprint_two", "name": "Split issue"}]},
-            format="json",
-        )
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/split",
+                data={"fingerprints": [{"fingerprint": "fingerprint_two", "name": "Split issue"}]},
+                format="json",
+            )
 
         assert response.status_code == 200, response.json()
+        mock_produce.assert_called_once()
+        event = mock_produce.call_args.kwargs["event"]
+        assert event.event == "$error_tracking_issue_split"
+        assert event.distinct_id == str(issue.id)
+        assert event.properties["split_issue_ids"] == response.json()["new_issue_ids"]
+        # The remaining fingerprint stays the link anchor for the source issue.
+        assert event.properties["fingerprint"] == "fingerprint_one"
+
         activity = ActivityLog.objects.get(scope="ErrorTrackingIssue", activity="split")
         assert activity.item_id == str(issue.id)
+        assert activity.detail is not None
         assert activity.detail["changes"][0]["after"] == response.json()["new_issue_ids"]
 
     def test_can_start_symbol_set_upload(self) -> None:

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -504,7 +504,7 @@ class TestErrorTracking(APIBaseTest):
         self, initial_status, new_status, event_name, status_prop, previous_prop
     ):
         issue = self.create_issue(fingerprints=["lifecycle_fingerprint"])
-        ErrorTrackingIssue.objects.filter(id=issue.id).update(status=initial_status)
+        ErrorTrackingIssue.objects.filter(id=issue.id).update(status=initial_status, severity="critical")
 
         with (
             patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
@@ -524,11 +524,19 @@ class TestErrorTracking(APIBaseTest):
         assert event.distinct_id == str(issue.id)
         assert event.properties["status"] == status_prop
         assert event.properties["previous_status"] == previous_prop
+        # The issue-property set destination filters can reference, matching the
+        # ingestion-driven events.
+        assert event.properties["severity"] == "critical"
+        assert event.properties["issue_description"] == issue.description
+        assert event.properties["first_seen"] == issue.created_at.isoformat()
         # Destination templates deep-link issues from the fingerprint; no
         # exception_timestamp, so the issue scene falls back to the latest event.
         assert event.properties["fingerprint"] == "lifecycle_fingerprint"
         assert "exception_timestamp" not in event.properties
-        assert kwargs["person"].id == str(self.user.id)
+        person = kwargs["person"]
+        assert person.id == str(self.user.id)
+        # The person block reaches customer webhooks verbatim: minimal actor only.
+        assert set(person.properties.keys()) == {"id", "distinct_id", "email", "first_name"}
 
     def test_issue_update_without_status_transition_produces_no_lifecycle_event(self):
         issue = self.create_issue()

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -636,7 +636,8 @@ class TestErrorTracking(APIBaseTest):
         ):
             response = self.client.post(
                 f"/api/environments/{self.team.id}/error_tracking/issues/{issue_one.id}/merge",
-                data={"ids": [issue_two.id]},
+                # A ghost id and a duplicate must not be reported as merged.
+                data={"ids": [issue_two.id, str(uuid7()), issue_two.id]},
             )
 
         assert response.status_code == 200, response.json()
@@ -651,6 +652,47 @@ class TestErrorTracking(APIBaseTest):
         assert activity.item_id == str(issue_one.id)
         assert activity.detail is not None
         assert activity.detail["changes"][0]["after"] == [str(issue_two.id)]
+
+    def test_lifecycle_links_survive_merge_then_split_of_source_fingerprint(self):
+        issue_a = self.create_issue(fingerprints=["target_fingerprint"])
+        issue_b = self.create_issue(fingerprints=["source_fingerprint"])
+        # The source's fingerprint is older, so after the merge it is the
+        # longest-known fingerprint attached to the target.
+        ErrorTrackingIssueFingerprintV2.objects.filter(issue=issue_b).update(
+            first_seen=timezone.now() - timedelta(days=1)
+        )
+        merge = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue_a.id}/merge",
+            data={"ids": [issue_b.id]},
+        )
+        assert merge.status_code == 200, merge.json()
+
+        with (
+            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue_a.id}",
+                data={"status": "resolved"},
+            )
+        assert response.status_code == 200, response.json()
+        link_fingerprint = mock_produce.call_args.kwargs["event"].properties["fingerprint"]
+        assert link_fingerprint == "target_fingerprint"
+
+        # Splitting the merged-in fingerprint must not retarget the persisted link.
+        split = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue_a.id}/split",
+            data={"fingerprints": [{"fingerprint": "source_fingerprint", "name": "Split issue"}]},
+            format="json",
+        )
+        assert split.status_code == 200, split.json()
+
+        resolve = self.client.get(
+            f"/api/environments/{self.team.id}/error_tracking/fingerprints/resolve",
+            data={"fingerprint": link_fingerprint},
+        )
+        assert resolve.status_code == 200, resolve.json()
+        assert resolve.json()["issue_id"] == str(issue_a.id)
 
     def test_issue_merge_without_effect_logs_no_activity(self):
         issue = self.create_issue(fingerprints=["fingerprint_one"])

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -623,12 +623,6 @@ class TestErrorTracking(APIBaseTest):
     def test_issue_merge_produces_lifecycle_event_and_activity_log(self):
         issue_one = self.create_issue(fingerprints=["fingerprint_one"])
         issue_two = self.create_issue(fingerprints=["fingerprint_two"])
-        # The source's fingerprint is older, so after the merge it would sort first;
-        # the event must still carry one of the target's own pre-merge fingerprints,
-        # or a later split of the merged-in fingerprint retargets persisted links.
-        ErrorTrackingIssueFingerprintV2.objects.filter(issue=issue_two).update(
-            first_seen=timezone.now() - timedelta(days=1)
-        )
 
         with (
             patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
@@ -646,53 +640,11 @@ class TestErrorTracking(APIBaseTest):
         assert event.event == "$error_tracking_issue_merged"
         assert event.distinct_id == str(issue_one.id)
         assert event.properties["merged_issue_ids"] == [str(issue_two.id)]
-        assert event.properties["fingerprint"] == "fingerprint_one"
 
         activity = ActivityLog.objects.get(scope="ErrorTrackingIssue", activity="merged")
         assert activity.item_id == str(issue_one.id)
         assert activity.detail is not None
         assert activity.detail["changes"][0]["after"] == [str(issue_two.id)]
-
-    def test_lifecycle_links_survive_merge_then_split_of_source_fingerprint(self):
-        issue_a = self.create_issue(fingerprints=["target_fingerprint"])
-        issue_b = self.create_issue(fingerprints=["source_fingerprint"])
-        # The source's fingerprint is older, so after the merge it is the
-        # longest-known fingerprint attached to the target.
-        ErrorTrackingIssueFingerprintV2.objects.filter(issue=issue_b).update(
-            first_seen=timezone.now() - timedelta(days=1)
-        )
-        merge = self.client.post(
-            f"/api/environments/{self.team.id}/error_tracking/issues/{issue_a.id}/merge",
-            data={"ids": [issue_b.id]},
-        )
-        assert merge.status_code == 200, merge.json()
-
-        with (
-            patch("products.error_tracking.backend.logic.lifecycle_events.produce_internal_event") as mock_produce,
-            self.captureOnCommitCallbacks(execute=True),
-        ):
-            response = self.client.patch(
-                f"/api/environments/{self.team.id}/error_tracking/issues/{issue_a.id}",
-                data={"status": "resolved"},
-            )
-        assert response.status_code == 200, response.json()
-        link_fingerprint = mock_produce.call_args.kwargs["event"].properties["fingerprint"]
-        assert link_fingerprint == "target_fingerprint"
-
-        # Splitting the merged-in fingerprint must not retarget the persisted link.
-        split = self.client.post(
-            f"/api/environments/{self.team.id}/error_tracking/issues/{issue_a.id}/split",
-            data={"fingerprints": [{"fingerprint": "source_fingerprint", "name": "Split issue"}]},
-            format="json",
-        )
-        assert split.status_code == 200, split.json()
-
-        resolve = self.client.get(
-            f"/api/environments/{self.team.id}/error_tracking/fingerprints/resolve",
-            data={"fingerprint": link_fingerprint},
-        )
-        assert resolve.status_code == 200, resolve.json()
-        assert resolve.json()["issue_id"] == str(issue_a.id)
 
     def test_issue_merge_without_effect_logs_no_activity(self):
         issue = self.create_issue(fingerprints=["fingerprint_one"])
@@ -729,7 +681,7 @@ class TestErrorTracking(APIBaseTest):
         assert event.event == "$error_tracking_issue_split"
         assert event.distinct_id == str(issue.id)
         assert event.properties["split_issue_ids"] == response.json()["new_issue_ids"]
-        # The remaining fingerprint stays the link anchor for the source issue.
+        # The link fingerprint is one the source issue still owns after the split.
         assert event.properties["fingerprint"] == "fingerprint_one"
 
         activity = ActivityLog.objects.get(scope="ErrorTrackingIssue", activity="split")

--- a/products/error_tracking/frontend/components/ActivityDescriber.test.tsx
+++ b/products/error_tracking/frontend/components/ActivityDescriber.test.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react'
+
+import { ActivityChange, ActivityLogItem } from 'lib/components/ActivityLog/humanizeActivity'
+
+import { ActivityScope } from '~/types'
+
+import { ActivityDescriber } from './ActivityDescriber'
+
+const makeLogItem = (activity: string, change: Partial<ActivityChange>): ActivityLogItem => ({
+    user: { first_name: 'Ada', last_name: 'Lovelace', email: 'ada@example.com' },
+    activity,
+    created_at: '2026-06-04T00:00:00Z',
+    scope: ActivityScope.ERROR_TRACKING_ISSUE,
+    item_id: '018f0000-0000-0000-0000-000000000001',
+    detail: {
+        merge: null,
+        trigger: null,
+        name: 'TypeError',
+        changes: [
+            {
+                type: ActivityScope.ERROR_TRACKING_ISSUE,
+                action: 'changed',
+                ...change,
+            } as ActivityChange,
+        ],
+    },
+})
+
+const describedText = (item: ActivityLogItem): string => {
+    const { description } = ActivityDescriber(item)
+    if (!description) {
+        return ''
+    }
+    const { container } = render(description as JSX.Element)
+    return container.textContent || ''
+}
+
+describe('error tracking ActivityDescriber', () => {
+    it('describes merged rows instead of dropping them', () => {
+        const text = describedText(
+            makeLogItem('merged', {
+                action: 'merged',
+                field: 'merged_issue_ids',
+                after: ['018f0000-0000-0000-0000-000000000002', '018f0000-0000-0000-0000-000000000003'],
+            })
+        )
+        expect(text).toContain('merged 2 issues into')
+        expect(text).toContain('TypeError')
+    })
+
+    it('describes split rows instead of dropping them', () => {
+        const text = describedText(
+            makeLogItem('split', {
+                action: 'split',
+                field: 'split_issue_ids',
+                after: ['018f0000-0000-0000-0000-000000000002'],
+            })
+        )
+        expect(text).toContain('split')
+        expect(text).toContain('a new issue')
+    })
+})

--- a/products/error_tracking/frontend/components/ActivityDescriber.tsx
+++ b/products/error_tracking/frontend/components/ActivityDescriber.tsx
@@ -43,6 +43,13 @@ function AssigneeRenderer({ assignee }: { assignee: ErrorTrackingIssueAssignee }
     )
 }
 
+function relatedIssueIdsForLogItem(logItem: ActivityLogItem): string[] {
+    const change = (logItem.detail.changes || []).find(
+        (candidate) => candidate.field === 'merged_issue_ids' || candidate.field === 'split_issue_ids'
+    )
+    return Array.isArray(change?.after) ? change.after.map(String) : []
+}
+
 function nameAndLink(logItem?: ActivityLogItem): JSX.Element {
     const name = logItem?.detail.name
     return logItem?.item_id ? (
@@ -125,6 +132,40 @@ export function ActivityDescriber(logItem: ActivityLogItem, asNotification?: boo
     if (logItem.scope !== ActivityScope.ERROR_TRACKING_ISSUE) {
         console.error('describer received a non-error tracking activity')
         return { description: null }
+    }
+
+    if (logItem.activity == 'merged' || logItem.activity == 'split') {
+        const relatedIssueIds = relatedIssueIdsForLogItem(logItem)
+        const count = relatedIssueIds.length
+        return {
+            description: (
+                <SentenceList
+                    listParts={[
+                        logItem.activity == 'merged' ? (
+                            <>
+                                merged {count === 1 ? 'an issue' : `${count} issues`} into {nameAndLink(logItem)}
+                            </>
+                        ) : (
+                            <>
+                                split {nameAndLink(logItem)} into{' '}
+                                {count > 0 ? (
+                                    <SentenceList
+                                        listParts={relatedIssueIds.map((issueId, index) => (
+                                            <Link key={issueId} to={urls.errorTrackingIssue(issueId)}>
+                                                {count === 1 ? 'a new issue' : `new issue ${index + 1}`}
+                                            </Link>
+                                        ))}
+                                    />
+                                ) : (
+                                    'new issues'
+                                )}
+                            </>
+                        ),
+                    ]}
+                    prefix={<strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>}
+                />
+            ),
+        }
     }
 
     if (logItem.activity == 'updated' || logItem.activity == 'assigned') {


### PR DESCRIPTION
## Problem

Destinations subscribed to error tracking issue lifecycle events only hear about `created`, `reopened`, and `spiking` — the transitions cymbal detects during ingestion. When someone resolves, suppresses, assigns, or merges an issue in the app, nothing fires, so a Slack alert (or any other destination) never reports that an issue was handled.

This is the first layer of the native stateful alerting work ([RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1256)), but it is independently useful: existing hog-function destinations can subscribe to the new events today.

## Changes

- Manual issue mutations now emit internal lifecycle events: `$error_tracking_issue_resolved`, `$error_tracking_issue_suppressed`, `$error_tracking_issue_assigned`, `$error_tracking_issue_unassigned`, `$error_tracking_issue_merged`, `$error_tracking_issue_split`, and `$error_tracking_issue_reopened` on manual reactivation.
- The new events appear in the destination trigger dropdown and the event taxonomy, so users can build alerts on them.
- Events are wire-compatible with cymbal's ingestion-driven events: display-cased `status` values and byte-identical compact `assignee` JSON, so property filters match both paths.
- Events include one fingerprint currently attached to the issue for compatibility with existing Error Tracking destination templates. This is not a stable link to the issue that emitted the event: fingerprint URLs intentionally follow current ownership after merges and splits. The emitting issue ID is available as `event.distinct_id`; native alert messages link by issue ID.
- Merge and split now write activity log entries (`merged` / `split`), visible in the issue's activity feed.
- Events are produced via `transaction.on_commit`, and a produce failure never fails the mutation that triggered it.
- Mechanical: `merge_issues` / `split_issue` facade signatures gain `user` / `was_impersonated` for the activity logging.

## How did you test this code?

- API tests cover each transition: status updates (parameterized across resolve/suppress/reopen), bulk status updates (only actual transitions emit), assignment and unassignment (cymbal-compatible assignee serialization), merge (event reports only the ids the merge actually consumed; no-op merges emit nothing), and split (event + activity log).
- `products/error_tracking/backend/tests/api/test_error_tracking_api.py` passed locally; repo-wide mypy and ruff clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — taxonomy descriptions ship with the events.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Re-cut from the `cat/alerting-v2-poc` spike branch against current master; the bulk-update path was re-merged around master's `state_updated_at` batching and `_assign_one`'s no-op early-return so events only fire on real changes.
- Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-pr-descriptions, /stacking-prs.

