### PR TITLE
feat(cymbal): define resolution cache contract

### DIFF
--- a/rust/cymbal/src/core/mod.rs
+++ b/rust/cymbal/src/core/mod.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod error;
 pub mod ids;
 pub mod metric_consts;
+pub mod resolution_cache;
 pub mod resolver;
 pub mod sanitize;
 pub mod shutdown;

--- a/rust/cymbal/src/core/resolution_cache.rs
+++ b/rust/cymbal/src/core/resolution_cache.rs
@@ -1,0 +1,472 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use common_types::error_tracking::RawFrameId;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::core::{error::FrameError, symbolication::symbol::records::ErrorTrackingStackFrame};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheReadOutcome<T> {
+    Hit(T),
+    Miss,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheWriteOutcome {
+    Stored,
+    Deleted,
+    NotFound,
+    SkippedDisabled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheGateOutcome {
+    Acquired,
+    Held,
+    Disabled,
+}
+
+#[derive(Debug, Error)]
+pub enum ResolutionCacheError {
+    #[error("resolution cache timed out")]
+    Timeout,
+    #[error("resolution cache unavailable: {0}")]
+    Unavailable(String),
+    #[error("invalid resolution cache value: {0}")]
+    InvalidValue(String),
+    #[error("resolution cache value exceeds configured size limit")]
+    Oversized,
+}
+
+pub type ResolutionCacheResult<T> = Result<T, ResolutionCacheError>;
+
+#[async_trait]
+pub trait ResolutionCache: Send + Sync {
+    async fn get_frame(
+        &self,
+        id: &RawFrameId,
+    ) -> ResolutionCacheResult<CacheReadOutcome<Vec<ErrorTrackingStackFrame>>>;
+
+    async fn set_frame(
+        &self,
+        id: &RawFrameId,
+        records: &[ErrorTrackingStackFrame],
+        ttl: Duration,
+    ) -> ResolutionCacheResult<CacheWriteOutcome>;
+
+    async fn get_failure(
+        &self,
+        team_id: i32,
+        symbol_set_ref: &str,
+    ) -> ResolutionCacheResult<CacheReadOutcome<FrameError>>;
+
+    async fn set_failure(
+        &self,
+        team_id: i32,
+        symbol_set_ref: &str,
+        failure: &FrameError,
+        ttl: Duration,
+    ) -> ResolutionCacheResult<CacheWriteOutcome>;
+
+    async fn delete_failure(
+        &self,
+        team_id: i32,
+        symbol_set_ref: &str,
+    ) -> ResolutionCacheResult<CacheWriteOutcome>;
+
+    async fn try_acquire_touch(
+        &self,
+        symbol_set_id: Uuid,
+        token: &str,
+        ttl: Duration,
+    ) -> ResolutionCacheResult<CacheGateOutcome>;
+
+    async fn release_touch(
+        &self,
+        symbol_set_id: Uuid,
+        token: &str,
+    ) -> ResolutionCacheResult<CacheWriteOutcome>;
+}
+
+#[derive(Debug, Default)]
+pub struct DisabledResolutionCache;
+
+#[async_trait]
+impl ResolutionCache for DisabledResolutionCache {
+    async fn get_frame(
+        &self,
+        _id: &RawFrameId,
+    ) -> ResolutionCacheResult<CacheReadOutcome<Vec<ErrorTrackingStackFrame>>> {
+        Ok(CacheReadOutcome::Disabled)
+    }
+
+    async fn set_frame(
+        &self,
+        _id: &RawFrameId,
+        _records: &[ErrorTrackingStackFrame],
+        _ttl: Duration,
+    ) -> ResolutionCacheResult<CacheWriteOutcome> {
+        Ok(CacheWriteOutcome::SkippedDisabled)
+    }
+
+    async fn get_failure(
+        &self,
+        _team_id: i32,
+        _symbol_set_ref: &str,
+    ) -> ResolutionCacheResult<CacheReadOutcome<FrameError>> {
+        Ok(CacheReadOutcome::Disabled)
+    }
+
+    async fn set_failure(
+        &self,
+        _team_id: i32,
+        _symbol_set_ref: &str,
+        _failure: &FrameError,
+        _ttl: Duration,
+    ) -> ResolutionCacheResult<CacheWriteOutcome> {
+        Ok(CacheWriteOutcome::SkippedDisabled)
+    }
+
+    async fn delete_failure(
+        &self,
+        _team_id: i32,
+        _symbol_set_ref: &str,
+    ) -> ResolutionCacheResult<CacheWriteOutcome> {
+        Ok(CacheWriteOutcome::SkippedDisabled)
+    }
+
+    async fn try_acquire_touch(
+        &self,
+        _symbol_set_id: Uuid,
+        _token: &str,
+        _ttl: Duration,
+    ) -> ResolutionCacheResult<CacheGateOutcome> {
+        Ok(CacheGateOutcome::Disabled)
+    }
+
+    async fn release_touch(
+        &self,
+        _symbol_set_id: Uuid,
+        _token: &str,
+    ) -> ResolutionCacheResult<CacheWriteOutcome> {
+        Ok(CacheWriteOutcome::SkippedDisabled)
+    }
+}
+
+pub fn disabled_resolution_cache() -> Arc<dyn ResolutionCache> {
+    Arc::new(DisabledResolutionCache)
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct Expiring<T> {
+    value: T,
+    expires_at: Duration,
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct InMemoryState {
+    now: Duration,
+    frames: std::collections::HashMap<RawFrameId, Expiring<Vec<ErrorTrackingStackFrame>>>,
+    failures: std::collections::HashMap<(i32, String), Expiring<FrameError>>,
+    touches: std::collections::HashMap<Uuid, Expiring<String>>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Default)]
+pub(crate) struct InMemoryResolutionCache(std::sync::Mutex<InMemoryState>);
+
+#[cfg(test)]
+impl InMemoryResolutionCache {
+    pub fn advance(&self, duration: Duration) {
+        self.0.lock().unwrap().now += duration;
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl ResolutionCache for InMemoryResolutionCache {
+    async fn get_frame(
+        &self,
+        id: &RawFrameId,
+    ) -> ResolutionCacheResult<CacheReadOutcome<Vec<ErrorTrackingStackFrame>>> {
+        let mut state = self.0.lock().unwrap();
+        let now = state.now;
+        let outcome = match state.frames.get(id) {
+            Some(entry) if entry.expires_at > now => CacheReadOutcome::Hit(entry.value.clone()),
+            Some(_) => {
+                state.frames.remove(id);
+                CacheReadOutcome::Miss
+            }
+            None => CacheReadOutcome::Miss,
+        };
+        Ok(outcome)
+    }
+
+    async fn set_frame(
+        &self,
+        id: &RawFrameId,
+        records: &[ErrorTrackingStackFrame],
+        ttl: Duration,
+    ) -> ResolutionCacheResult<CacheWriteOutcome> {
+        let mut state = self.0.lock().unwrap();
+        let expires_at = state.now + ttl;
+        state.frames.insert(
+            id.clone(),
+            Expiring {
+                value: records.to_vec(),
+                expires_at,
+            },
+        );
+        Ok(CacheWriteOutcome::Stored)
+    }
+
+    async fn get_failure(
+        &self,
+        team_id: i32,
+        symbol_set_ref: &str,
+    ) -> ResolutionCacheResult<CacheReadOutcome<FrameError>> {
+        let mut state = self.0.lock().unwrap();
+        let now = state.now;
+        let key = (team_id, symbol_set_ref.to_string());
+        let outcome = match state.failures.get(&key) {
+            Some(entry) if entry.expires_at > now => CacheReadOutcome::Hit(entry.value.clone()),
+            Some(_) => {
+                state.failures.remove(&key);
+                CacheReadOutcome::Miss
+            }
+            None => CacheReadOutcome::Miss,
+        };
+        Ok(outcome)
+    }
+
+    async fn set_failure(
+        &self,
+        team_id: i32,
+        symbol_set_ref: &str,
+        failure: &FrameError,
+        ttl: Duration,
+    ) -> ResolutionCacheResult<CacheWriteOutcome> {
+        let mut state = self.0.lock().unwrap();
+        let expires_at = state.now + ttl;
+        state.failures.insert(
+            (team_id, symbol_set_ref.to_string()),
+            Expiring {
+                value: failure.clone(),
+                expires_at,
+            },
+        );
+        Ok(CacheWriteOutcome::Stored)
+    }
+
+    async fn delete_failure(
+        &self,
+        team_id: i32,
+        symbol_set_ref: &str,
+    ) -> ResolutionCacheResult<CacheWriteOutcome> {
+        let mut state = self.0.lock().unwrap();
+        let key = (team_id, symbol_set_ref.to_string());
+        let exists = state
+            .failures
+            .get(&key)
+            .is_some_and(|entry| entry.expires_at > state.now);
+        state.failures.remove(&key);
+        Ok(if exists {
+            CacheWriteOutcome::Deleted
+        } else {
+            CacheWriteOutcome::NotFound
+        })
+    }
+
+    async fn try_acquire_touch(
+        &self,
+        symbol_set_id: Uuid,
+        token: &str,
+        ttl: Duration,
+    ) -> ResolutionCacheResult<CacheGateOutcome> {
+        let mut state = self.0.lock().unwrap();
+        let now = state.now;
+        if state
+            .touches
+            .get(&symbol_set_id)
+            .is_some_and(|entry| entry.expires_at > now)
+        {
+            return Ok(CacheGateOutcome::Held);
+        }
+        let expires_at = now + ttl;
+        state.touches.insert(
+            symbol_set_id,
+            Expiring {
+                value: token.to_string(),
+                expires_at,
+            },
+        );
+        Ok(CacheGateOutcome::Acquired)
+    }
+
+    async fn release_touch(
+        &self,
+        symbol_set_id: Uuid,
+        token: &str,
+    ) -> ResolutionCacheResult<CacheWriteOutcome> {
+        let mut state = self.0.lock().unwrap();
+        let now = state.now;
+        let matches = state
+            .touches
+            .get(&symbol_set_id)
+            .is_some_and(|entry| entry.expires_at > now && entry.value == token);
+        if matches {
+            state.touches.remove(&symbol_set_id);
+            Ok(CacheWriteOutcome::Deleted)
+        } else {
+            Ok(CacheWriteOutcome::NotFound)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use common_types::error_tracking::RawFrameId;
+    use uuid::Uuid;
+
+    use super::{
+        CacheGateOutcome, CacheReadOutcome, CacheWriteOutcome, DisabledResolutionCache,
+        InMemoryResolutionCache, ResolutionCache,
+    };
+    use crate::core::error::{FrameError, JsResolveErr};
+
+    fn object_safe(cache: Arc<dyn ResolutionCache>) -> Arc<dyn ResolutionCache> {
+        cache
+    }
+
+    #[tokio::test]
+    async fn disabled_cache_never_stores_or_blocks_work() {
+        let cache = object_safe(Arc::new(DisabledResolutionCache));
+        let frame_id = RawFrameId::new("frame".to_string(), 1);
+        let symbol_set_id = Uuid::now_v7();
+
+        assert!(matches!(
+            cache.get_frame(&frame_id).await.unwrap(),
+            CacheReadOutcome::Disabled
+        ));
+        assert_eq!(
+            cache
+                .set_frame(&frame_id, &[], Duration::from_secs(30))
+                .await
+                .unwrap(),
+            CacheWriteOutcome::SkippedDisabled
+        );
+        assert_eq!(
+            cache
+                .get_failure(1, "https://example.test/app.js")
+                .await
+                .unwrap(),
+            CacheReadOutcome::Disabled
+        );
+        assert_eq!(
+            cache
+                .set_failure(
+                    1,
+                    "https://example.test/app.js",
+                    &FrameError::JavaScript(JsResolveErr::NoSourcemap("missing".to_string())),
+                    Duration::from_secs(30),
+                )
+                .await
+                .unwrap(),
+            CacheWriteOutcome::SkippedDisabled
+        );
+        assert_eq!(
+            cache
+                .delete_failure(1, "https://example.test/app.js")
+                .await
+                .unwrap(),
+            CacheWriteOutcome::SkippedDisabled
+        );
+        assert_eq!(
+            cache
+                .try_acquire_touch(symbol_set_id, "token", Duration::from_secs(30))
+                .await
+                .unwrap(),
+            CacheGateOutcome::Disabled
+        );
+        assert_eq!(
+            cache.release_touch(symbol_set_id, "token").await.unwrap(),
+            CacheWriteOutcome::SkippedDisabled
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_cache_expires_entries_and_releases_touch_by_token() {
+        let cache = InMemoryResolutionCache::default();
+        let failure = FrameError::JavaScript(JsResolveErr::NoSourcemap("missing".to_string()));
+        let ttl = Duration::from_secs(30);
+        let frame_id = RawFrameId::new("frame".to_string(), 1);
+        let symbol_set_id = Uuid::now_v7();
+
+        assert_eq!(
+            cache.set_frame(&frame_id, &[], ttl).await.unwrap(),
+            CacheWriteOutcome::Stored
+        );
+        assert!(matches!(
+            cache.get_frame(&frame_id).await.unwrap(),
+            CacheReadOutcome::Hit(records) if records.is_empty()
+        ));
+
+        assert_eq!(
+            cache
+                .set_failure(1, "https://example.test/app.js", &failure, ttl)
+                .await
+                .unwrap(),
+            CacheWriteOutcome::Stored
+        );
+        assert_eq!(
+            cache
+                .get_failure(1, "https://example.test/app.js")
+                .await
+                .unwrap(),
+            CacheReadOutcome::Hit(failure.clone())
+        );
+
+        assert_eq!(
+            cache
+                .try_acquire_touch(symbol_set_id, "winner", ttl)
+                .await
+                .unwrap(),
+            CacheGateOutcome::Acquired
+        );
+        assert_eq!(
+            cache
+                .try_acquire_touch(symbol_set_id, "loser", ttl)
+                .await
+                .unwrap(),
+            CacheGateOutcome::Held
+        );
+        assert_eq!(
+            cache.release_touch(symbol_set_id, "loser").await.unwrap(),
+            CacheWriteOutcome::NotFound
+        );
+        assert_eq!(
+            cache.release_touch(symbol_set_id, "winner").await.unwrap(),
+            CacheWriteOutcome::Deleted
+        );
+
+        cache.advance(ttl + Duration::from_secs(1));
+        assert!(matches!(
+            cache.get_frame(&frame_id).await.unwrap(),
+            CacheReadOutcome::Miss
+        ));
+        assert_eq!(
+            cache
+                .get_failure(1, "https://example.test/app.js")
+                .await
+                .unwrap(),
+            CacheReadOutcome::Miss
+        );
+    }
+}

--- a/rust/cymbal/src/modes/resolution/config.rs
+++ b/rust/cymbal/src/modes/resolution/config.rs
@@ -5,6 +5,119 @@ use envconfig::Envconfig;
 
 use crate::core::config::ResolverConfig;
 
+const DEFAULT_CACHE_KEY_PREFIX: &str = "@posthog/cymbal-resolution-cache";
+const DEFAULT_CACHE_RESPONSE_TIMEOUT_MS: u64 = 50;
+const DEFAULT_CACHE_CONNECTION_TIMEOUT_MS: u64 = 1_000;
+const DEFAULT_FAILURE_TTL_SECONDS: u64 = 86_400;
+const DEFAULT_TOUCH_TTL_SECONDS: u64 = 43_200;
+const DEFAULT_COMPRESSION_THRESHOLD_BYTES: usize = 512;
+const DEFAULT_COMPRESSION_LEVEL: i32 = 3;
+const DEFAULT_MAX_ENCODED_VALUE_BYTES: usize = 1024 * 1024;
+const DEFAULT_MAX_DECODED_VALUE_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Envconfig, Clone, Debug, PartialEq, Eq)]
+pub struct ResolutionCacheConfig {
+    #[envconfig(from = "RESOLUTION_CACHE_ENABLED", default = "false")]
+    pub enabled: bool,
+
+    #[envconfig(from = "RESOLUTION_CACHE_REDIS_URL")]
+    pub redis_url: Option<String>,
+
+    #[envconfig(
+        from = "RESOLUTION_CACHE_KEY_PREFIX",
+        default = "@posthog/cymbal-resolution-cache"
+    )]
+    pub key_prefix: String,
+
+    #[envconfig(from = "RESOLUTION_CACHE_RESPONSE_TIMEOUT_MS", default = "50")]
+    pub response_timeout_ms: u64,
+
+    #[envconfig(from = "RESOLUTION_CACHE_CONNECTION_TIMEOUT_MS", default = "1000")]
+    pub connection_timeout_ms: u64,
+
+    #[envconfig(from = "RESOLUTION_CACHE_FAILURE_TTL_SECONDS", default = "86400")]
+    pub failure_ttl_seconds: u64,
+
+    #[envconfig(from = "RESOLUTION_CACHE_TOUCH_TTL_SECONDS", default = "43200")]
+    pub touch_ttl_seconds: u64,
+
+    #[envconfig(from = "RESOLUTION_CACHE_COMPRESSION_ENABLED", default = "true")]
+    pub compression_enabled: bool,
+
+    #[envconfig(from = "RESOLUTION_CACHE_COMPRESSION_THRESHOLD_BYTES", default = "512")]
+    pub compression_threshold_bytes: usize,
+
+    #[envconfig(from = "RESOLUTION_CACHE_COMPRESSION_LEVEL", default = "3")]
+    pub compression_level: i32,
+
+    #[envconfig(from = "RESOLUTION_CACHE_MAX_ENCODED_VALUE_BYTES", default = "1048576")]
+    pub max_encoded_value_bytes: usize,
+
+    #[envconfig(from = "RESOLUTION_CACHE_MAX_DECODED_VALUE_BYTES", default = "4194304")]
+    pub max_decoded_value_bytes: usize,
+}
+
+impl Default for ResolutionCacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            redis_url: None,
+            key_prefix: DEFAULT_CACHE_KEY_PREFIX.to_string(),
+            response_timeout_ms: DEFAULT_CACHE_RESPONSE_TIMEOUT_MS,
+            connection_timeout_ms: DEFAULT_CACHE_CONNECTION_TIMEOUT_MS,
+            failure_ttl_seconds: DEFAULT_FAILURE_TTL_SECONDS,
+            touch_ttl_seconds: DEFAULT_TOUCH_TTL_SECONDS,
+            compression_enabled: true,
+            compression_threshold_bytes: DEFAULT_COMPRESSION_THRESHOLD_BYTES,
+            compression_level: DEFAULT_COMPRESSION_LEVEL,
+            max_encoded_value_bytes: DEFAULT_MAX_ENCODED_VALUE_BYTES,
+            max_decoded_value_bytes: DEFAULT_MAX_DECODED_VALUE_BYTES,
+        }
+    }
+}
+
+impl ResolutionCacheConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        if self
+            .redis_url
+            .as_deref()
+            .is_none_or(|url| url.trim().is_empty())
+        {
+            return Err("RESOLUTION_CACHE_REDIS_URL is required when enabled".to_string());
+        }
+        if self.key_prefix.trim().is_empty() {
+            return Err("RESOLUTION_CACHE_KEY_PREFIX cannot be empty".to_string());
+        }
+        if self.response_timeout_ms == 0 {
+            return Err("RESOLUTION_CACHE_RESPONSE_TIMEOUT_MS must be positive".to_string());
+        }
+        if self.connection_timeout_ms == 0 {
+            return Err("RESOLUTION_CACHE_CONNECTION_TIMEOUT_MS must be positive".to_string());
+        }
+        if self.failure_ttl_seconds == 0 {
+            return Err("RESOLUTION_CACHE_FAILURE_TTL_SECONDS must be positive".to_string());
+        }
+        if self.touch_ttl_seconds == 0 {
+            return Err("RESOLUTION_CACHE_TOUCH_TTL_SECONDS must be positive".to_string());
+        }
+        if !(0..=22).contains(&self.compression_level) {
+            return Err("RESOLUTION_CACHE_COMPRESSION_LEVEL must be between 0 and 22".to_string());
+        }
+        if self.max_encoded_value_bytes == 0 {
+            return Err("RESOLUTION_CACHE_MAX_ENCODED_VALUE_BYTES must be positive".to_string());
+        }
+        if self.max_decoded_value_bytes == 0 {
+            return Err("RESOLUTION_CACHE_MAX_DECODED_VALUE_BYTES must be positive".to_string());
+        }
+
+        Ok(())
+    }
+}
+
 /// Top-level config for resolution mode. Owns the shared resolver config and the
 /// resolution service settings — no processing-only knobs. `INTERNAL_API_SECRET`
 /// and `SYMBOL_RESOLUTION_CONCURRENCY` come from the nested `resolver`.
