### PR TITLE
feat(tasks): warn the agent before its sandbox runs out of memory

### DIFF
--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -385,6 +385,30 @@ container traffic because their network paths differ.
 The `use_modal_vm_sandbox` run-state key force-selects the VM runtime for trusted server-created runs
 (image builders) and is never accepted from client input.
 
+### Memory guard
+
+A sandbox that runs out of memory is killed outright, so the run ends mid-turn with no explanation
+and no chance to save anything. Starting a full dev stack is the usual way to get there.
+Behind the `tasks-cloud-run-sandbox-memory-guard` flag, the run watches for that instead of waiting
+for it: `check_sandbox_memory` reads the box's cgroup limit, falling back to `/proc/meminfo` on VM
+runtimes, which have no cgroup ceiling. The probe runs once a minute, and every 15 seconds once the
+box is above 85%.
+
+What the run does with a reading:
+
+- **85% (warning)** — a progress step tells the person watching. The agent is not interrupted.
+- **93% (critical)** — the agent is sent a steer naming the position and the largest processes,
+  telling it to free memory before the box is killed. At most 3 per run, at least 5 minutes apart.
+  Delivery is best-effort: a nudge that cannot be delivered never fails the run.
+- **Sandbox stops after a reading at 85% or above** — the run reports memory as the likely cause
+  instead of the generic "sandbox stopped" message.
+
+The guard cannot resize a live sandbox. A run that genuinely needs a bigger box has to be restarted
+with a `sandbox_resources` override, so the message tells the agent to save its work and say so.
+Thresholds and cadence live in `products/tasks/backend/logic/services/sandbox_memory.py` and
+`products/tasks/backend/temporal/constants.py`. `tasks_process_sandbox_memory_reading` counts
+readings by level, and `tasks_process_sandbox_memory_nudge` counts what happened to each nudge.
+
 ### Network access
 
 Network access is configured per-team via `SandboxEnvironment`:

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -217,6 +217,9 @@ RTK_DISABLED_FEATURE_FLAG = "tasks-rtk-disabled"
 CONTINUE_AS_NEW_FEATURE_FLAG = "tasks-cloud-run-continue-as-new"
 PR_BABYSIT_SNAPSHOT_FEATURE_FLAG = "tasks-pr-babysit-snapshot"
 SANDBOX_ROTATION_FEATURE_FLAG = "tasks-cloud-run-sandbox-rotation"
+# Gates the memory guard: the periodic probe of a sandbox's memory headroom and the
+# message it sends the agent when the box is close to being killed for using it all.
+SANDBOX_MEMORY_GUARD_FEATURE_FLAG = "tasks-cloud-run-sandbox-memory-guard"
 
 SnapshotKind = Literal["filesystem", "directory"]
 SNAPSHOT_KIND_FILESYSTEM: SnapshotKind = "filesystem"

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -44,6 +44,12 @@ from products.tasks.backend.logic.services.sandbox_config import (
     SANDBOX_TTL_SECONDS,
     VM_SANDBOX_CPU_CORES,
 )
+from products.tasks.backend.logic.services.sandbox_memory import (
+    MEMORY_PROBE_TIMEOUT_SECONDS,
+    SandboxMemory,
+    build_memory_probe_command,
+    parse_memory_probe,
+)
 
 if TYPE_CHECKING:
     from products.tasks.backend.temporal.process_task.utils import McpServerConfig
@@ -577,6 +583,23 @@ class SandboxBase(ABC):
 
     def read_cpu_usage_usec(self) -> int | None:
         return None
+
+    def read_memory_usage(self) -> SandboxMemory | None:
+        """How close this sandbox is to its memory ceiling, or None when nothing could be read.
+
+        One exec for every provider: the probe only reads kernel files, so a backend has
+        nothing to add beyond running the command. A box that is already dying answers
+        slowly or not at all, which is why the caller treats None as "unknown" rather than
+        "healthy".
+        """
+        try:
+            result = self.execute(build_memory_probe_command(), timeout_seconds=MEMORY_PROBE_TIMEOUT_SECONDS)
+        except Exception as e:
+            _logger.warning("sandbox_memory_probe_failed", sandbox_id=self.id, error=str(e))
+            return None
+        if result.exit_code != 0:
+            return None
+        return parse_memory_probe(result.stdout or "")
 
     def start_cpu_billing_sampler(self) -> bool:
         return False

