### PR TITLE
feat(error-tracking): replace the setup prompt with the product empty state

### DIFF
--- a/.agents/skills/building-product-empty-states/SKILL.md
+++ b/.agents/skills/building-product-empty-states/SKILL.md
@@ -69,6 +69,7 @@ Statuses: `loading` (not yet known - the gate holds a spinner, never flashes the
 - **`featureFlag`**: set it when the scene is already flag-gated (so the scene's own gate keeps handling flag-off) or to roll the empty state out gradually.
 - **Hedgehog**: a `pngHoggie(...)`-wrapped module — import only inside the product chunk (eager-graph guard: `frontend/bin/check-eager-graph.mjs`). Never hardcode image URLs (e.g. Cloudinary) — `@posthog/brand` assets only.
 - **`text` is keyed by mode**: provide the `needs-setup` base; add a `waiting-for-data` entry only if your product has that middle state (missing fields fall back to the base). Sentence case, benefit-first, no AI tells (see "User-facing copy" in `CLAUDE.md`).
+- **Key `primaryAction` by mode when it only fits one**: a one-click opt-in ("Enable session recording") is done once the status is `waiting-for-data`, and clicking it again re-sends the same team update. Pass `primaryAction: { 'needs-setup': { ... } }` and the button, along with the `hint` that introduces it, leaves the waiting screen. A single flat action still covers both modes - keep that when it reads correctly either way (support's "Open support settings").
 - **Product header**: the gate keeps the product header (name, description, icon) above the empty state automatically, sourced from the scene's `SceneConfig` in your product manifest — make sure your manifest's scene entry has `name`, `description`, and `iconType` set.
 
 ### 3. Build the signature preview

--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -32,7 +32,7 @@ tiles, or `FeaturePreviewSceneGate` rather than scene empty states.
 
 ## Adopted
 
-25 scenes. The 11 marked "in review" are the stack under PR #90607 and are not on `master` yet.
+Rows marked "in review" are not on `master` yet. See "Regenerating the lists" for a live count.
 
 | Product                | Scene                                                                               | Status                |
 | ---------------------- | ----------------------------------------------------------------------------------- | --------------------- |
@@ -50,7 +50,7 @@ tiles, or `FeaturePreviewSceneGate` rather than scene empty states.
 | Skills                 | `products/skills/frontend/LLMSkillsScene.tsx`                                       | on master             |
 | User interviews        | `products/user_interviews/frontend/UserInterviews.tsx`                              | on master             |
 | Web scripts            | `frontend/src/scenes/data-pipelines/WebScriptsScene.tsx`                            | on master             |
-| Error tracking         | `products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx` | in review             |
+| Error tracking         | `products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx` | on master             |
 | Logs                   | `products/logs/frontend/LogsScene.tsx`                                              | in review             |
 | Tracing                | `products/tracing/frontend/TracingScene.tsx`                                        | in review             |
 | Metrics                | `products/metrics/frontend/MetricsScene.tsx`                                        | in review             |

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1776,6 +1776,14 @@ snapshots:
         hash: v1.k794b7964.de021a6d2a8c7ec6bc031fc7c9586a2d9f12e80804b9a92ec1a9f464c096314e.jqj7jfnrY7rf7IO2Uqrc784pV_YXfH52sTArLcXn8c0
     components-product-empty-state--endpoints-needs-setup--light:
         hash: v1.k794b7964.f704e98aa8d0102c164b7db7390449584c4b84f461cc5bbeac426e48a16dc200.S0QeUPtO_6LQsU5lZ09MyJMaf_Q_CPBBuYbvKzik1cU
+    components-product-empty-state--error-tracking-needs-setup--dark:
+        hash: v1.k794b7964.a3fcfa83eb816f90ccc0a031486d1d493e3893df6d9b23ab8138efbbfe833374.AIGP2LVUdagSan_3zq5NEx5QT3To4HN4BwQv06ML7Nw
+    components-product-empty-state--error-tracking-needs-setup--light:
+        hash: v1.k794b7964.e14dd5aa0920ec0d2fe037a2bbe475dbe63aa94a8bb0d707d99bff904d03ceac.g1vL6Sreqh6sDhZZ73EXQfP24ijGmiecYFgz75lHR_c
+    components-product-empty-state--error-tracking-waiting-for-data--dark:
+        hash: v1.k794b7964.b4a3ce872a790b2f7ac8493f2779c8374b7a89092c1871c9e33196824dedc46d.XKxwszYrXHtHSSZkmmgmXVm_AEeT5MGBuA8khgFTuC4
+    components-product-empty-state--error-tracking-waiting-for-data--light:
+        hash: v1.k794b7964.606fcb85ae3de44040e6f9ca829eba813c3a76458b07309d9db2b9df3de5632d.WHMYLkvIW4k85BPm58UOLkrvxESRnrA0P107HNQZmfo
     components-product-empty-state--experiments-needs-setup--dark:
         hash: v1.k794b7964.4963f41af44c16dbfdacc188339ff9c4f5ca4aada2f5848ad4f195b52c1cc81d.SiIn79B-XFAK4ZwxeLxdLgGNGPbtraECPD_tfCokLdg
     components-product-empty-state--experiments-needs-setup--light:
@@ -6521,9 +6529,9 @@ snapshots:
     scenes-app-errortracking--list-page--light:
         hash: v1.k794b7964.ec828bd049bcf02367910abb18539201ef5f6447b602a75891a64d45d743c4f5.RAArjfFKQhB64bx3ypvlJdCR3svO5Yify4gANdrDJ94
     scenes-app-errortracking--list-page-with-ingestion-warning--dark:
-        hash: v1.k794b7964.97ebfc5cbd8a42f9812b6ae0af9d00cec4ba9ca7f46107868182a390024faab3.ooOBXcc0lMvw3a8ZbdAY85MWZUswPFAuGCXQoj6_5ig
+        hash: v1.k794b7964.ddc0508f1528d4495934ff8fa694b9437395a72a737b43f912e6510701cb8dae.ef-9ekf-CJcH-5LpaXgUAx1EImpupKQIwG6bYOLYSMU
     scenes-app-errortracking--list-page-with-ingestion-warning--light:
-        hash: v1.k794b7964.7b9f01e55b78170fce3391e35155eb18d06792895ba3258d414de3d1dbc0d4b5.c16uU0LYiIhXwjauAVxLiRe89gjPabGtgzW6nQ64oe0
+        hash: v1.k794b7964.5aa533d7446a1b64961e31c54bf2ce3bcf8cae59475396fafded5333f9c46ff8._LBuYyLkmYRNNFrSoBumRKSw1iUj7keg1vN2TjwasKU
     scenes-app-errortracking--list-page-with-source-maps-banner--dark:
         hash: v1.k794b7964.c8aff38ce4732c22ffb12634a8a88a7608eab6b35f19136a093c7a76c8b6dfb0.X7tIrVh7xeTeQGkJpJ6deLOaEofLRqPGo8tDDkffOrU
     scenes-app-errortracking--list-page-with-source-maps-banner--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1781,9 +1781,9 @@ snapshots:
     components-product-empty-state--error-tracking-needs-setup--light:
         hash: v1.k794b7964.e14dd5aa0920ec0d2fe037a2bbe475dbe63aa94a8bb0d707d99bff904d03ceac.g1vL6Sreqh6sDhZZ73EXQfP24ijGmiecYFgz75lHR_c
     components-product-empty-state--error-tracking-waiting-for-data--dark:
-        hash: v1.k794b7964.b4a3ce872a790b2f7ac8493f2779c8374b7a89092c1871c9e33196824dedc46d.XKxwszYrXHtHSSZkmmgmXVm_AEeT5MGBuA8khgFTuC4
+        hash: v1.k794b7964.574cdf4564785073be5f6199e47f8818070a50b52fc03eefc96c56f40ae51f06.T9kHDbgsBiwQgDUbvF_6K4FP5S4Ku_OAPM1X901Xslk
     components-product-empty-state--error-tracking-waiting-for-data--light:
-        hash: v1.k794b7964.606fcb85ae3de44040e6f9ca829eba813c3a76458b07309d9db2b9df3de5632d.WHMYLkvIW4k85BPm58UOLkrvxESRnrA0P107HNQZmfo
+        hash: v1.k794b7964.eff072a6e6de72483eb81c9f78e1582f0f5765038832e15dde0437c579af8a6c.MxorCvxObSX63Sd1i7-cam8gtY401euSXUpUrYtC1ko
     components-product-empty-state--experiments-needs-setup--dark:
         hash: v1.k794b7964.4963f41af44c16dbfdacc188339ff9c4f5ca4aada2f5848ad4f195b52c1cc81d.SiIn79B-XFAK4ZwxeLxdLgGNGPbtraECPD_tfCokLdg
     components-product-empty-state--experiments-needs-setup--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -9,6 +9,7 @@ import { webScriptsEmptyState } from 'products/cdp/frontend/emptyState/webScript
 import { supportEmptyState } from 'products/conversations/frontend/emptyState/supportEmptyState'
 import { earlyAccessFeaturesEmptyState } from 'products/early_access_features/frontend/emptyState/earlyAccessFeaturesEmptyState'
 import { endpointsEmptyState } from 'products/endpoints/frontend/emptyState/endpointsEmptyState'
+import { errorTrackingEmptyState } from 'products/error_tracking/frontend/emptyState/errorTrackingEmptyState'
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
 import { featureFlagsEmptyState } from 'products/feature_flags/frontend/emptyState/featureFlagsEmptyState'
 import { linksEmptyState } from 'products/links/frontend/emptyState/linksEmptyState'
@@ -176,3 +177,20 @@ const actionsMocks = {
 export const ActionsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(actionsEmptyState, 'needs-setup', {
     mocks: actionsMocks,
 })
+
+// Error tracking detection asks the issues-exists API on mount - answer "none yet".
+const errorTrackingMocks = {
+    get: { '/api/projects/:team_id/error_tracking/issues/exists/': [200, { exists: false }] },
+} as const
+
+export const ErrorTrackingNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    errorTrackingEmptyState,
+    'needs-setup',
+    { mocks: errorTrackingMocks }
+)
+
+export const ErrorTrackingWaitingForData: ProductEmptyStateStory = productEmptyStateStory(
+    errorTrackingEmptyState,
+    'waiting-for-data',
+    { mocks: errorTrackingMocks }
+)

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.test.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.test.tsx
@@ -67,4 +67,26 @@ describe('ProductEmptyState', () => {
 
         expect(screen.getByTestId('create-experiment').getAttribute('aria-disabled')).toBe(expected)
     })
+
+    // A one-click opt-in ("Enable X") must not survive into `waiting-for-data`, where the
+    // product is already on and clicking would re-send the same team update.
+    it.each([
+        ['needs-setup' as const, true],
+        ['waiting-for-data' as const, false],
+    ])('in %s renders a needs-setup-only action: %s', (mode, expected) => {
+        const modeKeyedConfig: ProductEmptyStateConfig = {
+            ...config,
+            text: {
+                'needs-setup': { headline: 'Headline', lead: 'Lead', hint: 'Hint' },
+                'waiting-for-data': { headline: 'Waiting' },
+            },
+            primaryAction: { 'needs-setup': { label: 'Enable experiments', dataAttr: 'enable-experiments' } },
+        }
+
+        render(<ProductEmptyState config={modeKeyedConfig} mode={mode} />)
+
+        expect(!!screen.queryByTestId('enable-experiments')).toBe(expected)
+        // The hint introduces the action, so it leaves with it rather than dangling.
+        expect(!!screen.queryByText('Hint')).toBe(expected)
+    })
 })

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
@@ -10,7 +10,12 @@ import { cn } from 'lib/utils/css-classes'
 import { useWizardCommand } from 'scenes/onboarding/shared/useWizardCommand'
 
 import { productSetupStatusLogic } from './productSetupStatusLogic'
-import type { ProductEmptyStateConfig, ProductEmptyStateMode, ProductEmptyStateText } from './types'
+import type {
+    ProductEmptyStateConfig,
+    ProductEmptyStateMode,
+    ProductEmptyStatePrimaryAction,
+    ProductEmptyStateText,
+} from './types'
 
 export interface ProductEmptyStateProps {
     config: ProductEmptyStateConfig
@@ -18,6 +23,17 @@ export interface ProductEmptyStateProps {
 }
 
 const ACCENT_TEXT = 'text-[var(--empty-state-accent)] dark:text-[var(--empty-state-accent-dark)]'
+
+/** A single action covers every mode; a mode-keyed one applies only to the modes it names. */
+function resolvePrimaryAction(
+    primaryAction: ProductEmptyStateConfig['primaryAction'],
+    mode: ProductEmptyStateMode
+): ProductEmptyStatePrimaryAction | undefined {
+    if (!primaryAction) {
+        return undefined
+    }
+    return 'label' in primaryAction ? primaryAction : primaryAction[mode]
+}
 
 /**
  * The product setup empty state: pitch + install command on the left, an animated
@@ -46,7 +62,7 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
     const Preview = config.Preview
     const hedgehogBeside = config.hedgehogPlacement === 'beside'
 
-    const { primaryAction } = config
+    const primaryAction = resolvePrimaryAction(config.primaryAction, mode)
     const primaryActionButton = primaryAction ? (
         <LemonButton
             type="primary"
@@ -72,6 +88,44 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
         ) : (
             primaryActionButton
         )
+
+    // The hint, the wizard card and the primary action are one block: the hint introduces
+    // whatever sits under it, so a mode without an action drops its lead-in too. Offering
+    // the manual setup link as the fallback CTA only fits a product still needing setup.
+    const callToAction = showWizard ? (
+        <>
+            <TerminalCard
+                command={wizardCommand}
+                copyLabel={`${config.productName} wizard command`}
+                onCopy={() => captureClick('wizard command copied')}
+            />
+            {guardedPrimaryAction ? (
+                <>
+                    <div className="flex items-center gap-3">
+                        <div className="h-px flex-1 bg-border-primary" />
+                        <span className="text-xs text-tertiary uppercase tracking-wide">or</span>
+                        <div className="h-px flex-1 bg-border-primary" />
+                    </div>
+                    {guardedPrimaryAction}
+                </>
+            ) : null}
+        </>
+    ) : config.PrimaryAction ? (
+        <config.PrimaryAction />
+    ) : guardedPrimaryAction ? (
+        guardedPrimaryAction
+    ) : manualUrl && mode === 'needs-setup' ? (
+        <LemonButton
+            type="primary"
+            to={manualUrl}
+            targetBlank
+            className="self-start"
+            onClick={() => captureClick('manual setup clicked')}
+            data-attr="product-empty-state-manual-setup"
+        >
+            Set up {config.productName}
+        </LemonButton>
+    ) : null
 
     return (
         <div
@@ -104,42 +158,9 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
                         <p className="text-secondary text-sm m-0">{text.lead}</p>
                     </div>
 
-                    {text.hint ? <div className="text-xs text-tertiary mt-2">{text.hint}</div> : null}
+                    {text.hint && callToAction ? <div className="text-xs text-tertiary mt-2">{text.hint}</div> : null}
 
-                    {showWizard ? (
-                        <>
-                            <TerminalCard
-                                command={wizardCommand}
-                                copyLabel={`${config.productName} wizard command`}
-                                onCopy={() => captureClick('wizard command copied')}
-                            />
-                            {guardedPrimaryAction ? (
-                                <>
-                                    <div className="flex items-center gap-3">
-                                        <div className="h-px flex-1 bg-border-primary" />
-                                        <span className="text-xs text-tertiary uppercase tracking-wide">or</span>
-                                        <div className="h-px flex-1 bg-border-primary" />
-                                    </div>
-                                    {guardedPrimaryAction}
-                                </>
-                            ) : null}
-                        </>
-                    ) : config.PrimaryAction ? (
-                        <config.PrimaryAction />
-                    ) : guardedPrimaryAction ? (
-                        guardedPrimaryAction
-                    ) : manualUrl ? (
-                        <LemonButton
-                            type="primary"
-                            to={manualUrl}
-                            targetBlank
-                            className="self-start"
-                            onClick={() => captureClick('manual setup clicked')}
-                            data-attr="product-empty-state-manual-setup"
-                        >
-                            Set up {config.productName}
-                        </LemonButton>
-                    ) : null}
+                    {callToAction}
 
                     {config.statusIndicator ? <div className="text-xs">{config.statusIndicator}</div> : null}
 

--- a/frontend/src/lib/components/ProductEmptyState/types.ts
+++ b/frontend/src/lib/components/ProductEmptyState/types.ts
@@ -23,7 +23,10 @@ export interface ProductEmptyStateText {
     /** Sentence case, benefit-first, e.g. "Know how agents actually use your tools" */
     headline: string
     lead: ReactNode
-    /** Small line above the install command, e.g. "Fastest way in — our wizard wires up the SDK for you:" */
+    /**
+     * Small line introducing the install command or primary action, e.g. "Fastest way in - our
+     * wizard wires up the SDK for you:". It only renders when the mode has one of those under it.
+     */
     hint?: ReactNode
 }
 
@@ -68,6 +71,16 @@ export interface ProductEmptyStatePrimaryAction {
     dataAttr?: string
 }
 
+/**
+ * A primary action keyed by mode, mirroring `text`: a mode left out has no primary
+ * action at all, and its hint goes with it. Key the action when it stops making sense
+ * once the product is on - a one-click "Enable X" would re-send the same opt-in while
+ * the screen waits for the first event.
+ */
+export type ProductEmptyStatePrimaryActionByMode = Partial<
+    Record<ProductEmptyStateMode, ProductEmptyStatePrimaryAction>
+>
+
 export interface ProductEmptyStateConfig {
     productKey: ProductKey
     /** Eyebrow text, sentence case, e.g. "MCP analytics" */
@@ -93,8 +106,9 @@ export interface ProductEmptyStateConfig {
      * Primary CTA for products set up in the UI rather than via the wizard, e.g. "Create your first flag".
      * With `wizard` also set, the terminal card stays the hero and this renders as a secondary button
      * (in place of the "Configure manually" link), for products with both a terminal and an in-app path.
+     * One action covers every mode; pass a `ProductEmptyStatePrimaryActionByMode` map to vary it.
      */
-    primaryAction?: ProductEmptyStatePrimaryAction
+    primaryAction?: ProductEmptyStatePrimaryAction | ProductEmptyStatePrimaryActionByMode
     /**
      * Rendered in the primary-action slot instead of the `primaryAction` button, for
      * actions that need hooks - e.g. a create flow that opens PostHog AI via `useMaxTool`.

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1683,6 +1683,7 @@ export const productSetupProbes: ProductSetupProbe[] = [
         hasDataEvents: ['$ai_generation', '$ai_trace', '$ai_span', '$ai_embedding'],
         staleAfterDays: 90,
     },
+    { productKey: ProductKey.ERROR_TRACKING, hasDataEvents: ['$exception'] },
     {
         productKey: ProductKey.MCP_ANALYTICS,
         hasDataEvents: ['$mcp_tool_call'],

--- a/products/conversations/frontend/emptyState/supportEmptyState.tsx
+++ b/products/conversations/frontend/emptyState/supportEmptyState.tsx
@@ -31,9 +31,7 @@ export const supportEmptyState: SceneProductEmptyState = {
                 lead: 'Tickets from your chat widget, email, and any other connected channels will show up here as they arrive. Send a test message through the widget to see one land, or finish connecting a channel in settings.',
             },
         },
-        // `primaryAction` isn't keyed by mode the way `text` is, and support is the only
-        // adopter with a middle state, so this copy has to read correctly both before
-        // support is switched on and while it waits for a first ticket.
+        // Settings are the next step in both modes: switching support on, then finishing a channel.
         primaryAction: { label: 'Open support settings', to: urls.supportSettings() },
         docsUrl: 'https://posthog.com/docs/support',
         previewLabel: 'Your inbox, once tickets arrive',

--- a/products/error_tracking/frontend/ErrorTracking.stories.tsx
+++ b/products/error_tracking/frontend/ErrorTracking.stories.tsx
@@ -638,13 +638,14 @@ function IngestionWarningStory(): JSX.Element | null {
     return ready ? <App /> : null
 }
 
-// No exceptions ingested yet, but autocapture enabled — the ingestion warning banner
-// renders above the issue list without the sticky filters bar overlapping it
+// A banner renders above the issue list without the sticky filters bar overlapping it.
+// Issues have to exist, or the scene's setup empty state takes over and there is no list
+// to lay the banner out against.
 export const ListPageWithIngestionWarning: Story = {
     decorators: [
         mswDecorator({
             get: {
-                '/api/environments/:team_id/error_tracking/issues/exists/': () => [200, { exists: false }],
+                '/api/environments/:team_id/error_tracking/issues/exists/': () => [200, { exists: true }],
             },
         }),
     ],

--- a/products/error_tracking/frontend/emptyState/ErrorTrackingPreview.scss
+++ b/products/error_tracking/frontend/emptyState/ErrorTrackingPreview.scss
@@ -1,0 +1,389 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.ErrorPreview {
+    --error-preview-accent: var(--empty-state-accent, var(--color-primary-500));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden crash state. A direct child of .ErrorPreview so `:checked ~` reaches all cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__app,
+    &__panel,
+    &__trace {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Before/after pairs are stacked on one grid cell and crossfaded, so throwing the
+    // bug never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-after {
+        @include preview-swap-hidden;
+    }
+
+    &__when-before {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    &__listening {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+        font-size: 0.6875rem;
+        color: var(--color-text-secondary);
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    // Mini checkout app
+
+    &__chrome {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+        padding: 0.4375rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__url {
+        margin-left: 0.375rem;
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        color: var(--color-text-secondary);
+    }
+
+    &__screen {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 0.75rem;
+    }
+
+    &__order {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.625rem;
+        font-size: 0.75rem;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: var(--radius);
+    }
+
+    &__order-name {
+        font-weight: 500;
+    }
+
+    &__order-price {
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-secondary);
+    }
+
+    &__toast-slot {
+        min-height: 1.5rem;
+    }
+
+    &__toast-spacer {
+        min-height: 1.5rem;
+    }
+
+    &__toast {
+        align-self: center;
+        padding: 0.25rem 0.5rem;
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        color: var(--color-text-error);
+        background: var(--danger-highlight);
+        border: 1px solid color-mix(in oklab, var(--danger) 35%, transparent);
+        border-radius: var(--radius);
+    }
+
+    &__cta {
+        display: block;
+        padding: 0.4375rem 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--color-bg-surface-primary);
+        text-align: center;
+        cursor: pointer;
+        user-select: none;
+        background: var(--error-preview-accent);
+        border-radius: var(--radius);
+        transition: filter 150ms ease;
+    }
+
+    &__cta:hover {
+        filter: brightness(1.05);
+    }
+
+    &__hint {
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+        text-align: center;
+    }
+
+    // Issues panel
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+    }
+
+    &__dot {
+        width: 7px;
+        height: 7px;
+        background: var(--danger);
+        border-radius: 50%;
+    }
+
+    &__dot--resolved {
+        background: var(--color-bg-fill-tertiary);
+    }
+
+    &__issue {
+        overflow: hidden;
+        font-family: var(--font-mono);
+        font-size: 0.6875rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__issue--resolved {
+        color: var(--color-text-tertiary);
+        text-decoration: line-through;
+    }
+
+    &__fresh {
+        padding: 0 0.3125rem;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        white-space: nowrap;
+        background: color-mix(in oklab, var(--error-preview-accent) 12%, var(--color-bg-surface-primary));
+        border-radius: 999px;
+
+        @include preview-accent-text(var(--error-preview-accent));
+    }
+
+    &__count {
+        font-size: 0.6875rem;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-secondary);
+        text-align: right;
+    }
+
+    &__count--bumped {
+        @include preview-accent-text(var(--error-preview-accent));
+    }
+
+    // Exceptions stat + sparkline, inside the issues panel
+
+    &__spark {
+        padding: 0.5rem 0.75rem 0.625rem;
+        border-top: 1px solid var(--color-border-primary);
+    }
+
+    &__spark-value {
+        font-size: 1.25rem;
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--error-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--error-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--error-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: ErrorPreview__trace 3.2s linear infinite;
+    }
+
+    // Stack trace card
+
+    &__frames {
+        padding: 0.5rem 0.75rem 0.625rem;
+    }
+
+    &__skeleton {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4375rem;
+        justify-content: center;
+    }
+
+    &__skeleton-line {
+        height: 0.5rem;
+        background: var(--color-skeleton-dark);
+        border-radius: 999px;
+        animation: ErrorPreview__shimmer 1.8s ease-in-out infinite;
+    }
+
+    &__skeleton-line:nth-child(2) {
+        width: 82%;
+        animation-delay: 200ms;
+    }
+
+    &__skeleton-line:nth-child(3) {
+        width: 64%;
+        animation-delay: 400ms;
+    }
+
+    &__frame-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1875rem;
+    }
+
+    &__frame {
+        display: flex;
+        gap: 0.5rem;
+        align-items: baseline;
+        padding: 0.1875rem 0.375rem;
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        border-radius: var(--radius);
+    }
+
+    &__frame--app {
+        background: color-mix(in oklab, var(--error-preview-accent) 10%, transparent);
+    }
+
+    &__fn {
+        font-weight: 600;
+    }
+
+    &__loc {
+        overflow: hidden;
+        color: var(--color-text-tertiary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__frame-tag {
+        margin-left: auto;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        white-space: nowrap;
+
+        @include preview-accent-text(var(--error-preview-accent));
+    }
+
+    @include preview-chrome-dot;
+    @include preview-sparkline;
+}
+
+// Thrown state (user clicked "Place order")
+
+.ErrorPreview__checkbox:checked ~ * .ErrorPreview__when-after {
+    @include preview-swap-visible;
+}
+
+.ErrorPreview__checkbox:checked ~ * .ErrorPreview__when-before {
+    @include preview-swap-hidden;
+}
+
+.ErrorPreview__checkbox:checked ~ .ErrorPreview__app .ErrorPreview__cta {
+    color: var(--color-text-error);
+    background: var(--danger-highlight);
+    box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--danger) 35%, transparent);
+}
+
+.ErrorPreview__checkbox:checked ~ .ErrorPreview__panel .ErrorPreview__row--hero {
+    background: color-mix(in oklab, var(--error-preview-accent) 8%, transparent);
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the button it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.ErrorPreview__checkbox:focus-visible ~ .ErrorPreview__app .ErrorPreview__cta {
+    outline: 2px solid var(--error-preview-accent);
+    outline-offset: 1px;
+}
+
+// Nudge attention at the order button until it's clicked.
+.ErrorPreview:not(.ErrorPreview--static) .ErrorPreview__checkbox:not(:checked) ~ .ErrorPreview__app .ErrorPreview__cta {
+    animation: ErrorPreview__nudge 2.4s ease-in-out infinite;
+}
+
+@keyframes ErrorPreview__nudge {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--error-preview-accent) 45%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--error-preview-accent) 20%, transparent);
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes ErrorPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+@keyframes ErrorPreview__shimmer {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.45;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; clicking the
+// order button still flips the state (transitions only).
+@include preview-motion-guards('ErrorPreview');

--- a/products/error_tracking/frontend/emptyState/ErrorTrackingPreview.tsx
+++ b/products/error_tracking/frontend/emptyState/ErrorTrackingPreview.tsx
@@ -1,0 +1,184 @@
+import './ErrorTrackingPreview.scss'
+
+import { Spinner } from '@posthog/lemon-ui'
+
+import type { ProductEmptyStateMode } from 'lib/components/ProductEmptyState/types'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored sparkline for the exceptions stat. The "after" series ticks up at the
+// far right, where the newly-thrown exception lands.
+const LINE_BEFORE = 'M 0 26 L 12 28 L 24 22 L 36 27 L 48 20 L 60 25 L 72 18 L 84 23 L 100 21'
+const LINE_AFTER = 'M 0 26 L 12 28 L 24 22 L 36 27 L 48 20 L 60 25 L 72 18 L 84 23 L 92 21 L 100 9'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the error tracking empty state: an issue list, the mini app
+ * that feeds it, and the stack trace of its top issue. Clicking "Place order" in the app
+ * throws a bug on purpose - the app shows the crash, the issue's occurrence count ticks
+ * up, the stack trace fills in, and the exceptions sparkline steps up. One hidden
+ * checkbox drives it all via `:checked ~` styles - no timers or state, per the preview
+ * rules in the `building-product-empty-states` skill. Before/after pairs are stacked in
+ * `__swap` grids and crossfaded, so nothing shifts.
+ */
+export function ErrorTrackingPreview({ mode }: { mode: ProductEmptyStateMode }): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('ErrorPreview', isStatic && 'ErrorPreview--static')}>
+            {/* Crash state, before all cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="error-preview-crash" className="ErrorPreview__checkbox" />
+
+            <div className="ErrorPreview__app">
+                <div className="ErrorPreview__chrome">
+                    <span className="ErrorPreview__chrome-dot" />
+                    <span className="ErrorPreview__chrome-dot" />
+                    <span className="ErrorPreview__chrome-dot" />
+                    <span className="ErrorPreview__url">yourapp.com/checkout</span>
+                </div>
+                <div className="ErrorPreview__screen">
+                    <div className="ErrorPreview__order">
+                        <span className="ErrorPreview__order-name">Sticker pack × 2</span>
+                        <span className="ErrorPreview__order-price">$12.00</span>
+                    </div>
+                    <div className="ErrorPreview__toast-slot ErrorPreview__swap" aria-hidden="true">
+                        <span className="ErrorPreview__toast-spacer ErrorPreview__when-before" />
+                        <span className="ErrorPreview__toast ErrorPreview__when-after">
+                            Uncaught TypeError: cart is undefined
+                        </span>
+                    </div>
+                    <label htmlFor="error-preview-crash" className="ErrorPreview__cta">
+                        <span className="ErrorPreview__swap">
+                            <span className="ErrorPreview__when-before">Place order</span>
+                            <span className="ErrorPreview__when-after">Place order (it throws)</span>
+                        </span>
+                    </label>
+                    <div className="ErrorPreview__hint ErrorPreview__swap">
+                        <span className="ErrorPreview__when-before">Click the button to throw a bug on purpose.</span>
+                        <span className="ErrorPreview__when-after">
+                            Caught, grouped, and counted below. Click again to undo.
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div className="ErrorPreview__panel">
+                <div className="ErrorPreview__head">
+                    <span className="ErrorPreview__title">Issues</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                {mode === 'waiting-for-data' ? (
+                    <div className="ErrorPreview__listening">
+                        <Spinner className="text-sm" />
+                        Listening for your first exception…
+                    </div>
+                ) : null}
+
+                <div className="ErrorPreview__rows">
+                    <div className="ErrorPreview__row ErrorPreview__row--hero">
+                        <span className="ErrorPreview__dot" aria-hidden="true" />
+                        <span className="ErrorPreview__issue">TypeError: cart is undefined</span>
+                        <span className="ErrorPreview__fresh ErrorPreview__when-after">just now</span>
+                        <span className="ErrorPreview__count ErrorPreview__swap">
+                            <span className="ErrorPreview__when-before">12</span>
+                            <span className="ErrorPreview__count--bumped ErrorPreview__when-after">13</span>
+                        </span>
+                    </div>
+                    <div className="ErrorPreview__row">
+                        <span className="ErrorPreview__dot" aria-hidden="true" />
+                        <span className="ErrorPreview__issue">ReferenceError: gtag is not defined</span>
+                        <span className="ErrorPreview__count">48</span>
+                    </div>
+                    <div className="ErrorPreview__row">
+                        <span className="ErrorPreview__dot ErrorPreview__dot--resolved" aria-hidden="true" />
+                        <span className="ErrorPreview__issue ErrorPreview__issue--resolved">
+                            Failed to fetch: /api/products
+                        </span>
+                        <span className="ErrorPreview__count">7</span>
+                    </div>
+                </div>
+
+                <div className="ErrorPreview__spark">
+                    <div className="ErrorPreview__spark-head">
+                        <span className="ErrorPreview__spark-title">Exceptions · 24 h</span>
+                    </div>
+                    <div className="ErrorPreview__spark-value">
+                        <span className="ErrorPreview__swap">
+                            <span className="ErrorPreview__when-before">214</span>
+                            <span className="ErrorPreview__when-after">215</span>
+                        </span>
+                    </div>
+                    <svg
+                        className="ErrorPreview__spark-svg"
+                        viewBox="0 0 100 40"
+                        preserveAspectRatio="none"
+                        aria-hidden="true"
+                    >
+                        <g className="ErrorPreview__spark-g ErrorPreview__when-before">
+                            <path className="ErrorPreview__spark-area" d={areaPath(LINE_BEFORE)} />
+                            <path
+                                className="ErrorPreview__spark-line"
+                                d={LINE_BEFORE}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="ErrorPreview__spark-trace"
+                                d={LINE_BEFORE}
+                                pathLength={100}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </g>
+                        <g className="ErrorPreview__spark-g ErrorPreview__when-after">
+                            <path className="ErrorPreview__spark-area" d={areaPath(LINE_AFTER)} />
+                            <path
+                                className="ErrorPreview__spark-line"
+                                d={LINE_AFTER}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="ErrorPreview__spark-trace"
+                                d={LINE_AFTER}
+                                pathLength={100}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </g>
+                    </svg>
+                </div>
+            </div>
+
+            <div className="ErrorPreview__trace">
+                <div className="ErrorPreview__head">
+                    <span className="ErrorPreview__title">Stack trace</span>
+                    <span className="ErrorPreview__fresh ErrorPreview__when-after">captured just now</span>
+                </div>
+                <div className="ErrorPreview__frames ErrorPreview__swap">
+                    <div className="ErrorPreview__skeleton ErrorPreview__when-before" aria-hidden="true">
+                        <span className="ErrorPreview__skeleton-line" />
+                        <span className="ErrorPreview__skeleton-line" />
+                        <span className="ErrorPreview__skeleton-line" />
+                    </div>
+                    <div className="ErrorPreview__frame-list ErrorPreview__when-after">
+                        <div className="ErrorPreview__frame ErrorPreview__frame--app">
+                            <span className="ErrorPreview__fn">processOrder</span>
+                            <span className="ErrorPreview__loc">checkout/orders.ts:118</span>
+                            <span className="ErrorPreview__frame-tag">in app</span>
+                        </div>
+                        <div className="ErrorPreview__frame">
+                            <span className="ErrorPreview__fn">submitCart</span>
+                            <span className="ErrorPreview__loc">checkout/CartButton.tsx:42</span>
+                        </div>
+                        <div className="ErrorPreview__frame">
+                            <span className="ErrorPreview__fn">onClick</span>
+                            <span className="ErrorPreview__loc">react-dom.production.min.js:189</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/error_tracking/frontend/emptyState/errorTrackingEmptyState.tsx
+++ b/products/error_tracking/frontend/emptyState/errorTrackingEmptyState.tsx
@@ -28,22 +28,24 @@ export const errorTrackingEmptyState: SceneProductEmptyState = {
             'waiting-for-data': {
                 headline: "You're set up. Waiting for the first exception",
                 lead: 'Exception capture is on. When your app throws, the error shows up here on its own, grouped into an issue with its stack trace.',
-                hint: 'Adding another platform? The docs cover every SDK:',
             },
         },
+        // Autocapture is already on in `waiting-for-data`, so the opt-in only belongs on the setup screen.
         primaryAction: {
-            label: 'Enable exception autocapture',
-            onClick: () => {
-                const mounted = teamLogic.findMounted()
-                mounted?.actions.addProductIntent({
-                    product_type: ProductKey.ERROR_TRACKING,
-                    intent_context: ProductIntentContext.ERROR_TRACKING_EXCEPTION_AUTOCAPTURE_ENABLED,
-                })
-                mounted?.actions.updateCurrentTeam({ autocapture_exceptions_opt_in: true })
-            },
-            accessControl: {
-                resourceType: AccessControlResourceType.ErrorTracking,
-                minAccessLevel: AccessControlLevel.Editor,
+            'needs-setup': {
+                label: 'Enable exception autocapture',
+                onClick: () => {
+                    const mounted = teamLogic.findMounted()
+                    mounted?.actions.addProductIntent({
+                        product_type: ProductKey.ERROR_TRACKING,
+                        intent_context: ProductIntentContext.ERROR_TRACKING_EXCEPTION_AUTOCAPTURE_ENABLED,
+                    })
+                    mounted?.actions.updateCurrentTeam({ autocapture_exceptions_opt_in: true })
+                },
+                accessControl: {
+                    resourceType: AccessControlResourceType.ErrorTracking,
+                    minAccessLevel: AccessControlLevel.Editor,
+                },
             },
         },
         docsUrl: 'https://posthog.com/docs/error-tracking',

--- a/products/error_tracking/frontend/emptyState/errorTrackingEmptyState.tsx
+++ b/products/error_tracking/frontend/emptyState/errorTrackingEmptyState.tsx
@@ -1,0 +1,54 @@
+import { IconWarning } from '@posthog/icons'
+
+import { WarningHog } from 'lib/components/hedgehogs'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { ErrorTrackingPreview } from './ErrorTrackingPreview'
+import { errorTrackingSetupLogic } from './errorTrackingSetupLogic'
+
+export const errorTrackingEmptyState: SceneProductEmptyState = {
+    statusLogic: errorTrackingSetupLogic,
+    config: {
+        productKey: ProductKey.ERROR_TRACKING,
+        productName: 'Error tracking',
+        icon: <IconWarning />,
+        accentColor: 'var(--color-product-error-tracking-light)',
+        accentColorDark: 'var(--color-product-error-tracking-dark)',
+        hedgehog: WarningHog,
+        text: {
+            'needs-setup': {
+                headline: 'Catch the errors your users actually hit',
+                lead: 'PostHog captures exceptions from your app and groups them into issues, with stack traces, affected users, and alerts. Triage, assign, and resolve them next to the rest of your product data.',
+                hint: 'Already using posthog-js? One click and errors start flowing:',
+            },
+            'waiting-for-data': {
+                headline: "You're set up. Waiting for the first exception",
+                lead: 'Exception capture is on. When your app throws, the error shows up here on its own, grouped into an issue with its stack trace.',
+                hint: 'Adding another platform? The docs cover every SDK:',
+            },
+        },
+        primaryAction: {
+            label: 'Enable exception autocapture',
+            onClick: () => {
+                const mounted = teamLogic.findMounted()
+                mounted?.actions.addProductIntent({
+                    product_type: ProductKey.ERROR_TRACKING,
+                    intent_context: ProductIntentContext.ERROR_TRACKING_EXCEPTION_AUTOCAPTURE_ENABLED,
+                })
+                mounted?.actions.updateCurrentTeam({ autocapture_exceptions_opt_in: true })
+            },
+            accessControl: {
+                resourceType: AccessControlResourceType.ErrorTracking,
+                minAccessLevel: AccessControlLevel.Editor,
+            },
+        },
+        docsUrl: 'https://posthog.com/docs/error-tracking',
+        manualSetupUrl: 'https://posthog.com/docs/error-tracking/installation',
+        previewLabel: 'Issues, once exceptions arrive',
+        Preview: ErrorTrackingPreview,
+    },
+}

--- a/products/error_tracking/frontend/emptyState/errorTrackingSetupLogic.test.ts
+++ b/products/error_tracking/frontend/emptyState/errorTrackingSetupLogic.test.ts
@@ -1,0 +1,46 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import type { TeamType } from '~/types'
+
+import { errorTrackingSetupLogic } from './errorTrackingSetupLogic'
+
+jest.mock('lib/api', () => ({
+    ...jest.requireActual('lib/api'),
+    ApiRequest: jest.fn(),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { ApiRequest } = require('lib/api')
+
+describe('errorTrackingSetupLogic', () => {
+    function mountWith(exists: boolean, autocaptureOptIn: boolean): void {
+        initKeaTests(true, {
+            ...MOCK_DEFAULT_TEAM,
+            autocapture_exceptions_opt_in: autocaptureOptIn,
+        } as TeamType)
+        ;(ApiRequest as jest.Mock).mockImplementation(() => ({
+            errorTrackingIssuesExists: () => ({ get: async () => ({ exists }) }),
+        }))
+        errorTrackingSetupLogic.mount()
+    }
+
+    // Guards the status mapping the scene gate hangs off: dropping the opt-in
+    // branch would show "install the SDK" to already-instrumented projects, and
+    // flipping the exists check would gate projects that have real issues.
+    it.each([
+        [true, false, 'has-data'],
+        [true, true, 'has-data'],
+        [false, true, 'waiting-for-data'],
+        [false, false, 'needs-setup'],
+    ])('exists=%s, autocapture=%s maps to %s', async (exists, autocaptureOptIn, expected) => {
+        mountWith(exists, autocaptureOptIn)
+        await expectLogic(errorTrackingSetupLogic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.ERROR_TRACKING }).values.status).toBe(expected)
+    })
+})

--- a/products/error_tracking/frontend/emptyState/errorTrackingSetupLogic.ts
+++ b/products/error_tracking/frontend/emptyState/errorTrackingSetupLogic.ts
@@ -1,0 +1,29 @@
+import { ApiRequest } from 'lib/api'
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+/**
+ * Setup detection for the error tracking empty state. An issue existing means
+ * exceptions have been captured and grouped; with none, exception autocapture
+ * being opted in means the JS SDK will start capturing on its own - the project
+ * is instrumented, an exception just hasn't happened yet.
+ */
+export const errorTrackingSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.ERROR_TRACKING,
+    path: ['products', 'error_tracking', 'frontend', 'emptyState', 'errorTrackingSetupLogic'],
+    detect: async () => {
+        const response = await new ApiRequest().errorTrackingIssuesExists().get()
+        if (response?.exists === true) {
+            return 'has-data'
+        }
+        return teamLogic.findMounted()?.values.currentTeam?.autocapture_exceptions_opt_in
+            ? 'waiting-for-data'
+            : 'needs-setup'
+    },
+    pollIntervalMs: 20000,
+    // Enabling autocapture (from this empty state or settings) must flip the
+    // screen to "waiting" right away, not on the next poll tick.
+    recheckActionTypes: () => [teamLogic.actionTypes.updateCurrentTeamSuccess],
+})

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { LemonBadge, LemonBanner, LemonButton, LemonTab, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
+import { LemonBadge, LemonButton, LemonTab, LemonTabs, Spinner } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { AccessDenied } from 'lib/components/AccessDenied'
@@ -16,15 +16,15 @@ import { Settings } from 'scenes/settings/Settings'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType, CyclotronJobFiltersType } from '~/types'
 
 import { IntegrationsMovedBanner } from '../../components/IntegrationsMovedBanner'
 import { ErrorTrackingIssueFilteringTool } from '../../components/IssueFilteringTool'
 import { issueFiltersLogic } from '../../components/IssueFilters/issueFiltersLogic'
 import { issueQueryOptionsLogic } from '../../components/IssueQueryOptions/issueQueryOptionsLogic'
-import { exceptionIngestionLogic } from '../../components/SetupPrompt/exceptionIngestionLogic'
-import { ErrorTrackingSetupPrompt } from '../../components/SetupPrompt/SetupPrompt'
 import { StyleVariables } from '../../components/StyleVariables'
+import { errorTrackingEmptyState } from '../../emptyState/errorTrackingEmptyState'
 import { ERROR_TRACKING_LOGIC_KEY } from '../../utils'
 import {
     ERROR_TRACKING_SCENE_LOGIC_KEY,
@@ -46,10 +46,11 @@ const ERROR_TRACKING_ALERT_FILTER_GROUPS: CyclotronJobFiltersType[] = [
 export const scene: SceneExport = {
     component: ErrorTrackingScene,
     logic: errorTrackingSceneLogic,
+    productKey: ProductKey.ERROR_TRACKING,
+    emptyState: errorTrackingEmptyState,
 }
 
 export function ErrorTrackingScene(): JSX.Element {
-    const { hasSentExceptionEvent, hasSentExceptionEventLoading } = useValues(exceptionIngestionLogic)
     const { activeTab } = useValues(errorTrackingSceneLogic)
     const { setActiveTab } = useActions(errorTrackingSceneLogic)
     const hasRecommendations = useFeatureFlag('ERROR_TRACKING_RECOMMENDATIONS')
@@ -80,14 +81,13 @@ export function ErrorTrackingScene(): JSX.Element {
             key: 'issues',
             label: 'Issues',
             content: (
-                <ErrorTrackingSetupPrompt>
-                    {hasSentExceptionEventLoading || hasSentExceptionEvent ? null : <IngestionStatusCheck />}
+                <>
                     <SourceMapsBanner />
                     <IssuesList />
                     {/* Renders a hidden div — keep it after IssuesList so the sticky bar's
                         first:-mt-4 can detect whether a banner renders above it */}
                     <ErrorTrackingIssueFilteringTool />
-                </ErrorTrackingSetupPrompt>
+                </>
             ),
         },
         {
@@ -240,22 +240,5 @@ const Header = (): JSX.Element => {
                 }
             />
         </>
-    )
-}
-
-const IngestionStatusCheck = (): JSX.Element | null => {
-    return (
-        <LemonBanner type="warning" className="my-2">
-            <p>
-                <strong>No Exception events have been detected!</strong>
-            </p>
-            <p>
-                To use the Error tracking product, please{' '}
-                <Link to="https://posthog.com/docs/error-tracking/installation">
-                    enable exception capture within the PostHog SDK
-                </Link>{' '}
-                (otherwise it'll be a little empty!)
-            </p>
-        </LemonBanner>
     )
 }

--- a/products/error_tracking/manifest.tsx
+++ b/products/error_tracking/manifest.tsx
@@ -57,6 +57,13 @@ export const manifest: ProductManifest = {
         '/error_tracking/symbol-sets': (_params, searchParams, hashParams) =>
             configurationRedirect('error-tracking-symbol-sets', searchParams, hashParams),
     },
+    // Boot-time approximation of errorTrackingSetupLogic: a $exception definition
+    // existing means issues exist. The in-scene check stays the source of truth
+    // (it also reads the autocapture opt-in for the waiting state).
+    setupProbe: {
+        productKey: ProductKey.ERROR_TRACKING,
+        hasDataEvents: ['$exception'],
+    },
     urls: {
         errorTracking: (params = {}): string => combineUrl('/error_tracking', params).url,
         errorTrackingConfiguration: (params = {}): string =>


### PR DESCRIPTION
## Problem

A user opening error tracking before any exception arrived gets a plain intro card inside the issues tab, and a user who enabled autocapture but hasn't thrown yet gets an empty issue list with a warning banner.

- The gate lives inside one tab (`ErrorTrackingSetupPrompt`), so the scene header and other tabs render around it.
- Stacks on #90606 (the shared detection factory); part of the empty-states stack.

## Changes

- The error tracking scene now shows the shared setup empty state until exceptions exist: an "Enable exception autocapture" action, per-SDK docs, and an interactive example preview. Screenshots below.
- No wizard terminal: the wizard CLI has no error-tracking subcommand, so the screen teaches the enable path instead of showing a generic install command.
- Autocapture enabled with no exceptions yet reads as a "waiting for the first exception" screen instead of an empty list. Enabling autocapture from the empty state flips it immediately (`recheckActionTypes` on team updates).
- The preview stages the product: clicking "Place order" in a mini shop throws an example bug, the issue's count ticks up, the stack trace fills in, and the exceptions sparkline steps. Pure CSS, guarded for reduced motion.
- A `$exception` boot probe resolves the status before the scene is first opened.
- The old `IngestionStatusCheck` banner is deleted; the platform's "isn't receiving data yet" skip banner replaces it.
- `ErrorTrackingSetupPrompt` stays for its other call sites (issue scene, fingerprints, dashboard widget); only the main scene migrates.

> [!NOTE]
> The hedgehog is the existing `WarningHog` asset by explicit request. It carries a deprecation notice (migrating to `@posthog/brand`), and the brand set has no warning hoggie yet; swap when one lands.

**Setup screen:**

![Setup screen](https://raw.githubusercontent.com/PostHog/pr-assets/7824a15b0718d9d8b4e5a1c6ba2d1a2ce48942a9/2026/08/8e13a0a3-91b5-4499-848a-9e87d11a4730.png)

**After clicking "Place order" in the preview:**

![After clicking "Place order" in the preview](https://raw.githubusercontent.com/PostHog/pr-assets/d3588940aa51adc4d2332165c5e57479814c313f/2026/08/3fff21b0-79c0-4368-8186-3ec9affa9f87.png)

**Waiting for the first exception (autocapture on):**

![Waiting for the first exception (autocapture on)](https://raw.githubusercontent.com/PostHog/pr-assets/0279b98bc4011b536bac547c78c68bf2c0868c42/2026/08/e0b4f636-b9f2-412e-a54d-883c06134eb3.png)

## How did you test this code?

- `errorTrackingSetupLogic.test.ts` (new): fails if the opt-in branch is dropped (already-instrumented projects would see "install the SDK") or the exists check is inverted (projects with issues would be gated).
- Factory behavior (polling, fail-open, caching) is covered in #90606.
- Not run: Playwright; the two new Storybook stories cover both modes for visual regression.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), directed by the assignee, who also chose the Warning hedgehog. Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`. The enable-autocapture action ships as a plain `primaryAction` dispatching through `teamLogic` (the product-tours pattern). A first version showed the base wizard command as the hero; it was dropped because the wizard CLI has no error-tracking subcommand.



