### PR TITLE
feat(flags): deprecate usage dashboard endpoints

### DIFF
--- a/docs/internal/feature-flags/django-api-endpoints.md
+++ b/docs/internal/feature-flags/django-api-endpoints.md
@@ -59,7 +59,8 @@ Standard REST on `/api/projects/{id}/feature_flags/`. Hard `DELETE` is blocked â
 | `POST` | `.../feature_flags/{pk}/create_static_cohort_for_flag/` | Create a static cohort from matched users                                       |
 | `GET`  | `.../feature_flags/{pk}/status/`                        | Flag status (ACTIVE, STALE, DELETED, UNKNOWN)                                   |
 | `GET`  | `.../feature_flags/{pk}/dependent_flags/`               | Flags that depend on this flag                                                  |
-| `POST` | `.../feature_flags/{pk}/dashboard/`                     | Create a usage dashboard for the flag                                           |
+| `POST` | `.../feature_flags/{pk}/dashboard/`                     | Deprecated: create a usage dashboard (sunsets September 25, 2026)               |
+| `POST` | `.../feature_flags/{pk}/enrich_usage_dashboard/`        | Deprecated: enrich an existing legacy usage dashboard (no removal date set)     |
 | `POST` | `.../feature_flags/{pk}/enable/`                        | Set `active: true` only                                                         |
 | `POST` | `.../feature_flags/{pk}/disable/`                       | Set `active: false` only                                                        |
 | `POST` | `.../feature_flags/{pk}/archive/`                       | Set `archived: true`, disabling the flag in the same write when needed          |

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -3559,8 +3559,10 @@ class FeatureFlagViewSet(
         except Exception:
             logger.exception("Failed to report deprecated feature flag usage dashboard endpoint call")
 
-    # No UI surface calls this, since the Usage tab renders its charts inline. It exists for API
-    # users who want a saved usage dashboard. It remains functional until the announced sunset.
+    # No UI surface calls this, since the Usage tab renders its charts inline.
+    # Without required_scopes, APIScopePermission rejects every personal API key, OAuth, and
+    # project secret key caller, so only a session-authenticated request reaches this action.
+    # It remains functional until the announced sunset.
     @extend_schema(
         request=None,
         responses={
@@ -3619,6 +3621,10 @@ class FeatureFlagViewSet(
         self._report_usage_dashboard_endpoint_call(request, "dashboard", outcome)
         return self._with_usage_dashboard_deprecation_headers(Response({"success": True}, status=status.HTTP_200_OK))
 
+    # Unlike `dashboard` above, the main app does call this: featureFlagLogic.ts's
+    # enrichUsageDashboard listener calls it automatically once a flag gains enriched
+    # analytics. As with `dashboard`, token callers are rejected before reaching this
+    # action, so nearly every call the telemetry below sees is that automatic one.
     @extend_schema(
         request=None,
         responses={

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -1207,7 +1207,7 @@ class FeatureFlagExperimentSetMetadataSerializer(serializers.Serializer):
 
 
 class FeatureFlagUsageDashboardSuccessSerializer(serializers.Serializer):
-    success = serializers.BooleanField(help_text="Whether a usage dashboard is available for the feature flag.")
+    success = serializers.BooleanField(help_text="Whether the usage dashboard operation completed successfully.")
 
 
 class FeatureFlagUsageDashboardErrorSerializer(FeatureFlagUsageDashboardSuccessSerializer):

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -9,7 +9,7 @@ import functools
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import asdict
 from datetime import datetime, timedelta
-from typing import Any, NoReturn, Optional, cast
+from typing import Any, Literal, NoReturn, Optional, cast
 
 from django.conf import settings
 from django.contrib.postgres.aggregates import ArrayAgg
@@ -149,6 +149,8 @@ scope_audit_logger = structlog.get_logger("posthog.feature_flag_scope_audit")
 # Dedicated name for the same startup-ordering reason as scope_audit_logger above. Emits
 # the violations that would have been 400s while the #50084 enforcement kill switch is off.
 filters_enforcement_logger = structlog.get_logger("posthog.feature_flag_filters_enforcement")
+
+FEATURE_FLAG_USAGE_DASHBOARD_SUNSET = "Fri, 25 Sep 2026 00:00:00 GMT"
 
 # DRF error messages echo caller-controlled input (a ChoiceField repeats the rejected value)
 # and bodies up to 20MB reach validation before the filter-size check runs, so an unbounded
@@ -1204,6 +1206,14 @@ class FeatureFlagExperimentSetMetadataSerializer(serializers.Serializer):
     )
 
 
+class FeatureFlagUsageDashboardSuccessSerializer(serializers.Serializer):
+    success = serializers.BooleanField(help_text="Whether a usage dashboard is available for the feature flag.")
+
+
+class FeatureFlagUsageDashboardErrorSerializer(FeatureFlagUsageDashboardSuccessSerializer):
+    error = serializers.CharField(help_text="Why the usage dashboard operation failed.")
+
+
 class FeatureFlagSerializer(
     TaggedItemSerializerMixin,
     EvaluationContextSerializerMixin,
@@ -1234,9 +1244,9 @@ class FeatureFlagSerializer(
         read_only=True,
         allow_null=True,
         help_text=(
-            "Dashboard of saved usage insights for this flag, or null if it has none. "
-            "Flags do not get one on creation; create it with "
-            "POST /api/projects/{project_id}/feature_flags/{id}/dashboard/."
+            "Legacy dashboard of saved usage insights for this flag, or null if it has none. "
+            "New flags show usage charts inline instead. The dashboard creation endpoint is deprecated "
+            "and will be removed after September 25, 2026."
         ),
     )
     analytics_dashboards = TeamScopedPrimaryKeyRelatedField(
@@ -3525,17 +3535,55 @@ class FeatureFlagViewSet(
             status=400,
         )
 
+    @staticmethod
+    def _with_usage_dashboard_deprecation_headers(response: Response, *, include_sunset: bool = True) -> Response:
+        response["Deprecation"] = "true"
+        if include_sunset:
+            response["Sunset"] = FEATURE_FLAG_USAGE_DASHBOARD_SUNSET
+        return response
+
+    @staticmethod
+    def _report_usage_dashboard_endpoint_call(
+        request: request.Request,
+        feature_flag: FeatureFlag,
+        endpoint: Literal["dashboard", "enrich_usage_dashboard"],
+        outcome: Literal["created", "existing", "success", "error"],
+    ) -> None:
+        try:
+            report_user_action(
+                request.user,
+                "deprecated feature flag usage dashboard endpoint called",
+                {"endpoint": endpoint, "outcome": outcome},
+                team=feature_flag.team,
+                request=request,
+            )
+        except Exception:
+            logger.exception("Failed to report deprecated feature flag usage dashboard endpoint call")
+
     # No UI surface calls this, since the Usage tab renders its charts inline. It exists for API
-    # users who want a saved usage dashboard.
-    @extend_schema(request=None)
+    # users who want a saved usage dashboard. It remains functional until the announced sunset.
+    @extend_schema(
+        request=None,
+        responses={
+            status.HTTP_200_OK: FeatureFlagUsageDashboardSuccessSerializer,
+            status.HTTP_400_BAD_REQUEST: FeatureFlagUsageDashboardErrorSerializer,
+        },
+        deprecated=True,
+        description=(
+            "Deprecated. Ensures a saved usage dashboard exists for a feature flag. "
+            "This endpoint will be removed after September 25, 2026; usage charts remain available "
+            "on the feature flag Usage tab."
+        ),
+    )
     @action(methods=["POST"], detail=True)
-    def dashboard(self, request: request.Request, **kwargs):
+    def dashboard(self, request: request.Request, **kwargs: Any) -> Response:
         from products.dashboards.backend.models.dashboard import Dashboard
 
         feature_flag: FeatureFlag = self.get_object()
         rejection = self._deleted_flag_rejection(feature_flag, "generating a usage dashboard")
         if rejection is not None:
-            return rejection
+            self._report_usage_dashboard_endpoint_call(request, feature_flag, "dashboard", "error")
+            return self._with_usage_dashboard_deprecation_headers(rejection)
         try:
             # The FK on the flag isn't cleared by a dashboard soft-delete, so look the id up
             # through the manager that excludes deleted rows rather than via the FK accessor,
@@ -3549,73 +3597,108 @@ class FeatureFlagViewSet(
             )
             if usage_dashboard is None:
                 usage_dashboard = _create_usage_dashboard(feature_flag, request.user)
+                outcome: Literal["created", "existing"] = "created"
+            else:
+                outcome = "existing"
 
             if feature_flag.has_enriched_analytics and not feature_flag.usage_dashboard_has_enriched_insights:
                 add_enriched_insights_to_feature_flag_dashboard(feature_flag, usage_dashboard)
 
         except Exception as e:
             capture_exception(e)
-            return Response(
-                {
-                    "success": False,
-                    "error": f"Unable to generate usage dashboard",
-                },
-                status=400,
+            self._report_usage_dashboard_endpoint_call(request, feature_flag, "dashboard", "error")
+            return self._with_usage_dashboard_deprecation_headers(
+                Response(
+                    {
+                        "success": False,
+                        "error": "Unable to generate usage dashboard",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             )
 
-        return Response({"success": True}, status=200)
+        self._report_usage_dashboard_endpoint_call(request, feature_flag, "dashboard", outcome)
+        return self._with_usage_dashboard_deprecation_headers(Response({"success": True}, status=status.HTTP_200_OK))
 
-    @extend_schema(request=None)
+    @extend_schema(
+        request=None,
+        responses={
+            status.HTTP_200_OK: FeatureFlagUsageDashboardSuccessSerializer,
+            status.HTTP_400_BAD_REQUEST: FeatureFlagUsageDashboardErrorSerializer,
+        },
+        deprecated=True,
+        description=(
+            "Deprecated. Adds enriched insights to an existing legacy feature flag usage dashboard. "
+            "No removal date has been set; usage charts remain available on the feature flag Usage tab."
+        ),
+    )
     @action(methods=["POST"], detail=True)
-    def enrich_usage_dashboard(self, request: request.Request, **kwargs):
+    def enrich_usage_dashboard(self, request: request.Request, **kwargs: Any) -> Response:
         feature_flag: FeatureFlag = self.get_object()
         rejection = self._deleted_flag_rejection(feature_flag, "enriching its usage dashboard")
         if rejection is not None:
-            return rejection
+            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            return self._with_usage_dashboard_deprecation_headers(rejection, include_sunset=False)
         usage_dashboard = feature_flag.usage_dashboard
 
         if not usage_dashboard:
-            return Response(
-                {
-                    "success": False,
-                    "error": (
-                        "Usage dashboard not found. Create one first with "
-                        "POST /api/projects/{project_id}/feature_flags/{id}/dashboard/"
-                    ),
-                },
-                status=400,
+            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            return self._with_usage_dashboard_deprecation_headers(
+                Response(
+                    {
+                        "success": False,
+                        "error": "Usage dashboard not found. Usage charts are available on the feature flag Usage tab.",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                ),
+                include_sunset=False,
             )
 
         if feature_flag.usage_dashboard_has_enriched_insights:
-            return Response(
-                {
-                    "success": False,
-                    "error": f"Usage dashboard already has enriched data",
-                },
-                status=400,
+            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            return self._with_usage_dashboard_deprecation_headers(
+                Response(
+                    {
+                        "success": False,
+                        "error": "Usage dashboard already has enriched data",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                ),
+                include_sunset=False,
             )
 
         if not feature_flag.has_enriched_analytics:
-            return Response(
-                {
-                    "success": False,
-                    "error": f"No enriched analytics available for this feature flag",
-                },
-                status=400,
+            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            return self._with_usage_dashboard_deprecation_headers(
+                Response(
+                    {
+                        "success": False,
+                        "error": "No enriched analytics available for this feature flag",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                ),
+                include_sunset=False,
             )
         try:
             add_enriched_insights_to_feature_flag_dashboard(feature_flag, usage_dashboard)
         except Exception as e:
             capture_exception(e)
-            return Response(
-                {
-                    "success": False,
-                    "error": f"Unable to enrich usage dashboard",
-                },
-                status=400,
+            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            return self._with_usage_dashboard_deprecation_headers(
+                Response(
+                    {
+                        "success": False,
+                        "error": "Unable to enrich usage dashboard",
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                ),
+                include_sunset=False,
             )
 
-        return Response({"success": True}, status=200)
+        self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "success")
+        return self._with_usage_dashboard_deprecation_headers(
+            Response({"success": True}, status=status.HTTP_200_OK), include_sunset=False
+        )
 
     @extend_schema(
         responses={200: DependentFlagSerializer(many=True)},

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -3542,10 +3542,9 @@ class FeatureFlagViewSet(
             response["Sunset"] = FEATURE_FLAG_USAGE_DASHBOARD_SUNSET
         return response
 
-    @staticmethod
     def _report_usage_dashboard_endpoint_call(
+        self,
         request: request.Request,
-        feature_flag: FeatureFlag,
         endpoint: Literal["dashboard", "enrich_usage_dashboard"],
         outcome: Literal["created", "existing", "success", "error"],
     ) -> None:
@@ -3554,8 +3553,8 @@ class FeatureFlagViewSet(
                 request.user,
                 "deprecated feature flag usage dashboard endpoint called",
                 {"endpoint": endpoint, "outcome": outcome},
-                team=feature_flag.team,
-                request=request,
+                team=self.team,
+                organization=self.team.organization,
             )
         except Exception:
             logger.exception("Failed to report deprecated feature flag usage dashboard endpoint call")
@@ -3582,7 +3581,7 @@ class FeatureFlagViewSet(
         feature_flag: FeatureFlag = self.get_object()
         rejection = self._deleted_flag_rejection(feature_flag, "generating a usage dashboard")
         if rejection is not None:
-            self._report_usage_dashboard_endpoint_call(request, feature_flag, "dashboard", "error")
+            self._report_usage_dashboard_endpoint_call(request, "dashboard", "error")
             return self._with_usage_dashboard_deprecation_headers(rejection)
         try:
             # The FK on the flag isn't cleared by a dashboard soft-delete, so look the id up
@@ -3606,7 +3605,7 @@ class FeatureFlagViewSet(
 
         except Exception as e:
             capture_exception(e)
-            self._report_usage_dashboard_endpoint_call(request, feature_flag, "dashboard", "error")
+            self._report_usage_dashboard_endpoint_call(request, "dashboard", "error")
             return self._with_usage_dashboard_deprecation_headers(
                 Response(
                     {
@@ -3617,7 +3616,7 @@ class FeatureFlagViewSet(
                 )
             )
 
-        self._report_usage_dashboard_endpoint_call(request, feature_flag, "dashboard", outcome)
+        self._report_usage_dashboard_endpoint_call(request, "dashboard", outcome)
         return self._with_usage_dashboard_deprecation_headers(Response({"success": True}, status=status.HTTP_200_OK))
 
     @extend_schema(
@@ -3637,12 +3636,12 @@ class FeatureFlagViewSet(
         feature_flag: FeatureFlag = self.get_object()
         rejection = self._deleted_flag_rejection(feature_flag, "enriching its usage dashboard")
         if rejection is not None:
-            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            self._report_usage_dashboard_endpoint_call(request, "enrich_usage_dashboard", "error")
             return self._with_usage_dashboard_deprecation_headers(rejection, include_sunset=False)
         usage_dashboard = feature_flag.usage_dashboard
 
         if not usage_dashboard:
-            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            self._report_usage_dashboard_endpoint_call(request, "enrich_usage_dashboard", "error")
             return self._with_usage_dashboard_deprecation_headers(
                 Response(
                     {
@@ -3655,7 +3654,7 @@ class FeatureFlagViewSet(
             )
 
         if feature_flag.usage_dashboard_has_enriched_insights:
-            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            self._report_usage_dashboard_endpoint_call(request, "enrich_usage_dashboard", "error")
             return self._with_usage_dashboard_deprecation_headers(
                 Response(
                     {
@@ -3668,7 +3667,7 @@ class FeatureFlagViewSet(
             )
 
         if not feature_flag.has_enriched_analytics:
-            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            self._report_usage_dashboard_endpoint_call(request, "enrich_usage_dashboard", "error")
             return self._with_usage_dashboard_deprecation_headers(
                 Response(
                     {
@@ -3683,7 +3682,7 @@ class FeatureFlagViewSet(
             add_enriched_insights_to_feature_flag_dashboard(feature_flag, usage_dashboard)
         except Exception as e:
             capture_exception(e)
-            self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "error")
+            self._report_usage_dashboard_endpoint_call(request, "enrich_usage_dashboard", "error")
             return self._with_usage_dashboard_deprecation_headers(
                 Response(
                     {
@@ -3695,7 +3694,7 @@ class FeatureFlagViewSet(
                 include_sunset=False,
             )
 
-        self._report_usage_dashboard_endpoint_call(request, feature_flag, "enrich_usage_dashboard", "success")
+        self._report_usage_dashboard_endpoint_call(request, "enrich_usage_dashboard", "success")
         return self._with_usage_dashboard_deprecation_headers(
             Response({"success": True}, status=status.HTTP_200_OK), include_sunset=False
         )

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -5087,22 +5087,42 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         # now enable enriched analytics
         instance.has_enriched_analytics = True
         instance.save()
+        mock_report_user_action.reset_mock()
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/{flag_id}/enrich_usage_dashboard",
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertNotIn("Sunset", response)
+        mock_report_user_action.assert_called_once_with(
+            self.user,
+            "deprecated feature flag usage dashboard endpoint called",
+            {"endpoint": "enrich_usage_dashboard", "outcome": "success"},
+            team=instance.team,
+            request=ANY,
+        )
 
         # now try enriching again
+        mock_report_user_action.reset_mock()
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/{flag_id}/enrich_usage_dashboard",
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertNotIn("Sunset", response)
         self.assertEqual(
             response.json(),
             {"error": "Usage dashboard already has enriched data", "success": False},
+        )
+        mock_report_user_action.assert_called_once_with(
+            self.user,
+            "deprecated feature flag usage dashboard endpoint called",
+            {"endpoint": "enrich_usage_dashboard", "outcome": "error"},
+            team=instance.team,
+            request=ANY,
         )
 
     @patch("products.feature_flags.backend.api.feature_flag.report_user_action")
@@ -5148,21 +5168,29 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         flag_id = response.json()["id"]
+        flag = FeatureFlag.objects.get(id=flag_id)
+        mock_report_user_action.reset_mock()
 
         response = self.client.post(
             f"/api/projects/{self.team.id}/feature_flags/{flag_id}/enrich_usage_dashboard",
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertNotIn("Sunset", response)
         self.assertEqual(
             response.json(),
             {
-                "error": (
-                    "Usage dashboard not found. Create one first with "
-                    "POST /api/projects/{project_id}/feature_flags/{id}/dashboard/"
-                ),
+                "error": "Usage dashboard not found. Usage charts are available on the feature flag Usage tab.",
                 "success": False,
             },
+        )
+        mock_report_user_action.assert_called_once_with(
+            self.user,
+            "deprecated feature flag usage dashboard endpoint called",
+            {"endpoint": "enrich_usage_dashboard", "outcome": "error"},
+            team=flag.team,
+            request=ANY,
         )
 
     def test_dashboard_endpoint_is_idempotent(self) -> None:
@@ -5183,6 +5211,81 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         self.assertEqual(instance.usage_dashboard_id, first_dashboard_id)
         self.assertTrue(Dashboard.objects.filter(id=first_dashboard_id, deleted=False).exists())
+
+    @patch("products.feature_flags.backend.api.feature_flag.report_user_action")
+    def test_dashboard_endpoint_announces_deprecation_and_reports_usage(
+        self, mock_report_user_action: MagicMock
+    ) -> None:
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="deprecated-dashboard-endpoint")
+
+        response = self.client.post(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/dashboard")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"success": True})
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertEqual(response["Sunset"], "Fri, 25 Sep 2026 00:00:00 GMT")
+        mock_report_user_action.assert_called_once_with(
+            self.user,
+            "deprecated feature flag usage dashboard endpoint called",
+            {"endpoint": "dashboard", "outcome": "created"},
+            team=flag.team,
+            request=ANY,
+        )
+
+        mock_report_user_action.reset_mock()
+        response = self.client.post(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/dashboard")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_report_user_action.assert_called_once_with(
+            self.user,
+            "deprecated feature flag usage dashboard endpoint called",
+            {"endpoint": "dashboard", "outcome": "existing"},
+            team=flag.team,
+            request=ANY,
+        )
+
+    @patch("products.feature_flags.backend.api.feature_flag.capture_exception")
+    @patch("products.feature_flags.backend.api.feature_flag.report_user_action")
+    @patch("products.feature_flags.backend.api.feature_flag._create_usage_dashboard", side_effect=RuntimeError)
+    def test_dashboard_endpoint_deprecation_headers_are_returned_on_error(
+        self,
+        mock_create_usage_dashboard: MagicMock,
+        mock_report_user_action: MagicMock,
+        mock_capture_exception: MagicMock,
+    ) -> None:
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="dashboard-generation-error")
+
+        response = self.client.post(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/dashboard")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json(), {"success": False, "error": "Unable to generate usage dashboard"})
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertEqual(response["Sunset"], "Fri, 25 Sep 2026 00:00:00 GMT")
+        mock_report_user_action.assert_called_once_with(
+            self.user,
+            "deprecated feature flag usage dashboard endpoint called",
+            {"endpoint": "dashboard", "outcome": "error"},
+            team=flag.team,
+            request=ANY,
+        )
+        mock_capture_exception.assert_called_once()
+        mock_create_usage_dashboard.assert_called_once()
+
+    @patch(
+        "products.feature_flags.backend.api.feature_flag.report_user_action",
+        side_effect=RuntimeError("telemetry unavailable"),
+    )
+    def test_dashboard_endpoint_ignores_telemetry_failures(self, mock_report_user_action: MagicMock) -> None:
+        flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="dashboard-telemetry-error")
+
+        response = self.client.post(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/dashboard")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertEqual(response["Sunset"], "Fri, 25 Sep 2026 00:00:00 GMT")
+        flag.refresh_from_db()
+        self.assertIsNotNone(flag.usage_dashboard_id)
+        mock_report_user_action.assert_called_once()
 
     def test_dashboard_endpoint_regenerates_after_dashboard_is_deleted(self) -> None:
         response = self.client.post(
@@ -5214,6 +5317,11 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("has been deleted", response.json()["error"])
+        self.assertEqual(response["Deprecation"], "true")
+        if endpoint == "dashboard":
+            self.assertEqual(response["Sunset"], "Fri, 25 Sep 2026 00:00:00 GMT")
+        else:
+            self.assertNotIn("Sunset", response)
         flag.refresh_from_db()
         self.assertIsNone(flag.usage_dashboard_id)
 

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -5101,7 +5101,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             "deprecated feature flag usage dashboard endpoint called",
             {"endpoint": "enrich_usage_dashboard", "outcome": "success"},
             team=instance.team,
-            request=ANY,
+            organization=self.organization,
         )
 
         # now try enriching again
@@ -5122,7 +5122,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             "deprecated feature flag usage dashboard endpoint called",
             {"endpoint": "enrich_usage_dashboard", "outcome": "error"},
             team=instance.team,
-            request=ANY,
+            organization=self.organization,
         )
 
     @patch("products.feature_flags.backend.api.feature_flag.report_user_action")
@@ -5190,7 +5190,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             "deprecated feature flag usage dashboard endpoint called",
             {"endpoint": "enrich_usage_dashboard", "outcome": "error"},
             team=flag.team,
-            request=ANY,
+            organization=self.organization,
         )
 
     def test_dashboard_endpoint_is_idempotent(self) -> None:
@@ -5229,7 +5229,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             "deprecated feature flag usage dashboard endpoint called",
             {"endpoint": "dashboard", "outcome": "created"},
             team=flag.team,
-            request=ANY,
+            organization=self.organization,
         )
 
         mock_report_user_action.reset_mock()
@@ -5241,7 +5241,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             "deprecated feature flag usage dashboard endpoint called",
             {"endpoint": "dashboard", "outcome": "existing"},
             team=flag.team,
-            request=ANY,
+            organization=self.organization,
         )
 
     @patch("products.feature_flags.backend.api.feature_flag.capture_exception")
@@ -5266,7 +5266,7 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
             "deprecated feature flag usage dashboard endpoint called",
             {"endpoint": "dashboard", "outcome": "error"},
             team=flag.team,
-            request=ANY,
+            organization=self.organization,
         )
         mock_capture_exception.assert_called_once()
         mock_create_usage_dashboard.assert_called_once()

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -542,7 +542,7 @@ export interface FeatureFlagApi {
     tags?: unknown[]
     evaluation_contexts?: unknown[]
     /**
-     * Dashboard of saved usage insights for this flag, or null if it has none. Flags do not get one on creation; create it with POST /api/projects/{project_id}/feature_flags/{id}/dashboard/.
+     * Legacy dashboard of saved usage insights for this flag, or null if it has none. New flags show usage charts inline instead. The dashboard creation endpoint is deprecated and will be removed after September 25, 2026.
      * @nullable
      */
     readonly usage_dashboard: number | null

--- a/products/feature_flags/frontend/generated/api.ts
+++ b/products/feature_flags/frontend/generated/api.ts
@@ -785,26 +785,6 @@ export const featureFlagsCreateStaticCohortForFlagCreate = async (
     })
 }
 
-export const getFeatureFlagsDashboardCreateUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/feature_flags/${id}/dashboard/`
-}
-
-/**
- * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
- *
- * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
- */
-export const featureFlagsDashboardCreate = async (
-    projectId: string,
-    id: number,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getFeatureFlagsDashboardCreateUrl(projectId, id), {
-        ...options,
-        method: 'POST',
-    })
-}
-
 export const getFeatureFlagsDependentFlagsListUrl = (projectId: string, id: number) => {
     return `/api/projects/${projectId}/feature_flags/${id}/dependent_flags/`
 }
@@ -866,26 +846,6 @@ export const featureFlagsEnableCreate = async (
     options?: RequestInit
 ): Promise<FeatureFlagApi> => {
     return apiMutator<FeatureFlagApi>(getFeatureFlagsEnableCreateUrl(projectId, id), {
-        ...options,
-        method: 'POST',
-    })
-}
-
-export const getFeatureFlagsEnrichUsageDashboardCreateUrl = (projectId: string, id: number) => {
-    return `/api/projects/${projectId}/feature_flags/${id}/enrich_usage_dashboard/`
-}
-
-/**
- * Create, read, update and delete feature flags. [See docs](https://posthog.com/docs/feature-flags) for more information on feature flags.
- *
- * If you're looking to use feature flags on your application, you can either use our JavaScript Library or our dedicated endpoint to check if feature flags are enabled for a given user.
- */
-export const featureFlagsEnrichUsageDashboardCreate = async (
-    projectId: string,
-    id: number,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getFeatureFlagsEnrichUsageDashboardCreateUrl(projectId, id), {
         ...options,
         method: 'POST',
     })

--- a/products/feature_flags/mcp/tools.yaml
+++ b/products/feature_flags/mcp/tools.yaml
@@ -407,9 +407,6 @@ tools:
     feature-flags-create-static-cohort-for-flag-create:
         operation: feature_flags_create_static_cohort_for_flag_create
         enabled: false
-    feature-flags-dashboard-create:
-        operation: feature_flags_dashboard_create
-        enabled: false
     feature-flags-dependent-flags-retrieve:
         operation: feature_flags_dependent_flags_list
         enabled: true
@@ -426,9 +423,6 @@ tools:
         param_overrides:
             id:
                 cast: string-int
-    feature-flags-enrich-usage-dashboard-create:
-        operation: feature_flags_enrich_usage_dashboard_create
-        enabled: false
     feature-flags-evaluation-reasons-retrieve:
         operation: feature_flags_evaluation_reasons_retrieve
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39866,7 +39866,7 @@ export namespace Schemas {
       tags?: unknown[];
       evaluation_contexts?: unknown[];
       /**
-         * Dashboard of saved usage insights for this flag, or null if it has none. Flags do not get one on creation; create it with POST /api/projects/{project_id}/feature_flags/{id}/dashboard/.
+         * Legacy dashboard of saved usage insights for this flag, or null if it has none. New flags show usage charts inline instead. The dashboard creation endpoint is deprecated and will be removed after September 25, 2026.
          * @nullable
          */
       readonly usage_dashboard: number | null;
@@ -40104,6 +40104,18 @@ export namespace Schemas {
       evaluation_distinct_id: string | null;
       /** Detailed analysis of each condition in the feature flag */
       conditions: FeatureFlagConditionAnalysis[];
+    }
+
+    export interface FeatureFlagUsageDashboardError {
+      /** Whether a usage dashboard is available for the feature flag. */
+      success: boolean;
+      /** Why the usage dashboard operation failed. */
+      error: string;
+    }
+
+    export interface FeatureFlagUsageDashboardSuccess {
+      /** Whether a usage dashboard is available for the feature flag. */
+      success: boolean;
     }
 
     export type FeatureFlagVersionResponseFilters = { [key: string]: unknown };

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -40107,14 +40107,14 @@ export namespace Schemas {
     }
 
     export interface FeatureFlagUsageDashboardError {
-      /** Whether a usage dashboard is available for the feature flag. */
+      /** Whether the usage dashboard operation completed successfully. */
       success: boolean;
       /** Why the usage dashboard operation failed. */
       error: string;
     }
 
     export interface FeatureFlagUsageDashboardSuccess {
-      /** Whether a usage dashboard is available for the feature flag. */
+      /** Whether the usage dashboard operation completed successfully. */
       success: boolean;
     }
 


### PR DESCRIPTION
## Problem

API consumers receive no formal migration signal for the legacy feature flag usage dashboard endpoints.

The main app shows flag usage inline, but two API actions still promote saved legacy dashboards.

## Changes

- Dashboard creation remains functional and announces deprecation with a September 25, 2026 `Sunset` header.
- Dashboard enrichment remains functional and announces deprecation without a removal date while its usage is measured.
- Server-side telemetry records the called endpoint and outcome without flag identifiers or request content.
- OpenAPI marks both actions deprecated, which removes them from newly generated clients.
- Generated client and schema changes are mechanical. No UI changes require screenshots.

## How did you test this code?

- Focused backend tests cover headers, telemetry outcomes, telemetry failures, idempotency, regeneration, and deleted flags.
- CI will rerun mypy, TypeScript checks, OpenAPI drift checks, and the backend suite.
- Manual testing was not run because this change has no UI surface.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the internal feature flag endpoint inventory and generated schema descriptions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop with Codex implemented and verified the change using repository tooling.
- Skills: `/review-code`, `/explain-open`, `/instrument-product-analytics`, `/commit`, `/reviewing-before-pr`, `/running-ci-preflight`, `/writing-pr-descriptions`, `/plain-writing`, and `/create-pr`.
- The user chose a compatibility window and explicitly skipped the local Greptile review. The normal PR bot review remains enabled.
- The diff contains no customer or operational data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*