### PR TITLE
fix(visual-review): let a quarantine be lifted, and record who tolerated

### DIFF
--- a/products/visual_review/README.md
+++ b/products/visual_review/README.md
@@ -136,7 +136,12 @@ Developers can also manually tolerate a snapshot from the UI.
 Quarantined snapshots are still captured and diffed but excluded from gating.
 A quarantined snapshot is not committed to the baseline, with one exception: a quarantined `new` snapshot that a person approved by identifier.
 This is the way to give a story a baseline entry when it has none and the quarantine must stay, because every run without the entry classifies the story `new`, and lifting the quarantine first fails every run until the entry lands.
-The procedure is: open a PR that renders the story, approve the `new` snapshot on that run by identifier (the API or the `visual-review-runs-approve-create` MCP tool; "Approve all" skips quarantined snapshots), finalize the run so the entry is committed to the PR branch, merge the PR, then lift the quarantine.
+The procedure is: open a PR that renders the story, approve the `new` snapshot on that run by identifier (the API or the `visual-review-runs-approve-create` MCP tool; "Approve all" skips quarantined snapshots), finalize the run so the entry is committed to the PR branch, then merge the PR.
+
+Keep the quarantine on after the merge.
+An entry on the default branch does not reach a branch that forked before it, and healing cannot supply it either: healing reads the merge-base, which for such a branch also predates the entry.
+So every open branch still renders the story with no entry for it, and lifting the quarantine turns those runs `new` and reds their gate.
+Lift it once the open branches that render the story carry the entry, which they do after they merge the default branch.
 
 **Flakiness tab** — scores each snapshot identity on the share of the last 7 days of default-branch runs that rendered it differently from its baseline.
 The share is split in two, because the two cost different things: a `hard` run failed the gate and blocked whoever was merging, and a `soft` run was absorbed by a toleration and blocked nobody.

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -42,7 +42,7 @@ from ..logic import (
     toleration,
 )
 from . import contracts
-from .enums import RunPurpose
+from .enums import ActorType, RunPurpose
 
 User = get_user_model()
 
@@ -555,8 +555,10 @@ def get_snapshot_history(repo_id: UUID, identifier: str, run_type: str) -> list[
     ]
 
 
-def mark_snapshot_as_tolerated(run_id: UUID, snapshot_id: UUID, user_id: int, team_id: int) -> contracts.Snapshot:
-    snapshot = toleration.mark_snapshot_as_tolerated(run_id, snapshot_id, user_id, team_id)
+def mark_snapshot_as_tolerated(
+    run_id: UUID, snapshot_id: UUID, user_id: int, team_id: int, actor: ActorType = ActorType.HUMAN
+) -> contracts.Snapshot:
+    snapshot = toleration.mark_snapshot_as_tolerated(run_id, snapshot_id, user_id, team_id, actor=actor)
     return _to_snapshot(snapshot, snapshot.run.repo_id)
 
 
