### PR TITLE
chore(skills): fire splitting-oversized-modules at its own gate

### DIFF
--- a/.agents/skills/splitting-oversized-modules/SKILL.md
+++ b/.agents/skills/splitting-oversized-modules/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: splitting-oversized-modules
 description: >
-  Split an oversized Python module (a 2000+ line logic.py, models.py, api.py, or its test
-  file) into a package of one module per concern, mechanically and provably without changing
-  behavior. Use on a request to split / break up / decompose a god module or move functions
-  out of one, or once a human has agreed to split one before some other change. Covers the
-  worth-it gate, assigning symbols to concerns with an acyclic dependency graph, the AST plus
-  tokenize move script, and proving the result is a pure move. Python only — for frontend
-  files use writing-ui-components. Not for extracting a shared helper into common/, and not
-  for moving code between products, which is isolating-product-facade-contracts.
+  Split an oversized Python module (a thousand-plus-line logic.py, models.py, api.py, or its
+  test file) into a package of one module per concern, mechanically and provably without
+  changing behavior. Use on a request to split / break up / decompose a god module or move
+  functions out of one, once a human has agreed to split one before some other change, or
+  before restructuring code inside a module already over roughly a thousand lines — breaking
+  up a long function or extracting helpers in place leaves everything in the same file, so
+  check the worth-it gate and propose the split first. Covers that gate, assigning symbols to
+  concerns with an acyclic dependency graph, the AST plus tokenize move script, and proving
+  the result is a pure move. Python only — for frontend files use writing-ui-components. Not
+  for extracting a shared helper into common/, and not for moving code between products,
+  which is isolating-product-facade-contracts.
 ---
 
 # Splitting oversized modules
@@ -27,6 +30,11 @@ All three must hold: over roughly a thousand lines, several concerns that change
 independently, and something still actively changing in it. A big cohesive frozen file buys
 nothing. Skip generated files, and skip a file several people are mid-change in
 (`git log --oneline -20 -- <file>`).
+
+A complexity warning on one function is a symptom of this, not a separate job. Extracting
+that function into helpers leaves every helper in the same file, so the read-set is
+unchanged and the file gets longer. Measure the file first (`wc -l`), and when it clears the
+gate, propose the split instead of the in-place extraction.
 
 Splitting is a separate PR from whatever you came to do. Land the move as its own base PR
 and branch your work on top — see `/stacking-prs`. Never bundle it into a feature diff, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,7 +284,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 - `/authoring-ci-workflows` — adding or editing any `.github/workflows` workflow, composite action, or reusable workflow
 - `/reviewing-personhog-protocol` — any personhog coordination-protocol change (leases, fencing, handoffs, supervisors, budgets, warming, changelog semantics), and any request for an exhaustive review of personhog code
 - `/gating-production-deploys` — any workflow that builds and pushes a production image or dispatches a deploy
-- `/splitting-oversized-modules` — splitting a Python module into a package, or deciding whether to propose splitting one before you work in it; propose, and land the move as a stacked base PR rather than inside your feature diff
+- `/splitting-oversized-modules` — splitting a Python module into a package, or deciding whether to propose splitting one before you work in it, including before you restructure code inside a module over roughly a thousand lines; propose, and land the move as a stacked base PR rather than inside your feature diff
 - `/auditing-llm-gateway-parity` — changing either gateway's auth, attribution, billing, endpoints, providers, models, routing, or metadata contract; reviewing a `services/llm-gateway` change; or refreshing `services/llm-gateway/PARITY.md`
 - `/finding-llm-gateway-migration-candidates` — finding, auditing, or ranking callers that could move from `services/llm-gateway` to `PostHog/ai-gateway`, including requests for the next or lowest-risk migration candidate
 - `/migrating-llm-gateway-callers` — adding an LLM gateway caller or migrating an existing caller from `services/llm-gateway` to `PostHog/ai-gateway`, including shared client and gateway setting changes made for that migration


### PR DESCRIPTION
## Problem

An agent told to reduce complexity in an oversized Python module refactors inside it instead of proposing a split, because the skill that would stop it never loads.

- `/splitting-oversized-modules` describes itself as being for "a 2000+ line logic.py", but its own worth-it gate is "over roughly a thousand lines".
- An agent matches on the description, so any file between those two numbers reads as out of scope.
- A recent self-driving PR hit this at 1292 lines. It split one 23-branch function into helpers in the same file, and [#90675](https://github.com/PostHog/posthog/pull/90675) was closed with "I'd honestly split the whole module and there is a skill for that in the repo".

## Changes

- The skill now fires on a thousand-plus-line module, matching the gate it already documents.
- It also fires before an agent restructures code inside such a module, which is the case that produced the closed PR.
- The worth-it section names that case: extracting helpers in place leaves them in the same file, so the read-set is unchanged and the file gets longer. Measure with `wc -l` first.
- The `AGENTS.md` trigger line picks up the same condition.

Docs only. No code, no behavior change.

## How did you test this code?

Not run: `hogli lint:skills` and `hogli ci:preflight`, since neither `hogli` nor `flox` is present in this sandbox. The diff is two markdown files.

The new description is 967 characters, under the 1024 limit in `/writing-skills`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app after tracing why [#90675](https://github.com/PostHog/posthog/pull/90675) proposed an in-place refactor. Skills invoked: `/writing-skills`, `/writing-pr-descriptions`.

The scout that raised the original report is a separate fix, and lives in the skills store rather than this repo.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1787916037377569)*
