### PR TITLE
perf(data-modeling): stop DESCRIBE from scanning subqueries

### DIFF
--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -71,8 +71,7 @@ MB_100_IN_BYTES = 100 * 1000 * 1000
 # The cluster profile sets distributed_product_mode=global, which makes ClickHouse build every
 # IN/JOIN subquery as a GLOBAL temporary table while it plans the query. DESCRIBE plans the query
 # too, so it scans the source tables for those subqueries just to return the column types. "allow"
-# leaves the subqueries in place, so the DESCRIBE reads nothing. The materialization query itself
-# keeps the profile mode, because "allow" would run each subquery once per shard at execution.
+# leaves the subqueries in place, so the DESCRIBE reads nothing.
 DESCRIBE_QUERY_SETTINGS = {"distributed_product_mode": "allow"}
 CLICKHOUSE_MAX_BLOCK_SIZE_ROWS = 50 * 1000
 DELTA_TABLE_RETENTION_HOURS = 24

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -20,6 +20,7 @@ from posthog.hogql.database.database import Database
 from posthog.hogql.errors import ParsingError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
+from posthog.hogql.visitor import CloningVisitor
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.exceptions_capture import capture_exception
@@ -68,11 +69,35 @@ LOGGER = get_logger(__name__)
 
 MB_100_IN_BYTES = 100 * 1000 * 1000
 
-# The cluster profile sets distributed_product_mode=global, which makes ClickHouse build every
-# IN/JOIN subquery as a GLOBAL temporary table while it plans the query. DESCRIBE plans the query
-# too, so it scans the source tables for those subqueries just to return the column types. "allow"
-# leaves the subqueries in place, so the DESCRIBE reads nothing.
+# ClickHouse builds every GLOBAL IN/JOIN subquery as a temporary table while it plans a query, and
+# DESCRIBE plans the query too, so the schema probe scans the source tables just to return column
+# types. The probe therefore prints a copy of the query with GLOBAL downgraded to plain IN/JOIN and
+# runs with "allow", which stops the cluster profile (distributed_product_mode=global) from adding
+# GLOBAL back. The materialization query itself is printed from the untouched AST.
 DESCRIBE_QUERY_SETTINGS = {"distributed_product_mode": "allow"}
+
+_LOCAL_COMPARE_OPS = {
+    ast.CompareOperationOp.GlobalIn: ast.CompareOperationOp.In,
+    ast.CompareOperationOp.GlobalNotIn: ast.CompareOperationOp.NotIn,
+}
+
+
+class _DowngradeGlobalSubqueries(CloningVisitor):
+    def __init__(self) -> None:
+        super().__init__(clear_types=False, clear_locations=False)
+
+    def visit_compare_operation(self, node: ast.CompareOperation) -> ast.CompareOperation:
+        cloned = super().visit_compare_operation(node)
+        cloned.op = _LOCAL_COMPARE_OPS.get(cloned.op, cloned.op)
+        return cloned
+
+    def visit_join_expr(self, node: ast.JoinExpr) -> ast.JoinExpr:
+        cloned = super().visit_join_expr(node)
+        if cloned.join_type is not None and cloned.join_type.startswith("GLOBAL "):
+            cloned.join_type = cloned.join_type.removeprefix("GLOBAL ")
+        return cloned
+
+
 CLICKHOUSE_MAX_BLOCK_SIZE_ROWS = 50 * 1000
 DELTA_TABLE_RETENTION_HOURS = 24
 
