### PR TITLE
feat(insights): track behavioral filter configuration

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.test.ts
@@ -1,16 +1,9 @@
-import { fireEvent, render } from '@testing-library/react'
-import { Provider } from 'kea'
-import posthog from 'posthog-js'
-import { createElement } from 'react'
-
 import {
-    BehavioralPropertyFilterRow,
     withBehavioralCount,
     withBehavioralEventFilters,
     withBehavioralNegation,
 } from 'lib/components/PropertyFilters/components/BehavioralPropertyFilterRow'
 
-import { initKeaTests } from '~/test/init'
 import {
     BehavioralEventType,
     BehavioralPropertyFilter,
@@ -19,49 +12,6 @@ import {
     PropertyOperator,
     TimeUnitType,
 } from '~/types'
-
-jest.mock('@posthog/lemon-ui', () => {
-    const React = jest.requireActual('react')
-
-    return {
-        ...jest.requireActual('@posthog/lemon-ui'),
-        LemonInput: ({ onChange, value, ...props }: any): JSX.Element =>
-            React.createElement('input', {
-                ...props,
-                value,
-                onChange: (event: { target: { value: string } }) => onChange(Number(event.target.value)),
-            }),
-        LemonSelect: ({ onChange, options, value, ...props }: any): JSX.Element =>
-            React.createElement(
-                'select',
-                {
-                    ...props,
-                    value: String(value),
-                    onChange: (event: { target: { value: string } }) =>
-                        onChange(options.find((option: any) => String(option.value) === event.target.value)?.value),
-                },
-                options.map((option: any) =>
-                    React.createElement(
-                        'option',
-                        { key: String(option.value), value: String(option.value) },
-                        option.label
-                    )
-                )
-            ),
-    }
-})
-
-jest.mock('lib/components/TaxonomicPopover/TaxonomicPopover', () => {
-    const React = jest.requireActual('react')
-
-    return {
-        TaxonomicPopover: ({ onChange, 'data-attr': dataAttr }: any): JSX.Element =>
-            React.createElement('button', {
-                'data-attr': dataAttr,
-                onClick: () => onChange(42, 'actions'),
-            }),
-    }
-})
 
 describe('BehavioralPropertyFilterRow value mapping', () => {
     const sourceIsWeb: EventPropertyFilter = {
@@ -83,11 +33,6 @@ describe('BehavioralPropertyFilterRow value mapping', () => {
         time_interval: TimeUnitType.Day,
         event_filters: [sourceIsWeb],
     }
-
-    beforeEach(() => {
-        initKeaTests()
-        jest.clearAllMocks()
-    })
 
     test.each<[string, PropertyOperator, number, Partial<BehavioralPropertyFilter>]>([
         [
@@ -149,61 +94,5 @@ describe('BehavioralPropertyFilterRow value mapping', () => {
 
     it('drops event_filters entirely when the last nested filter is removed', () => {
         expect(withBehavioralEventFilters(counted, [])).toEqual({ ...counted, event_filters: undefined })
-    })
-
-    it('captures each behavioral filter setting change without the selected event name', () => {
-        const { container } = render(
-            createElement(
-                Provider,
-                null,
-                createElement(BehavioralPropertyFilterRow, {
-                    filter: { ...counted, event_filters: undefined },
-                    onChange: jest.fn(),
-                    editable: true,
-                    pageKey: 'test',
-                })
-            )
-        )
-
-        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-negation"]')!, {
-            target: { value: 'true' },
-        })
-        fireEvent.click(container.querySelector('[data-attr="behavioral-filter-event"]')!)
-        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-count-operator"]')!, {
-            target: { value: PropertyOperator.LessThanOrEqual },
-        })
-        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-count-value"]')!, {
-            target: { value: '4' },
-        })
-        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-time-value"]')!, {
-            target: { value: '7' },
-        })
-        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-time-interval"]')!, {
-            target: { value: TimeUnitType.Week },
-        })
-
-        expect(posthog.capture).toHaveBeenCalledTimes(6)
-        expect(posthog.capture).toHaveBeenNthCalledWith(1, 'behavioral filter behavior changed', {
-            behavior: 'did_not_perform',
-        })
-        expect(posthog.capture).toHaveBeenNthCalledWith(2, 'behavioral filter event or action changed', {
-            event_type: 'actions',
-        })
-        expect(posthog.capture).toHaveBeenNthCalledWith(3, 'behavioral filter count changed', {
-            operator: PropertyOperator.LessThanOrEqual,
-            operator_value: 3,
-        })
-        expect(posthog.capture).toHaveBeenNthCalledWith(4, 'behavioral filter count changed', {
-            operator: PropertyOperator.GreaterThanOrEqual,
-            operator_value: 4,
-        })
-        expect(posthog.capture).toHaveBeenNthCalledWith(5, 'behavioral filter time period changed', {
-            time_value: 7,
-            time_interval: TimeUnitType.Day,
-        })
-        expect(posthog.capture).toHaveBeenNthCalledWith(6, 'behavioral filter time period changed', {
-            time_value: 30,
-            time_interval: TimeUnitType.Week,
-        })
     })
 })

