### PR TITLE
feat(session-replay): show the product empty state until recordings arrive

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -55,7 +55,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Tracing                | `products/tracing/frontend/TracingScene.tsx`                                        | on master             |
 | Metrics                | `products/metrics/frontend/MetricsScene.tsx`                                        | on master             |
 | Surveys                | `frontend/src/scenes/surveys/Surveys.tsx`                                           | on master             |
-| Session replay         | `frontend/src/scenes/session-recordings/SessionRecordings.tsx`                      | in review             |
+| Session replay         | `frontend/src/scenes/session-recordings/SessionRecordings.tsx`                      | on master             |
 | Web vitals             | `frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx`                           | in review             |
 | Data warehouse sources | `products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx`             | in review             |
 | Workflows              | `products/workflows/frontend/WorkflowsScene.tsx`                                    | in review             |

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1856,6 +1856,14 @@ snapshots:
         hash: v1.k794b7964.78d06d6c9f11d54919ad81abffe6a5d409dd1b4e7ba08a822a17485f8503617f.owccqODY_2d4-T-mAhHHfXx-rjYgbeohS0xVOLc5FXQ
     components-product-empty-state--replay-vision-needs-setup--light:
         hash: v1.k794b7964.251eee6169c98d22d57c361fdcf9747e16187d832d3ce775d93ce9418b67466a.QZzU0myILKJWAjynyGeUQybg5UwVqniqT1Q1TuT-jkE
+    components-product-empty-state--session-replay-needs-setup--dark:
+        hash: v1.k794b7964.df47e82b994f7ef3a3015ee0cc0c2744ae54badd8382b885549901d6935213a5.ZHU7jAayHU1qzdeAGgXqY9GLRexVyv7RQKamYEOzYZY
+    components-product-empty-state--session-replay-needs-setup--light:
+        hash: v1.k794b7964.f4359d8ea9ba08eb83ebcd19655f1f0772474b505b9ed557851d6a90415232c3.87yxPfiw4wvAnIuGBIupYBTSTWkpLllKEl-bg4tzxMM
+    components-product-empty-state--session-replay-waiting-for-data--dark:
+        hash: v1.k794b7964.cc8c1c17fa808feef5b537443040ff1f820bfacfd6c9a3875da35e6897747bf2.2etdmMjx52jxI4KVTTu5zVtIPwBXSuVwpgrjAu7OI14
+    components-product-empty-state--session-replay-waiting-for-data--light:
+        hash: v1.k794b7964.16cc3b59102cec6204dd171dfaa10f539ee30670ffd3d9243dd0dde38f9b937d.dR77we_J-giW8Eg7VC7LLYHrSweLA-W83Ib8GVfBtNY
     components-product-empty-state--skills-needs-setup--dark:
         hash: v1.k794b7964.7fb1bfe531cab39785cf3d98edc3fed01122cbe04f2fc10b23054648455ed423.VhFzyJUt9ckAydjv1P6BL83AKLhlKl3NRrb5fL1o2M8
     components-product-empty-state--skills-needs-setup--light:
@@ -5733,9 +5741,9 @@ snapshots:
     replay-tabs-home-success--recent-recordings--light:
         hash: v1.k794b7964.1c15c6439072ba99bc539ede94d6546436b78c44e4a026d638130a59e2bed515.RAh0r3lyA4w8xpZ1b0HeY_EBMhyx7A4GXQhD4Q1fzSA
     replay-tabs-home-success--recent-recordings-empty--dark:
-        hash: v1.k794b7964.7af42d273f62a6845cc834e1201b40750ce493f9e61d3595d8e3dd0124fb98b9.xMGDUrSSoQOsMXOuwt_whrN_drdBkS1Hcuy7Q01-C48
+        hash: v1.k794b7964.b96eb8ff3becd42ef223773f142db0fb5a5c7d743adcce158cb164940f170c20.5aj7iROHwfdLWjLstJZEx3YzsXaFoHJbn4sok-n-0XM
     replay-tabs-home-success--recent-recordings-empty--light:
-        hash: v1.k794b7964.0793b6f9179c6157206c54b391e5a5867b92d592789a268d4809af399121335c.dbuvjEe-sCNHJA8GhvTtmquD1WvzE-kxUlaoI_rMGGU
+        hash: v1.k794b7964.0c42a8397f876b6118b6003b38e691b849bccef88f7ce8b04d433149c387272c.AjQt0-zv3hc11T4bFY_chc_VTPx0aZVqQyNWKxWt4NA
     replay-tabs-home-success--recordings-play-list-no-pinned-recordings--dark:
         hash: v1.k794b7964.77abb01d4f00305236c2ebd0377e0aee47cd50743c75c68f692ae8fec111371d.iVejWxmTZ4MtP2WYTK-jLSresCBRZ-d57bcPFhoCDlc
     replay-tabs-home-success--recordings-play-list-no-pinned-recordings--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -20,6 +20,7 @@ import { logsEmptyState } from 'products/logs/frontend/emptyState/logsEmptyState
 import { mcpAnalyticsEmptyState } from 'products/mcp_analytics/frontend/emptyState/mcpAnalyticsEmptyState'
 import { metricsEmptyState } from 'products/metrics/frontend/emptyState/metricsEmptyState'
 import { productToursEmptyState } from 'products/product_tours/frontend/emptyState/productToursEmptyState'