@@ -511,7 +536,7 @@ async def hogql_table(
         raise EmptyHogQLResponseColumnsError()
 
     printed = await database_sync_to_async_pool(print_prepared_ast)(
-        prepared_hogql_query,
+        _DowngradeGlobalSubqueries().visit(prepared_hogql_query),
         context=context,
         dialect="clickhouse",
         settings=settings,

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -72,11 +72,11 @@ MB_100_IN_BYTES = 100 * 1000 * 1000
 # ClickHouse builds every GLOBAL IN subquery as a temporary table while it plans a query, and
 # DESCRIBE plans the query too, so the schema probe scans the source tables just to return column
 # types. The probe therefore prints a copy of the query with GLOBAL IN downgraded to plain IN and
-# runs with "allow", which stops the cluster profile (distributed_product_mode=global) from adding
-# GLOBAL back. Joins keep their GLOBAL prefix: the resolver adds it to events-to-S3 join chains to
-# work around a ClickHouse bug, not for cost. The materialization query itself is printed from the
-# untouched AST.
-DESCRIBE_QUERY_SETTINGS = {"distributed_product_mode": "allow"}
+# runs with the two settings that would add GLOBAL back pinned off (the cluster profile sets
+# distributed_product_mode=global). Joins keep their GLOBAL prefix: the resolver adds it to
+# events-to-S3 join chains to work around a ClickHouse bug, not for cost. The materialization query
+# itself is printed from the untouched AST.
+DESCRIBE_QUERY_SETTINGS = {"distributed_product_mode": "allow", "prefer_global_in_and_join": "0"}
 
 _LOCAL_COMPARE_OPS = {
     ast.CompareOperationOp.GlobalIn: ast.CompareOperationOp.In,
@@ -92,6 +92,13 @@ class _DowngradeGlobalIn(CloningVisitor):
         cloned = super().visit_compare_operation(node)
         cloned.op = _LOCAL_COMPARE_OPS.get(cloned.op, cloned.op)
         return cloned
+
+
+def _print_describe_variant(
+    prepared_query: ast.SelectQuery | ast.SelectSetQuery, context: HogQLContext, settings: HogQLGlobalSettings
+) -> str:
+    downgraded = _DowngradeGlobalIn().visit(prepared_query)
+    return print_prepared_ast(downgraded, context=context, dialect="clickhouse", settings=settings, stack=[])
 
 
 CLICKHOUSE_MAX_BLOCK_SIZE_ROWS = 50 * 1000
@@ -531,13 +538,7 @@ async def hogql_table(
     if prepared_hogql_query is None:
         raise EmptyHogQLResponseColumnsError()
 
-    printed = await database_sync_to_async_pool(print_prepared_ast)(
-        _DowngradeGlobalIn().visit(prepared_hogql_query),
-        context=context,
-        dialect="clickhouse",
-        settings=settings,
-        stack=[],
-    )
+    printed = await database_sync_to_async_pool(_print_describe_variant)(prepared_hogql_query, context, settings)
 
     table_describe_query = f"DESCRIBE TABLE ({printed}) FORMAT TabSeparatedRaw"
     arrow_type_conversion: dict[str, tuple[str, tuple[ast.Constant, ...]]] = {

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -69,11 +69,13 @@ LOGGER = get_logger(__name__)
 
 MB_100_IN_BYTES = 100 * 1000 * 1000
 
-# ClickHouse builds every GLOBAL IN/JOIN subquery as a temporary table while it plans a query, and
+# ClickHouse builds every GLOBAL IN subquery as a temporary table while it plans a query, and
 # DESCRIBE plans the query too, so the schema probe scans the source tables just to return column
-# types. The probe therefore prints a copy of the query with GLOBAL downgraded to plain IN/JOIN and
+# types. The probe therefore prints a copy of the query with GLOBAL IN downgraded to plain IN and
 # runs with "allow", which stops the cluster profile (distributed_product_mode=global) from adding
-# GLOBAL back. The materialization query itself is printed from the untouched AST.
+# GLOBAL back. Joins keep their GLOBAL prefix: the resolver adds it to events-to-S3 join chains to
+# work around a ClickHouse bug, not for cost. The materialization query itself is printed from the
+# untouched AST.
 DESCRIBE_QUERY_SETTINGS = {"distributed_product_mode": "allow"}
 
 _LOCAL_COMPARE_OPS = {
@@ -82,19 +84,13 @@ _LOCAL_COMPARE_OPS = {
 }
 
 
-class _DowngradeGlobalSubqueries(CloningVisitor):
+class _DowngradeGlobalIn(CloningVisitor):
     def __init__(self) -> None:
         super().__init__(clear_types=False, clear_locations=False)
 
     def visit_compare_operation(self, node: ast.CompareOperation) -> ast.CompareOperation:
         cloned = super().visit_compare_operation(node)
         cloned.op = _LOCAL_COMPARE_OPS.get(cloned.op, cloned.op)
-        return cloned
-
-    def visit_join_expr(self, node: ast.JoinExpr) -> ast.JoinExpr:
-        cloned = super().visit_join_expr(node)
-        if cloned.join_type is not None and cloned.join_type.startswith("GLOBAL "):
-            cloned.join_type = cloned.join_type.removeprefix("GLOBAL ")
         return cloned
 
 
@@ -536,7 +532,7 @@ async def hogql_table(
         raise EmptyHogQLResponseColumnsError()
 
     printed = await database_sync_to_async_pool(print_prepared_ast)(
-        _DowngradeGlobalSubqueries().visit(prepared_hogql_query),
+        _DowngradeGlobalIn().visit(prepared_hogql_query),
         context=context,
         dialect="clickhouse",
         settings=settings,

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -67,6 +67,13 @@ from products.warehouse_sources.backend.facade.temporal import AccountPropertyRo
 LOGGER = get_logger(__name__)
 
 MB_100_IN_BYTES = 100 * 1000 * 1000
+
+# The cluster profile sets distributed_product_mode=global, which makes ClickHouse build every
+# IN/JOIN subquery as a GLOBAL temporary table while it plans the query. DESCRIBE plans the query
+# too, so it scans the source tables for those subqueries just to return the column types. "allow"
+# leaves the subqueries in place, so the DESCRIBE reads nothing. The materialization query itself
+# keeps the profile mode, because "allow" would run each subquery once per shard at execution.
+DESCRIBE_QUERY_SETTINGS = {"distributed_product_mode": "allow"}
 CLICKHOUSE_MAX_BLOCK_SIZE_ROWS = 50 * 1000
 DELTA_TABLE_RETENTION_HOURS = 24
 
@@ -540,7 +547,10 @@ async def hogql_table(
     query_typings: list[tuple[str, str, tuple[str, tuple[ast.Constant, ...]] | None]] = []
     async with _clickhouse_query_semaphore, get_clickhouse_client() as client:
         async with client.apost_query(
-            query=table_describe_query, query_parameters=context.values, query_id=str(uuid.uuid4())
+            query=table_describe_query,
+            query_parameters=context.values,
+            query_id=str(uuid.uuid4()),
+            settings=DESCRIBE_QUERY_SETTINGS,
         ) as ch_response:
             table_describe_response = await ch_response.content.read()
             for line in table_describe_response.decode("utf-8").splitlines():

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1,6 +1,6 @@
 import asyncio
 import contextlib
-from collections.abc import AsyncIterator, Collection, Iterable
+from collections.abc import AsyncIterator, Callable, Collection, Iterable
 from dataclasses import replace
 from io import BytesIO
 from typing import Any, cast
@@ -18,7 +18,7 @@ import pyarrow.parquet as pq
 
 from posthog.hogql.resolver import ResolverFactory
 
-from posthog.models import User
+from posthog.models import Team, User
 from posthog.sync import database_sync_to_async
 from posthog.temporal.data_modeling.activities import (
     CreateDataModelingJobInputs,
@@ -1647,7 +1647,14 @@ class _EmptyArrowClient:
         self.describe_query: str | None = None
         self.arrow_query: str | None = None
 
-    async def astream_query_as_arrow(self, query, *data, query_parameters=None, query_id=None, on_schema=None):
+    async def astream_query_as_arrow(
+        self,
+        query: str,
+        *data: Any,
+        query_parameters: dict[str, Any] | None = None,
+        query_id: str | None = None,
+        on_schema: Callable[[pa.Schema], None] | None = None,
+    ) -> AsyncIterator[pa.RecordBatch]:
         self.arrow_query_calls += 1
         self.arrow_query = query
         if on_schema is not None:
@@ -1656,7 +1663,14 @@ class _EmptyArrowClient:
         yield  # type: ignore[unreachable]  # makes this an async generator that yields no batches
 
     @contextlib.asynccontextmanager
-    async def apost_query(self, query, *data, query_parameters=None, query_id=None, settings=None):
+    async def apost_query(
+        self,
+        query: str,
+        *data: Any,
+        query_parameters: dict[str, Any] | None = None,
+        query_id: str | None = None,
+        settings: dict[str, str] | None = None,
+    ) -> AsyncIterator[Any]:
         if query.startswith("DESCRIBE TABLE"):
             self.describe_settings = settings
             self.describe_query = query
@@ -1699,13 +1713,13 @@ class TestHogqlTableEmptyResults:
 
 
 class TestHogqlTableDescribeSettings:
-    async def test_describe_probe_drops_global_subqueries(self, ateam):
+    async def test_describe_probe_drops_global_subqueries(self, ateam: Team) -> None:
         client = _EmptyArrowClient(pa.schema([pa.field("distinct_id", pa.string())]))
         client.describe_body = b"distinct_id\tString\n"
         query = "SELECT distinct_id FROM events WHERE distinct_id IN (SELECT distinct_id FROM events WHERE event = 'x')"
 
         @contextlib.asynccontextmanager
-        async def fake_get_client(**kwargs):
+        async def fake_get_client(**kwargs: Any) -> AsyncIterator[_EmptyArrowClient]:
             yield client
 
         with unittest.mock.patch(
@@ -1726,7 +1740,14 @@ class _SlowDescribeClient(_EmptyArrowClient):
         self.describe_seconds = describe_seconds
 
     @contextlib.asynccontextmanager
-    async def apost_query(self, query, *data, query_parameters=None, query_id=None, settings=None):
+    async def apost_query(
+        self,
+        query: str,
+        *data: Any,
+        query_parameters: dict[str, Any] | None = None,
+        query_id: str | None = None,
+        settings: dict[str, str] | None = None,
+    ) -> AsyncIterator[Any]:
         await asyncio.sleep(self.describe_seconds)
         async with super().apost_query(
             query, *data, query_parameters=query_parameters, query_id=query_id, settings=settings

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1713,10 +1713,19 @@ class TestHogqlTableEmptyResults:
 
 
 class TestHogqlTableDescribeSettings:
-    async def test_describe_probe_drops_global_subqueries(self, ateam: Team) -> None:
+    @pytest.mark.parametrize(
+        "operator,global_function",
+        [("IN", "globalIn("), ("NOT IN", "globalNotIn(")],
+    )
+    async def test_describe_probe_drops_global_subqueries(
+        self, ateam: Team, operator: str, global_function: str
+    ) -> None:
         client = _EmptyArrowClient(pa.schema([pa.field("distinct_id", pa.string())]))
         client.describe_body = b"distinct_id\tString\n"
-        query = "SELECT distinct_id FROM events WHERE distinct_id IN (SELECT distinct_id FROM events WHERE event = 'x')"
+        query = (
+            f"SELECT distinct_id FROM events WHERE distinct_id {operator} "
+            "(SELECT distinct_id FROM events WHERE event = 'x')"
+        )
 
         @contextlib.asynccontextmanager
         async def fake_get_client(**kwargs: Any) -> AsyncIterator[_EmptyArrowClient]:
@@ -1728,8 +1737,8 @@ class TestHogqlTableDescribeSettings:
             _ = [batch async for batch in hogql_table(query, ateam, LOGGER.bind())]
 
         assert client.describe_settings == {"distributed_product_mode": "allow", "prefer_global_in_and_join": "0"}
-        assert client.describe_query is not None and "globalIn(" not in client.describe_query
-        assert client.arrow_query is not None and "globalIn(" in client.arrow_query
+        assert client.describe_query is not None and global_function not in client.describe_query
+        assert client.arrow_query is not None and global_function in client.arrow_query
 
 
 class _SlowDescribeClient(_EmptyArrowClient):

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1644,9 +1644,12 @@ class _EmptyArrowClient:
         self.arrow_query_calls = 0
         self.schema_query_calls = 0
         self.describe_settings: dict[str, str] | None = None
+        self.describe_query: str | None = None
+        self.arrow_query: str | None = None
 
     async def astream_query_as_arrow(self, query, *data, query_parameters=None, query_id=None, on_schema=None):
         self.arrow_query_calls += 1
+        self.arrow_query = query
         if on_schema is not None:
             on_schema(self.schema)
         return
@@ -1656,6 +1659,7 @@ class _EmptyArrowClient:
     async def apost_query(self, query, *data, query_parameters=None, query_id=None, settings=None):
         if query.startswith("DESCRIBE TABLE"):
             self.describe_settings = settings
+            self.describe_query = query
             body = self.describe_body
         else:
             self.schema_query_calls += 1
@@ -1695,8 +1699,10 @@ class TestHogqlTableEmptyResults:
 
 
 class TestHogqlTableDescribeSettings:
-    async def test_describe_disables_the_global_subquery_rewrite(self, ateam):
-        client = _EmptyArrowClient(pa.schema([pa.field("id", pa.int64())]))
+    async def test_describe_probe_drops_global_subqueries(self, ateam):
+        client = _EmptyArrowClient(pa.schema([pa.field("distinct_id", pa.string())]))
+        client.describe_body = b"distinct_id\tString\n"
+        query = "SELECT distinct_id FROM events WHERE distinct_id IN (SELECT distinct_id FROM events WHERE event = 'x')"
 
         @contextlib.asynccontextmanager
         async def fake_get_client(**kwargs):
@@ -1705,9 +1711,11 @@ class TestHogqlTableDescribeSettings:
         with unittest.mock.patch(
             "posthog.temporal.data_modeling.activities.materialize_view.get_clickhouse_client", fake_get_client
         ):
-            _ = [batch async for batch in hogql_table("SELECT 1", ateam, LOGGER.bind())]
+            _ = [batch async for batch in hogql_table(query, ateam, LOGGER.bind())]
 
         assert client.describe_settings == {"distributed_product_mode": "allow"}
+        assert client.describe_query is not None and "globalIn(" not in client.describe_query
+        assert client.arrow_query is not None and "globalIn(" in client.arrow_query
 
 
 class _SlowDescribeClient(_EmptyArrowClient):

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime as dt
 import contextlib
 from collections.abc import AsyncIterator, Collection, Iterable
 from dataclasses import replace
@@ -14,11 +15,13 @@ from django.test import override_settings
 
 import pyarrow as pa
 import deltalake
+import pytest_asyncio
 import pyarrow.parquet as pq
 
 from posthog.hogql.resolver import ResolverFactory
 
 from posthog.models import User
+from posthog.models.event.sql import EVENTS_DATA_TABLE, EVENTS_JSON_DATA_TABLE
 from posthog.sync import database_sync_to_async
 from posthog.temporal.data_modeling.activities import (
     CreateDataModelingJobInputs,
@@ -42,6 +45,7 @@ from posthog.temporal.data_modeling.activities.materialize_view import (
     hogql_table,
 )
 from posthog.temporal.data_modeling.activities.notify_materialization_failure import _SavedQueryViewers
+from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse, truncate_table
 
 from products.customer_analytics.backend.facade.temporal_contracts import StageAccountPropertySyncInput
 from products.customer_analytics.backend.temporal.account_property_sync import (
@@ -1692,6 +1696,65 @@ class TestHogqlTableEmptyResults:
         assert batches[0][0].num_rows == 0
         assert client.arrow_query_calls == 1
         assert client.schema_query_calls == 0
+
+
+@pytest_asyncio.fixture
+async def pageview_events(clickhouse_client, ateam):
+    table = EVENTS_JSON_DATA_TABLE if settings.CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA else EVENTS_DATA_TABLE()
+    await truncate_table(clickhouse_client, table)
+    end_time = dt.datetime.now(dt.UTC)
+    events, _, _ = await generate_test_events_in_clickhouse(
+        clickhouse_client,
+        ateam.pk,
+        end_time - dt.timedelta(days=1),
+        end_time,
+        event_name="$pageview",
+        count=20,
+        count_outside_range=0,
+        distinct_ids=["a", "b"],
+        table=table,
+    )
+    return events
+
+
+class TestHogqlTableAgainstClickHouse:
+    async def test_subquery_view_keeps_its_types_and_rows(self, ateam, pageview_events):
+        query = """
+        select
+          distinct_id as distinct_id,
+          min(timestamp) as first_seen,
+          count() as pageviews,
+          any(uuid) as any_uuid
+        from events
+        where event = '$pageview'
+          and distinct_id in (select distinct distinct_id from events where event = '$pageview')
+        group by distinct_id
+        """
+
+        batches = [batch async for batch in hogql_table(query, ateam, LOGGER.bind())]
+
+        assert batches[0][1] == [
+            ("distinct_id", "String"),
+            ("first_seen", "DateTime64(6, 'UTC')"),
+            ("pageviews", "UInt64"),
+            ("any_uuid", "UUID"),
+        ]
+        table = pa.Table.from_batches([batch for batch, _ in batches])
+        assert pa.types.is_timestamp(table.schema.field("first_seen").type)
+        assert pa.types.is_string(table.schema.field("any_uuid").type)
+        rows = sorted(table.to_pylist(), key=lambda row: row["distinct_id"])
+        expected_first_seen = {
+            distinct_id: min(
+                dt.datetime.fromisoformat(event["timestamp"]).replace(tzinfo=dt.UTC)
+                for event in pageview_events
+                if event["distinct_id"] == distinct_id
+            )
+            for distinct_id in ("a", "b")
+        }
+        assert [(row["distinct_id"], row["pageviews"], row["first_seen"]) for row in rows] == [
+            ("a", 10, expected_first_seen["a"]),
+            ("b", 10, expected_first_seen["b"]),
+        ]
 
 
 class TestHogqlTableDescribeSettings:

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1643,6 +1643,7 @@ class _EmptyArrowClient:
         self.schema = schema
         self.arrow_query_calls = 0
         self.schema_query_calls = 0
+        self.describe_settings: dict[str, str] | None = None
 
     async def astream_query_as_arrow(self, query, *data, query_parameters=None, query_id=None, on_schema=None):
         self.arrow_query_calls += 1
@@ -1652,8 +1653,9 @@ class _EmptyArrowClient:
         yield  # type: ignore[unreachable]  # makes this an async generator that yields no batches
 
     @contextlib.asynccontextmanager
-    async def apost_query(self, query, *data, query_parameters=None, query_id=None):
+    async def apost_query(self, query, *data, query_parameters=None, query_id=None, settings=None):
         if query.startswith("DESCRIBE TABLE"):
+            self.describe_settings = settings
             body = self.describe_body
         else:
             self.schema_query_calls += 1
@@ -1692,6 +1694,22 @@ class TestHogqlTableEmptyResults:
         assert client.schema_query_calls == 0
 
 
+class TestHogqlTableDescribeSettings:
+    async def test_describe_disables_the_global_subquery_rewrite(self, ateam):
+        client = _EmptyArrowClient(pa.schema([pa.field("id", pa.int64())]))
+
+        @contextlib.asynccontextmanager
+        async def fake_get_client(**kwargs):
+            yield client
+
+        with unittest.mock.patch(
+            "posthog.temporal.data_modeling.activities.materialize_view.get_clickhouse_client", fake_get_client
+        ):
+            _ = [batch async for batch in hogql_table("SELECT 1", ateam, LOGGER.bind())]
+
+        assert client.describe_settings == {"distributed_product_mode": "allow"}
+
+
 class _SlowDescribeClient(_EmptyArrowClient):
     describe_body = b"ts\tDateTime\n"
 
@@ -1700,9 +1718,11 @@ class _SlowDescribeClient(_EmptyArrowClient):
         self.describe_seconds = describe_seconds
 
     @contextlib.asynccontextmanager
-    async def apost_query(self, query, *data, query_parameters=None, query_id=None):
+    async def apost_query(self, query, *data, query_parameters=None, query_id=None, settings=None):
         await asyncio.sleep(self.describe_seconds)
-        async with super().apost_query(query, *data, query_parameters=query_parameters, query_id=query_id) as response:
+        async with super().apost_query(
+            query, *data, query_parameters=query_parameters, query_id=query_id, settings=settings
+        ) as response:
             yield response
 
 

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime as dt
 import contextlib
 from collections.abc import AsyncIterator, Collection, Iterable
 from dataclasses import replace
@@ -15,13 +14,11 @@ from django.test import override_settings
 
 import pyarrow as pa
 import deltalake
-import pytest_asyncio
 import pyarrow.parquet as pq
 
 from posthog.hogql.resolver import ResolverFactory
 
 from posthog.models import User
-from posthog.models.event.sql import EVENTS_DATA_TABLE, EVENTS_JSON_DATA_TABLE
 from posthog.sync import database_sync_to_async
 from posthog.temporal.data_modeling.activities import (
     CreateDataModelingJobInputs,
@@ -45,7 +42,6 @@ from posthog.temporal.data_modeling.activities.materialize_view import (
     hogql_table,
 )
 from posthog.temporal.data_modeling.activities.notify_materialization_failure import _SavedQueryViewers
-from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse, truncate_table
 
 from products.customer_analytics.backend.facade.temporal_contracts import StageAccountPropertySyncInput
 from products.customer_analytics.backend.temporal.account_property_sync import (
@@ -1696,65 +1692,6 @@ class TestHogqlTableEmptyResults:
         assert batches[0][0].num_rows == 0
         assert client.arrow_query_calls == 1
         assert client.schema_query_calls == 0
-
-
-@pytest_asyncio.fixture
-async def pageview_events(clickhouse_client, ateam):
-    table = EVENTS_JSON_DATA_TABLE if settings.CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA else EVENTS_DATA_TABLE()
-    await truncate_table(clickhouse_client, table)
-    end_time = dt.datetime.now(dt.UTC)
-    events, _, _ = await generate_test_events_in_clickhouse(
-        clickhouse_client,
-        ateam.pk,
-        end_time - dt.timedelta(days=1),
-        end_time,
-        event_name="$pageview",
-        count=20,
-        count_outside_range=0,
-        distinct_ids=["a", "b"],
-        table=table,
-    )
-    return events
-
-
-class TestHogqlTableAgainstClickHouse:
-    async def test_subquery_view_keeps_its_types_and_rows(self, ateam, pageview_events):
-        query = """
-        select
-          distinct_id as distinct_id,
-          min(timestamp) as first_seen,
-          count() as pageviews,
-          any(uuid) as any_uuid
-        from events
-        where event = '$pageview'
-          and distinct_id in (select distinct distinct_id from events where event = '$pageview')
-        group by distinct_id
-        """
-
-        batches = [batch async for batch in hogql_table(query, ateam, LOGGER.bind())]
-
-        assert batches[0][1] == [
-            ("distinct_id", "String"),
-            ("first_seen", "DateTime64(6, 'UTC')"),
-            ("pageviews", "UInt64"),
-            ("any_uuid", "UUID"),
-        ]
-        table = pa.Table.from_batches([batch for batch, _ in batches])
-        assert pa.types.is_timestamp(table.schema.field("first_seen").type)
-        assert pa.types.is_string(table.schema.field("any_uuid").type)
-        rows = sorted(table.to_pylist(), key=lambda row: row["distinct_id"])
-        expected_first_seen = {
-            distinct_id: min(
-                dt.datetime.fromisoformat(event["timestamp"]).replace(tzinfo=dt.UTC)
-                for event in pageview_events
-                if event["distinct_id"] == distinct_id
-            )
-            for distinct_id in ("a", "b")
-        }
-        assert [(row["distinct_id"], row["pageviews"], row["first_seen"]) for row in rows] == [
-            ("a", 10, expected_first_seen["a"]),
-            ("b", 10, expected_first_seen["b"]),
-        ]
 
 
 class TestHogqlTableDescribeSettings:

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1713,7 +1713,7 @@ class TestHogqlTableDescribeSettings:
         ):
             _ = [batch async for batch in hogql_table(query, ateam, LOGGER.bind())]
 
-        assert client.describe_settings == {"distributed_product_mode": "allow"}
+        assert client.describe_settings == {"distributed_product_mode": "allow", "prefer_global_in_and_join": "0"}
         assert client.describe_query is not None and "globalIn(" not in client.describe_query
         assert client.arrow_query is not None and "globalIn(" in client.arrow_query
 


### PR DESCRIPTION
## Problem

Every data modeling run first runs `DESCRIBE TABLE (<compiled view sql>)` to learn the output column types, then runs the real query. Our ClickHouse profile sets `distributed_product_mode=global`, so ClickHouse turns every IN/JOIN subquery into a GLOBAL temp table while it plans the query. 

DESCRIBE plans the query too, so the probe scans the source tables for those subqueries just to return a header. For a view that filters with `session_id IN (SELECT ... FROM events ...)` the DESCRIBE reads about half the bytes of the materialization itself, on every scheduled run.

In US, ~10% of bytes read by data modeling is from DESCRIBE (~1PB/day). Last 30d:

<img width="1007" height="539" alt="Screenshot 2026-08-27 at 5 55 31 PM" src="https://github.com/user-attachments/assets/a8bc7b27-bc96-4395-9ad8-0b639bd812df" />


https://us.posthog.com/project/2/insights/E7VJHol3

## Changes

- The DESCRIBE now prints a copy of the compiled query with `GLOBAL IN` downgraded to plain `IN`, and runs with `distributed_product_mode=allow` and `prefer_global_in_and_join=0`. Planning then reads nothing and the same column types come back.
- Both parts are needed. HogQL already prints IN-subqueries over events as `globalIn(`, which the settings alone don't touch, and without the settings the profile would add GLOBAL back onto the plain form. Joins keep their GLOBAL prefix since the resolver adds it to events-to-S3 join chains as a ClickHouse bug workaround, and no prod DESCRIBE bytes come from that shape.
- The materialization query is printed from the untouched AST under the profile mode, so results don't change.
- No user-visible change: same views, same output, the probe still runs but reads nothing.

Local benchmark (ClickHouse 26.6.2, 3M synthetic events, a 2-shard Distributed table, `distributed_product_mode=global`). Every variant returned the same schema.

| Variant | rows read | bytes | time |
|---|---|---|---|
| Full materialization query | 12.1M | 10.2 GB | 4.0 s |
| DESCRIBE with `globalIn(`, current | 6.0M | 4.9 GB | 1.2 s |
| DESCRIBE with `globalIn(` + `allow` only | 6.0M | 4.9 GB | 1.2 s |
| DESCRIBE downgraded to `in(` + `allow` | 0 | 0 | 7 ms |

JOIN subqueries and CTEs joined by name go to 0 bytes the same way. Scalar subqueries (`WHERE ts >= (SELECT max(ts) ...)`) still get evaluated during planning with either mode, those are under 1% of DESCRIBE bytes in prod. `LIMIT 0`, `WHERE 0` and `EXPLAIN` all read the full set too, so they don't work as a replacement.

## How did you test this code?

- test_describe_probe_drops_global_subqueries: fails if the DESCRIBE text still contains `globalIn(`, if either probe setting is missing, or if the downgrade leaks into the streaming query.
- Not run: the workflow against a real multi-shard cluster, the benchmark above ran the raw statements against local ClickHouse.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

Autonomy: Human-driven (agent-assisted)

Claude Code (Fable 5), session https://claude.ai/code/session_01WTsADuE5yJPEswD8WRiMLMH. Skills invoked: /querying-clickhouse-via-metabase, /writing-tests, /writing-code-comments, /writing-pr-descriptions, /qa-team. Started from a read-bytes breakdown of the data modeling workflow in prod query logs, then reproduced the DESCRIBE cost locally and compared settings before picking `allow`. A row cap on the DESCRIBE (`max_rows_to_read=1, read_overflow_mode=break`) also covered scalar subqueries but needed a fallback path, so it was left out. A /qa-team review found the first version only handled ClickHouse's implicit GLOBAL rewrite, which is about half of prod DESCRIBE bytes; the AST downgrade for the explicit `globalIn(` that HogQL prints was added after that.



