### PR TITLE
fix(desktop): correct GLM 5.3 Flash cost multiplier

### DIFF
--- a/products/desktop/packages/core/src/billing/modelPricing.test.ts
+++ b/products/desktop/packages/core/src/billing/modelPricing.test.ts
@@ -14,6 +14,7 @@ describe("modelPricing", () => {
     ["claude-opus-5", "2.5×"],
     ["gpt-5.5", "≈2.8×"],
     ["deepseek-v4", "≈0.05×"],
+    ["zai-org/glm-5.3-flash", "≈0.06×"],
   ] as const)("%s -> %s", (modelId, expected) => {
     expect(modelCostInfo(modelId)?.multiplierLabel).toBe(expected);
   });
@@ -26,6 +27,8 @@ describe("modelPricing", () => {
   it("matches specific families before the broader ones they contain", () => {
     expect(modelListPrice("gpt-5.6-luna")?.inputPerMtok).toBe(1);
     expect(modelListPrice("gpt-5.5")?.inputPerMtok).toBe(5);
+    expect(modelListPrice("zai-org/glm-5.3-flash")?.inputPerMtok).toBe(0.15);
+    expect(modelListPrice("zai-org/glm-5.3")?.inputPerMtok).toBe(1.4);
     expect(modelListPrice("claude-sonnet-4-5")?.inputPerMtok).toBe(3);
     expect(modelListPrice("claude-sonnet-5")?.inputPerMtok).toBe(2);
   });
@@ -80,6 +83,7 @@ describe("contract rates match the gateway's pinned table", () => {
   it.each([
     ["kimi", "KIMI_K3_COST"],
     ["glm", "BASETEN_GLM_COST"],
+    ["glm-5.3-flash", "BASETEN_GLM53_FLASH_COST"],
     ["deepseek", "BASETEN_DEEPSEEK_COST"],
     ["fable", "claude-fable-5"],
     ["gpt-5.6-sol", "gpt-5.6-sol"],

--- a/products/desktop/packages/core/src/billing/modelPricing.ts
+++ b/products/desktop/packages/core/src/billing/modelPricing.ts
@@ -30,7 +30,7 @@ export const MODEL_COST_BASELINE_NAME = "Claude Sonnet 5";
 const BASELINE: ModelListPrice = { inputPerMtok: 2, outputPerMtok: 10 };
 
 // Matched by lowercase substring, first hit wins, so keep specific ids
-// (gpt-5.6-*, sonnet-4) ahead of their broader families.
+// (gpt-5.6-*, glm-5.3-flash, sonnet-4) ahead of their broader families.
 const LIST_PRICES: [family: string, price: ModelListPrice][] = [
   ["fable", { inputPerMtok: 10, outputPerMtok: 50 }],
   ["mythos", { inputPerMtok: 10, outputPerMtok: 50 }],
@@ -43,6 +43,7 @@ const LIST_PRICES: [family: string, price: ModelListPrice][] = [
   ["gpt-5.6-luna", { inputPerMtok: 1, outputPerMtok: 6 }],
   ["gpt-5.5", { inputPerMtok: 5, outputPerMtok: 30 }],
   ["kimi", { inputPerMtok: 3, outputPerMtok: 15 }],
+  ["glm-5.3-flash", { inputPerMtok: 0.15, outputPerMtok: 0.5 }],
   ["glm", { inputPerMtok: 1.4, outputPerMtok: 4.4 }],
   ["deepseek", { inputPerMtok: 0.13, outputPerMtok: 0.26 }],
 ];


### PR DESCRIPTION
## Problem

People choosing GLM 5.3 Flash see the same cost multiplier as GLM 5.2, although Flash uses lower pinned rates.

**Why:** The picker should reflect actual gateway billing so model cost comparisons are trustworthy.

## Changes

- GLM 5.3 Flash now shows approximately 0.06× Claude Sonnet 5 instead of approximately 0.57×.
- The pricing mirror now checks Flash against the gateway pinned rate.

