### PR TITLE
fix(notifications): keep the save bar above the rows it covers

### DIFF
--- a/frontend/src/scenes/settings/organization/NotificationGovernanceSetting.tsx
+++ b/frontend/src/scenes/settings/organization/NotificationGovernanceSetting.tsx
@@ -83,7 +83,7 @@ function MemberNotifications(): JSX.Element {
             ))}
 
             {pendingChangeCount > 0 && (
-                <div className="sticky bottom-0 flex items-center justify-between gap-2 border rounded p-3 bg-surface-primary">
+                <div className="sticky bottom-0 z-10 flex items-center justify-between gap-2 border rounded p-3 bg-surface-primary">
                     <span className="text-sm">
                         {pluralize(pendingChangeCount, 'change')} pending for {pluralize(affectedMemberCount, 'member')}
                     </span>


### PR DESCRIPTION
## Problem

An admin scrolling the member notifications list sees member rows drawn on top of the pending-changes bar, obscuring Discard and Save.

## Changes

- The pending-changes bar now stays above the rows that scroll behind it.
- Cause: segmented buttons are flex items carrying `z-index: 2`, which applies at `position: static`. The bar was `position: sticky` with no `z-index`, so every row won the paint order. It now sits at `z-10`, matching the sticky footer in `QuestionInput`.

No screenshot: the surface is flag-gated and the overlap did not reproduce at the viewport height available here. The visual review baseline for this page covers the rendered result.

## How did you test this code?

Measured the computed stacking on the live page in a local stack: the bar resolved to `z-index: auto` while `.LemonSegmentedButton__option` resolved to `2`, then to `10` versus `2` after the change.

No test added. The regression is a paint-order rule with no behavior to assert through the public interface, and the snapshot that would catch it is the visual review baseline.

Not reproduced by scrolling: the browser available here had a 387px viewport, where the bar and the rows never overlapped. The stacking measurement is what establishes the cause and the fix.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills invoked: `/writing-ui-components`, `/writing-tests`, `/creating-pull-requests`.

Follow-up to #85987, from a screenshot of the shipped surface. The first hypothesis was a plain missing `z-index` on a sticky element; measuring the real elements showed the specific competitor is the segmented button's own `z-index: 2`, which is why only rows containing one overlapped.
