### PR TITLE
feat(workflows): show the product empty state until a workflow exists

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -58,7 +58,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Session replay         | `frontend/src/scenes/session-recordings/SessionRecordings.tsx`                      | on master             |
 | Web vitals             | `frontend/src/scenes/web-analytics/WebAnalyticsScene.tsx`                           | on master             |
 | Data warehouse sources | `products/data_warehouse/frontend/scenes/SourcesScene/SourcesScene.tsx`             | on master             |
-| Workflows              | `products/workflows/frontend/WorkflowsScene.tsx`                                    | in review             |
+| Workflows              | `products/workflows/frontend/WorkflowsScene.tsx`                                    | on master             |
 | Marketing analytics    | `frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx`               | in review             |
 | Customer analytics     | `products/customer_analytics/frontend/CustomerAnalyticsScene.tsx`                   | in review             |
 | Actions                | `products/actions/frontend/pages/Actions.tsx`                                       | on master             |

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1916,6 +1916,10 @@ snapshots:
         hash: v1.k794b7964.9f74f04645220e7f649d8086c82e822766320c8a29bcbfd3d5aa5345e9da964f.rzsACSxaLP53U_YzFwcDYxpVsCy4XN4Qg0U8-5SsCyk
     components-product-empty-state--web-vitals-waiting-for-data--light:
         hash: v1.k794b7964.eaac20368e776886dceff3b45c056fb19f21b7a09a22e6d7e229e9dab7140512.55yNDBmaE14aOQD_JQRC28OIos3A7vEZatViEIlgLSs
+    components-product-empty-state--workflows-needs-setup--dark:
+        hash: v1.k794b7964.63935ffbe9eb50a42da1299be2d30d74f63d40f8bd45f5c596b1bca660af45b5.5cSx0FK8vg7vXmIQR49wqJIEAv0ecNV3X8lHsQQaB3g
+    components-product-empty-state--workflows-needs-setup--light:
+        hash: v1.k794b7964.112e706a8e35787676a7c3023ce64ccfb8ac34ad710531d8f6276ed69cee375b.9kdpK9mKYvA75kyckBYxf6XDxVAMRr2bIRkFsPkWB1g
     components-productsetup-productsetuppopover--default--dark:
         hash: v1.k794b7964.8577f1ec7bdb47266c031df353e220d017de2e86125924d5da8b0f052c6ce1a6.cA5-fWqyOm-PbSjy7Y8JZ4rQXAe7hn0soi6VkQ36dfc
     components-productsetup-productsetuppopover--default--light:

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -214,7 +214,7 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
     },
     workflows: {
         icon: <IconDecisionTree />,
-        iconColor: ['var(--color-product-workflows-light)'],
+        iconColor: ['var(--color-product-workflows-light)', 'var(--color-product-workflows-dark)'],
     },
     notebook: {
         icon: <IconNotebook />,

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -29,6 +29,7 @@ import { surveysEmptyState } from 'products/surveys/frontend/emptyState/surveysE
 import { tracingEmptyState } from 'products/tracing/frontend/emptyState/tracingEmptyState'
 import { userInterviewsEmptyState } from 'products/user_interviews/frontend/emptyState/userInterviewsEmptyState'
 import { webVitalsEmptyState } from 'products/web_analytics/frontend/emptyState/webVitalsEmptyState'
+import { workflowsEmptyState } from 'products/workflows/frontend/emptyState/workflowsEmptyState'
 
 import { ProductEmptyState } from './ProductEmptyState'
 import { ProductEmptyStateStory, productEmptyStateStory } from './storybookHelpers'
@@ -317,3 +318,8 @@ export const DataWarehouseNeedsSetup: ProductEmptyStateStory = productEmptyState
         },
     }
 )
+
+// Workflows detection counts workflows on mount - answer "none yet".
+export const WorkflowsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(workflowsEmptyState, 'needs-setup', {
+    mocks: { get: { '/api/projects/:team_id/hog_flows/': [200, { count: 0, results: [] }] } },
+})

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -315,6 +315,7 @@
     --color-product-product-analytics-light: rgb(47 128 250);
     --color-product-product-analytics-dark: rgb(96 165 250);
     --color-product-workflows-light: rgb(47 128 250);
