### PR TITLE
chore(experiments): remove dead scaffolding in experiment view

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -177,7 +177,7 @@ export function Exposures(): JSX.Element {
     const headerContent = {
         style: { backgroundColor: 'var(--color-bg-table)' },
         children: (
-            <div className="flex items-center gap-3 metric-cell" style={{ minHeight: '33px' }}>
+            <div className="flex items-center gap-3 metric-cell min-h-[33px]">
                 <span className="metric-cell-header font-bold inline-flex items-center gap-1">
                     Exposures
                     <Tooltip title="Cumulative unique users exposed to the experiment. A user is counted once at first exposure, not per event.">

--- a/frontend/src/scenes/experiments/ExperimentView/useExperimentActions.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/useExperimentActions.tsx
@@ -118,7 +118,6 @@ export function useExperimentActions(dataAttrPrefix: string = ''): ExperimentAct
         isExperimentLaunched &&
             (exposureCohortId
                 ? {
-                      // TODO: add custom back button to the destination page
                       label: 'View exposure cohort',
                       icon: <IconPeople />,
                       sideIcon: <IconExternal />,

--- a/frontend/src/scenes/experiments/MetricsView/new/DetailsModal.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/DetailsModal.tsx
@@ -14,9 +14,6 @@ interface DetailsModalProps {
 }
 
 export function DetailsModal({ isOpen, onClose, metric, result, experiment }: DetailsModalProps): JSX.Element {
-    // :KLUDGE: workaround until we pass metric into the Frequentist result response
-    result.metric = metric
-
     return (
         <LemonModal
             isOpen={isOpen}

--- a/frontend/src/scenes/experiments/MetricsView/new/TableHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/TableHeader.tsx
@@ -9,7 +9,7 @@ import { ExperimentStatsMethod } from '~/types'
 
 import { useSvgResizeObserver } from '../hooks/useSvgResizeObserver'
 import { getNiceTickValues } from '../shared/utils'
-import { SVG_EDGE_MARGIN, TICK_FONT_SIZE_NEW, TICK_PANEL_HEIGHT, VIEW_BOX_WIDTH } from './constants'
+import { SVG_EDGE_MARGIN, TICK_FONT_SIZE, TICK_PANEL_HEIGHT, VIEW_BOX_WIDTH } from './constants'
 import { TickLabels } from './TickLabels'
 import { useAxisScale } from './useAxisScale'
 
@@ -103,7 +103,7 @@ export function TableHeader({
                                     scale={scale}
                                     y={(TICK_PANEL_HEIGHT + 13) / 2}
                                     viewBoxWidth={VIEW_BOX_WIDTH}
-                                    fontSize={TICK_FONT_SIZE_NEW}
+                                    fontSize={TICK_FONT_SIZE}
                                     fontWeight="600"
                                     dominantBaseline="middle"
                                     svgWidth={svgWidth}

--- a/frontend/src/scenes/experiments/MetricsView/new/constants.ts
+++ b/frontend/src/scenes/experiments/MetricsView/new/constants.ts
@@ -17,8 +17,5 @@ export const SIGNIFICANT_ROW_BG_ALPHA = '14'
 
 // Axis
 export const TICK_PANEL_HEIGHT = 20
-export const TICK_FONT_SIZE = 9
+export const TICK_FONT_SIZE = 11
 export const MAX_AXIS_RANGE = 1.5 // Cap at ±150% to prevent outliers from squishing other charts
-
-// New temporary values until the new table have been fully rolled out
-export const TICK_FONT_SIZE_NEW = 11


### PR DESCRIPTION
## Problem

Leftover scaffolding in the experiment view: a dead constant, a stale workaround, a stale TODO, and an inline style.

## Changes

All mechanical, nothing user-visible changes:

- `TICK_FONT_SIZE_NEW` is now `TICK_FONT_SIZE`; the old unused constant and its "temporary until rolled out" comment are gone (the rollout finished, legacy has its own copy).
- `DetailsModal` no longer mutates `result.metric`. Nothing on the current path reads it; `ResultDetails` receives the metric as a prop.
- Removed a stale TODO in `useExperimentActions`.
- The exposures header uses a `min-h` class instead of an inline style.

## How did you test this code?

Grep confirms `TICK_FONT_SIZE` (old) and `result.metric` have no readers outside the removed lines. Not run: typecheck and jest (light worktree).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, from the same experiment-view polish audit as #88216 and #88275. Skills invoked: /wt, /writing-pr-descriptions.
