### PR TITLE
feat(experiments): resume a paused experiment from the warning banner

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentWarningBanners.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentWarningBanners.tsx
@@ -3,11 +3,16 @@ import { useEffect } from 'react'
 
 import { LemonBanner, Link } from '@posthog/lemon-ui'
 
+import type { LemonBannerAction } from 'lib/lemon-ui/LemonBanner/LemonBanner'
+import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { urls } from 'scenes/urls'
 
+import { AccessControlLevel, AccessControlResourceType, type Experiment } from '~/types'
+
 import { experimentLogic } from '../experimentLogic'
 import type { ExperimentWarning } from '../experimentLogic'
+import { modalsLogic } from '../modalsLogic'
 
 function warningCaption(key: ExperimentWarning['key']): string {
     switch (key) {
@@ -33,8 +38,8 @@ function WarningDetail({
         case 'running_but_flag_disabled':
             return (
                 <>
-                    The linked feature flag {flagLink} is <strong>disabled</strong> while the experiment has not been
-                    ended. Resume or end the experiment.
+                    The linked feature flag {flagLink} is <strong>disabled</strong>, so nobody is seeing the experiment
+                    variants. Resume the experiment to re-enable the flag, or end it.
                 </>
             )
         case 'running_but_single_variant_shipped':
@@ -70,9 +75,29 @@ function WarningDetail({
     }
 }
 
+/**
+ * Resuming re-enables the flag, so the paused warning is the one case the banner can fix itself.
+ * Every other warning needs a judgement call about rollout or conclusion, and stays link-only.
+ */
+function resumeAction(experiment: Experiment, openResumeExperimentModal: () => void): LemonBannerAction {
+    const accessDisabledReason = getAccessControlDisabledReason(
+        AccessControlResourceType.Experiment,
+        AccessControlLevel.Editor,
+        experiment.user_access_level
+    )
+
+    return {
+        children: 'Resume experiment',
+        onClick: openResumeExperimentModal,
+        disabledReason: experiment.feature_flag ? (accessDisabledReason ?? undefined) : 'No feature flag linked',
+        'data-attr': 'experiment-warning-resume-experiment',
+    }
+}
+
 export function ExperimentWarningBanner(): JSX.Element | null {
     const { experimentWarning, experiment } = useValues(experimentLogic)
     const { reportExperimentInconsistencyWarningShown } = useActions(eventUsageLogic)
+    const { openResumeExperimentModal } = useActions(modalsLogic)
 
     useEffect(() => {
         if (experimentWarning) {
@@ -91,7 +116,15 @@ export function ExperimentWarningBanner(): JSX.Element | null {
     ) : null
 
     return (
-        <LemonBanner className="mb-4" type="warning">
+        <LemonBanner
+            className="mb-4"
+            type="warning"
+            action={
+                experimentWarning.key === 'running_but_flag_disabled'
+                    ? resumeAction(experiment, openResumeExperimentModal)
+                    : undefined
+            }
+        >
             <div>
                 <strong>{warningCaption(experimentWarning.key)}</strong>
             </div>

--- a/frontend/src/scenes/experiments/stories/ExperimentPausedWarning.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentPausedWarning.stories.tsx
@@ -21,7 +21,9 @@ const meta: Meta = {
         viewMode: 'story',
         mockDate: '2025-06-01',
         pageUrl: urls.experiment(PAUSED_EXPERIMENT.id),
-        testOptions: { waitForSelector: '[data-attr="experiment-warning-resume-experiment"]' },
+        // :visible because LemonBanner renders the action twice (inline + stacked, same data-attr)
+        // and Playwright's non-strict wait only checks the first match, which CSS may be hiding.
+        testOptions: { waitForSelector: '[data-attr="experiment-warning-resume-experiment"]:visible' },
     },
     decorators: [
         mswDecorator({
@@ -49,8 +51,8 @@ export const ExperimentPausedWarning: Story = { play: makeDelay(700) }
 // (LemonBanner's @container breakpoint swaps the inline button for the stacked one).
 export const ExperimentPausedWarningMobile: Story = {
     parameters: {
+        // waitForSelector is inherited from the meta parameters via Storybook's deep merge.
         testOptions: {
-            waitForSelector: '[data-attr="experiment-warning-resume-experiment"]',
             viewport: { width: 390, height: 844 },
         },
     },

--- a/frontend/src/scenes/experiments/stories/ExperimentPausedWarning.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentPausedWarning.stories.tsx
@@ -44,3 +44,15 @@ export default meta
 type Story = StoryObj<{}>
 
 export const ExperimentPausedWarning: Story = { play: makeDelay(700) }
+
+// At mobile width the banner stacks: content on top, full-width resume button underneath
+// (LemonBanner's @container breakpoint swaps the inline button for the stacked one).
+export const ExperimentPausedWarningMobile: Story = {
+    parameters: {
+        testOptions: {
+            waitForSelector: '[data-attr="experiment-warning-resume-experiment"]',
+            viewport: { width: 390, height: 844 },
+        },
+    },
+    play: makeDelay(700),
+}

--- a/frontend/src/scenes/experiments/stories/ExperimentPausedWarning.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentPausedWarning.stories.tsx
@@ -1,0 +1,46 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { makeDelay } from 'lib/utils/async'
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+import EXPERIMENT_WITH_FUNNEL_METRIC from '~/mocks/fixtures/api/experiments/experiment_with_funnel_metric.json'
+
+// A launched experiment whose flag has been disabled, so the warning banner offers to resume it.
+const PAUSED_EXPERIMENT = {
+    ...EXPERIMENT_WITH_FUNNEL_METRIC,
+    feature_flag: { ...EXPERIMENT_WITH_FUNNEL_METRIC.feature_flag, active: false },
+}
+
+const meta: Meta = {
+    component: App,
+    title: 'Scenes-App/Experiments',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2025-06-01',
+        pageUrl: urls.experiment(PAUSED_EXPERIMENT.id),
+        testOptions: { waitForSelector: '[data-attr="experiment-warning-resume-experiment"]' },
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                [`/api/projects/:team_id/experiments/${PAUSED_EXPERIMENT.id}/`]: PAUSED_EXPERIMENT,
+                '/api/projects/:team_id/experiment_holdouts': [],
+                '/api/projects/:team_id/experiment_saved_metrics/': [],
+                [`/api/projects/:team_id/feature_flags/${PAUSED_EXPERIMENT.feature_flag.id}/`]: {},
+                [`/api/projects/:team_id/feature_flags/${PAUSED_EXPERIMENT.feature_flag.id}/status/`]: {},
+                '/api/environments/:team_id/default_release_conditions/': [],
+            },
+            post: {
+                '/api/environments/:team_id/query/:kind': [200, { results: [] }],
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+export const ExperimentPausedWarning: Story = { play: makeDelay(700) }


### PR DESCRIPTION
## Problem

Someone running an experiment whose feature flag got disabled sees a warning that names the problem but offers no way to fix it. The banner says "Resume or end the experiment", and both actions live in the Actions menu in the page header, which the banner never points to. So the experiment sits in a state where nobody is being served a variant, the results page keeps rendering, and the person reading the warning has to go hunting for the fix.

This is easy to leave unresolved for a long time, and while it is unresolved the experiment collects no exposures.

## Changes

- The paused warning banner now has a **Resume experiment** button. It opens the same confirmation modal the Actions menu opens, which explains that resuming re-enables the flag.
- The banner copy now says what the disabled flag means — nobody is seeing the experiment variants — instead of restating that the experiment has not ended.
- The button is disabled with a reason when the experiment has no linked flag, or when the reader lacks editor access to the experiment.
- Only this warning gets an action. The other four warnings need a judgement call about rollout or conclusion, so they stay link-only.
- New Storybook story for the paused state, so the banner is covered by visual review. Mechanical.

![banner-wide](https://raw.githubusercontent.com/PostHog/pr-assets/8a2e0077bc04aa763e4aff8c81a3dc2069731c72/2026/08/87cee28a-d231-4316-bbba-93db6edf882a.png)

The same banner in a narrow scene, where the text wraps rather than clips:

![banner-narrow](https://raw.githubusercontent.com/PostHog/pr-assets/5788140f3843669ea074e4add8a8a2891eafe26d/2026/08/4afc7df6-bd96-430d-ae58-a900dc74edf1.png)

## How did you test this code?

No automated test added. Which warning shows is already covered by the `experimentWarning` selector cases in `experimentLogic.test.ts`. What this PR adds is presentational wiring, and asserting it would mean mounting `experimentLogic` plus `modalsLogic` to check that a button exists.

Verified by rendering the new story in Storybook and driving it with Playwright:

- The **Resume experiment** button renders in the banner at 1600px and at 560px, per the screenshots above.
- Clicking it opens the existing "Resume experiment" confirmation modal.

Also ran `pnpm --filter=@posthog/frontend fix`, `typescript:check` (no errors in the changed files; pre-existing quill module-resolution errors elsewhere are unrelated), and `hogli ci:preflight --fix`, which reported clean.

Not checked: the resume request against a real backend, and the two disabled-button paths (no linked flag, viewer-level reader).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus). A colleague asked for a look at one account's product usage and whether they had hit trouble with feature flags; experiments left in the paused-flag state came out of that, and this PR addresses the dead-end in the banner. Assignee still needs setting — the agent had no verified GitHub handle for the person who directed the work.

Skills invoked: none — no repo skills were available in this environment, so the frontend conventions in `frontend/src/CLAUDE.md` and the copy rules in the root `CLAUDE.md` were applied directly.

Two alternatives were dropped. Firing `resumeExperiment` straight from the banner is one genuine click, but it flips a production flag with no confirmation while every other entry point in the scene confirms first, so the banner reuses the modal. A second banner on the feature flag page, warning at disable time that a running experiment depends on the flag, was scoped out to keep this to one surface.

Public artifact: nothing here carries material from the originating conversation. The story reuses the existing `experiment_with_funnel_metric.json` mock with `feature_flag.active` flipped to `false`. No customer data, identifiers, or flag names were introduced, and the screenshots show only that mock.
