### PR TITLE
feat(web-analytics): show a setup empty state on the web vitals tab

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -56,7 +56,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Metrics                | `products/metrics/frontend/MetricsScene.tsx`                                        | on master             |
 | Surveys                | `frontend/src/scenes/surveys/Surveys.tsx`                                           | on master             |
 | Session replay         | `frontend/src/scenes/session-recordings/SessionRecordings.tsx`                      | on master             |
-| Web vitals             | `frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx`                           | in review             |
+| Web vitals             | `frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx`                           | on master             |
 | Data warehouse sources | `products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx`             | in review             |
 | Workflows              | `products/workflows/frontend/WorkflowsScene.tsx`                                    | in review             |
 | Marketing analytics    | `frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx`               | in review             |

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1900,6 +1900,14 @@ snapshots:
         hash: v1.k794b7964.bc46449177ab847f94c92990d63d818c36eee7c688fc4c694469bb4ffad13e99.YN8yq4k0SgUx8yRoP6iyXigFMsObNSJMRXij34vvvu0
     components-product-empty-state--web-scripts-needs-setup--light:
         hash: v1.k794b7964.d70b7bb0fd575b82e9fd19678205c7a6d54fbaf7301b7670494f07f198a46253.upjEetjILtgCy80wRPMBvXc8e2v_85QawiUUX_zQfWI
+    components-product-empty-state--web-vitals-needs-setup--dark:
+        hash: v1.k794b7964.a123b5fbeb5ec66e2b86029722bdb747f611edd6b3351d19aab595998f9a3e71.nq3NPk6-keGcErRmLOYzHUTNfhw9QZ-8yMF0CgMGhRA
+    components-product-empty-state--web-vitals-needs-setup--light:
+        hash: v1.k794b7964.ae9aaec0dabe879db5d840061203cf13d750f0164c9a2fdf911f79af6e814604.YkoWUrhiyFPv1Z9FSvQXitElTzMRVX4iNq_UoxxQDRA
+    components-product-empty-state--web-vitals-waiting-for-data--dark:
+        hash: v1.k794b7964.9f74f04645220e7f649d8086c82e822766320c8a29bcbfd3d5aa5345e9da964f.rzsACSxaLP53U_YzFwcDYxpVsCy4XN4Qg0U8-5SsCyk
+    components-product-empty-state--web-vitals-waiting-for-data--light:
+        hash: v1.k794b7964.eaac20368e776886dceff3b45c056fb19f21b7a09a22e6d7e229e9dab7140512.55yNDBmaE14aOQD_JQRC28OIos3A7vEZatViEIlgLSs
     components-productsetup-productsetuppopover--default--dark:
         hash: v1.k794b7964.8577f1ec7bdb47266c031df353e220d017de2e86125924d5da8b0f052c6ce1a6.cA5-fWqyOm-PbSjy7Y8JZ4rQXAe7hn0soi6VkQ36dfc
     components-productsetup-productsetuppopover--default--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -26,6 +26,7 @@ import { llmSkillsEmptyState } from 'products/skills/frontend/emptyState/llmSkil
 import { surveysEmptyState } from 'products/surveys/frontend/emptyState/surveysEmptyState'
 import { tracingEmptyState } from 'products/tracing/frontend/emptyState/tracingEmptyState'
 import { userInterviewsEmptyState } from 'products/user_interviews/frontend/emptyState/userInterviewsEmptyState'
+import { webVitalsEmptyState } from 'products/web_analytics/frontend/emptyState/webVitalsEmptyState'
 
 import { ProductEmptyState } from './ProductEmptyState'
 import { ProductEmptyStateStory, productEmptyStateStory } from './storybookHelpers'
@@ -272,4 +273,19 @@ export const SessionReplayWaitingForData: ProductEmptyStateStory = productEmptyS
     sessionReplayEmptyState,
     'waiting-for-data',
     { mocks: sessionReplayMocks }
