### PR TITLE
feat(mcp-store): add Calendly to the MCP server catalog

### DIFF
--- a/products/mcp_store/backend/catalog.py
+++ b/products/mcp_store/backend/catalog.py
@@ -61,6 +61,15 @@ MCP_SERVER_CATALOG: list[CatalogEntry] = [
         icon_domain="browserbase.com",
     ),
     CatalogEntry(
+        name="Calendly",
+        url="https://mcp.calendly.com",
+        description="Schedule meetings, manage availability, and share booking links.",
+        auth_type="oauth",
+        category="productivity",
+        icon_domain="calendly.com",
+        docs_url="https://developer.calendly.com/calendly-mcp-server",
+    ),
+    CatalogEntry(
         name="Circle",
         url="https://api.circle.com/v1/codegen/mcp",
         description="Build on Circle stablecoin, wallet, and payment infrastructure.",


### PR DESCRIPTION
## Problem

Anyone who wants Calendly in the MCP store has to add it as a custom server and find the endpoint URL themselves. The catalog has 39 servers and Calendly is not one of them.

Calendly supports Dynamic Client Registration, so a catalog entry needs no operator credential step. It activates on merge.

This was not addable until today. Our DCR request sent `client_name: "MCP Store (PostHog)"`, and Calendly rejects parentheses in that field, so the probe could not pass its activation gate. #90003 changed the name and unblocked this.

Refs #89998

## Changes

- The MCP store lists Calendly under Productivity, and connecting it runs the normal OAuth flow with no key to paste.
- The entry declares `auth_type="oauth"`, so each user mints their own client through DCR at install time.
- The server detail panel now shows a docs link for Calendly. This is the first catalog entry to set `docs_url`, a field that already existed and rendered.

Mechanical: one `CatalogEntry` in `catalog.py`, placed alphabetically between Browserbase and Circle. No other file changes.

## How did you test this code?

The probe passed against the real endpoint, on master with #90003 included:

<details>
<summary><code>python manage.py probe_mcp_server https://mcp.calendly.com</code></summary>

```json
{
  "reachable": true,
  "speaks_mcp": true,
  "auth_flavor": "oauth_dcr",
  "oauth_metadata": {
    "issuer": "https://calendly.com",
    "authorization_endpoint": "https://calendly.com/oauth/authorize",
    "token_endpoint": "https://calendly.com/oauth/token",
    "registration_endpoint": "https://calendly.com/oauth/register",
    "token_endpoint_auth_methods_supported": ["none"],
    "code_challenge_methods_supported": ["S256"],
    "resource": "https://mcp.calendly.com/",
    "resource_scopes_supported": ["mcp:scheduling:write", "mcp:scheduling:read"]
  },
  "dcr_registered": true,
  "authorize_endpoint_ok": true,
  "errors": [],
  "passed_activation_gate": true
}
```

</details>

`https://mcp.calendly.com/mcp` and `/sse` both return 404. The bare host is the endpoint, and Calendly's docs confirm it.

`test_catalog_entries_are_valid` passes. No test was added: that test already reads every catalog entry and checks the category, the auth type, the URL scheme, and the icon domain normalization, which is the whole surface a new entry can get wrong.

Not run: the 12 `TestSyncMCPCatalog` tests, because this sandbox has no Postgres. Each one passes its own `entries=[...]` fixture with a mocked probe, so a new catalog entry cannot reach them.

Not done: **Tier 2** verification. There is no Calendly account in this sandbox, so the OAuth consent screen, the token exchange, and the tool list are unverified. The probe covers everything up to consent.

Not verified: that logo.dev serves an icon for `calendly.com`. The PostHog icons endpoint rejects personal API keys, and `img.logo.dev` needs a publishable token. A miss degrades to a monogram rather than breaking the entry.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The catalog is not documented per server.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) after a Slack thread reported the OAuth error that turned out to be the `client_name` bug. That investigation produced #89998, then #90003. This PR is the follow-on that puts the server in the catalog now that the probe can pass.

Skills invoked: `/adding-mcp-store-servers` for the workflow and the entry shape, `/writing-pr-descriptions` for this body.

Two decisions worth flagging for review. The branch is `posthog/mcp-store/add-calendly` rather than the `mcp-store/`-prefixed name the skill asks for, because the signed-commit tooling in this environment requires a `posthog/` prefix. And `docs_url` is set even though no existing entry uses it, because the skill calls for it and the field already renders.

Public artifact: nothing here carries material from the agent session that is not already public. The probe output, the endpoint URL, and the auth model all come from Calendly's public docs and public endpoints.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1787825830415879?thread_ts=1787825830.415879&cid=C09SK2PAGKF)*
