### PR TITLE
fix(ingestion): parse the timestamp header as epoch milliseconds

### DIFF
--- a/nodejs/src/ingestion/common/steps/event-preprocessing/validate-historical-migration.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/validate-historical-migration.test.ts
@@ -5,29 +5,28 @@ import { EventHeaders } from '~/types'
 import { createValidateHistoricalMigrationStep } from './validate-historical-migration'
 
 const HOUR_MS = 60 * 60 * 1000
+const NOW = new Date('2023-01-15T12:00:00Z')
+
+// Capture sends `timestamp` as epoch milliseconds in a decimal string, so fixtures
+// that use an ISO date exercise a format the step never receives.
+const asHeaderTimestamp = (offsetMs: number): string => (NOW.getTime() + offsetMs).toString()
 
 describe('createValidateHistoricalMigrationStep', () => {
     let headers: EventHeaders
     let step: ReturnType<typeof createValidateHistoricalMigrationStep>
 
     beforeEach(() => {
-        headers = createTestEventHeaders({
-            now: new Date('2023-01-15T12:00:00Z'),
-        })
-
+        headers = createTestEventHeaders({ now: NOW })
         step = createValidateHistoricalMigrationStep()
         jest.clearAllMocks()
     })
 
-    describe('when historical_migration header is false', () => {
-        it('should return headers with historical_migration as false', async () => {
-            headers.historical_migration = false
-            const input = { headers }
+    it('should force historical_migration to false when the header is false', async () => {
+        headers.historical_migration = false
 
-            const result = await step(input)
+        const result = await step({ headers })
 
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: false } }))
-        })
+        expect(result).toEqual(ok({ headers: { ...headers, historical_migration: false } }))
     })
 
     describe('when historical_migration header is true', () => {
@@ -35,100 +34,36 @@ describe('createValidateHistoricalMigrationStep', () => {
             headers.historical_migration = true
         })
 
-        it('should return headers with historical_migration as true when no timestamp header is set', async () => {
-            const input = { headers }
+        it.each([
+            { age: '24 hours old', offsetMs: -24 * HOUR_MS, expected: false },
+            { age: '1 hour in the future', offsetMs: HOUR_MS, expected: false },
+            { age: 'exactly 48 hours old', offsetMs: -48 * HOUR_MS, expected: true },
+            { age: '49 hours old', offsetMs: -49 * HOUR_MS, expected: true },
+            { age: '7 days old', offsetMs: -7 * 24 * HOUR_MS, expected: true },
+        ])('should resolve historical_migration to $expected for an event $age', async ({ offsetMs, expected }) => {
+            headers.timestamp = asHeaderTimestamp(offsetMs)
 
-            const result = await step(input)
+            const result = await step({ headers })
+
+            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: expected } }))
+        })
+
+        // Keeping the flag when the age is unknown is the safe direction: an event the sender
+        // declared historical stays on the historical lane instead of joining live traffic.
+        it.each([
+            { scenario: 'no timestamp header', patch: {} },
+            { scenario: 'a non-numeric timestamp header', patch: { timestamp: 'invalid-timestamp' } },
+            { scenario: 'no now header', patch: { timestamp: asHeaderTimestamp(0), now: undefined } },
+            {
+                scenario: 'an unparseable now header',
+                patch: { timestamp: asHeaderTimestamp(0), now: new Date('invalid-date') },
+            },
+        ])('should keep historical_migration as true with $scenario', async ({ patch }) => {
+            Object.assign(headers, patch)
+
+            const result = await step({ headers })
 
             expect(result).toEqual(ok({ headers: { ...headers, historical_migration: true } }))
-        })
-
-        it('should return headers with historical_migration as false when timestamp is within 48 hours (recent event)', async () => {
-            const now = new Date('2023-01-15T12:00:00Z')
-            headers.now = now
-            headers.timestamp = new Date(now.getTime() - 24 * HOUR_MS).toISOString()
-
-            const input = { headers }
-            const result = await step(input)
-
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: false } }))
-        })
-
-        it('should return headers with historical_migration as true when timestamp is exactly 48 hours old', async () => {
-            const now = new Date('2023-01-15T12:00:00Z')
-            headers.now = now
-            headers.timestamp = new Date(now.getTime() - 48 * HOUR_MS).toISOString()
-
-            const input = { headers }
-            const result = await step(input)
-
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: true } }))
-        })
-
-        it('should return headers with historical_migration as true when timestamp is older than 48 hours (historical event)', async () => {
-            const now = new Date('2023-01-15T12:00:00Z')
-            headers.now = now
-            headers.timestamp = new Date(now.getTime() - 49 * HOUR_MS).toISOString()
-
-            const input = { headers }
-            const result = await step(input)
-
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: true } }))
-        })
-
-        it('should return headers with historical_migration as true when timestamp is much older than 48 hours (historical event)', async () => {
-            const now = new Date('2023-01-15T12:00:00Z')
-            headers.now = now
-            headers.timestamp = new Date(now.getTime() - 7 * 24 * HOUR_MS).toISOString()
-
-            const input = { headers }
-            const result = await step(input)
-
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: true } }))
-        })
-
-        it('should return headers with historical_migration as true when header timestamp is invalid', async () => {
-            headers.timestamp = 'invalid-timestamp'
-
-            const input = { headers }
-            const result = await step(input)
-
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: true } }))
-        })
-
-        it('should return headers with historical_migration as true when headers.now is undefined', async () => {
-            // Note: headers.now can only be undefined or a valid Date - the kafka header parser
-            // only sets headers.now when the date parses successfully
-            headers.now = undefined
-            headers.timestamp = '2023-01-15T12:00:00Z'
-
-            const input = { headers }
-            const result = await step(input)
-
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: true } }))
-        })
-
-        it('should return headers with historical_migration as true when headers.now is an invalid Date', async () => {
-            // Defensive test - in practice the kafka header parser won't produce invalid Dates,
-            // but we should handle them gracefully if they somehow occur
-            headers.now = new Date('invalid-date')
-            headers.timestamp = '2023-01-15T12:00:00Z'
-
-            const input = { headers }
-            const result = await step(input)
-
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: true } }))
-        })
-
-        it('should return headers with historical_migration as false when timestamp is in the future', async () => {
-            const now = new Date('2023-01-15T12:00:00Z')
-            headers.now = now
-            headers.timestamp = new Date(now.getTime() + 1 * HOUR_MS).toISOString()
-
-            const input = { headers }
-            const result = await step(input)
-
-            expect(result).toEqual(ok({ headers: { ...headers, historical_migration: false } }))
         })
     })
 })

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/validate-historical-migration.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/validate-historical-migration.ts
@@ -18,8 +18,8 @@ function validateHistoricalMigrationHeader(headers: EventHeaders): EventHeaders 
         return headers
     }
 