+)
+
+// Web vitals detection asks event definitions on mount - answer "none yet".
+const webVitalsMocks = {
+    get: { '/api/projects/:team_id/event_definitions/': [200, { results: [] }] },
+} as const
+
+export const WebVitalsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(webVitalsEmptyState, 'needs-setup', {
+    mocks: webVitalsMocks,
+})
+
+export const WebVitalsWaitingForData: ProductEmptyStateStory = productEmptyStateStory(
+    webVitalsEmptyState,
+    'waiting-for-data',
+    { mocks: webVitalsMocks }
 )

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyStateGate.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyStateGate.tsx
@@ -57,10 +57,14 @@ export interface ProductEmptyStateGateProps {
  */
 export function ProductEmptyStateGate({ emptyState, children }: ProductEmptyStateGateProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
+    const { activeSceneId } = useValues(sceneLogic)
 
-    // When the empty state is flag-gated, stay a strict no-op while the flag is off —
-    // don't even mount detection (the inner component is what mounts it).
+    // When the empty state is flag-gated or scoped to specific scenes, stay a strict
+    // no-op otherwise — don't even mount detection (the inner component mounts it).
     if (emptyState.featureFlag && !featureFlags[emptyState.featureFlag]) {
+        return <>{children}</>
+    }
+    if (emptyState.scenes && (!activeSceneId || !emptyState.scenes.includes(activeSceneId))) {
         return <>{children}</>
     }
     return <ProductEmptyStateGateInner emptyState={emptyState}>{children}</ProductEmptyStateGateInner>

--- a/frontend/src/lib/components/ProductEmptyState/types.ts
+++ b/frontend/src/lib/components/ProductEmptyState/types.ts
@@ -165,4 +165,11 @@ export interface SceneProductEmptyState {
      * roll the empty state out gradually.
      */
     featureFlag?: FeatureFlagKey
+    /**
+     * Only gate these scene ids (`Scene` values), for scene modules that serve
+     * several scenes (tabs) where just one is the product being gated - e.g. the
+     * web analytics module, where only the web vitals tab has a setup state.
+     * Omit to gate every scene the module serves.
+     */
+    scenes?: string[]
 }

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1733,6 +1733,7 @@ export const productSetupProbes: ProductSetupProbe[] = [
         waitingEvents: ['$mcp_initialize'],
         featureFlag: FEATURE_FLAGS.MCP_ANALYTICS,
     },
+    { productKey: ProductKey.WEB_ANALYTICS, hasDataEvents: ['$web_vitals'] },
 ]
 
 /** This const is auto-generated, as is the whole file */

--- a/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsDashboard.tsx
@@ -930,37 +930,6 @@ const WebAnalyticsTabs = (): JSX.Element => {
     )
 }
 
-const WebVitalsEmptyState = (): JSX.Element => {
-    const { currentTeam } = useValues(teamLogic)
-    const { updateCurrentTeam } = useActions(teamLogic)
-
-    return (
-        <div className="col-span-full w-full">
-            <ProductIntroduction
-                productName="Web Vitals"
-                productKey={ProductKey.WEB_ANALYTICS}
-                thingName="web vital"
-                isEmpty={true}
-                titleOverride="Enable web vitals to get started"
-                description="Track Core Web Vitals like LCP, FID, and CLS to understand your site's performance. 
-                Enabling this will capture performance metrics from your visitors, which counts towards your event quota.
-                You can always disable this feature in the settings."
-                docsURL="https://posthog.com/docs/web-analytics/web-vitals"
-                actionElementOverride={
-                    <LemonButton
-                        type="primary"
-                        onClick={() => updateCurrentTeam({ autocapture_web_vitals_opt_in: true })}
-                        data-attr="web-vitals-enable"
-                        disabledReason={currentTeam ? undefined : 'Loading...'}
-                    >
-                        Enable web vitals
-                    </LemonButton>
-                }
-            />
-        </div>
-    )
-}
-
 const getEmptyOnboardingContent = (
     featureFlags: FeatureFlagsSet,
     currentTeamLoading: boolean,
@@ -1006,10 +975,6 @@ const getEmptyOnboardingContent = (
                 />
             </div>
         )
-    }
-
-    if (productTab === ProductTab.WEB_VITALS && !currentTeam?.autocapture_web_vitals_opt_in) {
-        return <WebVitalsEmptyState />
     }
 
     return null