@@ -15,6 +128,9 @@ pub struct ResolutionConfig {
 
     #[envconfig(nested = true)]
     pub service: Config,
+
+    #[envconfig(nested = true)]
+    pub resolution_cache: ResolutionCacheConfig,
 
     #[envconfig(nested = true)]
     pub continuous_profiling: ContinuousProfilingConfig,
@@ -80,4 +196,71 @@ pub struct Config {
     /// clamped down so a misconfigured caller cannot make the stream stale.
     #[envconfig(from = "SUBSCRIBE_MAX_TICK_MS", default = "10000")]
     pub subscribe_max_tick_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ResolutionCacheConfig;
+
+    #[test]
+    fn resolution_cache_defaults_disabled_and_bounded() {
+        let config = ResolutionCacheConfig::default();
+
+        assert!(!config.enabled);
+        assert!(config.redis_url.is_none());
+        assert_eq!(config.key_prefix, "@posthog/cymbal-resolution-cache");
+        assert_eq!(config.response_timeout_ms, 50);
+        assert_eq!(config.connection_timeout_ms, 1_000);
+        assert_eq!(config.failure_ttl_seconds, 86_400);
+        assert_eq!(config.touch_ttl_seconds, 43_200);
+        assert!(config.compression_enabled);
+        assert_eq!(config.compression_threshold_bytes, 512);
+        assert_eq!(config.compression_level, 3);
+        assert_eq!(config.max_encoded_value_bytes, 1_048_576);
+        assert_eq!(config.max_decoded_value_bytes, 4_194_304);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn enabled_resolution_cache_requires_a_url_and_safe_limits() {
+        let mut config = ResolutionCacheConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        assert!(config.validate().unwrap_err().contains("REDIS_URL"));
+
+        config.redis_url = Some("redis://cache:6379".to_string());
+        assert!(config.validate().is_ok());
+
+        type InvalidMutation = (&'static str, fn(&mut ResolutionCacheConfig));
+        let invalid_mutations: [InvalidMutation; 6] = [
+            ("response timeout", |config: &mut ResolutionCacheConfig| {
+                config.response_timeout_ms = 0
+            }),
+            (
+                "connection timeout",
+                |config: &mut ResolutionCacheConfig| config.connection_timeout_ms = 0,
+            ),
+            ("failure ttl", |config: &mut ResolutionCacheConfig| {
+                config.failure_ttl_seconds = 0
+            }),
+            ("touch ttl", |config: &mut ResolutionCacheConfig| {
+                config.touch_ttl_seconds = 0
+            }),
+            ("encoded limit", |config: &mut ResolutionCacheConfig| {
+                config.max_encoded_value_bytes = 0
+            }),
+            ("decoded limit", |config: &mut ResolutionCacheConfig| {
+                config.max_decoded_value_bytes = 0
+            }),
+        ];
+        for (name, mutate) in invalid_mutations {
+            let mut invalid = config.clone();
+            mutate(&mut invalid);
+            assert!(invalid.validate().is_err(), "{name}");
+        }
+
+        config.key_prefix.clear();
+        assert!(config.validate().is_err());
+    }
 }


### PR DESCRIPTION
## Problem

Cymbal cannot add shared resolution caching without coupling its core resolver to Redis.

The next rollout stage needs a transport-independent contract and bounded configuration before any cache behavior is enabled. This follows #90778.

## Changes

- The resolver gains an object-safe contract for frame results, symbol failures, and retention touch gates.
- Disabled and in-memory implementations make cache absence and expiry behavior explicit and testable.
- Resolution mode gains dedicated Redis, timeout, TTL, compression, prefix, and value-size settings.
- The cache remains disabled by default. No runtime path connects to Redis or changes resolution behavior.

## How did you test this code?

- `SQLX_OFFLINE=true bin/hogli test rust/cymbal`
- Targeted contract and configuration tests after rebasing onto `master`.
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `SQLX_OFFLINE=true cargo clippy --manifest-path rust/Cargo.toml -p cymbal --all-targets -- -D warnings`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This PR adds an internal, disabled foundation without operator-visible behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented this change with the `/openspec-apply-change`, `/writing-tests`, `/stacking-prs`, `/pr`, and `/writing-pr-descriptions` skills. No public session link is available from this harness.

The layer stops before the Redis adapter so the contract and configuration can be reviewed independently from transport and codec behavior.