--- a/products/tasks/backend/logic/services/sandbox_memory.py
+++ b/products/tasks/backend/logic/services/sandbox_memory.py
@@ -1,0 +1,277 @@
+"""Shared memory-pressure probe plumbing for sandbox providers.
+
+Where a sandbox keeps its memory ceiling depends on how the box was made. A container
+reads its cgroup limit. A Modal VM has no cgroup limit, so its ceiling is the kernel's
+own view in ``/proc/meminfo``. Older kernels use the cgroup v1 file names. One probe
+reads every candidate in a single exec, and the parser takes the narrowest ceiling that
+is actually set. Providers differ only in how they run a command, so the command text
+and the parsing live here and must not fork between backends.
+"""
+
+from __future__ import annotations
+
+import shlex
+from enum import StrEnum
+
+from posthog.dataclasses import frozen
+
+_PROBE_MARKER = "@@"
+_PROCESS_SECTION = "processes"
+_TOP_PROCESS_COUNT = 5
+
+# cgroup writes a sentinel this large when no limit is set. A ceiling at that scale is
+# not a ceiling, so both cgroup versions are read through the same guard.
+_CGROUP_UNLIMITED_BYTES = 0x7FFFFFFFFFFFF000
+
+MEMORY_PROBE_TIMEOUT_SECONDS = 10
+
+_PROBE_FILES = (
+    ("cgroup2_current", "/sys/fs/cgroup/memory.current"),
+    ("cgroup2_max", "/sys/fs/cgroup/memory.max"),
+    ("cgroup2_peak", "/sys/fs/cgroup/memory.peak"),
+    ("cgroup2_events", "/sys/fs/cgroup/memory.events"),
+    ("cgroup1_current", "/sys/fs/cgroup/memory/memory.usage_in_bytes"),
+    ("cgroup1_max", "/sys/fs/cgroup/memory/memory.limit_in_bytes"),
+    ("cgroup1_peak", "/sys/fs/cgroup/memory/memory.max_usage_in_bytes"),
+    ("meminfo", "/proc/meminfo"),
+)
+
+
+class MemoryPressureLevel(StrEnum):
+    OK = "ok"
+    WATCH = "watch"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+# WATCH only labels the metric, so a rollout can see how many boxes sit in that band before
+# anyone retunes these numbers. At WARNING the run probes more often and tells the person
+# watching. At CRITICAL it interrupts the agent, so the threshold leaves enough headroom for
+# a dev stack to shut down after the message lands.
+MEMORY_WATCH_FRACTION = 0.70
+MEMORY_WARNING_FRACTION = 0.85
+MEMORY_CRITICAL_FRACTION = 0.93
+
+
+def memory_pressure_level(used_fraction: float) -> MemoryPressureLevel:
+    if used_fraction >= MEMORY_CRITICAL_FRACTION:
+        return MemoryPressureLevel.CRITICAL
+    if used_fraction >= MEMORY_WARNING_FRACTION:
+        return MemoryPressureLevel.WARNING
+    if used_fraction >= MEMORY_WATCH_FRACTION:
+        return MemoryPressureLevel.WATCH
+    return MemoryPressureLevel.OK
+
+
+@frozen
+class SandboxProcessMemory:
+    name: str
+    resident_bytes: int
+
+
+@frozen
+class SandboxMemory:
+    """What one probe saw.
+
+    ``peak_bytes`` is context for whoever reads the log, never a trigger. The kernel
+    measures it from boot, so a build that has already finished would hold a healthy box
+    above a threshold for the rest of the run.
+    """
+
+    used_bytes: int
+    limit_bytes: int
+    source: str
+    peak_bytes: int | None = None
+    oom_kills: int = 0
+    top_processes: tuple[SandboxProcessMemory, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.limit_bytes <= 0:
+            raise ValueError("limit_bytes must be positive")
+        if self.used_bytes < 0:
+            raise ValueError("used_bytes must not be negative")
+
+    @property
+    def used_fraction(self) -> float:
+        return self.used_bytes / self.limit_bytes
+
+    @property
+    def used_percent(self) -> int:
+        return round(self.used_fraction * 100)
+
+    @property
+    def level(self) -> MemoryPressureLevel:
+        return memory_pressure_level(self.used_fraction)
+
+
+@frozen
+class _Reading:
+    """One source's answer, before the narrowest ceiling is chosen."""
+
+    used_bytes: int
+    limit_bytes: int
+    source: str
+    peak_bytes: int | None = None
+
+
+def build_memory_probe_command() -> str:
+    """Read every candidate source in one shell invocation.
+
+    Each section is preceded by a marker line and followed by a newline, so a source that
+    does not exist contributes an empty section instead of shifting the ones after it. The
+    command always exits 0: a missing file is an expected answer, not a failure.
+    """
+    parts = [
+        f"printf '{_PROBE_MARKER}%s\\n' {shlex.quote(name)}; cat {shlex.quote(path)} 2>/dev/null; echo; "
+        for name, path in _PROBE_FILES
+    ]
+    parts.append(
+        f"printf '{_PROBE_MARKER}%s\\n' {shlex.quote(_PROCESS_SECTION)}; "
+        f"ps -eo rss=,comm= --sort=-rss 2>/dev/null | head -n {_TOP_PROCESS_COUNT}; echo; "
+    )
+    return "".join(parts) + "exit 0"
+
+
+def parse_memory_probe(stdout: str) -> SandboxMemory | None:
+    """The sandbox's memory position, or None when no source could be read."""
+    sections = _split_sections(stdout)
+    readings = [
+        reading
+        for reading in (
+            _cgroup_reading(sections, version=2),
+            _cgroup_reading(sections, version=1),
+            _meminfo_reading(sections.get("meminfo")),
+        )
+        if reading is not None
+    ]
+    if not readings:
+        return None
+
+    # Ties keep the earlier source, so a cgroup limit wins over an identical kernel total:
+    # it is the one the OOM killer enforces.
+    reading = min(readings, key=lambda candidate: candidate.limit_bytes)
+    return SandboxMemory(
+        used_bytes=min(reading.used_bytes, reading.limit_bytes),
+        limit_bytes=reading.limit_bytes,
+        source=reading.source,
+        peak_bytes=reading.peak_bytes,
+        oom_kills=_oom_kills(sections.get("cgroup2_events")),
+        top_processes=_top_processes(sections.get(_PROCESS_SECTION)),
+    )
+
+
+def format_memory_size(value: int) -> str:
+    if value >= 1024**3:
+        return f"{value / 1024**3:.1f} GB"
+    return f"{round(value / 1024**2)} MB"
+
+
+def describe_memory_position(memory: SandboxMemory) -> str:
+    return (
+        f"{format_memory_size(memory.used_bytes)} of {format_memory_size(memory.limit_bytes)} ({memory.used_percent}%)"
+    )
+
+
+def build_memory_pressure_nudge(*, position: str, top_processes: str) -> str:
+    """The message that interrupts an agent whose sandbox is nearly out of memory.
+
+    It names the run as the sender, because the agent must not read it as a turn from the
+    person it is working for.
+    """
+    largest = f"Largest processes: {top_processes}\n" if top_processes else ""
+    return (
+        "System notice from this run's sandbox monitor. This is not a message from the user.\n\n"
+        f"The sandbox is nearly out of memory. It is using {position}.\n"
+        f"{largest}\n"
+        "If the sandbox runs out of memory, it is killed, the run ends, and anything you have not "
+        "committed and pushed is lost.\n\n"
+        "Free memory before you continue:\n"
+        "1. Stop what is using it. A local dev stack is the usual cause, so `hogli down` or "
+        "`docker compose down` normally recovers the box.\n"
+        "2. Rerun heavy work with a smaller footprint, or one piece at a time.\n\n"
+        "This sandbox cannot be given more memory while it is running. If the work needs a bigger "
+        "box, commit and push what you have, tell the user what it needs, and stop."
+    )
+
+
+def build_memory_exhaustion_error(*, position: str) -> str:
+    """Why a run ended, when the sandbox was nearly full the last time anyone looked."""
+    return (
+        f"Sandbox stopped with memory nearly full ({position}); it most likely ran out of memory. "
+        "Start a new run with less running inside it."
+    )
+
+
+def _split_sections(stdout: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current: list[str] | None = None
+    for line in stdout.splitlines():
+        if line.startswith(_PROBE_MARKER):
+            current = sections.setdefault(line[len(_PROBE_MARKER) :].strip(), [])
+            continue
+        if current is not None:
+            current.append(line)
+    return {name: "\n".join(lines) for name, lines in sections.items()}
+
+
+def _read_int(text: str | None) -> int | None:
+    if text is None:
+        return None
+    value = text.strip()
+    return int(value) if value.isdigit() else None
+
+
+def _cgroup_reading(sections: dict[str, str], *, version: int) -> _Reading | None:
+    prefix = f"cgroup{version}"
+    used = _read_int(sections.get(f"{prefix}_current"))
+    limit = _read_int(sections.get(f"{prefix}_max"))
+    if used is None or limit is None or limit <= 0 or limit >= _CGROUP_UNLIMITED_BYTES:
+        return None
+    return _Reading(
+        used_bytes=used,
+        limit_bytes=limit,
+        source=f"cgroup_v{version}",
+        peak_bytes=_read_int(sections.get(f"{prefix}_peak")),
+    )
+
+
+def _meminfo_reading(text: str | None) -> _Reading | None:
+    """The kernel's own view, which is the only ceiling a VM-backed sandbox has."""
+    if not text:
+        return None
+    values: dict[str, int] = {}
+    for line in text.splitlines():
+        key, separator, rest = line.partition(":")
+        if not separator or key not in ("MemTotal", "MemAvailable"):
+            continue
+        fields = rest.split()
+        if fields and fields[0].isdigit():
+            values[key] = int(fields[0]) * 1024
+    total = values.get("MemTotal")
+    available = values.get("MemAvailable")
+    if total is None or available is None or total <= 0:
+        return None
+    return _Reading(used_bytes=max(0, total - available), limit_bytes=total, source="meminfo")
+
+
+def _oom_kills(text: str | None) -> int:
+    if not text:
+        return 0
+    for line in text.splitlines():
+        key, _, value = line.partition(" ")
+        if key == "oom_kill":
+            return _read_int(value) or 0
+    return 0
+
+
+def _top_processes(text: str | None) -> tuple[SandboxProcessMemory, ...]:
+    if not text:
+        return ()
+    processes: list[SandboxProcessMemory] = []
+    for line in text.splitlines():
+        resident, _, name = line.strip().partition(" ")
+        name = name.strip()
+        if not name or not resident.isdigit():
+            continue
+        processes.append(SandboxProcessMemory(name=name, resident_bytes=int(resident) * 1024))
+    return tuple(processes)

--- a/products/tasks/backend/logic/services/tests/test_sandbox_memory.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_memory.py
@@ -1,0 +1,147 @@
+from parameterized import parameterized
+
+from products.tasks.backend.logic.services.sandbox_memory import (
+    MemoryPressureLevel,
+    memory_pressure_level,
+    parse_memory_probe,
+)
+
+GIB = 1024**3
+
+
+def _probe(**sections: str) -> str:
+    return "".join(f"@@{name}\n{content}\n" for name, content in sections.items())
+
+
+def _meminfo(total_kb: int, available_kb: int) -> str:
+    return f"MemTotal:       {total_kb} kB\nMemFree:        1000 kB\nMemAvailable:   {available_kb} kB\n"
+
+
+class TestParseMemoryProbe:
+    @parameterized.expand(
+        [
+            # A container's cgroup ceiling is the one the kernel enforces, and /proc/meminfo
+            # reports the whole host. Taking the host total here would keep the guard silent
+            # on every container.
+            (
+                "container_prefers_its_cgroup_ceiling_over_the_host_total",
+                {
+                    "cgroup2_current": str(6 * GIB),
+                    "cgroup2_max": str(8 * GIB),
+                    "meminfo": _meminfo(total_kb=256 * 1024 * 1024, available_kb=200 * 1024 * 1024),
+                },
+                8 * GIB,
+                6 * GIB,
+                "cgroup_v2",
+            ),
+            # A VM-backed sandbox has no cgroup ceiling, so the kernel's own total is the
+            # only answer. This is the shape that runs a local dev stack.
+            (
+                "vm_falls_back_to_the_kernel_total_when_the_cgroup_is_unlimited",
+                {
+                    "cgroup2_current": str(2 * GIB),
+                    "cgroup2_max": "max",
+                    "meminfo": _meminfo(total_kb=16 * 1024 * 1024, available_kb=4 * 1024 * 1024),
+                },
+                16 * GIB,
+                12 * GIB,
+                "meminfo",
+            ),
+            (
+                "cgroup_v1_file_names_are_read_too",
+                {
+                    "cgroup1_current": str(3 * GIB),
+                    "cgroup1_max": str(4 * GIB),
+                },
+                4 * GIB,
+                3 * GIB,
+                "cgroup_v1",
+            ),
+            # cgroup v1 writes a huge sentinel rather than a word when nothing limits the box.
+            (
+                "cgroup_v1_sentinel_is_not_treated_as_a_ceiling",
+                {
+                    "cgroup1_current": str(2 * GIB),
+                    "cgroup1_max": "9223372036854771712",
+                    "meminfo": _meminfo(total_kb=8 * 1024 * 1024, available_kb=2 * 1024 * 1024),
+                },
+                8 * GIB,
+                6 * GIB,
+                "meminfo",
+            ),
+            # A ceiling smaller than the cgroup's still binds: the box cannot use memory the
+            # kernel does not have.
+            (
+                "the_narrowest_ceiling_wins",
+                {
+                    "cgroup2_current": str(1 * GIB),
+                    "cgroup2_max": str(64 * GIB),
+                    "meminfo": _meminfo(total_kb=4 * 1024 * 1024, available_kb=1 * 1024 * 1024),
+                },
+                4 * GIB,
+                3 * GIB,
+                "meminfo",
+            ),
+        ]
+    )
+    def test_it_picks_the_ceiling_the_box_is_actually_bound_by(
+        self, _name: str, sections: dict[str, str], limit_bytes: int, used_bytes: int, source: str
+    ) -> None:
+        memory = parse_memory_probe(_probe(**sections))
+
+        assert memory is not None
+        assert memory.limit_bytes == limit_bytes
+        assert memory.used_bytes == used_bytes
+        assert memory.source == source
+
+    @parameterized.expand(
+        [
+            ("nothing_readable", {}),
+            ("usage_without_a_ceiling", {"cgroup2_current": str(GIB)}),
+            ("non_numeric_values", {"cgroup2_current": "unknown", "cgroup2_max": "unknown"}),
+            ("meminfo_without_the_available_field", {"meminfo": "MemTotal:       16384 kB\n"}),
+        ]
+    )
+    def test_an_unreadable_probe_is_unknown_rather_than_healthy(self, _name: str, sections: dict[str, str]) -> None:
+        assert parse_memory_probe(_probe(**sections)) is None
+
+    def test_it_names_the_processes_holding_the_memory(self) -> None:
+        memory = parse_memory_probe(
+            _probe(
+                cgroup2_current=str(7 * GIB),
+                cgroup2_max=str(8 * GIB),
+                cgroup2_events="low 0\nhigh 12\nmax 3\noom 1\noom_kill 2\n",
+                processes="6291456 dockerd\n1048576 node\ngarbage line\n",
+            )
+        )
+
+        assert memory is not None
+        assert memory.oom_kills == 2
+        assert [(process.name, process.resident_bytes) for process in memory.top_processes] == [
+            ("dockerd", 6 * GIB),
+            ("node", GIB),
+        ]
+
+    def test_usage_above_the_ceiling_is_clamped(self) -> None:
+        memory = parse_memory_probe(_probe(cgroup2_current=str(9 * GIB), cgroup2_max=str(8 * GIB)))
+
+        assert memory is not None
+        assert memory.used_bytes == 8 * GIB
+        assert memory.used_percent == 100
+
+
+class TestMemoryPressureLevel:
+    @parameterized.expand(
+        [
+            (0.0, MemoryPressureLevel.OK),
+            (0.699, MemoryPressureLevel.OK),
+            (0.70, MemoryPressureLevel.WATCH),
+            (0.849, MemoryPressureLevel.WATCH),
+            (0.85, MemoryPressureLevel.WARNING),
+            (0.929, MemoryPressureLevel.WARNING),
+            (0.93, MemoryPressureLevel.CRITICAL),
+            (1.0, MemoryPressureLevel.CRITICAL),
+        ]
+    )
+    def test_each_threshold_is_inclusive(self, fraction: float, expected: MemoryPressureLevel) -> None:
+        assert memory_pressure_level(fraction) == expected

--- a/products/tasks/backend/temporal/__init__.py
+++ b/products/tasks/backend/temporal/__init__.py
@@ -14,6 +14,7 @@ from .create_snapshot.workflow import CreateSnapshotForRepositoryWorkflow
 from .loops import RunLoopWorkflow, run_loop_trigger_activity
 from .process_task.activities import (
     await_agent_server_ready,
+    check_sandbox_memory,
     checkout_branch_in_sandbox,
     cleanup_sandbox,
     clone_repository_in_sandbox,
@@ -93,6 +94,7 @@ ACTIVITIES = [
     relay_sandbox_events,
     relay_sandbox_events_deferred_completion,
     create_resume_snapshot,
+    check_sandbox_memory,
     post_permission_delivery_failure_notice,
     send_permission_denial_guidance,
     send_permission_response_to_sandbox,

--- a/products/tasks/backend/temporal/constants.py
+++ b/products/tasks/backend/temporal/constants.py
@@ -112,6 +112,21 @@ WARM_IDLE_TIMEOUT = timedelta(minutes=10)
 
 SANDBOX_TTL_SNAPSHOT_LEAD = timedelta(minutes=10)
 
+# Cadence of the sandbox memory probe. One cheap exec per tick, so a box with plenty of
+# headroom is checked rarely, and one that is climbing is checked often enough to warn
+# the agent before the kernel kills it.
+SANDBOX_MEMORY_CHECK_INTERVAL = timedelta(seconds=60)
+SANDBOX_MEMORY_CHECK_INTERVAL_UNDER_PRESSURE = timedelta(seconds=15)
+
+# Wait between two memory interruptions of the same run, and the cap on how many it gets.
+# A box that stays full must not become a stream of messages the agent cannot act on.
+SANDBOX_MEMORY_NUDGE_COOLDOWN = timedelta(minutes=5)
+MAX_SANDBOX_MEMORY_NUDGES = 3
+
+# Consecutive unreadable probes after which a run stops probing. A sandbox that cannot
+# answer is unlikely to start, and every attempt costs an exec.
+MAX_SANDBOX_MEMORY_PROBE_FAILURES = 3
+
 # CI follow-up cadence after the agent has been idle.
 CI_FOLLOW_UP_DELAY = timedelta(minutes=15)
 

--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -178,6 +178,29 @@ def increment_snapshot_create(snapshot_kind: str, outcome: str) -> None:
         pass
 
 
+def record_sandbox_memory_reading(level: str) -> None:
+    """Count memory probes by pressure level, so a rollout can see how often boxes run hot."""
+    try:
+        _metric_meter({"level": level}).create_counter(
+            "tasks_process_sandbox_memory_reading",
+            "Sandbox memory pressure readings by level for process-task runs",
+        ).add(1)
+    except Exception:
+        pass
+
+
+def increment_sandbox_memory_nudge(outcome: str) -> None:
+    """Emitted from the workflow, so it uses the workflow meter rather than the activity one."""
+    try:
+        meter = workflow.metric_meter().with_additional_attributes({"outcome": outcome})
+        meter.create_counter(
+            "tasks_process_sandbox_memory_nudge",
+            "Attempts to interrupt an agent whose sandbox is nearly out of memory",
+        ).add(1)
+    except Exception:
+        pass
+
+
 def record_snapshot_create_latency_ms(snapshot_kind: str, outcome: str, latency_ms: int) -> None:
     try:
         delta = dt.timedelta(milliseconds=latency_ms)

--- a/products/tasks/backend/temporal/process_task/activities/__init__.py
+++ b/products/tasks/backend/temporal/process_task/activities/__init__.py
@@ -1,3 +1,4 @@
+from .check_sandbox_memory import CheckSandboxMemoryInput, CheckSandboxMemoryOutput, check_sandbox_memory
 from .cleanup_sandbox import CleanupSandboxInput, CompleteRunStreamInput, cleanup_sandbox, complete_run_stream
 from .create_resume_snapshot import CreateResumeSnapshotInput, CreateResumeSnapshotOutput, create_resume_snapshot
 from .emit_progress_activity import EmitProgressInput, emit_progress_activity
@@ -127,6 +128,9 @@ __all__ = [
     "RecordPeerMessageOutcomeInput",
     "peer_message_id_from_context",
     "record_peer_message_outcome",
+    "CheckSandboxMemoryInput",
+    "CheckSandboxMemoryOutput",
+    "check_sandbox_memory",
     "cleanup_sandbox",
     "complete_run_stream",
     "create_resume_snapshot",

--- a/products/tasks/backend/temporal/process_task/activities/check_sandbox_memory.py
+++ b/products/tasks/backend/temporal/process_task/activities/check_sandbox_memory.py
@@ -1,0 +1,100 @@
+from dataclasses import dataclass
+
+import structlog
+from temporalio import activity
+
+from posthog.temporal.common.utils import asyncify
+
+from products.tasks.backend.logic.services.sandbox import get_sandbox_class
+from products.tasks.backend.logic.services.sandbox_memory import (
+    MemoryPressureLevel,
+    describe_memory_position,
+    format_memory_size,
+)
+from products.tasks.backend.temporal.metrics import record_sandbox_memory_reading
+from products.tasks.backend.temporal.observability import emit_agent_log
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class CheckSandboxMemoryInput:
+    sandbox_id: str
+    run_id: str
+
+
+@dataclass(frozen=False)
+class CheckSandboxMemoryOutput:
+    """One reading, or ``level = "unknown"`` when the sandbox could not answer.
+
+    Every field has a default so a payload written by an older worker still decodes, and
+    so an unknown reading is representable without a separate output type. The workflow
+    schedules its next probe from this, so nothing here may depend on wall-clock time.
+    """
+
+    level: str = "unknown"
+    used_bytes: int = 0
+    limit_bytes: int = 0
+    used_percent: int = 0
+    position: str = ""
+    top_processes: str = ""
+    source: str = ""
+    peak_bytes: int = 0
+    oom_kills: int = 0
+
+
+@activity.defn
+@asyncify
+def check_sandbox_memory(input: CheckSandboxMemoryInput) -> CheckSandboxMemoryOutput:
+    """Read how close a sandbox is to its memory ceiling.
+
+    Never raises: the caller reacts to an unknown reading by backing off, and a probe that
+    fails must not retry into the run's critical path or fail the run.
+    """
+    try:
+        sandbox = get_sandbox_class().get_by_id(input.sandbox_id)
+        memory = sandbox.read_memory_usage()
+    except Exception as e:
+        logger.warning(
+            "check_sandbox_memory_failed",
+            sandbox_id=input.sandbox_id,
+            run_id=input.run_id,
+            error=str(e),
+        )
+        record_sandbox_memory_reading("unknown")
+        return CheckSandboxMemoryOutput()
+
+    if memory is None:
+        record_sandbox_memory_reading("unknown")
+        return CheckSandboxMemoryOutput()
+
+    record_sandbox_memory_reading(memory.level.value)
+    if memory.level is not MemoryPressureLevel.OK:
+        logger.info(
+            "sandbox_memory_pressure",
+            sandbox_id=input.sandbox_id,
+            run_id=input.run_id,
+            level=memory.level.value,
+            used_percent=memory.used_percent,
+            source=memory.source,
+            oom_kills=memory.oom_kills,
+        )
+        emit_agent_log(
+            input.run_id,
+            "debug",
+            f"Sandbox memory {memory.level.value}: {describe_memory_position(memory)}",
+        )
+
+    return CheckSandboxMemoryOutput(
+        level=memory.level.value,
+        used_bytes=memory.used_bytes,
+        limit_bytes=memory.limit_bytes,
+        used_percent=memory.used_percent,
+        position=describe_memory_position(memory),
+        top_processes=", ".join(
+            f"{process.name} ({format_memory_size(process.resident_bytes)})" for process in memory.top_processes
+        ),
+        source=memory.source,
+        peak_bytes=memory.peak_bytes or 0,
+        oom_kills=memory.oom_kills,
+    )

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -26,6 +26,7 @@ from products.tasks.backend.constants import (
     PR_LOOP_ENABLED_STATE_KEY,
     RTK_DISABLED_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
+    SANDBOX_MEMORY_GUARD_FEATURE_FLAG,
     SANDBOX_ROTATION_FEATURE_FLAG,
     get_vm_sandbox_flag_payload,
     is_same_run_resume_state,
@@ -115,6 +116,7 @@ class TaskProcessingContext:
     # deterministic for the full run.
     sandbox_event_ingest_enabled: bool = False
     sandbox_rotation_enabled: bool = False
+    sandbox_memory_guard_enabled: bool = False
     # Captured at workflow start so telemetry env injection (and the run-log mirror,
     # which reads the same state stamp) is deterministic for the full run.
     agent_otel_telemetry_enabled: bool = False
@@ -931,6 +933,31 @@ def _is_sandbox_rotation_enabled(
     return enabled
 
 
+def _is_sandbox_memory_guard_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+) -> bool:
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                SANDBOX_MEMORY_GUARD_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("sandbox_memory_guard_flag_check_failed", run_id=run_id, error=str(e))
+        return False
+
+    log_with_activity_context("sandbox_memory_guard_flag_checked", run_id=run_id, sandbox_memory_guard_enabled=enabled)
+    return enabled
+
+
 def _is_continue_as_new_enabled(
     *,
     distinct_id: str,
@@ -1365,6 +1392,11 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         use_modal_directory_resume_snapshots=sandbox_backend != "hogland",
         sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
         sandbox_rotation_enabled=_is_sandbox_rotation_enabled(
+            distinct_id=distinct_id,
+            organization_id=organization_id,
+            run_id=run_id,
+        ),
+        sandbox_memory_guard_enabled=_is_sandbox_memory_guard_enabled(
             distinct_id=distinct_id,
             organization_id=organization_id,
             run_id=run_id,

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -23,16 +23,23 @@ from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxConfig, SandboxStatus, SandboxTemplate
+from products.tasks.backend.logic.services.sandbox_memory import MemoryPressureLevel
 from products.tasks.backend.models import SandboxSnapshot
 from products.tasks.backend.temporal.babysit_pr.snapshot import BabysitJournal
 from products.tasks.backend.temporal.constants import (
     INACTIVITY_TIMEOUT_USER_SECONDS,
+    MAX_SANDBOX_MEMORY_NUDGES,
+    MAX_SANDBOX_MEMORY_PROBE_FAILURES,
+    SANDBOX_MEMORY_CHECK_INTERVAL,
+    SANDBOX_MEMORY_CHECK_INTERVAL_UNDER_PRESSURE,
+    SANDBOX_MEMORY_NUDGE_COOLDOWN,
     SANDBOX_TTL_SNAPSHOT_LEAD,
     WARM_IDLE_TIMEOUT,
 )
 from products.tasks.backend.temporal.process_task import workflow as process_task_workflow_module
 from products.tasks.backend.temporal.process_task.activities import (
     STEER_DECLINED_OUTCOME,
+    CheckSandboxMemoryOutput,
     CleanupSandboxInput,
     CompleteRunStreamInput,
     CreateSandboxForRepositoryInput,
@@ -2951,3 +2958,158 @@ class TestContinueAsNew:
         fake_info.is_continue_as_new_suggested.return_value = True
         monkeypatch.setattr(process_task_workflow_module.workflow, "info", lambda: fake_info)
         assert wf._should_continue_as_new("sb-1") is True
+
+
+class TestSandboxMemoryGuard:
+    """The guard warns a run that is filling its box, without becoming a stream of messages
+    the agent cannot act on, and without reaching a run whose flag is off."""
+
+    NOW = datetime(2026, 8, 28, 12, 0, tzinfo=UTC)
+
+    def _workflow(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        guard_enabled: bool = True,
+        clock: Callable[[], datetime] | None = None,
+    ) -> ProcessTaskWorkflow:
+        wf = ProcessTaskWorkflow()
+        wf._context = _build_context(github_integration_id=123)
+        wf._context.sandbox_memory_guard_enabled = guard_enabled
+        monkeypatch.setattr(process_task_workflow_module.workflow, "logger", Mock())
+        monkeypatch.setattr(process_task_workflow_module.workflow, "patched", Mock(return_value=True))
+        monkeypatch.setattr(process_task_workflow_module.workflow, "now", clock or (lambda: self.NOW))
+        return wf
+
+    @staticmethod
+    def _reading(level: str, *, used_percent: int = 95) -> CheckSandboxMemoryOutput:
+        return CheckSandboxMemoryOutput(
+            level=level,
+            used_bytes=15_000_000_000,
+            limit_bytes=16_000_000_000,
+            used_percent=used_percent,
+            position=f"15.0 GB of 16.0 GB ({used_percent}%)",
+            top_processes="dockerd (6.1 GB)",
+            source="meminfo",
+        )
+
+    @parameterized.expand(
+        [
+            ("flag_on", {}, True),
+            ("flag_off", {"guard_enabled": False}, False),
+            ("probing_given_up", {"probing_active": False}, False),
+        ]
+    )
+    def test_only_a_run_with_the_flag_on_probes_its_sandbox(
+        self, _name: str, overrides: dict[str, bool], expected: bool
+    ) -> None:
+        # parameterized.expand cannot receive pytest fixtures, so the patches are scoped here.
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            wf = self._workflow(monkeypatch, guard_enabled=overrides.get("guard_enabled", True))
+            wf._memory_probing_active = overrides.get("probing_active", True)
+
+            assert wf._sandbox_memory_check_scheduled() is expected
+
+    async def test_a_full_box_interrupts_the_agent_once_per_cooldown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clock = {"now": self.NOW}
+        wf = self._workflow(monkeypatch, clock=lambda: clock["now"])
+        monkeypatch.setattr(wf, "_emit_progress", AsyncMock())
+        monkeypatch.setattr(
+            wf, "_read_sandbox_memory", AsyncMock(return_value=self._reading(MemoryPressureLevel.CRITICAL))
+        )
+        send = AsyncMock(return_value=None)
+        monkeypatch.setattr(wf, "_deliver_memory_nudge", send)
+
+        await wf._handle_sandbox_memory_check("sb-1")
+        clock["now"] += SANDBOX_MEMORY_NUDGE_COOLDOWN / 2
+        await wf._handle_sandbox_memory_check("sb-1")
+
+        assert send.await_count == 1
+
+        clock["now"] += SANDBOX_MEMORY_NUDGE_COOLDOWN
+        await wf._handle_sandbox_memory_check("sb-1")
+
+        assert send.await_count == 2
+        assert send.await_args is not None
+        assert "nearly out of memory" in send.await_args.args[0]
+
+    async def test_a_box_that_stays_full_stops_getting_messages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clock = {"now": self.NOW}
+        wf = self._workflow(monkeypatch, clock=lambda: clock["now"])
+        monkeypatch.setattr(wf, "_emit_progress", AsyncMock())
+        monkeypatch.setattr(
+            wf, "_read_sandbox_memory", AsyncMock(return_value=self._reading(MemoryPressureLevel.CRITICAL))
+        )
+        send = AsyncMock(return_value=None)
+        monkeypatch.setattr(wf, "_deliver_memory_nudge", send)
+
+        for _ in range(MAX_SANDBOX_MEMORY_NUDGES + 2):
+            await wf._handle_sandbox_memory_check("sb-1")
+            clock["now"] += SANDBOX_MEMORY_NUDGE_COOLDOWN * 2
+
+        assert send.await_count == MAX_SANDBOX_MEMORY_NUDGES
+
+    @parameterized.expand(
+        [
+            ("healthy", MemoryPressureLevel.OK, SANDBOX_MEMORY_CHECK_INTERVAL),
+            # A run with a dev stack in it sits here for hours, so it keeps the cheap cadence.
+            ("watch_band", MemoryPressureLevel.WATCH, SANDBOX_MEMORY_CHECK_INTERVAL),
+            ("nearly_full", MemoryPressureLevel.WARNING, SANDBOX_MEMORY_CHECK_INTERVAL_UNDER_PRESSURE),
+        ]
+    )
+    async def test_only_real_pressure_shortens_the_gap_between_probes(
+        self, _name: str, level: str, expected: timedelta
+    ) -> None:
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            wf = self._workflow(monkeypatch)
+            monkeypatch.setattr(wf, "_emit_progress", AsyncMock())
+            monkeypatch.setattr(wf, "_read_sandbox_memory", AsyncMock(return_value=self._reading(level)))
+
+            await wf._handle_sandbox_memory_check("sb-1")
+
+            assert wf._memory_check_interval == expected
+            assert wf._memory_next_check_at == self.NOW + expected
+
+    async def test_a_sandbox_that_never_answers_stops_being_probed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        wf = self._workflow(monkeypatch)
+        monkeypatch.setattr(wf, "_read_sandbox_memory", AsyncMock(return_value=None))
+
+        for _ in range(MAX_SANDBOX_MEMORY_PROBE_FAILURES):
+            await wf._handle_sandbox_memory_check("sb-1")
+
+        assert wf._sandbox_memory_check_scheduled() is False
+
+    @parameterized.expand(
+        [
+            ("never_read", None, False),
+            ("healthy_when_last_read", MemoryPressureLevel.OK, False),
+            ("nearly_full_when_last_read", MemoryPressureLevel.WARNING, True),
+            ("full_when_last_read", MemoryPressureLevel.CRITICAL, True),
+        ]
+    )
+    def test_a_dead_sandbox_names_memory_only_when_the_last_reading_supports_it(
+        self, _name: str, level: str | None, expects_memory: bool
+    ) -> None:
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            wf = self._workflow(monkeypatch)
+            wf._last_memory_reading = self._reading(level) if level is not None else None
+
+            reason = wf._sandbox_gone_reason()
+
+            assert ("ran out of memory" in reason) is expects_memory
+
+    async def test_a_nudge_that_cannot_be_delivered_leaves_the_run_alone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        wf = self._workflow(monkeypatch)
+        monkeypatch.setattr(wf, "_emit_progress", AsyncMock())
+        monkeypatch.setattr(
+            process_task_workflow_module.workflow,
+            "execute_activity",
+            AsyncMock(side_effect=RuntimeError("sandbox unreachable")),
+        )
+        monkeypatch.setattr(process_task_workflow_module.workflow, "uuid4", Mock(return_value=uuid.uuid4()))
+
+        await wf._nudge_agent_about_memory(self._reading(MemoryPressureLevel.CRITICAL))
+
+        assert wf._task_completed is False
+        assert wf._completion_status == "completed"
+        assert wf._completion_error is None

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -20,6 +20,11 @@ from posthog.temporal.oauth import PosthogMcpScopes
 from products.tasks.backend.constants import DEV_STACK_IMAGE_NAME, SNAPSHOT_KIND_FILESYSTEM, is_same_run_resume_state
 from products.tasks.backend.error_telemetry import truncate_error_message
 from products.tasks.backend.logic.services.sandbox import is_public_sandbox_repo
+from products.tasks.backend.logic.services.sandbox_memory import (
+    MemoryPressureLevel,
+    build_memory_exhaustion_error,
+    build_memory_pressure_nudge,
+)
 from products.tasks.backend.temporal.babysit_pr.prompts import (
     MAX_RENDERED_COMMENTS,
     MAX_RENDERED_THREADS,
@@ -27,7 +32,7 @@ from products.tasks.backend.temporal.babysit_pr.prompts import (
 )
 from products.tasks.backend.temporal.babysit_pr.snapshot import AttentionSet, BabysitJournal, PRSnapshot
 from products.tasks.backend.temporal.create_snapshot.workflow import CreateSnapshotForRepositoryInput
-from products.tasks.backend.temporal.metrics import increment_pr_babysit_decision
+from products.tasks.backend.temporal.metrics import increment_pr_babysit_decision, increment_sandbox_memory_nudge
 from products.tasks.backend.temporal.patches import ci_follow_up_actionable_gate
 from products.tasks.backend.temporal.process_task.activities.get_pr_babysit_snapshot import (
     GetPrBabysitSnapshotInput,
@@ -39,6 +44,7 @@ from products.tasks.backend.temporal.process_task.activities.get_pr_context impo
     is_pr_actionable,
 )
 
+from .activities.check_sandbox_memory import CheckSandboxMemoryInput, CheckSandboxMemoryOutput, check_sandbox_memory
 from .activities.cleanup_sandbox import (
     CleanupSandboxInput,
     CompleteRunStreamInput,
@@ -288,6 +294,7 @@ class TaskEvent(StrEnum):
     SANDBOX_GONE = "sandbox_gone"
     QUOTA_RECHECK = "quota_recheck"
     SANDBOX_TTL_APPROACHING = "sandbox_ttl_approaching"
+    SANDBOX_MEMORY_CHECK = "sandbox_memory_check"
 
 
 class CIFollowUpDecision(StrEnum):
@@ -310,8 +317,13 @@ from products.tasks.backend.temporal.constants import (  # noqa: E402
     DEFAULT_CI_MESSAGE,
     INACTIVITY_TIMEOUT,
     MAX_CI_REPETITIONS,
+    MAX_SANDBOX_MEMORY_NUDGES,
+    MAX_SANDBOX_MEMORY_PROBE_FAILURES,
     PENDING_MESSAGE_FORWARD_TIMEOUT_SECONDS,
     RELAY_SANDBOX_EVENTS_START_TO_CLOSE_TIMEOUT,
+    SANDBOX_MEMORY_CHECK_INTERVAL,
+    SANDBOX_MEMORY_CHECK_INTERVAL_UNDER_PRESSURE,
+    SANDBOX_MEMORY_NUDGE_COOLDOWN,
     SANDBOX_TTL_SNAPSHOT_LEAD,
     SEND_STEER_SIGNAL,
     STEERING_PROTOCOL_QUERY,
@@ -411,6 +423,11 @@ _PATCH_ID_FOLLOWUP_FAILURE_KEEPS_RUN = "tasks-followup-failure-keeps-run"
 
 _PATCH_ID_DEV_STACK_PREVIEW = "tasks-dev-stack-preview"
 
+# Gates the memory guard: a new Timer in `_wait_for_event`, the probe activity behind it,
+# and the message it sends the agent. Pre-rollout histories schedule none of them, so their
+# replays stay command-for-command identical. Same two-step cleanup lifecycle as above.
+_PATCH_ID_SANDBOX_MEMORY_GUARD = "tasks-sandbox-memory-guard"
+
 # `Task.OriginProduct.ONBOARDING`, mirrored as a literal so workflow code stays free of
 # Django model imports.
 _ONBOARDING_ORIGIN_PRODUCT = "onboarding"
@@ -507,6 +524,17 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         self._self_driving_quota_next_check_at: Optional[datetime] = None
         self._self_driving_quota_checks_active: bool = True
         self._current_slack_relay_workflow_id: Optional[str] = None
+        # Memory guard. Deadline-based for the same reason as the quota recheck above, and
+        # for a sharper one: an agent mid-turn heartbeats every few seconds, which is when
+        # the box is most likely to be filling up.
+        self._memory_next_check_at: Optional[datetime] = None
+        self._memory_check_interval: timedelta = SANDBOX_MEMORY_CHECK_INTERVAL
+        self._memory_probe_failures: int = 0
+        self._memory_probing_active: bool = True
+        self._memory_nudges_sent: int = 0
+        self._last_memory_nudge_at: Optional[datetime] = None
+        self._memory_warning_reported: bool = False
+        self._last_memory_reading: Optional[CheckSandboxMemoryOutput] = None
 
     @property
     def context(self) -> TaskProcessingContext:
@@ -781,6 +809,172 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             await workflow.sleep(remaining.total_seconds())
         return TaskEvent.QUOTA_RECHECK
 
+    def _sandbox_memory_check_scheduled(self) -> bool:
+        """Whether this run still watches how much memory its sandbox has left.
+
+        Both gates matter. The context field comes from recorded activity output, so a run
+        that started before the field existed decodes ``False`` and never schedules the
+        timer. The patch marker covers the same case for an execution whose recorded
+        context predates the field entirely.
+        """
+        return (
+            self._memory_probing_active
+            and self._context is not None
+            and self._context.sandbox_memory_guard_enabled
+            and workflow.patched(_PATCH_ID_SANDBOX_MEMORY_GUARD)
+        )
+
+    async def _wait_for_memory_check(self) -> TaskEvent:
+        if self._memory_next_check_at is None:
+            self._memory_next_check_at = workflow.now() + self._memory_check_interval
+        remaining = self._memory_next_check_at - workflow.now()
+        if remaining.total_seconds() > 0:
+            await workflow.sleep(remaining.total_seconds())
+        return TaskEvent.SANDBOX_MEMORY_CHECK
+
+    async def _handle_sandbox_memory_check(self, sandbox_id: str | None) -> None:
+        """Act on one memory reading, then set when the next one is due.
+
+        A reading nobody could take counts as unknown, not healthy: a box that has started
+        to die answers slowly or not at all.
+        """
+        self._memory_next_check_at = workflow.now() + self._memory_check_interval
+        if sandbox_id is None:
+            return
+
+        reading = await self._read_sandbox_memory(sandbox_id)
+        if reading is None:
+            self._memory_probe_failures += 1
+            if self._memory_probe_failures >= MAX_SANDBOX_MEMORY_PROBE_FAILURES:
+                self._memory_probing_active = False
+                workflow.logger.info(
+                    "sandbox_memory_probing_stopped",
+                    extra={"run_id": self.context.run_id, "sandbox_id": sandbox_id},
+                )
+            return
+
+        self._memory_probe_failures = 0
+        self._last_memory_reading = reading
+        # Only from WARNING up. A box holding steady in the WATCH band is normal for a run
+        # with a dev stack in it, and probing that every 15 seconds for hours buys nothing.
+        under_pressure = reading.level in (MemoryPressureLevel.WARNING, MemoryPressureLevel.CRITICAL)
+        self._memory_check_interval = (
+            SANDBOX_MEMORY_CHECK_INTERVAL_UNDER_PRESSURE if under_pressure else SANDBOX_MEMORY_CHECK_INTERVAL
+        )
+        self._memory_next_check_at = workflow.now() + self._memory_check_interval
+
+        if reading.level == MemoryPressureLevel.CRITICAL:
+            await self._nudge_agent_about_memory(reading)
+        elif reading.level == MemoryPressureLevel.WARNING and not self._memory_warning_reported:
+            # Once per run. The person watching gets told the box is filling up, while the
+            # agent is left alone until the reading is bad enough to interrupt it.
+            self._memory_warning_reported = True
+            await self._emit_progress(
+                step="sandbox_memory",
+                status="in_progress",
+                label="Memory is running high",
+                group="sandbox-memory",
+                detail=(
+                    f"This sandbox is using {reading.position}. Heavy work like a full local dev "
+                    "stack can use up the rest and stop the run."
+                ),
+            )
+
+    async def _read_sandbox_memory(self, sandbox_id: str) -> CheckSandboxMemoryOutput | None:
+        """One probe, or None when the sandbox gave no usable answer.
+
+        A single attempt on purpose. The next tick is the retry, and it carries a fresher
+        reading than a retry of this one would.
+        """
+        try:
+            reading = await workflow.execute_activity(
+                check_sandbox_memory,
+                CheckSandboxMemoryInput(sandbox_id=sandbox_id, run_id=self.context.run_id),
+                start_to_close_timeout=timedelta(seconds=30),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        except Exception as e:
+            workflow.logger.warning(
+                "sandbox_memory_check_failed",
+                extra={"run_id": self.context.run_id, "sandbox_id": sandbox_id, "error": str(e)},
+            )
+            return None
+        return reading if reading.limit_bytes > 0 else None
+
+    async def _nudge_agent_about_memory(self, reading: CheckSandboxMemoryOutput) -> None:
+        """Interrupt the agent so it can free memory before the sandbox is killed for using it all.
+
+        Sent as a steer, so it reaches the turn that is filling the box instead of queueing
+        behind it. A steer the agent declines is dropped: the next tick still sees the
+        pressure and tries again once the cooldown has passed.
+        """
+        if self._memory_nudges_sent >= MAX_SANDBOX_MEMORY_NUDGES:
+            increment_sandbox_memory_nudge("capped")
+            return
+        if (
+            self._last_memory_nudge_at is not None
+            and workflow.now() - self._last_memory_nudge_at < SANDBOX_MEMORY_NUDGE_COOLDOWN
+        ):
+            increment_sandbox_memory_nudge("cooldown")
+            return
+
+        self._last_memory_nudge_at = workflow.now()
+        self._memory_nudges_sent += 1
+        workflow.logger.warning(
+            "sandbox_memory_critical",
+            extra={
+                "run_id": self.context.run_id,
+                "used_percent": reading.used_percent,
+                "source": reading.source,
+                "top_processes": reading.top_processes,
+                "nudges_sent": self._memory_nudges_sent,
+            },
+        )
+        await self._emit_progress(
+            step="sandbox_memory",
+            status="in_progress",
+            label="This sandbox is nearly out of memory",
+            group="sandbox-memory",
+            detail=(
+                f"It is using {reading.position}. The agent has been asked to free some up. "
+                "If the sandbox runs out, the run stops."
+            ),
+        )
+        increment_sandbox_memory_nudge("dispatched")
+        await self._deliver_memory_nudge(
+            build_memory_pressure_nudge(position=reading.position, top_processes=reading.top_processes)
+        )
+
+    async def _deliver_memory_nudge(self, message: str) -> None:
+        """Send the nudge without going through `_send_followup_to_sandbox`.
+
+        That path terminalizes a background run when delivery fails, which is right for a
+        user message and wrong here: a warning that could not be delivered must not end an
+        otherwise healthy run. One attempt, because the next probe supersedes this message.
+        """
+        try:
+            await workflow.execute_activity(
+                send_followup_to_sandbox,
+                SendFollowupToSandboxInput(
+                    run_id=self.context.run_id,
+                    message=message,
+                    posthog_mcp_scopes=self._posthog_mcp_scopes,
+                    artifact_ids=[],
+                    message_id=str(workflow.uuid4()),
+                    steer=True,
+                    max_attempts=1,
+                ),
+                start_to_close_timeout=timedelta(minutes=10),
+                heartbeat_timeout=timedelta(minutes=1),
+                retry_policy=RetryPolicy(maximum_attempts=1),
+            )
+        except Exception as e:
+            increment_sandbox_memory_nudge("delivery_failed")
+            workflow.logger.warning(
+                "sandbox_memory_nudge_delivery_failed",
+                extra={"run_id": self.context.run_id, "error": str(e)},
+            )
+
     def _describe_wait(self, *, warm_idle: bool, ci_follow_up_scheduled: bool, inactivity_timeout: timedelta) -> str:
         """Human-readable summary of what the loop is blocked on, for the Temporal UI.
 
@@ -852,6 +1046,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 possible_events.append(asyncio.create_task(self._wait_for_max_run_duration(max_run_duration)))
         if self._sandbox_deadline_snapshot_scheduled():
             possible_events.append(asyncio.create_task(self._wait_for_sandbox_deadline()))
+        if self._sandbox_memory_check_scheduled():
+            possible_events.append(asyncio.create_task(self._wait_for_memory_check()))
         if ci_follow_up_scheduled:
             possible_events.append(asyncio.create_task(self._wait_for_ci_follow_up()))
         if not warm_idle and self._self_driving_quota_recheck_scheduled():
@@ -1342,6 +1538,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                             reason=rotation_reason,
                             duration=workflow.now() - deadline_started_at,
                         )
+                    case TaskEvent.SANDBOX_MEMORY_CHECK:
+                        await self._handle_sandbox_memory_check(sandbox_id)
                     case TaskEvent.QUOTA_RECHECK:
                         self._self_driving_quota_next_check_at = workflow.now() + SELF_DRIVING_QUOTA_RECHECK_INTERVAL
                         try:
@@ -2605,9 +2803,21 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         # A sandbox that vanished mid-setup is a failed setup for onboarding; see
         # _onboarding_exit_is_failure for why a run that already opened its PR is exempt.
         self._completion_status = "failed" if self._onboarding_exit_is_failure() else "completed"
-        self._completion_error = SANDBOX_GONE_ERROR_MESSAGE
+        self._completion_error = self._sandbox_gone_reason()
         self._completion_timeout_marker = SANDBOX_GONE_STATE_KEY
         self._task_completed = True
+
+    def _sandbox_gone_reason(self) -> str:
+        """Why the sandbox stopped, as far as the run can tell.
+
+        A dead box cannot be asked, so the last reading stands in for the cause. Naming
+        memory when the box was nearly full is worth more to whoever reads the run than the
+        generic message, and the wording says "most likely" because the run is inferring it.
+        """
+        reading = self._last_memory_reading
+        if reading is None or reading.level not in (MemoryPressureLevel.WARNING, MemoryPressureLevel.CRITICAL):
+            return SANDBOX_GONE_ERROR_MESSAGE
+        return build_memory_exhaustion_error(position=reading.position)
 
     async def _rotate_sandbox_before_deadline(
         self,


### PR DESCRIPTION
## Problem

A cloud run whose sandbox exhausts its memory dies with no explanation: the run ends mid-turn, and the person who opens it sees only "Sandbox stopped; resume to continue".

- Starting a full dev stack inside a run is the usual way to get there.
- The agent gets no signal, so it cannot stop the process, commit its work, or say what happened.
- Nothing in the run records memory, so diagnosing one afterwards means guessing from the transcript.

## Changes

The riskiest part is the workflow change; everything else is additive. All of it sits behind `tasks-cloud-run-sandbox-memory-guard` and is inert when the flag is off.

- A run at 85% memory shows a progress step saying the box is filling up. The agent is not interrupted.
- A run at 93% steers the agent with its memory position and largest processes, telling it to free memory before the box is killed. At most 3 per run, 5 minutes apart.
- A sandbox that stops after a reading at 85% or above reports memory as the likely cause instead of the generic message.
- `check_sandbox_memory` reads the cgroup ceiling in one exec, and falls back to `/proc/meminfo` when the cgroup is unlimited. That fallback is the whole point on VM runtimes, which have no cgroup ceiling and are where a dev stack runs.
- The probe runs once a minute, and every 15 seconds only from 85% up. A run with a dev stack in it sits in the 70-85% band for hours, so tightening the cadence there would buy nothing and cost an exec every 15 seconds.
- The nudge bypasses `_send_followup_to_sandbox` and swallows its own delivery failure. That path terminalizes a background run when delivery fails, which is right for a user message and wrong for a warning.
- The timer is deadline-based rather than restarted per loop pass. `_wait_for_event` rebuilds its timers on every signal, and an agent mid-turn heartbeats every few seconds, so a per-pass timer would be starved exactly when the box is filling.
- Mechanical: activity registration, two metrics, the feature flag constant, and a context field.

The guard cannot resize a live sandbox, so the message tells the agent to save its work and say what it needs. Restarting with a `sandbox_resources` override stays the way to get a bigger box.

Nothing changes for a run whose flag is off: the new timer is never scheduled, and the sandbox-gone message is byte-identical.

> [!NOTE]
> The new workflow commands sit behind `workflow.patched("tasks-sandbox-memory-guard")` and a context field defaulting to `False`, so in-flight executions replay command-for-command. Standard two-step patch cleanup applies.

This is an early warning, not a guarantee. It catches the slow ramps (docker pulls, a service boot, a large install) and reliably attributes the fast ones. A box that goes from healthy to dead between two probes still dies, but the run now names the cause.

## How did you test this code?

Automated, all new:

- `parse_memory_probe` cases in `test_sandbox_memory.py` catch the guard silently never firing. A container must prefer its cgroup ceiling over the host total that `/proc/meminfo` reports, and a VM must fall back to that total when the cgroup says `max`. Getting either backwards reads a healthy number forever.
- Threshold cases pin each boundary as inclusive. A flipped comparison either never interrupts an agent or interrupts every run.
- `TestSandboxMemoryGuard` covers the loop behavior: the flag gate, one nudge per cooldown, the per-run cap, giving up on a sandbox that never answers, and the cadence staying cheap in the watch band.
- One case covers the delivery-failure path found while writing this. Before the fix, a nudge that could not be delivered failed an otherwise healthy background run.

Verified locally against Postgres, ClickHouse, Redis, Kafka and object storage: `products/tasks/backend/temporal/process_task/tests/` and `products/tasks/backend/logic/services/tests/` pass, along with repo-wide mypy and `ci:preflight`.

The probe command itself was run against a real sandbox (this one), which reported `1.2 GB of 15.6 GB (8%)` from the `meminfo` source, the VM path.

Not checked: no run was executed end to end against Modal, so the steer has not been observed landing in a live agent turn. The rollout should start on one org and watch `tasks_process_sandbox_memory_nudge` before widening.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/published/handbook/engineering/ai/sandboxed-agents.md` gains a "Memory guard" section under Code execution.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with the PostHog Slack app (Claude Opus). Skills invoked: `/writing-dataclasses`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.

Two decisions worth flagging for review. The probe started as an in-sandbox sampler modelled on `cpu_billing_sampler.py`, but `memory.events` and `/proc/meminfo` already give the kernel's own numbers, so a single exec replaced it and dropped the image-rebuild dependency. `memory.peak` is read and logged but deliberately never drives a threshold: the kernel measures it from boot, so a build that already finished would hold a healthy box above the line for the rest of the run.

The thread that prompted this also discussed moving the agent harness outside the sandbox entirely. That is a much larger change and is not attempted here.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787906631739279?thread_ts=1787906631.739279&cid=C09G8Q32R6F)*
