### PR TITLE
feat(propdefs): add SKIP_EVENTPROPERTY_WRITES kill switch

### DIFF
--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -125,6 +125,12 @@ pub struct Config {
     #[envconfig(default = "opt_out")]
     pub filter_mode: TeamFilterMode,
 
+    // Emergency lever: drop posthog_eventproperty updates before they reach the dedup cache or
+    // Postgres. Event and property definitions are still written, so the taxonomy stays complete
+    // except for the per-event property association this table provides.
+    #[envconfig(from = "SKIP_EVENTPROPERTY_WRITES", default = "false")]
+    pub skip_eventproperty_writes: bool,
+
     #[envconfig(default = "100")]
     pub write_batch_size: usize,
 

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -8,7 +8,7 @@ use metrics_consts::{
     BATCH_ACQUIRE_TIME, CACHE_FILL_RATIO, CACHE_LEN, COMPACTED_UPDATES, DUPLICATES_IN_BATCH,
     EMPTY_EVENTS, EVENTS_RECEIVED, EVENT_PARSE_ERROR, FORCED_SMALL_BATCH, OFFSET_STORE_FAILURES,
     RECV_DEQUEUED, SKIPPED_DUE_TO_TEAM_FILTER, UPDATES_FILTERED_BY_CACHE, UPDATES_PER_EVENT,
-    UPDATES_SEEN, WORKER_BLOCKED,
+    UPDATES_SEEN, UPDATES_SKIPPED, WORKER_BLOCKED,
 };
 use types::{Event, Update};
 
@@ -32,6 +32,21 @@ pub mod metrics_buckets;
 pub mod metrics_consts;
 pub mod types;
 pub mod update_cache;
+
+/// Remove `Update::EventProperty` entries in place, counting each as a skipped update. Used when
+/// `SKIP_EVENTPROPERTY_WRITES` is set, before the updates reach the dedup cache.
+pub fn drop_eventproperty_updates(updates: &mut Vec<Update>) {
+    let before = updates.len();
+    updates.retain(|update| !matches!(update, Update::EventProperty(_)));
+    let dropped = (before - updates.len()) as u64;
+    if dropped > 0 {
+        metrics::counter!(
+            UPDATES_SKIPPED,
+            &[("reason", "eventproperty_writes_disabled")]
+        )
+        .increment(dropped);
+    }
+}
 
 pub async fn update_consumer_loop(
     config: Config,
@@ -213,10 +228,13 @@ pub async fn update_producer_loop(
                 continue;
             }
 
-            let updates = event.into_updates_with(
+            let mut updates = event.into_updates_with(
                 config.update_count_skip_threshold,
                 config.eventdef_last_seen_floor_secs,
             );
+            if config.skip_eventproperty_writes {
+                drop_eventproperty_updates(&mut updates);
+            }
 
             metrics::counter!(EVENTS_RECEIVED).increment(1);
             metrics::counter!(UPDATES_SEEN).increment(updates.len() as u64);

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use property_defs_rs::drop_eventproperty_updates;
 use property_defs_rs::types::{
     detect_property_type, floor_last_seen, last_seen_jitter_seed, Event, PropertyValueType, Update,
     DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS, MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS,
@@ -914,4 +915,46 @@ fn test_feature_flag_properties_skip_event_property_but_keep_property_definition
         prop_def_names.contains(&flagged_key),
         "expected PropertyDefinition for '{flagged_key}': {prop_def_names:?}"
     );
+}
+
+// The kill switch must remove every posthog_eventproperty write and nothing else, so the taxonomy
+// keeps receiving event and property definitions while the table stays untouched.
+#[test]
+fn test_drop_eventproperty_updates_keeps_definitions() {
+    let mut props_map = Map::new();
+    props_map.insert("page".to_string(), json!("/home"));
+    props_map.insert("$browser".to_string(), json!("Chrome"));
+    props_map.insert("$set".to_string(), json!({"plan": "free"}));
+
+    let event = Event {
+        team_id: 1,
+        project_id: 1,
+        event: "$pageview".to_string(),
+        properties: Some(Value::Object(props_map).to_string()),
+    };
+
+    let mut updates = event.into_updates(1000);
+    let event_properties_before = updates
+        .iter()
+        .filter(|u| matches!(u, Update::EventProperty(_)))
+        .count();
+    let definitions_before: Vec<Update> = updates
+        .iter()
+        .filter(|u| !matches!(u, Update::EventProperty(_)))
+        .cloned()
+        .collect();
+    assert_eq!(
+        event_properties_before, 2,
+        "page and $browser are event properties"
+    );
+
+    drop_eventproperty_updates(&mut updates);
+
+    assert!(
+        !updates
+            .iter()
+            .any(|u| matches!(u, Update::EventProperty(_))),
+        "event property updates survived the kill switch: {updates:?}"
+    );
+    assert_eq!(updates, definitions_before);
 }


### PR DESCRIPTION
## Problem

- Operators have no way to stop `property-defs-rs` from writing `posthog_eventproperty` without also stopping event and property definitions (`FILTERED_TEAMS`) or scaling the service to zero.
- That table is the largest on the Cloud primaries and its insert is the heaviest single write workload there. During cleanup or an incident, pausing only those writes is the lever that removes the load while the taxonomy keeps updating.

## Changes

- New env flag `SKIP_EVENTPROPERTY_WRITES` (default `false`). When set, `Update::EventProperty` entries are dropped before they reach the dedup cache or Postgres. Event and property definitions are unchanged.
- Dropped updates are counted under `prop_defs_skipped_updates{reason="eventproperty_writes_disabled"}` so the effect is visible on the propdefs dashboard.
- With the flag on, the taxonomy stops learning which properties appear on which event. Filters and pickers keep every property but lose the per-event ordering until the flag is cleared and the pairs are seen again.

> [!NOTE]
> No behavior change unless the flag is set. Charts do not set it; this PR only adds the lever.

## How did you test this code?

- `rust/property-defs-rs/tests/types.rs::test_drop_eventproperty_updates_keeps_definitions`: an event with event properties and `$set` person properties loses exactly its `EventProperty` updates and keeps every definition. Catches a filter that drops too much or too little.
- `cargo test -p property-defs-rs --test types`, `cargo clippy -p property-defs-rs --all-targets -- -D warnings`, `cargo fmt --check`.
- Not run: the Kafka-backed producer loop tests; the flag is read in the same loop that already applies `FILTER_MODE`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Fable 5). Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.
- Companion to #90631 (the `posthog_eventproperty` cleanup job). Filtering happens in the producer loop rather than inside `into_updates` so the pure event-to-updates conversion and its tests stay unchanged.