+import { sessionReplayEmptyState } from 'products/replay/frontend/emptyState/sessionReplayEmptyState'
 import { replayVisionEmptyState } from 'products/replay_vision/frontend/emptyState/replayVisionEmptyState'
 import { llmSkillsEmptyState } from 'products/skills/frontend/emptyState/llmSkillsEmptyState'
 import { surveysEmptyState } from 'products/surveys/frontend/emptyState/surveysEmptyState'
@@ -254,3 +255,21 @@ export const MetricsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
 export const SurveysNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(surveysEmptyState, 'needs-setup', {
     mocks: { get: { '/api/projects/:team_id/surveys/': [200, { count: 0, results: [] }] } },
 })
+
+// Session replay detection lists recordings on mount - answer "none yet".
+const sessionReplayMocks = {
+    // nosemgrep: no-environments-api-urls-frontend -- api.recordings is env-scoped, so the msw mock must match /api/environments to intercept it
+    get: { '/api/environments/:team_id/session_recordings': [200, { results: [] }] },
+} as const
+
+export const SessionReplayNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    sessionReplayEmptyState,
+    'needs-setup',
+    { mocks: sessionReplayMocks }
+)
+
+export const SessionReplayWaitingForData: ProductEmptyStateStory = productEmptyStateStory(
+    sessionReplayEmptyState,
+    'waiting-for-data',
+    { mocks: sessionReplayMocks }
+)

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
@@ -5,6 +5,8 @@ import { IconBook, IconGear } from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { TerminalCard } from 'lib/components/CommandBlock/TerminalCard'
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { cn } from 'lib/utils/css-classes'
 import { useWizardCommand } from 'scenes/onboarding/shared/useWizardCommand'
@@ -63,6 +65,13 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
     const hedgehogBeside = config.hedgehogPlacement === 'beside'
 
     const primaryAction = resolvePrimaryAction(config.primaryAction, mode)
+    // Safe to call unconditionally: it answers with a loading reason until the team lands, and
+    // the widest scope is a no-op for actions that declare no restriction.
+    const restrictionReason = useRestrictedArea({
+        scope: primaryAction?.restriction?.scope ?? RestrictionScope.Project,
+        minimumAccessLevel: primaryAction?.restriction?.minimumAccessLevel ?? TeamMembershipLevel.Member,
+    })
+    const primaryActionRestriction = primaryAction?.restriction ? restrictionReason : null
     const primaryActionButton = primaryAction ? (
         <LemonButton
             type="primary"
@@ -72,6 +81,7 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
                 primaryAction.onClick?.()
             }}
             className="self-start"
+            disabledReason={primaryActionRestriction}
             data-attr={primaryAction.dataAttr ?? 'product-empty-state-primary-action'}
         >
             {primaryAction.label}

--- a/frontend/src/lib/components/ProductEmptyState/types.ts
+++ b/frontend/src/lib/components/ProductEmptyState/types.ts
@@ -1,7 +1,8 @@
 import type { LogicWrapper } from 'kea'
 import type { ComponentType, CSSProperties, ReactNode } from 'react'
 
-import type { FeatureFlagKey } from 'lib/constants'
+import type { RestrictionScope } from 'lib/components/RestrictedArea'
+import type { FeatureFlagKey, TeamMembershipLevel } from 'lib/constants'
 
 import type { ProductKey } from '~/queries/schema/schema-general'
 import type { AccessControlLevel, AccessControlResourceType } from '~/types'
@@ -53,6 +54,11 @@ export interface ProductEmptyStateAccessControl {
     minAccessLevel: AccessControlLevel
 }
 