-    // Parse the timestamp header
-    const headerTimestampMs = Date.parse(headers.timestamp)
+    // The timestamp header is epoch milliseconds in a decimal string, not an ISO date.
+    const headerTimestampMs = Number(headers.timestamp)
     const nowMs = headers.now.getTime()
 
     // If either timestamp is invalid, accept the flag as-is (let other validation handle it)

--- a/nodejs/src/ingestion/ingestion-consumer.serial.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.serial.test.ts
@@ -807,7 +807,7 @@ describe('IngestionConsumer', () => {
                     headers: [
                         { token: Buffer.from(team.api_token) },
                         { distinct_id: Buffer.from('user-old-event') },
-                        { timestamp: Buffer.from(oldEventTime.toISO()!) }, // Event time (when it actually happened)
+                        { timestamp: Buffer.from(oldEventTime.toMillis().toString()) }, // Event time as epoch ms, matching capture
                         { now: Buffer.from(ingestionTime.toISO()!) }, // Ingestion time (when we received it)
                         { historical_migration: Buffer.from('true') },
                     ],
@@ -817,7 +817,7 @@ describe('IngestionConsumer', () => {
                     headers: [
                         { token: Buffer.from(team.api_token) },
                         { distinct_id: Buffer.from('user-recent-event') },
-                        { timestamp: Buffer.from(recentEventTime.toISO()!) }, // Event time (when it actually happened)
+                        { timestamp: Buffer.from(recentEventTime.toMillis().toString()) }, // Event time as epoch ms, matching capture
                         { now: Buffer.from(ingestionTime.toISO()!) }, // Ingestion time (when we received it)
                         { historical_migration: Buffer.from('true') },
                     ],

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -868,6 +868,10 @@ export interface EventHeaders {
     token?: string
     distinct_id?: string
     session_id?: string
+    /**
+     * Epoch milliseconds in a decimal string, already clock-skew corrected by capture.
+     * Parse it as a number. `Date.parse` returns NaN for this format.
+     */
     timestamp?: string
     event?: string
     uuid?: string


### PR DESCRIPTION
## Problem

Events sent with `historical_migration: true` keep the flag even when they are minutes old, so the `historical_migration` column in ClickHouse marks live traffic as backfill.

- Capture writes the `timestamp` Kafka header as epoch milliseconds in a decimal string, for example `1673784000000`.
- The step parsed that header with `Date.parse`, which returns NaN for the format.
- The step then took its "cannot determine age" branch and returned the headers unchanged, so the 48-hour age check never ran.

## Changes

- A recent event that declares `historical_migration: true` now has the flag cleared, so the stored column reflects the event's real age.
- The step parses the header as a number, matching the sibling `drop-old-events-step`, which already read it as epoch milliseconds.
- `EventHeaders.timestamp` now documents the format. The two readers of this header disagreed because the type declared only `string`.

Nothing user-visible changes in the app, and there is no UI to screenshot. The flag is written per event row and read by backfill tooling.

## How did you test this code?

The fixtures in `validate-historical-migration.test.ts` used ISO 8601 strings, so they exercised a format the step never receives and passed against the broken parse. Rebuilding them around epoch milliseconds is what makes the file catch this bug.

Two of the rebuilt cases fail against the old `Date.parse` and pass after the change: a 24-hour-old event and an event timestamped one hour in the future. Both expect the flag cleared, and both kept it before.

The five age cases and the four fail-open cases are now `test.each` rows, which removes nine copy-pasted bodies.

<details>
<summary>Cases failing before the change</summary>

```
● should resolve historical_migration to false for an event 24 hours old
● should resolve historical_migration to false for an event 1 hour in the future

    - "historical_migration": false,
    + "historical_migration": true,

Tests: 2 failed, 8 passed, 10 total
```

</details>

Not run: `process-personless-step.test.ts`, which needs Redis that this sandbox does not have, and the ClickHouse-backed and consumer integration suites. Repository typecheck does not pass here because `@posthog/hogvm` and `@posthog/replay-anonymizer` are unbuilt, which predates this change and touches none of these files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 4.5) while investigating a support report about a historical migration where events did not appear. This bug is not the cause of that report, and the investigation continues separately; the dead age check surfaced while tracing the `historical_migration` path from capture through to ClickHouse.

Skills invoked: `/resolving-ingestion-warnings`, `/writing-tests`, `/writing-pr-descriptions`.

The fix stays at one line rather than extracting a shared header parser. A shared helper would prevent the two readers diverging again, but it widens the diff in an ingestion hot path. Documenting the contract on the type puts the format in front of the next reader at the definition site for the same benefit.

The reporting project's data was never read, and no material from the support report reaches this diff.