+    --color-product-workflows-dark: rgb(96 156 255);
     --color-product-web-analytics-light: rgb(52 175 102);
     --color-product-web-analytics-dark: rgb(54 196 111); // original color
     --color-product-endpoints-light: rgb(243 153 109);

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -5,9 +5,7 @@ import { LemonCheckbox, LemonDivider, LemonInput, LemonSelect, LemonTag, Link, T
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { AppMetricsSparkline } from 'lib/components/AppMetrics/AppMetricsSparkline'
-import { MailHog } from 'lib/components/hedgehogs'
 import { MemberSelect } from 'lib/components/MemberSelect'
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -22,7 +20,6 @@ import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { getHogFlowStep } from './hogflows/steps/HogFlowSteps'
 import { HogFlow } from './hogflows/types'
-import { newWorkflowLogic } from './newWorkflowLogic'
 import { workflowLogic } from './workflowLogic'
 import {
     WORKFLOW_TRIGGER_TYPE_OPTIONS,
@@ -106,7 +103,6 @@ export function WorkflowsTable(): JSX.Element {
         workflowsLoading,
         workflows,
         pagination,
-        hasLoadedWorkflows,
         filters,
         selectedArchivedWorkflowIds,
         allArchivedSelected,
@@ -125,7 +121,6 @@ export function WorkflowsTable(): JSX.Element {
         selectAllArchivedWorkflows,
         clearArchivedWorkflowSelection,
     } = useActions(logic)
-    const { showNewWorkflowModal } = useActions(newWorkflowLogic)
 
     useOnMountEffect(() => {
         // Tricky: unmount the new workflow logic when leaving the new workflow scene
@@ -349,121 +344,88 @@ export function WorkflowsTable(): JSX.Element {
         },
     ]
 
-    const showProductIntroduction =
-        hasLoadedWorkflows &&
-        !workflowsLoading &&
-        workflows.results.length === 0 &&
-        !filters.search &&
-        !filters.createdBy &&
-        filters.status === 'all' &&
-        filters.type === 'all' &&
-        filters.triggerType === 'all' &&
-        // An empty page is not an empty project, so never offer onboarding while paging
-        filters.page === 1
-
     return (
         <div className="workflows-section" data-attr="workflows-table" data-loading={workflowsLoading}>
-            {showProductIntroduction && (
-                <ProductIntroduction
-                    productName="Workflow"
-                    thingName="workflow"
-                    description="Create workflows that automate actions or send messages to your users."
-                    docsURL="https://posthog.com/docs/workflows/start-here"
-                    action={() => {
-                        showNewWorkflowModal()
-                    }}
-                    customHog={MailHog}
-                    isEmpty
-                    mcpSurfaceKey="workflows.create"
-                />
-            )}
-            {!showProductIntroduction && (
-                <>
-                    <div className="flex justify-between gap-2 flex-wrap mb-4">
-                        <LemonInput
-                            type="search"
-                            placeholder="Search for workflows"
-                            onChange={(search) => setFilters({ search })}
-                            value={filters.search}
-                        />
-                        <div className="flex items-center gap-2 flex-wrap">
-                            <span>
-                                <b>Status</b>
-                            </span>
-                            <LemonSelect
-                                dropdownMatchSelectWidth={false}
-                                size="small"
-                                onChange={(value) => setFilters({ status: value as WorkflowStatusFilter })}
-                                options={[
-                                    { label: 'All', value: 'all' },
-                                    { label: 'Active', value: 'active' },
-                                    { label: 'Draft', value: 'draft' },
-                                    { label: 'Archived', value: 'archived' },
-                                ]}
-                                value={filters.status}
-                            />
-                            <span className="ml-1">
-                                <b>Type</b>
-                            </span>
-                            <LemonSelect
-                                dropdownMatchSelectWidth={false}
-                                size="small"
-                                onChange={(value) => setFilters({ type: value as WorkflowTypeFilter })}
-                                options={[
-                                    { label: 'All', value: 'all' },
-                                    { label: 'Messaging', value: 'messaging' },
-                                    { label: 'Automation', value: 'automation' },
-                                ]}
-                                value={filters.type}
-                            />
-                            <span className="ml-1">
-                                <b>Trigger</b>
-                            </span>
-                            <LemonSelect
-                                dropdownMatchSelectWidth={false}
-                                size="small"
-                                onChange={(value) => setFilters({ triggerType: value as WorkflowTriggerTypeFilter })}
-                                options={WORKFLOW_TRIGGER_TYPE_OPTIONS}
-                                value={filters.triggerType}
-                            />
-                            <span className="ml-1">
-                                <b>Created by</b>
-                            </span>
-                            <MemberSelect
-                                value={filters.createdBy}
-                                onChange={(user) => setFilters({ createdBy: user?.uuid || null })}
-                            />
-                        </div>
-                    </div>
-
-                    {isArchived && selectedArchivedCount > 0 && (
-                        <div className="flex items-center gap-2 mb-2">
-                            <span className="text-muted text-sm">
-                                {selectedArchivedCount} workflow{selectedArchivedCount !== 1 ? 's' : ''} selected
-                            </span>
-                            <LemonButton
-                                type="secondary"
-                                status="danger"
-                                size="small"
-                                onClick={deleteSelectedWorkflows}
-                            >
-                                Delete selected
-                            </LemonButton>
-                        </div>
-                    )}
-
-                    <LemonTable
-                        dataSource={workflows.results}
-                        loading={workflowsLoading}
-                        rowKey="id"
-                        columns={columns}
-                        defaultSorting={{ columnKey: 'updatedAt', order: 1 }}
-                        pagination={pagination}
-                        nouns={['workflow', 'workflows']}
-                        emptyState="No workflows matching filters"
+            <>
+                <div className="flex justify-between gap-2 flex-wrap mb-4">
+                    <LemonInput
+                        type="search"
+                        placeholder="Search for workflows"
+                        onChange={(search) => setFilters({ search })}
+                        value={filters.search}
                     />
-                </>
-            )}
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <span>
+                            <b>Status</b>
+                        </span>
+                        <LemonSelect
+                            dropdownMatchSelectWidth={false}
+                            size="small"
+                            onChange={(value) => setFilters({ status: value as WorkflowStatusFilter })}
+                            options={[
+                                { label: 'All', value: 'all' },
+                                { label: 'Active', value: 'active' },
+                                { label: 'Draft', value: 'draft' },
+                                { label: 'Archived', value: 'archived' },
+                            ]}
+                            value={filters.status}
+                        />
+                        <span className="ml-1">
+                            <b>Type</b>
+                        </span>
+                        <LemonSelect
+                            dropdownMatchSelectWidth={false}
+                            size="small"
+                            onChange={(value) => setFilters({ type: value as WorkflowTypeFilter })}
+                            options={[
+                                { label: 'All', value: 'all' },
+                                { label: 'Messaging', value: 'messaging' },
+                                { label: 'Automation', value: 'automation' },
+                            ]}
+                            value={filters.type}
+                        />
+                        <span className="ml-1">
+                            <b>Trigger</b>
+                        </span>
+                        <LemonSelect
+                            dropdownMatchSelectWidth={false}
+                            size="small"
+                            onChange={(value) => setFilters({ triggerType: value as WorkflowTriggerTypeFilter })}
+                            options={WORKFLOW_TRIGGER_TYPE_OPTIONS}
+                            value={filters.triggerType}
+                        />
+                        <span className="ml-1">
+                            <b>Created by</b>
+                        </span>
+                        <MemberSelect
+                            value={filters.createdBy}
+                            onChange={(user) => setFilters({ createdBy: user?.uuid || null })}
+                        />
+                    </div>
+                </div>
+
+                {isArchived && selectedArchivedCount > 0 && (
+                    <div className="flex items-center gap-2 mb-2">
+                        <span className="text-muted text-sm">
+                            {selectedArchivedCount} workflow{selectedArchivedCount !== 1 ? 's' : ''} selected
+                        </span>
+                        <LemonButton type="secondary" status="danger" size="small" onClick={deleteSelectedWorkflows}>
+                            Delete selected
+                        </LemonButton>
+                    </div>
+                )}
+
+                <LemonTable
+                    dataSource={workflows.results}
+                    loading={workflowsLoading}
+                    rowKey="id"
+                    columns={columns}
+                    defaultSorting={{ columnKey: 'updatedAt', order: 1 }}
+                    pagination={pagination}
+                    nouns={['workflow', 'workflows']}
+                    emptyState="No workflows matching filters"
+                />
+            </>
         </div>
     )
 }

--- a/products/workflows/frontend/WorkflowsScene.tsx
+++ b/products/workflows/frontend/WorkflowsScene.tsx
@@ -25,6 +25,7 @@ import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-genera
 import { AccessControlLevel, AccessControlResourceType, Breadcrumb } from '~/types'
 
 import { MessageChannels } from './Channels/MessageChannels'
+import { workflowsEmptyState } from './emptyState/workflowsEmptyState'
 import { optOutCategoriesLogic } from './OptOuts/optOutCategoriesLogic'
 import { OptOutScene } from './OptOuts/OptOutScene'
 import { SuppressionScene } from './Suppression/SuppressionScene'
@@ -129,6 +130,7 @@ export const scene: SceneExport<WorkflowsSceneProps> = {
     logic: workflowsSceneLogic,
     paramsToProps: ({ params: { tab } }) => ({ tab }),
     productKey: ProductKey.WORKFLOWS,
+    emptyState: workflowsEmptyState,
 }
 
 export function WorkflowsScene(props: WorkflowsSceneProps = {}): JSX.Element {

--- a/products/workflows/frontend/emptyState/WorkflowsPreview.scss
+++ b/products/workflows/frontend/emptyState/WorkflowsPreview.scss
@@ -1,0 +1,239 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.WorkflowsPreview {
+    --workflows-preview-accent: var(--empty-state-accent, var(--color-primary-500));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden branch state. A direct child of .WorkflowsPreview so `:checked ~` reaches both cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__canvas,
+    &__stat {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    &__stat {
+        padding: 0.5rem 0.75rem 0.625rem;
+    }
+
+    // Yes/no pairs are stacked on one grid cell and crossfaded, so flipping the
+    // branch never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-no {
+        @include preview-swap-hidden;
+    }
+
+    &__when-yes {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    &__live-dot {
+        width: 7px;
+        height: 7px;
+        background: var(--workflows-preview-accent);
+        border-radius: 50%;
+        animation: WorkflowsPreview__pulse 2s ease-in-out infinite;
+    }
+
+    // Canvas
+
+    &__graph {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 0.625rem 0.75rem 0.375rem;
+    }
+
+    &__node {
+        display: flex;
+        flex-direction: column;
+        gap: 0.0625rem;
+        min-width: 11rem;
+        padding: 0.3125rem 0.5rem;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    &__node--hero {
+        cursor: pointer;
+        user-select: none;
+        transition: box-shadow 250ms ease;
+    }
+
+    &__node--hero:hover {
+        background: var(--color-bg-fill-highlight-50);
+    }
+
+    &__node-kind {
+        font-size: 0.5625rem;
+        font-weight: 700;
+        text-transform: uppercase;
+
+        @include preview-accent-text(var(--workflows-preview-accent));
+    }
+
+    &__node-label {
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        white-space: nowrap;
+    }
+
+    &__edge {
+        position: relative;
+        width: 2px;
+        height: 0.75rem;
+        background: var(--color-border-primary);
+    }
+
+    // A run traveling the trunk, so the canvas feels alive at rest.
+    &__edge-run {
+        position: absolute;
+        top: 0;
+        left: -2px;
+        width: 6px;
+        height: 6px;
+        background: var(--workflows-preview-accent);
+        border-radius: 50%;
+        animation: WorkflowsPreview__run 3s ease-in-out infinite;
+    }
+
+    &__branches {
+        display: flex;
+        gap: 0.75rem;
+    }
+
+    &__node--branch {
+        min-width: 8.5rem;
+        opacity: 0.45;
+        transition:
+            opacity 250ms ease,
+            box-shadow 250ms ease;
+    }
+
+    &__hint {
+        padding: 0.375rem 0.75rem 0.5rem;
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    // Stat card
+
+    &__spark-sub {
+        font-size: 0.6875rem;
+        font-weight: 400;
+        color: var(--color-text-secondary);
+    }
+
+    @include preview-sparkline;
+}
+
+// Active branch follows the condition. Unchecked = yes (opened), checked = no.
+
+.WorkflowsPreview__checkbox:not(:checked) ~ .WorkflowsPreview__canvas .WorkflowsPreview__branch-yes,
+.WorkflowsPreview__checkbox:checked ~ .WorkflowsPreview__canvas .WorkflowsPreview__branch-no {
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--workflows-preview-accent) 55%, transparent);
+    opacity: 1;
+}
+
+.WorkflowsPreview__checkbox:checked ~ * .WorkflowsPreview__when-no {
+    @include preview-swap-visible;
+}
+
+.WorkflowsPreview__checkbox:checked ~ * .WorkflowsPreview__when-yes {
+    @include preview-swap-hidden;
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the node it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.WorkflowsPreview__checkbox:focus-visible ~ .WorkflowsPreview__canvas .WorkflowsPreview__node--hero {
+    outline: 2px solid var(--workflows-preview-accent);
+    outline-offset: 1px;
+}
+
+// Nudge attention at the condition node until it's flipped.
+.WorkflowsPreview:not(.WorkflowsPreview--static)
+    .WorkflowsPreview__checkbox:not(:checked)
+    ~ .WorkflowsPreview__canvas
+    .WorkflowsPreview__node--hero {
+    animation: WorkflowsPreview__nudge 2.4s ease-in-out infinite;
+}
+
+@keyframes WorkflowsPreview__nudge {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--workflows-preview-accent) 45%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--workflows-preview-accent) 20%, transparent);
+    }
+}
+
+@keyframes WorkflowsPreview__pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.35;
+    }
+}
+
+@keyframes WorkflowsPreview__run {
+    0% {
+        top: -10%;
+        opacity: 0;
+    }
+
+    20%,
+    80% {
+        opacity: 1;
+    }
+
+    100% {
+        top: 100%;
+        opacity: 0;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; clicking the
+// condition still flips the state (transitions only).
+@include preview-motion-guards('WorkflowsPreview');

--- a/products/workflows/frontend/emptyState/WorkflowsPreview.tsx
+++ b/products/workflows/frontend/emptyState/WorkflowsPreview.tsx
@@ -1,0 +1,94 @@
+import './WorkflowsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+/**
+ * Example-data preview for the workflows empty state: a mini canvas and the
+ * deliveries behind one of its branches. Clicking the condition node flips which
+ * branch runs, and the stat card follows. One hidden checkbox drives it via
+ * `:checked ~` styles - no timers or state, per the preview rules in the
+ * `building-product-empty-states` skill. Branch pairs are stacked in `__swap`
+ * grids, so nothing shifts.
+ */
+export function WorkflowsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('WorkflowsPreview', isStatic && 'WorkflowsPreview--static')}>
+            {/* Branch state, before both cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="workflows-preview-branch" className="WorkflowsPreview__checkbox" />
+
+            <div className="WorkflowsPreview__canvas">
+                <div className="WorkflowsPreview__head">
+                    <span className="WorkflowsPreview__title">
+                        <span className="WorkflowsPreview__live-dot" aria-hidden="true" />
+                        Welcome journey
+                    </span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+                <div className="WorkflowsPreview__graph">
+                    <div className="WorkflowsPreview__node">
+                        <span className="WorkflowsPreview__node-kind">Trigger</span>
+                        <span className="WorkflowsPreview__node-label">event: signed_up</span>
+                    </div>
+                    <span className="WorkflowsPreview__edge" aria-hidden="true">
+                        <span className="WorkflowsPreview__edge-run" />
+                    </span>
+                    <div className="WorkflowsPreview__node">
+                        <span className="WorkflowsPreview__node-kind">Wait</span>
+                        <span className="WorkflowsPreview__node-label">1 day</span>
+                    </div>
+                    <span className="WorkflowsPreview__edge" aria-hidden="true" />
+                    <label
+                        htmlFor="workflows-preview-branch"
+                        className="WorkflowsPreview__node WorkflowsPreview__node--hero"
+                    >
+                        <span className="WorkflowsPreview__node-kind">Condition</span>
+                        <span className="WorkflowsPreview__node-label WorkflowsPreview__swap">
+                            <span className="WorkflowsPreview__when-yes">opened welcome email? yes</span>
+                            <span className="WorkflowsPreview__when-no">opened welcome email? no</span>
+                        </span>
+                    </label>
+                    <span className="WorkflowsPreview__edge" aria-hidden="true" />
+                    <div className="WorkflowsPreview__branches">
+                        <div className="WorkflowsPreview__node WorkflowsPreview__node--branch WorkflowsPreview__branch-yes">
+                            <span className="WorkflowsPreview__node-kind">Email</span>
+                            <span className="WorkflowsPreview__node-label">Send tips</span>
+                        </div>
+                        <div className="WorkflowsPreview__node WorkflowsPreview__node--branch WorkflowsPreview__branch-no">
+                            <span className="WorkflowsPreview__node-kind">Push</span>
+                            <span className="WorkflowsPreview__node-label">Send reminder</span>
+                        </div>
+                    </div>
+                </div>
+                <div className="WorkflowsPreview__hint WorkflowsPreview__swap">
+                    <span className="WorkflowsPreview__when-yes">Click the condition to follow the other branch.</span>
+                    <span className="WorkflowsPreview__when-no">
+                        Unopened emails get a push instead. Click to flip back.
+                    </span>
+                </div>
+            </div>
+
+            <div className="WorkflowsPreview__stat">
+                <div className="WorkflowsPreview__spark-head">
+                    <span className="WorkflowsPreview__spark-title WorkflowsPreview__swap">
+                        <span className="WorkflowsPreview__when-yes">Tips email · deliveries, 7 days</span>
+                        <span className="WorkflowsPreview__when-no">Reminder push · deliveries, 7 days</span>
+                    </span>
+                </div>
+                <div className="WorkflowsPreview__spark-value">
+                    <span className="WorkflowsPreview__swap">
+                        <span className="WorkflowsPreview__when-yes">1,204</span>
+                        <span className="WorkflowsPreview__when-no">618</span>
+                    </span>
+                    <span className="WorkflowsPreview__spark-sub WorkflowsPreview__swap">
+                        <span className="WorkflowsPreview__when-yes">42% opened</span>
+                        <span className="WorkflowsPreview__when-no">28% tapped</span>
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/workflows/frontend/emptyState/workflowsEmptyState.tsx
+++ b/products/workflows/frontend/emptyState/workflowsEmptyState.tsx
@@ -1,0 +1,38 @@
+import * as workflowsPng from '@posthog/brand/hoggies/png/workflows'
+import { IconDecisionTree } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { WorkflowsPreview } from './WorkflowsPreview'
+import { workflowsSetupLogic } from './workflowsSetupLogic'
+
+const HedgehogWorkflows = pngHoggie(workflowsPng)
+
+export const workflowsEmptyState: SceneProductEmptyState = {
+    statusLogic: workflowsSetupLogic,
+    config: {
+        productKey: ProductKey.WORKFLOWS,
+        productName: 'Workflows',
+        icon: <IconDecisionTree />,
+        accentColor: 'var(--color-product-workflows-light)',
+        accentColorDark: 'var(--color-product-workflows-dark)',
+        hedgehog: HedgehogWorkflows,
+        text: {
+            'needs-setup': {
+                headline: 'Message users when it matters',
+                lead: 'Build journeys on a canvas: trigger on any event or cohort, wait, branch on behavior, and send email, SMS, or push. Connect a channel and design your first message along the way.',
+            },
+        },
+        primaryAction: {
+            label: 'New workflow',
+            to: urls.workflowNew(),
+        },
+        docsUrl: 'https://posthog.com/docs/workflows',
+        previewLabel: 'Your journeys, once running',
+        Preview: WorkflowsPreview,
+    },
+}

--- a/products/workflows/frontend/emptyState/workflowsSetupLogic.ts
+++ b/products/workflows/frontend/emptyState/workflowsSetupLogic.ts
@@ -1,0 +1,20 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { hogFlowsList } from '../generated/api'
+
+/**
+ * Setup detection for the workflows empty state. Workflows are a creation-first
+ * product, so "set up" simply means the project has at least one workflow.
+ */
+export const workflowsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.WORKFLOWS,
+    path: ['products', 'workflows', 'frontend', 'emptyState', 'workflowsSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await hogFlowsList(projectId, { limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+})


### PR DESCRIPTION
## Problem

A user opening workflows before creating one gets a per-tab intro card inside the table slot; channels and templates render empty around it.

Stacks on #90661; part of the empty-states stack based on #90606.

## Changes

- The workflows scene now shows the shared setup empty state: a "New workflow" action into the editor, docs, and an interactive example journey canvas. Screenshots below.
- The preview stages the product: a welcome journey where clicking the condition node flips which branch runs, and the deliveries stat follows.
- Skippable: the scene's channels, library, and opt-out tabs are useful before the first workflow, so the escape hatch stays.
- The intro card in the workflows table is deleted, along with its now-unused modal wiring. The MCP hint surface it carried (`workflows.create`) has no platform equivalent yet, same as the flags migration.

**Setup screen:**

![Setup screen](https://raw.githubusercontent.com/PostHog/pr-assets/a8adc02a023175a935dfe170e644a068c740f631/2026/08/af7f0813-4f57-49aa-afbd-aaabd14dc56e.png)

**After flipping the condition in the preview:**

![After flipping the condition](https://raw.githubusercontent.com/PostHog/pr-assets/992d8322070a8e4e9dfdf092a840d87fcf5d46e0/2026/08/7a3241c7-de92-45bc-b528-17988ad2f569.png)

## How did you test this code?

- No new test: detection is a one-line count over `hogFlowsList`, and the shared contract is covered by the factory tests in #90606.
- Not run: Playwright; the new Storybook story covers visual regression.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), directed by the assignee. Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/stacking-prs`. The action links to `/workflows/new/workflow` instead of opening the old new-workflow modal, because the modal lives inside the scene the gate replaces.
