### PR TITLE
fix(discussions): render comment formatting in mention emails

### DIFF
--- a/posthog/comment/formatting.py
+++ b/posthog/comment/formatting.py
@@ -3,7 +3,7 @@
 import re
 import html as html_mod
 import unicodedata
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 from urllib.parse import urlparse
 from uuid import UUID
@@ -918,6 +918,32 @@ def _escape_html(text: str) -> str:
     return html_mod.escape(text)
 
 
+# Schemes a mail client must never be handed as a clickable link. Anything else — including a
+# relative path pasted from the app — stays as written, so a working link is not lost.
+_UNSAFE_HTML_URL_SCHEMES = ("javascript", "data", "vbscript", "file")
+
+
+def _is_safe_html_url(href: str) -> bool:
+    try:
+        scheme = urlparse(href.strip()).scheme.lower()
+    except ValueError:
+        return False
+    return scheme not in _UNSAFE_HTML_URL_SCHEMES
+
+
+def _serialize_mention_to_html(node: JSON, mention_labels: Mapping[int, str] | None) -> str:
+    """
+    A mention carries only the mentioned user's id, so the display name has to be supplied by the
+    caller. Without a label the node would serialize to nothing and drop a word from the sentence.
+    """
+    attrs = node.get("attrs") or {}
+    label = attrs.get("label")
+    user_id = attrs.get("id")
+    if not label and mention_labels and isinstance(user_id, int):
+        label = mention_labels.get(user_id)
+    return f"<strong>@{_escape_html(str(label))}</strong>" if label else "<strong>@member</strong>"
+
+
 def _serialize_text_node_to_html(node: JSON) -> str:
     text = node.get("text", "")
     if not text:
@@ -942,18 +968,20 @@ def _serialize_text_node_to_html(node: JSON) -> str:
         elif mark_type == "link":
             link_href = mark.get("attrs", {}).get("href")
 
-    if link_href:
+    if link_href and _is_safe_html_url(link_href):
         escaped = f'<a href="{_escape_html(link_href)}">{escaped}</a>'
 
     return escaped
 
 
-def _serialize_inline_nodes_to_html(nodes: list[JSON]) -> str:
+def _serialize_inline_nodes_to_html(nodes: list[JSON], mention_labels: Mapping[int, str] | None = None) -> str:
     chunks: list[str] = []
     for node in nodes:
         node_type = node.get("type")
         if node_type == "text":
             chunks.append(_serialize_text_node_to_html(node))
+        elif node_type == "ph-mention":
+            chunks.append(_serialize_mention_to_html(node, mention_labels))
         elif node_type == "hardBreak":
             chunks.append("<br>")
         elif node_type == "image":
@@ -964,24 +992,24 @@ def _serialize_inline_nodes_to_html(nodes: list[JSON]) -> str:
     return "".join(chunks)
 
 
-def _serialize_block_node_to_html(node: JSON) -> str:
+def _serialize_block_node_to_html(node: JSON, mention_labels: Mapping[int, str] | None = None) -> str:
     """Serialize a single non-list block node to email-safe HTML. Lists are handled by
     _serialize_list_to_html."""
     node_type = node.get("type")
 
     if node_type == "paragraph":
-        return f"<p>{_serialize_inline_nodes_to_html(node.get('content', []))}</p>"
+        return f"<p>{_serialize_inline_nodes_to_html(node.get('content', []), mention_labels)}</p>"
 
     if node_type == "blockquote":
         inner_blocks: list[str] = []
         for child in node.get("content", []):
             child_type = child.get("type")
             if child_type in ("bulletList", "orderedList"):
-                inner_blocks.append(_serialize_list_to_html(child, child_type == "orderedList"))
+                inner_blocks.append(_serialize_list_to_html(child, child_type == "orderedList", mention_labels))
             elif child_type == "paragraph":
-                inner_blocks.append(_serialize_inline_nodes_to_html(child.get("content", [])))
+                inner_blocks.append(_serialize_inline_nodes_to_html(child.get("content", []), mention_labels))
             else:
-                inner_blocks.append(_serialize_block_node_to_html(child))
+                inner_blocks.append(_serialize_block_node_to_html(child, mention_labels))
         return f"<blockquote>{'<br>'.join(inner_blocks)}</blockquote>"
 
     if node_type == "heading":
