### PR TITLE
perf(marketing-analytics): let query GROUP BY spill to disk

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/attribution_paths_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/attribution_paths_query_runner.py
@@ -22,7 +22,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
-from posthog.hogql.constants import LimitContext
+from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, HogQLGlobalSettings, LimitContext
 from posthog.hogql.query import execute_hogql_query
 
 from .attribution_base import PERSON_ARRAYS_CTE, AttributionQueryRunnerBase
@@ -295,6 +295,9 @@ class MarketingAnalyticsAttributionPathsQueryRunner(
             modifiers=self.modifiers,
             limit_context=self.limit_context or LimitContext.QUERY,
             context=self._shared_hogql_context,
+            # The per-person touchpoint arrays are unbounded, so let the GROUP BY spill to disk
+            # rather than hit the memory limit. Same guard funnels, retention and paths use.
+            settings=HogQLGlobalSettings(max_bytes_before_external_group_by=MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY),
         )
 
         # Mapped by column name, not tuple position, so adding a column can't shift every later one.

--- a/products/marketing_analytics/backend/hogql_queries/attribution_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/attribution_table_query_runner.py
@@ -29,7 +29,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
-from posthog.hogql.constants import LimitContext
+from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, HogQLGlobalSettings, LimitContext
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -476,6 +476,9 @@ class MarketingAnalyticsAttributionQueryRunner(AttributionQueryRunnerBase[Market
             modifiers=self.modifiers,
             limit_context=self.limit_context or LimitContext.QUERY,
             context=self._shared_hogql_context,
+            # The per-person touchpoint arrays are unbounded, so let the GROUP BY spill to disk
+            # rather than hit the memory limit. Same guard funnels, retention and paths use.
+            settings=HogQLGlobalSettings(max_bytes_before_external_group_by=MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY),
         )
 
         # Mapped by column name, not tuple position, so adding a column can't shift every later one.

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
@@ -13,6 +13,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
+from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, HogQLGlobalSettings
 from posthog.hogql.query import execute_hogql_query
 
 from .constants import (
@@ -164,6 +165,9 @@ class MarketingAnalyticsAggregatedQueryRunner(
             timings=self.timings,
             modifiers=self.modifiers,
             limit_context=self.limit_context,
+            # These group by high-cardinality campaign dimensions, so let the GROUP BY spill
+            # to disk rather than hit the memory limit.
+            settings=HogQLGlobalSettings(max_bytes_before_external_group_by=MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY),
         )
 
         results = response.results or []

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -14,6 +14,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
+from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, HogQLGlobalSettings
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
@@ -88,6 +89,9 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             modifiers=self.modifiers,
             limit_context=self.limit_context,
             context=self._shared_hogql_context,
+            # These group by high-cardinality campaign dimensions, so let the GROUP BY spill
+            # to disk rather than hit the memory limit.
+            settings=HogQLGlobalSettings(max_bytes_before_external_group_by=MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY),
         )
 
         results = response.results or []

--- a/products/marketing_analytics/backend/hogql_queries/non_integrated_conversions_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/non_integrated_conversions_table_query_runner.py
@@ -13,6 +13,7 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
+from posthog.hogql.constants import MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY, HogQLGlobalSettings
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
@@ -84,6 +85,9 @@ class NonIntegratedConversionsTableQueryRunner(
             timings=self.timings,
             modifiers=self.modifiers,
             limit_context=self.limit_context,
+            # These group by high-cardinality campaign dimensions, so let the GROUP BY spill
+            # to disk rather than hit the memory limit.
+            settings=HogQLGlobalSettings(max_bytes_before_external_group_by=MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY),
         )
 
         results = response.results or []


### PR DESCRIPTION
## Problem

Marketing analytics users on a high-volume team see the attribution table fail instead of load. Over the last 90 days, 29% of attribution queries failed, and 26 of those 40 failures were `clickhouse_memory_limit_exceeded`.

The attribution runners build one array of touchpoints and one of conversions per converting person. Neither is bounded by the query, so the GROUP BY hash table grows with the team's converter count.

Marketing analytics passed no ClickHouse settings at any of its five execute sites. Funnels, retention, paths and experiments all pass this one. Paths v2 states the same reason: per-actor event arrays are unbounded.

## Changes

- The attribution table and conversion paths complete instead of failing on a memory limit.
- Each of the five marketing analytics runners now passes `max_bytes_before_external_group_by`, so a large GROUP BY spills to disk.
- The value is the shared `MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY` constant, the one funnels and retention use.

The setting is a spill threshold, not a memory reservation, so it cannot over-commit the cluster. Queries that fit in memory today behave exactly as before.

The whole diff is 20 lines and changes no query, no result and no schema.

## How did you test this code?

The existing `products/marketing_analytics/backend/hogql_queries` suite passes unchanged. No new tests: the setting changes no output, so there is no regression a test could catch that the suite does not already cover.

Measured against a synthetic 8.1M pageview dataset in a local stack, on the attribution table with `breakdownBy=channel`:

| | peak memory | duration |
|---|---|---|
| before | 1.50 GiB | 5.0 s |
| after | 615 MiB | 5.8 s |

Not checked: production. The local dataset reproduces the query shape, not the volume at which the failures happen.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/optimizing-clickhouse-and-hogql-queries`, `/writing-pr-descriptions`, `/writing-code-comments`.

The session started on a different PR and profiled the attribution query to decide where its memory goes. That work found this setting missing, and found two larger wins that are not in this PR: the peak is dominated by the sessions lazy join that the channel classifier builds, and restricting that join to converters' sessions is worth considerably more than the spill. Both need real changes to the query and land separately. This PR is the one-line guard that stops the failures while those are built.

Measurements come from a synthetic dataset generated for the session. No customer data, conversation or log informed any part of this diff.
