### PR TITLE
fix(dags): serialize ArrayField columns before the clickhouse insert

### DIFF
--- a/posthog/dags/postgres_to_clickhouse_etl.py
+++ b/posthog/dags/postgres_to_clickhouse_etl.py
@@ -75,6 +75,10 @@ class TableConfig:
     - ``bool_fields`` / ``uuid_fields`` / ``array_fields``: per-table type adaptations the generic
       transform applies (booleans to 0/1, UUIDs to strings, array NULL-coalescing and
       None-filtering).
+    - ``json_dumps_fields``: columns psycopg2 hands over as a Python list or dict that the mirror
+      stores as a JSON String. Postgres ``jsonb`` columns take the ``jsonb_text_cast`` route
+      instead; this list is for ``ArrayField`` columns, where ``::text`` would render Postgres
+      array literal syntax that JSONExtract* cannot read.
     - ``ddl``: callable producing the ``CREATE TABLE IF NOT EXISTS`` SQL for the ClickHouse mirror.
     - ``post_transform``: table-specific row fixups applied after the generic type adaptations.
     - ``lookback_seconds``: how far below the mirror's high-watermark the hourly sync rewinds each
@@ -92,6 +96,7 @@ class TableConfig:
     bool_fields: list[str] = field(default_factory=list)
     uuid_fields: list[str] = field(default_factory=list)
     array_fields: list[str] = field(default_factory=list)
+    json_dumps_fields: list[str] = field(default_factory=list)
     watermark_expr: Optional[str] = None
     post_transform: Optional[Callable[[dict], dict]] = None
     lookback_seconds: int = 86400
@@ -202,6 +207,8 @@ _ORG_JSONB_TEXT_CAST = {
     "customer_trust_scores",
     "personalization",
 }
+
+_ORG_JSON_DUMPS_FIELDS = ["available_product_features"]
 
 
 def _organization_ddl() -> str:
@@ -379,6 +386,12 @@ _TEAM_JSONB_TEXT_CAST = {
 }
 
 _TEAM_ARRAY_FIELDS = ["app_urls", "person_display_name_properties", "live_events_columns", "recording_domains"]
+
+_TEAM_JSON_DUMPS_FIELDS = [
+    "session_recording_url_trigger_config",
+    "session_recording_url_blocklist_config",
+    "session_recording_event_trigger_config",
+]
 
 
 def _team_ddl() -> str:
@@ -582,6 +595,7 @@ TABLE_CONFIGS: dict[str, TableConfig] = {
         bool_fields=_ORG_BOOL_FIELDS,
         uuid_fields=["id", "logo_media_id"],
         array_fields=["domain_whitelist"],
+        json_dumps_fields=_ORG_JSON_DUMPS_FIELDS,
         ddl=_organization_ddl,
     ),
     "posthog_team": TableConfig(
@@ -593,6 +607,7 @@ TABLE_CONFIGS: dict[str, TableConfig] = {
         bool_fields=_TEAM_BOOL_FIELDS,
         uuid_fields=["uuid", "organization_id"],
         array_fields=_TEAM_ARRAY_FIELDS,
+        json_dumps_fields=_TEAM_JSON_DUMPS_FIELDS,
         ddl=_team_ddl,
         post_transform=_finalize_team_row,
     ),
@@ -665,6 +680,9 @@ def transform_row(table_name: str, row: dict) -> dict:
             row[f] = []
         elif isinstance(row[f], list):
             row[f] = [v for v in row[f] if v is not None]
+    for f in cfg.json_dumps_fields:
+        if row.get(f) is not None:
+            row[f] = json.dumps(row[f])
     return cfg.post_transform(row) if cfg.post_transform else row
 
 

--- a/posthog/dags/tests/test_postgres_to_clickhouse_etl.py
+++ b/posthog/dags/tests/test_postgres_to_clickhouse_etl.py
@@ -3,12 +3,13 @@
 import json
 from datetime import datetime, timedelta
 from decimal import Decimal
+from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, patch
 
 from django.contrib.postgres.fields import ArrayField
-from django.db.models import JSONField
+from django.db.models import JSONField, Model
 
 from dagster import build_asset_context, build_op_context
 from parameterized import parameterized
@@ -17,6 +18,7 @@ from posthog.dags.postgres_to_clickhouse_etl import (
     TABLE_CONFIGS,
     IncrementalState,
     PostgresToClickHouseETLConfig,
+    TableConfig,
     _sync_table,
     create_clickhouse_tables,
     feature_flags_in_clickhouse,
@@ -30,6 +32,39 @@ from posthog.dags.postgres_to_clickhouse_etl import (
     verify_sync,
 )
 from posthog.models import Organization, Team
+
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+_MIRRORED_TABLES = [
+    ("posthog_organization", Organization),
+    ("posthog_team", Team),
+    ("posthog_featureflag", FeatureFlag),
+]
+
+
+def _fields_by_column(model: type[Model]) -> dict[str, Any]:
+    fields_by_column: dict[str, Any] = {}
+    for model_field in model._meta.get_fields():
+        column = getattr(model_field, "column", None)
+        if column:
+            fields_by_column[column] = model_field
+    return fields_by_column
+
+
+def _composite_columns(cfg: TableConfig, model: type[Model]) -> list[tuple[str, Any]]:
+    fields_by_column = _fields_by_column(model)
+    return [
+        (col, fields_by_column[col])
+        for col in cfg.select_columns
+        if isinstance(fields_by_column.get(col), ArrayField | JSONField)
+    ]
+
+
+def _post_transform_serializes(table_name: str, column: str, model_field: Any) -> bool:
+    # posthog_featureflag serializes `filters` inside its post_transform instead of declaring the
+    # column on the config, so ask the transform what it emits rather than restating that here.
+    probe = [{"probe": 1}] if isinstance(model_field, ArrayField) else {"probe": 1}
+    return isinstance(transform_row(table_name, {column: probe}).get(column), str)
 
 
 def _config(**overrides) -> PostgresToClickHouseETLConfig:
@@ -203,39 +238,29 @@ class TestTransformations:
 
 
 class TestConfigCoversPostgresCompositeTypes:
-    # Every mirrored column that psycopg2 hands over as a Python list or dict must have an
-    # adaptation on its TableConfig. Without one the value reaches a ClickHouse String column
-    # unserialized and the driver raises AttributeError instead of inserting.
-    @parameterized.expand(
-        [
-            ("posthog_organization", Organization),
-            ("posthog_team", Team),
-        ]
-    )
+    # Every mirrored column that psycopg2 hands over as a Python list or dict must be adapted before
+    # the insert, either by a TableConfig field list or by the table's post_transform. Without an
+    # adaptation the value reaches a ClickHouse String column unserialized and the driver raises
+    # AttributeError instead of inserting.
+    @parameterized.expand(_MIRRORED_TABLES)
     def test_every_array_and_json_column_has_an_adaptation(self, table_name, model):
         cfg = TABLE_CONFIGS[table_name]
-        fields_by_column = {f.column: f for f in model._meta.get_fields() if getattr(f, "column", None)}
-        serialized = set(cfg.jsonb_text_cast) | set(cfg.array_fields) | set(cfg.json_dumps_fields)
+        declared = set(cfg.jsonb_text_cast) | set(cfg.array_fields) | set(cfg.json_dumps_fields)
 
         unhandled = [
             col
-            for col in cfg.select_columns
-            if isinstance(fields_by_column.get(col), ArrayField | JSONField) and col not in serialized
+            for col, model_field in _composite_columns(cfg, model)
+            if col not in declared and not _post_transform_serializes(table_name, col, model_field)
         ]
 
         assert unhandled == []
 
-    @parameterized.expand(
-        [
-            ("posthog_organization", Organization),
-            ("posthog_team", Team),
-        ]
-    )
+    @parameterized.expand(_MIRRORED_TABLES)
     def test_array_columns_are_never_cast_to_text(self, table_name, model):
         # `col::text` on an ArrayField renders Postgres array literal syntax, which JSONExtract*
         # cannot read. Those columns must go through json_dumps_fields or array_fields instead.
         cfg = TABLE_CONFIGS[table_name]
-        fields_by_column = {f.column: f for f in model._meta.get_fields() if getattr(f, "column", None)}
+        fields_by_column = _fields_by_column(model)
 
         miscast = [col for col in cfg.jsonb_text_cast if isinstance(fields_by_column.get(col), ArrayField)]
 

--- a/posthog/dags/tests/test_postgres_to_clickhouse_etl.py
+++ b/posthog/dags/tests/test_postgres_to_clickhouse_etl.py
@@ -7,6 +7,9 @@ from decimal import Decimal
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.contrib.postgres.fields import ArrayField
+from django.db.models import JSONField
+
 from dagster import build_asset_context, build_op_context
 from parameterized import parameterized
 
@@ -26,6 +29,7 @@ from posthog.dags.postgres_to_clickhouse_etl import (
     transform_row,
     verify_sync,
 )
+from posthog.models import Organization, Team
 
 
 def _config(**overrides) -> PostgresToClickHouseETLConfig:
@@ -75,11 +79,12 @@ class TestTransformations:
             "logo_media_id": uuid.uuid4(),
             "is_member_join_email_enabled": True,
             "is_hipaa": False,
-            "available_product_features": '[{"key": "feature1"}]',  # ::text on the PG side
-            "usage": '{"events": 1000}',
+            "available_product_features": [{"key": "feature1"}],  # ArrayField, so psycopg2 parses it
+            "usage": '{"events": 1000}',  # ::text on the PG side
             "personalization": '{"role": "engineer"}',
             "domain_whitelist": ["example.com"],
         }
+        usage_text = row["usage"]
 
         transformed = transform_row("posthog_organization", row)
 
@@ -87,9 +92,11 @@ class TestTransformations:
         assert isinstance(transformed["logo_media_id"], str)
         assert transformed["is_member_join_email_enabled"] == 1
         assert transformed["is_hipaa"] == 0
-        # ::text columns pass through untouched — no parse-then-redump.
-        assert transformed["available_product_features"] == row["available_product_features"]
-        assert transformed["usage"] == row["usage"]
+        # ArrayField columns arrive as Python lists, but the mirror column is String, so the
+        # ClickHouse driver rejects any value the transform leaves unserialized.
+        assert transformed["available_product_features"] == '[{"key": "feature1"}]'
+        # ::text columns pass through untouched, with no parse-then-redump.
+        assert transformed["usage"] == usage_text
         assert transformed["domain_whitelist"] == ["example.com"]
 
     def test_transform_team_row(self):
@@ -107,9 +114,13 @@ class TestTransformations:
             "test_account_filters": '[{"key": "email", "value": "test@example.com"}]',
             "app_urls": ["https://app.example.com"],
             "person_display_name_properties": None,
+            "session_recording_url_trigger_config": [{"url": "example.com", "matching": "regex"}],
+            "session_recording_url_blocklist_config": None,
+            "session_recording_event_trigger_config": ["$pageview"],
             "session_recording_sample_rate": Decimal("0.50"),
             "drop_events_older_than": timedelta(days=30),
         }
