### PR TITLE
feat(data-warehouse): show the product empty state until a source exists

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -57,7 +57,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Surveys                | `frontend/src/scenes/surveys/Surveys.tsx`                                           | on master             |
 | Session replay         | `frontend/src/scenes/session-recordings/SessionRecordings.tsx`                      | on master             |
 | Web vitals             | `frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx`                           | on master             |
-| Data warehouse sources | `products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx`             | in review             |
+| Data warehouse sources | `products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx`             | on master             |
 | Workflows              | `products/workflows/frontend/WorkflowsScene.tsx`                                    | in review             |
 | Marketing analytics    | `frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx`               | in review             |
 | Customer analytics     | `products/customer_analytics/frontend/CustomerAnalyticsScene.tsx`                   | in review             |

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1780,6 +1780,10 @@ snapshots:
         hash: v1.k794b7964.b3a148d96ca0b54ca8929084054b91f4e52ae02160039f3a47ee04db7aeb62cc.SH8xd4Ro7F3Zuetn_B_qgVFVbWtT__aDzaW2YOr-Eac
     components-product-empty-state--dashboards-needs-setup--light:
         hash: v1.k794b7964.2782384906e9b2efb6153b3bf4b8135fc541639245f74f0abd3456a35023e641.vaJwGqX3KJ-_XLxP_slQ1vIyHx0QZ4fCXnrMtPJHnjg
+    components-product-empty-state--data-warehouse-needs-setup--dark:
+        hash: v1.k794b7964.3d7df6ce8c56af7c0c5200d0a381d5f28c885ad380cb370ea0e250266882d608.vwwreN_qibegkh3R21znmwi-Sp9TfdStRZyRxa-g69A
+    components-product-empty-state--data-warehouse-needs-setup--light:
+        hash: v1.k794b7964.5bdb2d34c7084ea2351b074cd03275e3558be2b79d0e8a7769d57bdb38e87faa.xNdrkZ0mjoEiJ5DAwDJn1W2x8biEG3DKPcO9wAzRM8c
     components-product-empty-state--early-access-features-needs-setup--dark:
         hash: v1.k794b7964.ce612c03290780c1098886d9e2e0f9d920bfa899c591fadfecabf969b1897fe6.RlwNrGim39bhZH0hO39-bt6bWPUPJU-5XgIq2smDxSk
     components-product-empty-state--early-access-features-needs-setup--light:

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -206,7 +206,7 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
     },
     data_warehouse: {
         icon: <IconDatabase />,
-        iconColor: ['var(--color-product-data-warehouse-light)'],
+        iconColor: ['var(--color-product-data-warehouse-light)', 'var(--color-product-data-warehouse-dark)'],
     },
     link: {
         icon: <IconExternal />,

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -10,6 +10,7 @@ import { webScriptsEmptyState } from 'products/cdp/frontend/emptyState/webScript
 import { cohortsEmptyState } from 'products/cohorts/frontend/emptyState/cohortsEmptyState'
 import { supportEmptyState } from 'products/conversations/frontend/emptyState/supportEmptyState'
 import { dashboardsEmptyState } from 'products/dashboards/frontend/emptyState/dashboardsEmptyState'
+import { dataWarehouseEmptyState } from 'products/data_warehouse/frontend/emptyState/dataWarehouseEmptyState'
 import { earlyAccessFeaturesEmptyState } from 'products/early_access_features/frontend/emptyState/earlyAccessFeaturesEmptyState'
 import { endpointsEmptyState } from 'products/endpoints/frontend/emptyState/endpointsEmptyState'
 import { errorTrackingEmptyState } from 'products/error_tracking/frontend/emptyState/errorTrackingEmptyState'
@@ -300,4 +301,19 @@ export const WebVitalsWaitingForData: ProductEmptyStateStory = productEmptyState
     webVitalsEmptyState,
     'waiting-for-data',
     { mocks: webVitalsMocks }
+)
+
+// Data warehouse detection lists sources and tables on mount - answer "none yet".
+export const DataWarehouseNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    dataWarehouseEmptyState,
+    'needs-setup',
+    {
+        mocks: {
+            get: {
+                // nosemgrep: no-environments-api-urls-frontend -- both APIs are env-scoped, so the msw mocks must match /api/environments to intercept them
+                '/api/environments/:team_id/external_data_sources/': [200, { results: [] }],
+                '/api/environments/:team_id/warehouse_tables/': [200, { results: [] }],
+            },
+        },
+    }
 )

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -336,6 +336,7 @@
     --color-product-product-tours-light: rgb(243 84 84);
     --color-product-product-tours-dark: rgb(248 121 121);
     --color-product-data-warehouse-light: rgb(133 103 255);