+export interface ProductEmptyStateRestriction {
+    scope: RestrictionScope
+    minimumAccessLevel: TeamMembershipLevel
+}
+
 export interface ProductEmptyStatePrimaryAction {
     label: string
     to?: string
@@ -63,6 +69,13 @@ export interface ProductEmptyStatePrimaryAction {
      * when the form fails to save.
      */
     accessControl?: ProductEmptyStateAccessControl
+    /**
+     * Membership level the action requires, for actions that write a team setting rather
+     * than create a resource. Resource access control cannot express this: recording
+     * Editor does not carry permission to flip the project's opt-in, so gating such an
+     * action on a resource level enables a button whose update the backend rejects.
+     */
+    restriction?: ProductEmptyStateRestriction
     /**
      * `data-attr` on the button, defaulting to `product-empty-state-primary-action`.
      * Set it to the attr the gated scene's create button carries, so end-to-end specs

--- a/frontend/src/scenes/session-recordings/SessionRecordings.tsx
+++ b/frontend/src/scenes/session-recordings/SessionRecordings.tsx
@@ -2,12 +2,11 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useState } from 'react'
 
-import { IconDocument, IconGear, IconHeadset, IconOpenSidebar } from '@posthog/icons'
+import { IconDocument, IconGear, IconHeadset } from '@posthog/icons'
 import { LemonBadge, LemonButton, Link } from '@posthog/lemon-ui'
 import { PostHogCaptureOnViewed } from '@posthog/react'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
-import { WarningHog } from 'lib/components/hedgehogs'
 import { LiveRecordingsCount } from 'lib/components/LiveUserCount'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
@@ -28,6 +27,8 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ScenePanel, ScenePanelActionsSection } from '~/layout/scenes/SceneLayout'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType, ReplayTab, ReplayTabs } from '~/types'
+
+import { sessionReplayEmptyState } from 'products/replay/frontend/emptyState/sessionReplayEmptyState'
 
 import { SessionRecordingCollections } from './collections/SessionRecordingCollections'
 import { SessionRecordingsPlaylistRedesign } from './playlist-redesign/SessionRecordingsPlaylistRedesign'
@@ -152,72 +153,6 @@ function ReplayVisionPromoBanner(): JSX.Element | null {
     )
 }
 
-function Warnings(): JSX.Element {
-    const { currentTeam } = useValues(teamLogic)
-    const recordingsDisabled = currentTeam && !currentTeam?.session_recording_opt_in
-
-    return (
-        <>
-            {recordingsDisabled ? (
-                <LemonBanner type="info" hideIcon={true}>
-                    <div className="flex gap-8 p-8 md:flex-row justify-center flex-wrap">
-                        <div className="flex justify-center items-center w-full md:w-50">
-                            <WarningHog className="w-full h-auto md:h-[200px] md:w-[200px] max-w-50" />
-                        </div>
-                        <div className="flex flex-col gap-2 flex-shrink max-w-180">
-                            <h2 className="text-lg font-semibold">
-                                Session recordings are not yet enabled for this project
-                            </h2>
-                            <p className="font-normal">Enabling session recordings will help you:</p>
-                            <ul className="list-disc list-inside font-normal">
-                                <li>
-                                    <strong>Understand user behavior:</strong> Get a clear view of how people navigate
-                                    and interact with your product.
-                                </li>
-                                <li>
-                                    <strong>Identify UI/UX issues:</strong> Spot friction points and refine your design
-                                    to increase usability.
-                                </li>
-                                <li>
-                                    <strong>Improve customer support:</strong> Quickly diagnose problems and provide
-                                    more accurate solutions.
-                                </li>
-                                <li>
-                                    <strong>Refine product decisions:</strong> Use real insights to prioritize features
-                                    and improvements.
-                                </li>
-                            </ul>
-                            <p className="font-normal">
-                                Enable session recordings to unlock these benefits and create better experiences for
-                                your users.
-                            </p>
-                            <div className="flex items-center gap-x-4 gap-y-2 flex-wrap">
-                                <LemonButton
-                                    className="hidden @md:flex"
-                                    type="primary"
-                                    icon={<IconGear />}
-                                    to={urls.replaySettings()}
-                                >
-                                    Configure
-                                </LemonButton>
-                                <LemonButton
-                                    type="tertiary"
-                                    sideIcon={<IconOpenSidebar className="w-4 h-4" />}
-                                    to="https://posthog.com/docs/session-replay?utm_medium=in-product&utm_campaign=empty-state-docs-link"
-                                    data-attr="product-introduction-docs-link"
-                                    targetBlank
-                                >
-                                    Learn more
-                                </LemonButton>
-                            </div>
-                        </div>
-                    </div>
-                </LemonBanner>
-            ) : null}
-        </>
-    )
-}
-
 // Keeps the recordings logic mounted for the scene's lifetime so its state survives tab
 // switches. Rendered only on the Home tab so landing on Collections/Templates does not mount
 // it — which would otherwise fire a wasted loadSessionRecordings ClickHouse query on load.
@@ -242,7 +177,6 @@ function MainPanel(): JSX.Element {
     return (
         <div className={cn('flex flex-col gap-y-4', ReplayTabs.Home === tab && 'grow')}>
             <ReplayVisionPromoBanner />
-            <Warnings />
 
             {!tab ? (
                 <Spinner />
@@ -336,4 +270,5 @@ export const scene: SceneExport = {
     component: SessionsRecordings,
     logic: sessionReplaySceneLogic,
     productKey: ProductKey.SESSION_REPLAY,
+    emptyState: sessionReplayEmptyState,
 }

--- a/playwright/e2e/event-definitions.spec.ts
+++ b/playwright/e2e/event-definitions.spec.ts
@@ -31,7 +31,18 @@ test.describe('Event Definitions', () => {
         const replayTab = await popupPromise
         await expect(replayTab).toHaveURL(/replay/)
 
-        await replayTab.locator('.LemonButton--has-icon .LemonButton__content').filter({ hasText: 'Filters' }).click()
+        // The demo project has events but no recordings, so replay opens on its setup
+        // empty state. Skip past it to reach the list this action deep-linked into.
+        const skipEmptyState = replayTab.locator('[data-attr="product-empty-state-skip"]')
+        const filtersButton = replayTab
+            .locator('.LemonButton--has-icon .LemonButton__content')
+            .filter({ hasText: 'Filters' })
+        await expect(skipEmptyState.or(filtersButton).first()).toBeVisible()
+        if (await skipEmptyState.isVisible()) {
+            await skipEmptyState.click()
+        }
+
+        await filtersButton.click()
 
         await expect(replayTab.locator('.UniversalFilterButton').first()).toContainText(eventName, {
             ignoreCase: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,7 +428,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -513,7 +513,7 @@ importers:
         version: 5.3.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       mockdate:
         specifier: ^3.0.5
         version: 3.0.5
@@ -1955,7 +1955,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4142,6 +4142,9 @@ importers:
 
   products/replay:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.10.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4166,6 +4169,10 @@ importers:
       react:
         specifier: 18.3.1
         version: 18.3.1
+    devDependencies:
+      kea-test-utils:
+        specifier: 'catalog:'
+        version: 0.2.4(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))
 
   products/replay_vision:
     dependencies:

--- a/products/replay/frontend/emptyState/SessionReplayPreview.scss
+++ b/products/replay/frontend/emptyState/SessionReplayPreview.scss
@@ -1,0 +1,375 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.ReplayPreview {
+    --replay-preview-accent: var(--empty-state-accent, var(--color-primary-500));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden playing state. A direct child of .ReplayPreview so `:checked ~` reaches both cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__list,
+    &__player {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Playing/paused pairs are stacked on one grid cell and crossfaded, so playback
+    // never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-playing {
+        @include preview-swap-hidden;
+    }
+
+    &__when-paused {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    &__rec-dot {
+        width: 7px;
+        height: 7px;
+        background: var(--danger);
+        border-radius: 50%;
+        animation: ReplayPreview__pulse 2s ease-in-out infinite;
+    }
+
+    // Recordings list
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: 6.5rem minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+        transition: background-color 250ms ease;
+    }
+
+    &__row--hero {
+        cursor: pointer;
+        user-select: none;
+    }
+
+    &__row--hero:hover {
+        background: var(--color-bg-fill-highlight-50);
+    }
+
+    &__person {
+        overflow: hidden;
+        font-size: 0.6875rem;
+        font-weight: 600;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__meta {
+        overflow: hidden;
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__duration {
+        font-size: 0.625rem;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-secondary);
+        text-align: right;
+    }
+
+    &__now-playing {
+        font-size: 0.5625rem;
+        font-weight: 600;
+        text-align: right;
+
+        @include preview-accent-text(var(--replay-preview-accent));
+    }
+
+    &__hint {
+        padding: 0.25rem 0.75rem 0.5rem;
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    // Player
+
+    &__screen {
+        position: relative;
+        height: 7.5rem;
+        overflow: hidden;
+        background: var(--color-bg-fill-tertiary);
+    }
+
+    &__wire {
+        position: absolute;
+        inset: 0.75rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.4375rem;
+    }
+
+    &__wire-nav {
+        height: 0.75rem;
+        background: var(--color-bg-surface-primary);
+        border-radius: var(--radius);
+    }
+
+    &__wire-line {
+        height: 0.5rem;
+        background: var(--color-bg-surface-primary);
+        border-radius: 999px;
+        opacity: 0.7;
+    }
+
+    &__wire-line--short {
+        width: 60%;
+    }
+
+    &__wire-button {
+        width: 5.5rem;
+        height: 1.125rem;
+        margin-top: auto;
+        background: color-mix(in oklab, var(--replay-preview-accent) 55%, var(--color-bg-surface-primary));
+        border-radius: var(--radius);
+    }
+
+    // The replayed cursor: travels the wireframe and "clicks" the button while playing.
+    &__cursor {
+        position: absolute;
+        top: 20%;
+        left: 30%;
+        width: 10px;
+        height: 10px;
+        background: var(--color-text-primary);
+        border: 2px solid var(--color-bg-surface-primary);
+        border-radius: 50% 50% 50% 0;
+        box-shadow: 0 1px 3px rgb(0 0 0 / 25%);
+        transform: rotate(-90deg);
+    }
+
+    &__overlay {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        background: color-mix(in oklab, var(--color-bg-surface-primary) 45%, transparent);
+    }
+
+    &__overlay-play {
+        display: grid;
+        place-items: center;
+        width: 2rem;
+        height: 2rem;
+        font-size: 0.75rem;
+        color: var(--color-bg-surface-primary);
+        background: var(--replay-preview-accent);
+        border-radius: 50%;
+    }
+
+    &__controls {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.4375rem 0.75rem;
+        border-top: 1px solid var(--color-border-primary);
+    }
+
+    &__play-glyph {
+        font-size: 0.625rem;
+        color: var(--color-text-secondary);
+    }
+
+    &__timeline {
+        position: relative;
+        flex: 1;
+        height: 6px;
+        overflow: hidden;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+    }
+
+    // Bursts of user activity along the timeline, like the real player's bar.
+    &__timeline-activity {
+        position: absolute;
+        inset: 0;
+        background: repeating-linear-gradient(
+            90deg,
+            transparent 0 12%,
+            color-mix(in oklab, var(--replay-preview-accent) 30%, transparent) 12% 16%,
+            transparent 16% 34%,
+            color-mix(in oklab, var(--replay-preview-accent) 30%, transparent) 34% 42%,
+            transparent 42% 70%,
+            color-mix(in oklab, var(--replay-preview-accent) 30%, transparent) 70% 78%,
+            transparent 78% 100%
+        );
+    }
+
+    &__timeline-progress {
+        position: absolute;
+        inset: 0 100% 0 0;
+        background: var(--replay-preview-accent);
+        border-radius: 999px;
+    }
+
+    &__time {
+        font-size: 0.625rem;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-tertiary);
+    }
+}
+
+// Playing state (user clicked the recording)
+
+.ReplayPreview__checkbox:checked ~ * .ReplayPreview__when-playing {
+    @include preview-swap-visible;
+}
+
+.ReplayPreview__checkbox:checked ~ * .ReplayPreview__when-paused {
+    @include preview-swap-hidden;
+}
+
+.ReplayPreview__checkbox:checked ~ .ReplayPreview__list .ReplayPreview__row--hero {
+    background: color-mix(in oklab, var(--replay-preview-accent) 8%, transparent);
+}
+
+// Playback motion runs only while playing - the user opted in, so this is not
+// an auto-toggling demo.
+.ReplayPreview__checkbox:checked ~ .ReplayPreview__player .ReplayPreview__cursor {
+    animation: ReplayPreview__cursor-path 8s ease-in-out infinite;
+}
+
+.ReplayPreview__checkbox:checked ~ .ReplayPreview__player .ReplayPreview__timeline-progress {
+    animation: ReplayPreview__progress 8s linear infinite;
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the row it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.ReplayPreview__checkbox:focus-visible ~ .ReplayPreview__list .ReplayPreview__row--hero {
+    outline: 2px solid var(--replay-preview-accent);
+    outline-offset: 1px;
+}
+
+// Nudge attention at the hero recording until it's played.
+.ReplayPreview:not(.ReplayPreview--static)
+    .ReplayPreview__checkbox:not(:checked)
+    ~ .ReplayPreview__player
+    .ReplayPreview__overlay-play {
+    animation: ReplayPreview__nudge 2.4s ease-in-out infinite;
+}
+
+@keyframes ReplayPreview__nudge {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--replay-preview-accent) 45%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 5px color-mix(in oklab, var(--replay-preview-accent) 20%, transparent);
+    }
+}
+
+@keyframes ReplayPreview__pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.35;
+    }
+}
+
+// The cursor tours the page and ends on the call-to-action, bottom left.
+@keyframes ReplayPreview__cursor-path {
+    0% {
+        top: 20%;
+        left: 30%;
+    }
+
+    25% {
+        top: 35%;
+        left: 70%;
+    }
+
+    50% {
+        top: 55%;
+        left: 45%;
+    }
+
+    75% {
+        top: 75%;
+        left: 22%;
+        transform: rotate(-90deg) scale(1);
+    }
+
+    82% {
+        top: 78%;
+        left: 20%;
+        transform: rotate(-90deg) scale(0.8);
+    }
+
+    90% {
+        top: 78%;
+        left: 20%;
+        transform: rotate(-90deg) scale(1);
+    }
+
+    100% {
+        top: 20%;
+        left: 30%;
+    }
+}
+
+@keyframes ReplayPreview__progress {
+    from {
+        inset: 0 100% 0 0;
+    }
+
+    to {
+        inset: 0 0% 0 0;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all motion; clicking the recording
+// still flips the state (transitions only).
+@include preview-motion-guards('ReplayPreview');

--- a/products/replay/frontend/emptyState/SessionReplayPreview.tsx
+++ b/products/replay/frontend/emptyState/SessionReplayPreview.tsx
@@ -1,0 +1,91 @@
+import './SessionReplayPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+/**
+ * Example-data preview for the session replay empty state: a recordings list and
+ * the player. Clicking the top recording plays it - the cursor moves through the
+ * mini app, the click ripples, and the timeline advances. One hidden checkbox
+ * drives it via `:checked ~` styles; the playback motion is CSS keyframes that
+ * only run while checked, per the preview rules in the
+ * `building-product-empty-states` skill. Playing/paused pairs are stacked in
+ * `__swap` grids, so nothing shifts.
+ */
+export function SessionReplayPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('ReplayPreview', isStatic && 'ReplayPreview--static')}>
+            {/* Playing state, before both cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="replay-preview-play" className="ReplayPreview__checkbox" />
+
+            <div className="ReplayPreview__list">
+                <div className="ReplayPreview__head">
+                    <span className="ReplayPreview__title">
+                        <span className="ReplayPreview__rec-dot" aria-hidden="true" />
+                        Recordings
+                    </span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+                <div className="ReplayPreview__rows">
+                    <label htmlFor="replay-preview-play" className="ReplayPreview__row ReplayPreview__row--hero">
+                        <span className="ReplayPreview__person">Mia K.</span>
+                        <span className="ReplayPreview__meta">checkout flow · 12 clicks</span>
+                        <span className="ReplayPreview__duration ReplayPreview__swap">
+                            <span className="ReplayPreview__when-paused">4:12</span>
+                            <span className="ReplayPreview__now-playing ReplayPreview__when-playing">playing</span>
+                        </span>
+                    </label>
+                    <div className="ReplayPreview__row">
+                        <span className="ReplayPreview__person">Anonymous user</span>
+                        <span className="ReplayPreview__meta">pricing page · 3 clicks</span>
+                        <span className="ReplayPreview__duration">1:03</span>
+                    </div>
+                    <div className="ReplayPreview__row">
+                        <span className="ReplayPreview__person">Sam T.</span>
+                        <span className="ReplayPreview__meta">dashboard · 41 clicks</span>
+                        <span className="ReplayPreview__duration">12:40</span>
+                    </div>
+                </div>
+                <div className="ReplayPreview__hint ReplayPreview__swap">
+                    <span className="ReplayPreview__when-paused">Click a recording to watch the session.</span>
+                    <span className="ReplayPreview__when-playing">
+                        Every click, scroll, and console log, replayed. Click again to pause.
+                    </span>
+                </div>
+            </div>
+
+            <div className="ReplayPreview__player">
+                <div className="ReplayPreview__screen">
+                    {/* The recorded app: a wireframe page the cursor travels through while playing. */}
+                    <div className="ReplayPreview__wire" aria-hidden="true">
+                        <span className="ReplayPreview__wire-nav" />
+                        <span className="ReplayPreview__wire-line" />
+                        <span className="ReplayPreview__wire-line ReplayPreview__wire-line--short" />
+                        <span className="ReplayPreview__wire-button" />
+                    </div>
+                    <span className="ReplayPreview__cursor" aria-hidden="true" />
+                    <div className="ReplayPreview__overlay ReplayPreview__when-paused" aria-hidden="true">
+                        <span className="ReplayPreview__overlay-play">▶</span>
+                    </div>
+                </div>
+                <div className="ReplayPreview__controls">
+                    <span className="ReplayPreview__play-glyph ReplayPreview__swap" aria-hidden="true">
+                        <span className="ReplayPreview__when-paused">▶</span>
+                        <span className="ReplayPreview__when-playing">❚❚</span>
+                    </span>
+                    <span className="ReplayPreview__timeline" aria-hidden="true">
+                        <span className="ReplayPreview__timeline-activity" />
+                        <span className="ReplayPreview__timeline-progress" />
+                    </span>
+                    <span className="ReplayPreview__time ReplayPreview__swap">
+                        <span className="ReplayPreview__when-paused">0:00 / 4:12</span>
+                        <span className="ReplayPreview__when-playing">· / 4:12</span>
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/replay/frontend/emptyState/sessionReplayEmptyState.tsx
+++ b/products/replay/frontend/emptyState/sessionReplayEmptyState.tsx
@@ -33,14 +33,17 @@ export const sessionReplayEmptyState: SceneProductEmptyState = {
                 lead: 'New sessions start recording as users visit your site. The first replays usually show up here a few minutes after a visit.',
             },
         },