@@ -990,13 +1018,13 @@ def _serialize_block_node_to_html(node: JSON) -> str:
             level = min(max(int(attrs.get("level") or 1), 1), 6)
         except (TypeError, ValueError):
             level = 1
-        return f"<h{level}>{_serialize_inline_nodes_to_html(node.get('content', []))}</h{level}>"
+        return f"<h{level}>{_serialize_inline_nodes_to_html(node.get('content', []), mention_labels)}</h{level}>"
 
     if node_type == "horizontalRule":
         return "<hr>"
 
     if node_type == "codeBlock":
-        return f"<pre><code>{_serialize_inline_nodes_to_html(node.get('content', []))}</code></pre>"
+        return f"<pre><code>{_serialize_inline_nodes_to_html(node.get('content', []), mention_labels)}</code></pre>"
 
     if node_type == "image":
         src = node.get("attrs", {}).get("src", "")
@@ -1006,14 +1034,14 @@ def _serialize_block_node_to_html(node: JSON) -> str:
         return ""
 
     if node.get("content"):
-        inner = _serialize_inline_nodes_to_html(node.get("content", []))
+        inner = _serialize_inline_nodes_to_html(node.get("content", []), mention_labels)
         if inner:
             return f"<p>{inner}</p>"
 
     return ""
 
 
-def _serialize_list_to_html(node: JSON, ordered: bool) -> str:
+def _serialize_list_to_html(node: JSON, ordered: bool, mention_labels: Mapping[int, str] | None = None) -> str:
     items: list[str] = []
     for item in node.get("content", []):
         if item.get("type") != "listItem":
@@ -1022,11 +1050,11 @@ def _serialize_list_to_html(node: JSON, ordered: bool) -> str:
         for child in item.get("content", []):
             child_type = child.get("type")
             if child_type == "paragraph":
-                inner_parts.append(_serialize_inline_nodes_to_html(child.get("content", [])))
+                inner_parts.append(_serialize_inline_nodes_to_html(child.get("content", []), mention_labels))
             elif child_type in ("bulletList", "orderedList"):
-                inner_parts.append(_serialize_list_to_html(child, child_type == "orderedList"))
+                inner_parts.append(_serialize_list_to_html(child, child_type == "orderedList", mention_labels))
             else:
-                inner_parts.append(_serialize_block_node_to_html(child))
+                inner_parts.append(_serialize_block_node_to_html(child, mention_labels))
         items.append(f"<li>{''.join(inner_parts)}</li>")
     if not ordered:
         return f"<ul>{''.join(items)}</ul>"
@@ -1035,8 +1063,12 @@ def _serialize_list_to_html(node: JSON, ordered: bool) -> str:
     return f"<ol{start_attr}>{''.join(items)}</ol>"
 
 
-def rich_content_to_html(rich_content: JSON | None) -> str:
-    """Serialize PostHog rich content JSON to email-safe HTML."""
+def rich_content_to_html_fragment(rich_content: JSON | None, mention_labels: Mapping[int, str] | None = None) -> str:
+    """
+    Serialize PostHog rich content JSON to an email-safe HTML fragment, for embedding in a
+    template that already provides the surrounding document. `mention_labels` maps a mentioned
+    user's id to the name to show — see _serialize_mention_to_html.
+    """
     if not rich_content or rich_content.get("type") != "doc":
         return ""
 
@@ -1045,14 +1077,22 @@ def rich_content_to_html(rich_content: JSON | None) -> str:
         node_type = node.get("type")
 
         if node_type in ("bulletList", "orderedList"):
-            blocks.append(_serialize_list_to_html(node, node_type == "orderedList"))
+            blocks.append(_serialize_list_to_html(node, node_type == "orderedList", mention_labels))
             continue
 
-        html = _serialize_block_node_to_html(node)
+        html = _serialize_block_node_to_html(node, mention_labels)
         if html:
             blocks.append(html)
 
