### PR TITLE
fix(desktop): serve GitHub comment images from the disk cache

### DIFF
--- a/products/desktop/packages/ui/src/features/editor/components/githubCommentImages.test.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/githubCommentImages.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { githubCommentComponents } from "./githubCommentImages";
+import { MarkdownRenderer } from "./MarkdownRenderer";
+
+vi.mock("@posthog/ui/shell/cachedImageUrl", () => ({
+  cachedImageUrl: (remoteUrl: string) =>
+    `posthog-cache://images/?src=${encodeURIComponent(remoteUrl)}`,
+}));
+
+const SOURCE = "https://user-images.githubusercontent.com/1/example.png";
+
+describe("githubCommentComponents", () => {
+  it("falls back to the origin when the cache declines the image", () => {
+    render(
+      <MarkdownRenderer
+        content={`![Screenshot](${SOURCE})`}
+        componentsOverride={githubCommentComponents}
+      />,
+    );
+
+    const image = screen.getByAltText("Screenshot");
+    expect(image).toHaveAttribute(
+      "src",
+      expect.stringContaining("posthog-cache://"),
+    );
+
+    fireEvent.error(image);
+
+    expect(screen.getByAltText("Screenshot")).toHaveAttribute("src", SOURCE);
+  });
+});

--- a/products/desktop/packages/ui/src/features/editor/components/githubCommentImages.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/githubCommentImages.tsx
@@ -1,3 +1,4 @@
+import { cachedImageUrl } from "@posthog/ui/shell/cachedImageUrl";
 import type { Components } from "react-markdown";
 
 const GITHUB_IMAGE_HOSTS = new Set([
@@ -9,7 +10,9 @@ const GITHUB_IMAGE_HOSTS = new Set([
   "user-images.githubusercontent.com",
 ]);
 
-export function isGitHubHostedImage(source: string | undefined): boolean {
+export function isGitHubHostedImage(
+  source: string | undefined,
+): source is string {
   if (!source) return false;
 
   try {
@@ -27,5 +30,7 @@ export function isGitHubHostedImage(source: string | undefined): boolean {
 
 export const githubCommentComponents: Partial<Components> = {
   img: ({ src, alt }) =>
-    isGitHubHostedImage(src) ? <img src={src} alt={alt ?? ""} /> : null,
+    isGitHubHostedImage(src) ? (
+      <img src={cachedImageUrl(src)} alt={alt ?? ""} />
+    ) : null,
 };

--- a/products/desktop/packages/ui/src/features/editor/components/githubCommentImages.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/githubCommentImages.tsx
@@ -1,4 +1,5 @@
 import { cachedImageUrl } from "@posthog/ui/shell/cachedImageUrl";
+import { useState } from "react";
 import type { Components } from "react-markdown";
 
 const GITHUB_IMAGE_HOSTS = new Set([
@@ -28,9 +29,28 @@ export function isGitHubHostedImage(
   }
 }
 
+/**
+ * A comment image, read from the disk cache with the origin as a fallback.
+ *
+ * The cache answers 404 for anything it declines to hold, and a screenshot or
+ * a screen-recording GIF often passes its size limit. GitHub serves those
+ * fine, so a decline must not leave the reader with a broken image.
+ */
+function CommentImage({ src, alt }: { src: string; alt: string }) {
+  const [declinedSrc, setDeclinedSrc] = useState<string | null>(null);
+
+  return (
+    <img
+      src={declinedSrc === src ? src : cachedImageUrl(src)}
+      alt={alt}
+      onError={() => setDeclinedSrc(src)}
+    />
+  );
+}
+
 export const githubCommentComponents: Partial<Components> = {
   img: ({ src, alt }) =>
     isGitHubHostedImage(src) ? (
-      <img src={cachedImageUrl(src)} alt={alt ?? ""} />
+      <CommentImage src={src} alt={alt ?? ""} />
     ) : null,
 };


### PR DESCRIPTION
## Problem

Screenshots in GitHub PR and issue comments reload from GitHub every time a thread renders. Avatars in the same threads already use the disk cache (#90680), the comment images didn't.

## Changes

- Comment body images now load through the disk cache. Same host allowlist as before.
- A comment image the cache declines still renders. The image element retries against GitHub, so a screenshot past the cache size limit shows instead of breaking.

## How did you test this code?

Comment thread and editor suites pass.

`packages/ui/src/features/editor/components/githubCommentImages.test.tsx` fires an error on the cached image and asserts the element swaps to the origin URL. No existing test covered the failure path, and the test fails if the fallback is removed.