### PR TITLE
fix(experiments): don't color tooltip delta dash red when there's no data

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroupTooltip.tsx
@@ -71,7 +71,7 @@ export const renderTooltipContent = (
                     {isBaseline ? (
                         <em className="text-muted-alt">Baseline</em>
                     ) : (
-                        <span className={winning ? 'text-success' : 'text-danger'}>
+                        <span className={winning === undefined ? undefined : winning ? 'text-success' : 'text-danger'}>
                             {formatDeltaPercent(variantResult)}
                         </span>
                     )}


### PR DESCRIPTION
## Problem

In the metric results tooltip, a variant without enough data shows a dash for Delta, but the dash renders red as if the variant were losing.

The color ternary treats `winning === undefined` (no credible interval yet) the same as `winning === false`.

## Changes

- The Delta dash now renders in the default text color when there is no data. Green/red coloring still applies once a delta exists.
- The results table already guards this case; only the tooltip was affected.

## How did you test this code?

Verified the `isWinning` code path returns `undefined` when the variant has no interval. Not run: visual check in the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Skills invoked: /wt, /writing-pr-descriptions. Investigated the tooltip rendering, found the unguarded ternary in `MetricRowGroupTooltip.tsx`, and applied a one-line fix.
