### PR TITLE
ci(tasks): speed the golden render migrate with the schema cache

### DIFF
--- a/.github/workflows/cd-tasks-golden-snapshot.yml
+++ b/.github/workflows/cd-tasks-golden-snapshot.yml
@@ -134,8 +134,9 @@ jobs:
         # `Run migrations` needs a database: 24 skill templates call
         # `render_hogql_example`, which reads `Team.objects.first()`. The schema
         # cache below makes migrate a top-up, but a cache miss is a 22-29 minute
-        # cold migrate (see cd-sandbox-base-image.yml), so budget 45 like that job.
-        timeout-minutes: 45
+        # cold migrate (see cd-sandbox-base-image.yml), so budget an hour for
+        # ample headroom over that worst case.
+        timeout-minutes: 60
         permissions:
             contents: read
 

--- a/.github/workflows/cd-tasks-golden-snapshot.yml
+++ b/.github/workflows/cd-tasks-golden-snapshot.yml
@@ -141,11 +141,6 @@ jobs:
               with:
                   ref: ${{ needs.validate_ref.outputs.ref }}
 
-            - name: Start Docker services
-              env:
-                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-              run: bin/ci-wait-for-docker launch
-
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
@@ -161,43 +156,6 @@ jobs:
 
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
-
-            - name: Install Rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: stable
-                  components: cargo
-
-            - name: Cache Rust dependencies
-              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-              with:
-                  shared-key: 'v2-rust-skills'
-                  workspaces: rust
-                  save-if: ${{ github.ref == 'refs/heads/master' }}
-
-            - name: Install sqlx-cli
-              uses: ./.github/actions/setup-sqlx-cli
-
-            - name: Wait for Docker services
-              env:
-                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
-              run: bin/ci-wait-for-docker wait
-
-            - name: Run migrations
-              env:
-                  SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
-                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
-                  REDIS_URL: 'redis://localhost'
-                  OBJECT_STORAGE_ENABLED: 'False'
-                  TEST: 1
-                  DEBUG: 1
-              run: |
-                  DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
-                    sqlx database create
-                  DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
-                    sqlx migrate run --source rust/persons_migrations/
-                  python manage.py migrate --noinput
-                  python manage.py setup_dev --no-data
 
             - name: Build skills
               env:

--- a/.github/workflows/cd-tasks-golden-snapshot.yml
+++ b/.github/workflows/cd-tasks-golden-snapshot.yml
@@ -131,7 +131,11 @@ jobs:
         if: vars.HOG_TASKS_GOLDEN_ENABLED == 'true' && github.ref == 'refs/heads/master'
         name: Render agent skills from source
         runs-on: ubuntu-latest
-        timeout-minutes: 30
+        # `Run migrations` needs a database: 24 skill templates call
+        # `render_hogql_example`, which reads `Team.objects.first()`. The schema
+        # cache below makes migrate a top-up, but a cache miss is a 22-29 minute
+        # cold migrate (see cd-sandbox-base-image.yml), so budget 45 like that job.
+        timeout-minutes: 45
         permissions:
             contents: read
 
