### PR TITLE
fix(clerk): stop failing the invitations sync on a 404 not-found

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
@@ -42,7 +42,15 @@ CLERK_ENDPOINTS: dict[str, ClerkEndpointConfig] = {
     "organization_memberships": ClerkEndpointConfig(
         name="organization_memberships", path="/organization_memberships", is_wrapped_response=True
     ),
-    "invitations": ClerkEndpointConfig(name="invitations", path="/invitations"),
+    "invitations": ClerkEndpointConfig(
+        name="invitations",
+        path="/invitations",
+        # Clerk answers 404 resource_not_found for the invitations list on instances where the
+        # resource isn't available — the same feature-off signal the domains and OAuth applications
+        # endpoints give. A 404 can't coexist with real data (that returns 200 with an array), so
+        # skip zero rows instead of failing the schema every run.
+        gated_feature="Invitations",
+    ),
     "sessions": ClerkEndpointConfig(
         name="sessions",
         path="/sessions",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -526,6 +526,8 @@ class TestClerkFeatureGatedEndpoints:
             ("domains", 404, {"errors": [{"code": "resource_not_found"}]}),
             # Organizations off: the invitations list answers the same 404 resource_not_found.
             ("organization_invitations", 404, {"errors": [{"code": "resource_not_found"}]}),
+            # Invitations unavailable: the list answers the same 404 resource_not_found.
+            ("invitations", 404, {"errors": [{"code": "resource_not_found"}]}),
         ],
     )
     def test_feature_not_enabled_syncs_no_rows_instead_of_failing(


### PR DESCRIPTION
## Problem

Teams syncing the Clerk `invitations` table saw the whole schema fail on every scheduled run when their Clerk instance answers the invitations list with `404 resource_not_found`. Each run burned a failed job and left the table in an error state with a raw HTTP 404 as the recorded error.

Clerk returns this 404 on instances where the invitations resource isn't available. It is deterministic — the same request re-fails every schedule — and it can't coexist with real data, since a populated list returns 200 with an array.

## Changes

- The `invitations` table now syncs zero rows and logs a warning instead of failing the schema when Clerk answers 404 `resource_not_found`.
- Mechanism: the endpoint gets the existing `gated_feature` flag, so the shared `_skip_when_feature_disabled` handler catches the 404 — the same handling already used for `organization_invitations`, `domains`, and OAuth applications.

## How did you test this code?

- Added one case to `TestClerkFeatureGatedEndpoints.test_feature_not_enabled_syncs_no_rows_instead_of_failing` for the plain `invitations` 404 `resource_not_found`. It catches the regression where dropping the flag makes the endpoint fail the schema again; no existing case covered plain invitations.
- Ran that test class locally, all cases pass. Not run: the full warehouse_sources suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found during a triage pass over data-warehouse sync failure classes; the Clerk invitations 404 stood out as a deterministic per-endpoint gap already solved for sibling endpoints. The failure data came from that triage; the committed test body is generic (`{"errors": [{"code": "resource_not_found"}]}`, matching existing cases) and carries no customer values.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Chose the existing `gated_feature` mechanism over a non-retryable-error mapping: the 404 can't coexist with real data, so syncing zero rows keeps the schema enabled and self-heals if the resource becomes available, rather than disabling the customer's table.
