### PR TITLE
feat(conversations): make widget ticket recovery text customizable

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -775,6 +775,8 @@ export interface ConversationsSettings {
     widget_identification_form_title?: string
     widget_identification_form_description?: string
     widget_placeholder_text?: string
+    widget_ticket_recovery_text?: string
+    widget_ticket_recovery_link_text?: string
     widget_position?: 'bottom_left' | 'bottom_right' | 'top_left' | 'top_right'
     slack_enabled?: boolean
     slack_team_id?: string | null

--- a/posthog/models/remote_config.py
+++ b/posthog/models/remote_config.py
@@ -301,6 +301,9 @@ class RemoteConfig(UUIDTModel):
                 "identificationFormDescription": conv_settings.get("widget_identification_form_description")
                 or "Please provide your details so we can help you better.",
                 "placeholderText": conv_settings.get("widget_placeholder_text") or "Type your message...",
+                "ticketRecoveryText": conv_settings.get("widget_ticket_recovery_text")
+                or "Don't see your previous tickets?",
+                "ticketRecoveryLinkText": conv_settings.get("widget_ticket_recovery_link_text") or "Recover them here",
                 "widgetPosition": conv_settings.get("widget_position") or "bottom_right",
             }
         else:

--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -194,6 +194,8 @@ class TestRemoteConfig(_RemoteConfigBase):
             == "Please provide your details so we can help you better."
         )
         assert self.remote_config.config["conversations"]["placeholderText"] == "Type your message..."
+        assert self.remote_config.config["conversations"]["ticketRecoveryText"] == "Don't see your previous tickets?"
+        assert self.remote_config.config["conversations"]["ticketRecoveryLinkText"] == "Recover them here"
 
     def test_conversations_enabled_with_custom_config(self):
         self.team.conversations_enabled = True
@@ -209,6 +211,8 @@ class TestRemoteConfig(_RemoteConfigBase):
             "widget_identification_form_title": "Let's get started",
             "widget_identification_form_description": "Tell us about yourself",
             "widget_placeholder_text": "Ask away...",
+            "widget_ticket_recovery_text": "Missing your tickets?",
+            "widget_ticket_recovery_link_text": "Restore access",
         }
         self.team.save()
         self.sync_remote_config()
@@ -223,6 +227,8 @@ class TestRemoteConfig(_RemoteConfigBase):
         assert self.remote_config.config["conversations"]["identificationFormTitle"] == "Let's get started"
         assert self.remote_config.config["conversations"]["identificationFormDescription"] == "Tell us about yourself"
         assert self.remote_config.config["conversations"]["placeholderText"] == "Ask away..."
+        assert self.remote_config.config["conversations"]["ticketRecoveryText"] == "Missing your tickets?"
+        assert self.remote_config.config["conversations"]["ticketRecoveryLinkText"] == "Restore access"
 
     def test_conversations_disabled_returns_false(self):
         self.team.conversations_enabled = False

