### PR TITLE
fix(web-analytics): don't classify cookieless events as bot traffic

### DIFF
--- a/posthog/hogql/database/schema/test/test_traffic_type.py
+++ b/posthog/hogql/database/schema/test/test_traffic_type.py
@@ -82,13 +82,57 @@ class TestFieldMarkers:
     @pytest.mark.parametrize("factory_fn,field_name,marker", FIELD_MARKERS)
     def test_emits_marker_over_user_agent_and_ip(self, factory_fn, field_name, marker):
         field = factory_fn(name=field_name)
-        assert isinstance(field.expr, ast.Call)
-        assert field.expr.name == marker
-        assert field.expr.args == [user_agent_expr(), client_ip_expr()]
+        marker_call = field.expr.args[2]
+        assert isinstance(marker_call, ast.Call)
+        assert marker_call.name == marker
+        assert marker_call.args == [user_agent_expr(), client_ip_expr()]
 
     @pytest.mark.parametrize("factory_fn,field_name,marker", FIELD_MARKERS)
     def test_marker_respects_custom_properties_path(self, factory_fn, field_name, marker):
         field = factory_fn(name=field_name, properties_path=["poe", "properties"])
+        marker_call = field.expr.args[2]
+        assert isinstance(marker_call, ast.Call)
+        assert marker_call.name == marker
+        assert marker_call.args == [user_agent_expr(["poe", "properties"]), client_ip_expr(["poe", "properties"])]
+
+
+# $cookieless_mode events always came from a real browser (a cookieless event with no user
+# agent is dropped at ingestion instead), so classification must skip the bot heuristics for
+# them entirely rather than reach the empty-UA fallback, which defaults to Automation/bot.
+COOKIELESS_OVERRIDES = [
+    (create_is_bot_field, "$virt_is_bot", False),
+    (create_traffic_type_field, "$virt_traffic_type", "Regular"),
+    (create_traffic_category_field, "$virt_traffic_category", "regular"),
+    (create_bot_name_field, "$virt_bot_name", ""),
+    (create_bot_operator_field, "$virt_bot_operator", ""),
+]
+
+
+class TestCookielessOverride:
+    @pytest.mark.parametrize("factory_fn,field_name,regular_value", COOKIELESS_OVERRIDES)
+    def test_short_circuits_to_the_regular_value_for_cookieless_events(self, factory_fn, field_name, regular_value):
+        field = factory_fn(name=field_name)
         assert isinstance(field.expr, ast.Call)
-        assert field.expr.name == marker
-        assert field.expr.args == [user_agent_expr(["poe", "properties"]), client_ip_expr(["poe", "properties"])]
+        assert field.expr.name == "if"
+        condition, when_cookieless, when_not = field.expr.args
+        assert isinstance(condition, ast.CompareOperation)
+        assert condition.op == ast.CompareOperationOp.Eq
+        assert condition.right == ast.Constant(value=True)
+        assert when_cookieless == ast.Constant(value=regular_value)
+        assert isinstance(when_not, ast.Call)
+
+    @pytest.mark.parametrize("factory_fn,field_name,regular_value", COOKIELESS_OVERRIDES)
+    def test_condition_reads_cookieless_mode_and_treats_missing_as_false(self, factory_fn, field_name, regular_value):
+        field = factory_fn(name=field_name)
+        condition = field.expr.args[0]
+        ifnull_call = condition.left
+        assert isinstance(ifnull_call, ast.Call)
+        assert ifnull_call.name == "ifNull"
+        assert ifnull_call.args[0] == ast.Field(chain=["properties", "$cookieless_mode"])
+        assert ifnull_call.args[1] == ast.Constant(value=False)
+
+    @pytest.mark.parametrize("factory_fn,field_name,regular_value", COOKIELESS_OVERRIDES)
+    def test_condition_respects_custom_properties_path(self, factory_fn, field_name, regular_value):
+        field = factory_fn(name=field_name, properties_path=["poe", "properties"])
+        ifnull_call = field.expr.args[0].left
+        assert ifnull_call.args[0] == ast.Field(chain=["poe", "properties", "$cookieless_mode"])

