### PR TITLE
fix(framer): return clean errors when project validation fails

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/framer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/framer.py
@@ -23,6 +23,8 @@ from websockets.headers import build_authorization_basic
 from websockets.sync.client import connect as websocket_connect
 from websockets.uri import Proxy, get_proxy, parse_proxy, parse_uri
 
+from posthog.exceptions_capture import capture_exception
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.framer import devalue
 from products.warehouse_sources.backend.temporal.data_imports.sources.framer.settings import (
@@ -307,9 +309,28 @@ def validate_credentials(project: str, api_key: str, protocol_version: str) -> t
                 False,
                 "Framer rejected the API key for this project. Generate an API key in the project's Site Settings → General and try again.",
             )
-        return False, str(e)
+        if e.code == "INVALID_REQUEST":
+            return (
+                False,
+                "The Framer project URL or ID is invalid. Paste your project URL (https://framer.com/projects/...) or the project ID.",
+            )
+        # Any other Framer error carries a raw "Framer API error <CODE>" string that means nothing
+        # to the user. Keep the detail for error tracking and surface a clean message instead. A
+        # retryable code is a transient channel condition (timeout, busy headless pool, dropped
+        # connection), so tell the user to retry rather than to change a value that is already right.
+        capture_exception(e)
+        if e.retryable:
+            return (
+                False,
+                "PostHog couldn't reach Framer to check your project. This is usually temporary, so wait a moment and try again.",
+            )
+        return (
+            False,
+            "Couldn't validate your Framer project. Check the project URL and API key, then try again.",
+        )
     except Exception as e:
-        return False, f"Could not connect to Framer: {e}"
+        capture_exception(e)
+        return False, "Couldn't connect to Framer. Check the project URL and API key, then try again."
 
 
 def _without_class_marker(node: dict[str, Any]) -> dict[str, Any]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/test_framer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/framer/tests/test_framer.py
@@ -381,6 +381,21 @@ class TestFramer:
         assert valid is False
         assert error is not None and "project URL or ID" in error
 
+    def test_validate_credentials_transient_error_is_clean(self) -> None:
+        # A transient channel condition must surface a clean retry message, not Framer's raw
+        # "Framer API error <CODE>" text.
+        server = FakeFramerServer(ready_message={"type": "error", "code": "POOL_EXHAUSTED", "message": "busy"})
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.framer.framer.websocket_connect",
+                server,
+            )
+            valid, error = validate_credentials(PROJECT_ID, "key", "0.1.29")
+        assert valid is False
+        assert error is not None
+        assert "Framer API error" not in error
+        assert "try again" in error
+
     def _run_endpoint(self, endpoint: str, methods: dict[str, Any]) -> list[dict[str, Any]]:
         server = FakeFramerServer(methods=methods)
         response = framer_source(PROJECT_ID, "key", endpoint, protocol_version="0.1.29")


### PR DESCRIPTION
## Problem

- A user validating a Framer source saw the client's raw "Framer API error TIMEOUT: ..." text, which names an internal code and gives no next step.
- `validate_credentials` only mapped the `UNAUTHORIZED` code to a clear message and returned `str(e)` for every other Framer error, so timeouts and other transient conditions leaked their raw wording.

## Changes

- A transient reach failure now reads "PostHog couldn't reach Framer to check your project. This is usually temporary, so wait a moment and try again."
- An invalid project reads "The Framer project URL or ID is invalid. Paste your project URL (https://framer.com/projects/...) or the project ID.", matching the sync-path message for the same code.
- Any other failure reads a generic "check the project URL and API key" message instead of the raw exception text.
- The raw detail goes to error tracking through `capture_exception`, so debugging keeps it.

## How did you test this code?

- Added `test_validate_credentials_transient_error_is_clean`, guarding against a regression where a transient Framer error leaks its raw "Framer API error <CODE>" text to the user.
- Ran the Framer test suites locally.
- Not run: database-backed suites and end-to-end source creation.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of data-warehouse source creation failures. Classified each source's error messages, then fixed the Framer validation path where transient errors leaked raw client text. Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-code-comments, /writing-pr-descriptions. Messages follow the house voice and reuse the wording already used on the sync path.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