+        test_account_filters_text = row["test_account_filters"]
 
         transformed = transform_row("posthog_team", row)
 
@@ -117,9 +128,15 @@ class TestTransformations:
         assert transformed["organization_id"] == str(org_uuid)
         assert transformed["anonymize_ips"] == 1
         assert transformed["session_recording_opt_in"] == 0
-        assert transformed["test_account_filters"] == row["test_account_filters"]
+        assert transformed["test_account_filters"] == test_account_filters_text
         assert transformed["app_urls"] == ["https://app.example.com"]
         assert transformed["person_display_name_properties"] == []
+        # ArrayField columns arrive as Python lists, but the mirror column is String, so the
+        # ClickHouse driver rejects any value the transform leaves unserialized.
+        assert transformed["session_recording_url_trigger_config"] == '[{"url": "example.com", "matching": "regex"}]'
+        assert transformed["session_recording_event_trigger_config"] == '["$pageview"]'
+        # The mirror column is Nullable(String), so a NULL source value stays NULL.
+        assert transformed["session_recording_url_blocklist_config"] is None
         assert transformed["session_recording_sample_rate"] == Decimal("0.50")
         assert transformed["drop_events_older_than"] == 30 * 24 * 60 * 60
 
@@ -183,6 +200,46 @@ class TestTransformations:
     def test_transform_row_unknown_table_raises(self):
         with pytest.raises(KeyError):
             transform_row("posthog_nonexistent", {})
+
+
+class TestConfigCoversPostgresCompositeTypes:
+    # Every mirrored column that psycopg2 hands over as a Python list or dict must have an
+    # adaptation on its TableConfig. Without one the value reaches a ClickHouse String column
+    # unserialized and the driver raises AttributeError instead of inserting.
+    @parameterized.expand(
+        [
+            ("posthog_organization", Organization),
+            ("posthog_team", Team),
+        ]
+    )
+    def test_every_array_and_json_column_has_an_adaptation(self, table_name, model):
+        cfg = TABLE_CONFIGS[table_name]
+        fields_by_column = {f.column: f for f in model._meta.get_fields() if getattr(f, "column", None)}
+        serialized = set(cfg.jsonb_text_cast) | set(cfg.array_fields) | set(cfg.json_dumps_fields)
+
+        unhandled = [
+            col
+            for col in cfg.select_columns
+            if isinstance(fields_by_column.get(col), ArrayField | JSONField) and col not in serialized
+        ]
+
+        assert unhandled == []
+
+    @parameterized.expand(
+        [
+            ("posthog_organization", Organization),
+            ("posthog_team", Team),
+        ]
+    )
+    def test_array_columns_are_never_cast_to_text(self, table_name, model):
+        # `col::text` on an ArrayField renders Postgres array literal syntax, which JSONExtract*
+        # cannot read. Those columns must go through json_dumps_fields or array_fields instead.
+        cfg = TABLE_CONFIGS[table_name]
+        fields_by_column = {f.column: f for f in model._meta.get_fields() if getattr(f, "column", None)}
+
+        miscast = [col for col in cfg.jsonb_text_cast if isinstance(fields_by_column.get(col), ArrayField)]
+
+        assert miscast == []
 
 
 class TestTableDdl:
@@ -275,7 +332,7 @@ def _org_row(**overrides):
             "id": 1,
             "name": "Org",
             "is_member_join_email_enabled": True,
-            "available_product_features": "[]",
+            "available_product_features": [],
             "created_at": datetime(2024, 1, 1),
             "updated_at": datetime(2024, 1, 2),
         }

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
+                  ([e__person.properties___fish] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,6 +44,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -111,7 +121,17 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -168,8 +188,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -178,6 +198,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -294,7 +324,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -326,7 +373,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([e__person.properties___fish] AS value) AS prop_basic,
+                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,16 +44,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -121,17 +111,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -188,8 +168,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -198,16 +178,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -324,24 +294,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -373,24 +326,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)


### PR DESCRIPTION
## Problem

The hourly `postgres_to_clickhouse_etl_job` cannot write teams or organizations, so `models.posthog_team` and `models.posthog_organization` in ClickHouse hold a stale snapshot and every reader of those mirrors sees old data.

- `sync_teams` and `sync_organizations` exhaust all 3 retries with `AttributeError: 'list' object has no attribute 'encode'`.
- Four mirrored columns are Django `ArrayField`, so psycopg2 returns a Python list.
- Nothing serializes that list, and the ClickHouse driver then calls `.encode()` on it while writing a `String` column.

| Table | Column | Django type |
| --- | --- | --- |
| `posthog_organization` | `available_product_features` | `ArrayField(JSONField)` |
| `posthog_team` | `session_recording_url_trigger_config` | `ArrayField(JSONField)` |
| `posthog_team` | `session_recording_url_blocklist_config` | `ArrayField(JSONField)` |
| `posthog_team` | `session_recording_event_trigger_config` | `ArrayField(TextField)` |

The failure is not data dependent. `session_recording_event_trigger_config` defaults to `[]`, and an empty list is still a list.

#85528 introduced this. It replaced the per-table `json.dumps` step with the `jsonb_text_cast` mechanism, which pushes serialization into Postgres as `col::text`. These four columns were correctly left out of that cast, because `::text` on an array renders Postgres array literal syntax that `JSONExtract*` cannot read. They were then left out of everything else too. Two code comments still describe the `json.dumps` that no longer existed.

## Changes

- `sync_teams` and `sync_organizations` complete again, so both mirrors resume receiving rows.
- `transform_row` serializes the four `ArrayField` columns with `json.dumps` before the insert.
- A `NULL` source value stays `NULL`, because all four mirror columns are `Nullable(String)`.
- `TableConfig` gains a `json_dumps_fields` list, alongside the existing `bool_fields`, `uuid_fields`, and `array_fields`. This is plumbing.
- No user-visible surface changes. The mirrors are internal ClickHouse tables with no UI.

> [!NOTE]
> The mirrors have missed every sync since #85528 landed. A `full_refresh` run rebuilds them once this ships.

## How did you test this code?

Automated tests only. This environment has no ClickHouse and no Postgres, so no end-to-end insert ran.

- Reverting only `postgres_to_clickhouse_etl.py` and keeping the test changes turns 4 tests red, so the new coverage catches the shipped bug.
- `test_transform_organization_row` and `test_transform_team_row` now feed the `ArrayField` columns as the lists psycopg2 returns. The org test previously fed a pre-serialized string labeled `# ::text on the PG side`, which is why the gap survived review.
- `TestConfigCoversPostgresCompositeTypes` checks every mirrored column against the live Django field type. It catches a future `ArrayField` or `JSONField` column added to `select_columns` with no adaptation, and an `ArrayField` wrongly added to `jsonb_text_cast`.
- The four affected columns were found by enumerating `_ORG_COLS` and `_TEAM_COLS` against `Model._meta`, not by reading the diff. No others were unhandled.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No document describes this ETL.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) diagnosed and fixed this from a Dagster failure traceback. Skills invoked: `/superpowers:systematic-debugging`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The traceback pointed at the driver, so the search ran backwards from the `String` column to the Postgres field type rather than forwards from the error. Comparing `TABLE_CONFIGS` against `Model._meta` found the four columns and confirmed no others, and that same comparison became the drift test.

An alternative fix was to add the columns to `jsonb_text_cast`. That was rejected: `::text` on a Postgres array produces array literal syntax, so the stored value would parse in ClickHouse as neither JSON nor an array.