--- a/products/conversations/frontend/scenes/settings/WidgetSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WidgetSection.tsx
@@ -19,7 +19,7 @@ import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { supportSettingsLogic } from './supportSettingsLogic'
 
 export function WidgetSection(): JSX.Element {
-    const { currentTeam } = useValues(teamLogic)
+    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
     const { updateCurrentTeam } = useActions(teamLogic)
     const {
         generateNewToken,
@@ -218,6 +218,7 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={saveTicketRecoveryText}
+                                            loading={currentTeamLoading}
                                             disabledReason={
                                                 !ticketRecoveryTextValue ? 'Enter ticket recovery text' : undefined
                                             }
@@ -248,6 +249,7 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={saveTicketRecoveryLinkText}
+                                            loading={currentTeamLoading}
                                             disabledReason={
                                                 !ticketRecoveryLinkTextValue
                                                     ? 'Enter ticket recovery link text'

--- a/products/conversations/frontend/scenes/settings/WidgetSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WidgetSection.tsx
@@ -148,9 +148,12 @@ export function WidgetSection(): JSX.Element {
                                 </div>
                                 <LemonDivider />
                                 <div className="flex items-center gap-4 py-2 justify-between">
-                                    <label className="w-40 shrink-0 font-medium">Greeting message</label>
+                                    <label htmlFor="widget-greeting-message" className="w-40 shrink-0 font-medium">
+                                        Greeting message
+                                    </label>
                                     <div className="flex gap-2 flex-1">
                                         <LemonInput
+                                            id="widget-greeting-message"
                                             value={
                                                 greetingInputValue ??
                                                 currentTeam?.conversations_settings?.widget_greeting_text ??
@@ -163,6 +166,7 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={saveGreetingText}
+                                            aria-label="Save greeting message"
                                             disabledReason={
                                                 !greetingInputValue ? 'Enter a greeting message' : undefined
                                             }
@@ -173,9 +177,12 @@ export function WidgetSection(): JSX.Element {
                                 </div>
                                 <LemonDivider />
                                 <div className="flex items-center gap-4 py-2 justify-between">
-                                    <label className="w-40 shrink-0 font-medium">Placeholder text</label>
+                                    <label htmlFor="widget-placeholder-text" className="w-40 shrink-0 font-medium">
+                                        Placeholder text
+                                    </label>
                                     <div className="flex gap-2 flex-1">
                                         <LemonInput
+                                            id="widget-placeholder-text"
                                             value={
                                                 placeholderTextValue ??
                                                 currentTeam?.conversations_settings?.widget_placeholder_text ??
@@ -188,6 +195,7 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={savePlaceholderText}
+                                            aria-label="Save placeholder text"
                                             disabledReason={
                                                 !placeholderTextValue ? 'Enter placeholder text' : undefined
                                             }
@@ -198,9 +206,17 @@ export function WidgetSection(): JSX.Element {
                                 </div>
                                 <LemonDivider />
                                 <div className="flex items-center gap-4 py-2 justify-between">
-                                    <label className="w-40 shrink-0 font-medium">Ticket recovery text</label>
+                                    <div className="w-40 shrink-0">
+                                        <label htmlFor="widget-ticket-recovery-text" className="font-medium">
+                                            Ticket recovery text
+                                        </label>
+                                        <p className="text-xs text-muted-alt mb-2">
+                                            Only shown to visitors who aren't identified.
+                                        </p>
+                                    </div>
                                     <div className="flex gap-2 flex-1">
                                         <LemonInput
+                                            id="widget-ticket-recovery-text"
                                             value={
                                                 ticketRecoveryTextValue ??
                                                 currentTeam?.conversations_settings?.widget_ticket_recovery_text ??
@@ -213,6 +229,7 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={saveTicketRecoveryText}
+                                            aria-label="Save ticket recovery text"
                                             disabledReason={
                                                 !ticketRecoveryTextValue ? 'Enter ticket recovery text' : undefined
                                             }
@@ -223,9 +240,17 @@ export function WidgetSection(): JSX.Element {
                                 </div>
                                 <LemonDivider />
                                 <div className="flex items-center gap-4 py-2 justify-between">
-                                    <label className="w-40 shrink-0 font-medium">Ticket recovery link</label>
+                                    <div className="w-40 shrink-0">
+                                        <label htmlFor="widget-ticket-recovery-link-text" className="font-medium">
+                                            Ticket recovery link text
+                                        </label>
+                                        <p className="text-xs text-muted-alt mb-2">
+                                            The clickable part of the ticket recovery message.
+                                        </p>
+                                    </div>
                                     <div className="flex gap-2 flex-1">
                                         <LemonInput
+                                            id="widget-ticket-recovery-link-text"
                                             value={
                                                 ticketRecoveryLinkTextValue ??
                                                 currentTeam?.conversations_settings?.widget_ticket_recovery_link_text ??
@@ -238,6 +263,7 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={saveTicketRecoveryLinkText}
+                                            aria-label="Save ticket recovery link text"
                                             disabledReason={
                                                 !ticketRecoveryLinkTextValue
                                                     ? 'Enter ticket recovery link text'
@@ -296,9 +322,15 @@ export function WidgetSection(): JSX.Element {
                                         </div>
                                         <LemonDivider />
                                         <div className="flex items-center gap-4 py-2 justify-between">
-                                            <label className="w-40 shrink-0 font-medium">Form title</label>
+                                            <label
+                                                htmlFor="widget-identification-form-title"
+                                                className="w-40 shrink-0 font-medium"
+                                            >
+                                                Form title
+                                            </label>
                                             <div className="flex gap-2 flex-1">
                                                 <LemonInput
+                                                    id="widget-identification-form-title"
                                                     value={
                                                         identificationFormTitleValue ??
                                                         currentTeam?.conversations_settings
@@ -312,6 +344,7 @@ export function WidgetSection(): JSX.Element {
                                                 <LemonButton
                                                     type="primary"
                                                     onClick={saveIdentificationFormTitle}
+                                                    aria-label="Save form title"
                                                     disabledReason={
                                                         !identificationFormTitleValue ? 'Enter form title' : undefined
                                                     }
@@ -322,9 +355,15 @@ export function WidgetSection(): JSX.Element {
                                         </div>
                                         <LemonDivider />
                                         <div className="flex items-center gap-4 py-2 justify-between">
-                                            <label className="w-40 shrink-0 font-medium">Form description</label>
+                                            <label
+                                                htmlFor="widget-identification-form-description"
+                                                className="w-40 shrink-0 font-medium"
+                                            >
+                                                Form description
+                                            </label>
                                             <div className="flex gap-2 flex-1">
                                                 <LemonInput
+                                                    id="widget-identification-form-description"
                                                     value={
                                                         identificationFormDescriptionValue ??
                                                         currentTeam?.conversations_settings
@@ -338,6 +377,7 @@ export function WidgetSection(): JSX.Element {
                                                 <LemonButton
                                                     type="primary"
                                                     onClick={saveIdentificationFormDescription}
+                                                    aria-label="Save form description"
                                                     disabledReason={
                                                         !identificationFormDescriptionValue
                                                             ? 'Enter form description'
@@ -355,13 +395,16 @@ export function WidgetSection(): JSX.Element {
                         <div className="pt-8">
                             <div className="flex items-center gap-4 py-2 justify-between">
                                 <div>
-                                    <label className="w-40 shrink-0 font-medium">Public token</label>
+                                    <label htmlFor="widget-public-token" className="w-40 shrink-0 font-medium">
+                                        Public token
+                                    </label>
                                     <p className="text-xs text-muted-alt mb-2">
                                         Automatically generated token used to authenticate widget requests.
                                     </p>
                                 </div>
                                 <div className="flex gap-2 flex-1">
                                     <LemonInput
+                                        id="widget-public-token"
                                         value={
                                             currentTeam?.conversations_settings?.widget_public_token ||
                                             'Token will be auto-generated on save'

--- a/products/conversations/frontend/scenes/settings/WidgetSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WidgetSection.tsx
@@ -148,12 +148,9 @@ export function WidgetSection(): JSX.Element {
                                 </div>
                                 <LemonDivider />
                                 <div className="flex items-center gap-4 py-2 justify-between">
-                                    <label htmlFor="widget-greeting-message" className="w-40 shrink-0 font-medium">
-                                        Greeting message
-                                    </label>
+                                    <label className="w-40 shrink-0 font-medium">Greeting message</label>
                                     <div className="flex gap-2 flex-1">
                                         <LemonInput
-                                            id="widget-greeting-message"
                                             value={
                                                 greetingInputValue ??
                                                 currentTeam?.conversations_settings?.widget_greeting_text ??
@@ -166,7 +163,6 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={saveGreetingText}
-                                            aria-label="Save greeting message"
                                             disabledReason={
                                                 !greetingInputValue ? 'Enter a greeting message' : undefined
                                             }
@@ -177,12 +173,9 @@ export function WidgetSection(): JSX.Element {
                                 </div>
                                 <LemonDivider />
                                 <div className="flex items-center gap-4 py-2 justify-between">
-                                    <label htmlFor="widget-placeholder-text" className="w-40 shrink-0 font-medium">
-                                        Placeholder text
-                                    </label>
+                                    <label className="w-40 shrink-0 font-medium">Placeholder text</label>
                                     <div className="flex gap-2 flex-1">
                                         <LemonInput
-                                            id="widget-placeholder-text"
                                             value={
                                                 placeholderTextValue ??
                                                 currentTeam?.conversations_settings?.widget_placeholder_text ??
@@ -195,7 +188,6 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={savePlaceholderText}
-                                            aria-label="Save placeholder text"
                                             disabledReason={
                                                 !placeholderTextValue ? 'Enter placeholder text' : undefined
                                             }
@@ -207,16 +199,13 @@ export function WidgetSection(): JSX.Element {
                                 <LemonDivider />
                                 <div className="flex items-center gap-4 py-2 justify-between">
                                     <div className="w-40 shrink-0">
-                                        <label htmlFor="widget-ticket-recovery-text" className="font-medium">
-                                            Ticket recovery text
-                                        </label>
+                                        <label className="font-medium">Ticket recovery text</label>
                                         <p className="text-xs text-muted-alt mb-2">
                                             Only shown to visitors who aren't identified.
                                         </p>
                                     </div>
                                     <div className="flex gap-2 flex-1">
                                         <LemonInput
-                                            id="widget-ticket-recovery-text"
                                             value={
                                                 ticketRecoveryTextValue ??
                                                 currentTeam?.conversations_settings?.widget_ticket_recovery_text ??
@@ -229,7 +218,6 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={saveTicketRecoveryText}
-                                            aria-label="Save ticket recovery text"
                                             disabledReason={
                                                 !ticketRecoveryTextValue ? 'Enter ticket recovery text' : undefined
                                             }
@@ -241,16 +229,13 @@ export function WidgetSection(): JSX.Element {
                                 <LemonDivider />
                                 <div className="flex items-center gap-4 py-2 justify-between">
                                     <div className="w-40 shrink-0">
-                                        <label htmlFor="widget-ticket-recovery-link-text" className="font-medium">
-                                            Ticket recovery link text
-                                        </label>
+                                        <label className="font-medium">Ticket recovery link text</label>
                                         <p className="text-xs text-muted-alt mb-2">
                                             The clickable part of the ticket recovery message.
                                         </p>
                                     </div>
                                     <div className="flex gap-2 flex-1">
                                         <LemonInput
-                                            id="widget-ticket-recovery-link-text"
                                             value={
                                                 ticketRecoveryLinkTextValue ??
                                                 currentTeam?.conversations_settings?.widget_ticket_recovery_link_text ??
@@ -263,7 +248,6 @@ export function WidgetSection(): JSX.Element {
                                         <LemonButton
                                             type="primary"
                                             onClick={saveTicketRecoveryLinkText}
-                                            aria-label="Save ticket recovery link text"
                                             disabledReason={
                                                 !ticketRecoveryLinkTextValue
                                                     ? 'Enter ticket recovery link text'
@@ -322,15 +306,9 @@ export function WidgetSection(): JSX.Element {
                                         </div>
                                         <LemonDivider />
                                         <div className="flex items-center gap-4 py-2 justify-between">
-                                            <label
-                                                htmlFor="widget-identification-form-title"
-                                                className="w-40 shrink-0 font-medium"
-                                            >
-                                                Form title
-                                            </label>
+                                            <label className="w-40 shrink-0 font-medium">Form title</label>
                                             <div className="flex gap-2 flex-1">
                                                 <LemonInput
-                                                    id="widget-identification-form-title"
                                                     value={
                                                         identificationFormTitleValue ??
                                                         currentTeam?.conversations_settings
@@ -344,7 +322,6 @@ export function WidgetSection(): JSX.Element {
                                                 <LemonButton
                                                     type="primary"
                                                     onClick={saveIdentificationFormTitle}
-                                                    aria-label="Save form title"
                                                     disabledReason={
                                                         !identificationFormTitleValue ? 'Enter form title' : undefined
                                                     }
@@ -355,15 +332,9 @@ export function WidgetSection(): JSX.Element {
                                         </div>
                                         <LemonDivider />
                                         <div className="flex items-center gap-4 py-2 justify-between">
-                                            <label
-                                                htmlFor="widget-identification-form-description"
-                                                className="w-40 shrink-0 font-medium"
-                                            >
-                                                Form description
-                                            </label>
+                                            <label className="w-40 shrink-0 font-medium">Form description</label>
                                             <div className="flex gap-2 flex-1">
                                                 <LemonInput
-                                                    id="widget-identification-form-description"
                                                     value={
                                                         identificationFormDescriptionValue ??
                                                         currentTeam?.conversations_settings
@@ -377,7 +348,6 @@ export function WidgetSection(): JSX.Element {
                                                 <LemonButton
                                                     type="primary"
                                                     onClick={saveIdentificationFormDescription}
-                                                    aria-label="Save form description"
                                                     disabledReason={
                                                         !identificationFormDescriptionValue
                                                             ? 'Enter form description'
@@ -395,16 +365,13 @@ export function WidgetSection(): JSX.Element {
                         <div className="pt-8">
                             <div className="flex items-center gap-4 py-2 justify-between">
                                 <div>
-                                    <label htmlFor="widget-public-token" className="w-40 shrink-0 font-medium">
-                                        Public token
-                                    </label>
+                                    <label className="w-40 shrink-0 font-medium">Public token</label>
                                     <p className="text-xs text-muted-alt mb-2">
                                         Automatically generated token used to authenticate widget requests.
                                     </p>
                                 </div>
                                 <div className="flex gap-2 flex-1">
                                     <LemonInput
-                                        id="widget-public-token"
                                         value={
                                             currentTeam?.conversations_settings?.widget_public_token ||
                                             'Token will be auto-generated on save'

--- a/products/conversations/frontend/scenes/settings/WidgetSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WidgetSection.tsx
@@ -201,7 +201,7 @@ export function WidgetSection(): JSX.Element {
                                     <div className="w-40 shrink-0">
                                         <label className="font-medium">Ticket recovery text</label>
                                         <p className="text-xs text-muted-alt mb-2">
-                                            Only shown to visitors who aren't identified.
+                                            Only shown to visitors who aren't using identity verification.
                                         </p>
                                     </div>
                                     <div className="flex gap-2 flex-1">

--- a/products/conversations/frontend/scenes/settings/WidgetSection.tsx
+++ b/products/conversations/frontend/scenes/settings/WidgetSection.tsx
@@ -32,6 +32,10 @@ export function WidgetSection(): JSX.Element {
         saveIdentificationFormDescription,
         setPlaceholderTextValue,
         savePlaceholderText,
+        setTicketRecoveryTextValue,
+        saveTicketRecoveryText,
+        setTicketRecoveryLinkTextValue,
+        saveTicketRecoveryLinkText,
     } = useActions(supportSettingsLogic)
     const {
         widgetEnabledLoading,
@@ -39,6 +43,8 @@ export function WidgetSection(): JSX.Element {
         identificationFormTitleValue,
         identificationFormDescriptionValue,
         placeholderTextValue,
+        ticketRecoveryTextValue,
+        ticketRecoveryLinkTextValue,
     } = useValues(supportSettingsLogic)
 
     return (
@@ -184,6 +190,58 @@ export function WidgetSection(): JSX.Element {
                                             onClick={savePlaceholderText}
                                             disabledReason={
                                                 !placeholderTextValue ? 'Enter placeholder text' : undefined
+                                            }
+                                        >
+                                            Save
+                                        </LemonButton>
+                                    </div>
+                                </div>
+                                <LemonDivider />
+                                <div className="flex items-center gap-4 py-2 justify-between">
+                                    <label className="w-40 shrink-0 font-medium">Ticket recovery text</label>
+                                    <div className="flex gap-2 flex-1">
+                                        <LemonInput
+                                            value={
+                                                ticketRecoveryTextValue ??
+                                                currentTeam?.conversations_settings?.widget_ticket_recovery_text ??
+                                                "Don't see your previous tickets?"
+                                            }
+                                            placeholder="Enter ticket recovery text"
+                                            onChange={setTicketRecoveryTextValue}
+                                            fullWidth
+                                        />
+                                        <LemonButton
+                                            type="primary"
+                                            onClick={saveTicketRecoveryText}
+                                            disabledReason={
+                                                !ticketRecoveryTextValue ? 'Enter ticket recovery text' : undefined
+                                            }
+                                        >
+                                            Save
+                                        </LemonButton>
+                                    </div>
+                                </div>
+                                <LemonDivider />
+                                <div className="flex items-center gap-4 py-2 justify-between">
+                                    <label className="w-40 shrink-0 font-medium">Ticket recovery link</label>
+                                    <div className="flex gap-2 flex-1">
+                                        <LemonInput
+                                            value={
+                                                ticketRecoveryLinkTextValue ??
+                                                currentTeam?.conversations_settings?.widget_ticket_recovery_link_text ??
+                                                'Recover them here'
+                                            }
+                                            placeholder="Enter ticket recovery link text"
+                                            onChange={setTicketRecoveryLinkTextValue}
+                                            fullWidth
+                                        />
+                                        <LemonButton
+                                            type="primary"
+                                            onClick={saveTicketRecoveryLinkText}
+                                            disabledReason={
+                                                !ticketRecoveryLinkTextValue
+                                                    ? 'Enter ticket recovery link text'
+                                                    : undefined
                                             }
                                         >
                                             Save

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -138,6 +138,8 @@ export interface supportSettingsLogicValues {
         name: string
     }[]
     teamsTeamsLoading: boolean
+    ticketRecoveryLinkTextValue: string | null
+    ticketRecoveryTextValue: string | null
     widgetEnabledLoading: boolean
 }
 
@@ -382,6 +384,12 @@ export interface supportSettingsLogicActions {
     saveSlackTicketEmoji: () => {
         value: true
     }
+    saveTicketRecoveryLinkText: () => {
+        value: true
+    }
+    saveTicketRecoveryText: () => {
+        value: true
+    }
     sendTestEmail: (configId: string) => {
         configId: string
     }
@@ -494,6 +502,12 @@ export interface supportSettingsLogicActions {
         status: 'error' | 'idle' | 'installed' | 'installing' | 'needs_org_catalog'
         teamId: string | null
     }
+    setTicketRecoveryLinkTextValue: (value: string | null) => {
+        value: string | null
+    }
+    setTicketRecoveryTextValue: (value: string | null) => {
+        value: string | null
+    }
     setWidgetEnabledLoading: (loading: boolean) => {
         loading: boolean
     }
@@ -600,6 +614,10 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         saveIdentificationFormDescription: true,
         setPlaceholderTextValue: (value: string | null) => ({ value }),
         savePlaceholderText: true,
+        setTicketRecoveryTextValue: (value: string | null) => ({ value }),
+        saveTicketRecoveryText: true,
+        setTicketRecoveryLinkTextValue: (value: string | null) => ({ value }),
+        saveTicketRecoveryLinkText: true,
         // Notification recipients
         setNotificationRecipients: (users: UserBasicType[]) => ({ users }),
         // Slack channel settings (SupportHog)
@@ -736,6 +754,18 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             null as string | null,
             {
                 setPlaceholderTextValue: (_, { value }) => value,
+            },
+        ],
+        ticketRecoveryTextValue: [
+            null as string | null,
+            {
+                setTicketRecoveryTextValue: (_, { value }) => value,
+            },
+        ],
+        ticketRecoveryLinkTextValue: [
+            null as string | null,
+            {
+                setTicketRecoveryLinkTextValue: (_, { value }) => value,
             },
         ],
         // Email multi-config state
@@ -1277,6 +1307,30 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 },
             })
         },
+        saveTicketRecoveryText: () => {
+            const trimmedValue = values.ticketRecoveryTextValue?.trim()
+            if (!trimmedValue) {
+                return
+            }
+            actions.updateCurrentTeam({
+                conversations_settings: {
+                    ...values.currentTeam?.conversations_settings,
+                    widget_ticket_recovery_text: trimmedValue,
+                },
+            })
+        },
+        saveTicketRecoveryLinkText: () => {
+            const trimmedValue = values.ticketRecoveryLinkTextValue?.trim()
+            if (!trimmedValue) {
+                return
+            }
+            actions.updateCurrentTeam({
+                conversations_settings: {
+                    ...values.currentTeam?.conversations_settings,
+                    widget_ticket_recovery_link_text: trimmedValue,
+                },
+            })
+        },
         setNotificationRecipients: ({ users }) => {
             actions.updateCurrentTeam({
                 conversations_settings: {
@@ -1647,6 +1701,8 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             actions.setIdentificationFormTitleValue(null)
             actions.setIdentificationFormDescriptionValue(null)
             actions.setPlaceholderTextValue(null)
+            actions.setTicketRecoveryTextValue(null)
+            actions.setTicketRecoveryLinkTextValue(null)
             actions.setSlackTicketEmojiValue(null)
             actions.setSlackBotIconUrlValue(null)
             actions.setSlackBotDisplayNameValue(null)


### PR DESCRIPTION
## Problem

Teams that run the support widget in another language can customize the greeting and the input placeholder, but the ticket recovery footer ("Don't see your previous tickets? Recover them here") stays hardcoded in English. A customer running the widget in a non-English product asked for a way to translate it.

## Changes

- The In-app widget settings gain two inputs under Visual settings: "Ticket recovery text" and "Ticket recovery link text".
- Both inputs carry a short description: the recovery footer only shows to visitors who aren't using identity verification, and the link text is the clickable part of the message.
- The two Save buttons show a loading state while a team update is in flight, so rapid saves cannot overwrite each other with a stale settings snapshot.
- Remote config serves the values as `ticketRecoveryText` and `ticketRecoveryLinkText` in the `conversations` block, defaulting to the current strings.
- The widget itself reads the new keys in the companion PR: PostHog/posthog-js#4668.
- The settings follow the same save-per-field pattern as the greeting and placeholder inputs; the kea logic changes are mechanical copies of that pattern.

![widget-visual-settings](https://raw.githubusercontent.com/PostHog/pr-assets/10259381f29cc934e1cfc900497de43ac985c825/2026/08/5fa36085-afb7-4494-b2ff-f6daf3bab058.png)

## How did you test this code?

- Extended `test_conversations_enabled_with_defaults` and `test_conversations_enabled_with_custom_config` in `test_remote_config.py`. They catch remote config dropping the default strings or ignoring the stored settings. Both pass locally.
- Manual check on a local stack, including the follow-up copy commits: saved custom values through the new inputs, confirmed they persist to `conversations_settings`, and confirmed the widget (on the companion branch) renders both custom recovery strings in the footer. The widget serves a cached config, so a hard refresh is needed to see fresh saves locally.
- Not run: the full frontend Jest suite; the logic change has no dedicated tests, matching the existing greeting and placeholder fields.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a support request. Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-pr-descriptions, /review-code. The session verified the change end to end on a local stack (settings UI save flow, Postgres persistence, remote config output). The follow-up commits apply copy findings from a multi-agent review: label wording and field descriptions. An accessibility pass over the widget form (label association, distinct Save button names) was drafted and then pulled back out; it is tracked as team follow-up work instead. No customer material appears in the diff; the test strings are invented.