--- a/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
+++ b/frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx
@@ -14,6 +14,8 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { webVitalsEmptyState } from 'products/web_analytics/frontend/emptyState/webVitalsEmptyState'
+
 export function WebAnalyticsScene(): JSX.Element {
     useMaxTool({
         identifier: 'web_analytics_doctor',
@@ -75,4 +77,5 @@ export const scene: SceneExport = {
     component: WebAnalyticsScene,
     logic: webAnalyticsLogic,
     productKey: ProductKey.WEB_ANALYTICS,
+    emptyState: webVitalsEmptyState,
 }

--- a/products/web_analytics/frontend/emptyState/WebVitalsPreview.scss
+++ b/products/web_analytics/frontend/emptyState/WebVitalsPreview.scss
@@ -1,0 +1,252 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.VitalsPreview {
+    --vitals-preview-accent: var(--empty-state-accent, var(--color-primary-500));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden focus state. A direct child of .VitalsPreview so `:checked ~` reaches both cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__tiles-card,
+    &__pages {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Focused/idle pairs are stacked on one grid cell and crossfaded, so focusing
+    // never changes any element's size (no layout shift). Fitting, for a CLS demo.
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-focused {
+        @include preview-swap-hidden;
+    }
+
+    &__when-idle {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    &__live-dot {
+        width: 7px;
+        height: 7px;
+        background: var(--vitals-preview-accent);
+        border-radius: 50%;
+        animation: VitalsPreview__pulse 2s ease-in-out infinite;
+    }
+
+    // Vitals tiles
+
+    &__tiles {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 0.5rem;
+        padding: 0.625rem 0.75rem 0.375rem;
+    }
+
+    &__tile {
+        display: flex;
+        flex-direction: column;
+        gap: 0.125rem;
+        padding: 0.4375rem 0.5rem;
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+        transition:
+            background-color 250ms ease,
+            box-shadow 250ms ease;
+    }
+
+    &__tile--hero {
+        cursor: pointer;
+        user-select: none;
+    }
+
+    &__tile--hero:hover {
+        background: var(--color-bg-fill-highlight-50);
+    }
+
+    &__tile-name {
+        font-size: 0.625rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+    }
+
+    &__tile-value {
+        font-size: 0.875rem;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+    }
+
+    &__tile-value--poor {
+        color: var(--color-text-error);
+    }
+
+    &__tile-band {
+        font-size: 0.5625rem;
+        font-weight: 600;
+        text-transform: uppercase;
+    }
+
+    &__tile-band--good {
+        color: var(--color-text-secondary);
+    }
+
+    &__tile-band--poor {
+        color: var(--color-text-error);
+    }
+
+    &__hint {
+        padding: 0.25rem 0.75rem 0.5rem;
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    // Pages list
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem 0.375rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto 4.5rem;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.3125rem 0.5rem;
+        border-radius: var(--radius);
+        transition: background-color 250ms ease;
+    }
+
+    &__path {
+        overflow: hidden;
+        font-family: var(--font-mono);
+        font-size: 0.6875rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__visits {
+        font-size: 0.625rem;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-tertiary);
+    }
+
+    &__score {
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-secondary);
+        text-align: right;
+    }
+
+    &__score--poor {
+        font-weight: 600;
+        color: var(--color-text-error);
+    }
+
+    &__fresh {
+        font-size: 0.5625rem;
+        font-weight: 600;
+
+        @include preview-accent-text(var(--vitals-preview-accent));
+    }
+}
+
+// Focused state (user clicked the CLS tile)
+
+.VitalsPreview__checkbox:checked ~ * .VitalsPreview__when-focused {
+    @include preview-swap-visible;
+}
+
+.VitalsPreview__checkbox:checked ~ * .VitalsPreview__when-idle {
+    @include preview-swap-hidden;
+}
+
+.VitalsPreview__checkbox:checked ~ .VitalsPreview__tiles-card .VitalsPreview__tile--hero {
+    background: color-mix(in oklab, var(--danger) 7%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--danger) 35%, transparent);
+}
+
+// Focusing CLS surfaces its offenders and dims the healthy pages.
+.VitalsPreview__checkbox:checked ~ .VitalsPreview__pages .VitalsPreview__row:not(.VitalsPreview__row--offender) {
+    opacity: 0.35;
+}
+
+.VitalsPreview__checkbox:checked ~ .VitalsPreview__pages .VitalsPreview__row--offender {
+    background: color-mix(in oklab, var(--danger) 7%, transparent);
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the tile it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.VitalsPreview__checkbox:focus-visible ~ .VitalsPreview__tiles-card .VitalsPreview__tile--hero {
+    outline: 2px solid var(--vitals-preview-accent);
+    outline-offset: 1px;
+}
+
+// Nudge attention at the failing tile until it's inspected.
+.VitalsPreview:not(.VitalsPreview--static)
+    .VitalsPreview__checkbox:not(:checked)
+    ~ .VitalsPreview__tiles-card
+    .VitalsPreview__tile--hero {
+    animation: VitalsPreview__nudge 2.4s ease-in-out infinite;
+}
+
+@keyframes VitalsPreview__nudge {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--danger) 40%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--danger) 15%, transparent);
+    }
+}
+
+@keyframes VitalsPreview__pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.35;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; clicking the
+// tile still flips the state (transitions only).
+@include preview-motion-guards('VitalsPreview');

