### PR TITLE
feat(desktop): align self-driving inbox experience with web

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.test.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.test.ts
@@ -1720,7 +1720,7 @@ describe("PostHogAPIClient", () => {
   });
 
   describe("getSignalReports", () => {
-    it("sends count-only requests to the reports endpoint", async () => {
+    it("sends report filters to the reports endpoint", async () => {
       const fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: async () => ({ count: 3, results: [] }),
@@ -1741,12 +1741,15 @@ describe("PostHogAPIClient", () => {
       };
 
       await expect(
-        client.getSignalReports({ count_only: true }),
+        client.getSignalReports({
+          actionability: "immediately_actionable,requires_human_input",
+          count_only: true,
+        }),
       ).resolves.toEqual({ count: 3, results: [] });
 
       const request = fetch.mock.calls[0]?.[0] as { url: URL };
       expect(request.url.toString()).toBe(
-        "http://localhost:8000/api/projects/123/signals/reports/?count_only=true",
+        "http://localhost:8000/api/projects/123/signals/reports/?actionability=immediately_actionable%2Crequires_human_input&count_only=true",
       );
     });
   });

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -4821,6 +4821,9 @@ export class PostHogAPIClient {
     if (params?.priority) {
       url.searchParams.set("priority", params.priority);
     }
+    if (params?.actionability) {
+      url.searchParams.set("actionability", params.actionability);
+    }
     if (params?.count_only != null) {
       url.searchParams.set("count_only", String(params.count_only));
     }

--- a/products/desktop/packages/core/src/inbox/engagement.test.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.test.ts
@@ -32,7 +32,7 @@ const NO_FILTERS = {
   sourceProductFilter: [],
   priorityFilter: [],
   searchQuery: "",
-  isDefaultScope: true,
+  scope: "for-you" as const,
 };
 
 describe("buildBulkActionEvents", () => {
@@ -171,7 +171,7 @@ describe("buildInboxViewedProperties", () => {
     ["source product", { sourceProductFilter: ["error_tracking"] }],
     ["priority", { priorityFilter: ["P0"] }],
     ["search", { searchQuery: "  crash  " }],
-    ["non-default scope", { isDefaultScope: false }],
+    ["non-default scope", { scope: "entire-project" as const }],
   ])("flags has_active_filters for a %s filter", (_label, partial) => {
     const props = buildInboxViewedProperties({
       visibleReports: [fakeReport()],
@@ -203,6 +203,7 @@ describe("buildInboxViewedProperties", () => {
 
     expect(props.pulls_tab_count).toBeUndefined();
     expect(props.reports_tab_count).toBeUndefined();
+    expect(props.scope).toBe("for-you");
   });
 });
 

--- a/products/desktop/packages/core/src/inbox/engagement.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.ts
@@ -1,6 +1,7 @@
 import type {
   InboxReportActionProperties,
   InboxReportActionSurface,
+  InboxReviewerScope,
   InboxViewedProperties,
 } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/domain-types";
@@ -105,12 +106,8 @@ interface InboxViewedFilterStateBase {
 interface DesktopInboxViewedFilterState extends InboxViewedFilterStateBase {
   surface: "desktop";
   searchQuery: string;
-  /**
-   * True when the reviewer scope is the default ("For you"). False when the
-   * user has narrowed to a teammate or the whole project — treated as an
-   * active filter for `has_active_filters`.
-   */
-  isDefaultScope: boolean;
+  /** Canonical scope value. Teammate UUIDs must not enter analytics. */
+  scope: InboxReviewerScope;
 }
 
 interface MobileInboxViewedFilterState extends InboxViewedFilterStateBase {
@@ -196,7 +193,7 @@ export function buildInboxViewedProperties(
     statusFiltered ||
     (filters.surface === "mobile" &&
       filters.suggestedReviewerFilter.length > 0) ||
-    (filters.surface === "desktop" && !filters.isDefaultScope);
+    (filters.surface === "desktop" && filters.scope !== "for-you");
 
   return {
     report_count: visibleReports.length,
@@ -219,6 +216,7 @@ export function buildInboxViewedProperties(
       actionabilityCounts.requires_human_input,
     actionability_not_actionable_count: actionabilityCounts.not_actionable,
     actionability_unknown_count: actionabilityCounts.unknown,
+    ...(filters.surface === "desktop" ? { scope: filters.scope } : {}),
     ...(tabCounts
       ? {
           pulls_tab_count: tabCounts.pulls,

--- a/products/desktop/packages/core/src/inbox/reportActions.test.ts
+++ b/products/desktop/packages/core/src/inbox/reportActions.test.ts
@@ -200,4 +200,19 @@ describe("canCreateImplementationPr", () => {
       canCreateImplementationPr({ ...base, implementation_pr_merged: true }),
     ).toBe(true);
   });
+
+  it("blocks creation while linked implementation work is loading or active", () => {
+    const report = {
+      id: "r",
+      status: "ready",
+      actionability: "immediately_actionable",
+    } as Partial<SignalReport> as SignalReport;
+
+    expect(
+      canCreateImplementationPr(report, { isTaskLookupPending: true }),
+    ).toBe(false);
+    expect(
+      canCreateImplementationPr(report, { hasLiveImplementationTask: true }),
+    ).toBe(false);
+  });
 });

--- a/products/desktop/packages/core/src/inbox/reportActions.ts
+++ b/products/desktop/packages/core/src/inbox/reportActions.ts
@@ -7,9 +7,19 @@ import type { SignalReport } from "@posthog/shared/types";
  *
  * Mirrors the server-side autostart rules: only when the report is ready and
  * actually actionable, or when it's blocked on user input the user can supply.
- * Hidden once an implementation PR exists or the issue is already fixed.
+ * Hidden while linked task state is unknown, implementation work is live, an
+ * implementation PR is open, or the issue is already fixed.
  */
-export function canCreateImplementationPr(report: SignalReport): boolean {
+export function canCreateImplementationPr(
+  report: SignalReport,
+  context: {
+    hasLiveImplementationTask?: boolean;
+    isTaskLookupPending?: boolean;
+  } = {},
+): boolean {
+  if (context.hasLiveImplementationTask || context.isTaskLookupPending) {
+    return false;
+  }
   // A merged PR doesn't block: a report that outlived its fix (evidence kept
   // arriving) legitimately gets another attempt.
   if (report.implementation_pr_url && !report.implementation_pr_merged) {

--- a/products/desktop/packages/core/src/inbox/reportFiltering.ts
+++ b/products/desktop/packages/core/src/inbox/reportFiltering.ts
@@ -51,6 +51,13 @@ export const REPORTS_INBOX_STATUS_FILTER = INBOX_PIPELINE_STATUSES.filter(
   (status) => status !== "potential",
 ).join(",");
 
+/** Web Inbox's actionable report set: ready reports plus ones waiting on human input. */
+export const INBOX_ACTIONABLE_REPORT_STATUS_FILTER = "ready,pending_input";
+
+/** The two judgments that web Inbox includes in Review and merge / Needs a PR. */
+export const INBOX_ACTIONABLE_ACTIONABILITY_FILTER =
+  "immediately_actionable,requires_human_input";
+
 /**
  * Status filter for the Reports tab's count. `isReportTabReport` keeps a report
  * only when it is `ready` and carries no PR, because every other pipeline status

--- a/products/desktop/packages/core/src/inbox/reportInboxSections.test.ts
+++ b/products/desktop/packages/core/src/inbox/reportInboxSections.test.ts
@@ -14,51 +14,51 @@ function report(overrides: Partial<SignalReport>): SignalReport {
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
     artefact_count: 0,
+    actionability: "immediately_actionable",
     ...overrides,
   } as SignalReport;
 }
 
 describe("reportInboxSections", () => {
   it.each([
-    // The boundary is status alone — the one dimension server counts can
-    // reproduce. Ready is a decision whatever else the report carries...
-    [{ status: "ready" }, "decision"],
-    [{ status: "ready", actionability: "not_actionable" }, "decision"],
-    [{ status: "ready", already_addressed: true }, "decision"],
+    [{ status: "ready" }, "needsPr"],
     [
       {
         status: "ready",
-        implementation_pr_url: "https://gh/pr/9",
-        implementation_pr_merged: true,
+        implementation_pr_url: "https://github.com/o/r/pull/1",
       },
-      "decision",
+      "reviewAndMerge",
     ],
-    [{ status: "pending_input" }, "attention"],
-    [{ status: "failed" }, "attention"],
-    [{ status: "in_progress" }, "inProgress"],
+    [{ status: "pending_input" }, "needsPr"],
+    [{ status: "ready", actionability: "not_actionable" }, null],
     [
-      { status: "in_progress", implementation_pr_url: "https://gh/pr/1" },
-      "inProgress",
+      {
+        status: "pending_input",
+        implementation_pr_url: "https://github.com/o/r/pull/2",
+      },
+      null,
     ],
-    [{ status: "candidate" }, "inProgress"],
+    [{ status: "failed" }, null],
+    [{ status: "in_progress" }, null],
+    [{ status: "candidate" }, null],
   ] as const)("%j lands in %s", (overrides, section) => {
     const sections = partitionInboxReports([
       report(overrides as Partial<SignalReport>),
     ]);
-    expect(sections.decision.length).toBe(section === "decision" ? 1 : 0);
-    expect(sections.attention.length).toBe(section === "attention" ? 1 : 0);
-    expect(sections.inProgress.length).toBe(section === "inProgress" ? 1 : 0);
+    expect(sections.reviewAndMerge.length).toBe(
+      section === "reviewAndMerge" ? 1 : 0,
+    );
+    expect(sections.needsPr.length).toBe(section === "needsPr" ? 1 : 0);
   });
 
   it("partition preserves the list's own order within each section", () => {
     const sections = partitionInboxReports([
-      report({ id: "d1" }),
-      report({ id: "a1", status: "pending_input" }),
-      report({ id: "d2" }),
-      report({ id: "p1", status: "candidate" }),
+      report({ id: "n1" }),
+      report({ id: "r1", implementation_pr_url: "https://gh/pr/1" }),
+      report({ id: "n2", status: "pending_input" }),
+      report({ id: "r2", implementation_pr_url: "https://gh/pr/2" }),
     ]);
-    expect(sections.decision.map((r) => r.id)).toEqual(["d1", "d2"]);
-    expect(sections.attention.map((r) => r.id)).toEqual(["a1"]);
-    expect(sections.inProgress.map((r) => r.id)).toEqual(["p1"]);
+    expect(sections.reviewAndMerge.map((r) => r.id)).toEqual(["r1", "r2"]);
+    expect(sections.needsPr.map((r) => r.id)).toEqual(["n1", "n2"]);
   });
 });

--- a/products/desktop/packages/core/src/inbox/reportInboxSections.ts
+++ b/products/desktop/packages/core/src/inbox/reportInboxSections.ts
@@ -1,54 +1,49 @@
 import type { SignalReport } from "@posthog/shared/types";
 
 /**
- * The global reports inbox shows every live report in two sections. The
- * boundary is deliberately a server-countable dimension — report status —
- * because the section headers and nav badges are server-side count queries,
- * and a boundary the API can't filter on (actionability, PR-merged state)
- * produces headline numbers no query can verify.
+ * The Desktop reports inbox follows web's actionable report grouping. Both
+ * boundaries are server-countable: report status plus whether an
+ * implementation PR exists.
  */
 export interface InboxReportSections {
-  /** Ready: research done, a person decides — act, review the PR, or archive. */
-  decision: SignalReport[];
-  /** A responder cannot continue without input, or its latest run failed. */
-  attention: SignalReport[];
-  /** Work the responder is still processing or preparing. */
-  inProgress: SignalReport[];
+  /** Ready reports with an implementation PR waiting for review. */
+  reviewAndMerge: SignalReport[];
+  /** Actionable ready/pending-input reports without an implementation PR. */
+  needsPr: SignalReport[];
+}
+
+function hasImplementationPr(report: SignalReport): boolean {
+  return !!report.implementation_pr_url?.trim();
+}
+
+function isActionable(report: SignalReport): boolean {
+  return (
+    report.actionability === "immediately_actionable" ||
+    report.actionability === "requires_human_input"
+  );
 }
 
 /**
- * Whether a report is in the "Needs a decision" section: exactly the `ready`
- * status. Archiving an FYI is a decision too, so ready-but-not-actionable
- * reports stay here (a row-level hint conveys that) rather than defining a
- * section boundary counts can't reproduce.
- */
-function reportNeedsDecision(report: SignalReport): boolean {
-  return report.status === "ready";
-}
-
-/**
- * Partition the loaded list into the two sections, preserving its order. The
- * list arrives sorted by the user's own sort (applied server-side by the
- * filter bar); section totals come from server count queries, not from this
- * partition — these arrays only feed the rendered rows.
+ * Partition the already actionability-filtered list, preserving its order.
+ * Pipeline and failed reports stay in Runs instead of appearing as a third
+ * report section.
  */
 export function partitionInboxReports(
   reports: SignalReport[],
 ): InboxReportSections {
-  const decision: SignalReport[] = [];
-  const attention: SignalReport[] = [];
-  const inProgress: SignalReport[] = [];
+  const reviewAndMerge: SignalReport[] = [];
+  const needsPr: SignalReport[] = [];
   for (const report of reports) {
-    if (reportNeedsDecision(report)) {
-      decision.push(report);
+    const hasPr = hasImplementationPr(report);
+    if (report.status === "ready" && hasPr) {
+      reviewAndMerge.push(report);
     } else if (
-      report.status === "pending_input" ||
-      report.status === "failed"
+      !hasPr &&
+      isActionable(report) &&
+      (report.status === "ready" || report.status === "pending_input")
     ) {
-      attention.push(report);
-    } else {
-      inProgress.push(report);
+      needsPr.push(report);
     }
   }
-  return { decision, attention, inProgress };
+  return { reviewAndMerge, needsPr };
 }

--- a/products/desktop/packages/core/src/inbox/reportMembership.ts
+++ b/products/desktop/packages/core/src/inbox/reportMembership.ts
@@ -1,3 +1,4 @@
+import type { InboxReviewerScope } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/types";
 
 /**
@@ -62,7 +63,26 @@ export function isTeammateInboxScope(
   return parseTeammateInboxScope(scope) != null;
 }
 
-function matchesInboxScope(report: SignalReport, scope: InboxScope): boolean {
+/** Analytics-safe scope value: teammate UUIDs never leave the client. */
+export function inboxReviewerScopeValue(scope: InboxScope): InboxReviewerScope {
+  if (scope === INBOX_SCOPE_FOR_YOU) return "for-you";
+  if (scope === INBOX_SCOPE_ENTIRE_PROJECT) return "entire-project";
+  return "teammate";
+}
+
+export function inboxScopeTriggerLabel(
+  scope: InboxScope,
+  teammateName?: string | null,
+): string {
+  if (scope === INBOX_SCOPE_FOR_YOU) return "For you";
+  if (scope === INBOX_SCOPE_ENTIRE_PROJECT) return "Entire project";
+  return teammateName?.trim() || "Teammate";
+}
+
+export function matchesInboxScope(
+  report: SignalReport,
+  scope: InboxScope,
+): boolean {
   if (isExcludedFromInbox(report)) return false;
   if (scope === INBOX_SCOPE_ENTIRE_PROJECT) return true;
   if (isTeammateInboxScope(scope)) return true;

--- a/products/desktop/packages/core/src/inbox/reportVerdict.ts
+++ b/products/desktop/packages/core/src/inbox/reportVerdict.ts
@@ -66,7 +66,7 @@ export function deriveReportVerdict(
     return {
       tone: "decision",
       title: "Review the open PR",
-      body: "Implementation is already in flight. Review the pull request, or continue the task that opened it — new work lands on the same branch.",
+      body: "Implementation is already in flight. Review the pull request, or ask about it for more context.",
     };
   }
   if (report.already_addressed) {

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -705,7 +705,23 @@ export type InboxReportActionSurface =
   | "detail_footer"
   | "toolbar"
   | "keyboard"
-  | "list_row";
+  | "list_row"
+  | "triage";
+
+export type InboxReviewerScope = "for-you" | "entire-project" | "teammate";
+
+export interface InboxTriageStartedProperties {
+  queue_size: number;
+  scope: InboxReviewerScope;
+  has_active_filters: boolean;
+}
+
+export interface InboxTriageEndedProperties
+  extends InboxTriageStartedProperties {
+  reports_reviewed: number;
+  duration_ms: number;
+  end_reason: "completed" | "exited";
+}
 
 /** Sentiment captured by the report usefulness thumbs. */
 export type InboxReportFeedbackSentiment = "positive" | "negative";
@@ -738,6 +754,8 @@ export interface InboxViewedProperties {
    */
   pulls_tab_count?: number;
   reports_tab_count?: number;
+  /** Reviewer scope on Desktop. Mobile omits this until it exposes the same control. */
+  scope?: InboxReviewerScope;
 }
 
 export interface InboxReportOpenedProperties {
@@ -1567,6 +1585,8 @@ export const ANALYTICS_EVENTS = {
   INBOX_REPORT_SCROLLED: "Inbox report scrolled",
   INBOX_REPORT_FEEDBACK: "Inbox report feedback",
   INBOX_REPORT_FEEDBACK_NOTE: "Inbox report feedback note",
+  INBOX_TRIAGE_STARTED: "Inbox triage started",
+  INBOX_TRIAGE_ENDED: "Inbox triage ended",
   SIGNAL_SOURCE_CONNECTED: "Signal source connected",
 
   // Agents page events
@@ -1768,6 +1788,8 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.INBOX_REPORT_SCROLLED]: InboxReportScrolledProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK]: InboxReportFeedbackProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK_NOTE]: InboxReportFeedbackNoteProperties;
+  [ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED]: InboxTriageStartedProperties;
+  [ANALYTICS_EVENTS.INBOX_TRIAGE_ENDED]: InboxTriageEndedProperties;
   [ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED]: SignalSourceConnectedProperties;
 
   // Agents page events

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -685,6 +685,7 @@ export type InboxReportActionType =
   | "reingest"
   | "create_pr"
   | "open_pr"
+  | "open_task"
   | "copy_link"
   | "discuss"
   | "expand_signal"

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -1076,6 +1076,8 @@ export interface SignalReportsQueryParams {
   suggested_reviewers?: string;
   /** Comma-separated `P0`–`P4` priorities — only returns reports with one of these priorities. */
   priority?: string;
+  /** Comma-separated actionability choices. Only returns reports with one of these latest judgments. */
+  actionability?: string;
   /** Return the filtered total without fetching or enriching report rows. */
   count_only?: boolean;
   /**

--- a/products/desktop/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/AgentRunDetail.tsx
@@ -1,9 +1,9 @@
 import {
   ArrowRightIcon,
   CaretDownIcon,
-  CopyIcon,
   FileTextIcon,
   GitPullRequestIcon,
+  LinkIcon,
   MagnifyingGlassIcon,
   TerminalIcon,
   WarningIcon,
@@ -348,7 +348,7 @@ function AgentRunDetailContent({ report }: { report: SignalReport }) {
               onClick={() => copyInboxReportLink(report)}
               title="Copy a deep link to this run"
             >
-              <CopyIcon size={12} />
+              <LinkIcon size={12} />
               Copy link
             </Button>
           </>

--- a/products/desktop/packages/ui/src/features/inbox/components/ConventionalCommitScopeTag.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ConventionalCommitScopeTag.tsx
@@ -9,35 +9,37 @@ import type { ReactNode } from "react";
 interface ConventionalCommitScopeTagProps {
   type: string;
   scope: string | null;
-  compact?: boolean;
+  size?: "compact" | "hero";
 }
 
 export function ConventionalCommitScopeTag({
   type,
   scope,
-  compact = false,
+  size = "compact",
 }: ConventionalCommitScopeTagProps): ReactNode {
   const meta = getConventionalCommitTypeMeta(type);
   const IconComponent = meta.icon;
   const label = formatConventionalCommitTag(type, scope);
+  const hero = size === "hero";
 
   // `align-middle` keeps the tag centered on the title's first line when it
   // renders as an inline prefix inside the title text; `font-normal` stops it
   // inheriting the title's weight.
   return (
     <InboxBadge
-      variant={compact ? "default" : meta.variant}
+      variant="default"
       className={cn(
-        "shrink-0 gap-1 font-mono",
-        compact &&
-          "mr-1.5 h-5 gap-0.5 border border-(--gray-4) bg-(--gray-2) px-1.5 py-0 align-middle font-normal text-[11px] text-gray-11 leading-none",
+        "shrink-0 border border-(--gray-4) bg-(--gray-2) align-middle font-mono font-normal text-gray-11 leading-none",
+        hero
+          ? "mr-3 h-8 gap-1.5 px-2.5 py-0 text-[15px]"
+          : "mr-1.5 h-5 gap-0.5 px-1.5 py-0 text-[11px]",
       )}
       title={label}
     >
       <IconComponent
-        size={compact ? 10 : 12}
+        size={hero ? 15 : 10}
         weight="bold"
-        className={compact ? meta.softIconClass : undefined}
+        className={meta.softIconClass}
         aria-hidden
       />
       {label}

--- a/products/desktop/packages/ui/src/features/inbox/components/ConventionalCommitScopeTag.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ConventionalCommitScopeTag.tsx
@@ -9,18 +9,15 @@ import type { ReactNode } from "react";
 interface ConventionalCommitScopeTagProps {
   type: string;
   scope: string | null;
-  size?: "compact" | "hero";
 }
 
 export function ConventionalCommitScopeTag({
   type,
   scope,
-  size = "compact",
 }: ConventionalCommitScopeTagProps): ReactNode {
   const meta = getConventionalCommitTypeMeta(type);
   const IconComponent = meta.icon;
   const label = formatConventionalCommitTag(type, scope);
-  const hero = size === "hero";
 
   // `align-middle` keeps the tag centered on the title's first line when it
   // renders as an inline prefix inside the title text; `font-normal` stops it
@@ -30,14 +27,12 @@ export function ConventionalCommitScopeTag({
       variant="default"
       className={cn(
         "shrink-0 border border-(--gray-4) bg-(--gray-2) align-middle font-mono font-normal text-gray-11 leading-none",
-        hero
-          ? "mr-3 h-8 gap-1.5 px-2.5 py-0 text-[15px]"
-          : "mr-1.5 h-5 gap-0.5 px-1.5 py-0 text-[11px]",
+        "mr-1.5 h-5 gap-0.5 px-1.5 py-0 text-[11px]",
       )}
       title={label}
     >
       <IconComponent
-        size={hero ? 15 : 10}
+        size={10}
         weight="bold"
         className={meta.softIconClass}
         aria-hidden

--- a/products/desktop/packages/ui/src/features/inbox/components/DetailBackLink.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DetailBackLink.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeftIcon } from "@phosphor-icons/react";
+import { useInboxTriageOrigin } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { Link } from "@tanstack/react-router";
 
 interface DetailBackLinkProps {
@@ -7,13 +8,24 @@ interface DetailBackLinkProps {
 }
 
 export function DetailBackLink({ to, label }: DetailBackLinkProps) {
+  const triageOrigin = useInboxTriageOrigin();
+  const returnsToTriage = to === "/inbox/reports" && triageOrigin !== null;
+
   return (
     <Link
       to={to}
+      state={
+        returnsToTriage
+          ? (previous) => ({
+              ...previous,
+              inboxTriageOrigin: triageOrigin,
+            })
+          : undefined
+      }
       className="inline-flex w-fit items-center gap-1.5 rounded-(--radius-1) text-[12.5px] text-gray-11 no-underline transition-colors hover:text-gray-12 focus-visible:text-gray-12 focus-visible:outline-(--gray-8) focus-visible:outline-2 focus-visible:outline-offset-2"
     >
       <ArrowLeftIcon size={14} />
-      {label}
+      {returnsToTriage ? "Back to triage" : label}
     </Link>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.test.tsx
@@ -1,0 +1,48 @@
+import type { SignalReport } from "@posthog/shared/types";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DismissReportDialog } from "./DismissReportDialog";
+
+const report = {
+  id: "report-1",
+  title: "Checkout errors",
+  summary: "Errors increased.",
+  status: "ready",
+  total_weight: 1,
+  signal_count: 1,
+  created_at: "2026-08-28T00:00:00Z",
+  updated_at: "2026-08-28T00:00:00Z",
+  artefact_count: 0,
+} satisfies SignalReport;
+
+describe("DismissReportDialog", () => {
+  it("distinguishes a project-wide archive from a temporary pause", async () => {
+    const user = userEvent.setup();
+    render(
+      <DismissReportDialog
+        open
+        onOpenChange={vi.fn()}
+        report={report}
+        isSubmitting={false}
+        snoozeDisabledReason={null}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('Archive report "Checkout errors" for everyone?'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/archives the report for everyone/)).toBeTruthy();
+
+    await user.click(screen.getByLabelText("Already fixed"));
+
+    expect(
+      screen.getByText('Pause report "Checkout errors"?'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/pauses the report for everyone/)).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Pause for everyone" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
@@ -25,7 +25,7 @@ export interface DismissReportDialogProps {
   selectedCount?: number;
   isSubmitting: boolean;
   /**
-   * When snooze is not allowed for the current selection, the "Already fixed elsewhere"
+   * When snooze is not allowed for the current selection, the "Already fixed"
    * option is disabled because that path snoozes instead of dismissing.
    */
   snoozeDisabledReason: string | null;
@@ -110,20 +110,26 @@ function DismissReportDialogBody({
   };
 
   const alreadyFixedDisabled = snoozeDisabledReason !== null;
+  const pausesReport = reason != null && isDismissalReasonSnooze(reason);
+  const reportNoun = selectedCount > 1 ? "reports" : "report";
 
   return (
     <>
       <Dialog.Title>
         <Text className="text-balance font-bold text-lg">
-          {selectedCount > 1
-            ? `Archive ${selectedCount} reports?`
-            : `Archive report "${report.title?.trim() ? report.title : "Untitled report"}"?`}
+          {pausesReport
+            ? selectedCount > 1
+              ? `Pause ${selectedCount} reports?`
+              : `Pause report "${report.title?.trim() ? report.title : "Untitled report"}"?`
+            : selectedCount > 1
+              ? `Archive ${selectedCount} reports for everyone?`
+              : `Archive report "${report.title?.trim() ? report.title : "Untitled report"}" for everyone?`}
         </Text>
       </Dialog.Title>
       <Dialog.Description className="text-gray-10 text-sm">
-        {selectedCount > 1
-          ? "These reports will be removed from Self-driving. Your feedback is saved on each report and helps the agent."
-          : "This report will be removed from Self-driving. Your feedback is saved on the report and helps the agent."}
+        {pausesReport
+          ? `This pauses the ${reportNoun} for everyone in this project until another matching signal arrives. The ${reportNoun} can then return.`
+          : `This archives the ${reportNoun} for everyone in this project. Your feedback is saved and helps the agent.`}
       </Dialog.Description>
 
       <Flex direction="column" gap="4" mt="4">
@@ -184,7 +190,7 @@ function DismissReportDialogBody({
           onClick={handleConfirm}
           loading={isSubmitting}
         >
-          Archive & teach the agent
+          {pausesReport ? "Pause for everyone" : "Archive for everyone"}
         </Button>
       </Flex>
     </>

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissedReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissedReportDetail.tsx
@@ -1,7 +1,7 @@
 import {
   ArrowCounterClockwiseIcon,
-  CopyIcon,
   FileTextIcon,
+  LinkIcon,
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import { Button } from "@posthog/quill";
@@ -89,7 +89,7 @@ function DismissedReportDetailContent({
             onClick={() => copyInboxReportLink(report)}
             title="Copy a deep link to this report"
           >
-            <CopyIcon size={12} />
+            <LinkIcon size={12} />
           </Button>
         </>
       }

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.test.tsx
@@ -1,0 +1,63 @@
+import { FileTextIcon } from "@phosphor-icons/react";
+import type { SignalReport } from "@posthog/shared/types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/ui/features/inbox/components/DetailBackLink", () => ({
+  DetailBackLink: () => null,
+}));
+
+vi.mock("@posthog/ui/features/inbox/components/ReportReviewersHeader", () => ({
+  ReportReviewersHeader: () => null,
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxReportDismissAction", () => ({
+  useInboxReportDismissAction: () => ({
+    actionButton: null,
+    dialog: null,
+  }),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxReports", () => ({
+  useInboxReportSignals: () => ({ data: { report: null, signals: [] } }),
+  useInboxReportArtefacts: () => ({ data: { results: [] } }),
+}));
+
+vi.mock(
+  "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown",
+  () => ({ SignalReportSummaryMarkdown: () => null }),
+);
+
+import { InboxDetailFrame } from "./InboxDetailFrame";
+
+const report: SignalReport = {
+  id: "report-1",
+  title: "feat(dashboards): add compact legend controls",
+  summary: "Dashboard legends need a compact display option.",
+  status: "ready",
+  total_weight: 1,
+  signal_count: 0,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  artefact_count: 0,
+  implementation_pr_url: null,
+};
+
+describe("InboxDetailFrame", () => {
+  it("shows the conventional commit tag beside the report title", () => {
+    render(
+      <InboxDetailFrame
+        report={report}
+        backTo="/inbox/reports"
+        backLabel="Back to reports"
+        fallbackTitle="Untitled report"
+        summarySection={{ Icon: FileTextIcon, title: "Summary" }}
+        evidenceSection={null}
+        showDismiss={false}
+      />,
+    );
+
+    expect(screen.getByText("feat(dashboards)")).toBeInTheDocument();
+    expect(screen.getByText("Add compact legend controls")).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -1,92 +1,43 @@
 import type { IconProps } from "@phosphor-icons/react";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
-import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
-import {
-  humanizeReportTitle,
-  parseConventionalCommitTitle,
-  splitReportSummary,
-} from "@posthog/core/inbox/reportPresentation";
-import {
-  Tabs,
-  TabsList,
-  TabsTrigger,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
-import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
-import { DetailBackLink } from "@posthog/ui/features/inbox/components/DetailBackLink";
-import { ReportChartsSection } from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
-import {
-  InboxMetaRow,
-  InboxMetaSeparator,
-  InboxMetaText,
-} from "@posthog/ui/features/inbox/components/InboxMetaRow";
-import { InboxMetaSourceStack } from "@posthog/ui/features/inbox/components/InboxMetaSourceStack";
+import { InboxDetailFrameView } from "@posthog/ui/features/inbox/components/InboxDetailFrameView";
 import { ReportReviewersHeader } from "@posthog/ui/features/inbox/components/ReportReviewersHeader";
-import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
 import {
   SignalsList,
   SignalsListSkeleton,
 } from "@posthog/ui/features/inbox/components/SignalsList";
-import { ForYouBadge } from "@posthog/ui/features/inbox/components/utils/ForYouBadge";
-import { SignalReportStatusBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportStatusBadge";
-import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown";
-import { hasKnownSourceProduct } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import type { InboxListRoute } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { useInboxReportDismissAction } from "@posthog/ui/features/inbox/hooks/useInboxReportDismissAction";
 import {
   useInboxReportArtefacts,
   useInboxReportSignals,
 } from "@posthog/ui/features/inbox/hooks/useInboxReports";
-import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
-import { type ComponentType, type ReactNode, useMemo, useState } from "react";
+import type { ComponentType, ReactNode } from "react";
 
 interface InboxDetailFrameProps {
   report: SignalReport;
-  /** List route for the back-link (e.g. "/inbox/pulls"). */
   backTo: InboxListRoute | (string & {});
   backLabel: string;
-  /**
-   * Whether to render the Dismiss button + dialog. Off for already-dismissed
-   * reports (the Dismissed tab), where dismissing again makes no sense.
-   */
   showDismiss?: boolean;
-  /** Title fallback when `report.title` is blank. */
   fallbackTitle: string;
-  /** Optional breadcrumb fragment (e.g. PR repo slug + number). */
   breadcrumb?: ReactNode;
-  /** Meta items rendered before the signals count + timestamp. */
   metaPrefix?: ReactNode;
-  /** Meta items appended after the timestamp + source (e.g. PR diff stats). */
   metaSuffix?: ReactNode;
-  /** Variant-specific primary action button (e.g. "Open PR in GitHub" or "Copy link"). */
   primaryAction?: ReactNode;
-  /** Rendered at the top of the main column, before the summary (the verdict banner). */
   aboveSummary?: ReactNode;
-  /** Summary section: icon + title (e.g. "Summary" / "What the agent looked at"). */
   summarySection: {
     Icon: ComponentType<IconProps>;
     title: string;
   };
-  /** Sections rendered in the main column under the summary (e.g. PR comments). */
   belowSummary?: ReactNode;
-  /** Content that closes the overview after both responsive columns. */
   footer?: ReactNode;
-  /** Optional "Evidence" section icon + title; null hides it. */
   evidenceSection: {
     Icon: ComponentType<IconProps>;
     title: string;
   } | null;
-  /** Right-column cards rendered above the Evidence card (checks, reviewers). */
   aboveEvidence?: ReactNode;
-  /**
-   * Second tab beside Overview (the web detail's "Files changed"). Its content
-   * replaces the whole overview grid while selected.
-   */
   secondaryTab?: { label: ReactNode; content: ReactNode };
-  /** Sections rendered alongside the summary (Tasks, Activity, …). */
   children?: ReactNode;
 }
 
@@ -108,270 +59,57 @@ export function InboxDetailFrame({
   secondaryTab,
   showDismiss = true,
   children,
-}: InboxDetailFrameProps) {
-  const [activeTab, setActiveTab] = useState("overview");
+}: InboxDetailFrameProps): React.JSX.Element {
   const { data: signalsResp } = useInboxReportSignals(report.id);
   const signals = signalsResp?.signals ?? [];
   const signalsLoaded = signalsResp !== undefined;
-  const hasSource = hasKnownSourceProduct(report.source_products);
-  // The repo the report's own selection step chose — the one a Discuss, Canvas,
-  // or PR run will work in (the server resolves runs from this same artefact).
-  // Null covers both "no selection yet" and a deliberate no-repo choice; the
-  // byline stays quiet for those. The decision section already fetches these
-  // artefacts, so this query is warm.
   const { data: artefactsResp } = useInboxReportArtefacts(report.id);
   const runRepository = extractRepoSelectionRepository(artefactsResp?.results);
   const { actionButton: dismissButton, dialog: dismissDialog } =
     useInboxReportDismissAction(report);
 
-  const EvidenceIcon = evidenceSection?.Icon;
   const evidenceUnavailable =
     signalsLoaded && signalsResp?.report === null && report.signal_count > 0;
-  // Preserve the report's known count while loading or when the detail request
-  // failed. An unavailable response must not make Evidence disappear while a
-  // generic activity log remains on screen.
   const evidenceCount =
     !signalsLoaded || evidenceUnavailable
       ? report.signal_count
       : signals.length;
-  const hasEvidence =
-    evidenceSection != null && EvidenceIcon != null && evidenceCount > 0;
-  const conventionalTitle = parseConventionalCommitTitle(report.title);
-  const displayTitle = humanizeReportTitle(report.title, fallbackTitle);
-  const title = (
-    <>
-      {conventionalTitle && (
-        <ConventionalCommitScopeTag
-          type={conventionalTitle.type}
-          scope={conventionalTitle.scope}
-        />
-      )}
-      {displayTitle}
-    </>
-  );
-
-  const reportMeta = (
-    <>
-      {metaPrefix}
-      {evidenceCount > 0 && (
-        <>
-          <InboxMetaText className="tabular-nums">
-            {evidenceCount} signal{evidenceCount === 1 ? "" : "s"}
-          </InboxMetaText>
-          <InboxMetaSeparator />
-        </>
-      )}
-      <RelativeTimestamp
-        timestamp={report.updated_at ?? report.created_at}
-        className="text-[13px]"
-      />
-      {hasSource && (
-        <>
-          <InboxMetaSeparator />
-          <InboxMetaSourceStack
-            sourceProducts={report.source_products}
-            labelPrefix="Agent · "
-          />
-        </>
-      )}
-      {report.priority && (
-        <>
-          <InboxMetaSeparator />
-          <InboxMetaText>{report.priority}</InboxMetaText>
-        </>
-      )}
-      {runRepository && (
-        <>
-          <InboxMetaSeparator />
-          <Tooltip>
-            <TooltipTrigger
-              render={<InboxMetaText mono className="cursor-help" />}
-            >
-              {runRepository}
-            </TooltipTrigger>
-            <TooltipContent side="top">
-              Agent runs for this report work in this repository
-            </TooltipContent>
-          </Tooltip>
-        </>
-      )}
-      {metaSuffix}
-    </>
+  const evidenceContent = evidenceUnavailable ? (
+    <p className="m-0 text-[13px] text-gray-10">
+      Couldn't load the evidence for this report. Reopen the report to try
+      again.
+    </p>
+  ) : signals.length > 0 ? (
+    <SignalsList signals={signals} />
+  ) : (
+    <SignalsListSkeleton count={evidenceCount} />
   );
 
   return (
-    <div className="@container flex min-h-full flex-col">
-      <div className="mx-auto flex w-full max-w-[calc(160ch+5rem)] flex-wrap items-center justify-between gap-3 px-6 py-4">
-        <div className="flex items-center gap-2 text-[13.5px] text-gray-11">
-          <DetailBackLink to={backTo} label={backLabel} />
-          {breadcrumb}
-        </div>
-        <div className="flex items-center gap-2.5">
-          <ReportReviewersHeader report={report} />
-          {primaryAction}
-          {showDismiss && dismissButton}
-        </div>
-      </div>
-
-      <div className="mx-auto w-full max-w-[calc(160ch+5rem)] px-6 pb-5 text-[14px]">
-        <div className="flex @5xl:flex-row flex-col @5xl:items-start overflow-hidden rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)">
-          <aside className="@5xl:order-none order-2 flex @5xl:w-[26rem] w-full min-w-0 @5xl:shrink-0 flex-col gap-5 @5xl:self-stretch border-(--gray-5) border-t @5xl:border-t-0 @5xl:border-r p-5">
-            {hasEvidence && (
-              <RightColumnSection
-                Icon={EvidenceIcon}
-                title={evidenceSection.title}
-                collapsible
-                rightSlot={
-                  <span className="cursor-default select-none text-[12px] text-gray-10 tabular-nums">
-                    {evidenceCount} signal
-                    {evidenceCount === 1 ? "" : "s"}
-                  </span>
-                }
-              >
-                {evidenceUnavailable ? (
-                  <p className="m-0 text-[13px] text-gray-10">
-                    Couldn't load the evidence for this report. Reopen the
-                    report to try again.
-                  </p>
-                ) : signals.length > 0 ? (
-                  <SignalsList signals={signals} />
-                ) : (
-                  <SignalsListSkeleton count={evidenceCount} />
-                )}
-              </RightColumnSection>
-            )}
-            {aboveEvidence}
-            {children}
-          </aside>
-
-          <main className="@5xl:order-none order-1 flex min-w-0 flex-1 flex-col @5xl:px-8 px-6 py-5">
-            {secondaryTab ? (
-              <Tabs value={activeTab} onValueChange={setActiveTab}>
-                <TabsList
-                  variant="line"
-                  className="mb-5 h-auto w-full justify-start gap-0.5 border-(--gray-5) border-b"
-                >
-                  <TabsTrigger value="overview" className="gap-1.5 px-2.5 py-2">
-                    <span className="font-medium text-[14px]">
-                      {summarySection.title}
-                    </span>
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="secondary"
-                    className="gap-1.5 px-2.5 py-2"
-                  >
-                    <span className="flex items-center gap-1.5 font-medium text-[14px]">
-                      {secondaryTab.label}
-                    </span>
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-            ) : (
-              <div className="mb-5 flex items-center gap-2.5 border-(--gray-5) border-b pb-3">
-                <span className="font-semibold text-[14px] text-gray-12">
-                  {summarySection.title}
-                </span>
-                <span className="flex-1" />
-                <span className="text-[12px] text-gray-10">
-                  Generated <RelativeTimestamp timestamp={report.created_at} />
-                </span>
-              </div>
-            )}
-
-            {secondaryTab && activeTab === "secondary" ? (
-              <div className="flex min-w-0 flex-col gap-5">
-                <h1 className="m-0 min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
-                  {title}
-                </h1>
-                {secondaryTab.content}
-              </div>
-            ) : (
-              <div className="flex min-h-full min-w-0 flex-col gap-6">
-                <div className="flex flex-col gap-2">
-                  <h1 className="m-0 min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
-                    {title}
-                  </h1>
-                  <div className="flex flex-wrap items-center gap-2">
-                    {report.status !== "ready" && (
-                      <SignalReportStatusBadge status={report.status} />
-                    )}
-                    {report.is_suggested_reviewer && <ForYouBadge />}
-                    <InboxMetaRow>{reportMeta}</InboxMetaRow>
-                  </div>
-                </div>
-                {aboveSummary}
-                <ReportSummaryDocument report={report} />
-                {belowSummary}
-                {footer && <div className="mt-auto">{footer}</div>}
-              </div>
-            )}
-          </main>
-        </div>
-        {showDismiss && dismissDialog}
-      </div>
-    </div>
-  );
-}
-
-function ReportSummaryDocument({ report }: { report: SignalReport }) {
-  const split = useMemo(
-    () => splitReportSummary(report.summary),
-    [report.summary],
-  );
-  const chartIds = renderableReportChartIds(report.charts);
-
-  if (split.sections.length === 0) {
-    return (
-      <div className="flex flex-col gap-5">
-        <SignalReportSummaryMarkdown
-          content={report.summary}
-          fallback="No summary yet. The agent is still investigating."
-          variant="detail"
-          pending={report.status === "in_progress"}
-          chartIds={chartIds}
-        />
-        {report.charts && report.charts.length > 0 && (
-          <ReportChartsSection reportId={report.id} charts={report.charts} />
-        )}
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-6">
-      {split.lede && (
-        <div className="text-[16px] text-gray-12">
-          <SignalReportSummaryMarkdown
-            content={split.lede}
-            fallback=""
-            variant="detail"
-            pending={report.status === "in_progress"}
-            chartIds={chartIds}
-          />
-        </div>
-      )}
-      {report.charts && report.charts.length > 0 && (
-        <div className="flex flex-col gap-3">
-          <ReportChartsSection reportId={report.id} charts={report.charts} />
-        </div>
-      )}
-      {split.sections.map((section, index) => (
-        <section
-          key={`${section.title}-${index}`}
-          className="flex flex-col gap-2"
-        >
-          <h2 className="m-0 font-semibold text-[18px] text-gray-12">
-            {section.title}
-          </h2>
-          <SignalReportSummaryMarkdown
-            content={section.body}
-            fallback=""
-            variant="detail"
-            pending={false}
-            chartIds={chartIds}
-          />
-        </section>
-      ))}
-    </div>
+    <InboxDetailFrameView
+      report={report}
+      backTo={backTo}
+      backLabel={backLabel}
+      fallbackTitle={fallbackTitle}
+      breadcrumb={breadcrumb}
+      metaPrefix={metaPrefix}
+      metaSuffix={metaSuffix}
+      primaryAction={primaryAction}
+      reviewerHeader={<ReportReviewersHeader report={report} />}
+      aboveSummary={aboveSummary}
+      summarySection={summarySection}
+      belowSummary={belowSummary}
+      footer={footer}
+      evidenceSection={evidenceSection}
+      evidenceCount={evidenceCount}
+      evidenceContent={evidenceContent}
+      runRepository={runRepository}
+      aboveEvidence={aboveEvidence}
+      secondaryTab={secondaryTab}
+      dismissButton={showDismiss ? dismissButton : undefined}
+      dismissDialog={showDismiss ? dismissDialog : undefined}
+    >
+      {children}
+    </InboxDetailFrameView>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -1,14 +1,10 @@
-import {
-  ChartLineUpIcon,
-  type IconProps,
-  LightbulbIcon,
-  TargetIcon,
-  WarningCircleIcon,
-  WrenchIcon,
-} from "@phosphor-icons/react";
+import type { IconProps } from "@phosphor-icons/react";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
-import { splitReportSummary } from "@posthog/core/inbox/reportPresentation";
+import {
+  humanizeReportTitle,
+  splitReportSummary,
+} from "@posthog/core/inbox/reportPresentation";
 import {
   Tabs,
   TabsList,
@@ -18,10 +14,10 @@ import {
   TooltipTrigger,
 } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
-import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { DetailBackLink } from "@posthog/ui/features/inbox/components/DetailBackLink";
 import { ReportChartsSection } from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
-import { InboxDetailPageHeader } from "@posthog/ui/features/inbox/components/InboxDetailPageHeader";
 import {
+  InboxMetaRow,
   InboxMetaSeparator,
   InboxMetaText,
 } from "@posthog/ui/features/inbox/components/InboxMetaRow";
@@ -92,14 +88,6 @@ interface InboxDetailFrameProps {
   children?: ReactNode;
 }
 
-/**
- * Shared chrome for inbox detail screens. The body lays out the report
- * summary on the left and supporting sections (Evidence, Tasks, Suggested
- * reviewers) on the right when the container is wide enough; everything
- * stacks into a single column below the breakpoint. AgentRunDetail keeps
- * its own layout – its sections (Run summary, Task log) diverge enough that
- * sharing this frame would obscure intent.
- */
 export function InboxDetailFrame({
   report,
   backTo,
@@ -134,216 +122,193 @@ export function InboxDetailFrame({
   const { actionButton: dismissButton, dialog: dismissDialog } =
     useInboxReportDismissAction(report);
 
-  const SummaryIcon = summarySection.Icon;
   const EvidenceIcon = evidenceSection?.Icon;
-  // While the signals query is in flight we already know how many findings to
-  // expect – use `report.signal_count` so the meta row and Evidence skeleton
-  // render immediately. Once the actual signals load, switch to the live count.
-  const evidenceCount = signalsLoaded ? signals.length : report.signal_count;
+  const evidenceUnavailable =
+    signalsLoaded && signalsResp?.report === null && report.signal_count > 0;
+  // Preserve the report's known count while loading or when the detail request
+  // failed. An unavailable response must not make Evidence disappear while a
+  // generic activity log remains on screen.
+  const evidenceCount =
+    !signalsLoaded || evidenceUnavailable
+      ? report.signal_count
+      : signals.length;
   const hasEvidence =
     evidenceSection != null && EvidenceIcon != null && evidenceCount > 0;
+  const displayTitle = humanizeReportTitle(report.title, fallbackTitle);
+
+  const reportMeta = (
+    <>
+      {metaPrefix}
+      {evidenceCount > 0 && (
+        <>
+          <InboxMetaText className="tabular-nums">
+            {evidenceCount} signal{evidenceCount === 1 ? "" : "s"}
+          </InboxMetaText>
+          <InboxMetaSeparator />
+        </>
+      )}
+      <RelativeTimestamp
+        timestamp={report.updated_at ?? report.created_at}
+        className="text-[13px]"
+      />
+      {hasSource && (
+        <>
+          <InboxMetaSeparator />
+          <InboxMetaSourceStack
+            sourceProducts={report.source_products}
+            labelPrefix="Agent · "
+          />
+        </>
+      )}
+      {report.priority && (
+        <>
+          <InboxMetaSeparator />
+          <InboxMetaText>{report.priority}</InboxMetaText>
+        </>
+      )}
+      {runRepository && (
+        <>
+          <InboxMetaSeparator />
+          <Tooltip>
+            <TooltipTrigger
+              render={<InboxMetaText mono className="cursor-help" />}
+            >
+              {runRepository}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              Agent runs for this report work in this repository
+            </TooltipContent>
+          </Tooltip>
+        </>
+      )}
+      {metaSuffix}
+    </>
+  );
 
   return (
-    <div className="flex min-h-full flex-col">
-      <InboxDetailPageHeader
-        backTo={backTo}
-        backLabel={backLabel}
-        breadcrumb={breadcrumb}
-        reportTitle={report.title}
-        fallbackTitle={fallbackTitle}
-        badges={
-          <>
-            {/* Ready is the default state and the decision block says so; only
-                an exceptional status (failed, running, archived) earns a badge. */}
-            {report.status !== "ready" && (
-              <SignalReportStatusBadge status={report.status} />
-            )}
-            {report.is_suggested_reviewer && <ForYouBadge />}
-          </>
-        }
-        meta={
-          <>
-            {metaPrefix}
-            {evidenceCount > 0 && (
-              <>
-                <InboxMetaText className="tabular-nums">
-                  {evidenceCount} signal{evidenceCount === 1 ? "" : "s"}
-                </InboxMetaText>
-                <InboxMetaSeparator />
-              </>
-            )}
-            <RelativeTimestamp
-              timestamp={report.updated_at ?? report.created_at}
-              className="text-[13px]"
-            />
-            {hasSource && (
-              <>
-                <InboxMetaSeparator />
-                <InboxMetaSourceStack
-                  sourceProducts={report.source_products}
-                  labelPrefix="Agent · "
-                />
-              </>
-            )}
-            {report.priority && (
-              <>
-                <InboxMetaSeparator />
-                <InboxMetaText>{report.priority}</InboxMetaText>
-              </>
-            )}
-            {runRepository && (
-              <>
-                <InboxMetaSeparator />
-                <Tooltip>
-                  <TooltipTrigger
-                    render={<InboxMetaText mono className="cursor-help" />}
-                  >
-                    {runRepository}
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    Agent runs for this report work in this repository
-                  </TooltipContent>
-                </Tooltip>
-              </>
-            )}
-            {metaSuffix}
-          </>
-        }
-        actions={
-          <div className="flex items-center gap-2.5">
-            <ReportReviewersHeader report={report} />
-            {primaryAction}
-            {showDismiss && dismissButton}
-          </div>
-        }
-      />
-
-      {secondaryTab && (
-        <div className="border-(--gray-5) border-b px-6">
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList variant="line" className="h-auto gap-0.5">
-              <TabsTrigger value="overview" className="gap-1.5 px-2.5 py-2">
-                <span className="font-medium text-[14px]">Overview</span>
-              </TabsTrigger>
-              <TabsTrigger value="secondary" className="gap-1.5 px-2.5 py-2">
-                <span className="flex items-center gap-1.5 font-medium text-[14px]">
-                  {secondaryTab.label}
-                </span>
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
+    <div className="@container flex min-h-full flex-col">
+      <div className="mx-auto flex w-full max-w-[calc(160ch+5rem)] flex-wrap items-center justify-between gap-3 px-6 py-4">
+        <div className="flex items-center gap-2 text-[13.5px] text-gray-11">
+          <DetailBackLink to={backTo} label={backLabel} />
+          {breadcrumb}
         </div>
-      )}
+        <div className="flex items-center gap-2.5">
+          <ReportReviewersHeader report={report} />
+          {primaryAction}
+          {showDismiss && dismissButton}
+        </div>
+      </div>
 
-      {/*
-         The detail body is a container-query grid:
-           - Left column caps at 80ch – matches the prose width inside, because
-             we set the same 14px font context that the prose uses so `ch` here
-             resolves to the same width as inside the markdown.
-           - Right column grows beyond the prose to use the leftover space, but
-             the grid container is capped so the right column never exceeds 50%
-             of total width. Wider viewports just get larger side gutters.
-        */}
-      <div className="@container mx-auto w-full max-w-[calc(160ch+5rem)] px-6 py-5 text-[14px]">
-        {secondaryTab && activeTab === "secondary" ? (
-          <div className="flex min-w-0 flex-col gap-5">
-            {secondaryTab.content}
-          </div>
-        ) : (
-          <div className="grid @4xl:grid-cols-[minmax(0,80ch)_minmax(0,1fr)] grid-cols-1 gap-5">
-            <div className="flex min-w-0 flex-col gap-5">
-              {aboveSummary}
-              <ReportSummarySlots
-                report={report}
-                fallbackTitle={summarySection.title}
-                Icon={SummaryIcon}
-              />
-              {belowSummary}
-            </div>
+      <div className="mx-auto w-full max-w-[calc(160ch+5rem)] px-6 pb-5 text-[14px]">
+        <div className="flex @5xl:flex-row flex-col @5xl:items-start overflow-hidden rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)">
+          <aside className="@5xl:order-none order-2 flex @5xl:w-[26rem] w-full min-w-0 @5xl:shrink-0 flex-col gap-5 @5xl:self-stretch border-(--gray-5) border-t @5xl:border-t-0 @5xl:border-r p-5">
+            {hasEvidence && (
+              <RightColumnSection
+                Icon={EvidenceIcon}
+                title={evidenceSection.title}
+                collapsible
+                rightSlot={
+                  <span className="cursor-default select-none text-[12px] text-gray-10 tabular-nums">
+                    {evidenceCount} signal
+                    {evidenceCount === 1 ? "" : "s"}
+                  </span>
+                }
+              >
+                {evidenceUnavailable ? (
+                  <p className="m-0 text-[13px] text-gray-10">
+                    Couldn't load the evidence for this report. Reopen the
+                    report to try again.
+                  </p>
+                ) : signals.length > 0 ? (
+                  <SignalsList signals={signals} />
+                ) : (
+                  <SignalsListSkeleton count={evidenceCount} />
+                )}
+              </RightColumnSection>
+            )}
+            {aboveEvidence}
+            {children}
+          </aside>
 
-            <div className="flex min-w-0 flex-col gap-5">
-              {aboveEvidence}
-              {hasEvidence && (
-                <RightColumnSection
-                  Icon={EvidenceIcon}
-                  title={evidenceSection.title}
-                  collapsible
-                  rightSlot={
-                    <span className="cursor-default select-none text-[12px] text-gray-10 tabular-nums">
-                      {evidenceCount} signal
-                      {evidenceCount === 1 ? "" : "s"}
-                    </span>
-                  }
+          <main className="@5xl:order-none order-1 flex min-w-0 flex-1 flex-col @5xl:px-8 px-6 py-5">
+            {secondaryTab ? (
+              <Tabs value={activeTab} onValueChange={setActiveTab}>
+                <TabsList
+                  variant="line"
+                  className="mb-5 h-auto w-full justify-start gap-0.5 border-(--gray-5) border-b"
                 >
-                  {signals.length > 0 ? (
-                    <SignalsList signals={signals} />
-                  ) : (
-                    <SignalsListSkeleton count={evidenceCount} />
-                  )}
-                </RightColumnSection>
-              )}
-              {children}
-            </div>
-          </div>
-        )}
-        {(!secondaryTab || activeTab === "overview") && footer && (
-          <div className="mt-5">{footer}</div>
-        )}
+                  <TabsTrigger value="overview" className="gap-1.5 px-2.5 py-2">
+                    <span className="font-medium text-[14px]">
+                      {summarySection.title}
+                    </span>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="secondary"
+                    className="gap-1.5 px-2.5 py-2"
+                  >
+                    <span className="flex items-center gap-1.5 font-medium text-[14px]">
+                      {secondaryTab.label}
+                    </span>
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            ) : (
+              <div className="mb-5 flex items-center gap-2.5 border-(--gray-5) border-b pb-3">
+                <span className="font-semibold text-[14px] text-gray-12">
+                  {summarySection.title}
+                </span>
+                <span className="flex-1" />
+                <span className="text-[12px] text-gray-10">
+                  Generated <RelativeTimestamp timestamp={report.created_at} />
+                </span>
+              </div>
+            )}
+
+            {secondaryTab && activeTab === "secondary" ? (
+              <div className="flex min-w-0 flex-col gap-5">
+                <h1 className="m-0 min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
+                  {displayTitle}
+                </h1>
+                {secondaryTab.content}
+              </div>
+            ) : (
+              <div className="flex min-h-full min-w-0 flex-col gap-6">
+                <div className="flex flex-col gap-2">
+                  <h1 className="m-0 min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
+                    {displayTitle}
+                  </h1>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {report.status !== "ready" && (
+                      <SignalReportStatusBadge status={report.status} />
+                    )}
+                    {report.is_suggested_reviewer && <ForYouBadge />}
+                    <InboxMetaRow>{reportMeta}</InboxMetaRow>
+                  </div>
+                </div>
+                {aboveSummary}
+                <ReportSummaryDocument report={report} />
+                {belowSummary}
+                {footer && <div className="mt-auto">{footer}</div>}
+              </div>
+            )}
+          </main>
+        </div>
         {showDismiss && dismissDialog}
       </div>
     </div>
   );
 }
 
-/**
- * The summary rendered as labeled slots instead of one wall of prose: the
- * lede (the summary's own tl;dr) stays above the fold, the first section
- * opens by default, and the rest sit behind disclosure. Nothing is cut —
- * the reader jumps to the slot they need instead of reading linearly.
- * Heading-less summaries render whole, exactly as before.
- */
-function ReportSummarySlots({
-  report,
-  fallbackTitle,
-  Icon,
-}: {
-  report: SignalReport;
-  fallbackTitle: string;
-  Icon: ComponentType<IconProps>;
-}) {
+function ReportSummaryDocument({ report }: { report: SignalReport }) {
   const split = useMemo(
     () => splitReportSummary(report.summary),
     [report.summary],
   );
   const chartIds = renderableReportChartIds(report.charts);
-  const charts = report.charts && report.charts.length > 0 && (
-    <div className="mt-4">
-      <ReportChartsSection reportId={report.id} charts={report.charts} />
-    </div>
-  );
-
-  const sectionIcon = (title: string): ComponentType<IconProps> => {
-    const normalizedTitle = title.toLowerCase();
-    if (normalizedTitle.includes("problem")) return WarningCircleIcon;
-    if (normalizedTitle.includes("impact")) return ChartLineUpIcon;
-    if (
-      normalizedTitle.includes("solution") ||
-      normalizedTitle.includes("recommend")
-    ) {
-      return LightbulbIcon;
-    }
-    if (
-      normalizedTitle.includes("implementation") ||
-      normalizedTitle.includes("fix")
-    ) {
-      return WrenchIcon;
-    }
-    return TargetIcon;
-  };
 
   if (split.sections.length === 0) {
     return (
-      <DetailSection Icon={Icon} title={fallbackTitle} collapsible>
+      <div className="flex flex-col gap-5">
         <SignalReportSummaryMarkdown
           content={report.summary}
           fallback="No summary yet. The agent is still investigating."
@@ -351,15 +316,17 @@ function ReportSummarySlots({
           pending={report.status === "in_progress"}
           chartIds={chartIds}
         />
-        {charts}
-      </DetailSection>
+        {report.charts && report.charts.length > 0 && (
+          <ReportChartsSection reportId={report.id} charts={report.charts} />
+        )}
+      </div>
     );
   }
 
   return (
-    <>
+    <div className="flex flex-col gap-6">
       {split.lede && (
-        <DetailSection Icon={Icon} title={fallbackTitle}>
+        <div className="text-[16px] text-gray-12">
           <SignalReportSummaryMarkdown
             content={split.lede}
             fallback=""
@@ -367,23 +334,21 @@ function ReportSummarySlots({
             pending={report.status === "in_progress"}
             chartIds={chartIds}
           />
-        </DetailSection>
+        </div>
       )}
-      {/* Charts answer "how much and how fast?" more quickly than prose, so
-          keep them above the longer analysis sections. */}
       {report.charts && report.charts.length > 0 && (
-        <DetailSection Icon={ChartLineUpIcon} title="Charts">
+        <div className="flex flex-col gap-3">
           <ReportChartsSection reportId={report.id} charts={report.charts} />
-        </DetailSection>
+        </div>
       )}
       {split.sections.map((section, index) => (
-        <DetailSection
+        <section
           key={`${section.title}-${index}`}
-          Icon={sectionIcon(section.title)}
-          title={section.title}
-          collapsible
-          defaultCollapsed={index > 0}
+          className="flex flex-col gap-2"
         >
+          <h2 className="m-0 font-semibold text-[18px] text-gray-12">
+            {section.title}
+          </h2>
           <SignalReportSummaryMarkdown
             content={section.body}
             fallback=""
@@ -391,8 +356,8 @@ function ReportSummarySlots({
             pending={false}
             chartIds={chartIds}
           />
-        </DetailSection>
+        </section>
       ))}
-    </>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -369,6 +369,13 @@ function ReportSummarySlots({
           />
         </DetailSection>
       )}
+      {/* Charts answer "how much and how fast?" more quickly than prose, so
+          keep them above the longer analysis sections. */}
+      {report.charts && report.charts.length > 0 && (
+        <DetailSection Icon={ChartLineUpIcon} title="Charts">
+          <ReportChartsSection reportId={report.id} charts={report.charts} />
+        </DetailSection>
+      )}
       {split.sections.map((section, index) => (
         <DetailSection
           key={`${section.title}-${index}`}
@@ -386,13 +393,6 @@ function ReportSummarySlots({
           />
         </DetailSection>
       ))}
-      {/* Charts stay outside the collapsibles: in-prose chart links jump to
-          these anchors, and a jump into a folded section lands nowhere. */}
-      {report.charts && report.charts.length > 0 && (
-        <DetailSection Icon={ChartLineUpIcon} title="Charts">
-          <ReportChartsSection reportId={report.id} charts={report.charts} />
-        </DetailSection>
-      )}
     </>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrame.tsx
@@ -3,6 +3,7 @@ import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
 import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
 import {
   humanizeReportTitle,
+  parseConventionalCommitTitle,
   splitReportSummary,
 } from "@posthog/core/inbox/reportPresentation";
 import {
@@ -14,6 +15,7 @@ import {
   TooltipTrigger,
 } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
+import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
 import { DetailBackLink } from "@posthog/ui/features/inbox/components/DetailBackLink";
 import { ReportChartsSection } from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
 import {
@@ -134,7 +136,19 @@ export function InboxDetailFrame({
       : signals.length;
   const hasEvidence =
     evidenceSection != null && EvidenceIcon != null && evidenceCount > 0;
+  const conventionalTitle = parseConventionalCommitTitle(report.title);
   const displayTitle = humanizeReportTitle(report.title, fallbackTitle);
+  const title = (
+    <>
+      {conventionalTitle && (
+        <ConventionalCommitScopeTag
+          type={conventionalTitle.type}
+          scope={conventionalTitle.scope}
+        />
+      )}
+      {displayTitle}
+    </>
+  );
 
   const reportMeta = (
     <>
@@ -267,7 +281,7 @@ export function InboxDetailFrame({
             {secondaryTab && activeTab === "secondary" ? (
               <div className="flex min-w-0 flex-col gap-5">
                 <h1 className="m-0 min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
-                  {displayTitle}
+                  {title}
                 </h1>
                 {secondaryTab.content}
               </div>
@@ -275,7 +289,7 @@ export function InboxDetailFrame({
               <div className="flex min-h-full min-w-0 flex-col gap-6">
                 <div className="flex flex-col gap-2">
                   <h1 className="m-0 min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
-                    {displayTitle}
+                    {title}
                   </h1>
                   <div className="flex flex-wrap items-center gap-2">
                     {report.status !== "ready" && (

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrameView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrameView.stories.tsx
@@ -1,0 +1,141 @@
+import {
+  ArchiveIcon,
+  ClockCounterClockwiseIcon,
+  FileTextIcon,
+  GitPullRequestIcon,
+  MagnifyingGlassIcon,
+  TerminalIcon,
+  UsersThreeIcon,
+} from "@phosphor-icons/react";
+import { Button } from "@posthog/quill";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { InboxDetailFrameView } from "@posthog/ui/features/inbox/components/InboxDetailFrameView";
+import {
+  inboxStoryReport,
+  inboxStorySignal,
+} from "@posthog/ui/features/inbox/components/inboxStoryFixtures";
+import { SignalsList } from "@posthog/ui/features/inbox/components/SignalsList";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+
+const report = inboxStoryReport();
+const signals = [
+  inboxStorySignal(),
+  inboxStorySignal({
+    signal_id: "story-signal-2",
+    content:
+      "A second scheduled calculation started before the previous calculation released its lease.",
+    timestamp: "2026-08-26T16:15:00Z",
+  }),
+];
+
+const pageAt = (width: number) => (Story: () => ReactNode) => (
+  <div className="min-h-[760px] bg-gray-1" style={{ width }}>
+    <Story />
+  </div>
+);
+
+const meta: Meta<typeof InboxDetailFrameView> = {
+  title: "Inbox/Reports/Single report",
+  component: InboxDetailFrameView,
+  parameters: { layout: "fullscreen" },
+  decorators: [pageAt(1360)],
+  args: {
+    report,
+    backTo: "/inbox/reports",
+    backLabel: "Back to reports",
+    fallbackTitle: "Untitled report",
+    primaryAction: (
+      <Button type="button" variant="outline" size="sm">
+        Ask about it
+      </Button>
+    ),
+    reviewerHeader: (
+      <span className="rounded bg-(--gray-3) px-1.5 py-0.5 text-[12px] text-gray-11">
+        2 reviewers
+      </span>
+    ),
+    summarySection: { Icon: FileTextIcon, title: "Summary" },
+    evidenceSection: { Icon: MagnifyingGlassIcon, title: "Evidence" },
+    evidenceCount: signals.length,
+    evidenceContent: <SignalsList signals={signals} />,
+    runRepository: "PostHog/posthog",
+    belowSummary: (
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-(--radius-2) border border-(--amber-6) bg-(--amber-2) p-4">
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="font-semibold text-[14px] text-gray-12">
+            Ready for a decision
+          </span>
+          <span className="text-[13px] text-gray-11">
+            Start a pull request or archive this report.
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="outline">
+            <ArchiveIcon />
+            Archive…
+          </Button>
+          <Button type="button" variant="primary">
+            <GitPullRequestIcon />
+            Create PR
+          </Button>
+        </div>
+      </div>
+    ),
+    children: (
+      <>
+        <DetailSection Icon={UsersThreeIcon} title="Reviewers" collapsible>
+          <p className="text-[13px] text-gray-11">
+            Example reviewer · recent ownership in cohort calculations
+          </p>
+        </DetailSection>
+        <DetailSection
+          Icon={TerminalIcon}
+          title="Runs"
+          collapsible
+          defaultCollapsed
+        >
+          <p className="text-[13px] text-gray-11">
+            Research completed 3 days ago
+          </p>
+        </DetailSection>
+        <DetailSection
+          Icon={ClockCounterClockwiseIcon}
+          title="Activity"
+          collapsible
+          defaultCollapsed
+        >
+          <p className="text-[13px] text-gray-11">
+            Priority changed from P2 to P1
+          </p>
+        </DetailSection>
+      </>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InboxDetailFrameView>;
+
+export const EvidenceFirst: Story = {};
+
+export const NoEvidence: Story = {
+  args: {
+    report: inboxStoryReport({ signal_count: 0 }),
+    evidenceCount: 0,
+    evidenceContent: undefined,
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    report: inboxStoryReport({
+      title:
+        "fix(cohorts): prevent overlapping recurring calculations from delaying every queued membership update in large projects",
+    }),
+  },
+};
+
+export const Narrow: Story = {
+  decorators: [pageAt(720)],
+};

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrameView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxDetailFrameView.tsx
@@ -1,0 +1,255 @@
+import type { IconProps } from "@phosphor-icons/react";
+import {
+  humanizeReportTitle,
+  parseConventionalCommitTitle,
+} from "@posthog/core/inbox/reportPresentation";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import type { SignalReport } from "@posthog/shared/types";
+import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
+import { DetailBackLink } from "@posthog/ui/features/inbox/components/DetailBackLink";
+import {
+  InboxMetaRow,
+  InboxMetaSeparator,
+  InboxMetaText,
+} from "@posthog/ui/features/inbox/components/InboxMetaRow";
+import { InboxMetaSourceStack } from "@posthog/ui/features/inbox/components/InboxMetaSourceStack";
+import { ReportSummaryDocument } from "@posthog/ui/features/inbox/components/ReportSummaryDocument";
+import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
+import { ForYouBadge } from "@posthog/ui/features/inbox/components/utils/ForYouBadge";
+import { SignalReportStatusBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportStatusBadge";
+import { hasKnownSourceProduct } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
+import type { InboxListRoute } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import type { ComponentType, ReactNode } from "react";
+import { useState } from "react";
+
+export interface InboxDetailFrameViewProps {
+  report: SignalReport;
+  backTo: InboxListRoute | (string & {});
+  backLabel: string;
+  fallbackTitle: string;
+  breadcrumb?: ReactNode;
+  metaPrefix?: ReactNode;
+  metaSuffix?: ReactNode;
+  primaryAction?: ReactNode;
+  reviewerHeader?: ReactNode;
+  aboveSummary?: ReactNode;
+  summarySection: { Icon: ComponentType<IconProps>; title: string };
+  belowSummary?: ReactNode;
+  footer?: ReactNode;
+  evidenceSection: {
+    Icon: ComponentType<IconProps>;
+    title: string;
+  } | null;
+  evidenceCount: number;
+  evidenceContent?: ReactNode;
+  runRepository?: string | null;
+  aboveEvidence?: ReactNode;
+  secondaryTab?: { label: ReactNode; content: ReactNode };
+  dismissButton?: ReactNode;
+  dismissDialog?: ReactNode;
+  children?: ReactNode;
+}
+
+export function InboxDetailFrameView({
+  report,
+  backTo,
+  backLabel,
+  fallbackTitle,
+  breadcrumb,
+  metaPrefix,
+  metaSuffix,
+  primaryAction,
+  reviewerHeader,
+  aboveSummary,
+  summarySection,
+  belowSummary,
+  footer,
+  evidenceSection,
+  evidenceCount,
+  evidenceContent,
+  runRepository,
+  aboveEvidence,
+  secondaryTab,
+  dismissButton,
+  dismissDialog,
+  children,
+}: InboxDetailFrameViewProps): React.JSX.Element {
+  const [activeTab, setActiveTab] = useState("overview");
+  const hasSource = hasKnownSourceProduct(report.source_products);
+  const EvidenceIcon = evidenceSection?.Icon;
+  const hasEvidence =
+    evidenceSection != null && EvidenceIcon != null && evidenceCount > 0;
+  const conventionalTitle = parseConventionalCommitTitle(report.title);
+  const displayTitle = humanizeReportTitle(report.title, fallbackTitle);
+  const title = (
+    <>
+      {conventionalTitle && (
+        <ConventionalCommitScopeTag
+          type={conventionalTitle.type}
+          scope={conventionalTitle.scope}
+        />
+      )}
+      {displayTitle}
+    </>
+  );
+
+  const reportMeta = (
+    <>
+      {metaPrefix}
+      {evidenceCount > 0 && (
+        <>
+          <InboxMetaText className="tabular-nums">
+            {evidenceCount} signal{evidenceCount === 1 ? "" : "s"}
+          </InboxMetaText>
+          <InboxMetaSeparator />
+        </>
+      )}
+      <RelativeTimestamp
+        timestamp={report.updated_at ?? report.created_at}
+        className="text-[13px]"
+      />
+      {hasSource && (
+        <>
+          <InboxMetaSeparator />
+          <InboxMetaSourceStack
+            sourceProducts={report.source_products}
+            labelPrefix="Agent · "
+          />
+        </>
+      )}
+      {report.priority && (
+        <>
+          <InboxMetaSeparator />
+          <InboxMetaText>{report.priority}</InboxMetaText>
+        </>
+      )}
+      {runRepository && (
+        <>
+          <InboxMetaSeparator />
+          <Tooltip>
+            <TooltipTrigger
+              render={<InboxMetaText mono className="cursor-help" />}
+            >
+              {runRepository}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              Agent runs for this report work in this repository
+            </TooltipContent>
+          </Tooltip>
+        </>
+      )}
+      {metaSuffix}
+    </>
+  );
+
+  return (
+    <div className="@container flex min-h-full flex-col">
+      <div className="mx-auto flex w-full max-w-[calc(160ch+5rem)] flex-wrap items-center justify-between gap-3 px-6 py-4">
+        <div className="flex items-center gap-2 text-[13.5px] text-gray-11">
+          <DetailBackLink to={backTo} label={backLabel} />
+          {breadcrumb}
+        </div>
+        <div className="flex items-center gap-2.5">
+          {reviewerHeader}
+          {primaryAction}
+          {dismissButton}
+        </div>
+      </div>
+
+      <div className="mx-auto w-full max-w-[calc(160ch+5rem)] px-6 pb-5 text-[14px]">
+        <div className="flex @5xl:flex-row flex-col @5xl:items-start overflow-hidden rounded-(--radius-3) border border-(--gray-5) bg-(--color-panel-solid)">
+          <aside className="@5xl:order-none order-2 flex @5xl:w-[26rem] w-full min-w-0 @5xl:shrink-0 flex-col gap-5 @5xl:self-stretch border-(--gray-5) border-t @5xl:border-t-0 @5xl:border-r p-5">
+            {hasEvidence && (
+              <RightColumnSection
+                Icon={EvidenceIcon}
+                title={evidenceSection.title}
+                collapsible
+                rightSlot={
+                  <span className="cursor-default select-none text-[12px] text-gray-10 tabular-nums">
+                    {evidenceCount} signal{evidenceCount === 1 ? "" : "s"}
+                  </span>
+                }
+              >
+                {evidenceContent}
+              </RightColumnSection>
+            )}
+            {aboveEvidence}
+            {children}
+          </aside>
+
+          <main className="@5xl:order-none order-1 flex min-w-0 flex-1 flex-col @5xl:px-8 px-6 py-5">
+            {secondaryTab ? (
+              <Tabs value={activeTab} onValueChange={setActiveTab}>
+                <TabsList
+                  variant="line"
+                  className="mb-5 h-auto w-full justify-start gap-0.5 border-(--gray-5) border-b"
+                >
+                  <TabsTrigger value="overview" className="gap-1.5 px-2.5 py-2">
+                    <span className="font-medium text-[14px]">
+                      {summarySection.title}
+                    </span>
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="secondary"
+                    className="gap-1.5 px-2.5 py-2"
+                  >
+                    <span className="flex items-center gap-1.5 font-medium text-[14px]">
+                      {secondaryTab.label}
+                    </span>
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            ) : (
+              <div className="mb-5 flex items-center gap-2.5 border-(--gray-5) border-b pb-3">
+                <span className="font-semibold text-[14px] text-gray-12">
+                  {summarySection.title}
+                </span>
+                <span className="flex-1" />
+                <span className="text-[12px] text-gray-10">
+                  Generated <RelativeTimestamp timestamp={report.created_at} />
+                </span>
+              </div>
+            )}
+
+            {secondaryTab && activeTab === "secondary" ? (
+              <div className="flex min-w-0 flex-col gap-5">
+                <h1 className="m-0 min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
+                  {title}
+                </h1>
+                {secondaryTab.content}
+              </div>
+            ) : (
+              <div className="flex min-h-full min-w-0 flex-col gap-6">
+                <div className="flex flex-col gap-2">
+                  <h1 className="m-0 min-w-0 font-bold text-[24px] text-gray-12 leading-tight tracking-tight">
+                    {title}
+                  </h1>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {report.status !== "ready" && (
+                      <SignalReportStatusBadge status={report.status} />
+                    )}
+                    {report.is_suggested_reviewer && <ForYouBadge />}
+                    <InboxMetaRow>{reportMeta}</InboxMetaRow>
+                  </div>
+                </div>
+                {aboveSummary}
+                <ReportSummaryDocument report={report} />
+                {belowSummary}
+                {footer && <div className="mt-auto">{footer}</div>}
+              </div>
+            )}
+          </main>
+        </div>
+        {dismissDialog}
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportDetailGate.tsx
@@ -10,6 +10,7 @@ import { DetailBackLink } from "@posthog/ui/features/inbox/components/DetailBack
 import {
   asInboxBackTarget,
   type InboxListRoute,
+  useInboxTriageOrigin,
 } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { useInboxReportById } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import {
@@ -80,6 +81,7 @@ export function InboxReportDetailGate({
   children,
 }: InboxReportDetailGateProps) {
   const navigate = useNavigate();
+  const triageOrigin = useInboxTriageOrigin();
   const {
     data: report,
     isLoading,
@@ -135,16 +137,19 @@ export function InboxReportDetailGate({
       // the user is returning to. Validated because `backTo` may be a literal
       // path on the in-space route (which never redirects, but types can't see
       // that).
-      state:
-        redirectTo === "/inbox/dismissed/$reportId"
+      state: (previous) => ({
+        ...previous,
+        ...(redirectTo === "/inbox/dismissed/$reportId"
           ? {
               inboxBackOrigin:
                 asInboxBackTarget({ to: backTo, label: backLabel }) ??
                 undefined,
             }
-          : undefined,
+          : {}),
+        ...(triageOrigin ? { inboxTriageOrigin: triageOrigin } : {}),
+      }),
     });
-  }, [redirectTo, redirectReportId, navigate, backTo, backLabel]);
+  }, [redirectTo, redirectReportId, navigate, backTo, backLabel, triageOrigin]);
 
   if ((isLoading && !resolvedReport) || statusUnconfirmed) {
     return (

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportRow.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportRow.tsx
@@ -1,0 +1,29 @@
+import type { SignalReport } from "@posthog/shared/types";
+import { InboxReportRowView } from "@posthog/ui/features/inbox/components/InboxReportRowView";
+import { ReportRestoreButton } from "@posthog/ui/features/inbox/components/ReportRestoreButton";
+import { SuggestedReviewerAvatarStack } from "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack";
+import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
+import { navigateToInboxReportDetail } from "@posthog/ui/router/navigationBridge";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+
+export function InboxReportRow({
+  report,
+}: {
+  report: SignalReport;
+}): React.JSX.Element {
+  const { pointerHandlers } = useInboxReportDetailPrefetch({
+    to: "/inbox/reports/$reportId",
+    params: { reportId: report.id },
+  });
+
+  return (
+    <InboxReportRowView
+      report={report}
+      prefetchHandlers={pointerHandlers}
+      reviewers={<SuggestedReviewerAvatarStack report={report} />}
+      restoreAction={<ReportRestoreButton report={report} />}
+      onOpen={() => navigateToInboxReportDetail(report.id)}
+      onOpenPr={openExternalUrl}
+    />
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportRowView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportRowView.tsx
@@ -1,0 +1,148 @@
+import {
+  ArchiveIcon,
+  CheckCircleIcon,
+  GitMergeIcon,
+  GitPullRequestIcon,
+} from "@phosphor-icons/react";
+import { humanizeIdentifier } from "@posthog/core/inbox/activityLog";
+import {
+  deriveHeadline,
+  humanizeReportTitle,
+  parseConventionalCommitTitle,
+  parsePrUrl,
+} from "@posthog/core/inbox/reportPresentation";
+import type { SignalReport } from "@posthog/shared/types";
+import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
+import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import type { HTMLAttributes, ReactNode } from "react";
+
+export interface InboxReportRowViewProps {
+  report: SignalReport;
+  reviewers?: ReactNode;
+  restoreAction?: ReactNode;
+  prefetchHandlers?: Pick<
+    HTMLAttributes<HTMLDivElement>,
+    "onPointerEnter" | "onPointerLeave" | "onFocus" | "onBlur"
+  >;
+  onOpen: () => void;
+  onOpenPr: (url: string) => void;
+}
+
+export function InboxReportRowView({
+  report,
+  reviewers,
+  restoreAction,
+  prefetchHandlers,
+  onOpen,
+  onOpenPr,
+}: InboxReportRowViewProps): React.JSX.Element {
+  const conventionalTitle = parseConventionalCommitTitle(report.title);
+  const products = (report.source_products ?? [])
+    .map((product) => humanizeIdentifier(product).toLowerCase())
+    .join(" · ");
+  const headline = deriveHeadline(report.summary);
+  const prUrl = report.implementation_pr_url ?? null;
+  const pr = prUrl ? parsePrUrl(prUrl) : null;
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: The row contains independent PR and restore buttons.
+    <div
+      role="button"
+      tabIndex={0}
+      {...prefetchHandlers}
+      onClick={onOpen}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen();
+        }
+      }}
+      className="flex w-full cursor-pointer items-center gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-3 py-2 text-left transition hover:border-(--gray-6) hover:bg-(--gray-2)"
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="truncate font-medium text-[14px] text-gray-12">
+          {conventionalTitle && (
+            <ConventionalCommitScopeTag
+              type={conventionalTitle.type}
+              scope={conventionalTitle.scope}
+            />
+          )}
+          <span>{humanizeReportTitle(report.title, "Untitled report")}</span>
+        </span>
+        {headline && (
+          <span className="line-clamp-2 text-[13px] text-gray-11">
+            {headline}
+          </span>
+        )}
+        <span className="flex items-center gap-1.5 text-[12.5px] text-gray-10">
+          {products && <span className="truncate">{products}</span>}
+          <RelativeTimestamp
+            timestamp={report.created_at}
+            className="shrink-0 text-[12.5px]"
+          />
+        </span>
+      </div>
+      <span className="flex shrink-0 items-center gap-2">
+        {report.status === "resolved" && (
+          <span
+            title="The fix shipped and this report closed"
+            className="flex items-center gap-1 rounded border border-(--green-6) bg-(--green-2) px-1.5 py-0.5 text-[12px] text-green-11"
+          >
+            <CheckCircleIcon size={11} />
+            Shipped
+          </span>
+        )}
+        {report.status === "suppressed" && (
+          <span
+            title={report.dismissal_note ?? undefined}
+            className="flex items-center gap-1 rounded border border-(--gray-6) bg-(--gray-2) px-1.5 py-0.5 text-[12px] text-gray-11"
+          >
+            <ArchiveIcon size={11} />
+            Archived
+            {report.dismissal_reason
+              ? ` · ${humanizeIdentifier(report.dismissal_reason)}`
+              : ""}
+          </span>
+        )}
+        {reviewers}
+        <SignalReportPriorityBadge priority={report.priority} />
+        <span className="font-mono text-[13px] text-gray-11 tabular-nums">
+          {report.signal_count} signal{report.signal_count === 1 ? "" : "s"}
+        </span>
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: This span only stops nested controls from opening the row. */}
+        <span
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}
+          className="flex items-center gap-1.5"
+        >
+          {pr && prUrl && (
+            <button
+              type="button"
+              onClick={() => onOpenPr(prUrl)}
+              title={
+                report.implementation_pr_merged
+                  ? "This report's earlier PR merged, but evidence kept arriving"
+                  : "Open the pull request on GitHub"
+              }
+              className={
+                report.implementation_pr_merged
+                  ? "flex items-center gap-1 rounded border border-(--gray-6) px-1.5 py-0.5 font-mono text-[12px] text-gray-11 hover:bg-(--gray-3) hover:text-gray-12"
+                  : "flex items-center gap-1 rounded border border-(--accent-7) bg-(--accent-2) px-1.5 py-0.5 font-mono text-(--accent-11) text-[12px] hover:bg-(--accent-3)"
+              }
+            >
+              {report.implementation_pr_merged ? (
+                <GitMergeIcon size={11} />
+              ) : (
+                <GitPullRequestIcon size={11} />
+              )}
+              #{pr.number}
+              {report.implementation_pr_merged ? " merged" : ""}
+            </button>
+          )}
+          {restoreAction}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxReportSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxReportSection.tsx
@@ -1,0 +1,108 @@
+import { CaretDownIcon } from "@phosphor-icons/react";
+import { Button, Spinner } from "@posthog/quill";
+import type { SignalReport } from "@posthog/shared/types";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+const SECTION_PREVIEW_LIMIT = 5;
+
+export interface InboxReportSectionProps {
+  title: string;
+  reports: SignalReport[];
+  count: number;
+  emptyNote?: string;
+  defaultOpen?: boolean;
+  isLoading?: boolean;
+  renderReport: (report: SignalReport) => ReactNode;
+  onShowMore?: () => void;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function InboxReportSection({
+  title,
+  reports,
+  count,
+  emptyNote,
+  defaultOpen = true,
+  isLoading = false,
+  renderReport,
+  onShowMore,
+  onOpenChange,
+}: InboxReportSectionProps): React.JSX.Element | null {
+  const [open, setOpen] = useState(defaultOpen);
+  const [visibleCount, setVisibleCount] = useState(SECTION_PREVIEW_LIMIT);
+  if (count === 0 && reports.length === 0 && !emptyNote) return null;
+
+  const visible = reports.slice(0, visibleCount);
+  const hidden = reports.length - visible.length;
+
+  return (
+    <section className="flex flex-col gap-2">
+      <button
+        type="button"
+        className="flex w-full cursor-pointer items-center gap-2 rounded px-0.5 py-1 text-left"
+        onClick={() =>
+          setOpen((current) => {
+            const next = !current;
+            onOpenChange?.(next);
+            return next;
+          })
+        }
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-1 font-mono font-semibold text-[11px] text-gray-10 uppercase tracking-widest">
+          {title}
+          <span className="tabular-nums">({count})</span>
+        </span>
+        <div className="h-px flex-1 bg-(--gray-5)" />
+        <CaretDownIcon
+          size={12}
+          className={`text-gray-9 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open &&
+        (isLoading ? (
+          <div className="flex justify-center py-3">
+            <Spinner />
+          </div>
+        ) : reports.length === 0 ? (
+          <p className="px-1 py-2 text-[13.5px] text-gray-10">{emptyNote}</p>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {visible.map((report) => renderReport(report))}
+            {hidden > 0 && (
+              <Button
+                type="button"
+                variant="link-muted"
+                size="sm"
+                className="self-center text-gray-10"
+                onClick={() =>
+                  setVisibleCount((current) =>
+                    Math.min(current + SECTION_PREVIEW_LIMIT, reports.length),
+                  )
+                }
+              >
+                Show more ({hidden})
+              </Button>
+            )}
+            {onShowMore && hidden === 0 && count > reports.length && (
+              <Button
+                type="button"
+                variant="link-muted"
+                size="sm"
+                className="self-center text-gray-10"
+                onClick={() => {
+                  setVisibleCount((current) =>
+                    Math.min(current + SECTION_PREVIEW_LIMIT, count),
+                  );
+                  onShowMore();
+                }}
+              >
+                Show more ({Math.max(0, count - reports.length)})
+              </Button>
+            )}
+          </div>
+        ))}
+    </section>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/InboxSearchFilterBar.tsx
@@ -4,7 +4,6 @@ import {
   CheckIcon,
   CrosshairSimpleIcon,
   FlagIcon,
-  GitPullRequestIcon,
   MagnifyingGlassIcon,
 } from "@phosphor-icons/react";
 import {
@@ -21,21 +20,15 @@ import { type ReactNode, useId, useMemo } from "react";
 
 interface InboxSearchFilterBarProps {
   searchPlaceholder?: string;
-  /** The sectioned inbox filters by PR state; the legacy tabs already are one. */
-  showPrFilter?: boolean;
+  showSourceFilter?: boolean;
 }
-
-const PR_FILTER_OPTIONS = [
-  { value: "with_pr", label: "Has a PR" },
-  { value: "without_pr", label: "No PR yet" },
-] as const;
 
 const FILTER_ITEM_CLASS =
   "flex w-full items-center justify-between rounded-sm px-1.5 py-1 text-left text-[14px] text-gray-12 transition-colors hover:bg-(--gray-3) focus-visible:bg-(--gray-3) focus-visible:outline-none";
 
 export function InboxSearchFilterBar({
   searchPlaceholder = "Search by title or description…",
-  showPrFilter = false,
+  showSourceFilter = true,
 }: InboxSearchFilterBarProps) {
   const inputId = useId();
   const searchQuery = useInboxSignalsFilterStore((s) => s.searchQuery);
@@ -57,9 +50,6 @@ export function InboxSearchFilterBar({
   const setPriorityFilter = useInboxSignalsFilterStore(
     (s) => s.setPriorityFilter,
   );
-  const prFilter = useInboxSignalsFilterStore((s) => s.prFilter);
-  const setPrFilter = useInboxSignalsFilterStore((s) => s.setPrFilter);
-
   const sourceOptions = useInboxSourceFilterOptions(sourceProductFilter);
   const selectedSources = useMemo(
     () => new Set(sourceProductFilter),
@@ -89,70 +79,38 @@ export function InboxSearchFilterBar({
         />
       </label>
 
-      <InboxFilterPopover
-        label="Source"
-        value={inboxSourceFilterLabel(sourceProductFilter)}
-        icon={<CrosshairSimpleIcon size={13} className="text-gray-10" />}
-        active={sourceProductFilter.length > 0}
-      >
-        <Flex direction="column" gap="0">
-          <InboxFilterAnyItem
-            active={sourceProductFilter.length === 0}
-            onClick={clearSourceProductFilter}
-          />
-          {sourceOptions.map((option) => {
-            const isActive = selectedSources.has(option.value);
-            return (
-              <button
-                key={option.value}
-                type="button"
-                className={FILTER_ITEM_CLASS}
-                onClick={() => toggleSourceProduct(option.value)}
-              >
-                <span className="flex min-w-0 items-center gap-1.5">
-                  {option.icon}
-                  <span className="truncate">{option.label}</span>
-                </span>
-                {isActive ? (
-                  <CheckIcon size={12} className="shrink-0 text-gray-12" />
-                ) : null}
-              </button>
-            );
-          })}
-        </Flex>
-      </InboxFilterPopover>
-
-      {showPrFilter && (
+      {showSourceFilter && (
         <InboxFilterPopover
-          label="Pull request"
-          value={
-            PR_FILTER_OPTIONS.find((option) => option.value === prFilter)
-              ?.label ?? "All reports"
-          }
-          icon={<GitPullRequestIcon size={13} className="text-gray-10" />}
-          active={prFilter !== "all"}
+          label="Source"
+          value={inboxSourceFilterLabel(sourceProductFilter)}
+          icon={<CrosshairSimpleIcon size={13} className="text-gray-10" />}
+          active={sourceProductFilter.length > 0}
         >
-          <div className="flex flex-col">
+          <Flex direction="column" gap="0">
             <InboxFilterAnyItem
-              active={prFilter === "all"}
-              onClick={() => setPrFilter("all")}
+              active={sourceProductFilter.length === 0}
+              onClick={clearSourceProductFilter}
             />
-            {PR_FILTER_OPTIONS.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                className={FILTER_ITEM_CLASS}
-                onClick={() =>
-                  setPrFilter(prFilter === option.value ? "all" : option.value)
-                }
-              >
-                <span className="truncate">{option.label}</span>
-                {prFilter === option.value ? (
-                  <CheckIcon size={12} className="shrink-0 text-gray-12" />
-                ) : null}
-              </button>
-            ))}
-          </div>
+            {sourceOptions.map((option) => {
+              const isActive = selectedSources.has(option.value);
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={FILTER_ITEM_CLASS}
+                  onClick={() => toggleSourceProduct(option.value)}
+                >
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    {option.icon}
+                    <span className="truncate">{option.label}</span>
+                  </span>
+                  {isActive ? (
+                    <CheckIcon size={12} className="shrink-0 text-gray-12" />
+                  ) : null}
+                </button>
+              );
+            })}
+          </Flex>
         </InboxFilterPopover>
       )}
 

--- a/products/desktop/packages/ui/src/features/inbox/components/PriorityMonogram.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PriorityMonogram.tsx
@@ -10,9 +10,13 @@ const PRIORITY_CLASSES: Record<SignalReportPriority, string> = {
 
 interface PriorityMonogramProps {
   priority: SignalReportPriority | null | undefined;
+  size?: "default" | "large";
 }
 
-export function PriorityMonogram({ priority }: PriorityMonogramProps) {
+export function PriorityMonogram({
+  priority,
+  size = "default",
+}: PriorityMonogramProps) {
   const label = priority ?? "–";
   const toneClass = priority
     ? PRIORITY_CLASSES[priority]
@@ -21,7 +25,8 @@ export function PriorityMonogram({ priority }: PriorityMonogramProps) {
   return (
     <div
       className={[
-        "flex h-6 w-6 shrink-0 items-center justify-center rounded-(--radius-1) font-bold text-[9px] tracking-tight",
+        "flex shrink-0 items-center justify-center rounded-(--radius-1) font-bold tracking-tight",
+        size === "large" ? "h-10 w-10 text-[12px]" : "h-6 w-6 text-[9px]",
         toneClass,
       ].join(" ")}
       aria-label={priority ? `Priority ${priority}` : "Priority unknown"}

--- a/products/desktop/packages/ui/src/features/inbox/components/PriorityMonogram.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PriorityMonogram.tsx
@@ -10,7 +10,7 @@ const PRIORITY_CLASSES: Record<SignalReportPriority, string> = {
 
 interface PriorityMonogramProps {
   priority: SignalReportPriority | null | undefined;
-  size?: "default" | "large";
+  size?: "default" | "large" | "hero";
 }
 
 export function PriorityMonogram({
@@ -26,7 +26,11 @@ export function PriorityMonogram({
     <div
       className={[
         "flex shrink-0 items-center justify-center rounded-(--radius-1) font-bold tracking-tight",
-        size === "large" ? "h-10 w-10 text-[12px]" : "h-6 w-6 text-[9px]",
+        size === "hero"
+          ? "h-20 w-20 text-[20px]"
+          : size === "large"
+            ? "h-10 w-10 text-[12px]"
+            : "h-6 w-6 text-[9px]",
         toneClass,
       ].join(" ")}
       aria-label={priority ? `Priority ${priority}` : "Priority unknown"}

--- a/products/desktop/packages/ui/src/features/inbox/components/PriorityMonogram.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PriorityMonogram.tsx
@@ -10,7 +10,7 @@ const PRIORITY_CLASSES: Record<SignalReportPriority, string> = {
 
 interface PriorityMonogramProps {
   priority: SignalReportPriority | null | undefined;
-  size?: "default" | "large" | "hero";
+  size?: "default" | "large";
 }
 
 export function PriorityMonogram({
@@ -26,11 +26,7 @@ export function PriorityMonogram({
     <div
       className={[
         "flex shrink-0 items-center justify-center rounded-(--radius-1) font-bold tracking-tight",
-        size === "hero"
-          ? "h-20 w-20 text-[20px]"
-          : size === "large"
-            ? "h-10 w-10 text-[12px]"
-            : "h-6 w-6 text-[9px]",
+        size === "large" ? "h-10 w-10 text-[12px]" : "h-6 w-6 text-[9px]",
         toneClass,
       ].join(" ")}
       aria-label={priority ? `Priority ${priority}` : "Priority unknown"}

--- a/products/desktop/packages/ui/src/features/inbox/components/PullRequestCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/PullRequestCard.tsx
@@ -79,7 +79,6 @@ export function PullRequestCardView({
                 <ConventionalCommitScopeTag
                   type={conventionalTitle.type}
                   scope={conventionalTitle.scope}
-                  compact
                 />
               )
             }

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportCard.tsx
@@ -123,7 +123,6 @@ export function ReportCardView(props: ReportCardViewProps) {
                 <ConventionalCommitScopeTag
                   type={conventionalTitle.type}
                   scope={conventionalTitle.scope}
-                  compact
                 />
               )
             }

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -4,6 +4,7 @@ import {
   AskAboutSelection,
   quoteSelection,
 } from "@posthog/ui/features/inbox/components/AskAboutSelection";
+import { ReportActivitySection } from "@posthog/ui/features/inbox/components/detail/ReportActivitySection";
 import { ReportFeedbackFooter } from "@posthog/ui/features/inbox/components/detail/ReportFeedbackFooter";
 import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDetailFrame";
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
@@ -53,8 +54,8 @@ export function ReportDetail({
 /**
  * A report reads story-first: the summary and charts, then the evidence.
  * The document stays pure content while its conversation owns follow-up
- * actions. Pipeline machinery (runs, activity logs, reviewer reasoning)
- * deliberately doesn't render.
+ * actions. Activity stays available but collapsed so someone can tell whether
+ * work already started without letting the implementation log dominate.
  *
  * The report owns its own scroll so the chat dock can sit full-height beside
  * it: reading and asking share one screen, and highlighting a passage quotes
@@ -109,7 +110,9 @@ function ReportDetailContent({
           summarySection={{ Icon: FileTextIcon, title: "Summary" }}
           footer={<ReportFeedbackFooter report={report} />}
           evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
-        />
+        >
+          <ReportActivitySection reportId={report.id} />
+        </InboxDetailFrame>
       </div>
       <AskAboutSelection containerRef={contentRef} onAsk={handleAsk} />
       {chatOpen && <ReportChatSidebar report={report} />}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -10,6 +10,8 @@ import { InboxDetailFrame } from "@posthog/ui/features/inbox/components/InboxDet
 import { InboxReportDetailGate } from "@posthog/ui/features/inbox/components/InboxReportDetailGate";
 import { ReportChatSidebar } from "@posthog/ui/features/inbox/components/ReportChatSidebar";
 import { ReportDetailActions } from "@posthog/ui/features/inbox/components/ReportDetailActions";
+import { ReportReviewersSection } from "@posthog/ui/features/inbox/components/ReportReviewersSection";
+import { ReportRunsSection } from "@posthog/ui/features/inbox/components/ReportRunsSection";
 import { ReportVerdictBanner } from "@posthog/ui/features/inbox/components/ReportVerdictBanner";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { useCallback, useEffect, useRef } from "react";
@@ -100,7 +102,7 @@ function ReportDetailContent({
           primaryAction={
             <ReportDetailActions report={report} placement="header" />
           }
-          aboveSummary={
+          belowSummary={
             <ReportVerdictBanner
               key={report.id}
               report={report}
@@ -111,6 +113,8 @@ function ReportDetailContent({
           footer={<ReportFeedbackFooter report={report} />}
           evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
         >
+          <ReportReviewersSection report={report} />
+          <ReportRunsSection report={report} />
           <ReportActivitySection reportId={report.id} />
         </InboxDetailFrame>
       </div>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowSquareOutIcon,
-  ClockIcon,
   CopyIcon,
   DotsThreeIcon,
   ReceiptIcon,
@@ -28,13 +27,12 @@ import { useChannelReportsEnabled } from "@posthog/ui/features/feature-flags/use
 import { RefundReportDialog } from "@posthog/ui/features/inbox/components/RefundReportDialog";
 import { ReportChatToggle } from "@posthog/ui/features/inbox/components/ReportChatToggle";
 import { useCreateCanvasReport } from "@posthog/ui/features/inbox/hooks/useCreateCanvasReport";
-import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useRefundReport } from "@posthog/ui/features/inbox/hooks/useRefundReport";
 import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { copyInboxReportLink } from "@posthog/ui/features/inbox/utils/copyInboxReportLink";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 
 interface ReportDetailActionsProps {
   report: SignalReport;
@@ -97,16 +95,6 @@ export function ReportDetailActions({
   const safePrUrl = prUrl && parsePrUrl(prUrl) ? prUrl : null;
   const refund = useRefundReport(report);
   const [refundOpen, setRefundOpen] = useState(false);
-  const reportsForBulk = useMemo(() => [report], [report]);
-  const bulkActions = useInboxBulkActions(
-    reportsForBulk,
-    report.id,
-    "detail_pane",
-  );
-  const canDefer =
-    report.status === "ready" ||
-    report.status === "failed" ||
-    report.status === "pending_input";
 
   const [canvasOpen, setCanvasOpen] = useState(false);
   const [canvasDirection, setCanvasDirection] = useState("");
@@ -137,18 +125,6 @@ export function ReportDetailActions({
         }
       />
       <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
-        {canDefer && (
-          <DropdownMenuItem
-            disabled={
-              bulkActions.snoozeDisabledReason !== null ||
-              bulkActions.isSnoozing
-            }
-            onClick={() => void bulkActions.snoozeSelected()}
-          >
-            <ClockIcon size={13} />
-            Defer
-          </DropdownMenuItem>
-        )}
         <DropdownMenuItem onClick={() => copyInboxReportLink(report)}>
           <CopyIcon size={13} />
           Copy link
@@ -196,29 +172,6 @@ export function ReportDetailActions({
       <>
         {githubButton}
         <ReportChatToggle report={report} />
-        {canDefer && (
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon-xs"
-                  className="h-7 w-7"
-                  aria-label="Defer"
-                  loading={bulkActions.isSnoozing}
-                  disabled={bulkActions.snoozeDisabledReason !== null}
-                  onClick={() => void bulkActions.snoozeSelected()}
-                />
-              }
-            >
-              <ClockIcon size={13} />
-            </TooltipTrigger>
-            <TooltipContent>
-              {bulkActions.snoozeDisabledReason ?? "Defer"}
-            </TooltipContent>
-          </Tooltip>
-        )}
         <Tooltip>
           <TooltipTrigger
             render={

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -237,36 +237,26 @@ export function ReportDetailActions({
           <TooltipContent>Copy link</TooltipContent>
         </Tooltip>
         {refund.canRefund && (
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <DropdownMenuTrigger
-                    render={
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon-xs"
-                        aria-label="More report actions"
-                      >
-                        <DotsThreeIcon size={13} weight="bold" />
-                      </Button>
-                    }
-                  />
-                }
-              />
-              <TooltipContent>More report actions</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
-              <DropdownMenuItem
-                disabled={refund.disabledReason !== null}
-                onClick={() => setRefundOpen(true)}
-              >
-                <ReceiptIcon size={13} />
-                Refund…
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-xs"
+                  className="h-7 w-7"
+                  aria-label="Refund"
+                  disabled={refund.disabledReason !== null}
+                  onClick={() => setRefundOpen(true)}
+                />
+              }
+            >
+              <ReceiptIcon />
+            </TooltipTrigger>
+            <TooltipContent>
+              {refund.disabledReason ?? "Refund this PR and archive the report"}
+            </TooltipContent>
+          </Tooltip>
         )}
         {refund.canRefund && (
           <RefundReportDialog

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetailActions.tsx
@@ -1,7 +1,7 @@
 import {
   ArrowSquareOutIcon,
-  CopyIcon,
   DotsThreeIcon,
+  LinkIcon,
   ReceiptIcon,
   ShapesIcon,
 } from "@phosphor-icons/react";
@@ -126,7 +126,7 @@ export function ReportDetailActions({
       />
       <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
         <DropdownMenuItem onClick={() => copyInboxReportLink(report)}>
-          <CopyIcon size={13} />
+          <LinkIcon size={13} />
           Copy link
         </DropdownMenuItem>
         {refund.canRefund && !isResolved && (
@@ -185,7 +185,7 @@ export function ReportDetailActions({
               />
             }
           >
-            <CopyIcon size={13} />
+            <LinkIcon size={13} />
           </TooltipTrigger>
           <TooltipContent>Copy link</TooltipContent>
         </Tooltip>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportReviewersSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportReviewersSection.tsx
@@ -1,0 +1,58 @@
+import { UsersThreeIcon } from "@phosphor-icons/react";
+import { suggestedReviewerDisplayName } from "@posthog/core/inbox/artefacts";
+import { selectSuggestedReviewersArtefact } from "@posthog/core/inbox/reportArtefacts";
+import type { SignalReport } from "@posthog/shared/types";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { SuggestedReviewerAvatar } from "@posthog/ui/features/inbox/components/utils/SuggestedReviewerAvatar";
+import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+
+export function ReportReviewersSection({ report }: { report: SignalReport }) {
+  const { data } = useInboxReportArtefacts(report.id);
+  const reviewers = selectSuggestedReviewersArtefact(
+    data?.results ?? [],
+  )?.content;
+
+  if (!reviewers || reviewers.length === 0) return null;
+
+  return (
+    <DetailSection
+      Icon={UsersThreeIcon}
+      title="Reviewers"
+      collapsible
+      rightSlot={
+        <span className="text-[12px] text-gray-10 tabular-nums">
+          {reviewers.length}
+        </span>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        {reviewers.map((reviewer) => (
+          <div
+            key={reviewer.user?.uuid ?? reviewer.github_login}
+            className="flex min-w-0 flex-col gap-1.5"
+          >
+            <div className="flex items-center gap-2">
+              {reviewer.github_login && (
+                <SuggestedReviewerAvatar
+                  githubLogin={reviewer.github_login}
+                  size="sm"
+                />
+              )}
+              <span className="truncate font-medium text-[13px] text-gray-12">
+                {suggestedReviewerDisplayName(reviewer)}
+              </span>
+            </div>
+            {reviewer.relevant_commits.map((commit) => (
+              <p
+                key={commit.sha}
+                className="m-0 text-[12px] text-gray-10 leading-relaxed"
+              >
+                {commit.reason}
+              </p>
+            ))}
+          </div>
+        ))}
+      </div>
+    </DetailSection>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportRunsSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportRunsSection.tsx
@@ -1,0 +1,53 @@
+import { TerminalIcon } from "@phosphor-icons/react";
+import { humanizeIdentifier } from "@posthog/core/inbox/activityLog";
+import type { SignalReport } from "@posthog/shared/types";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { useReportTasks } from "@posthog/ui/features/inbox/hooks/useReportTasks";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import { useOpenTask } from "@posthog/ui/router/useOpenTask";
+
+export function ReportRunsSection({ report }: { report: SignalReport }) {
+  const { data: runs } = useReportTasks(report.id, report.status);
+  const openTask = useOpenTask();
+
+  if (!runs || runs.length === 0) return null;
+
+  return (
+    <DetailSection
+      Icon={TerminalIcon}
+      title="Runs"
+      collapsible
+      defaultCollapsed
+      rightSlot={
+        <span className="text-[12px] text-gray-10 tabular-nums">
+          {runs.length}
+        </span>
+      }
+    >
+      <div className="flex flex-col gap-1">
+        {runs.map(({ task, purposeLabel, startedAt }) => (
+          <button
+            key={task.id}
+            type="button"
+            className="flex min-w-0 items-center gap-2 rounded-(--radius-1) px-1 py-1.5 text-left hover:bg-(--gray-3)"
+            onClick={() => void openTask(task)}
+          >
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-(--gray-8)" />
+            <span className="min-w-0 flex-1 truncate font-medium text-[12px] text-gray-11">
+              {purposeLabel}
+            </span>
+            {task.latest_run?.status && (
+              <span className="shrink-0 text-[11px] text-gray-10">
+                {humanizeIdentifier(task.latest_run.status)}
+              </span>
+            )}
+            <RelativeTimestamp
+              timestamp={startedAt}
+              className="shrink-0 text-[11px]"
+            />
+          </button>
+        ))}
+      </div>
+    </DetailSection>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportSummaryDocument.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportSummaryDocument.tsx
@@ -1,0 +1,69 @@
+import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
+import { splitReportSummary } from "@posthog/core/inbox/reportPresentation";
+import type { SignalReport } from "@posthog/shared/types";
+import { ReportChartsSection } from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
+import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown";
+
+export function ReportSummaryDocument({
+  report,
+}: {
+  report: SignalReport;
+}): React.JSX.Element {
+  const split = splitReportSummary(report.summary);
+  const chartIds = renderableReportChartIds(report.charts);
+
+  if (split.sections.length === 0) {
+    return (
+      <div className="flex flex-col gap-5">
+        <SignalReportSummaryMarkdown
+          content={report.summary}
+          fallback="No summary yet. The agent is still investigating."
+          variant="detail"
+          pending={report.status === "in_progress"}
+          chartIds={chartIds}
+        />
+        {report.charts && report.charts.length > 0 && (
+          <ReportChartsSection reportId={report.id} charts={report.charts} />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {split.lede && (
+        <div className="text-[16px] text-gray-12">
+          <SignalReportSummaryMarkdown
+            content={split.lede}
+            fallback=""
+            variant="detail"
+            pending={report.status === "in_progress"}
+            chartIds={chartIds}
+          />
+        </div>
+      )}
+      {report.charts && report.charts.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <ReportChartsSection reportId={report.id} charts={report.charts} />
+        </div>
+      )}
+      {split.sections.map((section, index) => (
+        <section
+          key={`${section.title}-${index}`}
+          className="flex flex-col gap-2"
+        >
+          <h2 className="m-0 font-semibold text-[18px] text-gray-12">
+            {section.title}
+          </h2>
+          <SignalReportSummaryMarkdown
+            content={section.body}
+            fallback=""
+            variant="detail"
+            pending={false}
+            chartIds={chartIds}
+          />
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isInteractiveTarget } from "./ReportTriageFocus";
+import { isInteractiveTarget, triageEnterAction } from "./ReportTriageFocus";
 
 describe("isInteractiveTarget", () => {
   function firstEl(html: string): HTMLElement {
@@ -29,5 +29,27 @@ describe("isInteractiveTarget", () => {
   it("returns false for null or a non-element target", () => {
     expect(isInteractiveTarget(null)).toBe(false);
     expect(isInteractiveTarget(document)).toBe(false);
+  });
+});
+
+describe("triageEnterAction", () => {
+  const plainTarget = document.createElement("div");
+  const buttonTarget = document.createElement("button");
+
+  it.each([
+    ["plain Enter expands in place", false, false, plainTarget, "toggle"],
+    ["Command+Enter opens the full report", true, false, plainTarget, "open"],
+    ["Control+Enter opens the full report", false, true, plainTarget, "open"],
+    ["a focused control owns Enter", false, false, buttonTarget, null],
+  ] as const)("%s", (_label, metaKey, ctrlKey, target, expected) => {
+    expect(
+      triageEnterAction({
+        key: "Enter",
+        metaKey,
+        ctrlKey,
+        altKey: false,
+        target,
+      }),
+    ).toBe(expected);
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -119,13 +119,6 @@ export function ReportTriageFocus({
     [bulkActions],
   );
 
-  // Defer = snooze without a dialog: one keystroke, the report re-promotes
-  // itself when enough new evidence lands. Auto-advances like archive.
-  const deferReport = useCallback(async () => {
-    if (bulkActions.snoozeDisabledReason !== null) return;
-    await bulkActions.snoozeSelected();
-  }, [bulkActions]);
-
   const goNext = useCallback(
     () => setIndex((i) => Math.min(i + 1, reports.length - 1)),
     [reports.length],
@@ -154,10 +147,6 @@ export function ReportTriageFocus({
           event.preventDefault();
           if (report) setDismissOpen(true);
           break;
-        case "d":
-          event.preventDefault();
-          if (report && !dismissPending) void deferReport();
-          break;
         case "Enter":
           // A focused control (button, link) owns Enter — let the browser
           // activate it instead of hijacking the key to exit triage.
@@ -176,15 +165,7 @@ export function ReportTriageFocus({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [
-    dismissOpen,
-    report,
-    dismissPending,
-    deferReport,
-    goNext,
-    goPrev,
-    onExit,
-  ]);
+  }, [dismissOpen, report, goNext, goPrev, onExit]);
 
   if (!report) {
     // The queue ran dry mid-session — every decision is made.
@@ -333,9 +314,6 @@ export function ReportTriageFocus({
           </span>
           <span className="flex items-center gap-1">
             <KeyCap>a</KeyCap> ask
-          </span>
-          <span className="flex items-center gap-1">
-            <KeyCap>d</KeyCap> defer
           </span>
           <span className="flex items-center gap-1">
             <KeyCap>e</KeyCap> archive

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -313,6 +313,7 @@ export function ReportTriageFocus({
           <ReportVerdictBanner
             report={report}
             actionHotkey={dismissOpen ? undefined : "f"}
+            askHotkey={dismissOpen ? undefined : "a"}
             // The triage card hosts no dock: engaging opens the report page,
             // where the dock (already flagged open) shows the conversation.
             onEngaged={() => {
@@ -331,10 +332,13 @@ export function ReportTriageFocus({
             <KeyCap>f</KeyCap> fix
           </span>
           <span className="flex items-center gap-1">
+            <KeyCap>a</KeyCap> ask
+          </span>
+          <span className="flex items-center gap-1">
             <KeyCap>d</KeyCap> defer
           </span>
           <span className="flex items-center gap-1">
-            <KeyCap>e</KeyCap> dismiss
+            <KeyCap>e</KeyCap> archive
           </span>
           <span className="flex items-center gap-1">
             <KeyCap>↵</KeyCap> open

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowDownIcon,
+  ArrowsOutSimpleIcon,
   ArrowUpIcon,
   ChartLineUpIcon,
   FileTextIcon,
@@ -271,15 +272,11 @@ export function ReportTriageFocus({
       }
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       switch (event.key) {
-        case "j":
         case "ArrowDown":
-        case "ArrowRight":
           event.preventDefault();
           goNext();
           break;
-        case "k":
         case "ArrowUp":
-        case "ArrowLeft":
           event.preventDefault();
           goPrev();
           break;
@@ -472,18 +469,20 @@ export function ReportTriageFocus({
               <div className="ml-auto flex items-center gap-2">
                 <Button
                   type="button"
-                  variant="default"
+                  variant="outline"
                   className="h-9 gap-2 px-4 text-[14px]"
                   onClick={handleOpenReport}
                 >
+                  <ArrowsOutSimpleIcon />
                   Open report
                 </Button>
                 <Button
                   type="button"
-                  variant="default"
+                  variant="outline"
                   className="h-9 gap-2 px-4 text-[14px]"
                   onClick={() => setExpanded((current) => !current)}
                 >
+                  <FileTextIcon />
                   {expanded ? "Hide summary" : "Read summary"}
                 </Button>
               </div>
@@ -509,8 +508,8 @@ export function ReportTriageFocus({
 
           <div className="flex flex-wrap items-center justify-center gap-4 text-[13px] text-gray-10">
             <span className="flex items-center gap-1">
-              <KeyHint>J</KeyHint>
-              <KeyHint>K</KeyHint>
+              <KeyHint>↑</KeyHint>
+              <KeyHint>↓</KeyHint>
               move
             </span>
             {prShortcut && (

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -92,6 +92,7 @@ export function ReportTriageFocus({
   allReports,
   scope,
   hasActiveFilters,
+  initialReportId,
   onExit,
 }: {
   /** The decision queue, in the list's current sort order. */
@@ -101,9 +102,15 @@ export function ReportTriageFocus({
   /** Scope and filter context inherited from the list that opened triage. */
   scope: InboxScope;
   hasActiveFilters: boolean;
+  initialReportId?: string;
   onExit: () => void;
 }) {
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useState(() => {
+    const initialIndex = initialReportId
+      ? reports.findIndex((report) => report.id === initialReportId)
+      : -1;
+    return Math.max(0, initialIndex);
+  });
   const [dismissOpen, setDismissOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const chatOpen = useReportChatPanelStore((state) => state.open);
@@ -210,9 +217,9 @@ export function ReportTriageFocus({
   }, [finishSession, onExit]);
   const handleOpenReport = useCallback(() => {
     if (!report) return;
-    handleExit();
-    navigateToInboxReportDetail(report.id);
-  }, [handleExit, report]);
+    finishSession("exited");
+    navigateToInboxReportDetail(report.id, { returnToTriage: true });
+  }, [finishSession, report]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -301,7 +308,6 @@ export function ReportTriageFocus({
             >
               <XIcon />
               Exit triage
-              <KeyHint>Esc</KeyHint>
             </Button>
           </div>
 
@@ -432,8 +438,7 @@ export function ReportTriageFocus({
               <ReportVerdictBanner
                 report={report}
                 variant="triage-actions"
-                actionHotkey={dismissOpen ? undefined : "f"}
-                archiveHotkey={dismissOpen ? undefined : "a"}
+                actionHotkey={dismissOpen ? undefined : "c"}
                 surface="triage"
               />
               <div className="ml-auto flex items-center gap-2">
@@ -443,7 +448,6 @@ export function ReportTriageFocus({
                   onClick={handleOpenReport}
                 >
                   Open report
-                  <KeyHint>O</KeyHint>
                 </Button>
                 <Button
                   type="button"
@@ -451,7 +455,6 @@ export function ReportTriageFocus({
                   onClick={() => setExpanded((current) => !current)}
                 >
                   {expanded ? "Hide summary" : "Read summary"}
-                  <KeyHint>↵</KeyHint>
                 </Button>
               </div>
             </div>
@@ -473,6 +476,34 @@ export function ReportTriageFocus({
               </span>
             </Button>
           )}
+
+          <div className="flex flex-wrap items-center justify-center gap-4 text-[13px] text-gray-10">
+            <span className="flex items-center gap-1">
+              <KeyHint>J</KeyHint>
+              <KeyHint>K</KeyHint>
+              move
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyHint>C</KeyHint>
+              create PR
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyHint>A</KeyHint>
+              archive
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyHint>O</KeyHint>
+              open
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyHint>Enter</KeyHint>
+              summary
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyHint>Esc</KeyHint>
+              exit
+            </span>
+          </div>
         </div>
 
         {dismissOpen && (

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -1,14 +1,23 @@
 import {
+  ArrowsOutSimpleIcon,
   CaretLeftIcon,
   CaretRightIcon,
+  ChartLineUpIcon,
   FileTextIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
+import {
+  type InboxScope,
+  inboxReviewerScopeValue,
+  inboxScopeTriggerLabel,
+} from "@posthog/core/inbox/reportMembership";
 import {
   humanizeReportTitle,
   splitReportSummary,
 } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { isDismissalReasonSnooze } from "@posthog/shared/dismissalReasons";
 import type { SignalReport } from "@posthog/shared/types";
 import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
@@ -16,14 +25,22 @@ import {
   DismissReportDialog,
   type DismissReportDialogResult,
 } from "@posthog/ui/features/inbox/components/DismissReportDialog";
+import { ReportChartsSection } from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
+import { ReportChatSidebar } from "@posthog/ui/features/inbox/components/ReportChatSidebar";
 import { ReportVerdictBanner } from "@posthog/ui/features/inbox/components/ReportVerdictBanner";
+import { SuggestedReviewerAvatarStack } from "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack";
 import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
 import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown";
 import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
+import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { navigateToInboxReportDetail } from "@posthog/ui/router/navigationBridge";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { track } from "@posthog/ui/shell/analytics";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const isMac =
+  typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
 /** A keyboard hint chip; quill has no kbd primitive, so plain HTML carries it. */
 function KeyCap({ children }: { children: string }) {
@@ -57,35 +74,86 @@ export function isInteractiveTarget(target: EventTarget | null): boolean {
   );
 }
 
+export function triageEnterAction(input: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  target: EventTarget | null;
+}): "toggle" | "open" | null {
+  if (
+    input.key !== "Enter" ||
+    input.altKey ||
+    isInteractiveTarget(input.target)
+  ) {
+    return null;
+  }
+  return input.metaKey || input.ctrlKey ? "open" : "toggle";
+}
+
 /**
  * One report at a time, keyboard-driven: the fast way through a pile of
  * decisions. Walks the needs-a-decision queue in the list's order — j/k (or
- * arrows) move, e opens archive, enter opens the full report, esc leaves.
+ * arrows) move, e opens archive, enter expands in place, esc leaves.
  * Archiving auto-advances: the archived report drops out of the queue and the
  * next one takes its place under the same index.
  */
 export function ReportTriageFocus({
   reports,
   allReports,
+  scope,
+  hasActiveFilters,
   onExit,
 }: {
   /** The decision queue, in the list's current sort order. */
   reports: SignalReport[];
   /** Superset backing archive eligibility (mirrors the list shells). */
   allReports: SignalReport[];
+  /** Scope and filter context inherited from the list that opened triage. */
+  scope: InboxScope;
+  hasActiveFilters: boolean;
   onExit: () => void;
 }) {
   const [index, setIndex] = useState(0);
   const [dismissOpen, setDismissOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const chatOpen = useReportChatPanelStore((state) => state.open);
+  const setChatOpen = useReportChatPanelStore((state) => state.setOpen);
+  const sessionContextRef = useRef({
+    queue_size: reports.length,
+    scope: inboxReviewerScopeValue(scope),
+    has_active_filters: hasActiveFilters,
+  });
+  const sessionStartedAtRef = useRef(Date.now());
+  const reviewedReportIdsRef = useRef(new Set<string>());
+  const sessionEndedRef = useRef(false);
+
+  const finishSession = useCallback((endReason: "completed" | "exited") => {
+    if (sessionEndedRef.current) return;
+    sessionEndedRef.current = true;
+    track(ANALYTICS_EVENTS.INBOX_TRIAGE_ENDED, {
+      ...sessionContextRef.current,
+      reports_reviewed: reviewedReportIdsRef.current.size,
+      duration_ms: Date.now() - sessionStartedAtRef.current,
+      end_reason: endReason,
+    });
+  }, []);
+
+  useEffect(() => {
+    track(ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED, sessionContextRef.current);
+    return () => finishSession("exited");
+  }, [finishSession]);
 
   // The queue shrinks under us when a report is archived; clamping (rather
   // than resetting) is what makes archive-and-advance work.
   const clamped = Math.min(index, Math.max(0, reports.length - 1));
   const report = reports[clamped];
+  const reportId = report?.id;
   const summarySplit = useMemo(
     () => splitReportSummary(report?.summary),
     [report?.summary],
   );
+  const chartIds = renderableReportChartIds(report?.charts);
   const { prefetch } = useInboxReportDetailPrefetch(
     report
       ? {
@@ -94,6 +162,17 @@ export function ReportTriageFocus({
         }
       : null,
   );
+
+  useEffect(() => {
+    if (!reportId) {
+      setChatOpen(false);
+      finishSession("completed");
+      return;
+    }
+    reviewedReportIdsRef.current.add(reportId);
+    setExpanded(false);
+    setChatOpen(false);
+  }, [finishSession, reportId, setChatOpen]);
 
   // Triage is intentionally sequential, so the next destination is known as
   // soon as the card renders. Warm it before Enter/Review is pressed instead
@@ -105,7 +184,7 @@ export function ReportTriageFocus({
   const bulkActions = useInboxBulkActions(
     allReports,
     report?.id ?? null,
-    "list_row",
+    "triage",
   );
   const dismissPending = bulkActions.isSuppressing || bulkActions.isSnoozing;
 
@@ -124,11 +203,29 @@ export function ReportTriageFocus({
     [reports.length],
   );
   const goPrev = useCallback(() => setIndex((i) => Math.max(i - 1, 0)), []);
+  const handleExit = useCallback(() => {
+    finishSession("exited");
+    onExit();
+  }, [finishSession, onExit]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       // The dialog owns the keyboard while open; typing surfaces always do.
       if (dismissOpen || isTypingTarget(event.target)) return;
+      const enterAction = triageEnterAction(event);
+      if (enterAction === "open") {
+        event.preventDefault();
+        if (report) {
+          handleExit();
+          navigateToInboxReportDetail(report.id);
+        }
+        return;
+      }
+      if (enterAction === "toggle") {
+        event.preventDefault();
+        if (report) setExpanded((current) => !current);
+        return;
+      }
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       switch (event.key) {
         case "k":
@@ -147,25 +244,15 @@ export function ReportTriageFocus({
           event.preventDefault();
           if (report) setDismissOpen(true);
           break;
-        case "Enter":
-          // A focused control (button, link) owns Enter — let the browser
-          // activate it instead of hijacking the key to exit triage.
-          if (isInteractiveTarget(event.target)) break;
-          event.preventDefault();
-          if (report) {
-            onExit();
-            navigateToInboxReportDetail(report.id);
-          }
-          break;
         case "Escape":
           event.preventDefault();
-          onExit();
+          handleExit();
           break;
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [dismissOpen, report, goNext, goPrev, onExit]);
+  }, [dismissOpen, report, goNext, goPrev, handleExit]);
 
   if (!report) {
     // The queue ran dry mid-session — every decision is made.
@@ -177,7 +264,7 @@ export function ReportTriageFocus({
         <span className="text-[14px] text-gray-11">
           Nothing left in the queue.
         </span>
-        <Button type="button" variant="outline" size="sm" onClick={onExit}>
+        <Button type="button" variant="outline" size="sm" onClick={handleExit}>
           Back to the list
         </Button>
       </div>
@@ -185,158 +272,189 @@ export function ReportTriageFocus({
   }
 
   return (
-    <>
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-6 py-4">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="icon-sm"
-              aria-label="Previous report"
-              disabled={clamped === 0}
-              onClick={goPrev}
-            >
-              <CaretLeftIcon size={14} />
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon-sm"
-              aria-label="Next report"
-              disabled={clamped >= reports.length - 1}
-              onClick={goNext}
-            >
-              <CaretRightIcon size={14} />
-            </Button>
-            <span className="text-[13px] text-gray-10 tabular-nums">
-              {clamped + 1} of {reports.length}
-            </span>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={onExit}
-            className="gap-1"
-          >
-            <XIcon size={12} />
-            Exit triage
-          </Button>
-        </div>
-
-        <div className="flex flex-col gap-3 rounded-lg border border-border bg-(--color-panel-solid) p-5">
-          <div className="flex flex-col gap-1.5">
-            <h2 className="font-semibold text-[17px] text-gray-12 leading-snug">
-              {humanizeReportTitle(report.title, "Untitled report")}
-            </h2>
-            <div className="flex items-center gap-2 text-[13px] text-gray-10">
-              <SignalReportPriorityBadge priority={report.priority} />
-              <span className="tabular-nums">
-                {report.signal_count} signal
-                {report.signal_count === 1 ? "" : "s"}
+    <div className="flex h-full min-h-0">
+      <div className="min-w-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-6 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                aria-label="Previous report"
+                disabled={clamped === 0}
+                onClick={goPrev}
+              >
+                <CaretLeftIcon size={14} />
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-sm"
+                aria-label="Next report"
+                disabled={clamped >= reports.length - 1}
+                onClick={goNext}
+              >
+                <CaretRightIcon size={14} />
+              </Button>
+              <span className="text-[13px] text-gray-10 tabular-nums">
+                {clamped + 1} of {reports.length} ·{" "}
+                {inboxScopeTriggerLabel(scope)}
+                {hasActiveFilters ? " · Filtered" : ""}
               </span>
-              <RelativeTimestamp
-                timestamp={report.updated_at ?? report.created_at}
-                className="text-[13px]"
-              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setExpanded((current) => !current)}
+                className="gap-1"
+              >
+                <ArrowsOutSimpleIcon size={12} />
+                {expanded ? "Collapse report" : "Show report"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleExit}
+                className="gap-1"
+              >
+                <XIcon size={12} />
+                Exit triage
+              </Button>
             </div>
           </div>
 
-          {/* The proof stays sorted and folded — the same labeled slots as
+          <div className="flex flex-col gap-3 rounded-lg border border-border bg-(--color-panel-solid) p-5">
+            <div className="flex flex-col gap-1.5">
+              <h2 className="font-semibold text-[17px] text-gray-12 leading-snug">
+                {humanizeReportTitle(report.title, "Untitled report")}
+              </h2>
+              <div className="flex items-center gap-2 text-[13px] text-gray-10">
+                <SignalReportPriorityBadge priority={report.priority} />
+                <span className="tabular-nums">
+                  {report.signal_count} signal
+                  {report.signal_count === 1 ? "" : "s"}
+                </span>
+                <RelativeTimestamp
+                  timestamp={report.updated_at ?? report.created_at}
+                  className="text-[13px]"
+                />
+                <SuggestedReviewerAvatarStack
+                  report={report}
+                  surface="triage"
+                />
+              </div>
+            </div>
+
+            {/* The proof stays sorted and folded — the same labeled slots as
               the detail page. The lede (the summary's own tl;dr) shows since
               it's triage-sized; each section opens on demand. Triage reads
               the verdict; research opens the full report. */}
-          {summarySplit.sections.length === 0 ? (
-            <DetailSection
-              Icon={FileTextIcon}
-              title="How we know"
-              collapsible
-              defaultCollapsed
-            >
-              <SignalReportSummaryMarkdown
-                content={report.summary}
-                fallback="No summary yet. The agent is still investigating."
-                variant="detail"
-                pending={report.status === "in_progress"}
-              />
-            </DetailSection>
-          ) : (
-            <>
-              {summarySplit.lede && (
+            {report.charts && report.charts.length > 0 && (
+              <DetailSection Icon={ChartLineUpIcon} title="Charts">
+                <ReportChartsSection
+                  reportId={report.id}
+                  charts={report.charts}
+                />
+              </DetailSection>
+            )}
+            {summarySplit.sections.length === 0 ? (
+              <DetailSection
+                key={`${report.id}-${expanded}`}
+                Icon={FileTextIcon}
+                title="How we know"
+                collapsible
+                defaultCollapsed={!expanded}
+              >
                 <SignalReportSummaryMarkdown
-                  content={summarySplit.lede}
-                  fallback=""
+                  content={report.summary}
+                  fallback="No summary yet. The agent is still investigating."
                   variant="detail"
                   pending={report.status === "in_progress"}
+                  chartIds={chartIds}
                 />
-              )}
-              {summarySplit.sections.map((section, sectionIndex) => (
-                <DetailSection
-                  key={`${section.title}-${sectionIndex}`}
-                  Icon={FileTextIcon}
-                  title={section.title}
-                  collapsible
-                  defaultCollapsed
-                >
+              </DetailSection>
+            ) : (
+              <>
+                {summarySplit.lede && (
                   <SignalReportSummaryMarkdown
-                    content={section.body}
+                    content={summarySplit.lede}
                     fallback=""
                     variant="detail"
-                    pending={false}
+                    pending={report.status === "in_progress"}
+                    chartIds={chartIds}
                   />
-                </DetailSection>
-              ))}
-            </>
-          )}
+                )}
+                {summarySplit.sections.map((section, sectionIndex) => (
+                  <DetailSection
+                    key={`${report.id}-${expanded}-${section.title}-${sectionIndex}`}
+                    Icon={FileTextIcon}
+                    title={section.title}
+                    collapsible
+                    defaultCollapsed={!expanded}
+                  >
+                    <SignalReportSummaryMarkdown
+                      content={section.body}
+                      fallback=""
+                      variant="detail"
+                      pending={false}
+                      chartIds={chartIds}
+                    />
+                  </DetailSection>
+                ))}
+              </>
+            )}
 
-          {/* The decision closes the card: read first, then accept. */}
-          <ReportVerdictBanner
+            {/* The decision closes the card: read first, then accept. */}
+            <ReportVerdictBanner
+              report={report}
+              actionHotkey={dismissOpen ? undefined : "f"}
+              askHotkey={dismissOpen ? undefined : "a"}
+              surface="triage"
+            />
+          </div>
+
+          <div className="flex items-center justify-center gap-4 text-[13px] text-gray-10">
+            <span className="flex items-center gap-1">
+              <KeyCap>j</KeyCap>
+              <KeyCap>k</KeyCap> move
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyCap>f</KeyCap> fix
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyCap>a</KeyCap> ask
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyCap>e</KeyCap> archive
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyCap>↵</KeyCap> show
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyCap>{isMac ? "⌘↵" : "Ctrl+↵"}</KeyCap> open
+            </span>
+            <span className="flex items-center gap-1">
+              <KeyCap>esc</KeyCap> exit
+            </span>
+          </div>
+        </div>
+
+        {dismissOpen && (
+          <DismissReportDialog
+            open
+            onOpenChange={setDismissOpen}
             report={report}
-            actionHotkey={dismissOpen ? undefined : "f"}
-            askHotkey={dismissOpen ? undefined : "a"}
-            // The triage card hosts no dock: engaging opens the report page,
-            // where the dock (already flagged open) shows the conversation.
-            onEngaged={() => {
-              onExit();
-              navigateToInboxReportDetail(report.id);
-            }}
+            isSubmitting={dismissPending}
+            snoozeDisabledReason={bulkActions.snoozeDisabledReason}
+            onConfirm={handleDismissConfirm}
           />
-        </div>
-
-        <div className="flex items-center justify-center gap-4 text-[13px] text-gray-10">
-          <span className="flex items-center gap-1">
-            <KeyCap>j</KeyCap>
-            <KeyCap>k</KeyCap> move
-          </span>
-          <span className="flex items-center gap-1">
-            <KeyCap>f</KeyCap> fix
-          </span>
-          <span className="flex items-center gap-1">
-            <KeyCap>a</KeyCap> ask
-          </span>
-          <span className="flex items-center gap-1">
-            <KeyCap>e</KeyCap> archive
-          </span>
-          <span className="flex items-center gap-1">
-            <KeyCap>↵</KeyCap> open
-          </span>
-          <span className="flex items-center gap-1">
-            <KeyCap>esc</KeyCap> exit
-          </span>
-        </div>
+        )}
       </div>
-
-      {dismissOpen && (
-        <DismissReportDialog
-          open
-          onOpenChange={setDismissOpen}
-          report={report}
-          isSubmitting={dismissPending}
-          snoozeDisabledReason={bulkActions.snoozeDisabledReason}
-          onConfirm={handleDismissConfirm}
-        />
-      )}
-    </>
+      {chatOpen && <ReportChatSidebar report={report} />}
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -5,6 +5,7 @@ import {
   FileTextIcon,
   XIcon,
 } from "@phosphor-icons/react";
+import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
 import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
 import {
   type InboxScope,
@@ -15,6 +16,7 @@ import {
   deriveHeadline,
   displayConventionalCommitTitle,
   parseConventionalCommitTitle,
+  parsePrUrl,
   splitReportSummary,
 } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
@@ -36,6 +38,11 @@ import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/componen
 import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
+import {
+  findContinuableImplementationTask,
+  getTaskPrUrl,
+  useReportTasks,
+} from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { KeyHint } from "@posthog/ui/primitives/KeyHint";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
@@ -145,6 +152,27 @@ export function ReportTriageFocus({
   const clamped = Math.min(index, Math.max(0, reports.length - 1));
   const report = reports[clamped];
   const reportId = report?.id;
+  const { data: reportTasks, isLoading: reportTasksLoading } = useReportTasks(
+    reportId ?? "",
+    report?.status ?? "candidate",
+  );
+  const continuableTask = findContinuableImplementationTask(reportTasks);
+  const canCreatePr =
+    report?.status === "ready" &&
+    canCreateImplementationPr(report, {
+      hasLiveImplementationTask: continuableTask !== null,
+      isTaskLookupPending: reportTasksLoading,
+    });
+  const livePrUrl = report?.implementation_pr_merged
+    ? null
+    : report?.implementation_pr_url;
+  const existingPrUrl =
+    livePrUrl ?? (continuableTask ? getTaskPrUrl(continuableTask) : null);
+  const canOpenPr =
+    report?.status === "ready" &&
+    !!existingPrUrl &&
+    parsePrUrl(existingPrUrl) !== null;
+  const prShortcut = canOpenPr ? "open" : canCreatePr ? "create" : null;
   const previousReport = clamped > 0 ? reports[clamped - 1] : null;
   const nextReport = clamped < reports.length - 1 ? reports[clamped + 1] : null;
   const conventionalTitle = parseConventionalCommitTitle(report?.title);
@@ -438,7 +466,8 @@ export function ReportTriageFocus({
               <ReportVerdictBanner
                 report={report}
                 variant="triage-actions"
-                actionHotkey={dismissOpen ? undefined : "c"}
+                prHotkey={dismissOpen || !prShortcut ? undefined : "c"}
+                askHotkey={dismissOpen ? undefined : "q"}
                 surface="triage"
               />
               <div className="ml-auto flex items-center gap-2">
@@ -483,9 +512,15 @@ export function ReportTriageFocus({
               <KeyHint>K</KeyHint>
               move
             </span>
+            {prShortcut && (
+              <span className="flex items-center gap-1">
+                <KeyHint>C</KeyHint>
+                {prShortcut === "open" ? "open PR" : "create PR"}
+              </span>
+            )}
             <span className="flex items-center gap-1">
-              <KeyHint>C</KeyHint>
-              create PR
+              <KeyHint>Q</KeyHint>
+              ask
             </span>
             <span className="flex items-center gap-1">
               <KeyHint>A</KeyHint>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -1,7 +1,6 @@
 import {
-  ArrowsOutSimpleIcon,
-  CaretLeftIcon,
-  CaretRightIcon,
+  ArrowDownIcon,
+  ArrowUpIcon,
   ChartLineUpIcon,
   FileTextIcon,
   XIcon,
@@ -13,43 +12,36 @@ import {
   inboxScopeTriggerLabel,
 } from "@posthog/core/inbox/reportMembership";
 import {
-  humanizeReportTitle,
+  deriveHeadline,
+  displayConventionalCommitTitle,
+  parseConventionalCommitTitle,
   splitReportSummary,
 } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { isDismissalReasonSnooze } from "@posthog/shared/dismissalReasons";
 import type { SignalReport } from "@posthog/shared/types";
+import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
 import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
 import {
   DismissReportDialog,
   type DismissReportDialogResult,
 } from "@posthog/ui/features/inbox/components/DismissReportDialog";
 import { ReportChartsSection } from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
+import { PriorityMonogram } from "@posthog/ui/features/inbox/components/PriorityMonogram";
 import { ReportChatSidebar } from "@posthog/ui/features/inbox/components/ReportChatSidebar";
 import { ReportVerdictBanner } from "@posthog/ui/features/inbox/components/ReportVerdictBanner";
 import { SuggestedReviewerAvatarStack } from "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack";
-import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
 import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown";
+import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
+import { KeyHint } from "@posthog/ui/primitives/KeyHint";
 import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { navigateToInboxReportDetail } from "@posthog/ui/router/navigationBridge";
 import { track } from "@posthog/ui/shell/analytics";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-const isMac =
-  typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
-
-/** A keyboard hint chip; quill has no kbd primitive, so plain HTML carries it. */
-function KeyCap({ children }: { children: string }) {
-  return (
-    <kbd className="rounded border border-(--gray-6) bg-(--gray-2) px-1 font-mono text-[11.5px] text-gray-11">
-      {children}
-    </kbd>
-  );
-}
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -92,11 +84,8 @@ export function triageEnterAction(input: {
 }
 
 /**
- * One report at a time, keyboard-driven: the fast way through a pile of
- * decisions. Walks the needs-a-decision queue in the list's order — j/k (or
- * arrows) move, e opens archive, enter expands in place, esc leaves.
- * Archiving auto-advances: the archived report drops out of the queue and the
- * next one takes its place under the same index.
+ * Archiving auto-advances because the archived report drops out of the queue
+ * and the next report takes its place under the same index.
  */
 export function ReportTriageFocus({
   reports,
@@ -149,6 +138,18 @@ export function ReportTriageFocus({
   const clamped = Math.min(index, Math.max(0, reports.length - 1));
   const report = reports[clamped];
   const reportId = report?.id;
+  const previousReport = clamped > 0 ? reports[clamped - 1] : null;
+  const nextReport = clamped < reports.length - 1 ? reports[clamped + 1] : null;
+  const conventionalTitle = parseConventionalCommitTitle(report?.title);
+  const reportTitle = displayConventionalCommitTitle(
+    report?.title,
+    "Untitled report",
+  );
+  const headline = deriveHeadline(report?.summary);
+  const sourceMeta = (report?.source_products ?? [])
+    .map((sourceProduct) => getSourceProductMeta(sourceProduct))
+    .find((item) => item !== null);
+  const SourceIcon = sourceMeta?.Icon;
   const summarySplit = useMemo(
     () => splitReportSummary(report?.summary),
     [report?.summary],
@@ -207,18 +208,25 @@ export function ReportTriageFocus({
     finishSession("exited");
     onExit();
   }, [finishSession, onExit]);
+  const handleOpenReport = useCallback(() => {
+    if (!report) return;
+    handleExit();
+    navigateToInboxReportDetail(report.id);
+  }, [handleExit, report]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      // The dialog owns the keyboard while open; typing surfaces always do.
-      if (dismissOpen || isTypingTarget(event.target)) return;
+      if (
+        dismissOpen ||
+        isTypingTarget(event.target) ||
+        document.querySelector('[role="dialog"], [role="alertdialog"]')
+      ) {
+        return;
+      }
       const enterAction = triageEnterAction(event);
       if (enterAction === "open") {
         event.preventDefault();
-        if (report) {
-          handleExit();
-          navigateToInboxReportDetail(report.id);
-        }
+        handleOpenReport();
         return;
       }
       if (enterAction === "toggle") {
@@ -228,21 +236,25 @@ export function ReportTriageFocus({
       }
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       switch (event.key) {
-        case "k":
+        case "j":
         case "ArrowDown":
         case "ArrowRight":
           event.preventDefault();
           goNext();
           break;
-        case "j":
+        case "k":
         case "ArrowUp":
         case "ArrowLeft":
           event.preventDefault();
           goPrev();
           break;
-        case "e":
+        case "a":
           event.preventDefault();
           if (report) setDismissOpen(true);
+          break;
+        case "o":
+          event.preventDefault();
+          handleOpenReport();
           break;
         case "Escape":
           event.preventDefault();
@@ -252,7 +264,7 @@ export function ReportTriageFocus({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [dismissOpen, report, goNext, goPrev, handleExit]);
+  }, [dismissOpen, report, goNext, goPrev, handleExit, handleOpenReport]);
 
   if (!report) {
     // The queue ran dry mid-session — every decision is made.
@@ -274,173 +286,193 @@ export function ReportTriageFocus({
   return (
     <div className="flex h-full min-h-0">
       <div className="min-w-0 flex-1 overflow-y-auto">
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 px-6 py-4">
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="icon-sm"
-                aria-label="Previous report"
-                disabled={clamped === 0}
-                onClick={goPrev}
-              >
-                <CaretLeftIcon size={14} />
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="icon-sm"
-                aria-label="Next report"
-                disabled={clamped >= reports.length - 1}
-                onClick={goNext}
-              >
-                <CaretRightIcon size={14} />
-              </Button>
-              <span className="text-[13px] text-gray-10 tabular-nums">
-                {clamped + 1} of {reports.length} ·{" "}
-                {inboxScopeTriggerLabel(scope)}
-                {hasActiveFilters ? " · Filtered" : ""}
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => setExpanded((current) => !current)}
-                className="gap-1"
-              >
-                <ArrowsOutSimpleIcon size={12} />
-                {expanded ? "Collapse report" : "Show report"}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={handleExit}
-                className="gap-1"
-              >
-                <XIcon size={12} />
-                Exit triage
-              </Button>
-            </div>
+        <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col justify-center gap-3 px-6 py-6">
+          <div className="flex items-center justify-between gap-3 px-1">
+            <span className="text-[13px] text-gray-10 tabular-nums">
+              {clamped + 1} of {reports.length} ·{" "}
+              {inboxScopeTriggerLabel(scope)}
+              {hasActiveFilters ? " · Filtered" : ""}
+            </span>
+            <Button
+              type="button"
+              variant="link-muted"
+              size="sm"
+              onClick={handleExit}
+            >
+              <XIcon />
+              Exit triage
+              <KeyHint>Esc</KeyHint>
+            </Button>
           </div>
 
-          <div className="flex flex-col gap-3 rounded-lg border border-border bg-(--color-panel-solid) p-5">
-            <div className="flex flex-col gap-1.5">
-              <h2 className="font-semibold text-[17px] text-gray-12 leading-snug">
-                {humanizeReportTitle(report.title, "Untitled report")}
-              </h2>
-              <div className="flex items-center gap-2 text-[13px] text-gray-10">
-                <SignalReportPriorityBadge priority={report.priority} />
+          {previousReport && (
+            <Button
+              type="button"
+              variant="outline"
+              className="h-12 w-full justify-start gap-3 px-4 text-gray-9"
+              onClick={goPrev}
+            >
+              <ArrowUpIcon />
+              <span className="truncate">
+                {displayConventionalCommitTitle(
+                  previousReport.title,
+                  "Untitled report",
+                )}
+              </span>
+            </Button>
+          )}
+
+          <section className="overflow-hidden rounded-lg border border-border bg-(--color-panel-solid)">
+            <div className="flex flex-col gap-5 p-6">
+              {sourceMeta && SourceIcon && (
+                <div className="flex items-center gap-2 font-medium text-[13px] text-gray-10">
+                  <SourceIcon style={{ color: sourceMeta.color }} />
+                  <span>{sourceMeta.label}</span>
+                </div>
+              )}
+
+              <div className="flex items-start gap-3">
+                <PriorityMonogram priority={report.priority} size="large" />
+                <h2 className="min-w-0 font-semibold text-[22px] text-gray-12 leading-tight tracking-tight">
+                  {conventionalTitle && (
+                    <ConventionalCommitScopeTag
+                      type={conventionalTitle.type}
+                      scope={conventionalTitle.scope}
+                      compact
+                    />
+                  )}
+                  {reportTitle}
+                </h2>
+              </div>
+
+              {headline && (
+                <p className="text-[15px] text-gray-11 leading-relaxed">
+                  {headline}
+                </p>
+              )}
+
+              <div className="flex flex-wrap items-center gap-2 text-[13px] text-gray-10">
                 <span className="tabular-nums">
                   {report.signal_count} signal
                   {report.signal_count === 1 ? "" : "s"}
                 </span>
-                <RelativeTimestamp
-                  timestamp={report.updated_at ?? report.created_at}
-                  className="text-[13px]"
-                />
+                <span aria-hidden>·</span>
+                <span className="flex items-center gap-1">
+                  First seen
+                  <RelativeTimestamp
+                    timestamp={report.created_at}
+                    className="text-[13px]"
+                  />
+                </span>
+                <span aria-hidden>·</span>
+                <span className="flex items-center gap-1">
+                  Last updated
+                  <RelativeTimestamp
+                    timestamp={report.updated_at ?? report.created_at}
+                    className="text-[13px]"
+                  />
+                </span>
                 <SuggestedReviewerAvatarStack
                   report={report}
                   surface="triage"
                 />
               </div>
-            </div>
 
-            {/* The proof stays sorted and folded — the same labeled slots as
-              the detail page. The lede (the summary's own tl;dr) shows since
-              it's triage-sized; each section opens on demand. Triage reads
-              the verdict; research opens the full report. */}
-            {report.charts && report.charts.length > 0 && (
-              <DetailSection Icon={ChartLineUpIcon} title="Charts">
-                <ReportChartsSection
-                  reportId={report.id}
-                  charts={report.charts}
-                />
-              </DetailSection>
-            )}
-            {summarySplit.sections.length === 0 ? (
-              <DetailSection
-                key={`${report.id}-${expanded}`}
-                Icon={FileTextIcon}
-                title="How we know"
-                collapsible
-                defaultCollapsed={!expanded}
-              >
-                <SignalReportSummaryMarkdown
-                  content={report.summary}
-                  fallback="No summary yet. The agent is still investigating."
-                  variant="detail"
-                  pending={report.status === "in_progress"}
-                  chartIds={chartIds}
-                />
-              </DetailSection>
-            ) : (
-              <>
-                {summarySplit.lede && (
-                  <SignalReportSummaryMarkdown
-                    content={summarySplit.lede}
-                    fallback=""
-                    variant="detail"
-                    pending={report.status === "in_progress"}
-                    chartIds={chartIds}
-                  />
-                )}
-                {summarySplit.sections.map((section, sectionIndex) => (
-                  <DetailSection
-                    key={`${report.id}-${expanded}-${section.title}-${sectionIndex}`}
-                    Icon={FileTextIcon}
-                    title={section.title}
-                    collapsible
-                    defaultCollapsed={!expanded}
-                  >
+              {expanded && (
+                <div className="flex flex-col gap-3 border-(--gray-5) border-t pt-5">
+                  {report.charts && report.charts.length > 0 && (
+                    <DetailSection Icon={ChartLineUpIcon} title="Charts">
+                      <ReportChartsSection
+                        reportId={report.id}
+                        charts={report.charts}
+                      />
+                    </DetailSection>
+                  )}
+                  {summarySplit.sections.length === 0 ? (
                     <SignalReportSummaryMarkdown
-                      content={section.body}
-                      fallback=""
+                      content={report.summary}
+                      fallback="No summary yet. The agent is still investigating."
                       variant="detail"
-                      pending={false}
+                      pending={report.status === "in_progress"}
                       chartIds={chartIds}
                     />
-                  </DetailSection>
-                ))}
-              </>
-            )}
+                  ) : (
+                    <>
+                      {summarySplit.lede && (
+                        <SignalReportSummaryMarkdown
+                          content={summarySplit.lede}
+                          fallback=""
+                          variant="detail"
+                          pending={report.status === "in_progress"}
+                          chartIds={chartIds}
+                        />
+                      )}
+                      {summarySplit.sections.map((section, sectionIndex) => (
+                        <DetailSection
+                          key={`${report.id}-${section.title}-${sectionIndex}`}
+                          Icon={FileTextIcon}
+                          title={section.title}
+                        >
+                          <SignalReportSummaryMarkdown
+                            content={section.body}
+                            fallback=""
+                            variant="detail"
+                            pending={false}
+                            chartIds={chartIds}
+                          />
+                        </DetailSection>
+                      ))}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
 
-            {/* The decision closes the card: read first, then accept. */}
-            <ReportVerdictBanner
-              report={report}
-              actionHotkey={dismissOpen ? undefined : "f"}
-              askHotkey={dismissOpen ? undefined : "a"}
-              surface="triage"
-            />
-          </div>
+            <div className="flex flex-wrap items-center justify-between gap-3 border-(--gray-5) border-t bg-(--gray-2) px-5 py-3">
+              <ReportVerdictBanner
+                report={report}
+                variant="triage-actions"
+                actionHotkey={dismissOpen ? undefined : "f"}
+                archiveHotkey={dismissOpen ? undefined : "a"}
+                surface="triage"
+              />
+              <div className="ml-auto flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="default"
+                  onClick={handleOpenReport}
+                >
+                  Open report
+                  <KeyHint>O</KeyHint>
+                </Button>
+                <Button
+                  type="button"
+                  variant="default"
+                  onClick={() => setExpanded((current) => !current)}
+                >
+                  {expanded ? "Hide summary" : "Read summary"}
+                  <KeyHint>↵</KeyHint>
+                </Button>
+              </div>
+            </div>
+          </section>
 
-          <div className="flex items-center justify-center gap-4 text-[13px] text-gray-10">
-            <span className="flex items-center gap-1">
-              <KeyCap>j</KeyCap>
-              <KeyCap>k</KeyCap> move
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyCap>f</KeyCap> fix
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyCap>a</KeyCap> ask
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyCap>e</KeyCap> archive
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyCap>↵</KeyCap> show
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyCap>{isMac ? "⌘↵" : "Ctrl+↵"}</KeyCap> open
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyCap>esc</KeyCap> exit
-            </span>
-          </div>
+          {nextReport && (
+            <Button
+              type="button"
+              variant="outline"
+              className="h-12 w-full justify-start gap-3 px-4 text-gray-9"
+              onClick={goNext}
+            >
+              <ArrowDownIcon />
+              <span className="truncate">
+                {displayConventionalCommitTitle(
+                  nextReport.title,
+                  "Untitled report",
+                )}
+              </span>
+            </Button>
+          )}
         </div>
 
         {dismissOpen && (

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -362,14 +362,14 @@ export function ReportTriageFocus({
                 </div>
               )}
 
-              <div className="flex items-start gap-3">
-                <PriorityMonogram priority={report.priority} size="large" />
-                <h2 className="min-w-0 font-semibold text-[22px] text-gray-12 leading-tight tracking-tight">
+              <div className="flex items-center gap-5">
+                <PriorityMonogram priority={report.priority} size="hero" />
+                <h2 className="min-w-0 font-semibold text-[32px] text-gray-12 leading-tight tracking-tight">
                   {conventionalTitle && (
                     <ConventionalCommitScopeTag
                       type={conventionalTitle.type}
                       scope={conventionalTitle.scope}
-                      compact
+                      size="hero"
                     />
                   )}
                   {reportTitle}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -467,13 +467,13 @@ export function ReportTriageFocus({
                 report={report}
                 variant="triage-actions"
                 prHotkey={dismissOpen || !prShortcut ? undefined : "c"}
-                askHotkey={dismissOpen ? undefined : "q"}
                 surface="triage"
               />
               <div className="ml-auto flex items-center gap-2">
                 <Button
                   type="button"
                   variant="default"
+                  className="h-9 gap-2 px-4 text-[14px]"
                   onClick={handleOpenReport}
                 >
                   Open report
@@ -481,6 +481,7 @@ export function ReportTriageFocus({
                 <Button
                   type="button"
                   variant="default"
+                  className="h-9 gap-2 px-4 text-[14px]"
                   onClick={() => setExpanded((current) => !current)}
                 >
                   {expanded ? "Hide summary" : "Read summary"}
@@ -518,10 +519,6 @@ export function ReportTriageFocus({
                 {prShortcut === "open" ? "open PR" : "create PR"}
               </span>
             )}
-            <span className="flex items-center gap-1">
-              <KeyHint>Q</KeyHint>
-              ask
-            </span>
             <span className="flex items-center gap-1">
               <KeyHint>A</KeyHint>
               archive

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -1,42 +1,22 @@
-import {
-  ArrowDownIcon,
-  ArrowsOutSimpleIcon,
-  ArrowUpIcon,
-  ChartLineUpIcon,
-  FileTextIcon,
-  XIcon,
-} from "@phosphor-icons/react";
 import { canCreateImplementationPr } from "@posthog/core/inbox/reportActions";
-import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
 import {
   type InboxScope,
   inboxReviewerScopeValue,
   inboxScopeTriggerLabel,
 } from "@posthog/core/inbox/reportMembership";
-import {
-  deriveHeadline,
-  displayConventionalCommitTitle,
-  parseConventionalCommitTitle,
-  parsePrUrl,
-  splitReportSummary,
-} from "@posthog/core/inbox/reportPresentation";
+import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { isDismissalReasonSnooze } from "@posthog/shared/dismissalReasons";
 import type { SignalReport } from "@posthog/shared/types";
-import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
-import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
 import {
   DismissReportDialog,
   type DismissReportDialogResult,
 } from "@posthog/ui/features/inbox/components/DismissReportDialog";
-import { ReportChartsSection } from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
-import { PriorityMonogram } from "@posthog/ui/features/inbox/components/PriorityMonogram";
 import { ReportChatSidebar } from "@posthog/ui/features/inbox/components/ReportChatSidebar";
+import { ReportTriageFocusView } from "@posthog/ui/features/inbox/components/ReportTriageFocusView";
 import { ReportVerdictBanner } from "@posthog/ui/features/inbox/components/ReportVerdictBanner";
 import { SuggestedReviewerAvatarStack } from "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack";
-import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown";
-import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
 import {
@@ -45,11 +25,9 @@ import {
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
-import { KeyHint } from "@posthog/ui/primitives/KeyHint";
-import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { navigateToInboxReportDetail } from "@posthog/ui/router/navigationBridge";
 import { track } from "@posthog/ui/shell/analytics";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -176,21 +154,6 @@ export function ReportTriageFocus({
   const prShortcut = canOpenPr ? "open" : canCreatePr ? "create" : null;
   const previousReport = clamped > 0 ? reports[clamped - 1] : null;
   const nextReport = clamped < reports.length - 1 ? reports[clamped + 1] : null;
-  const conventionalTitle = parseConventionalCommitTitle(report?.title);
-  const reportTitle = displayConventionalCommitTitle(
-    report?.title,
-    "Untitled report",
-  );
-  const headline = deriveHeadline(report?.summary);
-  const sourceMeta = (report?.source_products ?? [])
-    .map((sourceProduct) => getSourceProductMeta(sourceProduct))
-    .find((item) => item !== null);
-  const SourceIcon = sourceMeta?.Icon;
-  const summarySplit = useMemo(
-    () => splitReportSummary(report?.summary),
-    [report?.summary],
-  );
-  const chartIds = renderableReportChartIds(report?.charts);
   const { prefetch } = useInboxReportDetailPrefetch(
     report
       ? {
@@ -318,224 +281,33 @@ export function ReportTriageFocus({
   return (
     <div className="flex h-full min-h-0">
       <div className="min-w-0 flex-1 overflow-y-auto">
-        <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col justify-center gap-3 px-6 py-6">
-          <div className="flex items-center justify-between gap-3 px-1">
-            <span className="text-[13px] text-gray-10 tabular-nums">
-              {clamped + 1} of {reports.length} ·{" "}
-              {inboxScopeTriggerLabel(scope)}
-              {hasActiveFilters ? " · Filtered" : ""}
-            </span>
-            <Button
-              type="button"
-              variant="link-muted"
-              size="sm"
-              onClick={handleExit}
-            >
-              <XIcon />
-              Exit triage
-            </Button>
-          </div>
-
-          {previousReport && (
-            <Button
-              type="button"
-              variant="outline"
-              className="h-12 w-full justify-start gap-3 px-4 text-gray-9"
-              onClick={goPrev}
-            >
-              <ArrowUpIcon />
-              <span className="truncate">
-                {displayConventionalCommitTitle(
-                  previousReport.title,
-                  "Untitled report",
-                )}
-              </span>
-            </Button>
-          )}
-
-          <section className="overflow-hidden rounded-lg border border-border bg-(--color-panel-solid)">
-            <div className="flex flex-col gap-5 p-6">
-              {sourceMeta && SourceIcon && (
-                <div className="flex items-center gap-2 font-medium text-[13px] text-gray-10">
-                  <SourceIcon style={{ color: sourceMeta.color }} />
-                  <span>{sourceMeta.label}</span>
-                </div>
-              )}
-
-              <div className="flex items-center gap-5">
-                <PriorityMonogram priority={report.priority} size="hero" />
-                <h2 className="min-w-0 font-semibold text-[32px] text-gray-12 leading-tight tracking-tight">
-                  {conventionalTitle && (
-                    <ConventionalCommitScopeTag
-                      type={conventionalTitle.type}
-                      scope={conventionalTitle.scope}
-                      size="hero"
-                    />
-                  )}
-                  {reportTitle}
-                </h2>
-              </div>
-
-              {headline && (
-                <p className="text-[15px] text-gray-11 leading-relaxed">
-                  {headline}
-                </p>
-              )}
-
-              <div className="flex flex-wrap items-center gap-2 text-[13px] text-gray-10">
-                <span className="tabular-nums">
-                  {report.signal_count} signal
-                  {report.signal_count === 1 ? "" : "s"}
-                </span>
-                <span aria-hidden>·</span>
-                <span className="flex items-center gap-1">
-                  First seen
-                  <RelativeTimestamp
-                    timestamp={report.created_at}
-                    className="text-[13px]"
-                  />
-                </span>
-                <span aria-hidden>·</span>
-                <span className="flex items-center gap-1">
-                  Last updated
-                  <RelativeTimestamp
-                    timestamp={report.updated_at ?? report.created_at}
-                    className="text-[13px]"
-                  />
-                </span>
-                <SuggestedReviewerAvatarStack
-                  report={report}
-                  surface="triage"
-                />
-              </div>
-
-              {expanded && (
-                <div className="flex flex-col gap-3 border-(--gray-5) border-t pt-5">
-                  {report.charts && report.charts.length > 0 && (
-                    <DetailSection Icon={ChartLineUpIcon} title="Charts">
-                      <ReportChartsSection
-                        reportId={report.id}
-                        charts={report.charts}
-                      />
-                    </DetailSection>
-                  )}
-                  {summarySplit.sections.length === 0 ? (
-                    <SignalReportSummaryMarkdown
-                      content={report.summary}
-                      fallback="No summary yet. The agent is still investigating."
-                      variant="detail"
-                      pending={report.status === "in_progress"}
-                      chartIds={chartIds}
-                    />
-                  ) : (
-                    <>
-                      {summarySplit.lede && (
-                        <SignalReportSummaryMarkdown
-                          content={summarySplit.lede}
-                          fallback=""
-                          variant="detail"
-                          pending={report.status === "in_progress"}
-                          chartIds={chartIds}
-                        />
-                      )}
-                      {summarySplit.sections.map((section, sectionIndex) => (
-                        <DetailSection
-                          key={`${report.id}-${section.title}-${sectionIndex}`}
-                          Icon={FileTextIcon}
-                          title={section.title}
-                        >
-                          <SignalReportSummaryMarkdown
-                            content={section.body}
-                            fallback=""
-                            variant="detail"
-                            pending={false}
-                            chartIds={chartIds}
-                          />
-                        </DetailSection>
-                      ))}
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
-
-            <div className="flex flex-wrap items-center justify-between gap-3 border-(--gray-5) border-t bg-(--gray-2) px-5 py-3">
-              <ReportVerdictBanner
-                report={report}
-                variant="triage-actions"
-                prHotkey={dismissOpen || !prShortcut ? undefined : "c"}
-                surface="triage"
-              />
-              <div className="ml-auto flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="h-9 gap-2 px-4 text-[14px]"
-                  onClick={handleOpenReport}
-                >
-                  <ArrowsOutSimpleIcon />
-                  Open report
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="h-9 gap-2 px-4 text-[14px]"
-                  onClick={() => setExpanded((current) => !current)}
-                >
-                  <FileTextIcon />
-                  {expanded ? "Hide summary" : "Read summary"}
-                </Button>
-              </div>
-            </div>
-          </section>
-
-          {nextReport && (
-            <Button
-              type="button"
-              variant="outline"
-              className="h-12 w-full justify-start gap-3 px-4 text-gray-9"
-              onClick={goNext}
-            >
-              <ArrowDownIcon />
-              <span className="truncate">
-                {displayConventionalCommitTitle(
-                  nextReport.title,
-                  "Untitled report",
-                )}
-              </span>
-            </Button>
-          )}
-
-          <div className="flex flex-wrap items-center justify-center gap-4 text-[13px] text-gray-10">
-            <span className="flex items-center gap-1">
-              <KeyHint>↑</KeyHint>
-              <KeyHint>↓</KeyHint>
-              move
-            </span>
-            {prShortcut && (
-              <span className="flex items-center gap-1">
-                <KeyHint>C</KeyHint>
-                {prShortcut === "open" ? "open PR" : "create PR"}
-              </span>
-            )}
-            <span className="flex items-center gap-1">
-              <KeyHint>A</KeyHint>
-              archive
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyHint>O</KeyHint>
-              open
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyHint>Enter</KeyHint>
-              summary
-            </span>
-            <span className="flex items-center gap-1">
-              <KeyHint>Esc</KeyHint>
-              exit
-            </span>
-          </div>
-        </div>
+        <ReportTriageFocusView
+          report={report}
+          position={clamped + 1}
+          total={reports.length}
+          scopeLabel={inboxScopeTriggerLabel(scope)}
+          hasActiveFilters={hasActiveFilters}
+          previousReport={previousReport}
+          nextReport={nextReport}
+          expanded={expanded}
+          prShortcut={prShortcut}
+          actions={
+            <ReportVerdictBanner
+              report={report}
+              variant="triage-actions"
+              prHotkey={dismissOpen || !prShortcut ? undefined : "c"}
+              surface="triage"
+            />
+          }
+          reviewers={
+            <SuggestedReviewerAvatarStack report={report} surface="triage" />
+          }
+          onExit={handleExit}
+          onPrevious={goPrev}
+          onNext={goNext}
+          onOpenReport={handleOpenReport}
+          onToggleSummary={() => setExpanded((current) => !current)}
+        />
 
         {dismissOpen && (
           <DismissReportDialog

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusView.stories.tsx
@@ -1,0 +1,135 @@
+import {
+  ArchiveIcon,
+  ArrowSquareOutIcon,
+  GitPullRequestIcon,
+} from "@phosphor-icons/react";
+import { Button } from "@posthog/quill";
+import { inboxStoryReport } from "@posthog/ui/features/inbox/components/inboxStoryFixtures";
+import { ReportTriageFocusView } from "@posthog/ui/features/inbox/components/ReportTriageFocusView";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+
+const report = inboxStoryReport();
+const previousReport = inboxStoryReport({
+  id: "previous-report",
+  title: "fix(flags): avoid duplicate evaluations after a reconnect",
+  priority: "P2",
+});
+const nextReport = inboxStoryReport({
+  id: "next-report",
+  title: "feat(insights): preserve breakdown order in saved results",
+  priority: "P2",
+});
+
+const viewportAt = (width: number) => (Story: () => ReactNode) => (
+  <div className="h-[760px] bg-gray-1" style={{ width }}>
+    <Story />
+  </div>
+);
+
+function createPrActions(): React.JSX.Element {
+  return (
+    <div className="flex flex-wrap items-center gap-2.5">
+      <Button
+        type="button"
+        variant="outline"
+        className="h-9 gap-2 px-4 text-[14px]"
+      >
+        <ArchiveIcon />
+        Archive…
+      </Button>
+      <Button
+        type="button"
+        variant="primary"
+        className="h-9 gap-2 px-4 text-[14px]"
+      >
+        <GitPullRequestIcon />
+        Create PR
+      </Button>
+    </div>
+  );
+}
+
+function openPrActions(): React.JSX.Element {
+  return (
+    <div className="flex flex-wrap items-center gap-2.5">
+      <Button
+        type="button"
+        variant="outline"
+        className="h-9 gap-2 px-4 text-[14px]"
+      >
+        <ArchiveIcon />
+        Archive…
+      </Button>
+      <Button
+        type="button"
+        variant="primary"
+        className="h-9 gap-2 px-4 text-[14px]"
+      >
+        <ArrowSquareOutIcon />
+        View PR on GitHub
+      </Button>
+    </div>
+  );
+}
+
+const meta: Meta<typeof ReportTriageFocusView> = {
+  title: "Inbox/Reports/Triage mode",
+  component: ReportTriageFocusView,
+  parameters: { layout: "fullscreen" },
+  decorators: [viewportAt(1100)],
+  args: {
+    report,
+    position: 2,
+    total: 8,
+    scopeLabel: "For you",
+    hasActiveFilters: false,
+    previousReport,
+    nextReport,
+    expanded: false,
+    prShortcut: "create",
+    actions: createPrActions(),
+    reviewers: (
+      <span className="rounded bg-(--gray-3) px-1.5 py-0.5 text-[12px] text-gray-11">
+        2 reviewers
+      </span>
+    ),
+    onExit: () => {},
+    onPrevious: () => {},
+    onNext: () => {},
+    onOpenReport: () => {},
+    onToggleSummary: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ReportTriageFocusView>;
+
+export const NeedsAPr: Story = {};
+
+export const ExistingPr: Story = {
+  args: {
+    report: inboxStoryReport({
+      implementation_pr_url: "https://github.com/PostHog/posthog/pull/12345",
+    }),
+    prShortcut: "open",
+    actions: openPrActions(),
+  },
+};
+
+export const ExpandedSummary: Story = {
+  args: { expanded: true },
+};
+
+export const LongTitle: Story = {
+  args: {
+    report: inboxStoryReport({
+      title:
+        "fix(cohorts): prevent overlapping recurring calculations from delaying every queued membership update in large projects",
+    }),
+  },
+};
+
+export const CompactViewport: Story = {
+  decorators: [viewportAt(720)],
+};

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusView.tsx
@@ -1,0 +1,283 @@
+import {
+  ArrowDownIcon,
+  ArrowsOutSimpleIcon,
+  ArrowUpIcon,
+  ChartLineUpIcon,
+  FileTextIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { renderableReportChartIds } from "@posthog/core/inbox/reportCharts";
+import {
+  deriveHeadline,
+  displayConventionalCommitTitle,
+  parseConventionalCommitTitle,
+  splitReportSummary,
+} from "@posthog/core/inbox/reportPresentation";
+import { Button } from "@posthog/quill";
+import type { SignalReport } from "@posthog/shared/types";
+import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
+import { DetailSection } from "@posthog/ui/features/inbox/components/DetailSection";
+import { ReportChartsSection } from "@posthog/ui/features/inbox/components/detail/ReportChartCard";
+import { PriorityMonogram } from "@posthog/ui/features/inbox/components/PriorityMonogram";
+import { SignalReportSummaryMarkdown } from "@posthog/ui/features/inbox/components/utils/SignalReportSummaryMarkdown";
+import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
+import { KeyHint } from "@posthog/ui/primitives/KeyHint";
+import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
+import type { ReactNode } from "react";
+
+export interface ReportTriageFocusViewProps {
+  report: SignalReport;
+  position: number;
+  total: number;
+  scopeLabel: string;
+  hasActiveFilters: boolean;
+  previousReport?: SignalReport | null;
+  nextReport?: SignalReport | null;
+  expanded: boolean;
+  prShortcut: "open" | "create" | null;
+  actions: ReactNode;
+  reviewers?: ReactNode;
+  onExit: () => void;
+  onPrevious: () => void;
+  onNext: () => void;
+  onOpenReport: () => void;
+  onToggleSummary: () => void;
+}
+
+export function ReportTriageFocusView({
+  report,
+  position,
+  total,
+  scopeLabel,
+  hasActiveFilters,
+  previousReport,
+  nextReport,
+  expanded,
+  prShortcut,
+  actions,
+  reviewers,
+  onExit,
+  onPrevious,
+  onNext,
+  onOpenReport,
+  onToggleSummary,
+}: ReportTriageFocusViewProps): React.JSX.Element {
+  const conventionalTitle = parseConventionalCommitTitle(report.title);
+  const reportTitle = displayConventionalCommitTitle(
+    report.title,
+    "Untitled report",
+  );
+  const headline = deriveHeadline(report.summary);
+  const sourceMeta = (report.source_products ?? [])
+    .map((sourceProduct) => getSourceProductMeta(sourceProduct))
+    .find((item) => item !== null);
+  const SourceIcon = sourceMeta?.Icon;
+  const summarySplit = splitReportSummary(report.summary);
+  const chartIds = renderableReportChartIds(report.charts);
+
+  return (
+    <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col justify-center gap-3 px-6 py-6">
+      <div className="flex items-center justify-between gap-3 px-1">
+        <span className="text-[13px] text-gray-10 tabular-nums">
+          {position} of {total} · {scopeLabel}
+          {hasActiveFilters ? " · Filtered" : ""}
+        </span>
+        <Button type="button" variant="link-muted" size="sm" onClick={onExit}>
+          <XIcon />
+          Exit triage
+        </Button>
+      </div>
+
+      {previousReport && (
+        <Button
+          type="button"
+          variant="outline"
+          className="h-12 w-full justify-start gap-3 px-4 text-gray-9"
+          onClick={onPrevious}
+        >
+          <ArrowUpIcon />
+          <span className="truncate">
+            {displayConventionalCommitTitle(
+              previousReport.title,
+              "Untitled report",
+            )}
+          </span>
+        </Button>
+      )}
+
+      <section className="overflow-hidden rounded-lg border border-border bg-(--color-panel-solid)">
+        <div className="flex flex-col gap-4 p-5">
+          {sourceMeta && SourceIcon && (
+            <div className="flex items-center gap-2 font-medium text-[13px] text-gray-10">
+              <SourceIcon style={{ color: sourceMeta.color }} />
+              <span>{sourceMeta.label}</span>
+            </div>
+          )}
+
+          <div className="flex items-center gap-4">
+            <PriorityMonogram priority={report.priority} size="large" />
+            <h2 className="min-w-0 font-semibold text-[22px] text-gray-12 leading-tight tracking-tight">
+              {conventionalTitle && (
+                <ConventionalCommitScopeTag
+                  type={conventionalTitle.type}
+                  scope={conventionalTitle.scope}
+                />
+              )}
+              {reportTitle}
+            </h2>
+          </div>
+
+          {headline && (
+            <p className="text-[14px] text-gray-11 leading-relaxed">
+              {headline}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2 text-[13px] text-gray-10">
+            <span className="tabular-nums">
+              {report.signal_count} signal
+              {report.signal_count === 1 ? "" : "s"}
+            </span>
+            <span aria-hidden>·</span>
+            <span className="flex items-center gap-1">
+              First seen
+              <RelativeTimestamp
+                timestamp={report.created_at}
+                className="text-[13px]"
+              />
+            </span>
+            <span aria-hidden>·</span>
+            <span className="flex items-center gap-1">
+              Last updated
+              <RelativeTimestamp
+                timestamp={report.updated_at ?? report.created_at}
+                className="text-[13px]"
+              />
+            </span>
+            {reviewers}
+          </div>
+
+          {expanded && (
+            <div className="flex flex-col gap-3 border-(--gray-5) border-t pt-5">
+              {report.charts && report.charts.length > 0 && (
+                <DetailSection Icon={ChartLineUpIcon} title="Charts">
+                  <ReportChartsSection
+                    reportId={report.id}
+                    charts={report.charts}
+                  />
+                </DetailSection>
+              )}
+              {summarySplit.sections.length === 0 ? (
+                <SignalReportSummaryMarkdown
+                  content={report.summary}
+                  fallback="No summary yet. The agent is still investigating."
+                  variant="detail"
+                  pending={report.status === "in_progress"}
+                  chartIds={chartIds}
+                />
+              ) : (
+                <>
+                  {summarySplit.lede && (
+                    <SignalReportSummaryMarkdown
+                      content={summarySplit.lede}
+                      fallback=""
+                      variant="detail"
+                      pending={report.status === "in_progress"}
+                      chartIds={chartIds}
+                    />
+                  )}
+                  {summarySplit.sections.map((section, sectionIndex) => (
+                    <DetailSection
+                      key={`${report.id}-${section.title}-${sectionIndex}`}
+                      Icon={FileTextIcon}
+                      title={section.title}
+                    >
+                      <SignalReportSummaryMarkdown
+                        content={section.body}
+                        fallback=""
+                        variant="detail"
+                        pending={false}
+                        chartIds={chartIds}
+                      />
+                    </DetailSection>
+                  ))}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 border-(--gray-5) border-t bg-(--gray-2) px-5 py-3">
+          {actions}
+          <div className="ml-auto flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="h-9 gap-2 px-4 text-[14px]"
+              onClick={onOpenReport}
+            >
+              <ArrowsOutSimpleIcon />
+              Open report
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-9 gap-2 px-4 text-[14px]"
+              onClick={onToggleSummary}
+            >
+              <FileTextIcon />
+              {expanded ? "Hide summary" : "Read summary"}
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      {nextReport && (
+        <Button
+          type="button"
+          variant="outline"
+          className="h-12 w-full justify-start gap-3 px-4 text-gray-9"
+          onClick={onNext}
+        >
+          <ArrowDownIcon />
+          <span className="truncate">
+            {displayConventionalCommitTitle(
+              nextReport.title,
+              "Untitled report",
+            )}
+          </span>
+        </Button>
+      )}
+
+      <div className="flex flex-wrap items-center justify-center gap-4 text-[13px] text-gray-10">
+        <span className="flex items-center gap-1">
+          <KeyHint>↑</KeyHint>
+          <KeyHint>↓</KeyHint>
+          move
+        </span>
+        {prShortcut && (
+          <span className="flex items-center gap-1">
+            <KeyHint>C</KeyHint>
+            {prShortcut === "open" ? "open PR" : "create PR"}
+          </span>
+        )}
+        <span className="flex items-center gap-1">
+          <KeyHint>A</KeyHint>
+          archive
+        </span>
+        <span className="flex items-center gap-1">
+          <KeyHint>O</KeyHint>
+          open
+        </span>
+        <span className="flex items-center gap-1">
+          <KeyHint>Enter</KeyHint>
+          summary
+        </span>
+        <span className="flex items-center gap-1">
+          <KeyHint>Esc</KeyHint>
+          exit
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -6,12 +6,14 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
+  createPrReport,
   discussReport,
   invalidateQueries,
   setQueryData,
   useDiscussReport,
   useReportTasks,
 } = vi.hoisted(() => ({
+  createPrReport: vi.fn(),
   discussReport: vi.fn(),
   invalidateQueries: vi.fn(),
   setQueryData: vi.fn(),
@@ -39,7 +41,7 @@ vi.mock(
 );
 
 vi.mock("@posthog/ui/features/inbox/hooks/useCreatePrReport", () => ({
-  useCreatePrReport: () => ({ createPrReport: vi.fn(), isCreatingPr: false }),
+  useCreatePrReport: () => ({ createPrReport, isCreatingPr: false }),
 }));
 
 vi.mock("@posthog/ui/features/inbox/hooks/useDiscussReport", () => ({
@@ -111,6 +113,21 @@ const discussionTask = {
   startedAt: "2026-08-26T00:00:00.000Z",
 } satisfies ReportTaskData;
 
+const runningImplementationTask = {
+  task: {
+    ...task,
+    title: "Implement fix",
+    latest_run: {
+      id: "run-1",
+      status: "in_progress",
+      output: null,
+    } as Task["latest_run"],
+  },
+  purpose: "implementation",
+  purposeLabel: "Implementation",
+  startedAt: "2026-08-26T00:00:00.000Z",
+} satisfies ReportTaskData;
+
 describe("ReportVerdictBanner", () => {
   let onDiscussionCreated: ((task: Task) => void) | undefined;
 
@@ -120,6 +137,7 @@ describe("ReportVerdictBanner", () => {
       startedTaskIdByReport: {},
     });
     useReportTasks.mockReturnValue({ data: [], isLoading: false });
+    createPrReport.mockReset();
     discussReport.mockReset();
     discussReport.mockResolvedValue(undefined);
     invalidateQueries.mockReset();
@@ -186,5 +204,27 @@ describe("ReportVerdictBanner", () => {
     expect(screen.getByText("Ask about it")).toBeInTheDocument();
     expect(screen.queryByText("Continue the task")).not.toBeInTheDocument();
     expect(screen.queryByText("Fix & monitor")).not.toBeInTheDocument();
+  });
+
+  it("does not start duplicate work while an implementation is running", async () => {
+    const user = userEvent.setup();
+    useReportTasks.mockReturnValue({
+      data: [runningImplementationTask],
+      isLoading: false,
+    });
+
+    render(
+      <ReportVerdictBanner
+        report={{ ...report, actionability: "immediately_actionable" }}
+        actionHotkey="f"
+      />,
+    );
+
+    expect(screen.getByText("Ask about it")).toBeInTheDocument();
+    expect(screen.queryByText("Fix & monitor")).not.toBeInTheDocument();
+
+    await user.keyboard("f");
+
+    expect(createPrReport).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -171,4 +171,20 @@ describe("ReportVerdictBanner", () => {
 
     expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
   });
+
+  it("offers review and discussion for an existing fix without a continue action", () => {
+    render(
+      <ReportVerdictBanner
+        report={{
+          ...report,
+          implementation_pr_url: "https://github.com/PostHog/posthog/pull/1",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("View PR on GitHub")).toBeInTheDocument();
+    expect(screen.getByText("Ask about it")).toBeInTheDocument();
+    expect(screen.queryByText("Continue the task")).not.toBeInTheDocument();
+    expect(screen.queryByText("Fix & monitor")).not.toBeInTheDocument();
+  });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -55,14 +55,6 @@ vi.mock("@posthog/ui/features/canvas/hooks/useTaskChannels", () => ({
   }),
 }));
 
-vi.mock("@posthog/ui/features/inbox/hooks/useInboxBulkActions", () => ({
-  useInboxBulkActions: () => ({
-    isSnoozing: false,
-    snoozeDisabledReason: null,
-    snoozeSelected: vi.fn(),
-  }),
-}));
-
 vi.mock("@posthog/ui/features/inbox/hooks/useInboxReportDismissAction", () => ({
   useInboxReportDismissAction: () => ({
     dialog: null,
@@ -210,6 +202,7 @@ describe("ReportVerdictBanner", () => {
     expect(screen.getByText("Ask about it")).toBeInTheDocument();
     expect(screen.queryByText("Continue the task")).not.toBeInTheDocument();
     expect(screen.queryByText("Fix & monitor")).not.toBeInTheDocument();
+    expect(screen.queryByText("Defer")).not.toBeInTheDocument();
   });
 
   it("does not start duplicate work while an implementation is running", async () => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -153,12 +153,18 @@ describe("ReportVerdictBanner", () => {
 
   it("starts a discussion with optional direction and hides the actions after creation", async () => {
     const user = userEvent.setup();
-    render(<ReportVerdictBanner report={report} initialEngagementOnly />);
+    render(
+      <ReportVerdictBanner
+        report={report}
+        initialEngagementOnly
+        askHotkey="a"
+      />,
+    );
 
     const askButton = screen.getByText("Ask about it");
     expect(askButton.closest(".select-none")).not.toBeNull();
 
-    await user.click(askButton);
+    await user.keyboard("a");
     await user.type(
       screen.getByLabelText("Optional question for the agent"),
       "Focus on whether this affects new projects",

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -208,7 +208,7 @@ describe("ReportVerdictBanner", () => {
     expect(screen.getByText("View PR on GitHub")).toBeInTheDocument();
     expect(screen.getByText("Ask about it")).toBeInTheDocument();
     expect(screen.queryByText("Continue the task")).not.toBeInTheDocument();
-    expect(screen.queryByText("Fix & monitor")).not.toBeInTheDocument();
+    expect(screen.queryByText("Create PR")).not.toBeInTheDocument();
     expect(screen.queryByText("Defer")).not.toBeInTheDocument();
   });
 
@@ -222,44 +222,41 @@ describe("ReportVerdictBanner", () => {
     render(
       <ReportVerdictBanner
         report={{ ...report, actionability: "immediately_actionable" }}
-        actionHotkey="f"
+        actionHotkey="c"
       />,
     );
 
     expect(screen.getByText("View task")).toBeInTheDocument();
     expect(screen.getByText("Ask about it")).toBeInTheDocument();
-    expect(screen.queryByText("Fix & monitor")).not.toBeInTheDocument();
+    expect(screen.queryByText("Create PR")).not.toBeInTheDocument();
 
-    await user.keyboard("f");
+    await user.keyboard("c");
 
     expect(openTask).toHaveBeenCalledWith(runningImplementationTask.task);
     expect(createPrReport).not.toHaveBeenCalled();
   });
 
-  it("keeps triage fix direction before starting the implementation task", async () => {
+  it("keeps triage direction before creating the implementation task", async () => {
     const user = userEvent.setup();
     render(
       <ReportVerdictBanner
         report={{ ...report, actionability: "immediately_actionable" }}
         variant="triage-actions"
-        actionHotkey="f"
-        archiveHotkey="a"
+        actionHotkey="c"
         surface="triage"
       />,
     );
 
     expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
-    expect(screen.getByText("F")).toBeInTheDocument();
-    expect(screen.getByText("A")).toBeInTheDocument();
 
-    await user.keyboard("f");
+    await user.keyboard("c");
 
     const direction = screen.getByLabelText("Optional direction for the agent");
     expect(direction).toBeInTheDocument();
     expect(createPrReport).not.toHaveBeenCalled();
 
     await user.type(direction, "Start with the smallest safe change");
-    await user.click(screen.getAllByText("Fix & monitor")[1]);
+    await user.click(screen.getAllByText("Create PR")[1]);
 
     expect(createPrReport).toHaveBeenCalledWith(
       "Start with the smallest safe change",

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -9,6 +9,7 @@ const {
   createPrReport,
   discussReport,
   invalidateQueries,
+  openExternalUrl,
   openTask,
   setQueryData,
   useDiscussReport,
@@ -17,6 +18,7 @@ const {
   createPrReport: vi.fn(),
   discussReport: vi.fn(),
   invalidateQueries: vi.fn(),
+  openExternalUrl: vi.fn(),
   openTask: vi.fn(),
   setQueryData: vi.fn(),
   useDiscussReport: vi.fn(),
@@ -74,6 +76,10 @@ vi.mock("@posthog/ui/features/inbox/hooks/useReportActionTracker", () => ({
 
 vi.mock("@posthog/ui/router/useOpenTask", () => ({
   useOpenTask: () => openTask,
+}));
+
+vi.mock("@posthog/ui/shell/openExternal", () => ({
+  openExternalUrl,
 }));
 
 import { ReportVerdictBanner } from "./ReportVerdictBanner";
@@ -139,6 +145,7 @@ describe("ReportVerdictBanner", () => {
     discussReport.mockReset();
     discussReport.mockResolvedValue(undefined);
     invalidateQueries.mockReset();
+    openExternalUrl.mockReset();
     openTask.mockReset();
     setQueryData.mockReset();
     onDiscussionCreated = undefined;
@@ -195,13 +202,15 @@ describe("ReportVerdictBanner", () => {
     expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
   });
 
-  it("offers review and discussion for an existing fix without a continue action", () => {
+  it("uses the PR shortcut to open an existing PR", async () => {
+    const user = userEvent.setup();
     render(
       <ReportVerdictBanner
         report={{
           ...report,
           implementation_pr_url: "https://github.com/PostHog/posthog/pull/1",
         }}
+        prHotkey="c"
       />,
     );
 
@@ -210,9 +219,15 @@ describe("ReportVerdictBanner", () => {
     expect(screen.queryByText("Continue the task")).not.toBeInTheDocument();
     expect(screen.queryByText("Create PR")).not.toBeInTheDocument();
     expect(screen.queryByText("Defer")).not.toBeInTheDocument();
+
+    await user.keyboard("c");
+
+    expect(openExternalUrl).toHaveBeenCalledWith(
+      "https://github.com/PostHog/posthog/pull/1",
+    );
   });
 
-  it("opens running implementation work without starting a duplicate", async () => {
+  it("does not use the PR shortcut for running work without a PR", async () => {
     const user = userEvent.setup();
     useReportTasks.mockReturnValue({
       data: [runningImplementationTask],
@@ -222,7 +237,7 @@ describe("ReportVerdictBanner", () => {
     render(
       <ReportVerdictBanner
         report={{ ...report, actionability: "immediately_actionable" }}
-        actionHotkey="c"
+        prHotkey="c"
       />,
     );
 
@@ -232,7 +247,7 @@ describe("ReportVerdictBanner", () => {
 
     await user.keyboard("c");
 
-    expect(openTask).toHaveBeenCalledWith(runningImplementationTask.task);
+    expect(openTask).not.toHaveBeenCalled();
     expect(createPrReport).not.toHaveBeenCalled();
   });
 
@@ -242,12 +257,13 @@ describe("ReportVerdictBanner", () => {
       <ReportVerdictBanner
         report={{ ...report, actionability: "immediately_actionable" }}
         variant="triage-actions"
-        actionHotkey="c"
+        prHotkey="c"
+        askHotkey="q"
         surface="triage"
       />,
     );
 
-    expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
+    expect(screen.getByText("Ask about it")).toBeInTheDocument();
 
     await user.keyboard("c");
 
@@ -261,5 +277,22 @@ describe("ReportVerdictBanner", () => {
     expect(createPrReport).toHaveBeenCalledWith(
       "Start with the smallest safe change",
     );
+  });
+
+  it("opens report chat from the triage ask shortcut", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReportVerdictBanner
+        report={report}
+        variant="triage-actions"
+        askHotkey="q"
+        surface="triage"
+      />,
+    );
+
+    await user.keyboard("q");
+
+    expect(useReportChatPanelStore.getState().open).toBe(true);
+    expect(discussReport).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -159,18 +159,12 @@ describe("ReportVerdictBanner", () => {
 
   it("starts a discussion with optional direction and hides the actions after creation", async () => {
     const user = userEvent.setup();
-    render(
-      <ReportVerdictBanner
-        report={report}
-        initialEngagementOnly
-        askHotkey="a"
-      />,
-    );
+    render(<ReportVerdictBanner report={report} initialEngagementOnly />);
 
     const askButton = screen.getByText("Ask about it");
     expect(askButton.closest(".select-none")).not.toBeNull();
 
-    await user.keyboard("a");
+    await user.click(askButton);
     await user.type(
       screen.getByLabelText("Optional question for the agent"),
       "Focus on whether this affects new projects",
@@ -258,12 +252,11 @@ describe("ReportVerdictBanner", () => {
         report={{ ...report, actionability: "immediately_actionable" }}
         variant="triage-actions"
         prHotkey="c"
-        askHotkey="q"
         surface="triage"
       />,
     );
 
-    expect(screen.getByText("Ask about it")).toBeInTheDocument();
+    expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
 
     await user.keyboard("c");
 
@@ -277,22 +270,5 @@ describe("ReportVerdictBanner", () => {
     expect(createPrReport).toHaveBeenCalledWith(
       "Start with the smallest safe change",
     );
-  });
-
-  it("opens report chat from the triage ask shortcut", async () => {
-    const user = userEvent.setup();
-    render(
-      <ReportVerdictBanner
-        report={report}
-        variant="triage-actions"
-        askHotkey="q"
-        surface="triage"
-      />,
-    );
-
-    await user.keyboard("q");
-
-    expect(useReportChatPanelStore.getState().open).toBe(true);
-    expect(discussReport).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -235,4 +235,34 @@ describe("ReportVerdictBanner", () => {
     expect(openTask).toHaveBeenCalledWith(runningImplementationTask.task);
     expect(createPrReport).not.toHaveBeenCalled();
   });
+
+  it("keeps triage fix direction before starting the implementation task", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReportVerdictBanner
+        report={{ ...report, actionability: "immediately_actionable" }}
+        variant="triage-actions"
+        actionHotkey="f"
+        archiveHotkey="a"
+        surface="triage"
+      />,
+    );
+
+    expect(screen.queryByText("Ask about it")).not.toBeInTheDocument();
+    expect(screen.getByText("F")).toBeInTheDocument();
+    expect(screen.getByText("A")).toBeInTheDocument();
+
+    await user.keyboard("f");
+
+    const direction = screen.getByLabelText("Optional direction for the agent");
+    expect(direction).toBeInTheDocument();
+    expect(createPrReport).not.toHaveBeenCalled();
+
+    await user.type(direction, "Start with the smallest safe change");
+    await user.click(screen.getAllByText("Fix & monitor")[1]);
+
+    expect(createPrReport).toHaveBeenCalledWith(
+      "Start with the smallest safe change",
+    );
+  });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.test.tsx
@@ -9,6 +9,7 @@ const {
   createPrReport,
   discussReport,
   invalidateQueries,
+  openTask,
   setQueryData,
   useDiscussReport,
   useReportTasks,
@@ -16,6 +17,7 @@ const {
   createPrReport: vi.fn(),
   discussReport: vi.fn(),
   invalidateQueries: vi.fn(),
+  openTask: vi.fn(),
   setQueryData: vi.fn(),
   useDiscussReport: vi.fn(),
   useReportTasks: vi.fn(),
@@ -68,6 +70,10 @@ vi.mock("@posthog/ui/features/inbox/hooks/useInboxReports", () => ({
 
 vi.mock("@posthog/ui/features/inbox/hooks/useReportActionTracker", () => ({
   useReportActionTracker: () => vi.fn(),
+}));
+
+vi.mock("@posthog/ui/router/useOpenTask", () => ({
+  useOpenTask: () => openTask,
 }));
 
 import { ReportVerdictBanner } from "./ReportVerdictBanner";
@@ -133,6 +139,7 @@ describe("ReportVerdictBanner", () => {
     discussReport.mockReset();
     discussReport.mockResolvedValue(undefined);
     invalidateQueries.mockReset();
+    openTask.mockReset();
     setQueryData.mockReset();
     onDiscussionCreated = undefined;
     useDiscussReport.mockImplementation(
@@ -205,7 +212,7 @@ describe("ReportVerdictBanner", () => {
     expect(screen.queryByText("Defer")).not.toBeInTheDocument();
   });
 
-  it("does not start duplicate work while an implementation is running", async () => {
+  it("opens running implementation work without starting a duplicate", async () => {
     const user = userEvent.setup();
     useReportTasks.mockReturnValue({
       data: [runningImplementationTask],
@@ -219,11 +226,13 @@ describe("ReportVerdictBanner", () => {
       />,
     );
 
+    expect(screen.getByText("View task")).toBeInTheDocument();
     expect(screen.getByText("Ask about it")).toBeInTheDocument();
     expect(screen.queryByText("Fix & monitor")).not.toBeInTheDocument();
 
     await user.keyboard("f");
 
+    expect(openTask).toHaveBeenCalledWith(runningImplementationTask.task);
     expect(createPrReport).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -2,7 +2,6 @@ import {
   ArchiveIcon,
   ArrowSquareOutIcon,
   ChatCircleIcon,
-  ClockIcon,
   GitPullRequestIcon,
 } from "@phosphor-icons/react";
 import { extractRepoSelectionRepository } from "@posthog/core/inbox/artefacts";
@@ -23,15 +22,11 @@ import {
   PopoverTrigger,
   Spinner,
   Textarea,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from "@posthog/quill";
 import type { SignalReport, Task } from "@posthog/shared/types";
 import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
 import { useDiscussReport } from "@posthog/ui/features/inbox/hooks/useDiscussReport";
-import { useInboxBulkActions } from "@posthog/ui/features/inbox/hooks/useInboxBulkActions";
 import { useInboxReportDismissAction } from "@posthog/ui/features/inbox/hooks/useInboxReportDismissAction";
 import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
@@ -46,7 +41,7 @@ import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/repor
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 const isMac =
   typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
@@ -87,7 +82,7 @@ interface ReportVerdictBannerProps {
 /**
  * The report's decision bar, closing the document: what state the report is
  * in, what it asks of the reader, and every action that answers the ask -
- * start the fix (or continue the one in flight), defer, or archive.
+ * start the fix (or continue the one in flight), discuss, or archive.
  */
 export function ReportVerdictBanner({
   report,
@@ -199,14 +194,6 @@ export function ReportVerdictBanner({
   // Dismiss covers that rare case.
   const { dialog: dismissDialog, openDialog: openDismissDialog } =
     useInboxReportDismissAction(report);
-  // Defer = snooze: the report re-promotes itself when enough new evidence
-  // lands. Same mechanism the triage card's d key uses.
-  const reportsForBulk = useMemo(() => [report], [report]);
-  const bulkActions = useInboxBulkActions(
-    reportsForBulk,
-    report.id,
-    "detail_pane",
-  );
   const canArchiveHere =
     report.status === "ready" ||
     report.status === "failed" ||
@@ -505,31 +492,6 @@ export function ReportVerdictBanner({
           </div>
         </PopoverContent>
       </Popover>
-      {canArchiveHere && !compact && (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Button
-                type="button"
-                variant="outline"
-                disabled={
-                  bulkActions.snoozeDisabledReason !== null ||
-                  bulkActions.isSnoozing
-                }
-                onClick={() => void bulkActions.snoozeSelected()}
-                className={buttonClass}
-              >
-                {bulkActions.isSnoozing ? <Spinner /> : <ClockIcon size={16} />}
-                Defer
-              </Button>
-            }
-          />
-          <TooltipContent side="bottom">
-            {bulkActions.snoozeDisabledReason ??
-              "Snooze until enough new evidence arrives"}
-          </TooltipContent>
-        </Tooltip>
-      )}
       {canArchiveHere && !compact && (
         <Button
           type="button"

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -73,6 +73,8 @@ interface ReportVerdictBannerProps {
   variant?: ReportVerdictBannerVariant;
   /** Key that fires the primary action (triage mode passes "f"). */
   actionHotkey?: string;
+  /** Key that opens the question field (triage mode passes "a"). */
+  askHotkey?: string;
   /** Hide the full banner after the reader starts or resumes report work. */
   initialEngagementOnly?: boolean;
   /**
@@ -91,6 +93,7 @@ export function ReportVerdictBanner({
   report,
   variant = "full",
   actionHotkey,
+  askHotkey,
   initialEngagementOnly = false,
   onEngaged,
 }: ReportVerdictBannerProps) {
@@ -272,12 +275,14 @@ export function ReportVerdictBanner({
     report.status === "deleted";
   const showActions = !isTerminalReport;
 
-  // One key fires the primary action (triage mode passes "f"): open the PR
-  // when one exists, otherwise start the fix with no extra direction.
+  // Keyboard actions use the same guards as their buttons so shortcuts cannot
+  // bypass loading, disabled, or duplicate-work states.
   useEffect(() => {
-    if (!actionHotkey) return;
+    if (!actionHotkey && !askHotkey) return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== actionHotkey) return;
+      const matchesAction = event.key === actionHotkey;
+      const matchesAsk = event.key === askHotkey;
+      if (!matchesAction && !matchesAsk) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       const target = event.target;
       if (
@@ -287,9 +292,22 @@ export function ReportVerdictBanner({
       ) {
         return;
       }
-      // An open dialog owns the keyboard: its buttons aren't typing targets,
-      // but f must not start a PR underneath the archive dialog.
+      // An open dialog owns the keyboard because its buttons are not typing
+      // targets and actions must not open underneath it.
       if (document.querySelector('[role="dialog"], [role="alertdialog"]')) {
+        return;
+      }
+      if (matchesAsk) {
+        if (
+          isCreatingPr ||
+          isDiscussing ||
+          awaitingChannel ||
+          reportTasksLoading
+        ) {
+          return;
+        }
+        event.preventDefault();
+        setAskOpen(true);
         return;
       }
       if (report.status !== "ready" || isCreatingPr) return;
@@ -305,8 +323,12 @@ export function ReportVerdictBanner({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [
     actionHotkey,
+    askHotkey,
     report.status,
     isCreatingPr,
+    isDiscussing,
+    awaitingChannel,
+    reportTasksLoading,
     externalPrUrl,
     hasExistingPr,
     canCreatePr,

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -127,6 +127,8 @@ export function ReportVerdictBanner({
   const existingPrUrl =
     livePrUrl ?? (continuableTask ? getTaskPrUrl(continuableTask) : null);
   const hasExistingPr = !!existingPrUrl || !!continuableTask;
+  const externalPrUrl =
+    existingPrUrl && parsePrUrl(existingPrUrl) ? existingPrUrl : null;
   const startedTaskId = useReportChatPanelStore(
     (state) => state.startedTaskIdByReport[report.id] ?? null,
   );
@@ -220,15 +222,11 @@ export function ReportVerdictBanner({
     void createPrReport(trimmed || undefined);
   }, [createPrReport, fireAction, prFeedback]);
 
-  const handleContinuePr = useCallback(() => {
-    if (!continuableTask) return;
+  const handleOpenPr = useCallback(() => {
+    if (!externalPrUrl) return;
     fireAction("open_pr");
-    // The conversation opens docked beside the report — the full task page
-    // stays one click away in the dock header.
-    setEngaged(true);
-    setChatOpen(true);
-    onEngaged?.();
-  }, [continuableTask, fireAction, setChatOpen, onEngaged]);
+    openExternalUrl(externalPrUrl);
+  }, [externalPrUrl, fireAction]);
 
   const handleAsk = useCallback(() => {
     if (isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading) {
@@ -263,10 +261,10 @@ export function ReportVerdictBanner({
     discussReport,
   ]);
 
-  // The banner carries the report's one action: create the PR, or continue the
-  // one in flight. Offer it whenever the report can start a PR (`canCreatePr`
+  // The banner carries the report's one action: create a PR, or review the one
+  // already in flight. Offer it whenever the report can start a PR (`canCreatePr`
   // already restricts that to ready-actionable and pending-input reports) or
-  // already holds live implementation work — matching the old decision block.
+  // already holds live implementation work.
   // Terminal reports (merged/archived) get no action; their verdict says so.
   const isTerminalReport =
     report.status === "resolved" ||
@@ -274,8 +272,8 @@ export function ReportVerdictBanner({
     report.status === "deleted";
   const showActions = !isTerminalReport;
 
-  // One key fires the primary action (triage mode passes "f"): continue the
-  // task when a PR exists, otherwise start the fix with no extra direction.
+  // One key fires the primary action (triage mode passes "f"): open the PR
+  // when one exists, otherwise start the fix with no extra direction.
   useEffect(() => {
     if (!actionHotkey) return;
     const onKeyDown = (event: KeyboardEvent) => {
@@ -294,11 +292,12 @@ export function ReportVerdictBanner({
       if (document.querySelector('[role="dialog"], [role="alertdialog"]')) {
         return;
       }
-      event.preventDefault();
       if (report.status !== "ready" || isCreatingPr) return;
-      if (hasExistingPr) {
-        if (continuableTask) handleContinuePr();
+      if (externalPrUrl) {
+        event.preventDefault();
+        handleOpenPr();
       } else if (canCreatePr) {
+        event.preventDefault();
         handleCreatePr();
       }
     };
@@ -308,10 +307,9 @@ export function ReportVerdictBanner({
     actionHotkey,
     report.status,
     isCreatingPr,
-    hasExistingPr,
-    continuableTask,
+    externalPrUrl,
     canCreatePr,
-    handleContinuePr,
+    handleOpenPr,
     handleCreatePr,
   ]);
 
@@ -325,35 +323,17 @@ export function ReportVerdictBanner({
   const actionsRow = showActions ? (
     <div className="flex flex-wrap items-center gap-2.5">
       {report.status === "ready" && hasExistingPr ? (
-        <>
+        externalPrUrl && (
           <Button
             type="button"
             variant="primary"
-            disabled={isCreatingPr || isDiscussing || !continuableTask}
-            onClick={handleContinuePr}
+            onClick={handleOpenPr}
             className={buttonClass}
           >
-            {reportTasksLoading && !continuableTask ? (
-              <Spinner />
-            ) : (
-              <GitPullRequestIcon size={15} />
-            )}
-            Continue the task
+            <ArrowSquareOutIcon size={16} />
+            View PR on GitHub
           </Button>
-          {existingPrUrl && !compact && (
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => {
-                if (existingPrUrl) openExternalUrl(existingPrUrl);
-              }}
-              className={buttonClass}
-            >
-              <ArrowSquareOutIcon size={16} />
-              View PR on GitHub
-            </Button>
-          )}
-        </>
+        )
       ) : report.status === "ready" && canCreatePr ? (
         <Popover
           open={prOpen}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -296,7 +296,7 @@ export function ReportVerdictBanner({
       if (externalPrUrl) {
         event.preventDefault();
         handleOpenPr();
-      } else if (canCreatePr) {
+      } else if (!hasExistingPr && canCreatePr) {
         event.preventDefault();
         handleCreatePr();
       }
@@ -308,6 +308,7 @@ export function ReportVerdictBanner({
     report.status,
     isCreatingPr,
     externalPrUrl,
+    hasExistingPr,
     canCreatePr,
     handleOpenPr,
     handleCreatePr,

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -64,7 +64,7 @@ type ReportVerdictBannerVariant = "full" | "header-actions" | "triage-actions";
 interface ReportVerdictBannerProps {
   report: SignalReport;
   variant?: ReportVerdictBannerVariant;
-  actionHotkey?: string;
+  prHotkey?: string;
   askHotkey?: string;
   /** Hide the full banner after the reader starts or resumes report work. */
   initialEngagementOnly?: boolean;
@@ -82,7 +82,7 @@ interface ReportVerdictBannerProps {
 export function ReportVerdictBanner({
   report,
   variant = "full",
-  actionHotkey,
+  prHotkey,
   askHotkey,
   initialEngagementOnly = false,
   onEngaged,
@@ -91,7 +91,6 @@ export function ReportVerdictBanner({
   const compact = variant === "header-actions";
   const triageActions = variant === "triage-actions";
   const buttonClass = BIG_BUTTON;
-  const canCreatePr = canCreateImplementationPr(report);
   const { data: artefactsResp } = useInboxReportArtefacts(report.id);
   const cloudRepository = extractRepoSelectionRepository(
     artefactsResp?.results,
@@ -107,6 +106,10 @@ export function ReportVerdictBanner({
     report.status,
   );
   const continuableTask = findContinuableImplementationTask(reportTasks);
+  const canCreatePr = canCreateImplementationPr(report, {
+    hasLiveImplementationTask: continuableTask !== null,
+    isTaskLookupPending: reportTasksLoading,
+  });
   // A merged PR is history, not live work: the report only still exists
   // because evidence kept arriving after the fix, so it reads by its own
   // state (usually "needs your decision" again) rather than "review the PR".
@@ -227,6 +230,11 @@ export function ReportVerdictBanner({
     void openTask(continuableTask);
   }, [continuableTask, fireAction, onEngaged, openTask, setChatOpen, surface]);
 
+  const handleOpenChat = useCallback(() => {
+    setChatOpen(true);
+    onEngaged?.();
+  }, [onEngaged, setChatOpen]);
+
   const handleAsk = useCallback(() => {
     if (isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading) {
       return;
@@ -274,11 +282,11 @@ export function ReportVerdictBanner({
   // Keyboard actions use the same guards as their buttons so shortcuts cannot
   // bypass loading, disabled, or duplicate-work states.
   useEffect(() => {
-    if (!actionHotkey && !askHotkey) return;
+    if (!prHotkey && !askHotkey) return;
     const onKeyDown = (event: KeyboardEvent) => {
-      const matchesAction = event.key === actionHotkey;
+      const matchesPr = event.key === prHotkey;
       const matchesAsk = event.key === askHotkey;
-      if (!matchesAction && !matchesAsk) return;
+      if (!matchesPr && !matchesAsk) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       const target = event.target;
       if (
@@ -294,26 +302,21 @@ export function ReportVerdictBanner({
         return;
       }
       if (matchesAsk) {
-        if (
-          isCreatingPr ||
-          isDiscussing ||
-          awaitingChannel ||
-          reportTasksLoading
-        ) {
-          return;
-        }
+        if (isCreatingPr || isDiscussing) return;
+        if (!triageActions && (awaitingChannel || reportTasksLoading)) return;
         event.preventDefault();
-        setAskOpen(true);
+        if (triageActions) {
+          handleOpenChat();
+        } else {
+          setAskOpen(true);
+        }
         return;
       }
       if (report.status !== "ready" || isCreatingPr) return;
       if (externalPrUrl) {
         event.preventDefault();
         handleOpenPr();
-      } else if (continuableTask) {
-        event.preventDefault();
-        handleOpenTask();
-      } else if (!hasExistingPr && canCreatePr) {
+      } else if (canCreatePr) {
         event.preventDefault();
         setPrOpen(true);
       }
@@ -321,19 +324,18 @@ export function ReportVerdictBanner({
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [
-    actionHotkey,
+    prHotkey,
     askHotkey,
     report.status,
     isCreatingPr,
     isDiscussing,
     awaitingChannel,
     reportTasksLoading,
+    triageActions,
+    handleOpenChat,
     externalPrUrl,
-    continuableTask,
-    hasExistingPr,
     canCreatePr,
     handleOpenPr,
-    handleOpenTask,
   ]);
 
   if (
@@ -449,6 +451,18 @@ export function ReportVerdictBanner({
           </PopoverContent>
         </Popover>
       ) : null}
+      {triageActions && (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isCreatingPr || isDiscussing}
+          className={buttonClass}
+          onClick={handleOpenChat}
+        >
+          <ChatCircleIcon size={16} />
+          Ask about it
+        </Button>
+      )}
       {!triageActions && (
         <Popover
           open={askOpen}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -65,7 +65,6 @@ interface ReportVerdictBannerProps {
   report: SignalReport;
   variant?: ReportVerdictBannerVariant;
   prHotkey?: string;
-  askHotkey?: string;
   /** Hide the full banner after the reader starts or resumes report work. */
   initialEngagementOnly?: boolean;
   /** Called after an action opens the report's conversation dock. */
@@ -83,7 +82,6 @@ export function ReportVerdictBanner({
   report,
   variant = "full",
   prHotkey,
-  askHotkey,
   initialEngagementOnly = false,
   onEngaged,
   surface = "detail_pane",
@@ -230,11 +228,6 @@ export function ReportVerdictBanner({
     void openTask(continuableTask);
   }, [continuableTask, fireAction, onEngaged, openTask, setChatOpen, surface]);
 
-  const handleOpenChat = useCallback(() => {
-    setChatOpen(true);
-    onEngaged?.();
-  }, [onEngaged, setChatOpen]);
-
   const handleAsk = useCallback(() => {
     if (isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading) {
       return;
@@ -282,11 +275,10 @@ export function ReportVerdictBanner({
   // Keyboard actions use the same guards as their buttons so shortcuts cannot
   // bypass loading, disabled, or duplicate-work states.
   useEffect(() => {
-    if (!prHotkey && !askHotkey) return;
+    if (!prHotkey) return;
     const onKeyDown = (event: KeyboardEvent) => {
       const matchesPr = event.key === prHotkey;
-      const matchesAsk = event.key === askHotkey;
-      if (!matchesPr && !matchesAsk) return;
+      if (!matchesPr) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       const target = event.target;
       if (
@@ -299,17 +291,6 @@ export function ReportVerdictBanner({
       // An open dialog owns the keyboard because its buttons are not typing
       // targets and actions must not open underneath it.
       if (document.querySelector('[role="dialog"], [role="alertdialog"]')) {
-        return;
-      }
-      if (matchesAsk) {
-        if (isCreatingPr || isDiscussing) return;
-        if (!triageActions && (awaitingChannel || reportTasksLoading)) return;
-        event.preventDefault();
-        if (triageActions) {
-          handleOpenChat();
-        } else {
-          setAskOpen(true);
-        }
         return;
       }
       if (report.status !== "ready" || isCreatingPr) return;
@@ -325,14 +306,8 @@ export function ReportVerdictBanner({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [
     prHotkey,
-    askHotkey,
     report.status,
     isCreatingPr,
-    isDiscussing,
-    awaitingChannel,
-    reportTasksLoading,
-    triageActions,
-    handleOpenChat,
     externalPrUrl,
     canCreatePr,
     handleOpenPr,
@@ -451,18 +426,6 @@ export function ReportVerdictBanner({
           </PopoverContent>
         </Popover>
       ) : null}
-      {triageActions && (
-        <Button
-          type="button"
-          variant="outline"
-          disabled={isCreatingPr || isDiscussing}
-          className={buttonClass}
-          onClick={handleOpenChat}
-        >
-          <ChatCircleIcon size={16} />
-          Ask about it
-        </Button>
-      )}
       {!triageActions && (
         <Popover
           open={askOpen}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -41,7 +41,6 @@ import {
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
-import { KeyHint } from "@posthog/ui/primitives/KeyHint";
 import { useOpenTask } from "@posthog/ui/router/useOpenTask";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { useQueryClient } from "@tanstack/react-query";
@@ -52,7 +51,6 @@ const isMac =
 
 // Same sizing as PrDecisionBlock: the decision is the page's one ask.
 const BIG_BUTTON = "h-9 gap-2 px-4 text-[14px]";
-const PRIMARY_KEY_CLASS = "border-(--gray-12) bg-(--gray-12) text-(--gray-1)";
 
 const TONE_CLASS: Record<ReportVerdictTone, string> = {
   decision: "border-(--amber-6) bg-(--amber-2)",
@@ -68,7 +66,6 @@ interface ReportVerdictBannerProps {
   variant?: ReportVerdictBannerVariant;
   actionHotkey?: string;
   askHotkey?: string;
-  archiveHotkey?: string;
   /** Hide the full banner after the reader starts or resumes report work. */
   initialEngagementOnly?: boolean;
   /** Called after an action opens the report's conversation dock. */
@@ -87,7 +84,6 @@ export function ReportVerdictBanner({
   variant = "full",
   actionHotkey,
   askHotkey,
-  archiveHotkey,
   initialEngagementOnly = false,
   onEngaged,
   surface = "detail_pane",
@@ -189,10 +185,10 @@ export function ReportVerdictBanner({
     onTaskCreated: handleTaskCreated,
   });
 
-  // Archive is the "no" beside Fix & monitor's "yes" — a decision, so it lives in
-  // the decision row. Offered wherever the report is waiting on a person
+  // Keep Archive beside Create PR because both resolve the review decision.
+  // Offer it wherever the report is waiting on a person
   // (several verdict bodies tell the reader to archive; the button should be
-  // right there). Running reports keep it out of the banner — the header's
+  // right there). Running reports keep it out of the banner because the header's
   // Dismiss covers that rare case.
   const { dialog: dismissDialog, openDialog: openDismissDialog } =
     useInboxReportDismissAction(report, surface);
@@ -356,7 +352,6 @@ export function ReportVerdictBanner({
     >
       <ArchiveIcon size={15} />
       Archive…
-      {archiveHotkey && <KeyHint>{archiveHotkey.toUpperCase()}</KeyHint>}
     </Button>
   );
 
@@ -372,11 +367,6 @@ export function ReportVerdictBanner({
         >
           <ArrowSquareOutIcon size={16} />
           View PR on GitHub
-          {actionHotkey && (
-            <KeyHint className={PRIMARY_KEY_CLASS}>
-              {actionHotkey.toUpperCase()}
-            </KeyHint>
-          )}
         </Button>
       ) : report.status === "ready" && continuableTask ? (
         <Button
@@ -388,11 +378,6 @@ export function ReportVerdictBanner({
         >
           <ArrowsOutSimpleIcon />
           {surface === "triage" ? "Continue in chat" : "View task"}
-          {actionHotkey && (
-            <KeyHint className={PRIMARY_KEY_CLASS}>
-              {actionHotkey.toUpperCase()}
-            </KeyHint>
-          )}
         </Button>
       ) : report.status === "ready" && !hasExistingPr && canCreatePr ? (
         <Popover
@@ -411,12 +396,7 @@ export function ReportVerdictBanner({
                 className={buttonClass}
               >
                 {isCreatingPr ? <Spinner /> : <GitPullRequestIcon size={15} />}
-                Fix & monitor
-                {actionHotkey && (
-                  <KeyHint className={PRIMARY_KEY_CLASS}>
-                    {actionHotkey.toUpperCase()}
-                  </KeyHint>
-                )}
+                Create PR
               </Button>
             }
           />
@@ -463,7 +443,7 @@ export function ReportVerdictBanner({
                 disabled={isCreatingPr || isDiscussing}
                 onClick={handleCreatePr}
               >
-                Fix & monitor
+                Create PR
               </Button>
             </div>
           </PopoverContent>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -24,6 +24,7 @@ import {
   Spinner,
   Textarea,
 } from "@posthog/quill";
+import type { InboxReportActionSurface } from "@posthog/shared/analytics-events";
 import type { SignalReport, Task } from "@posthog/shared/types";
 import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useCreatePrReport } from "@posthog/ui/features/inbox/hooks/useCreatePrReport";
@@ -74,11 +75,10 @@ interface ReportVerdictBannerProps {
   askHotkey?: string;
   /** Hide the full banner after the reader starts or resumes report work. */
   initialEngagementOnly?: boolean;
-  /**
-   * Called after an action opens the report's conversation dock. Surfaces
-   * without a dock (the triage card) navigate to the report here.
-   */
+  /** Called after an action opens the report's conversation dock. */
   onEngaged?: () => void;
+  /** Analytics and behavior context for actions rendered in this banner. */
+  surface?: InboxReportActionSurface;
 }
 
 /**
@@ -93,6 +93,7 @@ export function ReportVerdictBanner({
   askHotkey,
   initialEngagementOnly = false,
   onEngaged,
+  surface = "detail_pane",
 }: ReportVerdictBannerProps) {
   const compact = variant === "header-actions";
   const buttonClass = BIG_BUTTON;
@@ -139,7 +140,7 @@ export function ReportVerdictBanner({
 
   const verdict = deriveReportVerdict(report, { hasExistingPr });
 
-  const fireAction = useReportActionTracker(report);
+  const fireAction = useReportActionTracker(report, surface);
   const openTask = useOpenTask();
   const queryClient = useQueryClient();
   const [prOpen, setPrOpen] = useState(false);
@@ -196,7 +197,7 @@ export function ReportVerdictBanner({
   // right there). Running reports keep it out of the banner — the header's
   // Dismiss covers that rare case.
   const { dialog: dismissDialog, openDialog: openDismissDialog } =
-    useInboxReportDismissAction(report);
+    useInboxReportDismissAction(report, surface);
   const canArchiveHere =
     report.status === "ready" ||
     report.status === "failed" ||
@@ -224,8 +225,13 @@ export function ReportVerdictBanner({
   const handleOpenTask = useCallback(() => {
     if (!continuableTask) return;
     fireAction("open_task");
+    if (surface === "triage") {
+      setChatOpen(true);
+      onEngaged?.();
+      return;
+    }
     void openTask(continuableTask);
-  }, [continuableTask, fireAction, openTask]);
+  }, [continuableTask, fireAction, onEngaged, openTask, setChatOpen, surface]);
 
   const handleAsk = useCallback(() => {
     if (isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading) {
@@ -365,7 +371,7 @@ export function ReportVerdictBanner({
           data-attr="inbox-report-view-task"
         >
           <ArrowsOutSimpleIcon />
-          View task
+          {surface === "triage" ? "Continue in chat" : "View task"}
         </Button>
       ) : report.status === "ready" && !hasExistingPr && canCreatePr ? (
         <Popover

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -1,6 +1,7 @@
 import {
   ArchiveIcon,
   ArrowSquareOutIcon,
+  ArrowsOutSimpleIcon,
   ChatCircleIcon,
   GitPullRequestIcon,
 } from "@phosphor-icons/react";
@@ -39,6 +40,7 @@ import {
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { useOpenTask } from "@posthog/ui/router/useOpenTask";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
@@ -82,7 +84,7 @@ interface ReportVerdictBannerProps {
 /**
  * The report's decision bar, closing the document: what state the report is
  * in, what it asks of the reader, and every action that answers the ask -
- * start the fix (or continue the one in flight), discuss, or archive.
+ * start the fix, review work in flight, discuss, or archive.
  */
 export function ReportVerdictBanner({
   report,
@@ -138,6 +140,7 @@ export function ReportVerdictBanner({
   const verdict = deriveReportVerdict(report, { hasExistingPr });
 
   const fireAction = useReportActionTracker(report);
+  const openTask = useOpenTask();
   const queryClient = useQueryClient();
   const [prOpen, setPrOpen] = useState(false);
   const [prFeedback, setPrFeedback] = useState("");
@@ -217,6 +220,12 @@ export function ReportVerdictBanner({
     fireAction("open_pr");
     openExternalUrl(externalPrUrl);
   }, [externalPrUrl, fireAction]);
+
+  const handleOpenTask = useCallback(() => {
+    if (!continuableTask) return;
+    fireAction("open_task");
+    void openTask(continuableTask);
+  }, [continuableTask, fireAction, openTask]);
 
   const handleAsk = useCallback(() => {
     if (isCreatingPr || isDiscussing || awaitingChannel || reportTasksLoading) {
@@ -301,6 +310,9 @@ export function ReportVerdictBanner({
       if (externalPrUrl) {
         event.preventDefault();
         handleOpenPr();
+      } else if (continuableTask) {
+        event.preventDefault();
+        handleOpenTask();
       } else if (!hasExistingPr && canCreatePr) {
         event.preventDefault();
         handleCreatePr();
@@ -317,9 +329,11 @@ export function ReportVerdictBanner({
     awaitingChannel,
     reportTasksLoading,
     externalPrUrl,
+    continuableTask,
     hasExistingPr,
     canCreatePr,
     handleOpenPr,
+    handleOpenTask,
     handleCreatePr,
   ]);
 
@@ -332,19 +346,28 @@ export function ReportVerdictBanner({
 
   const actionsRow = showActions ? (
     <div className="flex flex-wrap items-center gap-2.5">
-      {report.status === "ready" && hasExistingPr ? (
-        externalPrUrl && (
-          <Button
-            type="button"
-            variant="primary"
-            onClick={handleOpenPr}
-            className={buttonClass}
-          >
-            <ArrowSquareOutIcon size={16} />
-            View PR on GitHub
-          </Button>
-        )
-      ) : report.status === "ready" && canCreatePr ? (
+      {report.status === "ready" && externalPrUrl ? (
+        <Button
+          type="button"
+          variant="primary"
+          onClick={handleOpenPr}
+          className={buttonClass}
+        >
+          <ArrowSquareOutIcon size={16} />
+          View PR on GitHub
+        </Button>
+      ) : report.status === "ready" && continuableTask ? (
+        <Button
+          type="button"
+          variant="primary"
+          onClick={handleOpenTask}
+          className={buttonClass}
+          data-attr="inbox-report-view-task"
+        >
+          <ArrowsOutSimpleIcon />
+          View task
+        </Button>
+      ) : report.status === "ready" && !hasExistingPr && canCreatePr ? (
         <Popover
           open={prOpen}
           onOpenChange={(next) => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -41,6 +41,7 @@ import {
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { KeyHint } from "@posthog/ui/primitives/KeyHint";
 import { useOpenTask } from "@posthog/ui/router/useOpenTask";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { useQueryClient } from "@tanstack/react-query";
@@ -51,6 +52,7 @@ const isMac =
 
 // Same sizing as PrDecisionBlock: the decision is the page's one ask.
 const BIG_BUTTON = "h-9 gap-2 px-4 text-[14px]";
+const PRIMARY_KEY_CLASS = "border-(--gray-12) bg-(--gray-12) text-(--gray-1)";
 
 const TONE_CLASS: Record<ReportVerdictTone, string> = {
   decision: "border-(--amber-6) bg-(--amber-2)",
@@ -59,20 +61,14 @@ const TONE_CLASS: Record<ReportVerdictTone, string> = {
   info: "border-(--gray-5) bg-(--gray-1)",
 };
 
-type ReportVerdictBannerVariant = "full" | "header-actions";
+type ReportVerdictBannerVariant = "full" | "header-actions" | "triage-actions";
 
 interface ReportVerdictBannerProps {
   report: SignalReport;
-  /**
-   * full: status box + action row (the triage card). header-actions: the
-   * compact action row alone (the detail page's sticky top bar owns the
-   * verbs, and the page shows no status box).
-   */
   variant?: ReportVerdictBannerVariant;
-  /** Key that fires the primary action (triage mode passes "f"). */
   actionHotkey?: string;
-  /** Key that opens the question field (triage mode passes "a"). */
   askHotkey?: string;
+  archiveHotkey?: string;
   /** Hide the full banner after the reader starts or resumes report work. */
   initialEngagementOnly?: boolean;
   /** Called after an action opens the report's conversation dock. */
@@ -91,11 +87,13 @@ export function ReportVerdictBanner({
   variant = "full",
   actionHotkey,
   askHotkey,
+  archiveHotkey,
   initialEngagementOnly = false,
   onEngaged,
   surface = "detail_pane",
 }: ReportVerdictBannerProps) {
   const compact = variant === "header-actions";
+  const triageActions = variant === "triage-actions";
   const buttonClass = BIG_BUTTON;
   const canCreatePr = canCreateImplementationPr(report);
   const { data: artefactsResp } = useInboxReportArtefacts(report.id);
@@ -321,7 +319,7 @@ export function ReportVerdictBanner({
         handleOpenTask();
       } else if (!hasExistingPr && canCreatePr) {
         event.preventDefault();
-        handleCreatePr();
+        setPrOpen(true);
       }
     };
     window.addEventListener("keydown", onKeyDown);
@@ -340,7 +338,6 @@ export function ReportVerdictBanner({
     canCreatePr,
     handleOpenPr,
     handleOpenTask,
-    handleCreatePr,
   ]);
 
   if (
@@ -350,8 +347,22 @@ export function ReportVerdictBanner({
     return null;
   }
 
+  const archiveButton = canArchiveHere && !compact && (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={openDismissDialog}
+      className={buttonClass}
+    >
+      <ArchiveIcon size={15} />
+      Archive…
+      {archiveHotkey && <KeyHint>{archiveHotkey.toUpperCase()}</KeyHint>}
+    </Button>
+  );
+
   const actionsRow = showActions ? (
     <div className="flex flex-wrap items-center gap-2.5">
+      {triageActions && archiveButton}
       {report.status === "ready" && externalPrUrl ? (
         <Button
           type="button"
@@ -361,6 +372,11 @@ export function ReportVerdictBanner({
         >
           <ArrowSquareOutIcon size={16} />
           View PR on GitHub
+          {actionHotkey && (
+            <KeyHint className={PRIMARY_KEY_CLASS}>
+              {actionHotkey.toUpperCase()}
+            </KeyHint>
+          )}
         </Button>
       ) : report.status === "ready" && continuableTask ? (
         <Button
@@ -372,6 +388,11 @@ export function ReportVerdictBanner({
         >
           <ArrowsOutSimpleIcon />
           {surface === "triage" ? "Continue in chat" : "View task"}
+          {actionHotkey && (
+            <KeyHint className={PRIMARY_KEY_CLASS}>
+              {actionHotkey.toUpperCase()}
+            </KeyHint>
+          )}
         </Button>
       ) : report.status === "ready" && !hasExistingPr && canCreatePr ? (
         <Popover
@@ -391,6 +412,11 @@ export function ReportVerdictBanner({
               >
                 {isCreatingPr ? <Spinner /> : <GitPullRequestIcon size={15} />}
                 Fix & monitor
+                {actionHotkey && (
+                  <KeyHint className={PRIMARY_KEY_CLASS}>
+                    {actionHotkey.toUpperCase()}
+                  </KeyHint>
+                )}
               </Button>
             }
           />
@@ -443,101 +469,105 @@ export function ReportVerdictBanner({
           </PopoverContent>
         </Popover>
       ) : null}
-      <Popover
-        open={askOpen}
-        onOpenChange={(next) => {
-          setAskOpen(next);
-          if (!next && !isDiscussing) setAskQuestion("");
-        }}
-      >
-        <PopoverTrigger
-          render={
-            <Button
-              type="button"
-              variant="outline"
-              disabled={
-                isCreatingPr ||
-                isDiscussing ||
-                awaitingChannel ||
-                reportTasksLoading
-              }
-              className={buttonClass}
-            >
-              <ChatCircleIcon size={16} />
-              Ask about it
-            </Button>
-          }
-        />
-        <PopoverContent
-          align="start"
-          side="bottom"
-          sideOffset={6}
-          className="flex w-[420px] flex-col gap-2 p-3"
+      {!triageActions && (
+        <Popover
+          open={askOpen}
+          onOpenChange={(next) => {
+            setAskOpen(next);
+            if (!next && !isDiscussing) setAskQuestion("");
+          }}
         >
-          <Field>
-            <FieldLabel
-              className="sr-only"
-              htmlFor={`report-question-${report.id}`}
-            >
-              Optional question for the agent
-            </FieldLabel>
-            <Textarea
-              id={`report-question-${report.id}`}
-              autoFocus
-              placeholder="Ask a question or add direction (optional)…"
-              rows={4}
-              value={askQuestion}
-              onChange={(event) => setAskQuestion(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-                  event.preventDefault();
-                  handleAsk();
+          <PopoverTrigger
+            render={
+              <Button
+                type="button"
+                variant="outline"
+                disabled={
+                  isCreatingPr ||
+                  isDiscussing ||
+                  awaitingChannel ||
+                  reportTasksLoading
                 }
-              }}
-            />
-            <FieldDescription>
-              The full report and its evidence are included.
-            </FieldDescription>
-          </Field>
-          <div className="flex items-center justify-between gap-2">
-            <span className="text-[12px] text-gray-10">
-              {isMac ? "⌘↵" : "Ctrl+↵"} to start
-            </span>
-            <Button
-              type="button"
-              variant="primary"
-              size="sm"
-              loading={isDiscussing}
-              disabled={
-                isCreatingPr ||
-                isDiscussing ||
-                awaitingChannel ||
-                reportTasksLoading
-              }
-              onClick={handleAsk}
-            >
-              Start chat
-            </Button>
-          </div>
-        </PopoverContent>
-      </Popover>
-      {canArchiveHere && !compact && (
-        <Button
-          type="button"
-          variant="outline"
-          onClick={openDismissDialog}
-          className={buttonClass}
-        >
-          <ArchiveIcon size={15} />
-          Archive…
-        </Button>
+                className={buttonClass}
+              >
+                <ChatCircleIcon size={16} />
+                Ask about it
+              </Button>
+            }
+          />
+          <PopoverContent
+            align="start"
+            side="bottom"
+            sideOffset={6}
+            className="flex w-[420px] flex-col gap-2 p-3"
+          >
+            <Field>
+              <FieldLabel
+                className="sr-only"
+                htmlFor={`report-question-${report.id}`}
+              >
+                Optional question for the agent
+              </FieldLabel>
+              <Textarea
+                id={`report-question-${report.id}`}
+                autoFocus
+                placeholder="Ask a question or add direction (optional)…"
+                rows={4}
+                value={askQuestion}
+                onChange={(event) => setAskQuestion(event.target.value)}
+                onKeyDown={(event) => {
+                  if (
+                    event.key === "Enter" &&
+                    (event.metaKey || event.ctrlKey)
+                  ) {
+                    event.preventDefault();
+                    handleAsk();
+                  }
+                }}
+              />
+              <FieldDescription>
+                The full report and its evidence are included.
+              </FieldDescription>
+            </Field>
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[12px] text-gray-10">
+                {isMac ? "⌘↵" : "Ctrl+↵"} to start
+              </span>
+              <Button
+                type="button"
+                variant="primary"
+                size="sm"
+                loading={isDiscussing}
+                disabled={
+                  isCreatingPr ||
+                  isDiscussing ||
+                  awaitingChannel ||
+                  reportTasksLoading
+                }
+                onClick={handleAsk}
+              >
+                Start chat
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
       )}
+      {!triageActions && archiveButton}
     </div>
   ) : null;
 
   if (variant === "header-actions") {
     if (!actionsRow) return null;
     return actionsRow;
+  }
+
+  if (variant === "triage-actions") {
+    return (
+      <>
+        {actionsRow}
+        {dismissDialog}
+      </>
+    );
   }
 
   return (

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
@@ -181,7 +181,7 @@ describe("ReportsInboxView", () => {
     mocks.activeReports = [activeReport("active-report", "Checkout summary")];
     render(<ReportsInboxView />);
 
-    await userEvent.click(screen.getByText("Resolved & archived"));
+    await userEvent.click(screen.getByText("Resolved"));
 
     expect(screen.getByText("Checkout errors")).toBeInTheDocument();
     expect(screen.queryByText("Slow dashboards")).not.toBeInTheDocument();
@@ -192,7 +192,7 @@ describe("ReportsInboxView", () => {
     render(<ReportsInboxView />);
 
     expect(screen.getByText("No reports match your filters")).toBeTruthy();
-    expect(screen.queryByText("Resolved & archived")).toBeNull();
+    expect(screen.queryByText("Resolved")).toBeNull();
   });
 
   it("opens a report on the first click without preloading its route", async () => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
     inboxTriageOrigin?: { reportId: string };
   },
   navigate: vi.fn(),
+  allReportsOptions: null as { applySourceFilter?: boolean } | null,
+  filterBarProps: null as { showSourceFilter?: boolean } | null,
 }));
 
 vi.mock("@posthog/ui/features/feature-flags/useTriageFocusEnabled", () => ({
@@ -34,20 +36,24 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("@posthog/ui/features/inbox/hooks/useInboxAllReports", () => ({
-  useInboxAllReports: () => ({
-    scopedReports: mocks.activeReports,
-    allReports: mocks.activeReports,
-    isLoading: false,
-    hasNextPage: false,
-    isFetchingNextPage: false,
-    fetchNextPage: vi.fn(),
-    searchQuery: mocks.searchQuery,
-    totalCount: 0,
-    scope: "entire_project",
-    isSuccess: true,
-    sourceProductFilter: [],
-    priorityFilter: [],
-  }),
+  useInboxAllReports: (options: { applySourceFilter?: boolean }) => {
+    mocks.allReportsOptions = options;
+    return {
+      scopedReports: mocks.activeReports,
+      allReports: mocks.activeReports,
+      isLoading: false,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      searchQuery: mocks.searchQuery,
+      totalCount: 0,
+      scope: "entire_project",
+      isSuccess: true,
+      sourceProductFilter: [],
+      priorityFilter: [],
+      prFilter: "all",
+    };
+  },
 }));
 
 vi.mock("@posthog/ui/features/inbox/hooks/useInboxReports", () => ({
@@ -98,13 +104,6 @@ vi.mock("@posthog/ui/router/navigationBridge", () => ({
   navigateToInboxReportDetail: mocks.navigateToInboxReportDetail,
 }));
 
-vi.mock("@posthog/ui/features/inbox/hooks/useInboxReportDismissAction", () => ({
-  useInboxReportDismissAction: () => ({
-    actionButton: null,
-    dialog: null,
-  }),
-}));
-
 vi.mock(
   "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack",
   () => ({ SuggestedReviewerAvatarStack: () => null }),
@@ -130,7 +129,10 @@ vi.mock("@posthog/ui/features/inbox/components/ReportTriageFocus", () => ({
 }));
 
 vi.mock("@posthog/ui/features/inbox/components/InboxSearchFilterBar", () => ({
-  InboxSearchFilterBar: () => null,
+  InboxSearchFilterBar: (props: { showSourceFilter?: boolean }) => {
+    mocks.filterBarProps = props;
+    return null;
+  },
 }));
 
 vi.mock("@posthog/ui/features/inbox/components/InboxScopeSelect", () => ({
@@ -174,11 +176,12 @@ describe("ReportsInboxView", () => {
     mocks.triageFocusEnabled = false;
     mocks.triageProps = null;
     mocks.locationState = {};
+    mocks.allReportsOptions = null;
+    mocks.filterBarProps = null;
     useInboxSignalsFilterStore.setState({
       searchQuery: "checkout",
       sourceProductFilter: [],
       priorityFilter: [],
-      prFilter: "all",
     });
   });
 
@@ -267,6 +270,10 @@ describe("ReportsInboxView", () => {
     expect(needsPrSection).not.toHaveTextContent("Pipeline report");
     expect(screen.queryByText("In progress")).toBeNull();
     expect(screen.queryByText(/need a decision/)).toBeNull();
+    expect(screen.queryByText("Review")).toBeNull();
+    expect(screen.queryByLabelText(/Archive this report/)).toBeNull();
+    expect(mocks.filterBarProps?.showSourceFilter).toBe(false);
+    expect(mocks.allReportsOptions?.applySourceFilter).toBe(false);
   });
 
   it("returns to the same report in triage mode", () => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
@@ -150,6 +150,7 @@ describe("ReportsInboxView", () => {
   });
 
   it("applies report search to the resolved and archived section", async () => {
+    mocks.activeReports = [activeReport("active-report", "Checkout summary")];
     render(<ReportsInboxView />);
 
     await userEvent.click(screen.getByText("Resolved & archived"));
@@ -157,6 +158,13 @@ describe("ReportsInboxView", () => {
     expect(screen.getByText("Checkout errors")).toBeInTheDocument();
     expect(screen.queryByText("Slow dashboards")).not.toBeInTheDocument();
     await waitFor(() => expect(mocks.fetchNextPage).toHaveBeenCalledOnce());
+  });
+
+  it("does not show terminal sections when the active inbox is empty", () => {
+    render(<ReportsInboxView />);
+
+    expect(screen.getByText("No reports match your filters")).toBeTruthy();
+    expect(screen.queryByText("Resolved & archived")).toBeNull();
   });
 
   it("opens a report on the first click without preloading its route", async () => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
@@ -12,10 +12,25 @@ const mocks = vi.hoisted(() => ({
   prefetchReport: vi.fn(),
   prefetchRoute: vi.fn(),
   searchQuery: "",
+  triageFocusEnabled: false,
+  triageProps: null as {
+    initialReportId?: string;
+    onExit: () => void;
+  } | null,
+  locationState: {} as {
+    inboxTriageOrigin?: { reportId: string };
+  },
+  navigate: vi.fn(),
 }));
 
 vi.mock("@posthog/ui/features/feature-flags/useTriageFocusEnabled", () => ({
-  useTriageFocusEnabled: () => false,
+  useTriageFocusEnabled: () => mocks.triageFocusEnabled,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: ({ select }: { select: (location: unknown) => unknown }) =>
+    select({ state: mocks.locationState }),
+  useNavigate: () => mocks.navigate,
 }));
 
 vi.mock("@posthog/ui/features/inbox/hooks/useInboxAllReports", () => ({
@@ -100,6 +115,16 @@ vi.mock("@posthog/ui/features/inbox/components/ReportRestoreButton", () => ({
   ReportRestoreButton: () => null,
 }));
 
+vi.mock("@posthog/ui/features/inbox/components/ReportTriageFocus", () => ({
+  ReportTriageFocus: (props: {
+    initialReportId?: string;
+    onExit: () => void;
+  }) => {
+    mocks.triageProps = props;
+    return null;
+  },
+}));
+
 vi.mock("@posthog/ui/features/inbox/components/InboxSearchFilterBar", () => ({
   InboxSearchFilterBar: () => null,
 }));
@@ -141,6 +166,9 @@ describe("ReportsInboxView", () => {
       archivedReport("hidden-report", "Slow dashboards"),
     ];
     mocks.searchQuery = "checkout";
+    mocks.triageFocusEnabled = false;
+    mocks.triageProps = null;
+    mocks.locationState = {};
     useInboxSignalsFilterStore.setState({
       searchQuery: "checkout",
       sourceProductFilter: [],
@@ -184,5 +212,21 @@ describe("ReportsInboxView", () => {
     expect(mocks.navigateToInboxReportDetail).toHaveBeenCalledWith(
       "first-report",
     );
+  });
+
+  it("returns to the same report in triage mode", () => {
+    mocks.activeReports = [
+      activeReport("first-report", "First report"),
+      activeReport("second-report", "Second report"),
+    ];
+    mocks.searchQuery = "";
+    mocks.triageFocusEnabled = true;
+    mocks.locationState = {
+      inboxTriageOrigin: { reportId: "second-report" },
+    };
+
+    render(<ReportsInboxView />);
+
+    expect(mocks.triageProps?.initialReportId).toBe("second-report");
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
@@ -62,11 +62,15 @@ vi.mock("@posthog/ui/features/inbox/hooks/useInboxReports", () => ({
 
 vi.mock("@posthog/ui/features/inbox/hooks/useInboxSectionCounts", () => ({
   useInboxSectionCounts: () => ({
-    decision: mocks.activeReports.filter((report) => report.status === "ready")
-      .length,
-    decisionPr: 0,
-    attention: 0,
-    inProgress: 0,
+    reviewAndMerge: mocks.activeReports.filter(
+      (report) => report.status === "ready" && !!report.implementation_pr_url,
+    ).length,
+    needsPr: mocks.activeReports.filter(
+      (report) =>
+        (report.status === "ready" || report.status === "pending_input") &&
+        !report.implementation_pr_url,
+    ).length,
+    resolved: mocks.archivedReports.length,
     isLoading: false,
   }),
 }));
@@ -147,6 +151,7 @@ function archivedReport(id: string, title: string): SignalReport {
     updated_at: "2026-01-01T00:00:00Z",
     artefact_count: 0,
     implementation_pr_url: null,
+    actionability: "immediately_actionable",
   };
 }
 
@@ -212,6 +217,56 @@ describe("ReportsInboxView", () => {
     expect(mocks.navigateToInboxReportDetail).toHaveBeenCalledWith(
       "first-report",
     );
+  });
+
+  it("shows five more reports at a time", async () => {
+    mocks.activeReports = Array.from({ length: 11 }, (_, index) =>
+      activeReport(`report-${index + 1}`, `Report ${index + 1}`),
+    );
+    mocks.searchQuery = "";
+
+    render(<ReportsInboxView />);
+
+    expect(screen.getByText("Report 5")).toBeInTheDocument();
+    expect(screen.queryByText("Report 6")).toBeNull();
+
+    await userEvent.click(screen.getByText("Show more (6)"));
+
+    expect(screen.getByText("Report 10")).toBeInTheDocument();
+    expect(screen.queryByText("Report 11")).toBeNull();
+
+    await userEvent.click(screen.getByText("Show more (1)"));
+
+    expect(screen.getByText("Report 11")).toBeInTheDocument();
+  });
+
+  it("groups actionable reports by PR state and omits pipeline sections", () => {
+    mocks.activeReports = [
+      {
+        ...activeReport("with-pr", "Report with PR"),
+        implementation_pr_url: "https://github.com/PostHog/posthog/pull/1",
+      },
+      activeReport("without-pr", "Report without PR"),
+      {
+        ...activeReport("pipeline", "Pipeline report"),
+        status: "in_progress",
+      },
+    ];
+    mocks.searchQuery = "";
+
+    render(<ReportsInboxView />);
+
+    const reviewSection = screen
+      .getByText("Review and merge")
+      .closest("section");
+    const needsPrSection = screen.getByText("Needs a PR").closest("section");
+
+    expect(reviewSection).toHaveTextContent("Report with PR");
+    expect(reviewSection).not.toHaveTextContent("Report without PR");
+    expect(needsPrSection).toHaveTextContent("Report without PR");
+    expect(needsPrSection).not.toHaveTextContent("Pipeline report");
+    expect(screen.queryByText("In progress")).toBeNull();
+    expect(screen.queryByText(/need a decision/)).toBeNull();
   });
 
   it("returns to the same report in triage mode", () => {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.test.tsx
@@ -246,7 +246,7 @@ describe("ReportsInboxView", () => {
   it("groups actionable reports by PR state and omits pipeline sections", () => {
     mocks.activeReports = [
       {
-        ...activeReport("with-pr", "Report with PR"),
+        ...activeReport("with-pr", "feat(cohorts): Report with PR"),
         implementation_pr_url: "https://github.com/PostHog/posthog/pull/1",
       },
       activeReport("without-pr", "Report without PR"),
@@ -265,6 +265,7 @@ describe("ReportsInboxView", () => {
     const needsPrSection = screen.getByText("Needs a PR").closest("section");
 
     expect(reviewSection).toHaveTextContent("Report with PR");
+    expect(reviewSection).toHaveTextContent("feat(cohorts)");
     expect(reviewSection).not.toHaveTextContent("Report without PR");
     expect(needsPrSection).toHaveTextContent("Report without PR");
     expect(needsPrSection).not.toHaveTextContent("Pipeline report");

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -258,7 +258,7 @@ export function ReportsInboxView() {
               />
               <TooltipContent side="bottom">
                 Step through reports that need a decision, one at a time. Fix,
-                defer, or archive each with a single key.
+                ask about, or archive each from the keyboard.
               </TooltipContent>
             </Tooltip>
           )}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -46,7 +46,6 @@ import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { useInboxTriageOrigin } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
-import { useInboxReportDismissAction } from "@posthog/ui/features/inbox/hooks/useInboxReportDismissAction";
 import { useInboxReportsInfinite } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useInboxSectionCounts } from "@posthog/ui/features/inbox/hooks/useInboxSectionCounts";
 import { useTrackReportsInboxViewed } from "@posthog/ui/features/inbox/hooks/useTrackReportsInboxViewed";
@@ -111,7 +110,7 @@ export function ReportsInboxView() {
     priorityFilter,
   } = useInboxAllReports({
     statusFilter: INBOX_ACTIONABLE_REPORT_STATUS_FILTER,
-    applyPrFilter: true,
+    applySourceFilter: false,
   });
   const triageFocusEnabled = useTriageFocusEnabled();
   const triageOrigin = useInboxTriageOrigin();
@@ -140,7 +139,12 @@ export function ReportsInboxView() {
   // Search is the one exception: it's a client-side title match, so a
   // searching page counts its matching rows instead.
   const serverCounts = useInboxSectionCounts();
-  const hasActiveFilters = useInboxSignalsFilterStore(hasActiveInboxFilters);
+  const hasActiveFilters = useInboxSignalsFilterStore((state) =>
+    hasActiveInboxFilters(state, {
+      includePrFilter: false,
+      includeSourceFilter: false,
+    }),
+  );
   const resetFilters = useInboxSignalsFilterStore((s) => s.resetFilters);
   const searchActive = searchQuery.trim().length > 0;
   const reviewAndMergeCount = searchActive
@@ -278,7 +282,7 @@ export function ReportsInboxView() {
         <div className="mx-auto flex w-full max-w-5xl flex-col gap-2.5 px-6 py-3">
           <InboxSearchFilterBar
             searchPlaceholder="Search reports…"
-            showPrFilter
+            showSourceFilter={false}
           />
         </div>
       </div>
@@ -430,10 +434,6 @@ function InboxSection({
   );
 }
 
-// A row carries what the old inbox's cards proved useful: the humanized
-// title, one line of the summary's tl;dr (deciding without opening), where it
-// came from, reviewers, the PR when there is one, and archive on hover — at
-// row density rather than card height.
 function InboxReportRow({ report }: { report: SignalReport }) {
   const products = (report.source_products ?? [])
     .map((product) => humanizeIdentifier(product).toLowerCase())
@@ -445,15 +445,13 @@ function InboxReportRow({ report }: { report: SignalReport }) {
   const pr = report.implementation_pr_url
     ? parsePrUrl(report.implementation_pr_url)
     : null;
-  const { actionButton: archiveButton, dialog: archiveDialog } =
-    useInboxReportDismissAction(report, "list_row");
   const { pointerHandlers } = useInboxReportDetailPrefetch({
     to: "/inbox/reports/$reportId",
     params: { reportId: report.id },
   });
   return (
     <>
-      {/* biome-ignore lint/a11y/useSemanticElements: the row holds a real archive <button>, which a <button> row would illegally nest */}
+      {/* biome-ignore lint/a11y/useSemanticElements: A semantic button cannot contain the PR and restore buttons. */}
       <div
         role="button"
         tabIndex={0}
@@ -465,7 +463,7 @@ function InboxReportRow({ report }: { report: SignalReport }) {
             navigateToInboxReportDetail(report.id);
           }
         }}
-        className="group flex w-full cursor-pointer items-center gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-3 py-2 text-left transition hover:border-(--gray-6) hover:bg-(--gray-2)"
+        className="flex w-full cursor-pointer items-center gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-3 py-2 text-left transition hover:border-(--gray-6) hover:bg-(--gray-2)"
       >
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <span className="flex items-center gap-1.5">
@@ -551,27 +549,10 @@ function InboxReportRow({ report }: { report: SignalReport }) {
                 {report.implementation_pr_merged ? " merged" : ""}
               </button>
             )}
-            {report.implementation_pr_url &&
-              !report.implementation_pr_merged && (
-                <Button
-                  type="button"
-                  variant="primary"
-                  size="sm"
-                  onClick={() => navigateToInboxReportDetail(report.id)}
-                >
-                  Review
-                </Button>
-              )}
             <ReportRestoreButton report={report} />
-            {report.status !== "suppressed" && (
-              <span className="opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
-                {archiveButton}
-              </span>
-            )}
           </span>
         </span>
       </div>
-      {archiveDialog}
     </>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -11,8 +11,8 @@ import {
 import { humanizeIdentifier } from "@posthog/core/inbox/activityLog";
 import {
   filterReportsBySearch,
+  INBOX_ACTIONABLE_REPORT_STATUS_FILTER,
   INBOX_DISMISSED_STATUS_FILTER,
-  REPORTS_INBOX_STATUS_FILTER,
 } from "@posthog/core/inbox/reportFiltering";
 import { partitionInboxReports } from "@posthog/core/inbox/reportInboxSections";
 import { inboxReviewerScopeValue } from "@posthog/core/inbox/reportMembership";
@@ -57,7 +57,6 @@ import {
 import {
   PageHeader,
   PageHeaderActions,
-  PageHeaderChip,
   PageHeaderDescription,
   PageHeaderHeading,
   PageHeaderTitle,
@@ -93,10 +92,9 @@ const SECTION_PREVIEW_LIMIT = 5;
 const AUTOPAGE_REPORT_LIMIT = 400;
 
 /**
- * The global reports inbox: every report in the project on one page,
- * sectioned by what it asks (a decision, or just watching), quantified by the
- * evidence behind it, and triageable one at a time in focus mode. The
- * per-space sidebar list stays the working set; this is everything else.
+ * The global reports inbox groups actionable reports by whether a PR is ready
+ * to review, with terminal reports available separately. The per-space sidebar
+ * list stays the working set; this is everything else.
  */
 export function ReportsInboxView() {
   const {
@@ -107,13 +105,12 @@ export function ReportsInboxView() {
     isFetchingNextPage,
     fetchNextPage,
     searchQuery,
-    totalCount,
     scope,
     isSuccess,
     sourceProductFilter,
     priorityFilter,
   } = useInboxAllReports({
-    statusFilter: REPORTS_INBOX_STATUS_FILTER,
+    statusFilter: INBOX_ACTIONABLE_REPORT_STATUS_FILTER,
     applyPrFilter: true,
   });
   const triageFocusEnabled = useTriageFocusEnabled();
@@ -143,22 +140,22 @@ export function ReportsInboxView() {
   // Search is the one exception: it's a client-side title match, so a
   // searching page counts its matching rows instead.
   const serverCounts = useInboxSectionCounts();
-  const prFilter = useInboxSignalsFilterStore((s) => s.prFilter);
   const hasActiveFilters = useInboxSignalsFilterStore(hasActiveInboxFilters);
   const resetFilters = useInboxSignalsFilterStore((s) => s.resetFilters);
   const searchActive = searchQuery.trim().length > 0;
-  const decisionCount = searchActive
-    ? sections.decision.length
-    : serverCounts.decision;
-  const attentionCount = searchActive
-    ? sections.attention.length
-    : serverCounts.attention;
-  const inProgressCount = searchActive
-    ? sections.inProgress.length
-    : serverCounts.inProgress;
+  const reviewAndMergeCount = searchActive
+    ? sections.reviewAndMerge.length
+    : serverCounts.reviewAndMerge;
+  const needsPrCount = searchActive
+    ? sections.needsPr.length
+    : serverCounts.needsPr;
+  const triageReports = useMemo(
+    () => [...sections.reviewAndMerge, ...sections.needsPr],
+    [sections.reviewAndMerge, sections.needsPr],
+  );
   useTrackReportsInboxViewed({
-    reports: scopedReports,
-    totalCount: searchActive ? scopedReports.length : totalCount,
+    reports: triageReports,
+    totalCount: reviewAndMergeCount + needsPrCount,
     isReady: isSuccess && !serverCounts.isLoading,
     sourceProductFilter,
     priorityFilter,
@@ -194,20 +191,20 @@ export function ReportsInboxView() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (isTypingTarget(event.target)) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
-      if (event.key === "t" && sections.decision.length > 0) {
+      if (event.key === "t" && triageReports.length > 0) {
         event.preventDefault();
         setFocusMode(true);
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [triageFocusEnabled, focusMode, sections.decision.length]);
+  }, [triageFocusEnabled, focusMode, triageReports.length]);
 
   if (triageFocusEnabled && focusMode && !isLoading) {
     return (
       <div className="h-full min-h-0">
         <ReportTriageFocus
-          reports={sections.decision}
+          reports={triageReports}
           allReports={allReports}
           scope={scope}
           hasActiveFilters={hasActiveFilters}
@@ -219,13 +216,10 @@ export function ReportsInboxView() {
   }
 
   const isEmpty = searchActive
-    ? sections.decision.length === 0 &&
-      sections.attention.length === 0 &&
-      sections.inProgress.length === 0
+    ? sections.reviewAndMerge.length === 0 && sections.needsPr.length === 0
     : !serverCounts.isLoading &&
-      serverCounts.decision === 0 &&
-      serverCounts.attention === 0 &&
-      serverCounts.inProgress === 0;
+      serverCounts.reviewAndMerge === 0 &&
+      serverCounts.needsPr === 0;
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-gray-1">
@@ -233,14 +227,6 @@ export function ReportsInboxView() {
         <PageHeaderHeading>
           <PageHeaderTitleRow>
             <PageHeaderTitle>Self-driving</PageHeaderTitle>
-            {serverCounts.decision > 0 && (
-              <PageHeaderChip
-                icon={<EnvelopeSimpleIcon size={12} weight="fill" />}
-              >
-                {serverCounts.decision} need
-                {serverCounts.decision === 1 ? "s" : ""} a decision
-              </PageHeaderChip>
-            )}
             <PageHeaderActions>
               <Button
                 type="button"
@@ -265,7 +251,7 @@ export function ReportsInboxView() {
                     type="button"
                     variant="outline"
                     className="gap-2"
-                    disabled={sections.decision.length === 0}
+                    disabled={triageReports.length === 0}
                     onClick={() => setFocusMode(true)}
                   >
                     <ListChecksIcon size={16} />
@@ -345,27 +331,16 @@ export function ReportsInboxView() {
               ) : (
                 <>
                   <InboxSection
-                    title="Needs a decision"
-                    reports={sections.decision}
-                    count={decisionCount}
-                    caption={
-                      !searchActive &&
-                      prFilter === "all" &&
-                      serverCounts.decisionPr > 0
-                        ? `${serverCounts.decisionPr} with a PR to review`
-                        : undefined
-                    }
-                    emptyNote="Nothing waiting on you."
+                    title="Review and merge"
+                    reports={sections.reviewAndMerge}
+                    count={reviewAndMergeCount}
+                    emptyNote="No pull requests open yet. Start one from a report below."
                   />
                   <InboxSection
-                    title="Needs attention"
-                    reports={sections.attention}
-                    count={attentionCount}
-                  />
-                  <InboxSection
-                    title="In progress"
-                    reports={sections.inProgress}
-                    count={inProgressCount}
+                    title="Needs a PR"
+                    reports={sections.needsPr}
+                    count={needsPrCount}
+                    emptyNote="No reports are waiting for a pull request."
                   />
                   {isFetchingNextPage && (
                     <div className="flex justify-center py-2">
@@ -374,7 +349,12 @@ export function ReportsInboxView() {
                   )}
                 </>
               )}
-              {!isEmpty && <ResolvedSection searchQuery={searchQuery} />}
+              {!isEmpty && (
+                <ResolvedSection
+                  searchQuery={searchQuery}
+                  count={serverCounts.resolved}
+                />
+              )}
             </>
           )}
         </div>
@@ -383,14 +363,12 @@ export function ReportsInboxView() {
   );
 }
 
-// A section header + capped rows. "Needs a decision" renders even when empty
-// (the page's whole question deserves an explicit answer); others only with
-// content.
+// Web keeps both actionable sections visible even when one is empty, which
+// makes the PR/no-PR split legible without requiring reports in both states.
 function InboxSection({
   title,
   reports,
   count,
-  caption,
   emptyNote,
 }: {
   title: string;
@@ -398,14 +376,12 @@ function InboxSection({
   reports: SignalReport[];
   /** The section's true total, from a server-side count query. */
   count: number;
-  /** Secondary breakdown shown after the count (e.g. "37 with a PR to review"). */
-  caption?: string;
   emptyNote?: string;
 }) {
   const [open, setOpen] = useState(true);
-  const [expanded, setExpanded] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(SECTION_PREVIEW_LIMIT);
   if (count === 0 && reports.length === 0 && !emptyNote) return null;
-  const visible = expanded ? reports : reports.slice(0, SECTION_PREVIEW_LIMIT);
+  const visible = reports.slice(0, visibleCount);
   const hidden = reports.length - visible.length;
   return (
     <section className="flex flex-col gap-2">
@@ -419,9 +395,6 @@ function InboxSection({
           {title}
           <span className="tabular-nums">({count})</span>
         </span>
-        {caption && (
-          <span className="text-[12px] text-gray-10">· {caption}</span>
-        )}
         <div className="h-px flex-1 bg-(--gray-5)" />
         <CaretDownIcon
           size={12}
@@ -442,7 +415,11 @@ function InboxSection({
                 variant="link-muted"
                 size="sm"
                 className="self-center text-gray-10"
-                onClick={() => setExpanded(true)}
+                onClick={() =>
+                  setVisibleCount((current) =>
+                    Math.min(current + SECTION_PREVIEW_LIMIT, reports.length),
+                  )
+                }
               >
                 Show more ({hidden})
               </Button>
@@ -603,8 +580,10 @@ function InboxReportRow({ report }: { report: SignalReport }) {
 // section fetches lazily on first expand and stays collapsed by default.
 function ResolvedSection({
   searchQuery,
+  count,
 }: {
   searchQuery: string;
+  count: number;
 }): React.JSX.Element {
   const [expanded, setExpanded] = useState(false);
   const {
@@ -615,7 +594,7 @@ function ResolvedSection({
     isFetchingNextPage,
   } = useInboxReportsInfinite(
     { status: INBOX_DISMISSED_STATUS_FILTER, ordering: "-updated_at" },
-    { enabled: expanded, pageSize: 25 },
+    { enabled: expanded, pageSize: SECTION_PREVIEW_LIMIT },
   );
   const matchingReports = useMemo(
     () => filterReportsBySearch(allReports, searchQuery),
@@ -638,8 +617,8 @@ function ResolvedSection({
         className="flex w-full cursor-pointer items-center gap-2 rounded px-0.5 py-1 text-left"
         aria-expanded={expanded}
       >
-        <span className="font-mono font-semibold text-[11px] text-gray-10 uppercase tracking-widest">
-          Resolved
+        <span className="flex items-center gap-1 font-mono font-semibold text-[11px] text-gray-10 uppercase tracking-widest">
+          Resolved <span className="tabular-nums">({count})</span>
         </span>
         <div className="h-px flex-1 bg-(--gray-5)" />
         <CaretDownIcon
@@ -678,7 +657,9 @@ function ResolvedSection({
                 disabled={isFetchingNextPage}
                 onClick={() => fetchNextPage()}
               >
-                Show more
+                {searchActive
+                  ? "Show more"
+                  : `Show more (${Math.max(0, count - matchingReports.length)})`}
               </Button>
             )}
           </div>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -19,6 +19,7 @@ import { inboxReviewerScopeValue } from "@posthog/core/inbox/reportMembership";
 import {
   deriveHeadline,
   humanizeReportTitle,
+  parseConventionalCommitTitle,
   parsePrUrl,
 } from "@posthog/core/inbox/reportPresentation";
 import {
@@ -37,6 +38,7 @@ import {
 } from "@posthog/quill";
 import type { SignalReport } from "@posthog/shared/types";
 import { useTriageFocusEnabled } from "@posthog/ui/features/feature-flags/useTriageFocusEnabled";
+import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
 import { InboxScopeSelect } from "@posthog/ui/features/inbox/components/InboxScopeSelect";
 import { InboxSearchFilterBar } from "@posthog/ui/features/inbox/components/InboxSearchFilterBar";
 import { ReportRestoreButton } from "@posthog/ui/features/inbox/components/ReportRestoreButton";
@@ -435,6 +437,7 @@ function InboxSection({
 }
 
 function InboxReportRow({ report }: { report: SignalReport }) {
+  const conventionalTitle = parseConventionalCommitTitle(report.title);
   const products = (report.source_products ?? [])
     .map((product) => humanizeIdentifier(product).toLowerCase())
     .join(" · ");
@@ -466,10 +469,14 @@ function InboxReportRow({ report }: { report: SignalReport }) {
         className="flex w-full cursor-pointer items-center gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-3 py-2 text-left transition hover:border-(--gray-6) hover:bg-(--gray-2)"
       >
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="flex items-center gap-1.5">
-            <span className="truncate font-medium text-[14px] text-gray-12">
-              {humanizeReportTitle(report.title, "Untitled report")}
-            </span>
+          <span className="truncate font-medium text-[14px] text-gray-12">
+            {conventionalTitle && (
+              <ConventionalCommitScopeTag
+                type={conventionalTitle.type}
+                scope={conventionalTitle.scope}
+              />
+            )}
+            <span>{humanizeReportTitle(report.title, "Untitled report")}</span>
           </span>
           {headline && (
             <span className="line-clamp-2 text-[13px] text-gray-11">

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -402,41 +402,53 @@ function InboxSection({
   caption?: string;
   emptyNote?: string;
 }) {
+  const [open, setOpen] = useState(true);
   const [expanded, setExpanded] = useState(false);
   if (count === 0 && reports.length === 0 && !emptyNote) return null;
   const visible = expanded ? reports : reports.slice(0, SECTION_PREVIEW_LIMIT);
   const hidden = reports.length - visible.length;
   return (
-    <section className="flex flex-col gap-1.5">
-      <h2 className="flex items-baseline gap-2 border-(--gray-5) border-b pb-1 font-medium text-[12px] text-gray-10 uppercase tracking-wide">
-        {title}
-        <span className="tabular-nums">({count})</span>
+    <section className="flex flex-col gap-2">
+      <button
+        type="button"
+        className="flex w-full cursor-pointer items-center gap-2 rounded px-0.5 py-1 text-left"
+        onClick={() => setOpen((current) => !current)}
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-1 font-mono font-semibold text-[11px] text-gray-10 uppercase tracking-widest">
+          {title}
+          <span className="tabular-nums">({count})</span>
+        </span>
         {caption && (
-          <span className="font-normal normal-case tracking-normal">
-            · {caption}
-          </span>
+          <span className="text-[12px] text-gray-10">· {caption}</span>
         )}
-      </h2>
-      {count === 0 && reports.length === 0 ? (
-        <p className="px-1 py-2 text-[13.5px] text-gray-10">{emptyNote}</p>
-      ) : (
-        <div className="flex flex-col gap-1">
-          {visible.map((report) => (
-            <InboxReportRow key={report.id} report={report} />
-          ))}
-          {hidden > 0 && (
-            <Button
-              type="button"
-              variant="link-muted"
-              size="sm"
-              className="self-center text-gray-10"
-              onClick={() => setExpanded(true)}
-            >
-              Show more ({hidden})
-            </Button>
-          )}
-        </div>
-      )}
+        <div className="h-px flex-1 bg-(--gray-5)" />
+        <CaretDownIcon
+          size={12}
+          className={`text-gray-9 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      {open &&
+        (count === 0 && reports.length === 0 ? (
+          <p className="px-1 py-2 text-[13.5px] text-gray-10">{emptyNote}</p>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {visible.map((report) => (
+              <InboxReportRow key={report.id} report={report} />
+            ))}
+            {hidden > 0 && (
+              <Button
+                type="button"
+                variant="link-muted"
+                size="sm"
+                className="self-center text-gray-10"
+                onClick={() => setExpanded(true)}
+              >
+                Show more ({hidden})
+              </Button>
+            )}
+          </div>
+        ))}
     </section>
   );
 }
@@ -619,16 +631,20 @@ function ResolvedSection({
   }, [expanded, canAutoPageSearch, isFetchingNextPage, fetchNextPage]);
 
   return (
-    <section className="flex flex-col gap-1.5">
+    <section className="flex flex-col gap-2">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="flex items-baseline gap-2 border-(--gray-5) border-b pb-1 text-left font-medium text-[12px] text-gray-10 uppercase tracking-wide"
+        className="flex w-full cursor-pointer items-center gap-2 rounded px-0.5 py-1 text-left"
+        aria-expanded={expanded}
       >
-        Resolved & archived
+        <span className="font-mono font-semibold text-[11px] text-gray-10 uppercase tracking-widest">
+          Resolved
+        </span>
+        <div className="h-px flex-1 bg-(--gray-5)" />
         <CaretDownIcon
-          size={11}
-          className={expanded ? "rotate-180 self-center" : "self-center"}
+          size={12}
+          className={`text-gray-9 transition-transform ${expanded ? "rotate-180" : ""}`}
         />
       </button>
       {expanded &&

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -1,74 +1,22 @@
-import {
-  ArchiveIcon,
-  CaretDownIcon,
-  CheckCircleIcon,
-  EnvelopeSimpleIcon,
-  FunnelIcon,
-  GitMergeIcon,
-  GitPullRequestIcon,
-  ListChecksIcon,
-} from "@phosphor-icons/react";
-import { humanizeIdentifier } from "@posthog/core/inbox/activityLog";
-import {
-  filterReportsBySearch,
-  INBOX_ACTIONABLE_REPORT_STATUS_FILTER,
-  INBOX_DISMISSED_STATUS_FILTER,
-} from "@posthog/core/inbox/reportFiltering";
+import { INBOX_ACTIONABLE_REPORT_STATUS_FILTER } from "@posthog/core/inbox/reportFiltering";
 import { partitionInboxReports } from "@posthog/core/inbox/reportInboxSections";
 import { inboxReviewerScopeValue } from "@posthog/core/inbox/reportMembership";
-import {
-  deriveHeadline,
-  humanizeReportTitle,
-  parseConventionalCommitTitle,
-  parsePrUrl,
-} from "@posthog/core/inbox/reportPresentation";
-import {
-  Button,
-  Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-  Skeleton,
-  Spinner,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@posthog/quill";
-import type { SignalReport } from "@posthog/shared/types";
 import { useTriageFocusEnabled } from "@posthog/ui/features/feature-flags/useTriageFocusEnabled";
-import { ConventionalCommitScopeTag } from "@posthog/ui/features/inbox/components/ConventionalCommitScopeTag";
+import { InboxReportRow } from "@posthog/ui/features/inbox/components/InboxReportRow";
 import { InboxScopeSelect } from "@posthog/ui/features/inbox/components/InboxScopeSelect";
 import { InboxSearchFilterBar } from "@posthog/ui/features/inbox/components/InboxSearchFilterBar";
-import { ReportRestoreButton } from "@posthog/ui/features/inbox/components/ReportRestoreButton";
+import { ReportsInboxViewPresentation } from "@posthog/ui/features/inbox/components/ReportsInboxViewPresentation";
 import { ReportTriageFocus } from "@posthog/ui/features/inbox/components/ReportTriageFocus";
-import { SuggestedReviewerAvatarStack } from "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack";
-import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
+import { ResolvedReportsSection } from "@posthog/ui/features/inbox/components/ResolvedReportsSection";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { useInboxTriageOrigin } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
-import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
-import { useInboxReportsInfinite } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 import { useInboxSectionCounts } from "@posthog/ui/features/inbox/hooks/useInboxSectionCounts";
 import { useTrackReportsInboxViewed } from "@posthog/ui/features/inbox/hooks/useTrackReportsInboxViewed";
 import {
   hasActiveInboxFilters,
   useInboxSignalsFilterStore,
 } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
-import {
-  PageHeader,
-  PageHeaderActions,
-  PageHeaderDescription,
-  PageHeaderHeading,
-  PageHeaderTitle,
-  PageHeaderTitleRow,
-} from "@posthog/ui/primitives/PageHeader";
-import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
-import {
-  navigateToAgents,
-  navigateToInboxReportDetail,
-} from "@posthog/ui/router/navigationBridge";
-import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { navigateToAgents } from "@posthog/ui/router/navigationBridge";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -82,22 +30,9 @@ function isTypingTarget(target: EventTarget | null): boolean {
   );
 }
 
-/** Rows shown per section before "Show more" — a scan, not a scroll. */
-const SECTION_PREVIEW_LIMIT = 5;
-
-/**
- * How many reports auto-paging will load before stopping and marking counts
- * incomplete ("+"). Bounds the page's cost on enormous projects while keeping
- * counts exact for realistic scoped populations.
- */
 const AUTOPAGE_REPORT_LIMIT = 400;
 
-/**
- * The global reports inbox groups actionable reports by whether a PR is ready
- * to review, with terminal reports available separately. The per-space sidebar
- * list stays the working set; this is everything else.
- */
-export function ReportsInboxView() {
+export function ReportsInboxView(): React.JSX.Element {
   const {
     scopedReports,
     allReports,
@@ -136,10 +71,6 @@ export function ReportsInboxView() {
     () => partitionInboxReports(scopedReports),
     [scopedReports],
   );
-  // Section totals are server-side count queries — at this dataset's size the
-  // loaded rows are always a window, so nothing user-facing counts them.
-  // Search is the one exception: it's a client-side title match, so a
-  // searching page counts its matching rows instead.
   const serverCounts = useInboxSectionCounts();
   const hasActiveFilters = useInboxSignalsFilterStore((state) =>
     hasActiveInboxFilters(state, {
@@ -147,7 +78,9 @@ export function ReportsInboxView() {
       includeSourceFilter: false,
     }),
   );
-  const resetFilters = useInboxSignalsFilterStore((s) => s.resetFilters);
+  const resetFilters = useInboxSignalsFilterStore(
+    (state) => state.resetFilters,
+  );
   const searchActive = searchQuery.trim().length > 0;
   const reviewAndMergeCount = searchActive
     ? sections.reviewAndMerge.length
@@ -159,6 +92,7 @@ export function ReportsInboxView() {
     () => [...sections.reviewAndMerge, ...sections.needsPr],
     [sections.reviewAndMerge, sections.needsPr],
   );
+
   useTrackReportsInboxViewed({
     reports: triageReports,
     totalCount: reviewAndMergeCount + needsPrCount,
@@ -169,15 +103,11 @@ export function ReportsInboxView() {
     scope: inboxReviewerScopeValue(scope),
   });
 
-  // Keep paging rows in (capped) so the sections have bodies to render —
-  // counts never depend on this; they come from the server queries above.
   useEffect(() => {
     if (
       !hasNextPage ||
       isFetchingNextPage ||
       isLoading ||
-      // Bound on rows actually loaded, not on search matches: a narrow
-      // search shrinks scopedReports and would otherwise page far past the cap.
       allReports.length >= AUTOPAGE_REPORT_LIMIT
     ) {
       return;
@@ -191,10 +121,9 @@ export function ReportsInboxView() {
     fetchNextPage,
   ]);
 
-  // Triage mode from anywhere on the page, matching the button's advertised key.
   useEffect(() => {
     if (!triageFocusEnabled || focusMode) return;
-    const onKeyDown = (event: KeyboardEvent) => {
+    const onKeyDown = (event: KeyboardEvent): void => {
       if (isTypingTarget(event.target)) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (event.key === "t" && triageReports.length > 0) {
@@ -228,430 +157,37 @@ export function ReportsInboxView() {
       serverCounts.needsPr === 0;
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-gray-1">
-      <PageHeader>
-        <PageHeaderHeading>
-          <PageHeaderTitleRow>
-            <PageHeaderTitle>Self-driving</PageHeaderTitle>
-            <PageHeaderActions>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => navigateToAgents()}
-              >
-                Configure agents
-              </Button>
-            </PageHeaderActions>
-          </PageHeaderTitleRow>
-          <PageHeaderDescription>
-            Issues and opportunities found in your product, ready to review
-          </PageHeaderDescription>
-        </PageHeaderHeading>
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          {triageFocusEnabled && (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="gap-2"
-                    disabled={triageReports.length === 0}
-                    onClick={() => setFocusMode(true)}
-                  >
-                    <ListChecksIcon size={16} />
-                    Triage mode
-                    <kbd className="rounded bg-(--gray-4) px-1.5 font-mono text-[12px] text-gray-11">
-                      T
-                    </kbd>
-                  </Button>
-                }
-              />
-              <TooltipContent side="bottom">
-                Step through reports that need a decision, one at a time. Open,
-                create a PR, or archive each from the keyboard.
-              </TooltipContent>
-            </Tooltip>
-          )}
-          <InboxScopeSelect />
-        </div>
-      </PageHeader>
-
-      {/* The filter bar stays pinned with the header; only the sections
-          scroll. */}
-      <div className="shrink-0 border-(--gray-5) border-b">
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-2.5 px-6 py-3">
-          <InboxSearchFilterBar
-            searchPlaceholder="Search reports…"
-            showSourceFilter={false}
+    <ReportsInboxViewPresentation
+      reviewAndMerge={sections.reviewAndMerge}
+      reviewAndMergeCount={reviewAndMergeCount}
+      needsPr={sections.needsPr}
+      needsPrCount={needsPrCount}
+      isLoading={isLoading}
+      isFetchingNextPage={isFetchingNextPage}
+      isEmpty={isEmpty}
+      hasActiveFilters={hasActiveFilters}
+      triageEnabled={triageFocusEnabled}
+      scopeControl={<InboxScopeSelect />}
+      searchControl={
+        <InboxSearchFilterBar
+          searchPlaceholder="Search reports…"
+          showSourceFilter={false}
+        />
+      }
+      resolvedSection={
+        !isEmpty ? (
+          <ResolvedReportsSection
+            searchQuery={searchQuery}
+            count={serverCounts.resolved}
           />
-        </div>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-6 py-4">
-          {isLoading && scopedReports.length === 0 ? (
-            <div aria-hidden className="flex flex-col gap-2 pt-2">
-              {[70, 55, 80, 60].map((width) => (
-                <div key={width} className="flex items-center gap-3 py-2">
-                  <Skeleton className="h-4" style={{ width: `${width}%` }} />
-                </div>
-              ))}
-            </div>
-          ) : (
-            <>
-              {isEmpty ? (
-                <Empty className="mx-auto max-w-md flex-none border-0 py-12">
-                  <EmptyHeader>
-                    <EmptyMedia variant="icon">
-                      {hasActiveFilters ? (
-                        <FunnelIcon size={24} />
-                      ) : (
-                        <EnvelopeSimpleIcon size={24} />
-                      )}
-                    </EmptyMedia>
-                    <EmptyTitle>
-                      {hasActiveFilters
-                        ? "No reports match your filters"
-                        : "Nothing to review"}
-                    </EmptyTitle>
-                    <EmptyDescription>
-                      {hasActiveFilters
-                        ? "Clear the filters to check for hidden reports."
-                        : "Reports show up here as your agents find things worth acting on."}
-                    </EmptyDescription>
-                  </EmptyHeader>
-                  {hasActiveFilters && (
-                    <EmptyContent>
-                      <Button
-                        variant="outline"
-                        size="default"
-                        onClick={() => resetFilters()}
-                      >
-                        Clear filters
-                      </Button>
-                    </EmptyContent>
-                  )}
-                </Empty>
-              ) : (
-                <>
-                  <InboxSection
-                    title="Review and merge"
-                    reports={sections.reviewAndMerge}
-                    count={reviewAndMergeCount}
-                    emptyNote="No pull requests open yet. Start one from a report below."
-                  />
-                  <InboxSection
-                    title="Needs a PR"
-                    reports={sections.needsPr}
-                    count={needsPrCount}
-                    emptyNote="No reports are waiting for a pull request."
-                  />
-                  {isFetchingNextPage && (
-                    <div className="flex justify-center py-2">
-                      <Spinner />
-                    </div>
-                  )}
-                </>
-              )}
-              {!isEmpty && (
-                <ResolvedSection
-                  searchQuery={searchQuery}
-                  count={serverCounts.resolved}
-                />
-              )}
-            </>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// Web keeps both actionable sections visible even when one is empty, which
-// makes the PR/no-PR split legible without requiring reports in both states.
-function InboxSection({
-  title,
-  reports,
-  count,
-  emptyNote,
-}: {
-  title: string;
-  /** The loaded rows to render — a window; never what the header counts. */
-  reports: SignalReport[];
-  /** The section's true total, from a server-side count query. */
-  count: number;
-  emptyNote?: string;
-}) {
-  const [open, setOpen] = useState(true);
-  const [visibleCount, setVisibleCount] = useState(SECTION_PREVIEW_LIMIT);
-  if (count === 0 && reports.length === 0 && !emptyNote) return null;
-  const visible = reports.slice(0, visibleCount);
-  const hidden = reports.length - visible.length;
-  return (
-    <section className="flex flex-col gap-2">
-      <button
-        type="button"
-        className="flex w-full cursor-pointer items-center gap-2 rounded px-0.5 py-1 text-left"
-        onClick={() => setOpen((current) => !current)}
-        aria-expanded={open}
-      >
-        <span className="flex items-center gap-1 font-mono font-semibold text-[11px] text-gray-10 uppercase tracking-widest">
-          {title}
-          <span className="tabular-nums">({count})</span>
-        </span>
-        <div className="h-px flex-1 bg-(--gray-5)" />
-        <CaretDownIcon
-          size={12}
-          className={`text-gray-9 transition-transform ${open ? "rotate-180" : ""}`}
-        />
-      </button>
-      {open &&
-        (count === 0 && reports.length === 0 ? (
-          <p className="px-1 py-2 text-[13.5px] text-gray-10">{emptyNote}</p>
-        ) : (
-          <div className="flex flex-col gap-1">
-            {visible.map((report) => (
-              <InboxReportRow key={report.id} report={report} />
-            ))}
-            {hidden > 0 && (
-              <Button
-                type="button"
-                variant="link-muted"
-                size="sm"
-                className="self-center text-gray-10"
-                onClick={() =>
-                  setVisibleCount((current) =>
-                    Math.min(current + SECTION_PREVIEW_LIMIT, reports.length),
-                  )
-                }
-              >
-                Show more ({hidden})
-              </Button>
-            )}
-          </div>
-        ))}
-    </section>
-  );
-}
-
-function InboxReportRow({ report }: { report: SignalReport }) {
-  const conventionalTitle = parseConventionalCommitTitle(report.title);
-  const products = (report.source_products ?? [])
-    .map((product) => humanizeIdentifier(product).toLowerCase())
-    .join(" · ");
-  const headline = useMemo(
-    () => deriveHeadline(report.summary),
-    [report.summary],
-  );
-  const pr = report.implementation_pr_url
-    ? parsePrUrl(report.implementation_pr_url)
-    : null;
-  const { pointerHandlers } = useInboxReportDetailPrefetch({
-    to: "/inbox/reports/$reportId",
-    params: { reportId: report.id },
-  });
-  return (
-    <>
-      {/* biome-ignore lint/a11y/useSemanticElements: A semantic button cannot contain the PR and restore buttons. */}
-      <div
-        role="button"
-        tabIndex={0}
-        {...pointerHandlers}
-        onClick={() => navigateToInboxReportDetail(report.id)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            navigateToInboxReportDetail(report.id);
-          }
-        }}
-        className="flex w-full cursor-pointer items-center gap-3 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-3 py-2 text-left transition hover:border-(--gray-6) hover:bg-(--gray-2)"
-      >
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="truncate font-medium text-[14px] text-gray-12">
-            {conventionalTitle && (
-              <ConventionalCommitScopeTag
-                type={conventionalTitle.type}
-                scope={conventionalTitle.scope}
-              />
-            )}
-            <span>{humanizeReportTitle(report.title, "Untitled report")}</span>
-          </span>
-          {headline && (
-            <span className="line-clamp-2 text-[13px] text-gray-11">
-              {headline}
-            </span>
-          )}
-          <span className="flex items-center gap-1.5 text-[12.5px] text-gray-10">
-            {products && <span className="truncate">{products}</span>}
-            <RelativeTimestamp
-              timestamp={report.created_at}
-              className="shrink-0 text-[12.5px]"
-            />
-          </span>
-        </div>
-        <span className="flex shrink-0 items-center gap-2">
-          {/* Terminal rows share one section, so each wears its end state:
-              resolved closed itself when the fix shipped; archived was a
-              person's call and carries their reason. */}
-          {report.status === "resolved" && (
-            <span
-              title="The fix shipped and this report closed"
-              className="flex items-center gap-1 rounded border border-(--green-6) bg-(--green-2) px-1.5 py-0.5 text-[12px] text-green-11"
-            >
-              <CheckCircleIcon size={11} />
-              Shipped
-            </span>
-          )}
-          {report.status === "suppressed" && (
-            <span
-              title={report.dismissal_note ?? undefined}
-              className="flex items-center gap-1 rounded border border-(--gray-6) bg-(--gray-2) px-1.5 py-0.5 text-[12px] text-gray-11"
-            >
-              <ArchiveIcon size={11} />
-              Archived
-              {report.dismissal_reason
-                ? ` · ${humanizeIdentifier(report.dismissal_reason)}`
-                : ""}
-            </span>
-          )}
-          <SuggestedReviewerAvatarStack report={report} />
-          <SignalReportPriorityBadge priority={report.priority} />
-          <span className="font-mono text-[13px] text-gray-11 tabular-nums">
-            {report.signal_count} signal{report.signal_count === 1 ? "" : "s"}
-          </span>
-          {/* Acting on a row must not also open it. */}
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: propagation guard for the buttons inside, not interactive itself */}
-          <span
-            onClick={(event) => event.stopPropagation()}
-            onKeyDown={(event) => event.stopPropagation()}
-            className="flex items-center gap-1.5"
-          >
-            {pr && (
-              <button
-                type="button"
-                onClick={() => {
-                  if (report.implementation_pr_url) {
-                    openExternalUrl(report.implementation_pr_url);
-                  }
-                }}
-                title={
-                  report.implementation_pr_merged
-                    ? "This report's earlier PR merged, but evidence kept arriving"
-                    : "Open the pull request on GitHub"
-                }
-                className={
-                  report.implementation_pr_merged
-                    ? "flex items-center gap-1 rounded border border-(--gray-6) px-1.5 py-0.5 font-mono text-[12px] text-gray-11 hover:bg-(--gray-3) hover:text-gray-12"
-                    : "flex items-center gap-1 rounded border border-(--accent-7) bg-(--accent-2) px-1.5 py-0.5 font-mono text-(--accent-11) text-[12px] hover:bg-(--accent-3)"
-                }
-              >
-                {report.implementation_pr_merged ? (
-                  <GitMergeIcon size={11} />
-                ) : (
-                  <GitPullRequestIcon size={11} />
-                )}
-                #{pr.number}
-                {report.implementation_pr_merged ? " merged" : ""}
-              </button>
-            )}
-            <ReportRestoreButton report={report} />
-          </span>
-        </span>
-      </div>
-    </>
-  );
-}
-
-// Archived and resolved reports come from their own server-side fetch, so the
-// section fetches lazily on first expand and stays collapsed by default.
-function ResolvedSection({
-  searchQuery,
-  count,
-}: {
-  searchQuery: string;
-  count: number;
-}): React.JSX.Element {
-  const [expanded, setExpanded] = useState(false);
-  const {
-    allReports,
-    isLoading,
-    hasNextPage,
-    fetchNextPage,
-    isFetchingNextPage,
-  } = useInboxReportsInfinite(
-    { status: INBOX_DISMISSED_STATUS_FILTER, ordering: "-updated_at" },
-    { enabled: expanded, pageSize: SECTION_PREVIEW_LIMIT },
-  );
-  const matchingReports = useMemo(
-    () => filterReportsBySearch(allReports, searchQuery),
-    [allReports, searchQuery],
-  );
-  const searchActive = searchQuery.trim().length > 0;
-  const canAutoPageSearch =
-    searchActive && hasNextPage && allReports.length < AUTOPAGE_REPORT_LIMIT;
-
-  useEffect(() => {
-    if (!expanded || !canAutoPageSearch || isFetchingNextPage) return;
-    void fetchNextPage();
-  }, [expanded, canAutoPageSearch, isFetchingNextPage, fetchNextPage]);
-
-  return (
-    <section className="flex flex-col gap-2">
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        className="flex w-full cursor-pointer items-center gap-2 rounded px-0.5 py-1 text-left"
-        aria-expanded={expanded}
-      >
-        <span className="flex items-center gap-1 font-mono font-semibold text-[11px] text-gray-10 uppercase tracking-widest">
-          Resolved <span className="tabular-nums">({count})</span>
-        </span>
-        <div className="h-px flex-1 bg-(--gray-5)" />
-        <CaretDownIcon
-          size={12}
-          className={`text-gray-9 transition-transform ${expanded ? "rotate-180" : ""}`}
-        />
-      </button>
-      {expanded &&
-        (isLoading ? (
-          <div className="flex justify-center py-3">
-            <Spinner />
-          </div>
-        ) : (
-          <div className="flex flex-col gap-1">
-            {matchingReports.length === 0 && !canAutoPageSearch && (
-              <p className="px-1 py-2 text-[13.5px] text-gray-10">
-                {searchActive
-                  ? "No resolved or archived reports match your search. Try a different search."
-                  : "Nothing resolved or archived yet."}
-              </p>
-            )}
-            {matchingReports.map((report) => (
-              <InboxReportRow key={report.id} report={report} />
-            ))}
-            {isFetchingNextPage && (
-              <div className="flex justify-center py-2">
-                <Spinner />
-              </div>
-            )}
-            {hasNextPage && !canAutoPageSearch && (
-              <Button
-                type="button"
-                variant="link-muted"
-                size="sm"
-                className="self-center text-gray-10"
-                disabled={isFetchingNextPage}
-                onClick={() => fetchNextPage()}
-              >
-                {searchActive
-                  ? "Show more"
-                  : `Show more (${Math.max(0, count - matchingReports.length)})`}
-              </Button>
-            )}
-          </div>
-        ))}
-    </section>
+        ) : undefined
+      }
+      renderReport={(report) => (
+        <InboxReportRow key={report.id} report={report} />
+      )}
+      onConfigureAgents={navigateToAgents}
+      onEnterTriage={() => setFocusMode(true)}
+      onClearFilters={resetFilters}
+    />
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -277,8 +277,8 @@ export function ReportsInboxView() {
                 }
               />
               <TooltipContent side="bottom">
-                Step through reports that need a decision, one at a time. Fix,
-                ask about, or archive each from the keyboard.
+                Step through reports that need a decision, one at a time. Open,
+                create a PR, or archive each from the keyboard.
               </TooltipContent>
             </Tooltip>
           )}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -292,7 +292,7 @@ export function ReportsInboxView() {
           ) : (
             <>
               {isEmpty ? (
-                <Empty className="mx-auto max-w-md py-16">
+                <Empty className="mx-auto max-w-md flex-none border-0 py-12">
                   <EmptyHeader>
                     <EmptyMedia variant="icon">
                       {hasActiveFilters ? (
@@ -356,7 +356,7 @@ export function ReportsInboxView() {
                   )}
                 </>
               )}
-              <ResolvedSection searchQuery={searchQuery} />
+              {!isEmpty && <ResolvedSection searchQuery={searchQuery} />}
             </>
           )}
         </div>

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -44,6 +44,7 @@ import { ReportTriageFocus } from "@posthog/ui/features/inbox/components/ReportT
 import { SuggestedReviewerAvatarStack } from "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack";
 import { SignalReportPriorityBadge } from "@posthog/ui/features/inbox/components/utils/SignalReportPriorityBadge";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
+import { useInboxTriageOrigin } from "@posthog/ui/features/inbox/hooks/useInboxBackTarget";
 import { useInboxReportDetailPrefetch } from "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch";
 import { useInboxReportDismissAction } from "@posthog/ui/features/inbox/hooks/useInboxReportDismissAction";
 import { useInboxReportsInfinite } from "@posthog/ui/features/inbox/hooks/useInboxReports";
@@ -68,7 +69,8 @@ import {
   navigateToInboxReportDetail,
 } from "@posthog/ui/router/navigationBridge";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
-import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -115,7 +117,22 @@ export function ReportsInboxView() {
     applyPrFilter: true,
   });
   const triageFocusEnabled = useTriageFocusEnabled();
-  const [focusMode, setFocusMode] = useState(false);
+  const triageOrigin = useInboxTriageOrigin();
+  const navigate = useNavigate();
+  const [focusMode, setFocusMode] = useState(() => triageOrigin !== null);
+
+  const exitFocusMode = useCallback(() => {
+    setFocusMode(false);
+    if (!triageOrigin) return;
+    void navigate({
+      to: "/inbox/reports",
+      replace: true,
+      state: (previous) => ({
+        ...previous,
+        inboxTriageOrigin: undefined,
+      }),
+    });
+  }, [navigate, triageOrigin]);
 
   const sections = useMemo(
     () => partitionInboxReports(scopedReports),
@@ -186,7 +203,7 @@ export function ReportsInboxView() {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [triageFocusEnabled, focusMode, sections.decision.length]);
 
-  if (triageFocusEnabled && focusMode) {
+  if (triageFocusEnabled && focusMode && !isLoading) {
     return (
       <div className="h-full min-h-0">
         <ReportTriageFocus
@@ -194,7 +211,8 @@ export function ReportsInboxView() {
           allReports={allReports}
           scope={scope}
           hasActiveFilters={hasActiveFilters}
-          onExit={() => setFocusMode(false)}
+          initialReportId={triageOrigin?.reportId}
+          onExit={exitFocusMode}
         />
       </div>
     );

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxView.tsx
@@ -15,7 +15,7 @@ import {
   REPORTS_INBOX_STATUS_FILTER,
 } from "@posthog/core/inbox/reportFiltering";
 import { partitionInboxReports } from "@posthog/core/inbox/reportInboxSections";
-import { INBOX_SCOPE_FOR_YOU } from "@posthog/core/inbox/reportMembership";
+import { inboxReviewerScopeValue } from "@posthog/core/inbox/reportMembership";
 import {
   deriveHeadline,
   humanizeReportTitle,
@@ -146,7 +146,7 @@ export function ReportsInboxView() {
     sourceProductFilter,
     priorityFilter,
     searchQuery,
-    isDefaultScope: scope === INBOX_SCOPE_FOR_YOU,
+    scope: inboxReviewerScopeValue(scope),
   });
 
   // Keep paging rows in (capped) so the sections have bodies to render —
@@ -188,10 +188,12 @@ export function ReportsInboxView() {
 
   if (triageFocusEnabled && focusMode) {
     return (
-      <div className="h-full min-h-0 overflow-y-auto">
+      <div className="h-full min-h-0">
         <ReportTriageFocus
           reports={sections.decision}
           allReports={allReports}
+          scope={scope}
+          hasActiveFilters={hasActiveFilters}
           onExit={() => setFocusMode(false)}
         />
       </div>
@@ -437,7 +439,7 @@ function InboxReportRow({ report }: { report: SignalReport }) {
     ? parsePrUrl(report.implementation_pr_url)
     : null;
   const { actionButton: archiveButton, dialog: archiveDialog } =
-    useInboxReportDismissAction(report);
+    useInboxReportDismissAction(report, "list_row");
   const { pointerHandlers } = useInboxReportDetailPrefetch({
     to: "/inbox/reports/$reportId",
     params: { reportId: report.id },

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxViewPresentation.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxViewPresentation.stories.tsx
@@ -1,0 +1,150 @@
+import { Button, Input } from "@posthog/quill";
+import type { SignalReport } from "@posthog/shared/types";
+import { InboxReportRowView } from "@posthog/ui/features/inbox/components/InboxReportRowView";
+import { InboxReportSection } from "@posthog/ui/features/inbox/components/InboxReportSection";
+import { inboxStoryReport } from "@posthog/ui/features/inbox/components/inboxStoryFixtures";
+import { ReportsInboxViewPresentation } from "@posthog/ui/features/inbox/components/ReportsInboxViewPresentation";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const reviewAndMerge = [
+  inboxStoryReport({
+    id: "review-1",
+    title: "fix(cohorts): keep recurring calculations within their budget",
+    implementation_pr_url: "https://github.com/PostHog/posthog/pull/12345",
+  }),
+  inboxStoryReport({
+    id: "review-2",
+    title: "feat(replay): expose buffer health in the player controls",
+    priority: "P2",
+    signal_count: 3,
+    implementation_pr_url: "https://github.com/PostHog/posthog/pull/12346",
+  }),
+];
+
+const needsPr = Array.from({ length: 8 }, (_, index) =>
+  inboxStoryReport({
+    id: `needs-pr-${index + 1}`,
+    title: `${index % 2 === 0 ? "fix(flags)" : "feat(insights)"}: ${
+      index % 2 === 0
+        ? "avoid duplicate evaluations after a reconnect"
+        : "preserve breakdown order in saved results"
+    }`,
+    priority: index < 2 ? "P1" : "P2",
+    signal_count: 9 - index,
+  }),
+);
+
+const resolved = [
+  inboxStoryReport({
+    id: "resolved-1",
+    status: "resolved",
+    title: "fix(webhooks): retry delivery after a transient timeout",
+  }),
+  inboxStoryReport({
+    id: "resolved-2",
+    status: "suppressed",
+    title: "chore(settings): clarify an unused configuration path",
+    dismissal_reason: "not_enough_evidence",
+  }),
+];
+
+function reportRow(report: SignalReport): React.JSX.Element {
+  return (
+    <InboxReportRowView
+      key={report.id}
+      report={report}
+      reviewers={
+        <span
+          className="h-5 w-5 rounded-full border-(--color-panel-solid) border-2 bg-(--accent-5)"
+          role="img"
+          aria-label="One suggested reviewer"
+        />
+      }
+      onOpen={() => {}}
+      onOpenPr={() => {}}
+    />
+  );
+}
+
+const meta: Meta<typeof ReportsInboxViewPresentation> = {
+  title: "Inbox/Reports/List view",
+  component: ReportsInboxViewPresentation,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      <div className="h-[760px] min-w-[720px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    reviewAndMerge,
+    reviewAndMergeCount: reviewAndMerge.length,
+    needsPr,
+    needsPrCount: needsPr.length,
+    isLoading: false,
+    isFetchingNextPage: false,
+    isEmpty: false,
+    hasActiveFilters: false,
+    triageEnabled: true,
+    scopeControl: (
+      <Button type="button" variant="outline" size="sm">
+        For you
+      </Button>
+    ),
+    searchControl: <Input placeholder="Search reports…" />,
+    resolvedSection: (
+      <InboxReportSection
+        title="Resolved"
+        reports={resolved}
+        count={resolved.length}
+        defaultOpen={false}
+        renderReport={reportRow}
+      />
+    ),
+    renderReport: reportRow,
+    onConfigureAgents: () => {},
+    onEnterTriage: () => {},
+    onClearFilters: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ReportsInboxViewPresentation>;
+
+export const MixedQueue: Story = {};
+
+export const EmptyInbox: Story = {
+  args: {
+    reviewAndMerge: [],
+    reviewAndMergeCount: 0,
+    needsPr: [],
+    needsPrCount: 0,
+    isEmpty: true,
+    resolvedSection: undefined,
+  },
+};
+
+export const FilteredEmpty: Story = {
+  args: {
+    reviewAndMerge: [],
+    reviewAndMergeCount: 0,
+    needsPr: [],
+    needsPrCount: 0,
+    isEmpty: true,
+    hasActiveFilters: true,
+    resolvedSection: undefined,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    reviewAndMerge: [],
+    reviewAndMergeCount: 0,
+    needsPr: [],
+    needsPrCount: 0,
+    isLoading: true,
+    isEmpty: false,
+    resolvedSection: undefined,
+  },
+};

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxViewPresentation.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportsInboxViewPresentation.tsx
@@ -1,0 +1,199 @@
+import {
+  EnvelopeSimpleIcon,
+  FunnelIcon,
+  ListChecksIcon,
+} from "@phosphor-icons/react";
+import {
+  Button,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Skeleton,
+  Spinner,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
+import type { SignalReport } from "@posthog/shared/types";
+import { InboxReportSection } from "@posthog/ui/features/inbox/components/InboxReportSection";
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderDescription,
+  PageHeaderHeading,
+  PageHeaderTitle,
+  PageHeaderTitleRow,
+} from "@posthog/ui/primitives/PageHeader";
+import type { ReactNode } from "react";
+
+export interface ReportsInboxViewPresentationProps {
+  reviewAndMerge: SignalReport[];
+  reviewAndMergeCount: number;
+  needsPr: SignalReport[];
+  needsPrCount: number;
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+  isEmpty: boolean;
+  hasActiveFilters: boolean;
+  triageEnabled: boolean;
+  scopeControl: ReactNode;
+  searchControl: ReactNode;
+  resolvedSection?: ReactNode;
+  renderReport: (report: SignalReport) => ReactNode;
+  onConfigureAgents: () => void;
+  onEnterTriage: () => void;
+  onClearFilters: () => void;
+}
+
+export function ReportsInboxViewPresentation({
+  reviewAndMerge,
+  reviewAndMergeCount,
+  needsPr,
+  needsPrCount,
+  isLoading,
+  isFetchingNextPage,
+  isEmpty,
+  hasActiveFilters,
+  triageEnabled,
+  scopeControl,
+  searchControl,
+  resolvedSection,
+  renderReport,
+  onConfigureAgents,
+  onEnterTriage,
+  onClearFilters,
+}: ReportsInboxViewPresentationProps): React.JSX.Element {
+  const triageReportCount = reviewAndMerge.length + needsPr.length;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-gray-1">
+      <PageHeader>
+        <PageHeaderHeading>
+          <PageHeaderTitleRow>
+            <PageHeaderTitle>Self-driving</PageHeaderTitle>
+            <PageHeaderActions>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onConfigureAgents}
+              >
+                Configure agents
+              </Button>
+            </PageHeaderActions>
+          </PageHeaderTitleRow>
+          <PageHeaderDescription>
+            Issues and opportunities found in your product, ready to review
+          </PageHeaderDescription>
+        </PageHeaderHeading>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {triageEnabled && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="gap-2"
+                    disabled={triageReportCount === 0}
+                    onClick={onEnterTriage}
+                  >
+                    <ListChecksIcon />
+                    Triage mode
+                    <kbd className="rounded bg-(--gray-4) px-1.5 font-mono text-[12px] text-gray-11">
+                      T
+                    </kbd>
+                  </Button>
+                }
+              />
+              <TooltipContent side="bottom">
+                Step through reports that need a decision, one at a time. Open,
+                create a PR, or archive each from the keyboard.
+              </TooltipContent>
+            </Tooltip>
+          )}
+          {scopeControl}
+        </div>
+      </PageHeader>
+
+      <div className="shrink-0 border-(--gray-5) border-b">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-2.5 px-6 py-3">
+          {searchControl}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-6 py-4">
+          {isLoading && reviewAndMerge.length === 0 && needsPr.length === 0 ? (
+            <div aria-hidden className="flex flex-col gap-2 pt-2">
+              {[70, 55, 80, 60].map((width) => (
+                <div key={width} className="flex items-center gap-3 py-2">
+                  <Skeleton className="h-4" style={{ width: `${width}%` }} />
+                </div>
+              ))}
+            </div>
+          ) : isEmpty ? (
+            <Empty className="mx-auto max-w-md flex-none border-0 py-12">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  {hasActiveFilters ? (
+                    <FunnelIcon size={24} />
+                  ) : (
+                    <EnvelopeSimpleIcon size={24} />
+                  )}
+                </EmptyMedia>
+                <EmptyTitle>
+                  {hasActiveFilters
+                    ? "No reports match your filters"
+                    : "Nothing to review"}
+                </EmptyTitle>
+                <EmptyDescription>
+                  {hasActiveFilters
+                    ? "Clear the filters to check for hidden reports."
+                    : "Reports show up here as your agents find things worth acting on."}
+                </EmptyDescription>
+              </EmptyHeader>
+              {hasActiveFilters && (
+                <EmptyContent>
+                  <Button
+                    variant="outline"
+                    size="default"
+                    onClick={onClearFilters}
+                  >
+                    Clear filters
+                  </Button>
+                </EmptyContent>
+              )}
+            </Empty>
+          ) : (
+            <>
+              <InboxReportSection
+                title="Review and merge"
+                reports={reviewAndMerge}
+                count={reviewAndMergeCount}
+                emptyNote="No pull requests open yet. Start one from a report below."
+                renderReport={renderReport}
+              />
+              <InboxReportSection
+                title="Needs a PR"
+                reports={needsPr}
+                count={needsPrCount}
+                emptyNote="No reports are waiting for a pull request."
+                renderReport={renderReport}
+              />
+              {isFetchingNextPage && (
+                <div className="flex justify-center py-2">
+                  <Spinner />
+                </div>
+              )}
+              {resolvedSection}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/ResolvedReportsSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ResolvedReportsSection.tsx
@@ -1,0 +1,77 @@
+import {
+  filterReportsBySearch,
+  INBOX_DISMISSED_STATUS_FILTER,
+} from "@posthog/core/inbox/reportFiltering";
+import { Spinner } from "@posthog/quill";
+import { InboxReportRow } from "@posthog/ui/features/inbox/components/InboxReportRow";
+import { InboxReportSection } from "@posthog/ui/features/inbox/components/InboxReportSection";
+import { useInboxReportsInfinite } from "@posthog/ui/features/inbox/hooks/useInboxReports";
+import { useEffect, useMemo, useState } from "react";
+
+const SECTION_PREVIEW_LIMIT = 5;
+const AUTOPAGE_REPORT_LIMIT = 400;
+
+export function ResolvedReportsSection({
+  searchQuery,
+  count,
+}: {
+  searchQuery: string;
+  count: number;
+}): React.JSX.Element | null {
+  const [expanded, setExpanded] = useState(false);
+  const {
+    allReports,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInboxReportsInfinite(
+    { status: INBOX_DISMISSED_STATUS_FILTER, ordering: "-updated_at" },
+    { enabled: expanded, pageSize: SECTION_PREVIEW_LIMIT },
+  );
+  const matchingReports = useMemo(
+    () => filterReportsBySearch(allReports, searchQuery),
+    [allReports, searchQuery],
+  );
+  const searchActive = searchQuery.trim().length > 0;
+  const canAutoPageSearch =
+    searchActive && hasNextPage && allReports.length < AUTOPAGE_REPORT_LIMIT;
+
+  useEffect(() => {
+    if (!expanded || !canAutoPageSearch || isFetchingNextPage) return;
+    void fetchNextPage();
+  }, [expanded, canAutoPageSearch, isFetchingNextPage, fetchNextPage]);
+
+  if (count === 0) return null;
+
+  return (
+    <>
+      <InboxReportSection
+        title="Resolved"
+        reports={matchingReports}
+        count={count}
+        defaultOpen={false}
+        isLoading={expanded && isLoading}
+        emptyNote={
+          searchActive
+            ? "No resolved or archived reports match your search. Try a different search."
+            : "Nothing resolved or archived yet."
+        }
+        renderReport={(report) => (
+          <InboxReportRow key={report.id} report={report} />
+        )}
+        onOpenChange={setExpanded}
+        onShowMore={
+          hasNextPage && !canAutoPageSearch
+            ? () => void fetchNextPage()
+            : undefined
+        }
+      />
+      {isFetchingNextPage && (
+        <div className="flex justify-center py-2">
+          <Spinner />
+        </div>
+      )}
+    </>
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
@@ -130,7 +130,7 @@ describe("SuggestedReviewerAvatarStack", () => {
     expect(screen.getByText("2 suggested reviewers")).toBeTruthy();
   });
 
-  it("removes the current user and tracks the list action", async () => {
+  it("removes the current user from the reviewer menu", async () => {
     const onCardClick = vi.fn();
     const user = userEvent.setup();
     document.addEventListener("click", onCardClick);
@@ -138,7 +138,15 @@ describe("SuggestedReviewerAvatarStack", () => {
       <SuggestedReviewerAvatarStack report={report} artefacts={artefacts} />,
     );
 
-    const button = screen.getByRole("button", { name: "Not for me" });
+    expect(screen.queryByRole("button", { name: "Not for me" })).toBeNull();
+    await user.click(
+      screen.getByRole("button", {
+        name: "View suggested reviewer rationale",
+      }),
+    );
+    const button = screen.getByRole("button", {
+      name: "Remove me from reviewers",
+    });
 
     await user.click(button);
 
@@ -158,7 +166,8 @@ describe("SuggestedReviewerAvatarStack", () => {
     document.removeEventListener("click", onCardClick);
   });
 
-  it("keeps the personal shortcut visible in triage and out of detail", () => {
+  it("does not render the reviewer action as a report status", async () => {
+    const user = userEvent.setup();
     const { rerender } = render(
       <SuggestedReviewerAvatarStack
         report={report}
@@ -166,8 +175,17 @@ describe("SuggestedReviewerAvatarStack", () => {
         surface="triage"
       />,
     );
-    expect(screen.getByRole("button", { name: "Not for me" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Not for me" })).toBeNull();
     expect(mocks.lastSurface).toBe("triage");
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "View suggested reviewer rationale",
+      }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Remove me from reviewers" }),
+    ).toBeTruthy();
 
     rerender(
       <SuggestedReviewerAvatarStack

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
@@ -138,17 +138,7 @@ describe("SuggestedReviewerAvatarStack", () => {
       <SuggestedReviewerAvatarStack report={report} artefacts={artefacts} />,
     );
 
-    await user.click(
-      screen.getByRole("button", {
-        name: "View suggested reviewer rationale",
-      }),
-    );
-    const button = await screen.findByRole("button", {
-      name: "Remove me from reviewers",
-    });
-    expect(
-      screen.getByText("Recently changed the affected request parser."),
-    ).toBeTruthy();
+    const button = screen.getByRole("button", { name: "Not for me" });
 
     await user.click(button);
 
@@ -166,5 +156,26 @@ describe("SuggestedReviewerAvatarStack", () => {
       },
     );
     document.removeEventListener("click", onCardClick);
+  });
+
+  it("keeps the personal shortcut visible in triage and out of detail", () => {
+    const { rerender } = render(
+      <SuggestedReviewerAvatarStack
+        report={report}
+        artefacts={artefacts}
+        surface="triage"
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Not for me" })).toBeTruthy();
+    expect(mocks.lastSurface).toBe("triage");
+
+    rerender(
+      <SuggestedReviewerAvatarStack
+        report={report}
+        artefacts={artefacts}
+        surface="detail_pane"
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Not for me" })).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
@@ -31,7 +31,6 @@ const MAX_VISIBLE = 4;
 // Keep this stable because autocapture insights and UI tests can depend on it.
 const REMOVE_SELF_DATA_ATTR = "inbox-remove-self-from-reviewers";
 const REMOVE_SELF_LABEL = "Remove me from reviewers";
-const NOT_FOR_ME_LABEL = "Not for me";
 
 interface SuggestedReviewerAvatarStackProps {
   report: SignalReport;
@@ -108,7 +107,7 @@ export function SuggestedReviewerAvatarStack({
     });
   };
 
-  const reviewerPopover = (
+  return (
     <Popover>
       <PopoverTrigger
         render={
@@ -184,34 +183,5 @@ export function SuggestedReviewerAvatarStack({
         ) : null}
       </PopoverContent>
     </Popover>
-  );
-
-  const showDirectRemove =
-    currentReviewer != null &&
-    reviewerArtefact != null &&
-    (surface === "list_row" || surface === "triage");
-
-  return (
-    <span className="flex items-center gap-1.5">
-      {reviewerPopover}
-      {showDirectRemove && (
-        <Button
-          type="button"
-          variant="link-muted"
-          size="xs"
-          className="h-auto p-0 text-[12px] no-underline hover:no-underline"
-          data-attr={REMOVE_SELF_DATA_ATTR}
-          loading={isPending}
-          title="Remove only you from this report's suggested reviewers"
-          onClick={(event) => {
-            event.preventDefault();
-            event.stopPropagation();
-            removeSelf();
-          }}
-        >
-          {NOT_FOR_ME_LABEL}
-        </Button>
-      )}
-    </span>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
@@ -31,6 +31,7 @@ const MAX_VISIBLE = 4;
 // Keep this stable because autocapture insights and UI tests can depend on it.
 const REMOVE_SELF_DATA_ATTR = "inbox-remove-self-from-reviewers";
 const REMOVE_SELF_LABEL = "Remove me from reviewers";
+const NOT_FOR_ME_LABEL = "Not for me";
 
 interface SuggestedReviewerAvatarStackProps {
   report: SignalReport;
@@ -107,7 +108,7 @@ export function SuggestedReviewerAvatarStack({
     });
   };
 
-  return (
+  const reviewerPopover = (
     <Popover>
       <PopoverTrigger
         render={
@@ -183,5 +184,34 @@ export function SuggestedReviewerAvatarStack({
         ) : null}
       </PopoverContent>
     </Popover>
+  );
+
+  const showDirectRemove =
+    currentReviewer != null &&
+    reviewerArtefact != null &&
+    (surface === "list_row" || surface === "triage");
+
+  return (
+    <span className="flex items-center gap-1.5">
+      {reviewerPopover}
+      {showDirectRemove && (
+        <Button
+          type="button"
+          variant="link-muted"
+          size="xs"
+          className="h-auto p-0 text-[12px] no-underline hover:no-underline"
+          data-attr={REMOVE_SELF_DATA_ATTR}
+          loading={isPending}
+          title="Remove only you from this report's suggested reviewers"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            removeSelf();
+          }}
+        >
+          {NOT_FOR_ME_LABEL}
+        </Button>
+      )}
+    </span>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
@@ -2,7 +2,6 @@ import { ClockCounterClockwiseIcon } from "@phosphor-icons/react";
 import { ArtefactLogList } from "@posthog/ui/features/inbox/components/detail/ArtefactLogList";
 import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
 import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
-import { Text } from "@radix-ui/themes";
 
 /**
  * The report's artefact log ("Activity"), shared by every report detail
@@ -36,9 +35,9 @@ export function ReportActivitySection({
       collapsible
       defaultCollapsed
       rightSlot={
-        <Text className="cursor-default select-none text-[12px] text-gray-10 tabular-nums">
+        <span className="cursor-default select-none text-[12px] text-gray-10 tabular-nums">
           {artefacts.length} entr{artefacts.length === 1 ? "y" : "ies"}
-        </Text>
+        </span>
       }
     >
       <ArtefactLogList

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/ReportActivitySection.tsx
@@ -1,13 +1,13 @@
 import { ClockCounterClockwiseIcon } from "@phosphor-icons/react";
 import { ArtefactLogList } from "@posthog/ui/features/inbox/components/detail/ArtefactLogList";
+import { selectUsefulReportActivity } from "@posthog/ui/features/inbox/components/detail/reportActivity";
 import { RightColumnSection } from "@posthog/ui/features/inbox/components/RightColumnSection";
 import { useInboxReportArtefacts } from "@posthog/ui/features/inbox/hooks/useInboxReports";
 
 /**
- * The report's artefact log ("Activity"), shared by every report detail
- * surface (reports, pull requests, runs) so the work log follows the report
- * wherever it is rendered. Renders nothing while loading or when the report
- * has no artefacts.
+ * The report's useful work history, shared by every report detail surface.
+ * Routine pipeline judgments and task links already appear in their own
+ * sections, so repeating them here would hide human-readable progress.
  */
 export function ReportActivitySection({
   reportId,
@@ -17,14 +17,13 @@ export function ReportActivitySection({
   /** Drop the per-commit diff toggle (PR detail shows the full diff already). */
   hideCommitDiffs?: boolean;
 }) {
-  // The log is a live work record — agents append artefacts while the report is
-  // open, so don't let the app-wide 5-minute staleTime sit on it. Poll gently
-  // while mounted.
+  // Agents append artefacts while the report is open, so the app-wide
+  // 5-minute stale time would hide progress from someone watching the report.
   const { data: artefactsResp } = useInboxReportArtefacts(reportId, {
     staleTime: 10_000,
     refetchInterval: 20_000,
   });
-  const artefacts = artefactsResp?.results ?? [];
+  const artefacts = selectUsefulReportActivity(artefactsResp?.results ?? []);
 
   if (artefacts.length === 0) return null;
 

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/reportActivity.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/reportActivity.test.ts
@@ -1,0 +1,33 @@
+import type { AnySignalReportArtefact } from "@posthog/shared/types";
+import { describe, expect, it } from "vitest";
+import { selectUsefulReportActivity } from "./reportActivity";
+
+function artefact(type: string): AnySignalReportArtefact {
+  return {
+    id: type,
+    type,
+    created_at: "2026-01-01T00:00:00Z",
+    content: {
+      session_id: "",
+      start_time: "",
+      end_time: "",
+      distinct_id: "",
+      content: "",
+      distance_to_centroid: null,
+    },
+  };
+}
+
+describe("selectUsefulReportActivity", () => {
+  it("removes routine pipeline records while preserving useful progress", () => {
+    const result = selectUsefulReportActivity([
+      artefact("task_run"),
+      artefact("safety_judgment"),
+      artefact("signal_finding"),
+      artefact("commit"),
+      artefact("note"),
+    ]);
+
+    expect(result.map((entry) => entry.type)).toEqual(["commit", "note"]);
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/reportActivity.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/reportActivity.ts
@@ -1,0 +1,19 @@
+import type { AnySignalReportArtefact } from "@posthog/shared/types";
+
+const ROUTINE_PIPELINE_ARTEFACTS = new Set([
+  "actionability_judgment",
+  "priority_judgment",
+  "repo_selection",
+  "safety_judgment",
+  "signal_finding",
+  "suggested_reviewers",
+  "task_run",
+]);
+
+export function selectUsefulReportActivity(
+  artefacts: AnySignalReportArtefact[],
+): AnySignalReportArtefact[] {
+  return artefacts.filter(
+    (artefact) => !ROUTINE_PIPELINE_ARTEFACTS.has(artefact.type),
+  );
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/inboxStoryFixtures.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/inboxStoryFixtures.ts
@@ -1,0 +1,38 @@
+import type { Signal, SignalReport } from "@posthog/shared/types";
+
+export function inboxStoryReport(
+  overrides: Partial<SignalReport> = {},
+): SignalReport {
+  return {
+    id: "story-report",
+    title: "fix(cohorts): keep recurring calculations within their budget",
+    summary:
+      "Recurring cohort calculations can overlap after a delayed run, which increases queue time for later updates.\n\n## Impact\n\nTeams see stale cohort membership until the overlapping calculations finish.\n\n## Recommendation\n\nCoalesce pending work by cohort and carry the newest requested calculation forward.",
+    status: "ready",
+    total_weight: 48,
+    signal_count: 6,
+    created_at: "2026-08-20T09:00:00Z",
+    updated_at: "2026-08-28T14:30:00Z",
+    artefact_count: 3,
+    priority: "P1",
+    actionability: "immediately_actionable",
+    is_suggested_reviewer: true,
+    source_products: ["signals_scout"],
+    ...overrides,
+  };
+}
+
+export function inboxStorySignal(overrides: Partial<Signal> = {}): Signal {
+  return {
+    signal_id: "story-signal",
+    content:
+      "The calculated membership remained unchanged after the scheduled update completed.",
+    source_product: "signals_scout",
+    source_type: "cross_source_issue",
+    source_id: "story-source",
+    weight: 8,
+    timestamp: "2026-08-27T12:00:00Z",
+    extra: { skill_name: "signals-scout-data-quality" },
+    ...overrides,
+  };
+}

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxAllReports.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxAllReports.test.tsx
@@ -17,6 +17,9 @@ const mockGetSignalReports = vi.hoisted(() => vi.fn());
 const mockClient = vi.hoisted(() => ({
   getSignalReports: mockGetSignalReports,
 }));
+const filterMocks = vi.hoisted(() => ({
+  sourceProductFilter: [] as string[],
+}));
 
 vi.mock("@posthog/ui/features/auth/authClient", () => ({
   useOptionalAuthenticatedClient: () => mockClient,
@@ -39,8 +42,9 @@ vi.mock("@posthog/ui/features/inbox/stores/inboxSignalsFilterStore", () => ({
       searchQuery: "",
       sortField: "priority",
       sortDirection: "desc",
-      sourceProductFilter: [],
+      sourceProductFilter: filterMocks.sourceProductFilter,
       priorityFilter: [],
+      prFilter: "all",
     }),
 }));
 
@@ -106,6 +110,7 @@ function reportsCountParams(): SignalReportsQueryParams | undefined {
 function renderCounts(options?: {
   enabled?: boolean;
   withReportsCount?: boolean;
+  applySourceFilter?: boolean;
 }) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -119,6 +124,7 @@ function renderCounts(options?: {
 describe("useInboxAllReports", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    filterMocks.sourceProductFilter = [];
     mockGetSignalReports.mockImplementation(async (params) =>
       fakeServer(params),
     );
@@ -173,5 +179,15 @@ describe("useInboxAllReports", () => {
     renderCounts({ enabled: false, withReportsCount: true });
 
     expect(mockGetSignalReports).not.toHaveBeenCalled();
+  });
+
+  it("ignores a saved source filter when its surface hides that control", async () => {
+    filterMocks.sourceProductFilter = ["github"];
+
+    const { result } = renderCounts({ applySourceFilter: false });
+
+    await waitFor(() => expect(result.current.allReports).toHaveLength(50));
+    expect(pipelineRequests()[0]?.source_product).toBeUndefined();
+    expect(result.current.sourceProductFilter).toEqual([]);
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxAllReports.ts
@@ -53,18 +53,15 @@ export function useInboxAllReports(options?: {
    */
   statusFilter?: string;
   /**
-   * Apply the persisted `prFilter` (with-PR / without-PR) to the query. Only
-   * the sectioned inbox renders the control that sets it, so only it opts in —
-   * otherwise a stored value would silently filter surfaces with no way to
-   * clear it (e.g. empty the legacy Reports tab, which then drops PR-backed
-   * reports itself).
+   * Apply the persisted source filter to the query. The sectioned inbox hides
+   * that control, so it opts out to avoid a stored value filtering the list.
    */
-  applyPrFilter?: boolean;
+  applySourceFilter?: boolean;
 }) {
   const enabled = options?.enabled ?? true;
   const ignoreScope = options?.ignoreScope ?? false;
   const ignoreFilters = options?.ignoreFilters ?? false;
-  const applyPrFilter = options?.applyPrFilter ?? false;
+  const applySourceFilter = options?.applySourceFilter ?? true;
   const refetchIntervalMs =
     options?.refetchIntervalMs ?? INBOX_REFETCH_INTERVAL_MS;
   // The Pull requests tab fetches a server-filtered list (reports that have a
@@ -84,13 +81,12 @@ export function useInboxAllReports(options?: {
     ignoreFilters ? "desc" : s.sortDirection,
   );
   const sourceProductFilter = useInboxSignalsFilterStore((s) =>
-    ignoreFilters ? EMPTY_FILTER_ARRAY : s.sourceProductFilter,
+    ignoreFilters || !applySourceFilter
+      ? EMPTY_FILTER_ARRAY
+      : s.sourceProductFilter,
   );
   const priorityFilter = useInboxSignalsFilterStore((s) =>
     ignoreFilters ? EMPTY_FILTER_ARRAY : s.priorityFilter,
-  );
-  const prFilter = useInboxSignalsFilterStore((s) =>
-    ignoreFilters || !applyPrFilter ? "all" : s.prFilter,
   );
   const isForYou = !ignoreScope && scope === INBOX_SCOPE_FOR_YOU;
   const teammateUuid = ignoreScope ? null : parseTeammateInboxScope(scope);
@@ -113,13 +109,7 @@ export function useInboxAllReports(options?: {
       status: pullRequestsOnly
         ? INBOX_PULL_REQUEST_STATUS_FILTER
         : (options?.statusFilter ?? INBOX_PIPELINE_STATUS_FILTER),
-      has_implementation_pr: pullRequestsOnly
-        ? true
-        : prFilter === "with_pr"
-          ? true
-          : prFilter === "without_pr"
-            ? false
-            : undefined,
+      has_implementation_pr: pullRequestsOnly ? true : undefined,
       ordering: buildSignalReportListOrdering(sortField, sortDirection),
       source_product:
         sourceProductFilter.length > 0

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBackTarget.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBackTarget.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { asInboxBackTarget } from "./useInboxBackTarget";
+import { asInboxBackTarget, asInboxTriageOrigin } from "./useInboxBackTarget";
 
-describe("asInboxBackTarget", () => {
+describe("inbox history state validation", () => {
   it.each([
     ["reports origin", { to: "/inbox/reports", label: "Back to reports" }],
     ["pulls origin", { to: "/inbox/pulls", label: "Back to pull requests" }],
@@ -24,4 +24,17 @@ describe("asInboxBackTarget", () => {
   ])("rejects %s and falls back", (_label, value) => {
     expect(asInboxBackTarget(value)).toBeNull();
   });
+
+  it("accepts a triage report origin", () => {
+    expect(asInboxTriageOrigin({ reportId: "report-1" })).toEqual({
+      reportId: "report-1",
+    });
+  });
+
+  it.each([undefined, null, "report-1", {}, { reportId: "" }, { reportId: 1 }])(
+    "rejects an invalid triage report origin: %s",
+    (value) => {
+      expect(asInboxTriageOrigin(value)).toBeNull();
+    },
+  );
 });

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBackTarget.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBackTarget.ts
@@ -22,11 +22,16 @@ export interface InboxBackTarget {
   label: string;
 }
 
+export interface InboxTriageOrigin {
+  reportId: string;
+}
+
 // Carried in history state across the status↔route redirect; declared here so
 // `navigate({ state })` and `useLocation().state` stay typed.
 declare module "@tanstack/react-router" {
   interface HistoryState {
     inboxBackOrigin?: InboxBackTarget;
+    inboxTriageOrigin?: InboxTriageOrigin;
   }
 }
 
@@ -44,6 +49,21 @@ export function asInboxBackTarget(value: unknown): InboxBackTarget | null {
     return null;
   }
   return { to: to as InboxListRoute, label };
+}
+
+export function asInboxTriageOrigin(value: unknown): InboxTriageOrigin | null {
+  if (!value || typeof value !== "object") return null;
+  const { reportId } = value as Record<string, unknown>;
+  return typeof reportId === "string" && reportId.length > 0
+    ? { reportId }
+    : null;
+}
+
+export function useInboxTriageOrigin(): InboxTriageOrigin | null {
+  const origin = useLocation({
+    select: (location) => location.state.inboxTriageOrigin,
+  });
+  return asInboxTriageOrigin(origin);
 }
 
 /**

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxDecisionCount.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxDecisionCount.ts
@@ -32,9 +32,6 @@ export function useInboxDecisionCount(options?: {
   const priorityFilter = useInboxSignalsFilterStore((state) =>
     ignoreFilters ? EMPTY_FILTER_ARRAY : state.priorityFilter,
   );
-  const prFilter = useInboxSignalsFilterStore((state) =>
-    ignoreFilters ? "all" : state.prFilter,
-  );
   const isForYou = scope === INBOX_SCOPE_FOR_YOU;
   const teammateUuid = parseTeammateInboxScope(scope);
   const client = useOptionalAuthenticatedClient();
@@ -48,12 +45,6 @@ export function useInboxDecisionCount(options?: {
   const query = useInboxReports(
     {
       status: "ready",
-      has_implementation_pr:
-        prFilter === "with_pr"
-          ? true
-          : prFilter === "without_pr"
-            ? false
-            : undefined,
       source_product:
         sourceProductFilter.length > 0
           ? sourceProductFilter.join(",")

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReportDismissAction.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReportDismissAction.tsx
@@ -6,6 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@posthog/quill";
+import type { InboxReportActionSurface } from "@posthog/shared/analytics-events";
 import { isDismissalReasonSnooze } from "@posthog/shared/dismissalReasons";
 import type { SignalReport } from "@posthog/shared/types";
 import {
@@ -18,7 +19,10 @@ import { type ReactElement, useCallback, useMemo, useState } from "react";
 const EMPTY_REPORTS: SignalReport[] = [];
 
 /** Archive flow used by every inbox detail screen – one report, one button + dialog. */
-export function useInboxReportDismissAction(report: SignalReport): {
+export function useInboxReportDismissAction(
+  report: SignalReport,
+  surface: InboxReportActionSurface = "detail_pane",
+): {
   actionButton: ReactElement;
   dialog: ReactElement | null;
   /** Open the archive dialog directly — for menu items and keyboard paths. */
@@ -35,7 +39,7 @@ export function useInboxReportDismissAction(report: SignalReport): {
   const bulkActions = useInboxBulkActions(
     reportsForActions,
     open ? report.id : null,
-    "detail_pane",
+    surface,
   );
 
   const isPending = bulkActions.isSuppressing || bulkActions.isSnoozing;
@@ -60,7 +64,7 @@ export function useInboxReportDismissAction(report: SignalReport): {
             variant="outline"
             size="icon-xs"
             className="h-7 w-7"
-            aria-label="Archive this report"
+            aria-label="Archive this report for everyone in the project"
             disabled={isPending}
             onClick={() => setOpen(true)}
           />
@@ -68,7 +72,7 @@ export function useInboxReportDismissAction(report: SignalReport): {
       >
         {isPending ? <Spinner /> : <ArchiveIcon size={12} />}
       </TooltipTrigger>
-      <TooltipContent>Archive</TooltipContent>
+      <TooltipContent>Archive for everyone in this project</TooltipContent>
     </Tooltip>
   );
 

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxSectionCounts.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxSectionCounts.ts
@@ -24,25 +24,16 @@ export interface InboxSectionCounts {
 /**
  * Server-side counts for the inbox's sections and badges.
  *
- * At this dataset's real size (tens of thousands of live reports in a shared
- * project) any count derived from loaded pages is a count of a window, not of
- * reality — which is where every badge/section mismatch came from. So each
- * number here is a count-only query on the dimensions the API can filter
- * server-side (status, actionability, PR presence, reviewer scope, source,
- * priority), and the sections are deliberately defined on those dimensions.
+ * Loaded pages only contain a window of the inbox, so each number uses a
+ * count-only query with the same server-side filters as its section.
  *
- * Scope and the filter bar's source/priority choices are mirrored into every
- * query so the counts move with what the list shows. Search is not — it's a
- * client-side title match, so surfaces showing searched rows must count those
- * rows instead.
+ * Scope and the priority filter are mirrored into every query so the counts
+ * move with what the list shows. Search is a client-side title match, so
+ * surfaces showing searched rows must count those rows instead.
  */
 export function useInboxSectionCounts(): InboxSectionCounts {
   const scope = useInboxReviewerScopeStore((s) => s.scope);
-  const sourceProductFilter = useInboxSignalsFilterStore(
-    (s) => s.sourceProductFilter,
-  );
   const priorityFilter = useInboxSignalsFilterStore((s) => s.priorityFilter);
-  const prFilter = useInboxSignalsFilterStore((s) => s.prFilter);
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client });
 
@@ -52,10 +43,6 @@ export function useInboxSectionCounts(): InboxSectionCounts {
     teammateUuid ?? (isForYou ? (currentUser?.uuid ?? null) : null);
 
   const shared = {
-    source_product:
-      sourceProductFilter.length > 0
-        ? sourceProductFilter.join(",")
-        : undefined,
     priority: buildPriorityFilterParam(priorityFilter),
     suggested_reviewers: reviewerUuid
       ? buildSuggestedReviewerFilterParam([reviewerUuid])
@@ -68,11 +55,9 @@ export function useInboxSectionCounts(): InboxSectionCounts {
     refetchIntervalInBackground: false,
   };
 
-  const reviewAndMergeEnabled = scopeReady && prFilter !== "without_pr";
-  const needsPrEnabled = scopeReady && prFilter !== "with_pr";
   const reviewAndMergeQuery = useInboxReports(
     { ...shared, status: "ready", has_implementation_pr: true },
-    { ...options, enabled: reviewAndMergeEnabled },
+    { ...options, enabled: scopeReady },
   );
   const needsPrQuery = useInboxReports(
     {
@@ -81,31 +66,23 @@ export function useInboxSectionCounts(): InboxSectionCounts {
       actionability: INBOX_ACTIONABLE_ACTIONABILITY_FILTER,
       has_implementation_pr: false,
     },
-    { ...options, enabled: needsPrEnabled },
+    { ...options, enabled: scopeReady },
   );
   const resolvedQuery = useInboxReports(
     {
       ...shared,
       status: "suppressed,resolved",
-      has_implementation_pr:
-        prFilter === "with_pr"
-          ? true
-          : prFilter === "without_pr"
-            ? false
-            : undefined,
     },
     { ...options, enabled: scopeReady },
   );
 
   return {
-    reviewAndMerge: reviewAndMergeEnabled
-      ? (reviewAndMergeQuery.data?.count ?? 0)
-      : 0,
-    needsPr: needsPrEnabled ? (needsPrQuery.data?.count ?? 0) : 0,
+    reviewAndMerge: reviewAndMergeQuery.data?.count ?? 0,
+    needsPr: needsPrQuery.data?.count ?? 0,
     resolved: resolvedQuery.data?.count ?? 0,
     isLoading:
-      (reviewAndMergeEnabled && reviewAndMergeQuery.isLoading) ||
-      (needsPrEnabled && needsPrQuery.isLoading) ||
+      reviewAndMergeQuery.isLoading ||
+      needsPrQuery.isLoading ||
       resolvedQuery.isLoading ||
       (isForYou && reviewerUuid == null),
   };

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxSectionCounts.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxSectionCounts.ts
@@ -1,6 +1,8 @@
 import {
   buildPriorityFilterParam,
   buildSuggestedReviewerFilterParam,
+  INBOX_ACTIONABLE_ACTIONABILITY_FILTER,
+  INBOX_ACTIONABLE_REPORT_STATUS_FILTER,
 } from "@posthog/core/inbox/reportFiltering";
 import {
   INBOX_SCOPE_FOR_YOU,
@@ -12,16 +14,10 @@ import { useInboxReports } from "@posthog/ui/features/inbox/hooks/useInboxReport
 import { useInboxReviewerScopeStore } from "@posthog/ui/features/inbox/stores/inboxReviewerScopeStore";
 import { useInboxSignalsFilterStore } from "@posthog/ui/features/inbox/stores/inboxSignalsFilterStore";
 
-const ATTENTION_STATUS_FILTER = "pending_input,failed";
-const IN_PROGRESS_STATUS_FILTER = "in_progress,candidate";
-
 export interface InboxSectionCounts {
-  /** Ready reports — the "Needs a decision" section's true total. */
-  decision: number;
-  /** The subset of ready reports carrying an implementation PR. */
-  decisionPr: number;
-  attention: number;
-  inProgress: number;
+  reviewAndMerge: number;
+  needsPr: number;
+  resolved: number;
   isLoading: boolean;
 }
 
@@ -32,8 +28,8 @@ export interface InboxSectionCounts {
  * project) any count derived from loaded pages is a count of a window, not of
  * reality — which is where every badge/section mismatch came from. So each
  * number here is a count-only query on the dimensions the API can filter
- * server-side (status, PR presence, reviewer scope, source, priority), and the
- * sections are deliberately defined on those dimensions.
+ * server-side (status, actionability, PR presence, reviewer scope, source,
+ * priority), and the sections are deliberately defined on those dimensions.
  *
  * Scope and the filter bar's source/priority choices are mirrored into every
  * query so the counts move with what the list shows. Search is not — it's a
@@ -61,51 +57,56 @@ export function useInboxSectionCounts(): InboxSectionCounts {
         ? sourceProductFilter.join(",")
         : undefined,
     priority: buildPriorityFilterParam(priorityFilter),
-    // The decision-PR caption query overrides this with `true` via spread.
-    has_implementation_pr:
-      prFilter === "with_pr"
-        ? true
-        : prFilter === "without_pr"
-          ? false
-          : undefined,
     suggested_reviewers: reviewerUuid
       ? buildSuggestedReviewerFilterParam([reviewerUuid])
       : undefined,
     count_only: true,
   };
+  const scopeReady = !isForYou || reviewerUuid != null;
   const options = {
-    // "For you" must carry the user's reviewer filter; hold until it resolves.
-    enabled: !isForYou || reviewerUuid != null,
     refetchInterval: 60_000,
     refetchIntervalInBackground: false,
   };
 
-  const decisionQuery = useInboxReports(
-    { ...shared, status: "ready" },
-    options,
-  );
-  const decisionPrQuery = useInboxReports(
+  const reviewAndMergeEnabled = scopeReady && prFilter !== "without_pr";
+  const needsPrEnabled = scopeReady && prFilter !== "with_pr";
+  const reviewAndMergeQuery = useInboxReports(
     { ...shared, status: "ready", has_implementation_pr: true },
-    options,
+    { ...options, enabled: reviewAndMergeEnabled },
   );
-  const attentionQuery = useInboxReports(
-    { ...shared, status: ATTENTION_STATUS_FILTER },
-    options,
+  const needsPrQuery = useInboxReports(
+    {
+      ...shared,
+      status: INBOX_ACTIONABLE_REPORT_STATUS_FILTER,
+      actionability: INBOX_ACTIONABLE_ACTIONABILITY_FILTER,
+      has_implementation_pr: false,
+    },
+    { ...options, enabled: needsPrEnabled },
   );
-  const inProgressQuery = useInboxReports(
-    { ...shared, status: IN_PROGRESS_STATUS_FILTER },
-    options,
+  const resolvedQuery = useInboxReports(
+    {
+      ...shared,
+      status: "suppressed,resolved",
+      has_implementation_pr:
+        prFilter === "with_pr"
+          ? true
+          : prFilter === "without_pr"
+            ? false
+            : undefined,
+    },
+    { ...options, enabled: scopeReady },
   );
 
   return {
-    decision: decisionQuery.data?.count ?? 0,
-    decisionPr: decisionPrQuery.data?.count ?? 0,
-    attention: attentionQuery.data?.count ?? 0,
-    inProgress: inProgressQuery.data?.count ?? 0,
+    reviewAndMerge: reviewAndMergeEnabled
+      ? (reviewAndMergeQuery.data?.count ?? 0)
+      : 0,
+    needsPr: needsPrEnabled ? (needsPrQuery.data?.count ?? 0) : 0,
+    resolved: resolvedQuery.data?.count ?? 0,
     isLoading:
-      decisionQuery.isLoading ||
-      attentionQuery.isLoading ||
-      inProgressQuery.isLoading ||
+      (reviewAndMergeEnabled && reviewAndMergeQuery.isLoading) ||
+      (needsPrEnabled && needsPrQuery.isLoading) ||
+      resolvedQuery.isLoading ||
       (isForYou && reviewerUuid == null),
   };
 }

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useTrackInboxViewed.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useTrackInboxViewed.ts
@@ -1,5 +1,5 @@
 import { buildInboxViewedProperties } from "@posthog/core/inbox/engagement";
-import { INBOX_SCOPE_FOR_YOU } from "@posthog/core/inbox/reportMembership";
+import { inboxReviewerScopeValue } from "@posthog/core/inbox/reportMembership";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useInboxAllReports } from "@posthog/ui/features/inbox/hooks/useInboxAllReports";
 import { track } from "@posthog/ui/shell/analytics";
@@ -52,7 +52,7 @@ export function useTrackInboxViewed(options?: { enabled?: boolean }): void {
           sourceProductFilter,
           priorityFilter,
           searchQuery,
-          isDefaultScope: scope === INBOX_SCOPE_FOR_YOU,
+          scope: inboxReviewerScopeValue(scope),
         },
       }),
     );

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useTrackReportsInboxViewed.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useTrackReportsInboxViewed.ts
@@ -1,4 +1,5 @@
 import { buildInboxViewedProperties } from "@posthog/core/inbox/engagement";
+import type { InboxReviewerScope } from "@posthog/shared/analytics-events";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { SignalReport } from "@posthog/shared/types";
 import { track } from "@posthog/ui/shell/analytics";
@@ -11,7 +12,7 @@ export function useTrackReportsInboxViewed({
   sourceProductFilter,
   priorityFilter,
   searchQuery,
-  isDefaultScope,
+  scope,
 }: {
   reports: SignalReport[];
   totalCount: number;
@@ -19,7 +20,7 @@ export function useTrackReportsInboxViewed({
   sourceProductFilter: string[];
   priorityFilter: string[];
   searchQuery: string;
-  isDefaultScope: boolean;
+  scope: InboxReviewerScope;
 }): void {
   const firedRef = useRef(false);
 
@@ -36,7 +37,7 @@ export function useTrackReportsInboxViewed({
           sourceProductFilter,
           priorityFilter,
           searchQuery,
-          isDefaultScope,
+          scope,
         },
       }),
     );
@@ -47,6 +48,6 @@ export function useTrackReportsInboxViewed({
     sourceProductFilter,
     priorityFilter,
     searchQuery,
-    isDefaultScope,
+    scope,
   ]);
 }

--- a/products/desktop/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.test.ts
@@ -195,6 +195,16 @@ describe("inboxSignalsFilterStore", () => {
     },
   );
 
+  it("ignores a saved source filter when the surface hides that control", () => {
+    useInboxSignalsFilterStore.getState().toggleSourceProduct("github");
+
+    expect(
+      hasActiveInboxFilters(useInboxSignalsFilterStore.getState(), {
+        includeSourceFilter: false,
+      }),
+    ).toBe(false);
+  });
+
   it("migrates pre-v2 localStorage by dropping the dead filter slots", () => {
     localStorage.setItem(
       "inbox-signals-filter-storage",

--- a/products/desktop/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.ts
+++ b/products/desktop/packages/ui/src/features/inbox/stores/inboxSignalsFilterStore.ts
@@ -51,18 +51,18 @@ type InboxSignalsFilterStore = InboxSignalsFilterState &
  * list, so it does not count. This is the single definition of "filtered" used
  * by the empty states and the filter bar.
  *
- * `includePrFilter` defaults to true. Surfaces that neither apply nor expose the
- * PR filter (the legacy Reports and Pull requests tabs) pass false, so a stored
- * PR filter they ignore does not make their empty state read as "filtered".
+ * Surfaces can exclude filters they do not expose, so a stored value they
+ * ignore does not make their empty state read as "filtered".
  */
 export function hasActiveInboxFilters(
   state: InboxSignalsFilterState,
-  options?: { includePrFilter?: boolean },
+  options?: { includePrFilter?: boolean; includeSourceFilter?: boolean },
 ): boolean {
   const includePrFilter = options?.includePrFilter ?? true;
+  const includeSourceFilter = options?.includeSourceFilter ?? true;
   return (
     state.searchQuery.trim().length > 0 ||
-    state.sourceProductFilter.length > 0 ||
+    (includeSourceFilter && state.sourceProductFilter.length > 0) ||
     state.priorityFilter.length > 0 ||
     (includePrFilter && state.prFilter !== "all")
   );

--- a/products/desktop/packages/ui/src/router/navigationBridge.ts
+++ b/products/desktop/packages/ui/src/router/navigationBridge.ts
@@ -142,10 +142,28 @@ export function navigateToInboxPullRequestDetail(reportId: string): void {
   });
 }
 
-export function navigateToInboxReportDetail(reportId: string): void {
-  void getRouterOrNull()?.navigate({
+export function navigateToInboxReportDetail(
+  reportId: string,
+  options?: { returnToTriage?: boolean },
+): void {
+  const router = getRouterOrNull();
+  if (!router) return;
+
+  const inboxTriageOrigin = options?.returnToTriage ? { reportId } : undefined;
+  if (inboxTriageOrigin) {
+    const location = router.history.location;
+    router.history.replace(location.href, {
+      ...location.state,
+      inboxTriageOrigin,
+    });
+  }
+
+  void router.navigate({
     to: "/inbox/reports/$reportId",
     params: { reportId },
+    state: inboxTriageOrigin
+      ? (previous) => ({ ...previous, inboxTriageOrigin })
+      : undefined,
   });
 }
 


### PR DESCRIPTION
## Problem

Desktop reviewers see a different report hierarchy and triage flow from web, which makes evidence and decisions harder to scan.

The list also shows misleading ownership copy and terminal sections beside a true empty state.

**Why:** Reviewers need one predictable, evidence-first workflow across web and Desktop to make fast, confident decisions.

## Changes

- Desktop now uses the same evidence-first hierarchy across the report list, triage mode, and report details.
- The report list separates pull requests awaiting review from reports that need a pull request.
- Resolved holds merged and archived reports, and Show more reveals five reports per click.
- The list removes source and PR-state filters, repeated counts, and row-level Review and Archive actions.
- Conventional-commit tags identify report type and scope across all three report surfaces.
- Report details put evidence beside a document-style summary, with low-value activity collapsed or omitted.
- Triage uses compact report cards with previous and next previews.
- Triage shows Arrow Up/Down, C, A, O, Enter, and Esc in a separate shortcut legend.
- C creates a pull request when available or opens the existing pull request.
- Create PR accepts optional direction and appends it to the implementation prompt.
- Opening a report from triage returns to the same triage item through Back.
- Empty inboxes hide terminal sections and use an unboxed empty state.
- Reviewer removal stays in the reviewer menu without presenting “Not for me” as report status.
- Storybook now covers the list, single-report page, and triage mode with backend-free fixtures.
- Analytics records reviewer scope, action source, and bounded triage outcomes without teammate identifiers.

Reference: [web report redesign](https://github.com/PostHog/posthog/pull/86671).

## Screenshots

### Report list

![Desktop Inbox report list](https://raw.githubusercontent.com/PostHog/pr-assets/b7d9a51bdb627ad48eea1aeb2fcd75f79f4f3fee/2026/08/234a956d-9022-4ccd-b17c-c14fde400306.png)

### Single report

![Desktop Inbox single report](https://raw.githubusercontent.com/PostHog/pr-assets/b4802d0782de4687e44b9b804fd4a70e39987e6c/2026/08/4a65dc66-9dde-49fa-bfcd-11ef8050576d.png)

### Triage mode

![Desktop Inbox triage mode](https://raw.githubusercontent.com/PostHog/pr-assets/e78a2c7ebe91174aa2d2bee7daa261fdac95d3f2/2026/08/c3f0fcf1-1af2-45bb-bd96-850a3b75bfbd.png)

## How did you test this code?

- Focused tests guard section grouping, five-row expansion, hidden filters, report titles, and triage keyboard behavior.
- The full Desktop workspace passes typecheck and lint.
- The static Storybook build passes.
- Headless Chromium renders the list, evidence-first detail, and long-title triage stories.
- The authenticated Inbox remains unchecked because the isolated Desktop profile is signed out.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. The Desktop documentation does not describe this report review layout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex in PostHog Desktop used GitHub CLI, signed Git tools, Electron accessibility inspection, and headless Chromium.

Skills: `/posthog-desktop`, `/storybook-stories`, `/querying-posthog-data`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/quill-code`, `/test-electron-app`, `/autoresolving-pr-conflicts`, and `/writing-pr-descriptions`.

The report presentation now has backend-free Storybook seams. Runtime containers retain fetching, analytics, keyboard listeners, and mutations.

Context came from an [internal Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787926186719499?thread_ts=1787926186.719499&cid=C09G8Q32R6F). Fixtures use invented data and do not reproduce private content.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