+        // Recording is already on in `waiting-for-data`, so the opt-in only belongs on the setup screen.
         primaryAction: {
-            label: 'Enable session recording',
-            onClick: () => {
-                teamLogic.findMounted()?.actions.updateCurrentTeam({ session_recording_opt_in: true })
-            },
-            accessControl: {
-                resourceType: AccessControlResourceType.SessionRecording,
-                minAccessLevel: AccessControlLevel.Editor,
+            'needs-setup': {
+                label: 'Enable session recording',
+                onClick: () => {
+                    teamLogic.findMounted()?.actions.updateCurrentTeam({ session_recording_opt_in: true })
+                },
+                accessControl: {
+                    resourceType: AccessControlResourceType.SessionRecording,
+                    minAccessLevel: AccessControlLevel.Editor,
+                },
             },
         },
         docsUrl: 'https://posthog.com/docs/session-replay',

--- a/products/replay/frontend/emptyState/sessionReplayEmptyState.tsx
+++ b/products/replay/frontend/emptyState/sessionReplayEmptyState.tsx
@@ -1,0 +1,50 @@
+import * as directorPng from '@posthog/brand/hoggies/png/director'
+import { IconRewindPlay } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { SessionReplayPreview } from './SessionReplayPreview'
+import { sessionReplaySetupLogic } from './sessionReplaySetupLogic'
+
+const HedgehogDirector = pngHoggie(directorPng)
+
+export const sessionReplayEmptyState: SceneProductEmptyState = {
+    statusLogic: sessionReplaySetupLogic,
+    config: {
+        productKey: ProductKey.SESSION_REPLAY,
+        productName: 'Session replay',
+        icon: <IconRewindPlay />,
+        accentColor: 'var(--color-product-session-replay-light)',
+        accentColorDark: 'var(--color-product-session-replay-dark)',
+        hedgehog: HedgehogDirector,
+        text: {
+            'needs-setup': {
+                headline: 'Watch how people really use your product',
+                lead: 'Record sessions and replay every click, scroll, and console log. See where users get stuck, reproduce bugs exactly as they happened, and jump from any event or error to the moment it occurred.',
+                hint: 'Already sending events with posthog-js? One click and recording starts:',
+            },
+            'waiting-for-data': {
+                headline: 'Recording is on. Waiting for the first session',
+                lead: 'New sessions start recording as users visit your site. The first replays usually show up here a few minutes after a visit.',
+            },
+        },
+        primaryAction: {
+            label: 'Enable session recording',
+            onClick: () => {
+                teamLogic.findMounted()?.actions.updateCurrentTeam({ session_recording_opt_in: true })
+            },
+            accessControl: {
+                resourceType: AccessControlResourceType.SessionRecording,
+                minAccessLevel: AccessControlLevel.Editor,
+            },
+        },
+        docsUrl: 'https://posthog.com/docs/session-replay',
+        previewLabel: 'Your recordings, once sessions arrive',
+        Preview: SessionReplayPreview,
+    },
+}

--- a/products/replay/frontend/emptyState/sessionReplayEmptyState.tsx
+++ b/products/replay/frontend/emptyState/sessionReplayEmptyState.tsx
@@ -3,10 +3,11 @@ import { IconRewindPlay } from '@posthog/icons'
 
 import { pngHoggie } from 'lib/brand/hoggies'
 import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { RestrictionScope } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { SessionReplayPreview } from './SessionReplayPreview'
 import { sessionReplaySetupLogic } from './sessionReplaySetupLogic'
@@ -40,9 +41,10 @@ export const sessionReplayEmptyState: SceneProductEmptyState = {
                 onClick: () => {
                     teamLogic.findMounted()?.actions.updateCurrentTeam({ session_recording_opt_in: true })
                 },
-                accessControl: {
-                    resourceType: AccessControlResourceType.SessionRecording,
-                    minAccessLevel: AccessControlLevel.Editor,
+                // Same gate as the settings toggle that writes this field (`ReplayGeneral`).
+                restriction: {
+                    scope: RestrictionScope.Project,
+                    minimumAccessLevel: TeamMembershipLevel.Admin,
                 },
             },
         },

--- a/products/replay/frontend/emptyState/sessionReplaySetupLogic.test.ts
+++ b/products/replay/frontend/emptyState/sessionReplaySetupLogic.test.ts
@@ -1,0 +1,33 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import type { TeamType } from '~/types'
+
+import { sessionReplaySetupLogic } from './sessionReplaySetupLogic'
+
+describe('sessionReplaySetupLogic', () => {
+    // Guards the three-state mapping the scene gate hangs off: recordings must
+    // outrank the toggle (turning recording off keeps old recordings, and this
+    // scene is the only place to watch them), and opt-in without recordings must
+    // read as waiting, not as "install".
+    it.each([
+        [true, false, 'has-data'],
+        [true, true, 'has-data'],
+        [false, true, 'waiting-for-data'],
+        [false, false, 'needs-setup'],
+    ])('recordings=%s, optIn=%s maps to %s', async (hasRecordings, optIn, expected) => {
+        initKeaTests(true, { ...MOCK_DEFAULT_TEAM, session_recording_opt_in: optIn } as TeamType)
+        jest.spyOn(api.recordings, 'list').mockResolvedValue({
+            results: hasRecordings ? [{ id: '1' }] : [],
+        } as any)
+        sessionReplaySetupLogic.mount()
+        await expectLogic(sessionReplaySetupLogic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.SESSION_REPLAY }).values.status).toBe(expected)
+    })
+})