--- a/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.test.ts
@@ -1,9 +1,16 @@
+import { fireEvent, render } from '@testing-library/react'
+import { Provider } from 'kea'
+import posthog from 'posthog-js'
+import { createElement } from 'react'
+
 import {
+    BehavioralPropertyFilterRow,
     withBehavioralCount,
     withBehavioralEventFilters,
     withBehavioralNegation,
 } from 'lib/components/PropertyFilters/components/BehavioralPropertyFilterRow'
 
+import { initKeaTests } from '~/test/init'
 import {
     BehavioralEventType,
     BehavioralPropertyFilter,
@@ -12,6 +19,49 @@ import {
     PropertyOperator,
     TimeUnitType,
 } from '~/types'
+
+jest.mock('@posthog/lemon-ui', () => {
+    const React = jest.requireActual('react')
+
+    return {
+        ...jest.requireActual('@posthog/lemon-ui'),
+        LemonInput: ({ onChange, value, ...props }: any): JSX.Element =>
+            React.createElement('input', {
+                ...props,
+                value,
+                onChange: (event: { target: { value: string } }) => onChange(Number(event.target.value)),
+            }),
+        LemonSelect: ({ onChange, options, value, ...props }: any): JSX.Element =>
+            React.createElement(
+                'select',
+                {
+                    ...props,
+                    value: String(value),
+                    onChange: (event: { target: { value: string } }) =>
+                        onChange(options.find((option: any) => String(option.value) === event.target.value)?.value),
+                },
+                options.map((option: any) =>
+                    React.createElement(
+                        'option',
+                        { key: String(option.value), value: String(option.value) },
+                        option.label
+                    )
+                )
+            ),
+    }
+})
+
+jest.mock('lib/components/TaxonomicPopover/TaxonomicPopover', () => {
+    const React = jest.requireActual('react')
+
+    return {
+        TaxonomicPopover: ({ onChange, 'data-attr': dataAttr }: any): JSX.Element =>
+            React.createElement('button', {
+                'data-attr': dataAttr,
+                onClick: () => onChange(42, 'actions'),
+            }),
+    }
+})
 
 describe('BehavioralPropertyFilterRow value mapping', () => {
     const sourceIsWeb: EventPropertyFilter = {
@@ -33,6 +83,11 @@ describe('BehavioralPropertyFilterRow value mapping', () => {
         time_interval: TimeUnitType.Day,
         event_filters: [sourceIsWeb],
     }
+
+    beforeEach(() => {
+        initKeaTests()
+        jest.clearAllMocks()
+    })
 
     test.each<[string, PropertyOperator, number, Partial<BehavioralPropertyFilter>]>([
         [
@@ -94,5 +149,61 @@ describe('BehavioralPropertyFilterRow value mapping', () => {
 
     it('drops event_filters entirely when the last nested filter is removed', () => {
         expect(withBehavioralEventFilters(counted, [])).toEqual({ ...counted, event_filters: undefined })
+    })
+
+    it('captures each behavioral filter setting change without the selected event name', () => {
+        const { container } = render(
+            createElement(
+                Provider,
+                null,
+                createElement(BehavioralPropertyFilterRow, {
+                    filter: { ...counted, event_filters: undefined },
+                    onChange: jest.fn(),
+                    editable: true,
+                    pageKey: 'test',
+                })
+            )
+        )
+
+        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-negation"]')!, {
+            target: { value: 'true' },
+        })
+        fireEvent.click(container.querySelector('[data-attr="behavioral-filter-event"]')!)
+        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-count-operator"]')!, {
+            target: { value: PropertyOperator.LessThanOrEqual },
+        })
+        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-count-value"]')!, {
+            target: { value: '4' },
+        })
+        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-time-value"]')!, {
+            target: { value: '7' },
+        })
+        fireEvent.change(container.querySelector('[data-attr="behavioral-filter-time-interval"]')!, {
+            target: { value: TimeUnitType.Week },
+        })
+
+        expect(posthog.capture).toHaveBeenCalledTimes(6)
+        expect(posthog.capture).toHaveBeenNthCalledWith(1, 'behavioral filter behavior changed', {
+            behavior: 'did_not_perform',
+        })
+        expect(posthog.capture).toHaveBeenNthCalledWith(2, 'behavioral filter event or action changed', {
+            event_type: 'actions',
+        })
+        expect(posthog.capture).toHaveBeenNthCalledWith(3, 'behavioral filter count changed', {
+            operator: PropertyOperator.LessThanOrEqual,
+            operator_value: 3,
+        })
+        expect(posthog.capture).toHaveBeenNthCalledWith(4, 'behavioral filter count changed', {
+            operator: PropertyOperator.GreaterThanOrEqual,
+            operator_value: 4,
+        })
+        expect(posthog.capture).toHaveBeenNthCalledWith(5, 'behavioral filter time period changed', {
+            time_value: 7,
+            time_interval: TimeUnitType.Day,
+        })
+        expect(posthog.capture).toHaveBeenNthCalledWith(6, 'behavioral filter time period changed', {
+            time_value: 30,
+            time_interval: TimeUnitType.Week,
+        })
     })
 })