-    body = "\n".join(blocks)
+    return "\n".join(blocks)
+
+
+def rich_content_to_html(rich_content: JSON | None, mention_labels: Mapping[int, str] | None = None) -> str:
+    """Serialize PostHog rich content JSON to a standalone email-safe HTML document."""
+    if not rich_content or rich_content.get("type") != "doc":
+        return ""
+
+    body = rich_content_to_html_fragment(rich_content, mention_labels)
     return f"""<!DOCTYPE html>
 <html>
 <head><meta charset="utf-8"></head>

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models import OuterRef, Subquery
 from django.utils import timezone
+from django.utils.html import linebreaks
 
 import structlog
 import posthoganalytics
@@ -17,6 +18,7 @@ from prometheus_client import Counter, Histogram
 
 from posthog.caching.login_device_cache import check_and_cache_login_device
 from posthog.cloud_utils import is_cloud
+from posthog.comment.formatting import rich_content_to_html_fragment
 from posthog.constants import AUTH_BACKEND_DISPLAY_NAMES, INVITE_DAYS_VALIDITY
 from posthog.email import EMAIL_TASK_KWARGS, EmailMessage, get_email_team_and_org_context, is_email_available
 from posthog.event_usage import groups
@@ -1567,6 +1569,22 @@ def send_error_tracking_issue_assigned(assignment_id: str | uuid.UUID, assigner_
     message.send()
 
 
+def _comment_body_html(comment: Comment, mentioned_user_ids: list[int]) -> str:
+    """
+    Render a comment for an email body. `Comment.rich_content` is the editor's document and the
+    only place the writer's formatting survives; `Comment.content` is a flattened copy that keeps
+    the words and drops the paragraphs, lists, and emphasis. Comments written before the editor
+    stored a document have `content` alone, so those keep their line breaks at least.
+    """
+    mention_labels = {
+        user.id: user.first_name or user.email
+        for user in User.objects.filter(id__in=mentioned_user_ids).only("id", "first_name", "email")
+    }
+    fragment = rich_content_to_html_fragment(comment.rich_content, mention_labels)
+    # `linebreaks` leaves its input raw unless told otherwise, and a comment is user-written.
+    return fragment or linebreaks(comment.content or "", autoescape=True)
+
+
 @shared_task(**EMAIL_TASK_KWARGS)
 def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], slug: str) -> None:
     with new_context():
@@ -1613,7 +1631,7 @@ def send_discussions_mentioned(comment_id: str, mentioned_user_ids: list[int], s
             template_name="discussions_mentioned",
             template_context={
                 "commenter": commenter,
-                "content": comment.content,
+                "content_html": _comment_body_html(comment, mentioned_user_ids),
                 "team": team,
                 "href": href,
             },

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -2101,6 +2101,83 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         # Verify the href falls back to base URL with discussion panel
         assert mocked_email_messages[0].properties["href"] == f"{settings.SITE_URL}#panel=discussion"
 
+    def test_send_discussions_mentioned_renders_the_comment_formatting(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+        mentioned_user = User.objects.create_and_join(
+            organization=self.organization, email="mentioned@posthog.com", password=None, first_name="Kyle"
+        )
+        comment = Comment.objects.create(
+            team=self.team,
+            content="Kyle two things:\nship it\ntell support",
+            rich_content={
+                "type": "doc",
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {"type": "ph-mention", "attrs": {"id": mentioned_user.id}},
+                            {"type": "text", "text": " two "},
+                            {"type": "text", "text": "things", "marks": [{"type": "bold"}]},
+                            {"type": "text", "text": ":"},
+                        ],
+                    },
+                    {
+                        "type": "bulletList",
+                        "content": [
+                            {
+                                "type": "listItem",
+                                "content": [{"type": "paragraph", "content": [{"type": "text", "text": "ship it"}]}],
+                            },
+                            {
+                                "type": "listItem",
+                                "content": [
+                                    {"type": "paragraph", "content": [{"type": "text", "text": "tell support"}]}
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            scope="Replay",
+            item_id="test-replay-id",
+            created_by=self.user,
+        )
+
+        send_discussions_mentioned(
+            comment_id=str(comment.id),
+            mentioned_user_ids=[mentioned_user.id],
+            slug="/replay/test-replay-id",
+        )
+
+        # The rendered body carries inlined styles, so match on the tag boundaries rather than
+        # whole elements.
+        html_body = mocked_email_messages[0].html_body
+        assert ">@Kyle</strong>" in html_body
+        assert ">things</strong>" in html_body
+        assert html_body.count("<li>") == 2
+
+    def test_send_discussions_mentioned_renders_plain_text_content_safely(self, MockEmailMessage: MagicMock) -> None:
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+        mentioned_user = User.objects.create_and_join(
+            organization=self.organization, email="mentioned@posthog.com", password=None
+        )
+        comment = Comment.objects.create(
+            team=self.team,
+            content="first line\nsecond <b>line</b>",
+            scope="Replay",
+            item_id="test-replay-id",
+            created_by=self.user,
+        )
+
+        send_discussions_mentioned(
+            comment_id=str(comment.id),
+            mentioned_user_ids=[mentioned_user.id],
+            slug="/replay/test-replay-id",
+        )
+
+        html_body = mocked_email_messages[0].html_body
+        assert "first line<br>second &lt;b&gt;line&lt;/b&gt;" in html_body
+
     @parameterized.expand(["task", "task_artifact", "desktop_canvas"])
     def test_send_discussions_mentioned_skips_desktop_comments(self, MockEmailMessage: MagicMock, scope: str) -> None:
         mocked_email_messages = mock_email_messages(MockEmailMessage)

--- a/posthog/templates/email/discussions_mentioned.html
+++ b/posthog/templates/email/discussions_mentioned.html
@@ -5,9 +5,9 @@
 <p>
     <b>{{ commenter.first_name }}</b> mentioned you in a comment in the project <b>{{ team.name }}</b>.
 </p>
-<p>
-    {{ content }}
-</p>
+<div class="quoted-body">
+    {{ content_html|safe }}
+</div>
 <div class="mb mt text-center">
     <a class="button" href="{{ href }}">Reply to comment</a>
 </div>

--- a/posthog/templates/email/styles.html
+++ b/posthog/templates/email/styles.html
@@ -186,6 +186,72 @@
         box-shadow: 0px 16px 16px -16px rgba(0, 0, 0, 0.25);
     }
 
+    /* Someone else's writing quoted inside an email, e.g. the comment you were mentioned in.
+       Mail clients have no default for most of these, so the rich text needs its own rules. */
+
+    .quoted-body {
+        border-left: 3px solid #d9d9d9;
+        padding-left: 16px;
+        margin: 24px 0;
+    }
+
+    .quoted-body p,
+    .quoted-body ul,
+    .quoted-body ol,
+    .quoted-body pre {
+        margin: 0 0 12px;
+    }
+
+    .quoted-body ul,
+    .quoted-body ol {
+        padding-left: 24px;
+    }
+
+    .quoted-body h1,
+    .quoted-body h2,
+    .quoted-body h3,
+    .quoted-body h4,
+    .quoted-body h5,
+    .quoted-body h6 {
+        font-size: 18px;
+        margin: 0 0 8px;
+    }
+
+    .quoted-body blockquote {
+        margin: 0 0 12px;
+        padding-left: 12px;
+        border-left: 3px solid #d9d9d9;
+        color: #5f5f5f;
+    }
+
+    .quoted-body code {
+        font-family: 'SFMono-Regular', Consolas, monospace;
+        font-size: 14px;
+        background-color: #ebebeb;
+        border-radius: 3px;
+        padding: 1px 4px;
+    }
+
+    .quoted-body pre {
+        background-color: #ebebeb;
+        border-radius: 3px;
+        padding: 12px;
+    }
+
+    .quoted-body pre code {
+        background-color: transparent;
+        padding: 0;
+    }
+
+    .quoted-body img {
+        max-width: 100%;
+    }
+
+    .quoted-body hr {
+        border: none;
+        border-top: 1px solid #d9d9d9;
+    }
+
     /* Header & Footer */
 
     .header {

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -11,6 +11,7 @@ from posthog.comment.formatting import (
     extract_images_from_rich_content,
     extract_slack_user_ids,
     rich_content_to_html,
+    rich_content_to_html_fragment,
     rich_content_to_markdown,
     rich_content_to_slack_payload,
     slack_to_content_and_rich_content,
@@ -778,6 +779,38 @@ class TestRichContentBlockNodes(SimpleTestCase):
         assert '<ol start="2"><li>parent<ul><li>child</li></ul></li></ol>' in html
         assert "<hr>" in html
         assert "<s>gone</s>" in html
+
+    @parameterized.expand(
+        [
+            (
+                "mention_with_a_known_label",
+                {"type": "ph-mention", "attrs": {"id": 7}},
+                "<p><strong>@Kyle</strong></p>",
+            ),
+            (
+                "mention_without_a_known_label",
+                {"type": "ph-mention", "attrs": {"id": 99}},
+                "<p><strong>@member</strong></p>",
+            ),
+            (
+                "link",
+                {"type": "text", "text": "docs", "marks": [{"type": "link", "attrs": {"href": "/docs"}}]},
+                '<p><a href="/docs">docs</a></p>',
+            ),
+            (
+                "link_with_an_unsafe_scheme",
+                {
+                    "type": "text",
+                    "text": "click me",
+                    "marks": [{"type": "link", "attrs": {"href": "javascript:alert(1)"}}],
+                },
+                "<p>click me</p>",
+            ),
+        ]
+    )
+    def test_rich_content_to_html_fragment_serializes_inline_nodes(self, _name: str, node: dict, expected: str) -> None:
+        doc = {"type": "doc", "content": [{"type": "paragraph", "content": [node]}]}
+        assert rich_content_to_html_fragment(doc, {7: "Kyle"}) == expected
 
     def test_rich_content_to_html_renders_unknown_block_inline_content_as_paragraph(self) -> None:
         doc = {


### PR DESCRIPTION
## Problem

Anyone mentioned in a discussion gets an email where the comment reads as one run-on line. Paragraphs, bullets, bold, links, and code all collapse, and the mention that caused the email is not in it.

The email renders `Comment.content`, a flattened copy of the comment that keeps the words and drops the formatting, inside a single `<p>`. The comment editor stores its document in `Comment.rich_content`, and that field never reached the email.

Raised in #team-messaging.

## Changes

- The email now shows the comment as it was written: paragraphs, lists, bold, italic, links, quotes, and code blocks.
- A mention renders as the person's name, so "@Kyle can you look at this" arrives whole.
- Comments stored before the editor kept a document keep their line breaks instead of collapsing.
- `send_discussions_mentioned` reads `rich_content` through `rich_content_to_html_fragment`, and falls back to `content` through Django's `linebreaks`.
- The shared serializer in `posthog/comment/formatting.py` learns mention nodes, so support ticket emails stop dropping them too.
- The serializer drops a link href whose scheme a mail client should never be handed, such as `javascript:`.
- `rich_content_to_html` splits into a fragment builder plus the document wrapper it already emitted. The wrapper's output does not change.
- The rest is mechanical: threading the mention labels through the four HTML serializers, and the `.quoted-body` rules in `styles.html` that give the rich text margins and code backgrounds a mail client has no default for.

### Before

![discussion-mention-email-before](https://raw.githubusercontent.com/PostHog/pr-assets/bfc49c4ee1e5618b320940f92d41c773be73f267/2026/08/864904b6-50d6-4710-997e-6a885bdc2fda.png)

### After

![discussion-mention-email-after](https://raw.githubusercontent.com/PostHog/pr-assets/bfc49c4ee1e5618b320940f92d41c773be73f267/2026/08/736cff0d-2fc5-4583-9211-72ae61e6b6fa.png)

> [!NOTE]
> The support ticket email in `products/conversations` already rendered `rich_content`. It gains only the mention and link-scheme fixes. The new ticket notification email still shows raw markdown, which this PR leaves alone: that task receives a string, not a document.

## How did you test this code?

Rendered both paths of the template with the real serializer, CSS inliner, and headless Chromium. The screenshots above are that output. The "before" shot renders the previous template against the flattened `content` the email used.

New tests, and the regression each one catches:

- `test_send_discussions_mentioned_renders_the_comment_formatting` — a revert to `comment.content` loses the mention, the bold, and the list. No existing test read `rich_content` at all.
- `test_send_discussions_mentioned_renders_plain_text_content_safely` — Django's `linebreaks` does not escape by default, so a comment containing `<b>` would inject raw HTML into the email.
- `test_rich_content_to_html_fragment_serializes_inline_nodes` — four cases on the serializer: a mention with and without a known label, and a link with a safe and an unsafe scheme. Added to the existing block-node test class rather than a new file.

Ran locally: the two email tests, `products/conversations/backend` in full, `posthog/api/test/test_comments.py`, and `uv run mypy --cache-fine-grained .` repo-wide. Not checked: delivery through a real mail client, so the `.quoted-body` rules are verified in Chromium only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus) from a Slack thread reporting the formatting. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The first attempt at the fix reused `rich_content_to_html` as-is, which wraps its output in a full `<!DOCTYPE html>` document and cannot sit inside an email template. Splitting the fragment out kept the existing caller's output byte-identical. Mention labels are threaded in as an argument because a mention node stores only the user id, and the serializer has no database access.

Nothing in this PR carries material from the originating thread beyond the report that the formatting was wrong. The test fixtures and screenshots use invented comment text.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1787842711300799?thread_ts=1787842711.300799&cid=C08S2L0S5MZ)*
