### PR TITLE
fix(flags): resolve cohort conditions against membership in flag tester

### DIFF
--- a/rust/feature-flags/src/api/types.rs
+++ b/rust/feature-flags/src/api/types.rs
@@ -1,4 +1,6 @@
 use crate::api::errors::FlagError;
+use crate::cohorts::cohort_models::CohortId;
+use crate::cohorts::cohort_operations::apply_cohort_membership_logic;
 use crate::flags::flag_group_type_mapping::GroupTypeIndex;
 use crate::flags::flag_match_reason::FeatureFlagMatchReason;
 use crate::flags::flag_matching::FeatureFlagMatch;
@@ -481,6 +483,7 @@ pub struct FlagEvaluationReason {
 
 pub trait FromFeatureAndMatch {
     fn create(flag: &FeatureFlag, flag_match: &FeatureFlagMatch) -> Self;
+    #[allow(clippy::too_many_arguments)]
     fn create_with_analysis(
         flag: &FeatureFlag,
         flag_match: &FeatureFlagMatch,
@@ -488,6 +491,7 @@ pub trait FromFeatureAndMatch {
         property_values: Option<&HashMap<String, Value>>,
         group_property_values: Option<&HashMap<GroupTypeIndex, HashMap<String, Value>>>,
         flag_evaluation_results: Option<&HashMap<FeatureFlagId, FlagValue>>,
+        cohort_matches: Option<&HashMap<CohortId, bool>>,
         matching_context: PropertyMatchingContext,
     ) -> Self;
     fn create_error(flag: &FeatureFlag, error: &FlagError, condition_index: Option<i32>) -> Self;
@@ -504,6 +508,7 @@ impl FromFeatureAndMatch for FlagDetails {
             None,
             None,
             None,
+            None,
             PropertyMatchingContext::new(Tz::UTC, false),
         )
     }
@@ -515,6 +520,7 @@ impl FromFeatureAndMatch for FlagDetails {
         property_values: Option<&HashMap<String, Value>>,
         group_property_values: Option<&HashMap<GroupTypeIndex, HashMap<String, Value>>>,
         flag_evaluation_results: Option<&HashMap<FeatureFlagId, FlagValue>>,
+        cohort_matches: Option<&HashMap<CohortId, bool>>,
         matching_context: PropertyMatchingContext,
     ) -> Self {
         FlagDetails {
@@ -541,6 +547,7 @@ impl FromFeatureAndMatch for FlagDetails {
                     property_values,
                     group_property_values,
                     flag_evaluation_results,
+                    cohort_matches,
                     matching_context,
                 ))
             } else {
@@ -609,6 +616,7 @@ impl FlagDetails {
         property_values: Option<&HashMap<String, Value>>,
         group_property_values: Option<&HashMap<GroupTypeIndex, HashMap<String, Value>>>,
         flag_evaluation_results: Option<&HashMap<FeatureFlagId, FlagValue>>,
+        cohort_matches: Option<&HashMap<CohortId, bool>>,
         matching_context: PropertyMatchingContext,
     ) -> Vec<ConditionAnalysis> {
         let mut analyses = Vec::new();
@@ -685,6 +693,47 @@ impl FlagDetails {
                             key: property.key.clone(),
                             operator: operator_str,
                             value: expected,
+                            r#type: type_str,
+                            actual_value: None,
+                            matched: property_matched,
+                            explanation,
+                        });
+                        continue;
+                    }
+
+                    // Cohort filters resolve against cohort membership, not against person
+                    // properties. match_property() cannot evaluate them: In/NotIn returns Err,
+                    // and Exact looks up a person property named `id`. Both make every cohort
+                    // filter report matched=false, which contradicts the condition-level outcome
+                    // the matcher computed. Resolve them against the membership results instead,
+                    // through the same helper the matcher uses, so this explanation cannot drift
+                    // from the outcome it explains.
+                    if property.is_cohort() {
+                        let empty = HashMap::new();
+                        let matches = cohort_matches.unwrap_or(&empty);
+                        let property_matched =
+                            apply_cohort_membership_logic(std::slice::from_ref(property), matches)
+                                .unwrap_or(false);
+                        let cohort_id = property.get_cohort_id();
+                        let cohort_label = match cohort_id {
+                            Some(id) => format!("cohort {id}"),
+                            None => "the targeted cohort".to_string(),
+                        };
+                        // State the membership rather than the verdict. The frontend renders this
+                        // line with no pass/fail marker, so on a `not in` filter "did not match"
+                        // alone would leave the reader guessing which way membership went.
+                        let is_member = cohort_id
+                            .and_then(|id| matches.get(&id).copied())
+                            .unwrap_or(false);
+                        let explanation = if is_member {
+                            format!("Person is in {cohort_label}")
+                        } else {
+                            format!("Person is not in {cohort_label}")
+                        };
+                        property_analyses.push(PropertyAnalysis {
+                            key: property.key.clone(),
+                            operator: operator_str,
+                            value: property.value.clone().unwrap_or(Value::Null),
                             r#type: type_str,
                             actual_value: None,
                             matched: property_matched,
@@ -1464,6 +1513,7 @@ mod tests {
             Some(&property_values),
             None,
             None,
+            None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
         );
 
@@ -1567,6 +1617,7 @@ mod tests {
             Some(&person_props),
             Some(&group_props),
             None,
+            None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
         );
 
@@ -1648,6 +1699,7 @@ mod tests {
             None,
             Some(&group_props),
             None,
+            None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
         );
 
@@ -1711,6 +1763,7 @@ mod tests {
             Some(&HashMap::new()),
             None,
             Some(&flag_results),
+            None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
         );
 
@@ -1744,6 +1797,7 @@ mod tests {
             Some(&HashMap::new()),
             None,
             Some(&flag_results),
+            None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
         );
 
@@ -1778,6 +1832,7 @@ mod tests {
             Some(&HashMap::new()),
             None,
             None, // empty — dependency flag 42 absent
+            None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
         );
 
@@ -1845,6 +1900,7 @@ mod tests {
             &flag,
             &flag_match,
             Some(&property_values),
+            None,
             None,
             None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
@@ -1922,6 +1978,7 @@ mod tests {
             Some(&property_values),
             None,
             None,
+            None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
         );
 
@@ -1963,6 +2020,7 @@ mod tests {
             &flag,
             &flag_match,
             Some(&property_values),
+            None,
             None,
             None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
@@ -2009,6 +2067,7 @@ mod tests {
             &flag,
             &flag_match,
             Some(&property_values),
+            None,
             None,
             None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
@@ -2066,6 +2125,7 @@ mod tests {
             &flag,
             &flag_match,
             Some(&property_values),
+            None,
             None,
             None,
             PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),

--- a/rust/feature-flags/src/api/types.rs
+++ b/rust/feature-flags/src/api/types.rs
@@ -711,24 +711,40 @@ impl FlagDetails {
                     if property.is_cohort() {
                         let empty = HashMap::new();
                         let matches = cohort_matches.unwrap_or(&empty);
-                        let property_matched =
-                            apply_cohort_membership_logic(std::slice::from_ref(property), matches)
-                                .unwrap_or(false);
                         let cohort_id = property.get_cohort_id();
                         let cohort_label = match cohort_id {
                             Some(id) => format!("cohort {id}"),
                             None => "the targeted cohort".to_string(),
                         };
-                        // State the membership rather than the verdict. The frontend renders this
-                        // line with no pass/fail marker, so on a `not in` filter "did not match"
-                        // alone would leave the reader guessing which way membership went.
-                        let is_member = cohort_id
-                            .and_then(|id| matches.get(&id).copied())
-                            .unwrap_or(false);
-                        let explanation = if is_member {
-                            format!("Person is in {cohort_label}")
-                        } else {
-                            format!("Person is not in {cohort_label}")
+                        // A missing entry means the membership was never resolved, not that the
+                        // person is outside the cohort. `apply_cohort_membership_logic` reads it as
+                        // a non-match, so a `not in` filter would report a match the matcher never
+                        // made: an evaluation at a past timestamp reuses the supplied person
+                        // properties and skips the DB preparation that loads cohorts, which leaves
+                        // this map empty while the matcher fails the condition closed.
+                        let membership = cohort_id.and_then(|id| matches.get(&id).copied());
+                        let (property_matched, explanation) = match membership {
+                            Some(is_member) => {
+                                let matched = apply_cohort_membership_logic(
+                                    std::slice::from_ref(property),
+                                    matches,
+                                )
+                                .unwrap_or(false);
+                                // State the membership rather than the verdict. The frontend renders
+                                // this line with no pass/fail marker, so on a `not in` filter "did
+                                // not match" alone would leave the reader guessing which way
+                                // membership went.
+                                let line = if is_member {
+                                    format!("Person is in {cohort_label}")
+                                } else {
+                                    format!("Person is not in {cohort_label}")
+                                };
+                                (matched, line)
+                            }
+                            None => (
+                                false,
+                                format!("Could not check if person is in {cohort_label}"),
+                            ),
                         };
                         property_analyses.push(PropertyAnalysis {
                             key: property.key.clone(),
@@ -1842,6 +1858,82 @@ mod tests {
             "Absent dependency flag must report matched=false, not error"
         );
         assert_eq!(analysis[0].properties[0].actual_value, None);
+    }
+
+    #[rstest]
+    #[case::is_in("in")]
+    #[case::is_not_in("not_in")]
+    fn test_condition_analysis_fails_cohort_filters_closed_when_membership_is_unresolved(
+        #[case] operator: &str,
+    ) {
+        use crate::flags::flag_models::FeatureFlag;
+        use std::collections::HashMap;
+
+        // An evaluation at a past timestamp skips the DB preparation that loads cohorts, so the
+        // membership map arrives empty and the matcher fails the condition closed. Reading the
+        // absent entry as "not a member" would make a `not in` filter claim a match the matcher
+        // never made, under a sentence asserting a membership nobody resolved.
+        let flag: FeatureFlag = serde_json::from_value(json!(
+            {
+                "id": 1,
+                "team_id": 1,
+                "name": "cohort-flag",
+                "key": "cohort-flag",
+                "active": true,
+                "filters": {
+                    "groups": [
+                        {
+                            "properties": [
+                                {
+                                    "key": "id",
+                                    "value": 12345,
+                                    "type": "cohort",
+                                    "operator": operator
+                                }
+                            ],
+                            "rollout_percentage": 100
+                        }
+                    ]
+                }
+            }
+        ))
+        .unwrap();
+
+        let flag_match = FeatureFlagMatch {
+            matches: false,
+            variant: None,
+            reason: FeatureFlagMatchReason::NoConditionMatch,
+            condition_index: None,
+            payload: None,
+        };
+
+        let analysis = FlagDetails::build_condition_analysis(
+            &flag,
+            &flag_match,
+            Some(&HashMap::new()),
+            None,
+            None,
+            None, // membership never resolved
+            PropertyMatchingContext::new(chrono_tz::Tz::UTC, false),
+        );
+
+        assert_eq!(analysis.len(), 1);
+        assert!(
+            !analysis[0].properties[0].matched,
+            "Unresolved cohort membership must report matched=false for both operators"
+        );
+        assert!(
+            !analysis[0].properties_matched,
+            "Condition must agree with the matcher, which fails closed without cohorts"
+        );
+        assert_eq!(
+            analysis[0].properties[0].explanation, "Could not check if person is in cohort 12345",
+            "The line must not assert a membership that was never resolved"
+        );
+        assert_eq!(
+            analysis[0].explanation,
+            "Condition 1 did not match properties"
+        );
     }
 
     #[rstest]

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -814,6 +814,23 @@ impl FeatureFlagMatcher {
         // Track cohort evaluations in canonical log
         with_canonical_log(|log| log.eval.cohorts_evaluated += cohort_property_filters.len());
 
+        let cohort_matches =
+            self.resolve_cohort_matches(cohort_property_filters, target_properties, cohorts)?;
+
+        // Apply cohort membership logic (IN|NOT_IN) to the cohort match results
+        apply_cohort_membership_logic(cohort_property_filters, &cohort_matches)
+    }
+
+    /// Resolves every cohort the given filters reference to a membership boolean.
+    ///
+    /// Starts from the memberships cached during `prepare_flag_evaluation_state` (static and
+    /// realtime) and evaluates any dynamic cohort that is not cached yet.
+    fn resolve_cohort_matches(
+        &self,
+        cohort_property_filters: &[&PropertyFilter],
+        target_properties: &HashMap<String, Value>,
+        cohorts: Arc<[Cohort]>,
+    ) -> Result<HashMap<CohortId, bool>, FlagError> {
         // Get cached cohort results (static + realtime, merged during prepare_flag_evaluation_state)
         let cached_matches = match self.flag_evaluation_state.get_cohort_matches() {
             Some(matches) => matches.clone(),
@@ -841,8 +858,50 @@ impl FeatureFlagMatcher {
             }
         }
 
-        // Apply cohort membership logic (IN|NOT_IN) to the cohort match results
-        apply_cohort_membership_logic(cohort_property_filters, &cohort_matches)
+        Ok(cohort_matches)
+    }
+
+    /// Resolves cohort memberships for every cohort filter on the flag, for detailed condition
+    /// analysis.
+    ///
+    /// `evaluate_cohort_filters` resolves dynamic cohorts into a map it then discards, so the
+    /// memberships cached on the evaluation state cover static and realtime cohorts only. Reading
+    /// that cache alone would report every dynamic cohort as a non-match and contradict the
+    /// condition outcome the matcher already computed.
+    fn cohort_matches_for_analysis(
+        &self,
+        flag: &FeatureFlag,
+        person_properties: Option<&HashMap<String, Value>>,
+    ) -> HashMap<CohortId, bool> {
+        let cohort_filters: Vec<&PropertyFilter> = flag
+            .filters
+            .groups
+            .iter()
+            .filter_map(|group| group.properties.as_ref())
+            .flatten()
+            .filter(|filter| filter.is_cohort())
+            .collect();
+
+        if cohort_filters.is_empty() {
+            return HashMap::new();
+        }
+
+        let Some(cohorts) = self.flag_evaluation_state.cohorts.clone() else {
+            return HashMap::new();
+        };
+
+        let target_properties = person_properties.unwrap_or(&EMPTY_PROPERTY_MAP);
+
+        // Analysis explains every condition, including ones the matcher short-circuited past, so
+        // a cohort it never needed can fail to resolve here. Fall back to the cached memberships
+        // rather than dropping the whole map.
+        self.resolve_cohort_matches(&cohort_filters, target_properties, cohorts)
+            .unwrap_or_else(|_| {
+                self.flag_evaluation_state
+                    .get_cohort_matches()
+                    .cloned()
+                    .unwrap_or_default()
+            })
     }
 
     /// Evaluates feature flags with property and hash key overrides.
@@ -1135,6 +1194,10 @@ impl FeatureFlagMatcher {
                     // filters resolve against the group rather than the person.
                     let merged_group_props =
                         self.merged_group_properties_for_flag(flag, group_property_overrides);
+                    // Cohort membership as the matcher resolved it, so cohort-typed condition
+                    // filters report the same outcome the flag actually evaluated to.
+                    let cohort_matches =
+                        self.cohort_matches_for_analysis(flag, merged_person_props.as_ref());
                     FlagDetails::create_with_analysis(
                         flag,
                         flag_match,
@@ -1142,6 +1205,7 @@ impl FeatureFlagMatcher {
                         merged_person_props.as_ref(),
                         Some(&merged_group_props),
                         Some(&self.flag_evaluation_state.flag_evaluation_results),
+                        Some(&cohort_matches),
                         PropertyMatchingContext::new(
                             self.timezone,
                             self.use_explicit_exact_matching,

--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -891,17 +891,63 @@ impl FeatureFlagMatcher {
         };
 
         let target_properties = person_properties.unwrap_or(&EMPTY_PROPERTY_MAP);
+        let cached_matches = self
+            .flag_evaluation_state
+            .get_cohort_matches()
+            .cloned()
+            .unwrap_or_default();
 
-        // Analysis explains every condition, including ones the matcher short-circuited past, so
-        // a cohort it never needed can fail to resolve here. Fall back to the cached memberships
-        // rather than dropping the whole map.
-        self.resolve_cohort_matches(&cohort_filters, target_properties, cohorts)
-            .unwrap_or_else(|_| {
-                self.flag_evaluation_state
-                    .get_cohort_matches()
-                    .cloned()
-                    .unwrap_or_default()
-            })
+        Self::resolve_cohort_matches_best_effort(
+            &cohort_filters,
+            target_properties,
+            &cohorts,
+            cached_matches,
+            PropertyMatchingContext::new(self.timezone, self.use_explicit_exact_matching),
+        )
+    }
+
+    /// Resolves each cohort filter on its own, keeping every membership that resolves.
+    ///
+    /// Analysis explains every condition, including ones the matcher short-circuited past, so it
+    /// reaches cohorts the matcher never needed. A condition can name a cohort the flags payload
+    /// no longer carries, because Django omits deleted and cross-team cohorts while keeping the
+    /// filters that name them. Resolving the set as a unit would drop the memberships of every
+    /// other condition on the first such cohort. A cohort left out of the map reads as unknown,
+    /// not as a non-match.
+    fn resolve_cohort_matches_best_effort(
+        cohort_property_filters: &[&PropertyFilter],
+        target_properties: &HashMap<String, Value>,
+        cohorts: &[Cohort],
+        cached_matches: HashMap<CohortId, bool>,
+        matching_context: PropertyMatchingContext,
+    ) -> HashMap<CohortId, bool> {
+        let mut cohort_matches = cached_matches;
+
+        for filter in cohort_property_filters {
+            let Some(cohort_id) = filter.get_cohort_id() else {
+                continue;
+            };
+            if cohort_matches.contains_key(&cohort_id) {
+                continue;
+            }
+            let resolved = evaluate_dynamic_cohorts(
+                cohort_id,
+                target_properties,
+                cohorts,
+                &cohort_matches,
+                matching_context,
+            );
+            match resolved {
+                Ok(is_member) => {
+                    cohort_matches.insert(cohort_id, is_member);
+                }
+                Err(e) => {
+                    warn!("Cohort {cohort_id} left unresolved for condition analysis: {e:?}")
+                }
+            }
+        }
+
+        cohort_matches
     }
 
     /// Evaluates feature flags with property and hash key overrides.
@@ -2993,5 +3039,75 @@ mod tests {
             assert_eq!(result.get(*k), Some(&Value::String((*v).to_string())));
         }
         assert_eq!(result.len(), 1 + expected_extras.len());
+    }
+
+    #[test]
+    fn test_cohort_analysis_keeps_resolved_memberships_when_another_cohort_fails() {
+        // A flag can name a cohort the flags payload no longer carries, because Django omits
+        // deleted and cross-team cohorts while keeping the filters that name them. Condition
+        // analysis explains every condition, so it reaches that cohort even when the matcher won
+        // on an earlier one. Resolving the set as a unit dropped the winning condition's
+        // membership too, which then rendered as MATCHED above "did not match properties".
+        let cohort: Cohort = serde_json::from_value(serde_json::json!({
+            "id": 1,
+            "team_id": 1,
+            "deleted": false,
+            "is_calculating": false,
+            "is_static": false,
+            "errors_calculating": 0,
+            "groups": [],
+            "filters": {
+                "properties": {
+                    "type": "OR",
+                    "values": [{
+                        "type": "OR",
+                        "values": [{
+                            "key": "plan",
+                            "type": "person",
+                            "value": "enterprise",
+                            "operator": "exact"
+                        }]
+                    }]
+                }
+            }
+        }))
+        .unwrap();
+
+        let filters: Vec<PropertyFilter> = [1, 999]
+            .into_iter()
+            .map(|id| {
+                serde_json::from_value(serde_json::json!({
+                    "key": "id",
+                    "value": id,
+                    "type": "cohort",
+                    "operator": "in"
+                }))
+                .unwrap()
+            })
+            .collect();
+        let filter_refs: Vec<&PropertyFilter> = filters.iter().collect();
+
+        let target_properties =
+            HashMap::from([("plan".to_string(), Value::String("enterprise".to_string()))]);
+
+        // Cohort 999 is absent from the loaded list, so resolving it fails.
+        let resolved = FeatureFlagMatcher::resolve_cohort_matches_best_effort(
+            &filter_refs,
+            &target_properties,
+            &[cohort],
+            HashMap::new(),
+            PropertyMatchingContext::new(Tz::UTC, false),
+        );
+
+        assert_eq!(
+            resolved.get(&1),
+            Some(&true),
+            "a resolved membership must survive another cohort failing"
+        );
+        assert_eq!(
+            resolved.get(&999),
+            None,
+            "an unresolvable cohort must be absent, so analysis reads it as unknown"
+        );
     }
 }

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -615,6 +615,140 @@ mod tests {
         assert_eq!(industry_analysis.actual_value, Some(json!("tech")));
     }
 
+    /// Regression test: detailed condition analysis must resolve a cohort filter against the
+    /// membership the matcher computed. `match_property` cannot evaluate a cohort filter, so
+    /// every one of them used to report `matched: false`, which made a winning condition claim
+    /// its own properties did not match. The cohort here is dynamic on purpose: the evaluation
+    /// state caches static and realtime memberships only, so a dynamic cohort is the case that
+    /// needs resolving rather than reading back from the cache.
+    #[tokio::test]
+    async fn test_detailed_analysis_resolves_cohort_filters_against_cohort_membership() {
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let team = context.insert_new_team(None).await.unwrap();
+
+        let cohort_row = context
+            .insert_cohort(
+                team.id,
+                None,
+                json!({
+                    "properties": {
+                        "type": "OR",
+                        "values": [{
+                            "type": "OR",
+                            "values": [{
+                                "key": "plan",
+                                "type": "person",
+                                "value": "enterprise",
+                                "negation": false,
+                                "operator": "exact"
+                            }]
+                        }]
+                    }
+                }),
+                false,
+            )
+            .await
+            .unwrap();
+
+        context
+            .insert_person(
+                team.id,
+                "cohort_member".to_string(),
+                Some(json!({"plan": "enterprise"})),
+            )
+            .await
+            .unwrap();
+        context
+            .insert_person(
+                team.id,
+                "non_member".to_string(),
+                Some(json!({"plan": "free"})),
+            )
+            .await
+            .unwrap();
+
+        let flag = mock!(FeatureFlag,
+            team_id: team.id,
+            filters: FlagFilters {
+                groups: vec![FlagPropertyGroup {
+                    properties: Some(vec![PropertyFilter {
+                        key: "id".to_string(),
+                        value: Some(json!(cohort_row.id)),
+                        operator: Some(OperatorType::In),
+                        prop_type: PropertyType::Cohort,
+                        group_type_index: None,
+                        negation: Some(false),
+                        compiled_regex: None,
+                        extra: Default::default(),
+                    }]),
+                    rollout_percentage: Some(100.0),
+                    variant: None,
+                    ..Default::default()
+                }],
+                multivariate: None,
+                aggregation_group_type_index: None,
+                payloads: None,
+                feature_enrollment: None,
+                holdout: None,
+                early_exit: None,
+                extra: Default::default(),
+            }
+        );
+
+        // (distinct_id, in the cohort, expected membership sentence)
+        for (distinct_id, is_member) in [("cohort_member", true), ("non_member", false)] {
+            let mut matcher = FeatureFlagMatcher::new(
+                distinct_id.to_string(),
+                None, // device_id
+                team.id,
+                context.create_postgres_router(),
+                cohort_cache.clone(),
+                empty_group_type_cache(),
+                None,
+            )
+            .with_detailed_analysis(true);
+
+            let flags = flag_list_with_metadata(vec![flag.clone()]);
+            let result = matcher
+                .evaluate_all_feature_flags(flags, None, None, None, Uuid::new_v4(), None, false)
+                .await
+                .unwrap();
+
+            assert!(!result.errors_while_computing_flags);
+            let flag_details = result.flags.get("test_flag").unwrap();
+            assert_eq!(flag_details.to_value(), FlagValue::Boolean(is_member));
+
+            let conditions = flag_details
+                .conditions
+                .as_ref()
+                .expect("detailed_analysis(true) should populate conditions");
+            assert_eq!(conditions.len(), 1);
+
+            // The contradiction being fixed: the condition analysis must agree with the
+            // condition's own outcome instead of reporting the cohort filter as unmatched.
+            assert_eq!(conditions[0].matched, is_member, "user {distinct_id}");
+            assert_eq!(
+                conditions[0].properties_matched, is_member,
+                "user {distinct_id}"
+            );
+
+            let properties = &conditions[0].properties;
+            assert_eq!(properties.len(), 1);
+            assert_eq!(properties[0].matched, is_member, "user {distinct_id}");
+            let expected = if is_member {
+                format!("Person is in cohort {}", cohort_row.id)
+            } else {
+                format!("Person is not in cohort {}", cohort_row.id)
+            };
+            assert_eq!(properties[0].explanation, expected, "user {distinct_id}");
+        }
+    }
+
     /// Helper to create a dependency filter for flag-depends-on-flag patterns.
     fn dep_filter(flag_id: i32, value: FlagValue) -> PropertyFilter {
         mock!(crate::properties::property_models::PropertyFilter,

--- a/rust/feature-flags/src/flags/test_flag_matching.rs
+++ b/rust/feature-flags/src/flags/test_flag_matching.rs
@@ -737,6 +737,18 @@ mod tests {
                 "user {distinct_id}"
             );
 
+            // The sentence the person reads under the badge. A matched condition used to
+            // render the "did not match properties" branch here, directly below MATCHED.
+            let expected_condition = if is_member {
+                "Condition 1 matched and passed 100% rollout"
+            } else {
+                "Condition 1 did not match properties"
+            };
+            assert_eq!(
+                conditions[0].explanation, expected_condition,
+                "user {distinct_id}"
+            );
+
             let properties = &conditions[0].properties;
             assert_eq!(properties.len(), 1);
             assert_eq!(properties[0].matched, is_member, "user {distinct_id}");


### PR DESCRIPTION
## Problem

- Someone testing a flag that targets a cohort sees a condition card marked **MATCHED**, with "Condition N did not match properties" printed directly underneath it.
- The property bullet under that line reads `Property 'id' is not in 12345`, naming a person property the flag never targeted.
- The Testing tab builds its explanation with a second pass over the filters, and that pass cannot evaluate a cohort filter, so it records every one as unmatched.
- Flag evaluation itself is correct. The rollout reaches exactly the cohort members, and no runtime response changes.
- Flag-dependency filters and group-typed filters each already have their own branch in this function, the latter from #68646. Cohort was the last filter kind with none.

## Changes

- A cohort condition in the flag tester now reads "Person is in cohort 12345", instead of naming a person property that does not exist.
- The condition's `properties_matched` now agrees with its `matched` outcome, so the badge and the explanation stop contradicting each other.
- `build_condition_analysis` resolves cohort filters through `apply_cohort_membership_logic`, the same helper the matcher uses. Re-deriving the in/not-in rules is how this class of bug appears in the first place.
- The line states membership rather than a verdict. The frontend renders it with no pass or fail marker, so "did not match" on a `not in` filter would hide which way membership went.
- Analysis re-resolves cohort membership rather than reading the cached map, which holds static and realtime cohorts only. A dynamic cohort would otherwise still report a false non-match.
- Runtime is untouched. The new code runs only under `detailed_analysis`, which is internal-only and sets `skip_writes`, and it adds no database queries.

| Filter kind | How condition analysis resolves it |
| --- | --- |
| Person or group property | `match_property` against the resolved property map |
| Flag dependency | `match_flag_value_to_flag_filter` against flag results |
| Cohort | `apply_cohort_membership_logic` against membership (new) |

Mechanical parts: `resolve_cohort_matches` is a pure extraction from `evaluate_cohort_filters`, and the new argument is threaded through 11 existing test call sites.

## How did you test this code?

- Added `test_detailed_analysis_resolves_cohort_filters_against_cohort_membership`, covering a cohort member and a non-member through `evaluate_all_feature_flags`. It sits at the same level as the group-filter test #68646 added.
- The regression it catches: no existing test asserts `properties_matched` on a condition whose only filter is a cohort. With the new branch disabled the test fails at `properties_matched`, expected true, got false.
- Its cohort is dynamic on purpose, so it exercises the re-resolution path rather than the cached map. A static cohort would pass even with the caching bug present.
- Ran locally against a Postgres test database: the feature-flags `flags::` and `api::types` suites, plus `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check`.
- Not run: the geoip tests, which fail in this sandbox for a missing GeoIP database on unmodified master as well.
- Tested locally in the Testing tab, with this branch merged into current master, a dynamic cohort, and a flag targeting it at 100% rollout.

| Case | Master | This PR |
| --- | --- | --- |
| Member, `in` cohort | MATCHED, but "did not match properties" and "Property 'id' is not in 3" | MATCHED, "Person is in cohort 3" |
| Non-member, `in` cohort | Not matched, "Property 'id' is not in 3" | Not matched, "Person is not in cohort 3" |
| Member, `not in` cohort | Not checked | Not matched, "Person is in cohort 3" |
| Non-member, `not in` cohort | Not checked | MATCHED, "Person is not in cohort 3" |

Cohort member, before:

![flag tester before fix, cohort member](https://raw.githubusercontent.com/PostHog/pr-assets/d8b16a5ad51f9bd3b12987731a2a9ccfeed3b73f/2026/09/87f0bb72-cd38-4950-9a77-67d642d5427a.png)

Cohort member, after:

![flag tester after fix, cohort member](https://raw.githubusercontent.com/PostHog/pr-assets/076b51add629ce5ba4f1be5ede5b7dcdb87a46a5/2026/09/2975dfb9-931a-4b5c-a64d-a9b270de1737.png)

Non-member, after:

![flag tester after fix, non-member](https://raw.githubusercontent.com/PostHog/pr-assets/6c6a9ba17694bd733c97db28611d52d61277eb9b/2026/09/e23f2544-e5d1-4cf7-b762-7fa030d2f962.png)

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in PostHog Desktop, while a support engineer investigated a report of the flag tester showing a self-contradictory condition card. Left unassigned because the driver's GitHub handle was not verified in the session; they should assign themselves.
- Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`.
- The first approach read `FlagEvaluationState.cohort_matches` directly. That map holds static and realtime memberships only, because `evaluate_cohort_filters` resolves dynamic cohorts into a map it then discards. Reading it would have left dynamic cohorts, the common case, still reporting a false non-match. Re-resolving through the extracted helper is what fixes that.
- Checked against #83866, which landed on master during this work and also concerns cohorts. It explains a flag that matches nobody and adds a banner on a non-match, so it does not overlap: this PR fixes a condition that did match.
- Also checked #60732, a closed unmerged PR with a near-identical title. Its fixes were layout, early-exit wording, and flag dependencies, and it was superseded by #60931. Not cohort.
- Rebased onto master after #90694 replaced `team_timezone: Tz` with `matching_context: PropertyMatchingContext` on the two signatures this PR edits. The conflicts were that rename only; no logic changed.
- Public artifact: nothing here carries material from the originating session. The cohort definition, person properties, and identifiers in the test are invented.


