### PR TITLE
feat(tasks): stamp task origin_key on sandbox LLM events

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.configure-environment.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.configure-environment.test.ts
@@ -13,6 +13,7 @@ interface TestableServer {
     taskRunId?: string | null;
     taskUserId?: number | null;
     taskTitle?: string | null;
+    taskOriginKey?: string | null;
     repositories?: string[];
     runtimeAdapter?: string | null;
     sandboxEnvironmentId?: string | null;
@@ -215,6 +216,7 @@ describe("AgentServer.configureEnvironment", () => {
       taskRunId: "run-xyz",
       taskUserId: 42,
       taskTitle: "Fix the bug",
+      taskOriginKey: "desktop_onboarding_session:42",
       repositories: ["posthog/posthog", "posthog/posthog-js"],
       runtimeAdapter: "claude",
       sandboxEnvironmentId: "environment-123",
@@ -231,6 +233,7 @@ describe("AgentServer.configureEnvironment", () => {
       "x-posthog-property-task_run_id": "run-xyz",
       "x-posthog-property-task_user_id": "42",
       "x-posthog-property-task_title": "Fix the bug",
+      "x-posthog-property-task_origin_key": "desktop_onboarding_session:42",
       "x-posthog-property-task_repositories":
         '["posthog/posthog","posthog/posthog-js"]',
       "x-posthog-property-task_runtime_adapter": "claude",
@@ -254,6 +257,7 @@ describe("AgentServer.configureEnvironment", () => {
       taskRunId: "run-xyz",
       taskUserId: 42,
       taskTitle: "Fix the bug",
+      taskOriginKey: "desktop_onboarding_session:42",
       repositories: ["posthog/posthog", "posthog/posthog-js"],
       runtimeAdapter: "claude",
       sandboxEnvironmentId: "environment-123",
@@ -271,6 +275,7 @@ describe("AgentServer.configureEnvironment", () => {
         "x-posthog-property-task_run_id: run-xyz",
         "x-posthog-property-task_user_id: 42",
         "x-posthog-property-task_title: Fix the bug",
+        "x-posthog-property-task_origin_key: desktop_onboarding_session:42",
         'x-posthog-property-task_repositories: ["posthog/posthog","posthog/posthog-js"]',
         "x-posthog-property-task_runtime_adapter: claude",
         "x-posthog-property-task_sandbox_environment_id: environment-123",

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -1832,6 +1832,7 @@ export class AgentServer {
       taskRunId: payload.run_id,
       taskUserId: payload.user_id || preTask?.created_by?.id || null,
       taskTitle: preTask?.title,
+      taskOriginKey: preTask?.origin_key,
       repositories: this.taskRepositories,
       runtimeAdapter,
       sandboxEnvironmentId: getTaskRunStateString(
@@ -4694,6 +4695,7 @@ ${commonInstructions}
     taskRunId,
     taskUserId,
     taskTitle,
+    taskOriginKey,
     repositories,
     runtimeAdapter,
     sandboxEnvironmentId,
@@ -4709,6 +4711,7 @@ ${commonInstructions}
     taskRunId?: string | null;
     taskUserId?: number | null;
     taskTitle?: string | null;
+    taskOriginKey?: string | null;
     repositories?: string[];
     runtimeAdapter?: string | null;
     sandboxEnvironmentId?: string | null;
@@ -4758,6 +4761,7 @@ ${commonInstructions}
       task_run_id: taskRunId,
       task_user_id: taskUserId,
       task_title: taskTitle,
+      task_origin_key: taskOriginKey,
       task_repositories: repositories?.length
         ? JSON.stringify(repositories)
         : null,

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -92,6 +92,8 @@ export interface Task {
   json_schema?: Record<string, unknown> | null;
   signal_report?: string | null;
   internal?: boolean;
+  /** Key of the server-side flow that created the task, e.g. `desktop_onboarding_session:<user_id>`. */
+  origin_key?: string | null;
   runtime?: AgentRuntime;
   /** Backend channel (tasks product Channel UUID) this task is owned by. */
   channel?: string | null;

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -636,6 +636,7 @@ def _task_detail_to_dto(
         latest_run_id=latest_run_id,
         channel=task.channel_id,
         slack_thread_references=_task_slack_thread_references(task),
+        origin_key=task.origin_key,
     )
 
 

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -199,6 +199,7 @@ class TaskDetailDTO:
     latest_run_id: UUID | None = None
     channel: UUID | None = None
     slack_thread_references: list[SlackThreadReferenceDTO] = Field(default_factory=list)
+    origin_key: str | None = None
 
 
 @dataclass(frozen=True)

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -517,6 +517,14 @@ class TaskSerializer(DataclassSerializer):
         choices=tasks_facade.TaskRuntime.choices,
         help_text="Agent protocol and harness used for this task's runs.",
     )
+    origin_key = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text=(
+            "Stable key of the server-side flow that created this task, e.g. "
+            "`desktop_onboarding_session:<user_id>`. Null for tasks people create themselves."
+        ),
+    )
 
     class Meta:
         dataclass = TaskDetailDTO
@@ -546,6 +554,7 @@ class TaskSerializer(DataclassSerializer):
             "ci_prompt",
             "channel",
             "slack_thread_references",
+            "origin_key",
         ]
 
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -4881,6 +4881,16 @@ class TestTaskInternalFilterAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.json()["internal"])
 
+    def test_origin_key_in_response(self):
+        self.external_task.origin_key = "desktop_onboarding_session:42"
+        self.external_task.save(update_fields=["origin_key"])
+        response = self.client.get(f"/api/projects/@current/tasks/{self.external_task.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["origin_key"], "desktop_onboarding_session:42")
+        self.assertIsNone(
+            self.client.get(f"/api/projects/@current/tasks/{self.internal_task.id}/").json()["origin_key"]
+        )
+
     def test_internal_field_defaults_to_false_on_create(self):
         response = self.client.post(
             "/api/projects/@current/tasks/",

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1665,6 +1665,11 @@ export interface TaskDetailDTOApi {
     /** @nullable */
     channel?: string | null
     readonly slack_thread_references: readonly SlackThreadReferenceDTOApi[]
+    /**
+     * Stable key of the server-side flow that created this task, e.g. `desktop_onboarding_session:<user_id>`. Null for tasks people create themselves.
+     * @nullable
+     */
+    origin_key?: string | null
 }
 
 export interface PaginatedTaskDetailDTOListApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -56601,6 +56601,11 @@ export namespace Schemas {
       /** @nullable */
       channel?: string | null;
       readonly slack_thread_references: readonly SlackThreadReferenceDTO[];
+      /**
+         * Stable key of the server-side flow that created this task, e.g. `desktop_onboarding_session:<user_id>`. Null for tasks people create themselves.
+         * @nullable
+         */
+      origin_key?: string | null;
     }
 
     export interface PaginatedTaskDetailDTOList {


### PR DESCRIPTION
## Problem

The Desktop concierge evals and the `signals-scout-desktop-concierge` scout find their sessions by `task_title = 'Getting set up'`. A title is a display string, so renaming it silently empties every eval and the scout's baseline.

`Task.origin_key` (#88617) is the stable identifier for server-created flows, but it only reaches the backend `Task.capture` events. The sandbox agent, which emits the `$ai_generation` events the evals read, never receives it because the task API does not expose it.

## Changes

- `$ai_generation` events from sandbox runs now carry `task_origin_key`, next to `task_title`. Evals and scouts can filter on it.
- The task detail API exposes `origin_key` (read-only, null for user-created tasks). Mechanical: DTO, serializer, and the desktop `Task` type.
- The sandbox agent reads `preTask.origin_key` and forwards it as a gateway property, the same path as `task_title`.

> [!NOTE]
> The concierge evals and scout in project 2 already accept `task_origin_key` alongside the title match. Drop the title condition once this deploys.

## How did you test this code?

- `agent-server.configure-environment.test.ts`: the two full-header cases now assert `task_origin_key` is forwarded on both the Anthropic and OpenAI header paths.
- `test_origin_key_in_response` in `test_api.py`: catches the field dropping out of the task detail response, which no existing test covered.
- Desktop typecheck and Biome ran clean.
- Not run: the Django test, and `hogli build:openapi` to regenerate `products/tasks/frontend/generated/` and the desktop `api-client` types. This machine had no database running. Both need to run before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5). The session started as a review of the Desktop concierge's opening message; the eval and scout filter came up as a side finding and the assignee asked for the fix. Skills invoked: `/improving-drf-endpoints`, `/reviewing-before-pr`, `/writing-pr-descriptions`, `/code-review`.

Local review: `hogli review` could not run (Greptile key unavailable in this session), so the harness `/code-review` fallback ran over the branch diff and reported no findings. The bot review should still run on this PR.