--- a/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.tsx
@@ -134,7 +134,9 @@ export function BehavioralPropertyFilterRow({
                         size={size}
                         value={!!filter.negation}
                         onChange={(negation) => {
-                            posthog.capture('behavioral filter behavior changed', { negation })
+                            posthog.capture('behavioral filter behavior changed', {
+                                behavior: negation ? 'did_not_perform' : 'performed',
+                            })
                             onChange(withBehavioralNegation(filter, negation))
                         }}
                         options={[

--- a/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/BehavioralPropertyFilterRow.tsx
@@ -1,4 +1,5 @@
 import { useValues } from 'kea'
+import posthog from 'posthog-js'
 import { useState } from 'react'
 
 import { IconFilter } from '@posthog/icons'
@@ -121,6 +122,7 @@ export function BehavioralPropertyFilterRow({
     const countValue = filter.operator_value ?? 1
 
     const setCount = (operator: PropertyOperator, operatorValue: number): void => {
+        posthog.capture('behavioral filter count changed', { operator, operator_value: operatorValue })
         onChange(withBehavioralCount(filter, operator, operatorValue))
     }
 
@@ -131,7 +133,10 @@ export function BehavioralPropertyFilterRow({
                     <LemonSelect
                         size={size}
                         value={!!filter.negation}
-                        onChange={(negation) => onChange(withBehavioralNegation(filter, negation))}
+                        onChange={(negation) => {
+                            posthog.capture('behavioral filter behavior changed', { negation })
+                            onChange(withBehavioralNegation(filter, negation))
+                        }}
                         options={[
                             { value: false, label: 'Performed' },
                             { value: true, label: 'Did not perform' },
@@ -149,14 +154,14 @@ export function BehavioralPropertyFilterRow({
                                 }
                                 groupTypes={[TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]}
                                 value={filter.event_type === 'actions' ? Number(filter.key) : filter.key}
-                                onChange={(value, groupType) =>
-                                    onChange({
-                                        ...filter,
-                                        key: String(value),
-                                        event_type:
-                                            groupType === TaxonomicFilterGroupType.Actions ? 'actions' : 'events',
+                                onChange={(value, groupType) => {
+                                    const eventType =
+                                        groupType === TaxonomicFilterGroupType.Actions ? 'actions' : 'events'
+                                    posthog.capture('behavioral filter event or action changed', {
+                                        event_type: eventType,
                                     })
-                                }
+                                    onChange({ ...filter, key: String(value), event_type: eventType })
+                                }}
                                 renderValue={() => <span>{behavioralEntityLabel(filter, actionsById)}</span>}
                                 placeholder="Select an event or action"
                                 fullWidth
@@ -219,13 +224,26 @@ export function BehavioralPropertyFilterRow({
                         min={1}
                         className="w-14"
                         value={filter.time_value ?? 30}
-                        onChange={(timeValue) => onChange({ ...filter, time_value: positiveOr(timeValue, 30) })}
+                        onChange={(timeValue) => {
+                            const nextTimeValue = positiveOr(timeValue, 30)
+                            posthog.capture('behavioral filter time period changed', {
+                                time_value: nextTimeValue,
+                                time_interval: filter.time_interval ?? TimeUnitType.Day,
+                            })
+                            onChange({ ...filter, time_value: nextTimeValue })
+                        }}
                         data-attr="behavioral-filter-time-value"
                     />
                     <LemonSelect
                         size={size}
                         value={filter.time_interval ?? TimeUnitType.Day}
-                        onChange={(timeInterval) => onChange({ ...filter, time_interval: timeInterval })}
+                        onChange={(timeInterval) => {
+                            posthog.capture('behavioral filter time period changed', {
+                                time_value: filter.time_value ?? 30,
+                                time_interval: timeInterval,
+                            })
+                            onChange({ ...filter, time_interval: timeInterval })
+                        }}
                         options={TIME_INTERVAL_OPTIONS}
                         data-attr="behavioral-filter-time-interval"
                     />

--- a/frontend/src/lib/utils/eventUsageLogic.test.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.test.ts
@@ -6,12 +6,13 @@ import type {
     ExperimentRatioMetric,
     ExperimentRetentionMetric,
     ExperimentTrendsQuery,
+    Node,
 } from '~/queries/schema/schema-general'
-import { BaseMathType } from '~/types'
+import { BaseMathType, BehavioralEventType, FilterLogicalOperator, PropertyFilterType } from '~/types'
 
-import { getEventPropertiesForMetric } from './eventUsageLogic'
+import { getEventPropertiesForMetric, sanitizeQuery } from './eventUsageLogic'
 
-describe('getEventPropertiesForMetric', () => {
+describe('eventUsageLogic', () => {
     describe('ExperimentMetric (new format)', () => {
         it('extracts funnel metric properties', () => {
             const metric: ExperimentFunnelMetric = {
@@ -207,6 +208,49 @@ describe('getEventPropertiesForMetric', () => {
 
             expect(result.funnel_steps_count).toBe(0)
             expect(result.property_filter_count).toBe(0)
+        })
+    })
+
+    describe('sanitizeQuery', () => {
+        it('counts behavioral filters across global and series filters', () => {
+            const query = {
+                kind: NodeKind.InsightVizNode,
+                source: {
+                    kind: NodeKind.TrendsQuery,
+                    series: [
+                        {
+                            kind: NodeKind.EventsNode,
+                            event: '$pageview',
+                            properties: [
+                                {
+                                    type: PropertyFilterType.Behavioral,
+                                    key: 'signed up',
+                                    value: BehavioralEventType.PerformEvent,
+                                    event_type: 'events',
+                                },
+                            ],
+                        },
+                    ],
+                    properties: {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            {
+                                type: FilterLogicalOperator.And,
+                                values: [
+                                    {
+                                        type: PropertyFilterType.Behavioral,
+                                        key: 'completed onboarding',
+                                        value: BehavioralEventType.PerformEvent,
+                                        event_type: 'events',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            } as unknown as Node
+
+            expect(sanitizeQuery(query).behavioral_filter_count).toBe(2)
         })
     })
 

--- a/frontend/src/lib/utils/eventUsageLogic.test.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.test.ts
@@ -8,7 +8,14 @@ import type {
     ExperimentTrendsQuery,
     Node,
 } from '~/queries/schema/schema-general'
-import { BaseMathType, BehavioralEventType, FilterLogicalOperator, PropertyFilterType } from '~/types'
+import {
+    BaseMathType,
+    BehavioralEventType,
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    TimeUnitType,
+} from '~/types'
 
 import { getEventPropertiesForMetric, sanitizeQuery } from './eventUsageLogic'
 
@@ -225,8 +232,12 @@ describe('eventUsageLogic', () => {
                                 {
                                     type: PropertyFilterType.Behavioral,
                                     key: 'signed up',
-                                    value: BehavioralEventType.PerformEvent,
-                                    event_type: 'events',
+                                    value: BehavioralEventType.PerformMultipleEvents,
+                                    event_type: 'actions',
+                                    operator: PropertyOperator.GreaterThanOrEqual,
+                                    operator_value: 3,
+                                    time_value: 7,
+                                    time_interval: TimeUnitType.Week,
                                 },
                             ],
                         },
@@ -242,6 +253,7 @@ describe('eventUsageLogic', () => {
                                         key: 'completed onboarding',
                                         value: BehavioralEventType.PerformEvent,
                                         event_type: 'events',
+                                        negation: true,
                                     },
                                 ],
                             },
@@ -250,7 +262,13 @@ describe('eventUsageLogic', () => {
                 },
             } as unknown as Node
 
-            expect(sanitizeQuery(query).behavioral_filter_count).toBe(2)
+            expect(sanitizeQuery(query)).toMatchObject({
+                behavioral_filter_count: 2,
+                has_negated_behavioral_filter: true,
+                has_custom_behavioral_filter_count: true,
+                has_custom_behavioral_filter_time: true,
+                has_action_behavioral_filter: true,
+            })
         })
     })
 

--- a/frontend/src/lib/utils/eventUsageLogic.test.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.test.ts
@@ -8,14 +8,7 @@ import type {
     ExperimentTrendsQuery,
     Node,
 } from '~/queries/schema/schema-general'
-import {
-    BaseMathType,
-    BehavioralEventType,
-    FilterLogicalOperator,
-    PropertyFilterType,
-    PropertyOperator,
-    TimeUnitType,
-} from '~/types'
+import { BaseMathType, BehavioralEventType, FilterLogicalOperator, PropertyFilterType } from '~/types'
 
 import { getEventPropertiesForMetric, sanitizeQuery } from './eventUsageLogic'
 
@@ -232,12 +225,8 @@ describe('eventUsageLogic', () => {
                                 {
                                     type: PropertyFilterType.Behavioral,
                                     key: 'signed up',
-                                    value: BehavioralEventType.PerformMultipleEvents,
-                                    event_type: 'actions',
-                                    operator: PropertyOperator.GreaterThanOrEqual,
-                                    operator_value: 3,
-                                    time_value: 7,
-                                    time_interval: TimeUnitType.Week,
+                                    value: BehavioralEventType.PerformEvent,
+                                    event_type: 'events',
                                 },
                             ],
                         },
@@ -253,7 +242,6 @@ describe('eventUsageLogic', () => {
                                         key: 'completed onboarding',
                                         value: BehavioralEventType.PerformEvent,
                                         event_type: 'events',
-                                        negation: true,
                                     },
                                 ],
                             },
@@ -262,13 +250,7 @@ describe('eventUsageLogic', () => {
                 },
             } as unknown as Node
 
-            expect(sanitizeQuery(query)).toMatchObject({
-                behavioral_filter_count: 2,
-                has_negated_behavioral_filter: true,
-                has_custom_behavioral_filter_count: true,
-                has_custom_behavioral_filter_time: true,
-                has_action_behavioral_filter: true,
-            })
+            expect(sanitizeQuery(query).behavioral_filter_count).toBe(2)
         })
     })
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -389,8 +389,23 @@ function sanitizeDashboard(dashboard: DashboardType<QueryBasedInsightModel> | nu
     }
 }
 
+function countBehavioralFilters(value: unknown): number {
+    if (Array.isArray(value)) {
+        return value.reduce((count, item) => count + countBehavioralFilters(item), 0)
+    }
+    if (!value || typeof value !== 'object') {
+        return 0
+    }
+
+    const record = value as Record<string, unknown>
+    return (
+        Number(record.type === PropertyFilterType.Behavioral) +
+        Object.values(record).reduce<number>((count, item) => count + countBehavioralFilters(item), 0)
+    )
+}
+
 /** Takes a query and returns an object with "useful" properties that don't contain sensitive data. */
-function sanitizeQuery(query: Node | null): Record<string, string | number | boolean | undefined> {
+export function sanitizeQuery(query: Node | null): Record<string, string | number | boolean | undefined> {
     const payload: Record<string, string | number | boolean | undefined> = {
         query_kind: query?.kind,
         query_source_kind: isNodeWithSource(query) ? query.source.kind : undefined,
@@ -418,6 +433,7 @@ function sanitizeQuery(query: Node | null): Record<string, string | number | boo
 
         // properties
         payload.has_properties = !!properties
+        payload.behavioral_filter_count = countBehavioralFilters(querySource)
         payload.filter_test_accounts = filterTestAccounts
 
         // breakdown

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -50,7 +50,6 @@ import {
 } from '~/queries/utils'
 import { PROPERTY_KEYS } from '~/taxonomy/taxonomy'
 import {
-    BehavioralEventType,
     ChartDisplayType,
     CohortType,
     DashboardTileSpacing,
@@ -78,7 +77,6 @@ import {
     type SDK,
     Survey,
     SurveyQuestionType,
-    TimeUnitType,
 } from '~/types'
 
 import type { ExperimentMetricUnion } from '../../queries/schema/schema-general'
@@ -391,19 +389,19 @@ function sanitizeDashboard(dashboard: DashboardType<QueryBasedInsightModel> | nu
     }
 }
 
-function findBehavioralFilters(value: unknown): Record<string, unknown>[] {
+function countBehavioralFilters(value: unknown): number {
     if (Array.isArray(value)) {
-        return value.flatMap(findBehavioralFilters)
+        return value.reduce((count, item) => count + countBehavioralFilters(item), 0)
     }
     if (!value || typeof value !== 'object') {
-        return []
+        return 0
     }
 
     const record = value as Record<string, unknown>
-    return [
-        ...(record.type === PropertyFilterType.Behavioral ? [record] : []),
-        ...Object.values(record).flatMap(findBehavioralFilters),
-    ]
+    return (
+        Number(record.type === PropertyFilterType.Behavioral) +
+        Object.values(record).reduce<number>((count, item) => count + countBehavioralFilters(item), 0)
+    )
 }
 
 /** Takes a query and returns an object with "useful" properties that don't contain sensitive data. */
@@ -434,20 +432,8 @@ export function sanitizeQuery(query: Node | null): Record<string, string | numbe
         payload.data_warehouse_entity_count = getSeries(querySource)?.filter((e) => isAnyDataWarehouseNode(e)).length
 
         // properties
-        const behavioralFilters = findBehavioralFilters(querySource)
         payload.has_properties = !!properties
-        payload.behavioral_filter_count = behavioralFilters.length
-        payload.has_negated_behavioral_filter = behavioralFilters.some((filter) => filter.negation === true)
-        payload.has_custom_behavioral_filter_count = behavioralFilters.some(
-            (filter) => filter.value === BehavioralEventType.PerformMultipleEvents
-        )
-        payload.has_custom_behavioral_filter_time = behavioralFilters.some(
-            (filter) =>
-                !!filter.explicit_datetime ||
-                (filter.time_value != null && filter.time_value !== 30) ||
-                (filter.time_interval != null && filter.time_interval !== TimeUnitType.Day)
-        )
-        payload.has_action_behavioral_filter = behavioralFilters.some((filter) => filter.event_type === 'actions')
+        payload.behavioral_filter_count = countBehavioralFilters(querySource)
         payload.filter_test_accounts = filterTestAccounts
 
         // breakdown

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -50,6 +50,7 @@ import {
 } from '~/queries/utils'
 import { PROPERTY_KEYS } from '~/taxonomy/taxonomy'
 import {
+    BehavioralEventType,
     ChartDisplayType,
     CohortType,
     DashboardTileSpacing,
@@ -77,6 +78,7 @@ import {
     type SDK,
     Survey,
     SurveyQuestionType,
+    TimeUnitType,
 } from '~/types'
 
 import type { ExperimentMetricUnion } from '../../queries/schema/schema-general'
@@ -389,19 +391,19 @@ function sanitizeDashboard(dashboard: DashboardType<QueryBasedInsightModel> | nu
     }
 }
 
-function countBehavioralFilters(value: unknown): number {
+function findBehavioralFilters(value: unknown): Record<string, unknown>[] {
     if (Array.isArray(value)) {
-        return value.reduce((count, item) => count + countBehavioralFilters(item), 0)
+        return value.flatMap(findBehavioralFilters)
     }
     if (!value || typeof value !== 'object') {
-        return 0
+        return []
     }
 
     const record = value as Record<string, unknown>
-    return (
-        Number(record.type === PropertyFilterType.Behavioral) +
-        Object.values(record).reduce<number>((count, item) => count + countBehavioralFilters(item), 0)
-    )
+    return [
+        ...(record.type === PropertyFilterType.Behavioral ? [record] : []),
+        ...Object.values(record).flatMap(findBehavioralFilters),
+    ]
 }
 
 /** Takes a query and returns an object with "useful" properties that don't contain sensitive data. */
@@ -432,8 +434,20 @@ export function sanitizeQuery(query: Node | null): Record<string, string | numbe
         payload.data_warehouse_entity_count = getSeries(querySource)?.filter((e) => isAnyDataWarehouseNode(e)).length
 
         // properties
+        const behavioralFilters = findBehavioralFilters(querySource)
         payload.has_properties = !!properties
-        payload.behavioral_filter_count = countBehavioralFilters(querySource)
+        payload.behavioral_filter_count = behavioralFilters.length
+        payload.has_negated_behavioral_filter = behavioralFilters.some((filter) => filter.negation === true)
+        payload.has_custom_behavioral_filter_count = behavioralFilters.some(
+            (filter) => filter.value === BehavioralEventType.PerformMultipleEvents
+        )
+        payload.has_custom_behavioral_filter_time = behavioralFilters.some(
+            (filter) =>
+                !!filter.explicit_datetime ||
+                (filter.time_value != null && filter.time_value !== 30) ||
+                (filter.time_interval != null && filter.time_interval !== TimeUnitType.Day)
+        )
+        payload.has_action_behavioral_filter = behavioralFilters.some((filter) => filter.event_type === 'actions')
         payload.filter_test_accounts = filterTestAccounts
 
         // breakdown

--- a/products/product_analytics/backend/models/insight.py
+++ b/products/product_analytics/backend/models/insight.py
@@ -37,6 +37,14 @@ _ANALYTICS_INSIGHT_QUERY_KINDS = frozenset(
 )
 
 
+def _count_behavioral_filters(value: object) -> int:
+    if isinstance(value, list):
+        return sum(_count_behavioral_filters(item) for item in value)
+    if not isinstance(value, dict):
+        return 0
+    return int(value.get("type") == "behavioral") + sum(_count_behavioral_filters(item) for item in value.values())
+
+
 if TYPE_CHECKING:
     from posthog.schema import NodeKind
 
@@ -219,6 +227,7 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
                 1 for s in series if isinstance(s, dict) and s.get("kind") == "DataWarehouseNode"
             )
         metadata["has_properties"] = bool(source.get("properties"))
+        metadata["behavioral_filter_count"] = _count_behavioral_filters(source)
         if "filterTestAccounts" in source:
             metadata["filter_test_accounts"] = source.get("filterTestAccounts")
         breakdown_filter = source.get("breakdownFilter")

--- a/products/product_analytics/backend/models/insight.py
+++ b/products/product_analytics/backend/models/insight.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional
 
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
@@ -37,16 +37,12 @@ _ANALYTICS_INSIGHT_QUERY_KINDS = frozenset(
 )
 
 
-def _find_behavioral_filters(value: object) -> list[dict[str, object]]:
+def _count_behavioral_filters(value: object) -> int:
     if isinstance(value, list):
-        return [match for item in value for match in _find_behavioral_filters(item)]
+        return sum(_count_behavioral_filters(item) for item in value)
     if not isinstance(value, dict):
-        return []
-
-    record = cast(dict[str, object], value)
-    return ([record] if record.get("type") == "behavioral" else []) + [
-        match for item in record.values() for match in _find_behavioral_filters(item)
-    ]
+        return 0
+    return int(value.get("type") == "behavioral") + sum(_count_behavioral_filters(item) for item in value.values())
 
 
 if TYPE_CHECKING:
@@ -230,24 +226,8 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
             metadata["data_warehouse_entity_count"] = sum(
                 1 for s in series if isinstance(s, dict) and s.get("kind") == "DataWarehouseNode"
             )
-        behavioral_filters = _find_behavioral_filters(source)
         metadata["has_properties"] = bool(source.get("properties"))
-        metadata["behavioral_filter_count"] = len(behavioral_filters)
-        metadata["has_negated_behavioral_filter"] = any(
-            behavioral_filter.get("negation") is True for behavioral_filter in behavioral_filters
-        )
-        metadata["has_custom_behavioral_filter_count"] = any(
-            behavioral_filter.get("value") == "performed_event_multiple" for behavioral_filter in behavioral_filters
-        )
-        metadata["has_custom_behavioral_filter_time"] = any(
-            behavioral_filter.get("explicit_datetime") is not None
-            or behavioral_filter.get("time_value") not in (None, 30)
-            or behavioral_filter.get("time_interval") not in (None, "day")
-            for behavioral_filter in behavioral_filters
-        )
-        metadata["has_action_behavioral_filter"] = any(
-            behavioral_filter.get("event_type") == "actions" for behavioral_filter in behavioral_filters
-        )
+        metadata["behavioral_filter_count"] = _count_behavioral_filters(source)
         if "filterTestAccounts" in source:
             metadata["filter_test_accounts"] = source.get("filterTestAccounts")
         breakdown_filter = source.get("breakdownFilter")

--- a/products/product_analytics/backend/models/insight.py
+++ b/products/product_analytics/backend/models/insight.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
@@ -37,12 +37,16 @@ _ANALYTICS_INSIGHT_QUERY_KINDS = frozenset(
 )
 
 
-def _count_behavioral_filters(value: object) -> int:
+def _find_behavioral_filters(value: object) -> list[dict[str, object]]:
     if isinstance(value, list):
-        return sum(_count_behavioral_filters(item) for item in value)
+        return [match for item in value for match in _find_behavioral_filters(item)]
     if not isinstance(value, dict):
-        return 0
-    return int(value.get("type") == "behavioral") + sum(_count_behavioral_filters(item) for item in value.values())
+        return []
+
+    record = cast(dict[str, object], value)
+    return ([record] if record.get("type") == "behavioral" else []) + [
+        match for item in record.values() for match in _find_behavioral_filters(item)
+    ]
 
 
 if TYPE_CHECKING:
@@ -226,8 +230,24 @@ class Insight(RootTeamMixin, FileSystemSyncMixin, models.Model):
             metadata["data_warehouse_entity_count"] = sum(
                 1 for s in series if isinstance(s, dict) and s.get("kind") == "DataWarehouseNode"
             )
+        behavioral_filters = _find_behavioral_filters(source)
         metadata["has_properties"] = bool(source.get("properties"))
-        metadata["behavioral_filter_count"] = _count_behavioral_filters(source)
+        metadata["behavioral_filter_count"] = len(behavioral_filters)
+        metadata["has_negated_behavioral_filter"] = any(
+            behavioral_filter.get("negation") is True for behavioral_filter in behavioral_filters
+        )
+        metadata["has_custom_behavioral_filter_count"] = any(
+            behavioral_filter.get("value") == "performed_event_multiple" for behavioral_filter in behavioral_filters
+        )
+        metadata["has_custom_behavioral_filter_time"] = any(
+            behavioral_filter.get("explicit_datetime") is not None
+            or behavioral_filter.get("time_value") not in (None, 30)
+            or behavioral_filter.get("time_interval") not in (None, "day")
+            for behavioral_filter in behavioral_filters
+        )
+        metadata["has_action_behavioral_filter"] = any(
+            behavioral_filter.get("event_type") == "actions" for behavioral_filter in behavioral_filters
+        )
         if "filterTestAccounts" in source:
             metadata["filter_test_accounts"] = source.get("filterTestAccounts")
         breakdown_filter = source.get("breakdownFilter")

--- a/products/product_analytics/backend/models/test/test_insight_model.py
+++ b/products/product_analytics/backend/models/test/test_insight_model.py
@@ -321,9 +321,36 @@ class TestInsightModel(BaseTest):
                 "source": {
                     "kind": "TrendsQuery",
                     "series": [
-                        {"kind": "EventsNode", "event": "$pageview"},
+                        {
+                            "kind": "EventsNode",
+                            "event": "$pageview",
+                            "properties": [
+                                {
+                                    "type": "behavioral",
+                                    "key": "signed up",
+                                    "value": "performed_event",
+                                    "event_type": "events",
+                                }
+                            ],
+                        },
                         {"kind": "ActionsNode", "id": 1},
                     ],
+                    "properties": {
+                        "type": "AND",
+                        "values": [
+                            {
+                                "type": "AND",
+                                "values": [
+                                    {
+                                        "type": "behavioral",
+                                        "key": "completed onboarding",
+                                        "value": "performed_event",
+                                        "event_type": "events",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
                     "dateRange": {"date_from": "-7d"},
                     "filterTestAccounts": True,
                     "breakdownFilter": {"breakdown_type": "event"},
@@ -336,7 +363,8 @@ class TestInsightModel(BaseTest):
             "event_entity_count": 1,
             "action_entity_count": 1,
             "data_warehouse_entity_count": 0,
-            "has_properties": False,
+            "has_properties": True,
+            "behavioral_filter_count": 2,
             "filter_test_accounts": True,
             "breakdown_type": "event",
             "has_formula": True,

--- a/products/product_analytics/backend/models/test/test_insight_model.py
+++ b/products/product_analytics/backend/models/test/test_insight_model.py
@@ -328,8 +328,12 @@ class TestInsightModel(BaseTest):
                                 {
                                     "type": "behavioral",
                                     "key": "signed up",
-                                    "value": "performed_event",
-                                    "event_type": "events",
+                                    "value": "performed_event_multiple",
+                                    "event_type": "actions",
+                                    "operator": "gte",
+                                    "operator_value": 3,
+                                    "time_value": 7,
+                                    "time_interval": "week",
                                 }
                             ],
                         },
@@ -346,6 +350,7 @@ class TestInsightModel(BaseTest):
                                         "key": "completed onboarding",
                                         "value": "performed_event",
                                         "event_type": "events",
+                                        "negation": True,
                                     }
                                 ],
                             }
@@ -365,6 +370,10 @@ class TestInsightModel(BaseTest):
             "data_warehouse_entity_count": 0,
             "has_properties": True,
             "behavioral_filter_count": 2,
+            "has_negated_behavioral_filter": True,
+            "has_custom_behavioral_filter_count": True,
+            "has_custom_behavioral_filter_time": True,
+            "has_action_behavioral_filter": True,
             "filter_test_accounts": True,
             "breakdown_type": "event",
             "has_formula": True,

--- a/products/product_analytics/backend/models/test/test_insight_model.py
+++ b/products/product_analytics/backend/models/test/test_insight_model.py
@@ -328,12 +328,8 @@ class TestInsightModel(BaseTest):
                                 {
                                     "type": "behavioral",
                                     "key": "signed up",
-                                    "value": "performed_event_multiple",
-                                    "event_type": "actions",
-                                    "operator": "gte",
-                                    "operator_value": 3,
-                                    "time_value": 7,
-                                    "time_interval": "week",
+                                    "value": "performed_event",
+                                    "event_type": "events",
                                 }
                             ],
                         },
@@ -350,7 +346,6 @@ class TestInsightModel(BaseTest):
                                         "key": "completed onboarding",
                                         "value": "performed_event",
                                         "event_type": "events",
-                                        "negation": True,
                                     }
                                 ],
                             }
@@ -370,10 +365,6 @@ class TestInsightModel(BaseTest):
             "data_warehouse_entity_count": 0,
             "has_properties": True,
             "behavioral_filter_count": 2,
-            "has_negated_behavioral_filter": True,
-            "has_custom_behavioral_filter_count": True,
-            "has_custom_behavioral_filter_time": True,
-            "has_action_behavioral_filter": True,
             "filter_test_accounts": True,
             "breakdown_type": "event",
             "has_formula": True,


### PR DESCRIPTION
## Problem

Product teams cannot measure how people configure behavioral filters while they edit insights.

Insight lifecycle events report the number of behavioral filters, but they do not report changes to each setting.

## Changes

- Behavioral filter controls now emit dedicated events when users change the behavior, target, count, or time period.
- Each event includes the selected configuration values but excludes event names and action names.
- Insight lifecycle events retain only `behavioral_filter_count` for behavioral filters.
- Nothing changes in the visible interface.

## How did you test this code?

- The focused `BehavioralPropertyFilterRow` and `eventUsageLogic` Jest suites passed.
- The frontend type check, Oxlint, Oxfmt, Ruff, and the available preflight checks passed.
- The backend model suite did not finish before the local environment timed out during setup.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing behavior or documentation changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code used repository tools and the PostHog MCP server.
- Skills used: `/instrument-product-analytics`, `/querying-posthog-data`, `/writing-tests`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.
- The final design uses interaction events instead of configuration metadata on insight lifecycle events.