@@ -140,6 +144,88 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: ${{ needs.validate_ref.outputs.ref }}
+                  # Deep + blob-less: enough history for the schema cache merge-base key.
+                  fetch-depth: 1000
+                  filter: blob:none
+
+            - name: Fetch base branch for merge-base computation
+              if: github.event_name == 'pull_request'
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+              # Scoped, blob-less, no-tags: without an explicit refspec, git fetch
+              # falls back to remote.origin.fetch and pulls every branch.
+              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+            - name: Compute schema cache keys
+              id: schema-key
+              # Restores the schema dump ci-backend saves on master pushes, so the
+              # migrate step below only tops up what is newer instead of replaying the
+              # full migration history. On a PR the migration-set key is the merge-base's;
+              # on a push or dispatch it is HEAD's. A cache miss falls through to a full
+              # migrate, so an absent or wrong key is never a correctness risk.
+              env:
+                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+                  IS_PR: ${{ github.event_name == 'pull_request' }}
+                  # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in
+                  # ci-backend.yml, which saves these caches on master pushes.
+                  SCHEMA_CACHE_EPOCH: v2
+              run: |
+                  if [ "$IS_PR" != "true" ]; then
+                      # Pushed or dispatched commit is checked out directly: no merge
+                      # commit, no base ref. The per-SHA key would point at this same
+                      # push's cache (saved concurrently by ci-backend, so racy); rely
+                      # on the stable migration-set key below.
+                      REF=HEAD
+                  else
+                      # HEAD is the synthetic merge commit; HEAD^2 is the PR branch tip.
+                      MERGE_BASE=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
+                      if [ -z "$MERGE_BASE" ]; then
+                          echo "key=" >> $GITHUB_OUTPUT
+                          echo "migrations_key=" >> $GITHUB_OUTPUT
+                          echo "::notice::merge-base not found (branch too stale?), so the schema cache is skipped"
+                          exit 0
+                      fi
+                      # Routing decides which app labels reach the dump, so an edited routing
+                      # config matches no master dump: drop both keys and migrate from scratch.
+                      DB_ROUTING_BASE=$(git ls-tree -r --format='%(objectname) %(path)' "$MERGE_BASE" -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                      DB_ROUTING_HEAD=$(git ls-tree -r --format='%(objectname) %(path)' HEAD -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                      if [ "$DB_ROUTING_BASE" != "$DB_ROUTING_HEAD" ]; then
+                          echo "key=" >> $GITHUB_OUTPUT
+                          echo "migrations_key=" >> $GITHUB_OUTPUT
+                          echo "::notice::db routing config or router differs from the merge base, so the schema cache is skipped"
+                          exit 0
+                      fi
+                      echo "key=posthog-schema-master-${MERGE_BASE}" >> $GITHUB_OUTPUT
+                      REF="$MERGE_BASE"
+                  fi
+                  # Last-resort restore prefix: matches the newest saved dump when the exact
+                  # keys miss. Gated on checkout age because a re-run of an old commit could
+                  # restore a dump newer than its code, which forward-only migrate cannot repair.
+                  HEAD_AGE_SECONDS=$(( $(date +%s) - $(git show -s --format=%ct HEAD) ))
+                  if [ "$HEAD_AGE_SECONDS" -lt 86400 ]; then
+                      echo "prefix_key=posthog-schema-mig-${SCHEMA_CACHE_EPOCH}-" >> $GITHUB_OUTPUT
+                  fi
+                  # Must match ci-backend.yml's save-side computation byte for byte or the key never hits.
+                  MIG_FILES=$(git ls-tree -r --format='%(objectname) %(path)' "$REF" \
+                      | grep -E '/migrations/[^/]+\.py$|^[0-9a-f]+ uv\.lock$' \
+                      | grep -vE '/(clickhouse|async_migrations)/migrations/' \
+                      | LC_ALL=C sort) || true
+                  # Routing decides which app labels are in the dump, so these inputs belong in the key.
+                  DB_ROUTING=$(git ls-tree -r --format='%(objectname) %(path)' "$REF" -- products/db_routing.yaml posthog/product_db_config.py posthog/product_db_router.py)
+                  PG_IMAGE=$(git show "${REF}:docker-compose.base.yml" 2>/dev/null \
+                      | grep -m1 -E '^[[:space:]]*image:[[:space:]]*postgres:' | tr -d '[:space:]')
+                  if [ -z "$MIG_FILES" ]; then
+                      echo "migrations_key=" >> $GITHUB_OUTPUT
+                      echo "::notice::no migration files matched, so restore falls back to the SHA schema key"
+                  else
+                      MIG_HASH=$(printf '%s\n%s\n%s' "$MIG_FILES" "$PG_IMAGE" "$DB_ROUTING" | sha256sum | cut -c1-40)
+                      echo "migrations_key=posthog-schema-mig-${SCHEMA_CACHE_EPOCH}-${MIG_HASH}" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Start Docker services
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker launch
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -156,6 +242,78 @@ jobs:
 
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: stable
+                  components: cargo
+
+            - name: Cache Rust dependencies
+              uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+              with:
+                  shared-key: 'v2-rust-skills'
+                  workspaces: rust
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
+
+            - name: Install sqlx-cli
+              uses: ./.github/actions/setup-sqlx-cli
+
+            - name: Wait for Docker services
+              env:
+                  COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+              run: bin/ci-wait-for-docker wait
+
+            - name: Restore schema cache from master
+              if: steps.schema-key.outputs.migrations_key != '' || steps.schema-key.outputs.key != ''
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: schema.sql.gz
+                  # Prefer the shared content key; fall back to the exact merge-base SHA
+                  # key, then to the newest dump of any migration set.
+                  key: ${{ steps.schema-key.outputs.migrations_key || steps.schema-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.schema-key.outputs.key }}
+                      ${{ steps.schema-key.outputs.prefix_key }}
+
+            - name: Prime posthog from cached schema
+              # db:restore-schema-fresh restores the dump and seeds the RunPython data a
+              # schema-only dump lacks; the migrate step below layers anything newer on
+              # top. On failure it leaves a fresh empty db, so migrate runs the full history.
+              env:
+                  SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
+                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+                  REDIS_URL: 'redis://localhost'
+                  OBJECT_STORAGE_ENABLED: 'False'
+                  TEST: 1
+                  DEBUG: 1
+                  TARGET_DB: posthog
+              run: |
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss, so the migrate step below runs the full history"
+                      exit 0
+                  fi
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  if ! ./bin/hogli db:restore-schema-fresh; then
+                      echo "::warning::Schema restore failed (stale or incompatible cached dump?), so the migrate step below runs the full history"
+                  fi
+
+            - name: Run migrations
+              env:
+                  SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da'
+                  DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+                  REDIS_URL: 'redis://localhost'
+                  OBJECT_STORAGE_ENABLED: 'False'
+                  TEST: 1
+                  DEBUG: 1
+              run: |
+                  DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
+                    sqlx database create
+                  DATABASE_URL="postgres://posthog:posthog@localhost:5432/posthog_persons" \
+                    sqlx migrate run --source rust/persons_migrations/
+                  python manage.py migrate --noinput
+                  python manage.py setup_dev --no-data
 
             - name: Build skills
               env:

--- a/products/tasks/backend/sandbox/images/hogland/GOLDEN_CI_RUNBOOK.md
+++ b/products/tasks/backend/sandbox/images/hogland/GOLDEN_CI_RUNBOOK.md
@@ -24,14 +24,15 @@ same contents into a hogland snapshot, it does not change the container image.
    `needs.validate_ref.outputs.ref`, never the raw input, and every privileged
    job additionally gates on `github.ref == 'refs/heads/master'`. This closes the
    `ref` RCE in the workflow YAML (see "Known open security issues").
-1. `render_skills` job — renders the agent skills the golden ships. It runs
-   `uv sync`, then `hogli build:skills` to expand the skill `.md.j2` templates
-   and merges in the context-mill skills. `build:skills` calls `django.setup()`
-   for model metadata but never connects to a database, so this job needs no
-   Docker, no Postgres, and no migrations — it finishes in a few minutes. Uploads
-   the merged set as the `tasks-golden-skills` artifact. Rendered once, reused by
-   every cluster. It shares the master arm gate, so an unarmed nightly renders
-   nothing.
+1. `render_skills` job — renders the agent skills the golden ships, the same way
+   `cd-sandbox-base-image.yml`'s `build_skills` job does. It stands up a DB,
+   restores the schema cache saved on master so `migrate` only tops up the newer
+   migrations, runs `setup_dev --no-data`, then `hogli build:skills` to expand the
+   skill `.md.j2` templates and merges in the context-mill skills. The DB is
+   needed because 24 skill templates call `render_hogql_example`, which reads
+   `Team.objects.first()`. Uploads the merged set as the `tasks-golden-skills`
+   artifact. Rendered once, reused by every cluster. It shares the master arm
+   gate, so an unarmed nightly renders nothing.
 2. Joins the hogland tailnet as `tag:hogland-ci` (the tag whose ACL reaches the
    `tag:hogplane` device serving the API).
 3. Authenticates to hogplane as a per-cluster `svc-ci-*` service-account

--- a/products/tasks/backend/sandbox/images/hogland/GOLDEN_CI_RUNBOOK.md
+++ b/products/tasks/backend/sandbox/images/hogland/GOLDEN_CI_RUNBOOK.md
@@ -24,8 +24,8 @@ same contents into a hogland snapshot, it does not change the container image.
    `needs.validate_ref.outputs.ref`, never the raw input, and every privileged
    job additionally gates on `github.ref == 'refs/heads/master'`. This closes the
    `ref` RCE in the workflow YAML (see "Known open security issues").
-1. `render_skills` job — renders the agent skills the golden ships. It `uv
-   sync`s, then runs `hogli build:skills` to expand the skill `.md.j2` templates
+1. `render_skills` job — renders the agent skills the golden ships. It runs
+   `uv sync`, then `hogli build:skills` to expand the skill `.md.j2` templates
    and merges in the context-mill skills. `build:skills` calls `django.setup()`
    for model metadata but never connects to a database, so this job needs no
    Docker, no Postgres, and no migrations — it finishes in a few minutes. Uploads

--- a/products/tasks/backend/sandbox/images/hogland/GOLDEN_CI_RUNBOOK.md
+++ b/products/tasks/backend/sandbox/images/hogland/GOLDEN_CI_RUNBOOK.md
@@ -24,13 +24,14 @@ same contents into a hogland snapshot, it does not change the container image.
    `needs.validate_ref.outputs.ref`, never the raw input, and every privileged
    job additionally gates on `github.ref == 'refs/heads/master'`. This closes the
    `ref` RCE in the workflow YAML (see "Known open security issues").
-1. `render_skills` job — renders the agent skills the golden ships, the same way
-   the sandbox-base image build does (`cd-sandbox-base-image.yml`'s `build_skills`
-   job): stands up a DB, `uv sync`s, migrates, runs `hogli build:skills` to expand
-   the skill `.md.j2` templates, then merges in the context-mill skills. Uploads
+1. `render_skills` job — renders the agent skills the golden ships. It `uv
+   sync`s, then runs `hogli build:skills` to expand the skill `.md.j2` templates
+   and merges in the context-mill skills. `build:skills` calls `django.setup()`
+   for model metadata but never connects to a database, so this job needs no
+   Docker, no Postgres, and no migrations — it finishes in a few minutes. Uploads
    the merged set as the `tasks-golden-skills` artifact. Rendered once, reused by
-   every cluster. It shares the master arm gate, so an unarmed nightly does not
-   pay for a full DB render.
+   every cluster. It shares the master arm gate, so an unarmed nightly renders
+   nothing.
 2. Joins the hogland tailnet as `tag:hogland-ci` (the tag whose ACL reaches the
    `tag:hogplane` device serving the API).
 3. Authenticates to hogplane as a per-cluster `svc-ci-*` service-account


### PR DESCRIPTION
## Problem

The tasks golden bake's `render_skills` job times out and the bake is skipped ([run 33104955253](https://github.com/PostHog/posthog/actions/runs/33104955253)). Its "Run migrations" step runs a cold `manage.py migrate` that builds the full ~80-app schema on a fresh DB — 22-29 minutes, over the job's 30-minute budget — so GitHub cancels it mid-migrate.

An earlier version of this PR removed the database on the assumption that `build:skills` never connects. That was wrong. @webjunkie's review showed `render_hogql_example` (called by 24 skill `.md.j2` templates) reads `Team.objects.first()` and raises without a Team, and `setup_dev --no-data` is what creates that Team. The render job genuinely needs the DB.

## Changes

- Keep the DB, but restore the schema cache saved on master pushes, the same pattern `cd-sandbox-base-image.yml`'s `build_skills` job uses. `migrate` then only tops up newer migrations instead of replaying the full history.
- Add to `render_skills`: checkout depth + merge-base fetch, "Compute schema cache keys", "Restore schema cache from master", and "Prime posthog from cached schema". These steps are copied byte-for-byte from that job so the cache key matches ci-backend's save side.
- Raise `render_skills` `timeout-minutes` 30 → 60 (an hour), ample headroom over a cache-miss cold migrate (22-29 min).
- Runbook updated to describe the DB + schema cache.

## How did you test this code?

I am an agent (Claude Code), work by Tom Owers. YAML parses; `actionlint` is clean at CI's `--severity=error` (the `SC2086` info notes on the copied key-computation step are the same ones master already carries and CI ignores); oxfmt is clean on the runbook. The schema-key steps are identical to the job already on master, so they resolve the same cached dumps. The real check is the next dev dispatch, which should now clear render into the bake.

## 🤖 Agent context

Agent-authored (Claude Code), authored by Tom Owers. This PR reversed course mid-review: I first removed the DB (wrong), then @webjunkie's evidence-backed review corrected it. The fix now mirrors the established `build_skills` schema-cache pattern rather than inventing one. The copied key-computation must stay in sync with `ci-backend.yml`'s save side and `cd-sandbox-base-image.yml`'s copy (shared `SCHEMA_CACHE_EPOCH`).