### PR TITLE
feat(tasks): add space auto-archive policies

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -118,6 +118,7 @@ from products.tasks.backend.facade.tasks import (
     reconcile_loop_trigger_schedules_task,
     refresh_dev_stack_image_task,
     refresh_stale_sandbox_custom_images_task,
+    sweep_inactive_tasks_task,
     sweep_loop_task_retention_task,
 )
 from products.warehouse_sources.backend.facade.tasks import sweep_stopped_schema_syncs
@@ -350,6 +351,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="4", minute="30"),
         sweep_loop_task_retention_task.s(),
         name="sweep loop task retention",
+    )
+
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(minute="15"),
+        sweep_inactive_tasks_task.s(),
+        name="archive inactive tasks",
     )
 
     # Loop trigger schedule reconciliation - every 10 minutes, re-syncs schedules

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
+                  ([e__person.properties___fish] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,6 +44,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -111,7 +121,17 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -168,8 +188,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -178,6 +198,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -294,7 +324,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -326,7 +373,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([e__person.properties___fish] AS value) AS prop_basic,
+                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,16 +44,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -121,17 +111,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -188,8 +168,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -198,16 +178,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -324,24 +294,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -373,24 +326,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/tasks/backend/access.py
+++ b/products/tasks/backend/access.py
@@ -1,6 +1,8 @@
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
+from django.conf import settings
+
 from posthog.cloud_utils import get_cached_instance_license
 from posthog.models.user import User
 from posthog.ph_client import feature_enabled_or_false, get_feature_flag_or_none
@@ -54,6 +56,10 @@ def _get_funding_status(user: User, organization: "Organization") -> Organizatio
 def get_desktop_access_decision(user: User, organization: "Organization") -> DesktopAccessDecision:
     if not user or not user.is_authenticated or not user.distinct_id:
         raise DesktopAccessResolutionError("Authentication is required to evaluate Desktop access")
+
+    if settings.DEBUG:
+        observe_desktop_access_decision(outcome="override")
+        return DesktopAccessDecision.ALLOWED
 
     organization_id = str(organization.id)
     groups = {"organization": organization_id}

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -165,6 +165,13 @@ WIZARD_CLOUD_RUN_RUNTIME_ADAPTER = "claude"
 WIZARD_CLOUD_RUN_MODEL = "claude-sonnet-5"
 WIZARD_CLOUD_RUN_AI_STAGE = "wizard_pr_agent"
 
+
+class _AutoArchiveUnchanged:
+    pass
+
+
+_AUTO_ARCHIVE_UNCHANGED = _AutoArchiveUnchanged()
+
 __all__ = [
     "SandboxNetworkAccessLevel",
     "SandboxSnapshotStatus",
@@ -7417,6 +7424,7 @@ def _channel_to_dto(channel: Channel, *, starred: bool = False) -> contracts.Cha
         system_role=channel.system_role,
         github_integration=channel.github_integration_id,
         repositories=channel.repositories,
+        auto_archive_after_days=channel.auto_archive_after_days,
         created_at=channel.created_at,
         created_by=_user_basic_info(channel.created_by if channel.created_by_id else None),
         starred=starred,
@@ -7648,6 +7656,7 @@ def update_channel(
     name: str | None = None,
     github_integration: Integration | None = None,
     repositories: list[str] | None = None,
+    auto_archive_after_days: int | None | _AutoArchiveUnchanged = _AUTO_ARCHIVE_UNCHANGED,
 ) -> contracts.ChannelDTO | str:
     """Update a visible channel."""
     channel = Channel.objects.filter(id=channel_id, team_id=team_id, deleted=False).first()
@@ -7671,6 +7680,9 @@ def update_channel(
         channel.repositories = repositories
         channel.github_integration = github_integration if repositories else None
         update_fields.extend(["repositories", "github_integration"])
+    if not isinstance(auto_archive_after_days, _AutoArchiveUnchanged):
+        channel.auto_archive_after_days = auto_archive_after_days
+        update_fields.append("auto_archive_after_days")
     if not update_fields:
         return _channel_to_dto(channel)
     try:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -7653,6 +7653,7 @@ def update_channel(
     team_id: int,
     user_id: int | None,
     *,
+    can_manage_shared_auto_archive: bool,
     name: str | None = None,
     github_integration: Integration | None = None,
     repositories: list[str] | None = None,
@@ -7667,6 +7668,11 @@ def update_channel(
             return "not_found"
         if name is not None:
             return "personal"
+    elif (
+        not isinstance(auto_archive_after_days, _AutoArchiveUnchanged)
+        and not can_manage_shared_auto_archive
+    ):
+        return "auto_archive_forbidden"
     if name is not None and _is_general_channel(channel):
         return "general"
     update_fields: list[str] = []

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -7668,10 +7668,7 @@ def update_channel(
             return "not_found"
         if name is not None:
             return "personal"
-    elif (
-        not isinstance(auto_archive_after_days, _AutoArchiveUnchanged)
-        and not can_manage_shared_auto_archive
-    ):
+    elif not isinstance(auto_archive_after_days, _AutoArchiveUnchanged) and not can_manage_shared_auto_archive:
         return "auto_archive_forbidden"
     if name is not None and _is_general_channel(channel):
         return "general"

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -211,6 +211,7 @@ class ChannelDTO:
     channel_type: str
     github_integration: int | None
     repositories: list[str]
+    auto_archive_after_days: int | None
     created_at: datetime
     created_by: "TaskUserBasicInfo | None" = None
     starred: bool = False

--- a/products/tasks/backend/facade/tasks.py
+++ b/products/tasks/backend/facade/tasks.py
@@ -10,8 +10,9 @@ from celery import shared_task
 
 from products.tasks.backend.loop_reconciliation import reconcile_loop_trigger_schedules_task
 from products.tasks.backend.loop_retention import sweep_loop_task_retention_task
+from products.tasks.backend.task_auto_archive import sweep_inactive_tasks_task
 
-__all__ = ["reconcile_loop_trigger_schedules_task", "sweep_loop_task_retention_task"]
+__all__ = ["reconcile_loop_trigger_schedules_task", "sweep_inactive_tasks_task", "sweep_loop_task_retention_task"]
 
 logger = logging.getLogger(__name__)
 

--- a/products/tasks/backend/migrations/0108_channel_auto_archive_after_days.py
+++ b/products/tasks/backend/migrations/0108_channel_auto_archive_after_days.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("tasks", "0107_remove_code_invites_from_state")]
+
+    operations = [
+        migrations.AddField(
+            model_name="channel",
+            name="auto_archive_after_days",
+            field=models.PositiveSmallIntegerField(
+                blank=True,
+                choices=[(1, "1 day"), (3, "3 days"), (7, "7 days"), (14, "14 days"), (30, "30 days")],
+                help_text=(
+                    "Archive inactive tasks in this channel after this many days. Null disables automatic archiving."
+                ),
+                null=True,
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/0108_channel_auto_archive_after_days.py
+++ b/products/tasks/backend/migrations/0108_channel_auto_archive_after_days.py
@@ -10,7 +10,6 @@ class Migration(migrations.Migration):
             name="auto_archive_after_days",
             field=models.PositiveSmallIntegerField(
                 blank=True,
-                choices=[(1, "1 day"), (3, "3 days"), (7, "7 days"), (14, "14 days"), (30, "30 days")],
                 help_text=(
                     "Archive inactive tasks in this channel after this many days. Null disables automatic archiving."
                 ),

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0107_remove_code_invites_from_state
+0108_channel_auto_archive_after_days

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -178,6 +178,13 @@ class Channel(TeamScopedRootMixin):
     PERSONAL_CHANNEL_LABEL = "personal"
     GENERAL_CHANNEL_NAME = "general"
 
+    class AutoArchiveAfterDays(models.IntegerChoices):
+        ONE_DAY = 1, "1 day"
+        THREE_DAYS = 3, "3 days"
+        SEVEN_DAYS = 7, "7 days"
+        FOURTEEN_DAYS = 14, "14 days"
+        THIRTY_DAYS = 30, "30 days"
+
     @classmethod
     def visible_to_q(cls, user_id: int | None, *, relation: Literal["", "channel", "task__channel"] = "") -> models.Q:
         """The channel-visibility rule as a queryset filter: a personal channel is
@@ -225,6 +232,12 @@ class Channel(TeamScopedRootMixin):
         db_default=[],
         blank=True,
         help_text="GitHub repositories inherited by new tasks in this channel",
+    )
+    auto_archive_after_days = models.PositiveSmallIntegerField(
+        choices=AutoArchiveAfterDays.choices,
+        null=True,
+        blank=True,
+        help_text="Archive inactive tasks in this channel after this many days. Null disables automatic archiving.",
     )
     deleted = models.BooleanField(default=False)
     created_at = models.DateTimeField(default=django_timezone.now)

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -178,13 +178,6 @@ class Channel(TeamScopedRootMixin):
     PERSONAL_CHANNEL_LABEL = "personal"
     GENERAL_CHANNEL_NAME = "general"
 
-    class AutoArchiveAfterDays(models.IntegerChoices):
-        ONE_DAY = 1, "1 day"
-        THREE_DAYS = 3, "3 days"
-        SEVEN_DAYS = 7, "7 days"
-        FOURTEEN_DAYS = 14, "14 days"
-        THIRTY_DAYS = 30, "30 days"
-
     @classmethod
     def visible_to_q(cls, user_id: int | None, *, relation: Literal["", "channel", "task__channel"] = "") -> models.Q:
         """The channel-visibility rule as a queryset filter: a personal channel is
@@ -234,7 +227,6 @@ class Channel(TeamScopedRootMixin):
         help_text="GitHub repositories inherited by new tasks in this channel",
     )
     auto_archive_after_days = models.PositiveSmallIntegerField(
-        choices=AutoArchiveAfterDays.choices,
         null=True,
         blank=True,
         help_text="Archive inactive tasks in this channel after this many days. Null disables automatic archiving.",

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2031,6 +2031,7 @@ class ChannelSerializer(DataclassSerializer):
             "channel_type",
             "github_integration",
             "repositories",
+            "auto_archive_after_days",
             "created_at",
             "created_by",
             "starred",
@@ -2155,10 +2156,20 @@ class ChannelUpdateSerializer(serializers.Serializer):
         max_length=10,
         help_text="GitHub repositories inherited by new tasks in this channel.",
     )
+    auto_archive_after_days = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="Days of inactivity before tasks in this channel are archived. Allowed values: 1, 3, 7, 14, or 30. Null disables automatic archiving.",
+    )
 
     def validate_name(self, value: str) -> str:
         if tasks_facade.is_reserved_channel_name(value):
             raise serializers.ValidationError("That name is reserved for a default space. Pick another name.")
+        return value
+
+    def validate_auto_archive_after_days(self, value: int | None) -> int | None:
+        if value is not None and value not in tasks_facade.Channel.AutoArchiveAfterDays.values:
+            raise serializers.ValidationError("Must be one of 1, 3, 7, 14, or 30.")
         return value
 
     def validate_github_integration(self, value):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2159,17 +2159,14 @@ class ChannelUpdateSerializer(serializers.Serializer):
     auto_archive_after_days = serializers.IntegerField(
         required=False,
         allow_null=True,
-        help_text="Days of inactivity before tasks in this channel are archived. Allowed values: 1, 3, 7, 14, or 30. Null disables automatic archiving.",
+        min_value=1,
+        max_value=365,
+        help_text="Days of inactivity before tasks in this channel are archived. Accepts 1 through 365. Null disables automatic archiving.",
     )
 
     def validate_name(self, value: str) -> str:
         if tasks_facade.is_reserved_channel_name(value):
             raise serializers.ValidationError("That name is reserved for a default space. Pick another name.")
-        return value
-
-    def validate_auto_archive_after_days(self, value: int | None) -> int | None:
-        if value is not None and value not in tasks_facade.Channel.AutoArchiveAfterDays.values:
-            raise serializers.ValidationError("Must be one of 1, 3, 7, 14, or 30.")
         return value
 
     def validate_github_integration(self, value):

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -14,6 +14,7 @@ from rest_framework.response import Response
 from posthog.api.mixins import validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.auth import OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.models import OrganizationMembership
 from posthog.models.user import User
 from posthog.permissions import APIScopePermission
 
@@ -244,13 +245,24 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def partial_update(self, request, pk=None, **kwargs):
         serializer = ChannelUpdateSerializer(data=request.data, context={"team_id": self.team_id}, partial=True)
         serializer.is_valid(raise_exception=True)
-        result = tasks_facade.update_channel(pk, self.team_id, self._user_id(), **serializer.validated_data)
+        membership_level = self.user_permissions.current_team.effective_membership_level
+        result = tasks_facade.update_channel(
+            pk,
+            self.team_id,
+            self._user_id(),
+            can_manage_shared_auto_archive=(
+                membership_level is not None and membership_level >= OrganizationMembership.Level.ADMIN
+            ),
+            **serializer.validated_data,
+        )
         if result == "not_found":
             raise NotFound()
         if result == "personal":
             raise PermissionDenied("Personal channels cannot be renamed")
         if result == "general":
             raise PermissionDenied("The general space can't be renamed")
+        if result == "auto_archive_forbidden":
+            raise PermissionDenied("Only project admins can change automatic archiving for shared spaces")
         if result == "invalid_name":
             return Response({"detail": "Invalid channel name"}, status=status.HTTP_400_BAD_REQUEST)
         if result == "name_taken":

--- a/products/tasks/backend/task_auto_archive.py
+++ b/products/tasks/backend/task_auto_archive.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from django.db import OperationalError, ProgrammingError
+from django.db.models import Exists, OuterRef, QuerySet
+from django.utils import timezone as django_timezone
+
+import structlog
+import psycopg.errors
+from celery import shared_task
+from celery.exceptions import SoftTimeLimitExceeded
+
+from posthog.exceptions_capture import capture_exception
+from posthog.scoping_audit import skip_team_scope_audit
+
+from products.tasks.backend.models import Channel, Task, TaskPin, TaskPresence, TaskRun
+
+logger = structlog.get_logger(__name__)
+
+AUTO_ARCHIVE_SWEEP_LIMIT = 5_000
+_NON_TERMINAL_RUN_STATUSES = (
+    TaskRun.Status.NOT_STARTED,
+    TaskRun.Status.QUEUED,
+    TaskRun.Status.IN_PROGRESS,
+)
+
+
+def _archivable_tasks(*, channel_id: UUID, team_id: int, cutoff: datetime, now: datetime) -> QuerySet[Task]:
+    active_run = TaskRun.objects.filter(  # nosemgrep: celery-task-team-scope-audit
+        task_id=OuterRef("pk"), status__in=_NON_TERMINAL_RUN_STATUSES
+    )
+    pin = TaskPin.objects.filter(task_id=OuterRef("pk"))
+    active_presence = TaskPresence.objects.unscoped().filter(
+        task_id=OuterRef("pk"), team_id=team_id, expires_at__gt=now
+    )
+    return (
+        Task.objects.filter(  # nosemgrep: celery-task-team-scope-audit
+            channel_id=channel_id,
+            team_id=team_id,
+            archived=False,
+            deleted=False,
+            internal=False,
+            last_activity_at__lt=cutoff,
+        )
+        .filter(~Exists(active_run))
+        .filter(~Exists(pin))
+        .filter(~Exists(active_presence))
+    )
+
+
+def sweep_inactive_tasks(*, at: datetime | None = None, limit: int = AUTO_ARCHIVE_SWEEP_LIMIT) -> int:
+    now = at or django_timezone.now()
+    archived_count = 0
+    policies = (
+        Channel.objects.unscoped()
+        .filter(deleted=False, auto_archive_after_days__isnull=False)
+        .values_list("id", "team_id", "auto_archive_after_days")
+        .iterator(chunk_size=500)
+    )
+
+    for channel_id, team_id, inactivity_days in policies:
+        if inactivity_days is None:
+            continue
+        remaining = limit - archived_count
+        if remaining <= 0:
+            break
+        cutoff = now - timedelta(days=inactivity_days)
+        task_ids = list(
+            _archivable_tasks(channel_id=channel_id, team_id=team_id, cutoff=cutoff, now=now)
+            .order_by("last_activity_at")
+            .values_list("id", flat=True)[:remaining]
+        )
+        if not task_ids:
+            continue
+        archived_count += (
+            _archivable_tasks(channel_id=channel_id, team_id=team_id, cutoff=cutoff, now=now)
+            .filter(id__in=task_ids)
+            .update(archived=True, archived_at=now)
+        )
+
+    return archived_count
+
+
+@shared_task(ignore_result=True, soft_time_limit=110, time_limit=170)
+@skip_team_scope_audit
+def sweep_inactive_tasks_task() -> None:
+    try:
+        archived_count = sweep_inactive_tasks()
+    except SoftTimeLimitExceeded:
+        raise
+    except ProgrammingError as exc:
+        if isinstance(exc.__cause__, psycopg.errors.UndefinedTable | psycopg.errors.UndefinedColumn):
+            logger.debug("task_auto_archive.sweep_missing_schema", exception=exc)
+            return
+        capture_exception(exc)
+        logger.exception("task_auto_archive.sweep_failed")
+        return
+    except OperationalError as exc:
+        logger.warning("task_auto_archive.sweep_transient_db_error", error=str(exc))
+        return
+    except Exception as exc:
+        capture_exception(exc)
+        logger.exception("task_auto_archive.sweep_failed")
+        return
+    logger.info("task_auto_archive.swept", archived_count=archived_count)

--- a/products/tasks/backend/task_auto_archive.py
+++ b/products/tasks/backend/task_auto_archive.py
@@ -27,12 +27,13 @@ _NON_TERMINAL_RUN_STATUSES = (
 
 def _archivable_tasks(*, channel_id: UUID, team_id: int, cutoff: datetime, now: datetime) -> QuerySet[Task]:
     active_run = TaskRun.objects.filter(  # nosemgrep: celery-task-team-scope-audit
-        task_id=OuterRef("pk"), status__in=_NON_TERMINAL_RUN_STATUSES
+        task_id=OuterRef("pk"), team_id=team_id, status__in=_NON_TERMINAL_RUN_STATUSES
     )
-    pin = TaskPin.objects.filter(task_id=OuterRef("pk"))
-    active_presence = TaskPresence.objects.unscoped().filter(
-        task_id=OuterRef("pk"), team_id=team_id, expires_at__gt=now
+    pin = TaskPin.objects.filter(
+        task_id=OuterRef("pk"),
+        task__team_id=team_id,
     )
+    active_presence = TaskPresence.objects.for_team(team_id).filter(task_id=OuterRef("pk"), expires_at__gt=now)
     return (
         Task.objects.filter(  # nosemgrep: celery-task-team-scope-audit
             channel_id=channel_id,

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -405,6 +405,32 @@ class ChannelsAPITestCase(TestCase):
         self.assertEqual(renamed.status_code, status.HTTP_200_OK, renamed.content)
         self.assertEqual(Channel.objects.unscoped().get(id=channel_id).name, "renamed")
 
+    def test_project_member_can_configure_shared_space_auto_archive(self):
+        channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
+        other_client = APIClient()
+        other_client.force_authenticate(self.other_user)
+
+        configured = other_client.patch(
+            f"{self._channels_url()}{channel_id}/", {"auto_archive_after_days": 7}, format="json"
+        )
+
+        self.assertEqual(configured.status_code, status.HTTP_200_OK, configured.content)
+        self.assertEqual(configured.json()["auto_archive_after_days"], 7)
+        listed = self.client.get(self._channels_url())
+        self.assertEqual(listed.json()[0]["auto_archive_after_days"], 7)
+
+        invalid = self.client.patch(
+            f"{self._channels_url()}{channel_id}/", {"auto_archive_after_days": 2}, format="json"
+        )
+        self.assertEqual(invalid.status_code, status.HTTP_400_BAD_REQUEST, invalid.content)
+        self.assertEqual(Channel.objects.unscoped().get(id=channel_id).auto_archive_after_days, 7)
+
+        disabled = self.client.patch(
+            f"{self._channels_url()}{channel_id}/", {"auto_archive_after_days": None}, format="json"
+        )
+        self.assertEqual(disabled.status_code, status.HTTP_200_OK, disabled.content)
+        self.assertIsNone(disabled.json()["auto_archive_after_days"])
+
     def test_public_channel_task_is_readable_but_not_controllable_by_teammates(self):
         channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
         created = self.client.post(

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -405,7 +405,7 @@ class ChannelsAPITestCase(TestCase):
         self.assertEqual(renamed.status_code, status.HTTP_200_OK, renamed.content)
         self.assertEqual(Channel.objects.unscoped().get(id=channel_id).name, "renamed")
 
-    def test_project_member_can_configure_shared_space_auto_archive(self):
+    def test_project_admin_can_configure_shared_space_auto_archive(self):
         channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
         other_client = APIClient()
         other_client.force_authenticate(self.other_user)
@@ -433,6 +433,31 @@ class ChannelsAPITestCase(TestCase):
         )
         self.assertEqual(disabled.status_code, status.HTTP_200_OK, disabled.content)
         self.assertIsNone(disabled.json()["auto_archive_after_days"])
+
+    def test_project_member_can_only_configure_their_personal_space_auto_archive(self):
+        OrganizationMembership.objects.filter(user=self.other_user, organization=self.organization).update(
+            level=OrganizationMembership.Level.MEMBER
+        )
+        shared_channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
+        other_client = APIClient()
+        other_client.force_authenticate(self.other_user)
+        personal_channel_id = next(
+            channel["id"]
+            for channel in self._provision(other_client)["channels"]
+            if channel["channel_type"] == "personal"
+        )
+
+        shared = other_client.patch(
+            f"{self._channels_url()}{shared_channel_id}/", {"auto_archive_after_days": 1}, format="json"
+        )
+        personal = other_client.patch(
+            f"{self._channels_url()}{personal_channel_id}/", {"auto_archive_after_days": 1}, format="json"
+        )
+
+        self.assertEqual(shared.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(personal.status_code, status.HTTP_200_OK, personal.content)
+        self.assertIsNone(Channel.objects.unscoped().get(id=shared_channel_id).auto_archive_after_days)
+        self.assertEqual(personal.json()["auto_archive_after_days"], 1)
 
     def test_public_channel_task_is_readable_but_not_controllable_by_teammates(self):
         channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -411,19 +411,22 @@ class ChannelsAPITestCase(TestCase):
         other_client.force_authenticate(self.other_user)
 
         configured = other_client.patch(
-            f"{self._channels_url()}{channel_id}/", {"auto_archive_after_days": 7}, format="json"
+            f"{self._channels_url()}{channel_id}/", {"auto_archive_after_days": 45}, format="json"
         )
 
         self.assertEqual(configured.status_code, status.HTTP_200_OK, configured.content)
-        self.assertEqual(configured.json()["auto_archive_after_days"], 7)
+        self.assertEqual(configured.json()["auto_archive_after_days"], 45)
         listed = self.client.get(self._channels_url())
-        self.assertEqual(listed.json()[0]["auto_archive_after_days"], 7)
+        self.assertEqual(listed.json()[0]["auto_archive_after_days"], 45)
 
-        invalid = self.client.patch(
-            f"{self._channels_url()}{channel_id}/", {"auto_archive_after_days": 2}, format="json"
-        )
-        self.assertEqual(invalid.status_code, status.HTTP_400_BAD_REQUEST, invalid.content)
-        self.assertEqual(Channel.objects.unscoped().get(id=channel_id).auto_archive_after_days, 7)
+        for invalid_days in (0, 366):
+            invalid = self.client.patch(
+                f"{self._channels_url()}{channel_id}/",
+                {"auto_archive_after_days": invalid_days},
+                format="json",
+            )
+            self.assertEqual(invalid.status_code, status.HTTP_400_BAD_REQUEST, invalid.content)
+        self.assertEqual(Channel.objects.unscoped().get(id=channel_id).auto_archive_after_days, 45)
 
         disabled = self.client.patch(
             f"{self._channels_url()}{channel_id}/", {"auto_archive_after_days": None}, format="json"

--- a/products/tasks/backend/tests/test_desktop_access.py
+++ b/products/tasks/backend/tests/test_desktop_access.py
@@ -2,6 +2,7 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
+from django.test import override_settings
 
 from parameterized import parameterized
 from rest_framework import status
@@ -29,6 +30,15 @@ class TestDesktopAccessPolicy(APIBaseTest):
     def tearDown(self) -> None:
         self.feature_flag_patcher.stop()
         super().tearDown()
+
+    @override_settings(DEBUG=True)
+    @patch("products.tasks.backend.access._get_funding_status")
+    def test_debug_mode_allows_access_without_external_resolution(self, mock_funding) -> None:
+        decision = get_desktop_access_decision(self.user, self.organization)
+
+        self.assertTrue(decision.allowed)
+        self.mock_feature_flag.assert_not_called()
+        mock_funding.assert_not_called()
 
     @parameterized.expand(
         [

--- a/products/tasks/backend/tests/test_task_auto_archive.py
+++ b/products/tasks/backend/tests/test_task_auto_archive.py
@@ -1,0 +1,101 @@
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone as django_timezone
+
+from posthog.models import Organization, Team, User, UserPushToken
+
+from products.tasks.backend.models import Channel, Task, TaskPin, TaskPresence, TaskRun
+from products.tasks.backend.task_auto_archive import sweep_inactive_tasks
+
+
+class TestTaskAutoArchive(TestCase):
+    def setUp(self) -> None:
+        organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=organization, name="Test Team")
+        self.user = User.objects.create_user(email="author@example.com", first_name="Author", password="password")
+        self.now = django_timezone.now()
+
+    def _channel(self, *, name: str, inactivity_days: int | None) -> Channel:
+        return Channel.objects.for_team(self.team.id).create(
+            team_id=self.team.id,
+            created_by=self.user,
+            name=name,
+            auto_archive_after_days=inactivity_days,
+        )
+
+    def _task(self, *, channel: Channel, age_days: int) -> Task:
+        task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            channel=channel,
+            title="Test task",
+            description="Test description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        Task.objects.filter(id=task.id).update(last_activity_at=self.now - timedelta(days=age_days))
+        task.refresh_from_db()
+        return task
+
+    def test_sweep_uses_each_space_threshold(self) -> None:
+        enabled = self._channel(name="enabled", inactivity_days=3)
+        disabled = self._channel(name="disabled", inactivity_days=None)
+        stale = self._task(channel=enabled, age_days=4)
+        recent = self._task(channel=enabled, age_days=2)
+        disabled_stale = self._task(channel=disabled, age_days=30)
+
+        self.assertEqual(sweep_inactive_tasks(at=self.now), 1)
+
+        stale.refresh_from_db()
+        recent.refresh_from_db()
+        disabled_stale.refresh_from_db()
+        self.assertTrue(stale.archived)
+        self.assertEqual(stale.archived_at, self.now)
+        self.assertFalse(recent.archived)
+        self.assertFalse(disabled_stale.archived)
+
+    def test_sweep_keeps_active_and_pinned_tasks(self) -> None:
+        channel = self._channel(name="protected", inactivity_days=1)
+        active = self._task(channel=channel, age_days=3)
+        pinned = self._task(channel=channel, age_days=3)
+        TaskRun.objects.create(task=active, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+        Task.objects.filter(id=active.id).update(last_activity_at=self.now - timedelta(days=3))
+        TaskPin.objects.create(user=self.user, task=pinned)
+
+        self.assertEqual(sweep_inactive_tasks(at=self.now), 0)
+
+        active.refresh_from_db()
+        pinned.refresh_from_db()
+        self.assertFalse(active.archived)
+        self.assertFalse(pinned.archived)
+
+    def test_sweep_keeps_task_with_active_presence(self) -> None:
+        channel = self._channel(name="protected", inactivity_days=1)
+        viewed = self._task(channel=channel, age_days=3)
+        no_longer_viewed = self._task(channel=channel, age_days=3)
+        push_token = UserPushToken.objects.create(
+            user=self.user,
+            token="ExponentPushToken[auto-archive-test]",
+            platform=UserPushToken.Platform.IOS,
+        )
+        TaskPresence.objects.unscoped().create(
+            team=self.team,
+            task=viewed,
+            user=self.user,
+            push_token=push_token,
+            expires_at=self.now + timedelta(minutes=1),
+        )
+        TaskPresence.objects.unscoped().create(
+            team=self.team,
+            task=no_longer_viewed,
+            user=self.user,
+            push_token=push_token,
+            expires_at=self.now - timedelta(minutes=1),
+        )
+
+        self.assertEqual(sweep_inactive_tasks(at=self.now), 1)
+
+        viewed.refresh_from_db()
+        no_longer_viewed.refresh_from_db()
+        self.assertFalse(viewed.archived)
+        self.assertTrue(no_longer_viewed.archived)

--- a/products/tasks/backend/tests/test_task_auto_archive.py
+++ b/products/tasks/backend/tests/test_task_auto_archive.py
@@ -99,3 +99,26 @@ class TestTaskAutoArchive(TestCase):
         no_longer_viewed.refresh_from_db()
         self.assertFalse(viewed.archived)
         self.assertTrue(no_longer_viewed.archived)
+
+    def test_sweep_scopes_protection_checks_to_the_task_team(self) -> None:
+        other_team = Team.objects.create(organization=self.team.organization, name="Other Team")
+        channel = self._channel(name="scoped", inactivity_days=1)
+        stale = self._task(channel=channel, age_days=3)
+        push_token = UserPushToken.objects.create(
+            user=self.user,
+            token="ExponentPushToken[other-team-auto-archive-test]",
+            platform=UserPushToken.Platform.IOS,
+        )
+        TaskRun.objects.create(task=stale, team=other_team, status=TaskRun.Status.IN_PROGRESS)
+        TaskPresence.objects.for_team(other_team.id).create(
+            team=other_team,
+            task=stale,
+            user=self.user,
+            push_token=push_token,
+            expires_at=self.now + timedelta(minutes=1),
+        )
+
+        self.assertEqual(sweep_inactive_tasks(at=self.now), 1)
+
+        stale.refresh_from_db()
+        self.assertTrue(stale.archived)

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1103,6 +1103,8 @@ export interface ChannelDTOApi {
     /** @nullable */
     github_integration: number | null
     repositories: string[]
+    /** @nullable */
+    auto_archive_after_days: number | null
     created_at: string
     created_by?: TaskUserBasicInfoApi | null
     starred?: boolean
@@ -1203,6 +1205,11 @@ export interface PatchedChannelUpdateApi {
      * @items.maxLength 255
      */
     repositories?: string[]
+    /**
+     * Days of inactivity before tasks in this channel are archived. Allowed values: 1, 3, 7, 14, or 30. Null disables automatic archiving.
+     * @nullable
+     */
+    auto_archive_after_days?: number | null
 }
 
 export interface ChannelDeleteConflictApi {

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1206,7 +1206,9 @@ export interface PatchedChannelUpdateApi {
      */
     repositories?: string[]
     /**
-     * Days of inactivity before tasks in this channel are archived. Allowed values: 1, 3, 7, 14, or 30. Null disables automatic archiving.
+     * Days of inactivity before tasks in this channel are archived. Accepts 1 through 365. Null disables automatic archiving.
+     * @minimum 1
+     * @maximum 365
      * @nullable
      */
     auto_archive_after_days?: number | null

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -968,6 +968,12 @@ export const TaskChannelsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .max(taskChannelsPartialUpdateBodyRepositoriesMax)
         .optional()
         .describe('GitHub repositories inherited by new tasks in this channel.'),
+    auto_archive_after_days: zod
+        .number()
+        .nullish()
+        .describe(
+            'Days of inactivity before tasks in this channel are archived. Allowed values: 1, 3, 7, 14, or 30. Null disables automatic archiving.'
+        ),
 })
 
 /**

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -953,6 +953,8 @@ export const taskChannelsPartialUpdateBodyRepositoriesItemMax = 255
 
 export const taskChannelsPartialUpdateBodyRepositoriesMax = 10
 
+export const taskChannelsPartialUpdateBodyAutoArchiveAfterDaysMax = 365
+
 export const TaskChannelsPartialUpdateBody = /* @__PURE__ */ zod.object({
     name: zod
         .string()
@@ -970,9 +972,11 @@ export const TaskChannelsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .describe('GitHub repositories inherited by new tasks in this channel.'),
     auto_archive_after_days: zod
         .number()
+        .min(1)
+        .max(taskChannelsPartialUpdateBodyAutoArchiveAfterDaysMax)
         .nullish()
         .describe(
-            'Days of inactivity before tasks in this channel are archived. Allowed values: 1, 3, 7, 14, or 30. Null disables automatic archiving.'
+            'Days of inactivity before tasks in this channel are archived. Accepts 1 through 365. Null disables automatic archiving.'
         ),
 })
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -60000,7 +60000,9 @@ export namespace Schemas {
          */
       repositories?: string[];
       /**
-         * Days of inactivity before tasks in this channel are archived. Allowed values: 1, 3, 7, 14, or 30. Null disables automatic archiving.
+         * Days of inactivity before tasks in this channel are archived. Accepts 1 through 365. Null disables automatic archiving.
+         * @minimum 1
+         * @maximum 365
          * @nullable
          */
       auto_archive_after_days?: number | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17064,6 +17064,8 @@ export namespace Schemas {
       /** @nullable */
       github_integration: number | null;
       repositories: string[];
+      /** @nullable */
+      auto_archive_after_days: number | null;
       created_at: string;
       created_by?: TaskUserBasicInfo | null;
       starred?: boolean;
@@ -59997,6 +59999,11 @@ export namespace Schemas {
          * @items.maxLength 255
          */
       repositories?: string[];
+      /**
+         * Days of inactivity before tasks in this channel are archived. Allowed values: 1, 3, 7, 14, or 30. Null disables automatic archiving.
+         * @nullable
+         */
+      auto_archive_after_days?: number | null;
     }
 
     export interface PatchedClusteringJob {


### PR DESCRIPTION
## Problem

Spaces cannot automatically clear inactive tasks, so old tasks remain visible until someone archives them manually.

**Why:** A server-side policy keeps cleanup consistent when Desktop is closed and across everyone in a shared space.

## Changes

- The channel API stores an optional inactivity threshold from 1 to 365 days.
- An hourly sweep archives inactive tasks after their space threshold passes.
- The sweep skips pinned, viewed, queued, and running tasks.
- Project admins manage shared-space policies; personal-space owners manage their own.
- Generated API clients expose the policy to the Desktop layer in [#91175](https://github.com/PostHog/posthog/pull/91175).

Before:

```mermaid
flowchart LR
A[Inactive task] --> B[Manual archive only]
classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
class A phYellow;
class B phGray;
```

After:

```mermaid
flowchart LR
A[Inactive task] --> B{Space policy}
B -->|Never| C[Keep active]
B -->|Threshold passed| D{Protected}
D -->|Yes| C
D -->|No| E[Archive]
classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
class B,D phBlue;
class A,E phYellow;
class C phGray;
```

No visible UI changes ship in this server layer.

## How did you test this code?

- Added coverage for custom thresholds and the accepted 1–365 day range.
- Regenerated the API contract with its numeric bounds.
- Added access-control coverage for shared and personal spaces.
- Database-backed tests were not run locally because PostgreSQL was unavailable; CI will validate them.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The dependent Desktop layer adds the user-facing documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and split this change using the `/posthog-desktop`, `/django-migrations`, `/improving-drf-endpoints`, `/writing-tests`, `/instrument-product-analytics`, `/debugging-ci-failures`, `/stacking-prs`, and `/writing-pr-descriptions` skills.

The CI release-order guard required separate server and Desktop layers.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