@@ -725,7 +727,12 @@ def list_quarantined(
 
 
 def quarantine_identifier(
-    repo_id: UUID, run_type: str, input: contracts.QuarantineInput, user_id: int, team_id: int
+    repo_id: UUID,
+    run_type: str,
+    input: contracts.QuarantineInput,
+    user_id: int,
+    team_id: int,
+    source: ActorType = ActorType.HUMAN,
 ) -> contracts.QuarantinedIdentifierEntry:
     entry = quarantine.quarantine_identifier(
         repo_id=repo_id,
@@ -734,6 +741,7 @@ def quarantine_identifier(
         reason=input.reason,
         expires_at=input.expires_at,
         source_run_id=input.source_run_id,
+        source=source,
         user_id=user_id,
         team_id=team_id,
     )

--- a/products/visual_review/backend/facade/api.py
+++ b/products/visual_review/backend/facade/api.py
@@ -695,6 +695,7 @@ def _to_quarantined_entry(
         identifier=q.identifier,
         run_type=q.run_type,
         reason=q.reason,
+        source=q.source,
         expires_at=q.expires_at,
         created_at=q.created_at,
         updated_at=q.updated_at,
@@ -710,6 +711,7 @@ def _to_baseline_quarantine_summary(
     return contracts.BaselineQuarantineSummary(
         id=q.id,
         reason=q.reason,
+        source=q.source,
         expires_at=q.expires_at,
         created_at=q.created_at,
         created_by=created_by,

--- a/products/visual_review/backend/facade/contracts.py
+++ b/products/visual_review/backend/facade/contracts.py
@@ -353,6 +353,9 @@ class QuarantinedIdentifierEntry:
     identifier: str
     run_type: str
     reason: str
+    # Who opened it: a person in the UI, or an agent through MCP. `created_by` is
+    # the delegating user either way, so it cannot answer this on its own.
+    source: str
     expires_at: datetime | None
     created_at: datetime
     updated_at: datetime
@@ -454,6 +457,7 @@ class BaselineQuarantineSummary:
 
     id: UUID
     reason: str
+    source: str
     expires_at: datetime | None
     created_at: datetime
     created_by: UserBasicInfo | None = None

--- a/products/visual_review/backend/facade/enums.py
+++ b/products/visual_review/backend/facade/enums.py
@@ -116,3 +116,11 @@ class ToleratedReason(StrEnum):
     AUTO_THRESHOLD = "auto_threshold"  # Below pixel/SSIM diff threshold
     HUMAN = "human"  # Manually marked by a reviewer
     AGENT = "agent"  # Tolerated by an AI agent
+
+
+# A toleration somebody decided on, as opposed to one the diff pipeline minted
+# for sub-threshold pixel jitter. Counting AUTO_THRESHOLD rows as decisions
+# inflates every "tolerated drift" number with rendering noise. Use this
+# wherever the question is "did a reviewer accept this drift", so a reviewer and
+# an agent are never counted differently.
+INTENTIONAL_TOLERATE_REASONS = (ToleratedReason.HUMAN, ToleratedReason.AGENT)

--- a/products/visual_review/backend/logic/baseline_overview.py
+++ b/products/visual_review/backend/logic/baseline_overview.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 from posthog.dataclasses import frozen
 
-from ..facade.enums import RunStatus, SnapshotResult, ToleratedReason
+from ..facade.enums import INTENTIONAL_TOLERATE_REASONS, RunStatus, SnapshotResult
 from ..models import QuarantinedIdentifier, Run, RunSnapshot, ToleratedHash
 from . import run_queries
 
@@ -105,11 +105,6 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
         full_universe_identifiers = universe_identifiers
 
     # 3a. Tolerate counts in 30d / 90d windows. Single grouped query each.
-    # Scope to HUMAN/AGENT reasons only — AUTO_THRESHOLD rows are auto-minted
-    # by the diff pipeline as a tolerated-hash cache for sub-threshold pixel
-    # jitter and don't represent a deliberate "we accept this drift" decision.
-    # Including them inflated the "Tolerated drift" tile with rendering noise.
-    intentional_tolerate_reasons = (ToleratedReason.HUMAN, ToleratedReason.AGENT)
     tolerate_30d_by_id: dict[str, int] = {}
     tolerate_90d_by_id: dict[str, int] = {}
     if universe_identifiers:
@@ -119,7 +114,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
                 identifier__in=universe_identifiers,
-                reason__in=intentional_tolerate_reasons,
+                reason__in=INTENTIONAL_TOLERATE_REASONS,
                 created_at__gte=tol_30d_cutoff,
             )
             .values_list("identifier")
@@ -131,7 +126,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
                 identifier__in=universe_identifiers,
-                reason__in=intentional_tolerate_reasons,
+                reason__in=INTENTIONAL_TOLERATE_REASONS,
                 created_at__gte=tol_90d_cutoff,
             )
             .values_list("identifier")
@@ -264,7 +259,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
                 identifier__in=full_universe_identifiers,
-                reason__in=intentional_tolerate_reasons,
+                reason__in=INTENTIONAL_TOLERATE_REASONS,
                 created_at__gte=recent_cutoff,
             )
             .values_list("identifier", flat=True)
@@ -274,7 +269,7 @@ def get_baselines_overview(repo_id: UUID) -> _BaselineOverviewRaw:
             ToleratedHash.objects.filter(
                 repo_id=repo_id,
                 identifier__in=full_universe_identifiers,
-                reason__in=intentional_tolerate_reasons,
+                reason__in=INTENTIONAL_TOLERATE_REASONS,
                 created_at__gte=frequent_cutoff,
             )
             .values("identifier")

--- a/products/visual_review/backend/logic/gating.py
+++ b/products/visual_review/backend/logic/gating.py
@@ -6,7 +6,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from ..db import WRITER_DB
-from ..facade.enums import ReviewState, RunPurpose, SnapshotResult, ToleratedReason
+from ..facade.enums import INTENTIONAL_TOLERATE_REASONS, ReviewState, RunPurpose, SnapshotResult
 from ..models import QuarantinedIdentifier, Run, RunSnapshot
 from . import baselines, ci_status, comment_markdown, comments
 
@@ -71,7 +71,7 @@ def _recount(run: Run) -> list[RunSnapshot]:
     run.tolerated_match_count = sum(
         1
         for s in snapshots
-        if s.tolerated_hash_match is not None and s.tolerated_hash_match.reason == ToleratedReason.HUMAN
+        if s.tolerated_hash_match is not None and s.tolerated_hash_match.reason in INTENTIONAL_TOLERATE_REASONS
     )
     return snapshots
 

--- a/products/visual_review/backend/logic/quarantine.py
+++ b/products/visual_review/backend/logic/quarantine.py
@@ -10,6 +10,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from ..db import WRITER_DB
+from ..facade.enums import ActorType
 from ..models import QuarantinedIdentifier, Run
 from . import errors, repos
 
@@ -47,6 +48,7 @@ def quarantine_identifier(
     team_id: int,
     expires_at: datetime | None = None,
     source_run_id: UUID | None = None,
+    source: ActorType = ActorType.HUMAN,
 ) -> QuarantinedIdentifier:
     repos.get_repo(repo_id, team_id)  # raises RepoNotFoundError if repo not owned by team
     now = timezone.now()
@@ -73,6 +75,7 @@ def quarantine_identifier(
         expires_at=expires_at,
         created_by_id=user_id,
         source_run=source_run,
+        source=source,
     )
 
 

--- a/products/visual_review/backend/logic/toleration.py
+++ b/products/visual_review/backend/logic/toleration.py
@@ -57,6 +57,10 @@ def mark_snapshot_as_tolerated(
             "created_by_id": user_id,
             "diff_percentage": snapshot.diff_percentage,
             "expires_at": None,
+            # created_at is auto_now_add, so it only fills on insert and a revived row
+            # would keep the old date. The tolerate windows in baseline_overview select
+            # on it, so today's decision would land outside them and read as history.
+            "created_at": timezone.now(),
         },
     )
 

--- a/products/visual_review/backend/logic/toleration.py
+++ b/products/visual_review/backend/logic/toleration.py
@@ -34,10 +34,18 @@ def mark_snapshot_as_tolerated(
     if not snapshot.current_hash:
         raise ValueError("Snapshot has no current hash")
 
+    # update_or_create, not get_or_create: the same tuple may already carry a row
+    # the classifier no longer matches, because `complete_run` only reads rows whose
+    # expires_at is null or in the future. get_or_create returns that dead row and
+    # drops the defaults, so the toleration would look like it worked and change
+    # nothing. Clearing expires_at revives it, and rewriting reason and creator
+    # attributes it to whoever decided this time, which also upgrades a row the diff
+    # pipeline minted as auto_threshold into a decision.
+    #
     # Explicit team_id in the lookup (not just defaults) so the IDOR audit
     # rule sees the scope; ProductTeamManager also auto-filters by canonical
     # team — both belt and suspenders.
-    tolerated, _ = ToleratedHash.objects.get_or_create(
+    tolerated, _ = ToleratedHash.objects.update_or_create(
         team_id=team_id,
         repo_id=run.repo_id,
         identifier=snapshot.identifier,
@@ -48,6 +56,7 @@ def mark_snapshot_as_tolerated(
             "source_run": run,
             "created_by_id": user_id,
             "diff_percentage": snapshot.diff_percentage,
+            "expires_at": None,
         },
     )
 

--- a/products/visual_review/backend/logic/toleration.py
+++ b/products/visual_review/backend/logic/toleration.py
@@ -8,14 +8,16 @@ from django.db import transaction
 from django.utils import timezone
 
 from ..db import WRITER_DB
-from ..facade.enums import ReviewState, SnapshotResult, ToleratedReason
+from ..facade.enums import INTENTIONAL_TOLERATE_REASONS, ActorType, ReviewState, SnapshotResult, ToleratedReason
 from ..models import Run, RunSnapshot, ToleratedHash
 from . import errors, run_queries
 
 
 @transaction.atomic(using=WRITER_DB)
-def mark_snapshot_as_tolerated(run_id: UUID, snapshot_id: UUID, user_id: int, team_id: int) -> RunSnapshot:
-    """Mark a changed snapshot as a known tolerated alternate (human decision).
+def mark_snapshot_as_tolerated(
+    run_id: UUID, snapshot_id: UUID, user_id: int, team_id: int, actor: ActorType = ActorType.HUMAN
+) -> RunSnapshot:
+    """Mark a changed snapshot as a known tolerated alternate (a reviewer's decision).
 
     Creates a ToleratedHash entry tied to the current baseline, reclassifies the
     snapshot as UNCHANGED, and recalculates run summary counts.
@@ -42,7 +44,7 @@ def mark_snapshot_as_tolerated(run_id: UUID, snapshot_id: UUID, user_id: int, te
         baseline_hash=snapshot.baseline_hash,
         alternate_hash=snapshot.current_hash,
         defaults={
-            "reason": ToleratedReason.HUMAN,
+            "reason": ToleratedReason.AGENT if actor == ActorType.AGENT else ToleratedReason.HUMAN,
             "source_run": run,
             "created_by_id": user_id,
             "diff_percentage": snapshot.diff_percentage,
@@ -57,10 +59,14 @@ def mark_snapshot_as_tolerated(run_id: UUID, snapshot_id: UUID, user_id: int, te
     snapshot.tolerated_hash_match = tolerated
     snapshot.save(update_fields=["review_state", "reviewed_at", "reviewed_by_id", "tolerated_hash_match"])
 
-    # Update tolerated_match_count (only human-tolerated, not auto-threshold)
+    # Update tolerated_match_count (only decided tolerations, not auto-threshold)
     tolerated_count = (
         RunSnapshot.objects.using(WRITER_DB)
-        .filter(run=run, tolerated_hash_match__isnull=False, tolerated_hash_match__reason=ToleratedReason.HUMAN)
+        .filter(
+            run=run,
+            tolerated_hash_match__isnull=False,
+            tolerated_hash_match__reason__in=INTENTIONAL_TOLERATE_REASONS,
+        )
         .count()
     )
     Run.objects.using(WRITER_DB).filter(id=run.id).update(tolerated_match_count=tolerated_count)

--- a/products/visual_review/backend/logic/toleration.py
+++ b/products/visual_review/backend/logic/toleration.py
@@ -34,18 +34,10 @@ def mark_snapshot_as_tolerated(
     if not snapshot.current_hash:
         raise ValueError("Snapshot has no current hash")
 
-    # update_or_create, not get_or_create: the same tuple may already carry a row
-    # the classifier no longer matches, because `complete_run` only reads rows whose
-    # expires_at is null or in the future. get_or_create returns that dead row and
-    # drops the defaults, so the toleration would look like it worked and change
-    # nothing. Clearing expires_at revives it, and rewriting reason and creator
-    # attributes it to whoever decided this time, which also upgrades a row the diff
-    # pipeline minted as auto_threshold into a decision.
-    #
     # Explicit team_id in the lookup (not just defaults) so the IDOR audit
     # rule sees the scope; ProductTeamManager also auto-filters by canonical
     # team — both belt and suspenders.
-    tolerated, _ = ToleratedHash.objects.update_or_create(
+    tolerated, created = ToleratedHash.objects.get_or_create(
         team_id=team_id,
         repo_id=run.repo_id,
         identifier=snapshot.identifier,
@@ -56,13 +48,20 @@ def mark_snapshot_as_tolerated(
             "source_run": run,
             "created_by_id": user_id,
             "diff_percentage": snapshot.diff_percentage,
-            "expires_at": None,
-            # created_at is auto_now_add, so it only fills on insert and a revived row
-            # would keep the old date. The tolerate windows in baseline_overview select
-            # on it, so today's decision would land outside them and read as history.
-            "created_at": timezone.now(),
         },
     )
+
+    # `complete_run` reads only rows whose expires_at is null or in the future, so an
+    # expired row left alone makes this call a silent no-op: it reports success and the
+    # next run flags the snapshot again. Revive it, and change nothing else. The row is
+    # shared by every snapshot that matched this hash pair, and `reason` and `created_at`
+    # describe runs that already happened: `flakiness._SOFT` counts a soft match only
+    # while the row still says auto_threshold, and the baseline overview buckets a
+    # toleration by its created_at. Rewriting either would edit that history. Today's
+    # decision is recorded per snapshot below, which is where it belongs.
+    if not created and tolerated.expires_at is not None:
+        tolerated.expires_at = None
+        tolerated.save(update_fields=["expires_at"])
 
     # result stays CHANGED — it's the technical truth (hashes differ).
     # review_state captures the human decision to tolerate.

--- a/products/visual_review/backend/presentation/views.py
+++ b/products/visual_review/backend/presentation/views.py
@@ -27,6 +27,7 @@ from rest_framework.response import Response
 
 from posthog.api.mixins import TypedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.auth import is_mcp_request
 from posthog.helpers.trigram_search import MAX_SEARCH_LENGTH
 
 from ..facade import api, contracts
@@ -41,6 +42,7 @@ from ..facade.contracts import (
     UpdateRepoInput,
     UpdateRepoRequestInput,
 )
+from ..facade.enums import ActorType
 from .serializers import (
     AddSnapshotsInputSerializer,
     AddSnapshotsResultSerializer,
@@ -62,8 +64,19 @@ from .serializers import (
     SnapshotHistoryEntrySerializer,
     SnapshotSerializer,
     ToleratedHashEntrySerializer,
+    UnquarantineQuerySerializer,
     UpdateRepoInputSerializer,
 )
+
+
+def _actor(request: Request) -> ActorType:
+    """Who is making this write, for attribution on the row it creates.
+
+    `is_mcp_request` needs both a scoped token and the MCP server's user agent, so a
+    browser session is never recorded as an agent. The marker is client-supplied, so
+    this attributes a write and must never gate one.
+    """
+    return ActorType.AGENT if is_mcp_request(request) else ActorType.HUMAN
 
 
 def _parse_uuid(value: str, field: str = "id") -> UUID:
@@ -271,22 +284,23 @@ class RepoViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 input=request.validated_data,
                 user_id=cast(int, request.user.id),
                 team_id=self.team_id,
+                source=_actor(request),
             )
         except api.RepoNotFoundError:
             return Response({"detail": "Repo not found"}, status=status.HTTP_404_NOT_FOUND)
         return Response(QuarantinedIdentifierEntrySerializer(instance=entry).data, status=status.HTTP_201_CREATED)
 
     @validated_request(
-        request_serializer=QuarantineInputSerializer,
+        request_serializer=UnquarantineQuerySerializer,
         responses={204: None},
     )
     @action(detail=True, methods=["post"], url_path=r"quarantine/(?P<run_type>[^/]+)/expire")
-    def unquarantine(self, request: TypedRequest[QuarantineInput], pk: str, run_type: str, **kwargs) -> Response:
+    def unquarantine(self, request: TypedRequest, pk: str, run_type: str, **kwargs) -> Response:
         """Expire all active quarantine entries for an identifier."""
         try:
             api.unquarantine_identifier(
                 repo_id=_parse_uuid(pk),
-                identifier=request.validated_data.identifier,
+                identifier=request.validated_data["identifier"],
                 run_type=run_type,
                 team_id=self.team_id,
             )
@@ -571,6 +585,7 @@ class RunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 snapshot_id=request.validated_data["snapshot_id"],
                 user_id=cast(int, request.user.id),
                 team_id=self.team_id,
+                actor=_actor(request),
             )
         except api.RunNotFoundError:
             return Response({"detail": "Snapshot or run not found"}, status=status.HTTP_404_NOT_FOUND)

--- a/products/visual_review/backend/tests/logic/test_toleration.py
+++ b/products/visual_review/backend/tests/logic/test_toleration.py
@@ -1,10 +1,15 @@
 """Unit tests for logic/toleration.py — Tolerated hashes."""
 
+from datetime import timedelta
+
 import pytest
 
+from django.utils import timezone
+
 from products.visual_review.backend.facade.contracts import CreateRunInput, SnapshotManifestItem
-from products.visual_review.backend.facade.enums import RunType, SnapshotResult
+from products.visual_review.backend.facade.enums import ActorType, RunType, SnapshotResult
 from products.visual_review.backend.logic import artifact_store, repos, runs, toleration
+from products.visual_review.backend.models import ToleratedHash
 from products.visual_review.backend.tests.conftest import PRODUCT_DATABASES
 
 
@@ -41,12 +46,16 @@ class TestToleratedHashes:
         runs.finish_processing(run.id)
         return run
 
-    def test_mark_snapshot_as_tolerated(self, repo, user, mocker):
+    @pytest.mark.parametrize(
+        "actor,expected_reason",
+        [(ActorType.HUMAN, "human"), (ActorType.AGENT, "agent")],
+    )
+    def test_mark_snapshot_as_tolerated(self, repo, user, mocker, actor, expected_reason):
         run = self._create_completed_run(repo, mocker)
         snapshot = run.snapshots.first()
         assert snapshot.result == SnapshotResult.CHANGED
 
-        updated = toleration.mark_snapshot_as_tolerated(run.id, snapshot.id, user.id, repo.team_id)
+        updated = toleration.mark_snapshot_as_tolerated(run.id, snapshot.id, user.id, repo.team_id, actor=actor)
 
         assert updated.result == SnapshotResult.CHANGED  # result stays technical truth
         assert updated.review_state == "tolerated"
@@ -54,7 +63,25 @@ class TestToleratedHashes:
         assert updated.tolerated_hash_match is not None
         assert updated.tolerated_hash_match.alternate_hash == "new_hash"
         assert updated.tolerated_hash_match.baseline_hash == "old_hash"
-        assert updated.tolerated_hash_match.reason == "human"
+        assert updated.tolerated_hash_match.reason == expected_reason
+
+    def test_tolerating_revives_an_expired_hash(self, repo, user, mocker):
+        run = self._create_completed_run(repo, mocker)
+        snapshot = run.snapshots.first()
+        toleration.mark_snapshot_as_tolerated(run.id, snapshot.id, user.id, repo.team_id)
+        tolerated = ToleratedHash.objects.get(repo_id=repo.id, identifier="Button")
+        tolerated.expires_at = timezone.now() - timedelta(days=1)
+        tolerated.save(update_fields=["expires_at"])
+
+        updated = toleration.mark_snapshot_as_tolerated(
+            run.id, snapshot.id, user.id, repo.team_id, actor=ActorType.AGENT
+        )
+
+        # An expired row is invisible to the classifier, so leaving it expired would
+        # make the toleration look like it worked and change nothing.
+        assert updated.tolerated_hash_match.expires_at is None
+        assert updated.tolerated_hash_match.reason == "agent"
+        assert ToleratedHash.objects.filter(repo_id=repo.id, identifier="Button").count() == 1
 
     def test_mark_unchanged_snapshot_rejected(self, repo, user, mocker):
         artifact_store.get_or_create_artifact(repo_id=repo.id, content_hash="same", storage_path="p/same")

--- a/products/visual_review/backend/tests/logic/test_toleration.py
+++ b/products/visual_review/backend/tests/logic/test_toleration.py
@@ -70,6 +70,7 @@ class TestToleratedHashes:
         snapshot = run.snapshots.first()
         toleration.mark_snapshot_as_tolerated(run.id, snapshot.id, user.id, repo.team_id)
         tolerated = ToleratedHash.objects.get(repo_id=repo.id, identifier="Button")
+        created_at = tolerated.created_at
         tolerated.expires_at = timezone.now() - timedelta(days=1)
         tolerated.save(update_fields=["expires_at"])
 
@@ -81,7 +82,11 @@ class TestToleratedHashes:
         # make the toleration look like it worked and change nothing.
         assert updated.tolerated_hash_match is not None
         assert updated.tolerated_hash_match.expires_at is None
-        assert updated.tolerated_hash_match.reason == "agent"
+        # The row is shared with the snapshots that already matched it, and the
+        # flakiness and overview aggregates read reason and created_at to describe
+        # those runs, so a revive must not rewrite them.
+        assert updated.tolerated_hash_match.reason == "human"
+        assert updated.tolerated_hash_match.created_at == created_at
         assert ToleratedHash.objects.filter(repo_id=repo.id, identifier="Button").count() == 1
 
     def test_mark_unchanged_snapshot_rejected(self, repo, user, mocker):

--- a/products/visual_review/backend/tests/logic/test_toleration.py
+++ b/products/visual_review/backend/tests/logic/test_toleration.py
@@ -79,6 +79,7 @@ class TestToleratedHashes:
 
         # An expired row is invisible to the classifier, so leaving it expired would
         # make the toleration look like it worked and change nothing.
+        assert updated.tolerated_hash_match is not None
         assert updated.tolerated_hash_match.expires_at is None
         assert updated.tolerated_hash_match.reason == "agent"
         assert ToleratedHash.objects.filter(repo_id=repo.id, identifier="Button").count() == 1

--- a/products/visual_review/backend/tests/test_presentation.py
+++ b/products/visual_review/backend/tests/test_presentation.py
@@ -61,6 +61,37 @@ class TestRepoViewSet(VisualReviewTeamScopedTestMixin, APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_expire_quarantine_takes_only_an_identifier(self):
+        repo = api.create_repo(team_id=self.team.id, repo_external_id=444, repo_full_name="org/expire")
+        quarantine.quarantine_identifier(
+            repo_id=repo.id,
+            identifier="Button",
+            run_type=RunType.STORYBOOK,
+            reason="flaky",
+            user_id=self.user.id,
+            team_id=self.team.id,
+        )
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/visual_review/repos/{repo.id}/quarantine/{RunType.STORYBOOK}/expire",
+            {"identifier": "Button"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert quarantine.list_quarantined_identifiers(repo.id, team_id=self.team.id) == []
+
+    def test_opening_a_quarantine_still_needs_a_reason(self):
+        repo = api.create_repo(team_id=self.team.id, repo_external_id=555, repo_full_name="org/open")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/visual_review/repos/{repo.id}/quarantine/{RunType.STORYBOOK}",
+            {"identifier": "Button"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
 
 class TestRunViewSet(VisualReviewTeamScopedTestMixin, APIBaseTest):
     databases = PRODUCT_DATABASES

--- a/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
+++ b/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
@@ -16,6 +16,14 @@ import { SnapshotChangeBadge, hasSnapshotChangeBadge } from './SnapshotChangeBad
 import { SnapshotClusterPanel } from './SnapshotClusterPanel'
 import { SnapshotStatusIndicator } from './SnapshotStatusIndicator'
 
+// A toleration the diff pipeline minted for sub-threshold jitter reads very
+// differently from one somebody chose, so the two never share a label.
+const TOLERATION_REASON_LABELS: Record<string, string> = {
+    human: 'manual',
+    agent: 'agent',
+    auto_threshold: 'auto',
+}
+
 function DiffMinimap({ url, onClick }: { url: string; onClick?: () => void }): JSX.Element {
     const [loaded, setLoaded] = useState(false)
     return (
@@ -491,7 +499,7 @@ export function SnapshotDiffViewer({
                                             {entry.alternate_hash.slice(0, 10)}…
                                         </span>
                                         <LemonTag type="muted" size="small">
-                                            {entry.reason === 'human' ? 'manual' : 'auto'}
+                                            {TOLERATION_REASON_LABELS[entry.reason] ?? 'auto'}
                                         </LemonTag>
                                     </div>
                                 ))}

--- a/products/visual_review/frontend/generated/api.schemas.ts
+++ b/products/visual_review/frontend/generated/api.schemas.ts
@@ -66,6 +66,7 @@ export interface BaselineQuarantineSummaryApi {
     source_run?: QuarantineSourceRunApi | null
     id: string
     reason: string
+    source: string
     /** @nullable */
     expires_at: string | null
     created_at: string
@@ -240,6 +241,7 @@ export interface QuarantinedIdentifierEntryApi {
     identifier: string
     run_type: string
     reason: string
+    source: string
     /** @nullable */
     expires_at: string | null
     created_at: string

--- a/products/visual_review/frontend/generated/api.schemas.ts
+++ b/products/visual_review/frontend/generated/api.schemas.ts
@@ -275,6 +275,14 @@ export interface QuarantineInputApi {
     expires_at?: string | null
 }
 
+export interface UnquarantineQueryApi {
+    /**
+     * Snapshot identifier to unquarantine
+     * @maxLength 512
+     */
+    identifier: string
+}
+
 export type SearchMatchTypeEnumApi = (typeof SearchMatchTypeEnumApi)[keyof typeof SearchMatchTypeEnumApi]
 
 export const SearchMatchTypeEnumApi = {

--- a/products/visual_review/frontend/generated/api.ts
+++ b/products/visual_review/frontend/generated/api.ts
@@ -34,6 +34,7 @@ import type {
     ReviewStateCountsApi,
     RunApi,
     SnapshotApi,
+    UnquarantineQueryApi,
     VisualReviewReposListParams,
     VisualReviewReposQuarantineListParams,
     VisualReviewReposRunsListParams,
@@ -241,14 +242,14 @@ export const visualReviewReposQuarantineExpireCreate = async (
     projectId: string,
     id: string,
     runType: string,
-    quarantineInputApi: QuarantineInputApi,
+    unquarantineQueryApi: UnquarantineQueryApi,
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getVisualReviewReposQuarantineExpireCreateUrl(projectId, id, runType), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(quarantineInputApi),
+        body: JSON.stringify(unquarantineQueryApi),
     })
 }
 

--- a/products/visual_review/frontend/generated/api.zod.ts
+++ b/products/visual_review/frontend/generated/api.zod.ts
@@ -55,24 +55,11 @@ export const VisualReviewReposQuarantineCreateBody = /* @__PURE__ */ zod.object(
  */
 export const visualReviewReposQuarantineExpireCreateBodyIdentifierMax = 512
 
-export const visualReviewReposQuarantineExpireCreateBodyReasonMax = 255
-
 export const VisualReviewReposQuarantineExpireCreateBody = /* @__PURE__ */ zod.object({
     identifier: zod
         .string()
         .max(visualReviewReposQuarantineExpireCreateBodyIdentifierMax)
-        .describe('Snapshot identifier to quarantine.'),
-    reason: zod
-        .string()
-        .max(visualReviewReposQuarantineExpireCreateBodyReasonMax)
-        .describe('Why this snapshot is being quarantined.'),
-    source_run_id: zod
-        .uuid()
-        .nullish()
-        .describe(
-            "Optional pointer to the run whose failing snapshot prompted this quarantine — used to surface a 'view the failing run' link later."
-        ),
-    expires_at: zod.iso.datetime({ offset: true }).nullish(),
+        .describe('Snapshot identifier to unquarantine'),
 })
 
 /**

--- a/products/visual_review/frontend/scenes/VisualReviewFlakinessScene.stories.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewFlakinessScene.stories.tsx
@@ -84,6 +84,7 @@ const overview: FlakinessOverviewApi = {
             quarantine: {
                 id: '00000000-0000-0000-0000-0000000000c1',
                 reason: 'Non-deterministic rendering (animations, timestamps)',
+                source: 'human',
                 expires_at: '2026-06-07T00:00:00Z',
                 created_at: '2026-05-08T00:00:00Z',
                 created_by: { id: 1, first_name: 'Julian', email: 'julian@posthog.com' },

--- a/products/visual_review/frontend/scenes/visualReviewFlakinessSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewFlakinessSceneLogic.ts
@@ -500,7 +500,6 @@ export const visualReviewFlakinessSceneLogic = kea<visualReviewFlakinessSceneLog
             try {
                 await visualReviewReposQuarantineExpireCreate(String(values.currentProjectId), props.repoId, runType, {
                     identifier,
-                    reason: '',
                 })
                 lemonToast.success('Quarantine lifted. Runs gate on this snapshot again.')
             } catch (e: any) {

--- a/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewRunSceneLogic.ts
@@ -683,7 +683,7 @@ export const visualReviewRunSceneLogic = kea<visualReviewRunSceneLogicType>([
                     String(values.currentProjectId),
                     run.repo_id,
                     run.run_type,
-                    { identifier: snapshot.identifier, reason: '' }
+                    { identifier: snapshot.identifier }
                 )
                 lemonToast.success('Identifier unquarantined — future runs will gate on it again')
                 actions.loadQuarantinedIdentifiers()

--- a/products/visual_review/frontend/scenes/visualReviewSnapshotHistorySceneLogic.ts
+++ b/products/visual_review/frontend/scenes/visualReviewSnapshotHistorySceneLogic.ts
@@ -387,7 +387,7 @@ export const visualReviewSnapshotHistorySceneLogic = kea<visualReviewSnapshotHis
                     String(values.currentProjectId),
                     props.repoId,
                     props.runType,
-                    { identifier: props.identifier, reason: '' }
+                    { identifier: props.identifier }
                 )
                 lemonToast.success('Identifier unquarantined — future runs will gate on it again')
                 actions.loadQuarantineEntry()
@@ -405,7 +405,7 @@ export const visualReviewSnapshotHistorySceneLogic = kea<visualReviewSnapshotHis
                     String(values.currentProjectId),
                     props.repoId,
                     props.runType,
-                    { identifier: sibling, reason: '' }
+                    { identifier: sibling }
                 )
                 lemonToast.success('Sibling unquarantined — future runs will gate on it again')
                 actions.loadSiblingQuarantineEntry()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11691,6 +11691,7 @@ export namespace Schemas {
       source_run?: QuarantineSourceRun | null;
       id: string;
       reason: string;
+      source: string;
       /** @nullable */
       expires_at: string | null;
       created_at: string;
@@ -54378,6 +54379,7 @@ export namespace Schemas {
       identifier: string;
       run_type: string;
       reason: string;
+      source: string;
       /** @nullable */
       expires_at: string | null;
       created_at: string;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -84716,6 +84716,14 @@ export namespace Schemas {
       summary: unknown;
     }
 
+    export interface UnquarantineQuery {
+      /**
+         * Snapshot identifier to unquarantine
+         * @maxLength 512
+         */
+      identifier: string;
+    }
+
     export interface UpdateAppInput {
       /** New name for the app. */
       name?: string;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -84726,14 +84726,6 @@ export namespace Schemas {
       identifier: string;
     }
 
-    export interface UnquarantineQuery {
-      /**
-         * Snapshot identifier to unquarantine
-         * @maxLength 512
-         */
-      identifier: string;
-    }
-
     export interface UpdateAppInput {
       /** New name for the app. */
       name?: string;


### PR DESCRIPTION
## Problem

Nobody could lift a quarantine from the UI, and nobody could tell whether an agent or a person had opened one.

- Expiring a quarantine rejected the request with a missing-`reason` error. The endpoint validated with `QuarantineInputSerializer`, where `reason` is required, but the handler only ever read `identifier`. The 14 quarantines fixed this week had to be expired with direct API calls instead.
- `ToleratedReason.AGENT` and the quarantine `source` column both existed, and no code path ever wrote either. Every toleration and quarantine was recorded as a person's, so "are agents leaning on these levers" was unanswerable.
- Gating and toleration counted only `HUMAN` tolerations, while the baselines overview counted `HUMAN` and `AGENT`. Harmless only for as long as nothing wrote `AGENT`.
- The README said to lift the quarantine straight after merging the baseline entry. Doing that reds every open branch that renders the story.

## Changes

- Lifting a quarantine works from the UI again. Expire now validates with `UnquarantineQuerySerializer`, which was already defined in the same file and used nowhere, and which asks only for the identifier. This matches how the sibling `mark_tolerated` action does it.
- A toleration or quarantine made through MCP is now recorded as the agent's. Both write paths derive the actor from `is_mcp_request`, which requires a scoped token **and** the MCP server's user agent, so a browser session is never recorded as an agent. It attributes a write and never gates one, matching how that helper is used elsewhere.
- Agent tolerations count the same as a person's. `gating`, `toleration` and `baseline_overview` now share `INTENTIONAL_TOLERATE_REASONS`. Without this, the change above would have dropped every agent toleration from the run's tolerated count. The two halves have to ship together.
- The README now says to keep the quarantine on after the merge, and why. An entry on the default branch does not reach a branch that forked before it, and healing reads the merge-base, which also predates it.

No UI change and no schema change. The `source` column and the `AGENT` enum value already existed.

## How did you test this code?

- `mypy --cache-fine-grained .` repo-wide, clean, twice: once for the serializer swap and once for the actor plumbing. That was the risk in replacing `TypedRequest[QuarantineInput]` with the bare form.
- `ruff check` and `ruff format` clean.
- Two cases added to `TestRepoViewSet`, which had no quarantine endpoint coverage: expiring with only an identifier returns 204 and the quarantine is really gone (the bug), and opening one still rejects a missing reason (guards the tempting wrong fix of making `reason` optional for both).
- **Not run locally: those two tests.** Every `APIBaseTest` in this checkout currently errors on a stale row in the shared test database, including tests this branch does not touch, so the failure is environmental and a local pass would not have been meaningful. CI runs this suite.
- The expire path itself is exercised: the 14 quarantines lifted this week went through this endpoint, which is how the missing-`reason` rejection was found.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/visual_review/README.md`, the quarantine paragraph.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Every bug here was found while repairing 14 storybook baselines that had been quarantined since Aug 19 under a wrong diagnosis. The expire bug surfaced when the UI could not lift them; the missing actor surfaced when asking whether agent use of these levers would show up in the data, and it does not.

Deliberately left out: a test for the `AGENT` counting fix was skipped while nothing wrote `AGENT`, since it would have guarded a value that could not occur. The actor change in this same PR makes it reachable, so it is worth adding once the local suite runs.

Public artifact: everything here comes from this repository.
