### PR TITLE
fix(dashboards): use internal project for customization flag

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -674,24 +674,34 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             Dashboard.objects.get(id=copied_id).customization, {"show_legend": False, "tile_spacing": "wide"}
         )
 
-    @patch(
-        "products.dashboards.backend.feature_flags.get_flags_from_service",
-        return_value={"flags": {"dashboard-customization": {"enabled": True}}},
-    )
+    @patch("products.dashboards.backend.feature_flags.get_flags_from_service")
     def test_dashboard_customization_uses_remote_flag_evaluation(self, mock_get_flags: MagicMock) -> None:
-        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        internal_rollout_token = "phc_internal_rollout_project"
 
-        _, updated = self.dashboard_api.update_dashboard(
-            dashboard_id,
-            {"grid_spacing": "condensed", "layout_compaction": "horizontal"},
-        )
+        def flag_result(token: str, *_args: object, **_kwargs: object) -> dict[str, dict[str, dict[str, bool]]]:
+            if token == internal_rollout_token:
+                return {"flags": {"dashboard-customization": {"enabled": True}}}
+            return {"flags": {}}
 
+        mock_get_flags.side_effect = flag_result
+
+        with patch("products.dashboards.backend.feature_flags.posthoganalytics.api_key", internal_rollout_token):
+            dashboard_id, created = self.dashboard_api.create_dashboard(
+                {"name": "dashboard", "grid_spacing": "condensed"}
+            )
+
+            _, updated = self.dashboard_api.update_dashboard(
+                dashboard_id,
+                {"layout_compaction": "horizontal"},
+            )
+
+        self.assertEqual(created["customization"], {"tile_spacing": "condensed"})
         self.assertEqual(
             updated["customization"],
             {"tile_spacing": "condensed", "layout_compaction": "horizontal"},
         )
         expected_flag_call = call(
-            self.team.api_token,
+            internal_rollout_token,
             self.user.distinct_id,
             groups={"organization": str(self.team.organization_id), "project": str(self.team.id)},
             flag_keys=["dashboard-customization"],

--- a/products/dashboards/backend/feature_flags.py
+++ b/products/dashboards/backend/feature_flags.py
@@ -43,13 +43,17 @@ def _remote_flag_enabled(flag: str, *, team: Team, user: User | None = None) -> 
     if flag in _FORCE_ENABLED_FLAGS:
         return True
 
+    internal_project_api_key = posthoganalytics.api_key
+    if not internal_project_api_key:
+        return False
+
     distinct_id = (user.distinct_id or str(user.uuid)) if user is not None else str(team.uuid)
     organization_id = str(team.organization_id)
     project_id = str(team.id)
 
     try:
         result = get_flags_from_service(
-            team.api_token,
+            internal_project_api_key,
             distinct_id,
             groups={"organization": organization_id, "project": project_id},
             flag_keys=[flag],


### PR DESCRIPTION
## Problem

Dashboard users cannot save tile density or layout compaction settings. The customization rollout flag lives in PostHog's internal project, but it was being evaluated against the customer's own project, where it does not exist, so the save was rejected.

Closes #90271

## Changes

- Dashboard users can now save customization settings when the internal rollout includes their user and groups.
- Remote cohort evaluation uses the internal project key while still passing the customer organization and project as groups, so cohort membership semantics are unchanged.
- Missing internal keys and remote errors stay fail-closed. Dashboard permissions are untouched.
- A local flag lookup was considered and rejected because it would lose cohort membership.

## How did you test this code?

A focused regression test covers the case where only the internal project enables the flag. It returns 400 before the change and 201 after. An adjacent test covers the remote-error path staying fail-closed. Targeted mypy, Ruff check, Ruff format, and preflight were run locally.

No manual testing in a browser was performed, and no frontend behavior changed beyond the settings save succeeding.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code under direction from @samvallad33, who reviewed the change and is the DRI. No repo-provided skills were invoked. The main decision during the session was choosing remote evaluation against the internal project key over a local flag lookup, since the local path drops group context and would silently change who is in the cohort. Nothing in this PR draws on customer conversations, tickets, or logs.