+    --color-product-data-warehouse-dark: rgb(160 135 255);
     --color-product-llm-analytics-light: rgb(182 42 217);
     --color-product-llm-analytics-dark: rgb(212 106 240);
     --color-product-llm-clusters-light: rgb(147 51 234);

--- a/products/data_warehouse/frontend/emptyState/DataWarehousePreview.scss
+++ b/products/data_warehouse/frontend/emptyState/DataWarehousePreview.scss
@@ -1,0 +1,219 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.WarehousePreview {
+    --warehouse-preview-accent: var(--empty-state-accent, var(--color-primary-500));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden run state. A direct child of .WarehousePreview so `:checked ~` reaches both cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__sources,
+    &__sql {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Idle/run pairs are stacked on one grid cell and crossfaded, so running the
+    // query never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-run {
+        @include preview-swap-hidden;
+    }
+
+    &__when-idle {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    // Sources
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem 0.375rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: 4.5rem minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+    }
+
+    &__source-name {
+        font-size: 0.6875rem;
+        font-weight: 600;
+    }
+
+    &__source-meta {
+        overflow: hidden;
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__badge {
+        display: inline-flex;
+        gap: 0.25rem;
+        align-items: center;
+        padding: 0.0625rem 0.4375rem;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        border-radius: 999px;
+    }
+
+    &__badge--synced {
+        background: color-mix(in oklab, var(--warehouse-preview-accent) 12%, var(--color-bg-surface-primary));
+
+        @include preview-accent-text(var(--warehouse-preview-accent));
+    }
+
+    &__badge--syncing {
+        color: var(--color-text-secondary);
+        background: var(--color-bg-fill-tertiary);
+    }
+
+    &__sync-spinner {
+        width: 7px;
+        height: 7px;
+        border: 1.5px solid color-mix(in oklab, var(--warehouse-preview-accent) 60%, transparent);
+        border-top-color: transparent;
+        border-radius: 50%;
+        animation: WarehousePreview__spin 1.1s linear infinite;
+    }
+
+    // SQL card
+
+    &__run {
+        font-size: 0.6875rem;
+        font-weight: 600;
+        cursor: pointer;
+        user-select: none;
+
+        @include preview-accent-text(var(--warehouse-preview-accent));
+    }
+
+    &__query {
+        padding: 0.5rem 0.75rem;
+        margin: 0;
+        overflow: hidden;
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        line-height: 1.5;
+        color: var(--color-text-secondary);
+        white-space: pre;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__results {
+        padding: 0.5rem 0.75rem 0.625rem;
+    }
+
+    &__results-hint {
+        align-self: center;
+        font-size: 0.6875rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__table {
+        display: flex;
+        flex-direction: column;
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+    }
+
+    &__tr {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 0.5rem;
+        padding: 0.1875rem 0.25rem;
+        font-variant-numeric: tabular-nums;
+    }
+
+    &__tr--head {
+        font-weight: 700;
+        color: var(--color-text-secondary);
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+}
+
+// Run state (user clicked Run)
+
+.WarehousePreview__checkbox:checked ~ * .WarehousePreview__when-run {
+    @include preview-swap-visible;
+}
+
+.WarehousePreview__checkbox:checked ~ * .WarehousePreview__when-idle {
+    @include preview-swap-hidden;
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the Run label
+// needs a visible focus indicator (WCAG 2.4.7).
+.WarehousePreview__checkbox:focus-visible ~ .WarehousePreview__sql .WarehousePreview__run {
+    outline: 2px solid var(--warehouse-preview-accent);
+    outline-offset: 1px;
+}
+
+// Nudge attention at Run until it's clicked.
+.WarehousePreview:not(.WarehousePreview--static)
+    .WarehousePreview__checkbox:not(:checked)
+    ~ .WarehousePreview__sql
+    .WarehousePreview__run {
+    animation: WarehousePreview__nudge 2.4s ease-in-out infinite;
+}
+
+@keyframes WarehousePreview__nudge {
+    0%,
+    100% {
+        text-shadow: 0 0 0 transparent;
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.55;
+    }
+}
+
+@keyframes WarehousePreview__spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; clicking Run
+// still flips the state (transitions only).
+@include preview-motion-guards('WarehousePreview');

--- a/products/data_warehouse/frontend/emptyState/DataWarehousePreview.tsx
+++ b/products/data_warehouse/frontend/emptyState/DataWarehousePreview.tsx
@@ -1,0 +1,87 @@
+import './DataWarehousePreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+/**
+ * Example-data preview for the data warehouse empty state: synced sources and a
+ * SQL join over them. Clicking "Run" fills the results with events joined to
+ * Stripe customers. One hidden checkbox drives it via `:checked ~` styles - no
+ * timers or state, per the preview rules in the `building-product-empty-states`
+ * skill. Idle/run pairs are stacked in `__swap` grids, so nothing shifts.
+ */
+export function DataWarehousePreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('WarehousePreview', isStatic && 'WarehousePreview--static')}>
+            {/* Run state, before both cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="warehouse-preview-run" className="WarehousePreview__checkbox" />
+
+            <div className="WarehousePreview__sources">
+                <div className="WarehousePreview__head">
+                    <span className="WarehousePreview__title">Sources</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+                <div className="WarehousePreview__rows">
+                    <div className="WarehousePreview__row">
+                        <span className="WarehousePreview__source-name">Stripe</span>
+                        <span className="WarehousePreview__source-meta">12 tables · synced 5 min ago</span>
+                        <span className="WarehousePreview__badge WarehousePreview__badge--synced">synced</span>
+                    </div>
+                    <div className="WarehousePreview__row">
+                        <span className="WarehousePreview__source-name">Postgres</span>
+                        <span className="WarehousePreview__source-meta">orders, customers, invoices…</span>
+                        <span className="WarehousePreview__badge WarehousePreview__badge--syncing">
+                            <span className="WarehousePreview__sync-spinner" aria-hidden="true" />
+                            syncing
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div className="WarehousePreview__sql">
+                <div className="WarehousePreview__head">
+                    <span className="WarehousePreview__title">SQL</span>
+                    <label htmlFor="warehouse-preview-run" className="WarehousePreview__run">
+                        <span className="WarehousePreview__swap">
+                            <span className="WarehousePreview__when-idle">▶ Run</span>
+                            <span className="WarehousePreview__when-run">Ran in 0.4 s</span>
+                        </span>
+                    </label>
+                </div>
+                <pre className="WarehousePreview__query">
+                    {`SELECT plan, count() AS signups
+FROM events
+JOIN stripe_customers ON email = person.properties.email
+WHERE event = 'signed_up'
+GROUP BY plan`}
+                </pre>
+                <div className="WarehousePreview__results WarehousePreview__swap">
+                    <div className="WarehousePreview__results-hint WarehousePreview__when-idle">
+                        Run the query to join your events with Stripe.
+                    </div>
+                    <div className="WarehousePreview__table WarehousePreview__when-run">
+                        <div className="WarehousePreview__tr WarehousePreview__tr--head">
+                            <span>plan</span>
+                            <span>signups</span>
+                        </div>
+                        <div className="WarehousePreview__tr">
+                            <span>scale</span>
+                            <span>128</span>
+                        </div>
+                        <div className="WarehousePreview__tr">
+                            <span>startup</span>
+                            <span>342</span>
+                        </div>
+                        <div className="WarehousePreview__tr">
+                            <span>free</span>
+                            <span>1,904</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/data_warehouse/frontend/emptyState/dataWarehouseEmptyState.tsx
+++ b/products/data_warehouse/frontend/emptyState/dataWarehouseEmptyState.tsx
@@ -1,0 +1,44 @@
+import * as organizedPng from '@posthog/brand/hoggies/png/organized'
+import { IconDatabase } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { DataWarehousePreview } from './DataWarehousePreview'
+import { dataWarehouseSetupLogic } from './dataWarehouseSetupLogic'
+
+const HedgehogOrganized = pngHoggie(organizedPng)
+
+export const dataWarehouseEmptyState: SceneProductEmptyState = {
+    statusLogic: dataWarehouseSetupLogic,
+    config: {
+        productKey: ProductKey.DATA_WAREHOUSE,
+        productName: 'Data warehouse',
+        icon: <IconDatabase />,
+        accentColor: 'var(--color-product-data-warehouse-light)',
+        accentColorDark: 'var(--color-product-data-warehouse-dark)',
+        hedgehog: HedgehogOrganized,
+        text: {
+            'needs-setup': {
+                headline: 'Query your business data next to your product data',
+                lead: 'Sync tables from Postgres, MySQL, Stripe, Hubspot, and more into PostHog, then join them with your events in SQL. Revenue next to retention, support tickets next to sessions.',
+                hint: 'Wizard detects your database and connects it for you:',
+            },
+        },
+        wizard: { slug: 'warehouse', pinProjectId: true },
+        primaryAction: {
+            label: 'New source',
+            to: urls.dataPipelinesNew('source'),
+            // pinned: the scene's own New source button carries this attr
+            dataAttr: 'new-source',
+        },
+        docsUrl: 'https://posthog.com/docs/data-warehouse',
+        previewLabel: 'Your sources, once connected',
+        Preview: DataWarehousePreview,
+        // Skipping would reveal three empty source tables; connecting one is the only next step.
+        skippable: false,
+    },
+}

--- a/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.ts
+++ b/products/data_warehouse/frontend/emptyState/dataWarehouseSetupLogic.ts
@@ -1,0 +1,21 @@
+import api from 'lib/api'
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+/**
+ * Setup detection for the data warehouse empty state. A managed source counts
+ * from the moment it's created (its row with sync status is the useful scene),
+ * and self-managed or direct-connect setups surface as warehouse tables.
+ */
+export const dataWarehouseSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.DATA_WAREHOUSE,
+    path: ['products', 'data_warehouse', 'frontend', 'emptyState', 'dataWarehouseSetupLogic'],
+    detect: async () => {
+        const [sources, tables] = await Promise.all([
+            api.externalDataSources.list(),
+            api.dataWarehouseTables.list({ limit: 1 }),
+        ])
+        return sources.results.length > 0 || tables.results.length > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/data_warehouse/frontend/scenes/SourcesScene/SourcesList.tsx
+++ b/products/data_warehouse/frontend/scenes/SourcesScene/SourcesList.tsx
@@ -1,39 +1,20 @@
-import { useValues } from 'kea'
-
 import { IconPlusSmall } from '@posthog/icons'
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 
 import { FlaggedFeature } from 'lib/components/FlaggedFeature'
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { HogFunctionList } from 'scenes/hog-functions/list/HogFunctionsList'
 import { urls } from 'scenes/urls'
 
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
-import { ProductKey } from '~/queries/schema/schema-general'
 
 import { DirectConnectSourcesTable } from 'products/data_warehouse/frontend/shared/components/DirectConnectSourcesTable'
 import { ManagedSourcesTable } from 'products/data_warehouse/frontend/shared/components/ManagedSourcesTable'
 import { SelfManagedSourcesTable } from 'products/data_warehouse/frontend/shared/components/SelfManagedSourcesTable'
-import { sourceManagementLogic } from 'products/data_warehouse/frontend/shared/logics/sourceManagementLogic'
 
-export function SourcesList({ action }: { action: JSX.Element }): JSX.Element {
-    const { dataWarehouseSources, dataWarehouseSourcesLoading } = useValues(sourceManagementLogic)
-
+export function SourcesList(): JSX.Element {
     return (
         <div className="flex flex-col gap-4">
-            {!dataWarehouseSourcesLoading && dataWarehouseSources?.results.length === 0 ? (
-                <ProductIntroduction
-                    productName="Data Warehouse Source"
-                    productKey={ProductKey.DATA_WAREHOUSE}
-                    thingName="data source"
-                    description="Use data warehouse sources to import data from your external data into PostHog."
-                    isEmpty={dataWarehouseSources.results.length === 0 && !dataWarehouseSourcesLoading}
-                    docsURL="https://posthog.com/docs/data-warehouse"
-                    actionElementOverride={action}
-                />
-            ) : null}
-
             <SceneSection
                 title="Managed data warehouse sources"
                 description="PostHog can connect to external sources and automatically import data from them into the PostHog data warehouse"

--- a/products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx
@@ -11,6 +11,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
+import { dataWarehouseEmptyState } from '../../emptyState/dataWarehouseEmptyState'
 import { SourcesList } from './SourcesList'
 import { sourcesSceneLogic } from './sourcesSceneLogic'
 
@@ -18,6 +19,7 @@ export const scene: SceneExport = {
     component: SourcesScene,
     logic: sourcesSceneLogic,
     productKey: ProductKey.DATA_WAREHOUSE,
+    emptyState: dataWarehouseEmptyState,
 }
 
 export function SourcesScene(): JSX.Element {
@@ -52,7 +54,7 @@ export function SourcesScene(): JSX.Element {
                 }}
                 actions={action}
             />
-            <SourcesList action={action} />
+            <SourcesList />
         </SceneContent>
     )
 }


### PR DESCRIPTION
## Problem

A user opening the sources scene before connecting anything gets an intro card above three empty source tables.

Stacks on #90655; part of the empty-states stack based on #90606.

## Changes

- The sources scene now shows the shared setup empty state: the `wizard warehouse` install command as the hero, a "New source" action into the connect flow, docs, and an interactive example preview. Screenshots below.
- The preview stages the product: synced sources feeding a SQL query, where clicking "Run" fills in events joined to Stripe customers.
- A source counts from the moment it's created (its row with sync status is the useful scene); self-managed and direct-connect setups surface through warehouse tables.
- Not skippable: skipping would reveal three empty tables, and connecting a source is the only next step.
- The old intro card in the sources list is deleted.

**Setup screen:**

![Setup screen](https://raw.githubusercontent.com/PostHog/pr-assets/dc84531968f6f81a13ff8b7215361aa5c39fd82e/2026/08/16598b71-2a1e-4449-b319-024a37fd4a41.png)

**After clicking "Run" in the preview:**

![After clicking Run](https://raw.githubusercontent.com/PostHog/pr-assets/ca5a3f13675334fdcdc692797f48953037026287/2026/08/755a930a-27ca-49d4-97df-70e6d9a3f15c.png)

## How did you test this code?

- No new test: detection is a one-line OR over two list calls, and the shared contract is covered by the factory tests in #90606.
- Not run: Playwright; the new Storybook story covers visual regression.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), directed by the assignee. Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/stacking-prs`. The `warehouse` wizard subcommand was confirmed against the wizard CLI's command list before wiring the terminal.