--- a/products/web_analytics/frontend/emptyState/WebVitalsPreview.tsx
+++ b/products/web_analytics/frontend/emptyState/WebVitalsPreview.tsx
@@ -1,0 +1,95 @@
+import './WebVitalsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+/**
+ * Example-data preview for the web vitals empty state: the four vitals tiles and
+ * the pages behind them. Clicking the failing CLS tile highlights the pages that
+ * drag it down. One hidden checkbox drives it via `:checked ~` styles - no timers
+ * or state, per the preview rules in the `building-product-empty-states` skill.
+ * Focused/unfocused pairs are stacked in `__swap` grids, so nothing shifts.
+ */
+export function WebVitalsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('VitalsPreview', isStatic && 'VitalsPreview--static')}>
+            {/* Focus state, before both cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="vitals-preview-focus" className="VitalsPreview__checkbox" />
+
+            <div className="VitalsPreview__tiles-card">
+                <div className="VitalsPreview__head">
+                    <span className="VitalsPreview__title">
+                        <span className="VitalsPreview__live-dot" aria-hidden="true" />
+                        Core Web Vitals · last 7 days
+                    </span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+                <div className="VitalsPreview__tiles">
+                    <div className="VitalsPreview__tile">
+                        <span className="VitalsPreview__tile-name">LCP</span>
+                        <span className="VitalsPreview__tile-value">2.1 s</span>
+                        <span className="VitalsPreview__tile-band VitalsPreview__tile-band--good">good</span>
+                    </div>
+                    <div className="VitalsPreview__tile">
+                        <span className="VitalsPreview__tile-name">INP</span>
+                        <span className="VitalsPreview__tile-value">180 ms</span>
+                        <span className="VitalsPreview__tile-band VitalsPreview__tile-band--good">good</span>
+                    </div>
+                    <label htmlFor="vitals-preview-focus" className="VitalsPreview__tile VitalsPreview__tile--hero">
+                        <span className="VitalsPreview__tile-name">CLS</span>
+                        <span className="VitalsPreview__tile-value VitalsPreview__tile-value--poor">0.24</span>
+                        <span className="VitalsPreview__tile-band VitalsPreview__tile-band--poor">poor</span>
+                    </label>
+                    <div className="VitalsPreview__tile">
+                        <span className="VitalsPreview__tile-name">FCP</span>
+                        <span className="VitalsPreview__tile-value">1.2 s</span>
+                        <span className="VitalsPreview__tile-band VitalsPreview__tile-band--good">good</span>
+                    </div>
+                </div>
+                <div className="VitalsPreview__hint VitalsPreview__swap">
+                    <span className="VitalsPreview__when-idle">
+                        Click the failing metric to find the pages behind it.
+                    </span>
+                    <span className="VitalsPreview__when-focused">
+                        Two pages shift their layout on load. Click again to unfocus.
+                    </span>
+                </div>
+            </div>
+
+            <div className="VitalsPreview__pages">
+                <div className="VitalsPreview__head">
+                    <span className="VitalsPreview__title VitalsPreview__swap">
+                        <span className="VitalsPreview__when-idle">Pages by traffic</span>
+                        <span className="VitalsPreview__when-focused">Pages by CLS</span>
+                    </span>
+                    <span className="VitalsPreview__fresh VitalsPreview__when-focused">worst first</span>
+                </div>
+                <div className="VitalsPreview__rows">
+                    <div className="VitalsPreview__row VitalsPreview__row--offender">
+                        <span className="VitalsPreview__path">/pricing</span>
+                        <span className="VitalsPreview__visits">8.1k visits</span>
+                        <span className="VitalsPreview__score VitalsPreview__score--poor">CLS 0.41</span>
+                    </div>
+                    <div className="VitalsPreview__row VitalsPreview__row--offender">
+                        <span className="VitalsPreview__path">/blog</span>
+                        <span className="VitalsPreview__visits">5.4k visits</span>
+                        <span className="VitalsPreview__score VitalsPreview__score--poor">CLS 0.29</span>
+                    </div>
+                    <div className="VitalsPreview__row">
+                        <span className="VitalsPreview__path">/</span>
+                        <span className="VitalsPreview__visits">21.9k visits</span>
+                        <span className="VitalsPreview__score">CLS 0.05</span>
+                    </div>
+                    <div className="VitalsPreview__row">
+                        <span className="VitalsPreview__path">/docs</span>
+                        <span className="VitalsPreview__visits">12.2k visits</span>
+                        <span className="VitalsPreview__score">CLS 0.02</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/web_analytics/frontend/emptyState/webVitalsEmptyState.tsx
+++ b/products/web_analytics/frontend/emptyState/webVitalsEmptyState.tsx
@@ -37,17 +37,20 @@ export const webVitalsEmptyState: SceneProductEmptyState = {
                 lead: 'Web vitals arrive with your next page visits. Open your site in another tab and the first samples show up here on their own.',
             },
         },
+        // Autocapture is already on in `waiting-for-data`, so the opt-in only belongs on the setup screen.
         primaryAction: {
-            label: 'Enable web vitals autocapture',
-            onClick: () => {
-                teamLogic.findMounted()?.actions.updateCurrentTeam({ autocapture_web_vitals_opt_in: true })
+            'needs-setup': {
+                label: 'Enable web vitals autocapture',
+                onClick: () => {
+                    teamLogic.findMounted()?.actions.updateCurrentTeam({ autocapture_web_vitals_opt_in: true })
+                },
+                accessControl: {
+                    resourceType: AccessControlResourceType.WebAnalytics,
+                    minAccessLevel: AccessControlLevel.Editor,
+                },
+                // pinned: Playwright and autocapture dashboards select the old enable button by this attr
+                dataAttr: 'web-vitals-enable',
             },
-            accessControl: {
-                resourceType: AccessControlResourceType.WebAnalytics,
-                minAccessLevel: AccessControlLevel.Editor,
-            },
-            // pinned: Playwright and autocapture dashboards select the old enable button by this attr
-            dataAttr: 'web-vitals-enable',
         },
         docsUrl: 'https://posthog.com/docs/web-analytics/web-vitals',
         previewLabel: 'Your vitals, once samples arrive',

--- a/products/web_analytics/frontend/emptyState/webVitalsEmptyState.tsx
+++ b/products/web_analytics/frontend/emptyState/webVitalsEmptyState.tsx
@@ -1,0 +1,56 @@
+import * as drivingHogzillaPng from '@posthog/brand/hoggies/png/driving-hogzilla'
+import { IconPieChart } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { Scene } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { WebVitalsPreview } from './WebVitalsPreview'
+import { webVitalsSetupLogic } from './webVitalsSetupLogic'
+
+const HedgehogDriving = pngHoggie(drivingHogzillaPng)
+
+export const webVitalsEmptyState: SceneProductEmptyState = {
+    statusLogic: webVitalsSetupLogic,
+    // Only the web vitals tab has a setup state; the analytics tabs the same
+    // scene module serves are never gated.
+    scenes: [Scene.WebAnalyticsWebVitals],
+    config: {
+        productKey: ProductKey.WEB_ANALYTICS,
+        productName: 'Web vitals',
+        icon: <IconPieChart />,
+        accentColor: 'var(--color-product-web-analytics-light)',
+        accentColorDark: 'var(--color-product-web-analytics-dark)',
+        hedgehog: HedgehogDriving,
+        text: {
+            'needs-setup': {
+                headline: 'Know how fast your site feels',
+                lead: 'Capture Core Web Vitals (LCP, CLS, INP, and FCP) from real visits and see which pages drag them down. Captured events count toward your event quota, and you can turn this off any time in settings.',
+                hint: 'Already sending pageviews with posthog-js? One click and vitals start flowing:',
+            },
+            'waiting-for-data': {
+                headline: 'Autocapture is on. Waiting for the first vitals',
+                lead: 'Web vitals arrive with your next page visits. Open your site in another tab and the first samples show up here on their own.',
+            },
+        },
+        primaryAction: {
+            label: 'Enable web vitals autocapture',
+            onClick: () => {
+                teamLogic.findMounted()?.actions.updateCurrentTeam({ autocapture_web_vitals_opt_in: true })
+            },
+            accessControl: {
+                resourceType: AccessControlResourceType.WebAnalytics,
+                minAccessLevel: AccessControlLevel.Editor,
+            },
+            // pinned: Playwright and autocapture dashboards select the old enable button by this attr
+            dataAttr: 'web-vitals-enable',
+        },
+        docsUrl: 'https://posthog.com/docs/web-analytics/web-vitals',
+        previewLabel: 'Your vitals, once samples arrive',
+        Preview: WebVitalsPreview,
+    },
+}

--- a/products/web_analytics/frontend/emptyState/webVitalsEmptyState.tsx
+++ b/products/web_analytics/frontend/emptyState/webVitalsEmptyState.tsx
@@ -3,11 +3,12 @@ import { IconPieChart } from '@posthog/icons'
 
 import { pngHoggie } from 'lib/brand/hoggies'
 import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { RestrictionScope } from 'lib/components/RestrictedArea'
+import { TeamMembershipLevel } from 'lib/constants'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { WebVitalsPreview } from './WebVitalsPreview'
 import { webVitalsSetupLogic } from './webVitalsSetupLogic'
@@ -44,9 +45,10 @@ export const webVitalsEmptyState: SceneProductEmptyState = {
                 onClick: () => {
                     teamLogic.findMounted()?.actions.updateCurrentTeam({ autocapture_web_vitals_opt_in: true })
                 },
-                accessControl: {
-                    resourceType: AccessControlResourceType.WebAnalytics,
-                    minAccessLevel: AccessControlLevel.Editor,
+                // Same gate as the settings toggle that writes this field.
+                restriction: {
+                    scope: RestrictionScope.Project,
+                    minimumAccessLevel: TeamMembershipLevel.Admin,
                 },
                 // pinned: Playwright and autocapture dashboards select the old enable button by this attr
                 dataAttr: 'web-vitals-enable',

--- a/products/web_analytics/frontend/emptyState/webVitalsSetupLogic.test.ts
+++ b/products/web_analytics/frontend/emptyState/webVitalsSetupLogic.test.ts
@@ -1,0 +1,35 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import type { TeamType } from '~/types'
+
+import { eventDefinitionsList } from 'products/event_definitions/frontend/generated/api'
+
+import { webVitalsSetupLogic } from './webVitalsSetupLogic'
+
+jest.mock('products/event_definitions/frontend/generated/api', () => ({ eventDefinitionsList: jest.fn() }))
+
+describe('webVitalsSetupLogic', () => {
+    // Guards the three-state mapping the web vitals gate hangs off: dropping the
+    // opt-in branch would show "enable autocapture" to already-enabled projects,
+    // and existing vitals must outrank the toggle.
+    it.each([
+        [true, false, 'has-data'],
+        [true, true, 'has-data'],
+        [false, true, 'waiting-for-data'],
+        [false, false, 'needs-setup'],
+    ])('definition=%s, optIn=%s maps to %s', async (hasDefinition, optIn, expected) => {
+        initKeaTests(true, { ...MOCK_DEFAULT_TEAM, autocapture_web_vitals_opt_in: optIn } as TeamType)
+        ;(eventDefinitionsList as jest.Mock).mockResolvedValue({
+            results: hasDefinition ? [{ name: '$web_vitals' }] : [],
+        })
+        webVitalsSetupLogic.mount()
+        await expectLogic(webVitalsSetupLogic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.WEB_ANALYTICS }).values.status).toBe(expected)
+    })
+})

--- a/products/web_analytics/frontend/emptyState/webVitalsSetupLogic.ts
+++ b/products/web_analytics/frontend/emptyState/webVitalsSetupLogic.ts
@@ -1,0 +1,34 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { eventDefinitionsList } from 'products/event_definitions/frontend/generated/api'
+
+/**
+ * Setup detection for the web vitals empty state (the web vitals tab of web
+ * analytics - the analytics tabs are not gated). Three-state: a `$web_vitals`
+ * event definition exists → has-data; autocapture opted in without one yet →
+ * waiting-for-data; neither → needs-setup.
+ */
+export const webVitalsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.WEB_ANALYTICS,
+    path: ['products', 'web_analytics', 'frontend', 'emptyState', 'webVitalsSetupLogic'],
+    detect: async () => {
+        const teamId = teamLogic.findMounted()?.values.currentTeamId
+        if (!teamId) {
+            return 'unknown'
+        }
+        const response = await eventDefinitionsList(String(teamId), { names: ['$web_vitals'], limit: 1 })
+        if (response.results.some((definition) => definition.name === '$web_vitals')) {
+            return 'has-data'
+        }
+        return teamLogic.findMounted()?.values.currentTeam?.autocapture_web_vitals_opt_in
+            ? 'waiting-for-data'
+            : 'needs-setup'
+    },
+    pollIntervalMs: 20000,
+    // Enabling autocapture (from this empty state or settings) must flip the
+    // screen to "waiting" right away, not on the next poll tick.
+    recheckActionTypes: () => [teamLogic.actionTypes.updateCurrentTeamSuccess],
+})