--- a/posthog/hogql/database/schema/traffic_type.py
+++ b/posthog/hogql/database/schema/traffic_type.py
@@ -25,18 +25,56 @@ def _classification_args(properties_path: Optional[list[str]] = None) -> list[as
     return [user_agent_expr(properties_path), client_ip_expr(properties_path)]
 
 
+def _cookieless_mode_expr(properties_path: Optional[list[str]] = None) -> ast.Expr:
+    if not properties_path:
+        properties_path = ["properties"]
+    return ast.Field(chain=[*properties_path, "$cookieless_mode"])
+
+
+def _with_cookieless_override(
+    classification_expr: ast.Expr, regular_value: bool | str, properties_path: Optional[list[str]] = None
+) -> ast.Expr:
+    """Skip bot classification for cookieless-mode events.
+
+    Cookieless ingestion strips $raw_user_agent and $ip for privacy before the event is
+    written (see cookieless-manager.ts), and a cookieless event with no real user agent is
+    dropped at ingestion instead of stored. So a stored cookieless event always came from a
+    real browser, but the empty-UA classification path can't tell that apart from an actual
+    automation hit with no user agent, and defaults every one of them to Automation/bot.
+    Short-circuit to the regular-traffic verdict for these events instead.
+    """
+    return ast.Call(
+        name="if",
+        args=[
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.Eq,
+                left=ast.Call(name="ifNull", args=[_cookieless_mode_expr(properties_path), ast.Constant(value=False)]),
+                right=ast.Constant(value=True),
+            ),
+            ast.Constant(value=regular_value),
+            classification_expr,
+        ],
+    )
+
+
 # These one-node calls are expanded to the classification SQL in the resolver (see Resolver.visit_call),
 # so the big expression only materializes for queries that select the field.
 def create_is_bot_field(name: str, properties_path: Optional[list[str]] = None) -> ExpressionField:
     return ExpressionField(
-        name=name, expr=ast.Call(name="isLikelyBot", args=_classification_args(properties_path)), isolate_scope=True
+        name=name,
+        expr=_with_cookieless_override(
+            ast.Call(name="isLikelyBot", args=_classification_args(properties_path)), False, properties_path
+        ),
+        isolate_scope=True,
     )
 
 
 def create_traffic_type_field(name: str, properties_path: Optional[list[str]] = None) -> ExpressionField:
     return ExpressionField(
         name=name,
-        expr=ast.Call(name="getTrafficType", args=_classification_args(properties_path)),
+        expr=_with_cookieless_override(
+            ast.Call(name="getTrafficType", args=_classification_args(properties_path)), "Regular", properties_path
+        ),
         isolate_scope=True,
     )
 
@@ -44,7 +82,11 @@ def create_traffic_type_field(name: str, properties_path: Optional[list[str]] = 
 def create_traffic_category_field(name: str, properties_path: Optional[list[str]] = None) -> ExpressionField:
     return ExpressionField(
         name=name,
-        expr=ast.Call(name="getTrafficCategory", args=_classification_args(properties_path)),
+        expr=_with_cookieless_override(
+            ast.Call(name="getTrafficCategory", args=_classification_args(properties_path)),
+            "regular",
+            properties_path,
+        ),
         isolate_scope=True,
     )
 
@@ -52,7 +94,9 @@ def create_traffic_category_field(name: str, properties_path: Optional[list[str]
 def create_bot_name_field(name: str, properties_path: Optional[list[str]] = None) -> ExpressionField:
     return ExpressionField(
         name=name,
-        expr=ast.Call(name="getBotName", args=_classification_args(properties_path)),
+        expr=_with_cookieless_override(
+            ast.Call(name="getBotName", args=_classification_args(properties_path)), "", properties_path
+        ),
         isolate_scope=True,
     )
 
@@ -60,6 +104,8 @@ def create_bot_name_field(name: str, properties_path: Optional[list[str]] = None
 def create_bot_operator_field(name: str, properties_path: Optional[list[str]] = None) -> ExpressionField:
     return ExpressionField(
         name=name,
-        expr=ast.Call(name="getBotOperator", args=_classification_args(properties_path)),
+        expr=_with_cookieless_override(
+            ast.Call(name="getBotOperator", args=_classification_args(properties_path)), "", properties_path
+        ),
         isolate_scope=True,
     )


### PR DESCRIPTION
## Problem

Every event captured in cookieless mode shows up as "Automation" in web analytics traffic-type breakdowns, and is excluded by any `$virt_is_bot = false` filter, even when it came from an ordinary browser.

Cookieless ingestion strips `$raw_user_agent` and `$ip` before the event is written, for privacy. The traffic classifier reads those two properties and treats a missing user agent as automation. Ingestion already guarantees a real browser sent the event (one with no user agent is dropped instead of stored), but the classifier can't see that once the properties are gone, so it defaults every cookieless event into the bot bucket.

Closes #88350

## Changes

- Web analytics traffic-type, traffic-category, bot-name, bot-operator, and is-bot fields now return the regular-traffic verdict for any event where `$cookieless_mode` is true, instead of falling through to the empty-user-agent automation path.
- The override is computed at query time, so it also corrects historical cookieless events, not just future ones.
- No visible change for any event outside cookieless mode.

## How did you test this code?

Added unit tests to `posthog/hogql/database/schema/test/test_traffic_type.py` asserting the generated AST short-circuits to the regular-traffic constant when `$cookieless_mode` is true, and that a missing `$cookieless_mode` property (the overwhelming majority of events) still falls through to the existing classification path unchanged. These extend the existing pure-AST-assertion style already used in this file, which does not require a live ClickHouse query.

This sandbox does not have the PostHog dev stack (Django, Postgres, ClickHouse) available, so `hogli test` / `ruff check` for the full test suite could not be run here. `ruff format` and `ruff check` were run directly against the two changed files and both pass. The change was traced by hand against `posthog/hogql/functions/traffic_type.py` and `posthog/hogql/database/schema/traffic_type.py` to confirm the wrapped `if()` expression composes correctly with the existing `isLikelyBot`/`getTrafficType`/`getTrafficCategory`/`getBotName`/`getBotOperator` calls, which the HogQL printer resolves generically regardless of nesting.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: this corrects the traffic classifier's existing documented behavior rather than changing a documented interface.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Tool used: Claude Code, no repo-provided skills invoked. The fix follows the "classifier-side" direction the issue itself suggested (treat `$cookieless_mode = true` as an explicit case rather than the empty-user-agent automation bucket) over the alternative "ingestion-side" direction, since it corrects historical data and needed no ingestion pipeline changes.
