### PR TITLE
fix(deletions): run person deletions when no overrides are pending

### DIFF
--- a/posthog/dags/deletes.py
+++ b/posthog/dags/deletes.py
@@ -2,7 +2,7 @@ import abc
 import time
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 
 from django.conf import settings
 from django.db.models import Q
@@ -451,13 +451,25 @@ class AdhocEventDeletesDictionary(Dictionary):
 def get_oldest_person_override_timestamp(
     cluster: dagster.ResourceParam[ClickhouseCluster],
 ) -> datetime:
-    """Get the oldest person override timestamp from the person_distinct_id_overrides table."""
+    """The oldest override still waiting to be squashed, which bounds how recent a person deletion may be.
+
+    With none waiting, no later squash can rewrite rows onto a person this run deletes, so every
+    request is safe and the bound is now.
+
+    ``minOrNull`` rather than ``min``: over an empty table ``min`` returns the DateTime default,
+    1970-01-01, and that reads as a bound admitting no person deletion at all rather than all of
+    them. The run stays green, the requests keep their null delete_verified_at, and nothing says
+    they were skipped.
+    """
 
     query = f"""
-    SELECT min(_timestamp) FROM {PERSON_DISTINCT_ID_OVERRIDES_TABLE}
+    SELECT minOrNull(_timestamp) FROM {PERSON_DISTINCT_ID_OVERRIDES_TABLE}
     """
-    [[result]] = cluster.any_host_by_role(lambda client: client.execute(query), NodeRole.DATA).result()
-    return result
+    [[oldest]] = cluster.any_host_by_role(lambda client: client.execute(query), NodeRole.DATA).result()
+    if oldest is not None:
+        return oldest
+    # Naive UTC, matching what ClickHouse hands back for the non-empty case.
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 @dagster.op

--- a/posthog/dags/tests/test_deletes.py
+++ b/posthog/dags/tests/test_deletes.py
@@ -781,3 +781,53 @@ def test_a_rerun_stages_over_the_previous_runs_object(cluster: ClickhouseCluster
     finally:
         cluster.any_host(dictionary.drop).result()
         cluster.any_host(table.drop).result()
+
+
+@pytest.mark.django_db
+def test_person_deletes_run_when_no_overrides_are_pending(cluster: ClickhouseCluster):
+    # deletes_job runs off the squash succeeding, and the squash deletes the overrides it applied,
+    # so an empty overrides table is an ordinary state. The bound is derived from that table, and
+    # min() over an empty one answers 1970-01-01, which excludes every person deletion instead of
+    # admitting them all. The run stays green either way, so nothing surfaces the skip.
+    team_id = 424244
+    deleted_person = UUID(int=21)
+    surviving_person = UUID(int=22)
+    # Comfortably in the past: the bound with no overrides is "now", and the request has to predate
+    # it by more than any clock skew between the test's naive local time and ClickHouse's UTC.
+    requested_at = datetime.now() - timedelta(days=1)
+
+    def insert_events(client: Client) -> None:
+        client.execute(
+            "INSERT INTO writable_events (team_id, distinct_id, person_id, timestamp) VALUES",
+            [
+                (team_id, "a", deleted_person, requested_at - timedelta(days=1)),
+                (team_id, "b", surviving_person, requested_at - timedelta(days=1)),
+            ],
+        )
+
+    def surviving_person_ids(client: Client) -> set[UUID]:
+        rows = client.execute(
+            "SELECT DISTINCT person_id FROM events WHERE team_id = %(team_id)s AND _row_exists = 1",
+            {"team_id": team_id},
+        )
+        return {row[0] for row in rows}
+
+    cluster.any_host(insert_events).result()
+
+    deletion = AsyncDeletion.objects.create(
+        team_id=team_id,
+        deletion_type=DeletionType.Person,
+        key=str(deleted_person),
+        delete_verified_at=None,
+    )
+    deletion.created_at = requested_at
+    deletion.save()
+
+    # No overrides inserted: person_distinct_id_overrides is empty for this run.
+    assert cluster.any_host(surviving_person_ids).result() == {deleted_person, surviving_person}
+
+    deletes_job.execute_in_process(resources={"cluster": cluster})
+
+    assert cluster.any_host(surviving_person_ids).result() == {surviving_person}
+    deletion.refresh_from_db()
+    assert deletion.delete_verified_at is not None


### PR DESCRIPTION
## Problem

`deletes_job` skips every person deletion whenever `person_distinct_id_overrides` is empty, and reports a green run.

The bound on how recent a person deletion may be comes from the oldest override still waiting to be squashed:

```python
SELECT min(_timestamp) FROM person_distinct_id_overrides
```

`_timestamp` is `DateTime`, not `Nullable`, so `min()` over an empty set returns the type default:

```
SELECT min(_timestamp) FROM posthog.person_distinct_id_overrides WHERE 1=0
→ 1970-01-01 00:00:00
```

That value goes straight into the Postgres filter, where it matches nothing:

```python
Q(deletion_type=DeletionType.Person, created_at__lte=create_pending_deletions_table.timestamp)
| Q(deletion_type=DeletionType.Team)
```

Team deletions still run, since they carry no bound. Person deletions are dropped, the requests keep a null `delete_verified_at`, and nothing records that they were skipped.

An empty table is not an edge case here. `deletes_job` runs off the squash succeeding, and the squash deletes the overrides it just applied.

## Changes

- `minOrNull` instead of `min`, so an empty table is `None` rather than the epoch.
- `None` means nothing is pending, so no later squash can rewrite rows onto a person this run deletes. Every request is safe and the bound becomes now.

The bound's purpose is unchanged for every other case: with overrides pending, the oldest one still caps which requests this run may act on.

## How did you test this code?

- `test_person_deletes_run_when_no_overrides_are_pending` runs the job with the overrides table empty and asserts the person's events are gone and the request is marked verified. I reverted the fix and confirmed the test fails without it, so it is pinned to this behavior rather than passing incidentally.
- The existing `deletes_job` suite passes unchanged, including `test_full_job_person_deletes`, which inserts overrides specifically to establish the bound.
- `mypy --cache-fine-grained .` reports nothing in the files this PR touches.

## Automatic notifications

- [ ] Publish to changelog?

Internal deletion machinery with no user-visible behavior, so no changelog entry.

## Docs update

None. The bound is described where it is computed, and its behavior with overrides pending is unchanged.