--- a/products/web_analytics/manifest.tsx
+++ b/products/web_analytics/manifest.tsx
@@ -6,6 +6,13 @@ import { FileSystemIconColor, ProductManifest } from '../../frontend/src/types'
 
 export const manifest: ProductManifest = {
     name: 'Web Analytics',
+    // Boot-time approximation of webVitalsSetupLogic - this gates only the web
+    // vitals tab, not the analytics tabs. The in-scene check stays the source of
+    // truth (it also reads the autocapture opt-in for the waiting state).
+    setupProbe: {
+        productKey: ProductKey.WEB_ANALYTICS,
+        hasDataEvents: ['$web_vitals'],
+    },
     urls: {
         webAnalytics: (): string => `/web`,
         webAnalyticsWebVitals: (): string => `/web/web-vitals`,


### PR DESCRIPTION
## Problem

A user opening the web vitals tab before enabling autocapture gets a flag-gated intro card inside the dashboard grid; without the flag they get an empty dashboard.

Stacks on #90654; part of the empty-states stack based on #90606.

## Changes

- The web vitals tab now shows the shared setup empty state until vitals arrive: a one-click "Enable web vitals autocapture" action, docs, and an interactive example vitals dashboard. Screenshots below.
- Only that tab is gated. The analytics tabs served by the same scene module are untouched, via a new `scenes` filter on the empty-state declaration (platform change in this PR).
- Enabling flips the screen to a waiting state immediately; a `$web_vitals` boot probe resolves the status before the tab is first opened.
- The preview stages the product: four vitals tiles where clicking the failing CLS re-sorts the page list to the offenders that drag it down. Pure CSS, guarded for reduced motion.
- The old flag-gated `WebVitalsEmptyState` intro card is deleted; the enable button keeps its `web-vitals-enable` data-attr.

**Setup screen:**

![Setup screen](https://raw.githubusercontent.com/PostHog/pr-assets/b5bd4b31c25f7b07d42d982faf5e6e54ec19b785/2026/08/5ce851b8-7928-4725-a195-7c232ca78efe.png)

**After clicking the failing CLS tile:**

![After clicking the failing CLS tile](https://raw.githubusercontent.com/PostHog/pr-assets/f0c8c79cec967bf75eb41a02f640befb868d2f48/2026/08/c673fcd3-edeb-4a12-9854-1e33554ae918.png)

**Waiting for the first vitals (autocapture on):**

![Waiting for the first vitals (autocapture on)](https://raw.githubusercontent.com/PostHog/pr-assets/e8b0aef980a8e027c318a6bdad7f48df393d2e53/2026/08/7457c1ee-90a4-4f68-988e-48f17fff2208.png)

## How did you test this code?

- `webVitalsSetupLogic.test.ts` (new): fails if the opt-in branch is dropped (already-enabled projects would see "enable autocapture") or if existing vitals stop outranking the toggle.
- Not run: Playwright; the two new Storybook stories cover both modes for visual regression.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), directed by the assignee, who scoped the empty state to the web vitals tab only. Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`, `/stacking-prs`. The status logic reuses `ProductKey.WEB_ANALYTICS` (no separate web vitals product key exists); the analytics tabs don't gate, so the key has one consumer.

