### PR TITLE
fix(google_ads): default report tables to segments.date incremental field

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -608,7 +608,12 @@ def google_ads_source(
     # incremental pipeline persists a cursor between runs, and the bounded windowed drain below is
     # only sound when it does.
     pipeline_is_incremental = should_use_incremental_field
-    if table.requires_filter and not should_use_incremental_field:
+    # Report tables can only ever be windowed by segments.date, so force it here — both when a
+    # full-refresh schema reaches the incremental path, and when a schema flagged incremental
+    # arrives without an incremental field (a config that would otherwise crash the drain below).
+    if table.requires_filter and (
+        not should_use_incremental_field or incremental_field is None or incremental_field_type is None
+    ):
         should_use_incremental_field = True
         incremental_field = "segments.date"
         incremental_field_type = IncrementalFieldType.Date

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -587,6 +587,20 @@ def _single_row_table() -> GoogleAdsTable:
     )
 
 
+def _stats_table() -> GoogleAdsTable:
+    # A report table (requires_filter=True) whose only incremental field is ever segments.date.
+    return GoogleAdsTable(
+        name="campaign_stats",
+        alias="campaign_stats",
+        columns=[_string_column("campaign.id"), _string_column("segments.date")],
+        parents=None,
+        requires_filter=True,
+        primary_key=["campaign.id", "segments.date"],
+        should_sync_default=True,
+        description=None,
+    )
+
+
 def _single_page() -> SimpleNamespace:
     return SimpleNamespace(
         field_mask=SimpleNamespace(paths=["campaign.name"]),
@@ -1845,6 +1859,37 @@ class TestVersionDeclaration:
         # A present pin is honored verbatim so an existing v23/v24 source is never silently moved; an
         # empty/missing pin falls back to the new v25 default that new sources are stamped with.
         assert GoogleAdsSource().resolve_api_version(pin) == expected
+
+
+class TestReportTableMissingIncrementalField:
+    def test_incremental_report_table_without_incremental_field_defaults_to_segments_date(self):
+        # A report table's schema can arrive flagged incremental but with no incremental field
+        # (a config inconsistency). Its only valid field is always segments.date, so the sync must
+        # default to it and run rather than crashing with "incremental_field ... can't be None".
+        table = _stats_table()
+        assert table.alias is not None
+        config = GoogleAdsSourceConfig(customer_id="1234567890", google_ads_integration_id=1)
+        with (
+            mock.patch(f"{_GOOGLE_ADS_MODULE}.get_schemas", return_value={table.alias: table}),
+            mock.patch(f"{_GOOGLE_ADS_MODULE}.google_ads_client", return_value=mock.Mock()),
+            mock.patch(f"{_GOOGLE_ADS_MODULE}._search_as_arrow_tables", return_value=iter([])) as search,
+        ):
+            response = google_ads_source(
+                config,
+                table.alias,
+                team_id=1,
+                resumable_source_manager=mock.Mock(),
+                api_version="v25",
+                should_use_incremental_field=True,
+                incremental_field=None,
+                incremental_field_type=None,
+                db_incremental_field_last_value=dt.date.today(),
+            )
+            list(typing.cast(collections.abc.Iterable, response.items()))
+
+        # The windowed drain ran (no crash) and queried on the defaulted segments.date field.
+        assert search.call_count >= 1
+        assert "segments.date" in search.call_args_list[0].args[2]
 
 
 class TestApiVersionDispatch:


### PR DESCRIPTION
## Problem

- A Google Ads sync of a report table crashed with `ValueError: incremental_field and incremental_field_type can't be None`, so the schema imported no rows. It hit 14 teams in a burst.
- The report table's schema was flagged incremental (`should_use_incremental_field=True`) but arrived with no incremental field. That state reached the windowed drain in `google_ads_source` with both `incremental_field` and `incremental_field_type` still `None`, and the guard there raised.
- Error tracking issue: https://us.posthog.com/project/2/error_tracking/01a04802-2b9d-7e83-946c-adf7c9205030

## Changes

- A report table that reaches the sync without an incremental field now imports on `segments.date` instead of failing the run.
- Report tables (`requires_filter`) can only ever be windowed by `segments.date`. The code already forces that field onto a full-refresh schema; this extends the same default to an incremental schema that arrives without the field.
- The `None`/`None` guard stays for tables that are not report tables, where no valid default exists.

## How did you test this code?

- Added `TestReportTableMissingIncrementalField` in `test_google_ads_source.py`: it drives `google_ads_source` for a `requires_filter` table with `should_use_incremental_field=True` and `incremental_field=None`, then asserts the drain runs and queries on `segments.date`. Reverting the fix reproduces the original `ValueError` at the raise site, so the test catches this regression, which no existing test did.
- Ran the source's full test file locally; CI reports the counts.
- Not run: the database-backed and Temporal end-to-end suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error tracking webhook. Read the stack trace and the `google_ads` source, confirmed the raise originates in `google_ads.py`, and traced the `should_use_incremental_field=True` / `incremental_field=None` state back through `SourceInputs` to the schema config.
- Decision: fixable bug, not a user or upstream error. For report tables the incremental field is never user-chosen (`filter_field_names` is always `segments.date`), so defaulting is correct rather than swallowing a real problem.
- Skills invoked: /writing-tests, /writing-pr-descriptions.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
