### PR TITLE
feat(experiments): add explainer tooltips for p-value and interval

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6497,25 +6497,25 @@ snapshots:
     scenes-app-experiments--draft-experiment--light:
         hash: v1.k794b7964.c25f2146cdcd2142f7b2c1bcd45890b6a0a7d9b03e82bccb1ef891b64cf2f493.2D2m-q3OCoqqC_zQqtJPYL4me6M9Ajd-esVxbM8bur4
     scenes-app-experiments--experiment-asymmetric-intervals--dark:
-        hash: v1.k794b7964.bf7de0d95fd6957a66852dd17ca6a9337bd52d161640743753affa3ac6447274.srHzGS4gYQ64kYkVNSiLB3SSboJUj6wdl9jmfuxovKU
+        hash: v1.k794b7964.3cf04bc235b610eb2e20c5149884dfab927ade290e53eba02aabe967776502f1.KP1G9_AO9UPwotpVfXAofXET1593JgE2X7lQ6s0Dvf4
     scenes-app-experiments--experiment-asymmetric-intervals--light:
-        hash: v1.k794b7964.b2f88c3e5cf6d621251402158277210de513f053465f9bd7457dd474d47c58ce.mlXqwZI6iFPTGP29XubXnVvM-KG6i50XjGVau81jpJg
+        hash: v1.k794b7964.cdb90502924fc61172f37180e3603b38541e9d689ae4959e7df2e9e96b7e5fb2.7jNaWZx5yCRIuZb17YgfLliN1z6uX4T7HeezJS9Tw4A
     scenes-app-experiments--experiment-code-tab--dark:
         hash: v1.k794b7964.a6d2aea20a3beea31a02b496003e06c9ead29a5739b67fe373f3a6691483667e.9NjTP48PGseyxT2-jbYawzRWiiSE7acbF_ES5TbLi4w
     scenes-app-experiments--experiment-code-tab--light:
         hash: v1.k794b7964.e7058a4c235c2202d5a63a7c5e32ab4eae2c69a422def4f9b494f7e18a61681a.30IpMGKStgL22CU4wcSp_p3KotOGPoTX5L146C-9tLg
     scenes-app-experiments--experiment-exposures-expanded--dark:
-        hash: v1.k794b7964.0a4465a38b5d6bdb99882c5e15112c7c84ee7dd51658e3ef6691c8e67152c6de.Gn0quaLD1veID5PR0yx-hItLfNo6CbGjz6DxSRyrIAU
+        hash: v1.k794b7964.b134c94bbdd398c538193656ff50bb0fd4c02949846ddd30fcfac3f2bc0eb309.VAV9WEbZWnPxaKq6gZoUuOFCb19bYSpPmiMbjIfFRks
     scenes-app-experiments--experiment-exposures-expanded--light:
-        hash: v1.k794b7964.b56d21d27f0d5fe3035ed9d7936934f77290a70c82f4524d1980a38212b3c942.EpT5uY1uBp5uNUcr1PZDhJIjeYwy34RuTag4AB8JIP4
+        hash: v1.k794b7964.d68b54d7694d67b7f640a94612481355a0a7b327e94e5ad5c17fae0b4c8a6aba.KBQusJhyfMEUjmjNHWnWGQSjf2Q6q8SIwUmb_pW5Iuc
     scenes-app-experiments--experiment-frequentist-five-variants--dark:
-        hash: v1.k794b7964.678985c04bc4a9936917c633d08399e2f119370da38850a1cf47fc31031af074.CQSVDkPGIPAYrBkiDWTDiqFgEtmDlF7JDesTEqaLvHA
+        hash: v1.k794b7964.5c82d4d12d7dfeba6573e0aafc424e487c88e600493924b5ca529ba21e9039f5.EDShC6F9fYtHFtt5hi9ViDYNo8h5LGXAWGmu8igr2eI
     scenes-app-experiments--experiment-frequentist-five-variants--light:
-        hash: v1.k794b7964.c7e29085b63136fca8d9f5e21cf1b6e450d099926b8e364dc19265e53eb653cc.2lg1g1bnhVdEytrYQyMJnESLzLOPDh_G_jChsHtGiU4
+        hash: v1.k794b7964.691f6a3945a8c06989ef54d63b9a8e3b5e79ec71576448a235589800d5d448bd.Lg7SGNcjl8mjjfxeH7aG2PyF9TnCWilZ8Nwb5bg0Yxg
     scenes-app-experiments--experiment-frequentist-two-variants--dark:
-        hash: v1.k794b7964.a38909c8222409c5fa2174c283833ab419c75a0ed5420da095a9aded11bf6532.5EK4l32txmbHcS11UWiwesynVVHf7FKe98dPAeWsjkw
+        hash: v1.k794b7964.a4753ab565ca3f44ae93f0bf19bb4bd25b2544c1bb796cebbd3a16b6aa146db5.k7wPrw7XnQ4KdxWMRQ9gVWew1fhgPOLCUVIuC24Kp1c
     scenes-app-experiments--experiment-frequentist-two-variants--light:
-        hash: v1.k794b7964.ec64583fd2debf87822296f1c9fc10e73c1c6b7e31fe55f0ca974d3920f8bd14.Ch64gBgjo0wR0Ypvkhap6047UPjXBaWSQCNoKDOiNHc
+        hash: v1.k794b7964.c3d7500050335234dac2b12a58ae26fe68611d4f4fb040ab162a0b22aa2816c4.yZkCSjTEKndRt6r5t2hSlLwgfIwnnDg5or8MZX0tAz0
     scenes-app-experiments--experiment-replay-scanner-backlink--dark:
         hash: v1.k794b7964.e04ec522e5f690078c89c21f4e160d067f13c755e65988852d89dbc624e4c74b.DbWktEPnIBX15xGlIGLocMuFHo7CzbH-yVTgowQMnck
     scenes-app-experiments--experiment-replay-scanner-backlink--light:
@@ -6537,9 +6537,9 @@ snapshots:
     scenes-app-experiments--experiment-with-legacy-trends-query--light:
         hash: v1.k794b7964.42c2f3656a5c989d4b1ee34296ca4bb59e186241920a5f8ca21f319069cc6825.6R2u2nPGBnbJYFX2aAn-ZEDtNpa4m1bQA-1aYg8Y7sM
     scenes-app-experiments--experiment-with-mean-metric--dark:
-        hash: v1.k794b7964.a7f14a7b731e329159bd73b93dc572cefaf00201e09ab255b637538a90fa3075.am8GE28o1WXLpWx5fVjJhg_DeDSaY4UpC0O4wUIAAvc
+        hash: v1.k794b7964.3f9934891ada35abfcaa7d3bdd9c08986c50b5f417c56804a09c78427e6322a6.Q_0MYAIS9e_C80-JVwO9dNWLhEsnTqnkOSdFrkOIsdI
     scenes-app-experiments--experiment-with-mean-metric--light:
-        hash: v1.k794b7964.4883b91ec3f875f8de3ba33ca097145cb4a8ff125576f62a8b2ef31f4f5837f8.SDAgyoY6ByGC_qlH7x_bjQHHXB7HA6X5yAurbRc8PDc
+        hash: v1.k794b7964.a8b9f37dbf2dee9d08443f8dcbc53022ef577d4b4de51d6246b0c7b35d73ff86.-uiFPPi9Cw3baxaPD5oKxRPvINwkp0iDRrwVR6CjtNM
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--dark:
         hash: v1.k794b7964.980b559b32f54de08e32932b4d9e14e203c2ff084a7dd0fd16bce311dff6540e.RjlN-Zl7Betwf5MoCvu-4XAx75Dqu5OI8f_qbvOsQ20
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--light:
@@ -6553,9 +6553,9 @@ snapshots:
     scenes-app-experiments--experiment-with-multiple-metrics-reordered--light:
         hash: v1.k794b7964.0587837efd7de868fdd36fe510c67061000245a3f452626997ca1b2abe1798ee.HRp_xAeT4-TdYyop38KB2aaQ6cOED7U0Md4U9l9qOzw
     scenes-app-experiments--experiment-with-ratio-metric--dark:
-        hash: v1.k794b7964.10cabdc0aa90e558fb2a01df0954a9eb636be3856be24d337d079e22d745d4e2.Et5U_-Fnfv3rJ5EbVMNEPEnYubFoQUT2GA-yrnaCRpQ
+        hash: v1.k794b7964.02cb4d2023fd4a7453185e99556ac1ecc4c3c37d0aa6d76b79961556c491337f.f1O4ewMw2v7_wbBhs3EpPc2hnvk2DZutmmekNjr3x2w
     scenes-app-experiments--experiment-with-ratio-metric--light:
-        hash: v1.k794b7964.92f5f6d966c38b93c02bddde09edbb7f266f01171084c2d394f9f77b51fa6550.P4ySQ-vSsVSYgBxJswjnUWRkkQyfOOkOUYlDsxWBa9o
+        hash: v1.k794b7964.eb1c966798493a74d3ead27852a7c52627cdf21530275c5135b6eead2eaa41a2.YbslELtaYfK4tfEl9upeV7fUmMoi9_jppoCmaj-wUpk
     scenes-app-experiments--experiments--dark:
         hash: v1.k794b7964.70b099ab31a4d95201bec15b209f4be5870d1c223af00881039ee6017c2bfd8b.mhGzyTB70VdAAThY7t9y6NgM6SkqDJsc0LC6eJ9mAsk
     scenes-app-experiments--experiments--light:

--- a/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ResultDetails.tsx
@@ -170,6 +170,8 @@ export function ResultDetails({
             title: result.variant_results?.[0]
                 ? `${getIntervalLabel(result.variant_results[0])} (95%)`
                 : 'Confidence interval (95%)',
+            tooltip:
+                "The range that likely contains the true effect. When it doesn't cross 0%, the result is significant.",
             render: (_, item: ExperimentVariantResult & { key: string }) => {
                 if (item.key === baselineKey) {
                     return '—'

--- a/frontend/src/scenes/experiments/MetricsView/new/TableHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/TableHeader.tsx
@@ -74,7 +74,12 @@ export function TableHeader({
                                 </Tooltip>
                             </span>
                         ) : (
-                            'p-value'
+                            <span className="inline-flex items-center gap-1">
+                                p-value
+                                <Tooltip title="The probability of seeing a difference at least this large if the variant had no real effect. The result is significant when the p-value drops below your threshold.">
+                                    <IconInfo className="text-secondary text-base" />
+                                </Tooltip>
+                            </span>
                         )
                     ) : (
                         <span className="inline-flex items-center gap-1">


### PR DESCRIPTION
## Problem

In the experiment results, the "Win %" header has an explainer tooltip but the p-value header (without sequential testing) and the confidence interval column have none.

## Changes

- The p-value table header now has a tooltip explaining what the value means and when a result is significant.
- The confidence/credible interval column in the metric details table now has a tooltip.

## How did you test this code?

Copy-only change using existing tooltip patterns (header `Tooltip` component, LemonTable's `tooltip` column prop). Not run: typecheck and jest (light worktree); no screenshots for the same reason.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, from the same experiment-view polish audit as #88216 and #88275. Skills invoked: /wt, /writing-user-facing-copy, /writing-pr-descriptions.
