### PR TITLE
fix(warehouse-sources): switch sync type when incremental can't work

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6670,6 +6670,12 @@ export interface ExternalDataSourceSchema extends SimpleExternalDataSourceSchema
     primary_key_columns: string[] | null
     cdc_table_mode?: 'consolidated' | 'cdc_only' | 'both'
     /**
+     * Why PostHog changed this table's sync type on its own, or null if it never did. Set when a
+     * sync run proved the configured sync type can't work for the table, such as an incremental
+     * sync on a table with no primary key.
+     */
+    sync_type_fallback_reason?: string | null
+    /**
      * User-selected source columns to sync. `null` means "sync all columns".
      * Primary-key + active incremental columns are always retained even if not listed.
      */

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -453,12 +453,19 @@ function ManagedSchemaTable({
                 {
                     title: 'Sync method',
                     key: 'sync_type',
-                    render: (_, schema) =>
-                        schema.sync_type ? (
-                            <LemonTag type="primary">{SyncTypeLabelMap[schema.sync_type]}</LemonTag>
+                    render: (_, schema) => {
+                        if (!schema.sync_type) {
+                            return <span className="text-muted">Not set up</span>
+                        }
+                        const tag = <LemonTag type="primary">{SyncTypeLabelMap[schema.sync_type]}</LemonTag>
+                        return schema.sync_type_fallback_reason ? (
+                            <Tooltip title={schema.sync_type_fallback_reason}>
+                                <span>{tag}</span>
+                            </Tooltip>
                         ) : (
-                            <span className="text-muted">Not set up</span>
-                        ),
+                            tag
+                        )
+                    },
                 },
                 {
                     title: 'Frequency',

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
+                  ([e__person.properties___fish] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,6 +44,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -111,7 +121,17 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -168,8 +188,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -178,6 +198,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -294,7 +324,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -326,7 +373,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([e__person.properties___fish] AS value) AS prop_basic,
+                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,16 +44,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -121,17 +111,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -188,8 +168,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -198,16 +178,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -324,24 +294,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -373,24 +326,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -544,6 +544,13 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         return None
 
     @property
+    def sync_type_fallback_reason(self) -> str | None:
+        if self.sync_type_config:
+            return self.sync_type_config.get("sync_type_fallback_reason", None)
+
+        return None
+
+    @property
     def chunk_size_override(self) -> int | None:
         if self.sync_type_config:
             return self.sync_type_config.get("chunk_size_override", None)
@@ -1122,6 +1129,60 @@ def aget_schema_by_id(schema_id: str, team_id: int) -> ExternalDataSchema | None
     return (
         ExternalDataSchema.objects.prefetch_related("source").exclude(deleted=True).get(id=schema_id, team_id=team_id)
     )
+
+
+@frozen
+class ResolvedSyncTypeFallback:
+    """The outcome of moving a schema off an incremental sync it can never run."""
+
+    to_sync_type: str
+    reason: str
+
+
+# How each fallback sync type is named to a customer. The stored enum values ("append",
+# "full_refresh") are internal, and the sync settings UI offers these labels instead.
+_SYNC_TYPE_FALLBACK_LABELS = {
+    ExternalDataSchemaSyncType.APPEND: "append-only sync",
+    ExternalDataSchemaSyncType.FULL_REFRESH: "full table replication",
+}
+
+
+def resolve_incremental_sync_fallback(
+    schema_id: str,
+    team_id: int,
+    reason_template: str,
+) -> ResolvedSyncTypeFallback | None:
+    """Move a schema off `incremental` when a run proved the merge can never work.
+
+    An incremental sync merges rows on a primary key. A table with no key, or with a key that does
+    not identify one row, fails the same way on every run, so leaving the schema on `incremental`
+    only reproduces the failure. `append` keeps reading from the stored cursor when the schema has
+    an incremental field. Without one the table has to be re-read in full.
+
+    `reason_template` takes a `{fallback}` placeholder because the customer-facing reason has to
+    name the sync type the table actually moved to, which is only known here. The formatted reason
+    is persisted so the sync settings UI can show why the sync type changed.
+
+    Returns None when the schema is no longer incremental, so a concurrent edit that already chose
+    a sync type wins instead of being overwritten.
+    """
+    schema = ExternalDataSchema.objects.get(id=schema_id, team_id=team_id)
+    if schema.sync_type != ExternalDataSchema.SyncType.INCREMENTAL:
+        return None
+
+    target = (
+        ExternalDataSchema.SyncType.APPEND
+        if (schema.sync_type_config or {}).get("incremental_field")
+        else ExternalDataSchema.SyncType.FULL_REFRESH
+    )
+    reason = reason_template.format(fallback=_SYNC_TYPE_FALLBACK_LABELS[target])
+    update_sync_type_config_keys(
+        schema_id,
+        team_id,
+        updates={"sync_type_fallback_reason": reason},
+        extra_model_fields={"sync_type": target},
+    )
+    return ResolvedSyncTypeFallback(to_sync_type=target.value, reason=reason)
 
 
 def update_should_sync(

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -1164,24 +1164,28 @@ def resolve_incremental_sync_fallback(
     is persisted so the sync settings UI can show why the sync type changed.
 
     Returns None when the schema is no longer incremental, so a concurrent edit that already chose
-    a sync type wins instead of being overwritten.
+    a sync type wins instead of being overwritten. That check and the write it guards share one row
+    lock. Without the lock, a sync type an operator commits between the two is replaced by the
+    fallback's own target.
     """
-    schema = ExternalDataSchema.objects.get(id=schema_id, team_id=team_id)
-    if schema.sync_type != ExternalDataSchema.SyncType.INCREMENTAL:
-        return None
+    with transaction.atomic():
+        schema = ExternalDataSchema.objects.select_for_update().get(id=schema_id, team_id=team_id)
+        if schema.sync_type != ExternalDataSchema.SyncType.INCREMENTAL:
+            return None
 
-    target = (
-        ExternalDataSchema.SyncType.APPEND
-        if (schema.sync_type_config or {}).get("incremental_field")
-        else ExternalDataSchema.SyncType.FULL_REFRESH
-    )
-    reason = reason_template.format(fallback=_SYNC_TYPE_FALLBACK_LABELS[target])
-    update_sync_type_config_keys(
-        schema_id,
-        team_id,
-        updates={"sync_type_fallback_reason": reason},
-        extra_model_fields={"sync_type": target},
-    )
+        target = (
+            ExternalDataSchema.SyncType.APPEND
+            if (schema.sync_type_config or {}).get("incremental_field")
+            else ExternalDataSchema.SyncType.FULL_REFRESH
+        )
+        reason = reason_template.format(fallback=_SYNC_TYPE_FALLBACK_LABELS[target])
+        # Re-takes a lock this transaction already holds, so the merge stays in the same section.
+        update_sync_type_config_keys(
+            schema_id,
+            team_id,
+            updates={"sync_type_fallback_reason": reason},
+            extra_model_fields={"sync_type": target},
+        )
     return ResolvedSyncTypeFallback(to_sync_type=target.value, reason=reason)
 
 

--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -350,6 +350,15 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         allow_null=True,
         help_text="For CDC syncs: consolidated, cdc_only, or both.",
     )
+    sync_type_fallback_reason = serializers.CharField(
+        read_only=True,
+        allow_null=True,
+        help_text=(
+            "Why PostHog changed this table's sync type on its own, or null if it never did. Set when "
+            "a sync run proved the configured sync type can't work for the table, such as an "
+            "incremental sync on a table with no primary key."
+        ),
+    )
     enabled_columns = serializers.ListField(
         child=serializers.CharField(),
         required=False,
@@ -429,6 +438,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
             "description",
             "primary_key_columns",
             "cdc_table_mode",
+            "sync_type_fallback_reason",
             "enabled_columns",
             "row_filters",
             "available_columns",
@@ -448,6 +458,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
             "latest_error",
             "status",
             "description",
+            "sync_type_fallback_reason",
             "available_columns",
             "source_column_metadata_available",
             "source",
@@ -639,6 +650,7 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         ret["incremental_field_lookback_seconds"] = instance.incremental_field_lookback_seconds
         ret["primary_key_columns"] = instance.primary_key_columns
         ret["cdc_table_mode"] = instance.cdc_table_mode
+        ret["sync_type_fallback_reason"] = instance.sync_type_fallback_reason
         return ret
 
     def _run_temporal_side_effect(self, callback: Callable[[], None]) -> None:
@@ -807,6 +819,10 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         # Only update sync_type if it was explicitly provided in the request
         if "sync_type" in data:
             validated_data["sync_type"] = sync_type
+            # A recorded fallback explains a sync type PostHog picked for the user. Once they pick
+            # one themselves, drop it so the UI stops explaining a decision they have replaced.
+            if instance.sync_type_config:
+                instance.sync_type_config.pop("sync_type_fallback_reason", None)
 
         # The sync type the schema will end up with: the new one if the request changes it, else the
         # existing one. Incremental-style config (incremental_field, incremental_field_type,

--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -45,6 +45,8 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import (
     AUTO_DISABLED_JOB_ERROR,
     ExternalDataSchema,
+    ResolvedSyncTypeFallback,
+    resolve_incremental_sync_fallback,
     update_should_sync,
 )
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -264,6 +266,51 @@ TRANSIENT_SOURCE_ERROR_MESSAGE = (
     "again on its next schedule."
 )
 
+# These two failures prove an incremental sync can never succeed for a table: it has no primary key
+# to merge rows on, or its primary key does not identify one row. Neither can resolve itself, so
+# disabling the schema leaves the customer to re-configure a table that will break again the moment
+# it is re-enabled. The schema moves to a sync type it can run instead, and `{fallback}` names that
+# sync type once `resolve_incremental_sync_fallback` has chosen it.
+Unsupported_Incremental_Sync_Errors: dict[str, str] = {
+    "Primary key required for incremental syncs": (
+        "This table has no primary key, so it can't sync incrementally. We switched it to {fallback} "
+        "so it keeps syncing. To sync it incrementally, choose a primary key in the table's sync settings."
+    ),
+    "The primary keys for this table are not unique": (
+        "The primary key set for this table isn't unique, so it can't sync incrementally. We switched it "
+        "to {fallback} so it keeps syncing. To sync it incrementally, choose a unique primary key in the "
+        "table's sync settings."
+    ),
+}
+
+
+async def _resolve_unsupported_incremental_sync(
+    schema_id: str,
+    team_id: int,
+    internal_error_normalized: str,
+) -> ResolvedSyncTypeFallback | None:
+    """Move the schema off `incremental` when this run proved the merge can never work.
+
+    Returns None when the error is a different failure, or when the schema is no longer
+    incremental, and the caller then disables the schema as before.
+    """
+    reason_template = next(
+        (
+            template
+            for error, template in Unsupported_Incremental_Sync_Errors.items()
+            if error_message_matches(internal_error_normalized, [error])
+        ),
+        None,
+    )
+    if reason_template is None:
+        return None
+
+    return await database_sync_to_async_pool(resolve_incremental_sync_fallback)(
+        schema_id=schema_id,
+        team_id=team_id,
+        reason_template=reason_template,
+    )
+
 
 def _customer_facing_error(cause: BaseException | None) -> str:
     """`latest_error` text a customer reads, without the leaked internal exception class name.
@@ -471,16 +518,27 @@ async def update_external_data_job_model(inputs: UpdateExternalDataJobStatusInpu
                 logger.exception(friendly_errors[0])
                 inputs.latest_error = friendly_errors[0]
 
-            # Computed after the friendly error so the teardown records the same message
-            # the job will show. Excluding this workflow keeps the disable's teardown from
-            # cancelling the very run that is already finishing through its failure path.
-            await database_sync_to_async_pool(update_should_sync)(
-                schema_id=inputs.schema_id,
-                team_id=inputs.team_id,
-                should_sync=False,
-                disable_error_message=inputs.latest_error or AUTO_DISABLED_JOB_ERROR,
-                disable_exclude_workflow_id=activity.info().workflow_id,
+            fallback = await _resolve_unsupported_incremental_sync(
+                inputs.schema_id, inputs.team_id, internal_error_normalized
             )
+            if fallback is not None:
+                inputs.latest_error = fallback.reason
+                logger.warning(
+                    "Moved schema off incremental sync",
+                    schema_id=inputs.schema_id,
+                    to_sync_type=fallback.to_sync_type,
+                )
+            else:
+                # Computed after the friendly error so the teardown records the same message
+                # the job will show. Excluding this workflow keeps the disable's teardown from
+                # cancelling the very run that is already finishing through its failure path.
+                await database_sync_to_async_pool(update_should_sync)(
+                    schema_id=inputs.schema_id,
+                    team_id=inputs.team_id,
+                    should_sync=False,
+                    disable_error_message=inputs.latest_error or AUTO_DISABLED_JOB_ERROR,
+                    disable_exclude_workflow_id=activity.info().workflow_id,
+                )
         elif not platform_failure:
             # A retryable failure that outlasted the whole retry budget lands here with
             # `latest_error` still set to the raw driver text. The generic transient copy is

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
@@ -3203,22 +3203,20 @@ async def test_postgres_duplicate_primary_key(team, postgres_config, postgres_co
 
     assert job.status == ExternalDataJobStatus.FAILED
     assert job.latest_error is not None
-    assert (
-        "The primary key set for this table isn't unique, so incremental syncing can't reliably match rows to update"
-        in job.latest_error
-    )
+    assert "The primary key set for this table isn't unique" in job.latest_error
 
     with pytest.raises(Exception):
         await sync_to_async(execute_hogql_query)(f"SELECT * FROM postgres_duplicate_primary_key", team)
 
+    # The table declares no primary key, so discovery inferred `id`, and the duplicate rows above
+    # prove that inference wrong. Disabling the schema would make the operator re-enable a sync that
+    # can only fail the same way, so it moves to a sync type it can run and stays enabled.
     schema: ExternalDataSchema = await sync_to_async(ExternalDataSchema.objects.get)(id=job.schema_id)
-    mock_update_should_sync.assert_called_once_with(
-        schema_id=str(schema.id),
-        team_id=team.id,
-        should_sync=False,
-        disable_error_message=job.latest_error,
-        disable_exclude_workflow_id=mock.ANY,
-    )
+    mock_update_should_sync.assert_not_called()
+    assert schema.sync_type == ExternalDataSchemaSyncType.APPEND
+    assert schema.should_sync is True
+    assert schema.sync_type_fallback_reason == job.latest_error
+    assert "append-only sync" in schema.sync_type_fallback_reason
 
 
 @pytest.mark.django_db(transaction=True)

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_external_data_job_activities.py
@@ -4,7 +4,9 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest import mock
 
+from django.db import connection
 from django.test import SimpleTestCase
+from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
 from temporalio.exceptions import ApplicationError, CancelledError
@@ -14,7 +16,10 @@ from posthog.models import Organization, Team
 from posthog.temporal.utils import ExternalDataWorkflowInputs
 
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_schema import (
+    ExternalDataSchema,
+    resolve_incremental_sync_fallback,
+)
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import (
     CANCELLED_RUN_MESSAGE,
@@ -364,3 +369,186 @@ def test_transient_failure_replaces_the_raw_driver_text_without_disabling_the_sc
 
     mock_update_should_sync.assert_not_called()
     assert mock_update_job_status.call_args.kwargs["latest_error"] == expected_message
+
+
+# transaction=True for the same reason as the tests above: the activity resolves the schema through
+# database_sync_to_async_pool, and the pool thread's connection can't see a test transaction.
+@parameterized.expand(
+    [
+        # No key to merge on. With a cursor column the table can still read forward, so it appends.
+        (
+            "missing_key_with_cursor",
+            "MissingPrimaryKeysException: Primary key required for incremental syncs",
+            {"incremental_field": "updated_at", "incremental_field_type": "datetime"},
+            ExternalDataSchema.SyncType.APPEND,
+            "has no primary key",
+            "append-only sync",
+        ),
+        # No key and no cursor column, so the only sync it can run re-reads the whole table.
+        (
+            "missing_key_without_cursor",
+            "MissingPrimaryKeysException: Primary key required for incremental syncs",
+            {},
+            ExternalDataSchema.SyncType.FULL_REFRESH,
+            "has no primary key",
+            "full table replication",
+        ),
+        # A key that does not identify one row. Redshift does not enforce primary keys, so a
+        # declared or inferred key can hold duplicates and the merge can never match rows.
+        (
+            "duplicate_key",
+            "DuplicatePrimaryKeysException: The primary keys for this table are not unique. "
+            "Primary keys being used are: ['id']",
+            {"incremental_field": "updated_at", "primary_key_columns": ["id"]},
+            ExternalDataSchema.SyncType.APPEND,
+            "isn't unique",
+            "append-only sync",
+        ),
+    ]
+)
+@pytest.mark.django_db(transaction=True)
+def test_incremental_sync_that_can_never_merge_falls_back_instead_of_disabling(
+    _name: str,
+    internal_error: str,
+    sync_type_config: dict,
+    expected_sync_type: str,
+    expected_cause: str,
+    expected_fallback_label: str,
+) -> None:
+    org = Organization.objects.create(name="org")
+    team = Team.objects.create(organization=org, name="team")
+    source = ExternalDataSource.objects.create(team=team, source_type=ExternalDataSourceType.REDSHIFT.value)
+    schema = ExternalDataSchema.objects.create(
+        team=team,
+        source=source,
+        name="table",
+        should_sync=True,
+        sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+        sync_type_config=sync_type_config,
+    )
+    job = ExternalDataJob.objects.create(
+        team=team, pipeline=source, schema=schema, status=ExternalDataJob.Status.RUNNING, rows_synced=0
+    )
+
+    env = ActivityEnvironment()
+    inputs = UpdateExternalDataJobStatusInputs(
+        team_id=team.id,
+        job_id=str(job.id),
+        schema_id=str(schema.id),
+        source_id=str(source.id),
+        status=ExternalDataJob.Status.FAILED,
+        internal_error=internal_error,
+        latest_error=internal_error,
+    )
+
+    with (
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.get_rows", return_value=0
+        ),
+        mock.patch("products.warehouse_sources.backend.temporal.data_imports.external_data_job.finish_row_tracking"),
+        mock.patch("products.warehouse_sources.backend.temporal.data_imports.external_data_job.capture_exception"),
+        mock.patch("posthoganalytics.capture"),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.update_should_sync"
+        ) as mock_update_should_sync,
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.update_external_job_status"
+        ) as mock_update_job_status,
+    ):
+        asyncio.run(env.run(update_external_data_job_model, inputs))
+
+    mock_update_should_sync.assert_not_called()
+    schema.refresh_from_db()
+    assert schema.sync_type == expected_sync_type
+    assert schema.should_sync is True
+
+    # The reason has to name the sync type the table actually moved to, not just restate the
+    # failure, or the operator can't tell what their table is doing now.
+    reason = schema.sync_type_fallback_reason or ""
+    assert expected_cause in reason
+    assert expected_fallback_label in reason
+    assert reason == mock_update_job_status.call_args.kwargs["latest_error"]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_missing_primary_key_on_a_non_incremental_schema_still_disables() -> None:
+    # Nothing to fall back to when the schema is already on a sync type that needs no key, so the
+    # failure is a real one the customer has to look at.
+    org = Organization.objects.create(name="org")
+    team = Team.objects.create(organization=org, name="team")
+    source = ExternalDataSource.objects.create(team=team, source_type=ExternalDataSourceType.REDSHIFT.value)
+    schema = ExternalDataSchema.objects.create(
+        team=team,
+        source=source,
+        name="table",
+        should_sync=True,
+        sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+    )
+    job = ExternalDataJob.objects.create(
+        team=team, pipeline=source, schema=schema, status=ExternalDataJob.Status.RUNNING, rows_synced=0
+    )
+
+    env = ActivityEnvironment()
+    inputs = UpdateExternalDataJobStatusInputs(
+        team_id=team.id,
+        job_id=str(job.id),
+        schema_id=str(schema.id),
+        source_id=str(source.id),
+        status=ExternalDataJob.Status.FAILED,
+        internal_error="MissingPrimaryKeysException: Primary key required for incremental syncs",
+        latest_error="Primary key required for incremental syncs",
+    )
+
+    with (
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.get_rows", return_value=0
+        ),
+        mock.patch("products.warehouse_sources.backend.temporal.data_imports.external_data_job.finish_row_tracking"),
+        mock.patch("products.warehouse_sources.backend.temporal.data_imports.external_data_job.capture_exception"),
+        mock.patch("posthoganalytics.capture"),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.update_should_sync"
+        ) as mock_update_should_sync,
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.external_data_job.update_external_job_status"
+        ),
+    ):
+        asyncio.run(env.run(update_external_data_job_model, inputs))
+
+    mock_update_should_sync.assert_called_once()
+    schema.refresh_from_db()
+    assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+    assert schema.sync_type_fallback_reason is None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_fallback_reads_the_schema_under_a_row_lock() -> None:
+    # The read that decides to move off `incremental` and the write that applies it have to share
+    # one critical section. An unlocked read lets a sync type the operator chose in the gap be
+    # replaced by the fallback's own target, and they picked theirs deliberately.
+    org = Organization.objects.create(name="org")
+    team = Team.objects.create(organization=org, name="team")
+    source = ExternalDataSource.objects.create(team=team, source_type=ExternalDataSourceType.REDSHIFT.value)
+    schema = ExternalDataSchema.objects.create(
+        team=team,
+        source=source,
+        name="table",
+        should_sync=True,
+        sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+        sync_type_config={"incremental_field": "updated_at"},
+    )
+
+    with CaptureQueriesContext(connection) as queries:
+        resolve_incremental_sync_fallback(str(schema.id), team.id, "switched to {fallback}")
+
+    table = ExternalDataSchema._meta.db_table
+    reads = [
+        query["sql"]
+        for query in queries.captured_queries
+        if query["sql"].lstrip().upper().startswith("SELECT") and table in query["sql"]
+    ]
+    assert reads
+    assert all("FOR UPDATE" in sql for sql in reads)
+
+    schema.refresh_from_db()
+    assert schema.sync_type == ExternalDataSchema.SyncType.APPEND

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -528,6 +528,7 @@ class TestExternalDataSchema(APIBaseTest):
             status=ExternalDataSchema.Status.COMPLETED,
             sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
             sync_time_of_day="12:00:00",
+            sync_type_config={"sync_type_fallback_reason": "This table has no primary key"},
         )
 
         with (
@@ -549,6 +550,8 @@ class TestExternalDataSchema(APIBaseTest):
             schema.refresh_from_db()
             assert schema.sync_type_config.get("reset_pipeline") is None
             assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+            # The recorded reason explained a sync type PostHog picked, so choosing one clears it.
+            assert schema.sync_type_fallback_reason is None
 
     def test_update_schema_sync_type_is_logged_to_activity(self):
         source = ExternalDataSource.objects.create(

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -3081,6 +3081,7 @@ class TestExternalDataSource(APIBaseTest):
                     "description": schema.description,
                     "primary_key_columns": None,
                     "cdc_table_mode": "consolidated",
+                    "sync_type_fallback_reason": None,
                     "enabled_columns": None,
                     "row_filters": None,
                     "available_columns": [],

--- a/products/warehouse_sources/frontend/generated/api.schemas.ts
+++ b/products/warehouse_sources/frontend/generated/api.schemas.ts
@@ -323,6 +323,11 @@ export interface ExternalDataSchemaApi {
      * * `both` - both */
     cdc_table_mode?: CdcTableModeEnumApi | null
     /**
+     * Why PostHog changed this table's sync type on its own, or null if it never did. Set when a sync run proved the configured sync type can't work for the table, such as an incremental sync on a table with no primary key.
+     * @nullable
+     */
+    readonly sync_type_fallback_reason: string | null
+    /**
      * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
      * @nullable
      */
@@ -485,6 +490,11 @@ export interface PatchedExternalDataSchemaApi {
      * * `cdc_only` - cdc_only
      * * `both` - both */
     cdc_table_mode?: CdcTableModeEnumApi | null
+    /**
+     * Why PostHog changed this table's sync type on its own, or null if it never did. Set when a sync run proved the configured sync type can't work for the table, such as an incremental sync on a table with no primary key.
+     * @nullable
+     */
+    readonly sync_type_fallback_reason?: string | null
     /**
      * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
      * @nullable

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37299,6 +37299,11 @@ export namespace Schemas {
        * * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
       /**
+         * Why PostHog changed this table's sync type on its own, or null if it never did. Set when a sync run proved the configured sync type can't work for the table, such as an incremental sync on a table with no primary key.
+         * @nullable
+         */
+      readonly sync_type_fallback_reason: string | null;
+      /**
          * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
          * @nullable
          */
@@ -64742,6 +64747,11 @@ export namespace Schemas {
        * * `cdc_only` - cdc_only
        * * `both` - both */
       cdc_table_mode?: CdcTableModeEnum | null;
+      /**
+         * Why PostHog changed this table's sync type on its own, or null if it never did. Set when a sync run proved the configured sync type can't work for the table, such as an incremental sync on a table with no primary key.
+         * @nullable
+         */
+      readonly sync_type_fallback_reason?: string | null;
       /**
          * Names of source columns to sync. `null` (default) syncs all columns. Primary-key columns and the active incremental field are always retained, even if not listed here.
          * @nullable


### PR DESCRIPTION
## Problem

A warehouse table set to incremental sync that has no primary key, or whose primary key holds duplicate values, fails on every run after its first. PostHog responds by disabling the table and telling the operator to pick a key or change the sync method. Re-enabling reproduces the identical failure, so the table cycles between disabled and failing and never syncs.

This lands hardest on Amazon Redshift, which treats primary key constraints as [informational only](https://docs.aws.amazon.com/redshift/latest/dg/t_Defining_constraints.html). Many tables declare no key, a declared key can still hold duplicates, and a view cannot declare one at all. A single source can arrive with most of its tables in this state, each carrying an error that asks for manual work.

The shared SQL base makes it worse by guessing: `SQLSource._default_primary_key_from_columns` treats an `id` column as the primary key when the source declares none. On an engine that does not enforce keys, that guess is often not unique, so the table is defaulted into a merge that can never match rows.

Refs #88056

## Changes

- A table whose sync run proves it can never merge keeps syncing instead of being disabled. It moves to an append-only sync when it has an incremental field, otherwise to full table replication. Incremental already requires a cursor column, so in practice almost all of these land on append rather than a full re-read.
- The sync method column explains the change on hover, so an operator can see which tables PostHog moved and why. The reason clears as soon as they choose a sync method themselves.
- Every other non-retryable error still disables the schema exactly as before.
- Mechanical: `sync_type_fallback_reason` is a new read-only field on the schema API, and the generated frontend and MCP types are regenerated.

Two failures are treated as proof rather than as something a human must resolve: `MissingPrimaryKeysException` and `DuplicatePrimaryKeysException`. Both repeat identically on every run, so the alternative to resolving the sync type is an unbounded disable/re-enable loop.

### Why this sits on the failure path

An earlier version guarded the schema at enable time instead. That was dropped for two reasons. Enable time cannot distinguish a genuinely keyless table from one whose key only live detection finds, because only the per-engine reconcile helpers persist detected keys, not the shared `reconcile_source_schema_metadata`. It also cannot know whether a key is unique without a full scan of every table. Acting on the run that already proved the failure avoids both problems and needs no extra round trip to the source.

## How did you test this code?

Automated tests only. No manual run against a live Redshift cluster, so the behavior against real unenforced-key tables is not verified here.

New coverage, and the regression each part catches:

- Parameterized cases over both failure shapes and both fallback targets in `test_external_data_job_activities.py`. These catch a change that disables the schema again instead of resolving it, which would restore the loop. They assert the recorded reason names the sync type the table actually moved to, so a reason that merely restates the failure fails the test.
- A case asserting a non-incremental schema hitting the same error still disables, catching a fallback that fires when there is nothing to fall back to.
- `test_update_schema_change_sync_type` now asserts the recorded reason clears when the operator picks a sync method, catching a stale explanation left in the UI.

Run locally: the full `test_external_data_job_activities.py` file and the two sync-type tests in `test_external_data_schema.py`, plus `ruff`, the frontend typecheck, `hogli build:openapi`, `hogli ci:preflight`, and a repo-wide `uv run mypy --cache-fine-grained .`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, directed to find and fix the cause of repeated Redshift sync failures rather than to implement a named change. Repo skills read and applied: `/writing-code-comments`, `/improving-drf-endpoints`, `/writing-tests`, `/announcing-behavior-changes`, `/writing-pr-descriptions`.

Decisions across the session:

- The starting hypothesis was that the default sync-type builder was at fault. Investigation showed the failing rows already have `incremental` persisted, so a change to the default builder cannot affect them. That work is a good complement but a separate concern, so this PR does not duplicate it.
- A second hypothesis, that the operator's manually chosen primary key was being discarded at sync time, was checked and disproved: `resolve_primary_keys` already prefers a persisted or operator-set key over live detection.
- `/announcing-behavior-changes` steers a backend-only condition toward a per-object API field rendered where the object appears, rather than a transition banner. That is the shape used here.

Public artifact: the failure pattern was identified from PostHog's own analytics on warehouse sync errors. No customer identifiers, source metadata, or operational figures appear anywhere in this diff, and the test fixtures are invented rather than derived from any real source.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