--- a/products/replay/frontend/emptyState/sessionReplaySetupLogic.test.ts
+++ b/products/replay/frontend/emptyState/sessionReplaySetupLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import api from 'lib/api'
 import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+import { recordingMetaJson } from 'scenes/session-recordings/__mocks__/recording_meta'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
@@ -24,8 +25,9 @@ describe('sessionReplaySetupLogic', () => {
     ])('recordings=%s, optIn=%s maps to %s', async (hasRecordings, optIn, expected) => {
         initKeaTests(true, { ...MOCK_DEFAULT_TEAM, session_recording_opt_in: optIn } as TeamType)
         jest.spyOn(api.recordings, 'list').mockResolvedValue({
-            results: hasRecordings ? [{ id: '1' }] : [],
-        } as any)
+            results: hasRecordings ? [recordingMetaJson] : [],
+            has_next: false,
+        })
         sessionReplaySetupLogic.mount()
         await expectLogic(sessionReplaySetupLogic).toFinishAllListeners()
         expect(productSetupStatusLogic({ productKey: ProductKey.SESSION_REPLAY }).values.status).toBe(expected)

--- a/products/replay/frontend/emptyState/sessionReplaySetupLogic.ts
+++ b/products/replay/frontend/emptyState/sessionReplaySetupLogic.ts
@@ -1,0 +1,30 @@
+import api from 'lib/api'
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { ProductKey } from '~/queries/schema/schema-general'
+
+/**
+ * Setup detection for the session replay empty state. Three-state: recordings
+ * exist → has-data; recording opt-in without recordings yet → waiting-for-data;
+ * neither → needs-setup. No has-data cache: recordings expire with retention,
+ * so a positive answer is not permanent.
+ */
+export const sessionReplaySetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.SESSION_REPLAY,
+    path: ['products', 'replay', 'frontend', 'emptyState', 'sessionReplaySetupLogic'],
+    detect: async () => {
+        const response = await api.recordings.list({ kind: NodeKind.RecordingsQuery, limit: 1 })
+        if (response.results.length > 0) {
+            return 'has-data'
+        }
+        return teamLogic.findMounted()?.values.currentTeam?.session_recording_opt_in
+            ? 'waiting-for-data'
+            : 'needs-setup'
+    },
+    pollIntervalMs: 20000,
+    // Enabling recording (from this empty state or settings) must flip the
+    // screen to "waiting" right away, not on the next poll tick.
+    recheckActionTypes: () => [teamLogic.actionTypes.updateCurrentTeamSuccess],
+})

