### PR TITLE
fix(shopify): explain when the app is not installed on the store

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
@@ -78,6 +78,15 @@ SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR = (
     "organization that contains your store and create the app there."
 )
 
+# Raised on a 4xx whose body reports `error: app_not_installed`. The client ID and secret are
+# valid, but the app is not installed on this store, so Shopify refuses to mint a token for it.
+# Re-entering the credentials cannot fix that; the user must install the app on the store first.
+# Surfaced separately so the message points at installing the app rather than the credentials.
+SHOPIFY_ACCESS_TOKEN_APP_NOT_INSTALLED_ERROR = (
+    "This Shopify app isn't installed on your store, so PostHog can't get an access token. "
+    "Install the app on your store, then re-enter the client ID and secret here."
+)
+
 # Raised when the OAuth token endpoint returns 404 — there is no store at
 # `<store-id>.myshopify.com`, so the store id is wrong or the store no longer exists.
 # Reconnecting the app can't fix a bad store id, so this is surfaced separately from the
@@ -389,6 +398,8 @@ def _access_token_auth_error_message(error_code: str | None) -> str:
         return SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR
     if error_code == "shop_not_permitted":
         return SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR
+    if error_code == "app_not_installed":
+        return SHOPIFY_ACCESS_TOKEN_APP_NOT_INSTALLED_ERROR
     return SHOPIFY_ACCESS_TOKEN_AUTH_ERROR
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
@@ -27,6 +27,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.co
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.settings import ENDPOINT_CONFIGS
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import (
+    SHOPIFY_ACCESS_TOKEN_APP_NOT_INSTALLED_ERROR,
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
     SHOPIFY_ACCESS_TOKEN_INVALID_CLIENT_ERROR,
     SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR,
@@ -79,6 +80,9 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
             # 4xx `shop_not_permitted`: the store is not in the app's Shopify organization, so
             # minting a token fails regardless of the credentials entered.
             SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR: SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR,
+            # 4xx `app_not_installed`: the credentials are valid but the app is not installed on
+            # the store, so minting a token fails until the user installs it. Retrying cannot fix it.
+            SHOPIFY_ACCESS_TOKEN_APP_NOT_INSTALLED_ERROR: SHOPIFY_ACCESS_TOKEN_APP_NOT_INSTALLED_ERROR,
             # 404 from the same endpoint — no store at this subdomain. Retrying cannot
             # recover; the user must correct the store id.
             SHOPIFY_STORE_NOT_FOUND_ERROR: SHOPIFY_STORE_NOT_FOUND_ERROR,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -4,6 +4,7 @@ from unittest import mock
 from requests.exceptions import ChunkedEncodingError, SSLError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import (
+    SHOPIFY_ACCESS_TOKEN_APP_NOT_INSTALLED_ERROR,
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
     SHOPIFY_ACCESS_TOKEN_INVALID_CLIENT_ERROR,
     SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR,
@@ -55,6 +56,7 @@ def test_get_access_token_4xx_is_non_retryable(status_code):
         ("invalid_client", SHOPIFY_ACCESS_TOKEN_INVALID_CLIENT_ERROR),
         ("unsupported_grant_type", SHOPIFY_ACCESS_TOKEN_UNSUPPORTED_GRANT_ERROR),
         ("shop_not_permitted", SHOPIFY_ACCESS_TOKEN_SHOP_NOT_PERMITTED_ERROR),
+        ("app_not_installed", SHOPIFY_ACCESS_TOKEN_APP_NOT_INSTALLED_ERROR),
     ],
 )
 def test_get_access_token_4xx_maps_shopify_error_code(error_code, expected_message):


### PR DESCRIPTION
## Problem

- A user connecting a Shopify source whose app is not installed on their store saw "Shopify rejected your app credentials. Check the client ID and secret", which points them at credentials that are already correct.
- Shopify returns `app_not_installed` from its OAuth token endpoint when the client ID and secret are valid but the app has never been installed on the store, so no token can be minted until the app is installed.
- The token path already maps other OAuth error codes (`invalid_client`, `unsupported_grant_type`, `shop_not_permitted`) to specific guidance, but `app_not_installed` fell through to the generic credentials message.

## Changes

- The user now sees "This Shopify app isn't installed on your store, so PostHog can't get an access token. Install the app on your store, then re-enter the client ID and secret here."
- `_access_token_auth_error_message` maps `app_not_installed` to the new message; `get_non_retryable_errors` registers it so the job still fails fast.
- The rest is mechanical: a new message constant and an import.

## How did you test this code?

- Extended the parametrized `test_get_access_token_4xx_maps_shopify_error_code` with an `app_not_installed` case, guarding against a regression where this code falls back to the generic credentials message.
- Ran the Shopify source test suite locally.
- Not run: database-backed suites and end-to-end source creation.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of data-warehouse source creation failures. Classified each source's error messages, then fixed the one Shopify case where our guidance misdiagnosed the cause. Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-code-comments, /writing-pr-descriptions. The message follows the house voice and the existing per-error-code pattern in this module.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