--- a/products/replay/package.json
+++ b/products/replay/package.json
@@ -8,7 +8,11 @@
         "kea-loaders": "catalog:",
         "kea-router": "catalog:"
     },
+    "devDependencies": {
+        "kea-test-utils": "catalog:"
+    },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",


### PR DESCRIPTION
## Problem

A user opening session replay before enabling recording gets a large benefits banner above an empty recordings list, and enabling only happens over in settings.

Stacks on #90628; part of the empty-states stack based on #90606.

## Changes

- The replay scene now shows the shared setup empty state: a one-click "Enable session recording" action, docs, and an interactive example player. Screenshots below.
- Enabling flips the screen to a "waiting for the first session" state immediately (`recheckActionTypes` on team updates), and a 20-second poll flips it to the real scene once recordings land.
- The preview stages the product: clicking a recording plays it - the cursor tours a mini page and clicks its button, the timeline advances. Playback motion runs only after the click and respects reduced motion.
- Recordings outrank the toggle: a project with old recordings and recording since disabled keeps its scene (the list is the only place to watch them).
- The in-scene benefits banner (`Warnings`) is deleted.
- No has-data caching: recordings expire with retention, so a positive answer is not permanent.

**Setup screen:**

![Setup screen](https://raw.githubusercontent.com/PostHog/pr-assets/f02a4dc8d261d20cc57b65eff109adaa459540fb/2026/08/901c309b-c0d7-492b-9a30-4e18235ac00e.png)

**Playing the example recording:**

![Playing the example recording](https://raw.githubusercontent.com/PostHog/pr-assets/5e9fd9fc4cb9d20af07da302bc3b400f0c9bd17a/2026/08/2ce8ad69-b7a4-436e-af58-47e2040bf89a.png)

**Waiting for the first session (recording on):**

![Waiting for the first session (recording on)](https://raw.githubusercontent.com/PostHog/pr-assets/162e5446939421f888859fcdba6469603c09bf2e/2026/08/66ea84c7-1a1a-41a2-9157-587eaeefdf47.png)

## How did you test this code?

- `sessionReplaySetupLogic.test.ts` (new): fails if recordings stop outranking the toggle (projects with old recordings would be gated) or if opt-in without recordings reads as "install" instead of "waiting".
- Not run: Playwright; the two new Storybook stories cover both modes for visual regression.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), directed by the assignee, who chose the one-click enable pattern over a settings link. Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`. No wizard terminal: the wizard CLI has no session-replay subcommand.

