### PR TITLE
feat(tasks): add agent boot clone holdout

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -209,6 +209,8 @@ STREAM_VIA_PROXY_FEATURE_FLAG = "tasks-stream-via-proxy"
 OVERLAP_CLONE_BOOT_FEATURE_FLAG = "tasks-overlap-clone-boot"
 DESKTOP_WORKSPACE_WARM_FEATURE_FLAG = "task-cloud-desktop-workspace-warm"
 TASK_SIGNALS_CLONING_BLOBLESS_FEATURE_FLAG = "task-signals-cloning-blobless"
+AGENT_BOOT_BLOBLESS_CLONE_FEATURE_FLAG = "tasks-agent-boot-blobless-clone"
+AGENT_BOOT_BLOBLESS_CLONE_STATE_KEY = "agent_boot_blobless_clone_enabled"
 # Kill switch: rtk command-output compression is on by default in cloud sandboxes;
 # enabling this flag disables it fleet-wide — over any per-run override — without
 # an image rebuild.

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -465,8 +465,10 @@ class SandboxBase(ABC):
         depth_flag = f" --depth {shlex.quote('1')}" if shallow else ""
         branch_flag = f" --branch {shlex.quote(branch)}" if branch else ""
         blob_filter = ""
-        if not shallow:
-            blob_filter = " --filter=blob:none" if blobless else " --filter=blob:limit=128k"
+        if blobless:
+            blob_filter = " --filter=blob:none"
+        elif not shallow:
+            blob_filter = " --filter=blob:limit=128k"
         clone_command = (
             f"rm -rf {shlex.quote(target_path)} && "
             f"mkdir -p {shlex.quote(org_path)} && "

--- a/products/tasks/backend/logic/services/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/test_docker_sandbox.py
@@ -348,6 +348,7 @@ class TestDockerSandboxUnit:
         "shallow,blobless,expected_in_command,not_expected_in_command",
         [
             (True, False, "--depth 1", "--filter=blob:"),
+            (True, True, "--filter=blob:none", "--filter=blob:limit=128k"),
             (False, False, "--filter=blob:limit=128k", "--filter=blob:none"),
             (False, True, "--filter=blob:none", "--filter=blob:limit=128k"),
         ],

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -1025,6 +1025,7 @@ class TestModalSandboxCommandEscaping:
         "shallow,blobless,expected_in_command,not_expected_in_command",
         [
             (True, False, "--depth 1", "--filter=blob:"),
+            (True, True, "--filter=blob:none", "--filter=blob:limit=128k"),
             (False, False, "--filter=blob:limit=128k", "--filter=blob:none"),
             (False, True, "--filter=blob:none", "--filter=blob:limit=128k"),
         ],

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -167,6 +167,7 @@ class GetSandboxForRepositoryOutput:
     # Per-phase boot durations, threaded through to the sandbox_started analytics event.
     create_ms: int | None = None
     clone_ms: int | None = None
+    clone_strategy: str | None = None
     checkout_ms: int | None = None
     launch_ms: int | None = None
     agent_prepare_ms: int | None = None

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -12,6 +12,8 @@ from posthog.temporal.common.utils import asyncify, close_db_connections
 
 from products.context_layer.backend.facade import api as context_layer_facade
 from products.tasks.backend.constants import (
+    AGENT_BOOT_BLOBLESS_CLONE_FEATURE_FLAG,
+    AGENT_BOOT_BLOBLESS_CLONE_STATE_KEY,
     AGENT_OTEL_TELEMETRY_STATE_KEY,
     AGENT_PEER_MESSAGING_FEATURE_FLAG,
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
@@ -124,6 +126,7 @@ class TaskProcessingContext:
     # (request == limit). Captured at workflow start so it's stable across activity retries.
     burstable_sandbox_resources_enabled: bool = True
     overlap_clone_boot_enabled: bool = False
+    agent_boot_blobless_clone_enabled: bool = False
     # Captured at workflow start so the warmup decision stays stable across retries.
     desktop_workspace_warm_enabled: bool = False
     # Captured at workflow start so the agent-proxy stream lifetime stays deterministic across retries.
@@ -676,6 +679,35 @@ def _is_overlap_clone_boot_enabled(
         overlap_clone_boot_enabled=enabled,
     )
     return enabled
+
+
+def _is_agent_boot_blobless_clone_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    origin_product: str | None,
+    state: dict | None = None,
+) -> bool:
+    if origin_product == Task.OriginProduct.SIGNAL_REPORT:
+        return False
+    state_override = (state or {}).get(AGENT_BOOT_BLOBLESS_CLONE_STATE_KEY)
+    if isinstance(state_override, bool):
+        return state_override
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                AGENT_BOOT_BLOBLESS_CLONE_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as error:
+        log_with_activity_context("agent_boot_blobless_clone_flag_check_failed", run_id=run_id, error=str(error))
+        return False
 
 
 def _is_desktop_workspace_warm_enabled(
@@ -1231,6 +1263,18 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"overlap_clone_boot_enabled: {overlap_clone_boot_enabled} for this task run",
     )
+    agent_boot_blobless_clone_enabled = _is_agent_boot_blobless_clone_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        origin_product=task.origin_product,
+        state=state,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"agent_boot_blobless_clone_enabled: {agent_boot_blobless_clone_enabled} for this task run",
+    )
     desktop_workspace_warm_enabled = _is_desktop_workspace_warm_enabled(
         distinct_id=distinct_id,
         organization_id=organization_id,
@@ -1374,6 +1418,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         use_modal_network_allowlist=use_modal_network_allowlist,
         burstable_sandbox_resources_enabled=burstable_sandbox_resources_enabled,
         overlap_clone_boot_enabled=overlap_clone_boot_enabled,
+        agent_boot_blobless_clone_enabled=agent_boot_blobless_clone_enabled,
         desktop_workspace_warm_enabled=desktop_workspace_warm_enabled,
         agent_proxy_keep_stream_open=agent_proxy_keep_stream_open,
         custom_image_name=custom_image_name,

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -162,6 +162,7 @@ class CreateSandboxForRepositoryOutput:
 @dataclass
 class CloneRepositoryInSandboxOutput:
     clone_ms: int | None = None
+    clone_strategy: str | None = None
 
 
 @dataclass
@@ -316,7 +317,6 @@ def _prewarmed_resume_needs_fresh_agent(
 def _is_blobless_signals_clone_enabled(ctx: TaskProcessingContext) -> bool:
     if ctx.origin_product != Task.OriginProduct.SIGNAL_REPORT:
         return False
-
     try:
         return bool(
             posthoganalytics.feature_enabled(
@@ -1006,7 +1006,13 @@ async def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) 
 @asyncify
 def clone_repository_in_sandbox(input: CloneRepositoryInSandboxInput) -> CloneRepositoryInSandboxOutput:
     ctx = input.context
-    blobless_clone = _is_blobless_signals_clone_enabled(ctx)
+    blobless_clone = _is_blobless_signals_clone_enabled(ctx) or (
+        input.shallow_clone and ctx.agent_boot_blobless_clone_enabled
+    )
+    if input.shallow_clone:
+        clone_strategy = "shallow_blobless" if blobless_clone else "shallow"
+    else:
+        clone_strategy = "blobless" if blobless_clone else "limited_blob"
 
     with log_activity_execution(
         "clone_repository_in_sandbox",
@@ -1070,7 +1076,7 @@ def clone_repository_in_sandbox(input: CloneRepositoryInSandboxInput) -> CloneRe
         if not will_checkout_later:
             _prepare_posthog_desktop_cloud_task(ctx, sandbox, input.repository)
 
-        return CloneRepositoryInSandboxOutput(clone_ms=clone_timer.elapsed_ms)
+        return CloneRepositoryInSandboxOutput(clone_ms=clone_timer.elapsed_ms, clone_strategy=clone_strategy)
 
 
 def _is_missing_remote_branch_clone_error(result: ExecutionResult) -> bool:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -12,6 +12,8 @@ from posthog.models import OrganizationMembership, User
 from posthog.models.user_integration import UserIntegration
 
 from products.tasks.backend.constants import (
+    AGENT_BOOT_BLOBLESS_CLONE_FEATURE_FLAG,
+    AGENT_BOOT_BLOBLESS_CLONE_STATE_KEY,
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
     DESKTOP_WORKSPACE_WARM_FEATURE_FLAG,
@@ -32,6 +34,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     GetTaskProcessingContextInput,
     TaskProcessingContext,
     VmSandboxDecision,
+    _is_agent_boot_blobless_clone_enabled,
     _is_agent_otel_telemetry_enabled,
     _is_agent_proxy_keep_stream_open_enabled,
     _is_burstable_sandbox_resources_enabled,
@@ -48,6 +51,85 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
 from products.tasks.backend.temporal.process_task.utils import get_actor_distinct_id
 
 VM_FLAG_PAYLOAD_TARGET = "products.tasks.backend.constants.posthoganalytics.get_feature_flag_payload"
+
+
+@pytest.mark.parametrize(("flag_result", "expected"), [(True, True), (False, False), (None, False)])
+def test_agent_boot_blobless_clone_uses_rollout_flag(flag_result, expected):
+    with patch(
+        "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+        return_value=flag_result,
+    ) as feature_enabled_mock:
+        assert (
+            _is_agent_boot_blobless_clone_enabled(
+                distinct_id="distinct-id",
+                organization_id="organization-id",
+                run_id="run-id",
+                origin_product=Task.OriginProduct.USER_CREATED,
+            )
+            is expected
+        )
+
+    feature_enabled_mock.assert_called_once_with(
+        AGENT_BOOT_BLOBLESS_CLONE_FEATURE_FLAG,
+        distinct_id="distinct-id",
+        groups={"organization": "organization-id"},
+        group_properties={"organization": {"id": "organization-id"}},
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
+
+
+def test_agent_boot_blobless_clone_fails_closed():
+    with patch(
+        "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+        side_effect=RuntimeError("flag service failed"),
+    ):
+        assert (
+            _is_agent_boot_blobless_clone_enabled(
+                distinct_id="distinct-id",
+                organization_id="organization-id",
+                run_id="run-id",
+                origin_product=Task.OriginProduct.USER_CREATED,
+            )
+            is False
+        )
+
+
+@pytest.mark.parametrize("state_override", [True, False])
+def test_agent_boot_blobless_clone_uses_stable_state_override(state_override):
+    with patch(
+        "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled"
+    ) as feature_enabled_mock:
+        assert (
+            _is_agent_boot_blobless_clone_enabled(
+                distinct_id="distinct-id",
+                organization_id="organization-id",
+                run_id="run-id",
+                origin_product=Task.OriginProduct.USER_CREATED,
+                state={AGENT_BOOT_BLOBLESS_CLONE_STATE_KEY: state_override},
+            )
+            is state_override
+        )
+
+    feature_enabled_mock.assert_not_called()
+
+
+def test_agent_boot_blobless_clone_excludes_signal_reports():
+    with patch(
+        "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled"
+    ) as feature_enabled_mock:
+        assert (
+            _is_agent_boot_blobless_clone_enabled(
+                distinct_id="distinct-id",
+                organization_id="organization-id",
+                run_id="run-id",
+                origin_product=Task.OriginProduct.SIGNAL_REPORT,
+                state={AGENT_BOOT_BLOBLESS_CLONE_STATE_KEY: True},
+            )
+            is False
+        )
+
+    feature_enabled_mock.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -348,6 +348,46 @@ def test_clone_repository_uses_saved_branch_only_for_resumes(mocker, activity_en
     )
 
 
+def test_clone_repository_reports_enabled_blobless_shallow_strategy(mocker, activity_environment):
+    context = TaskProcessingContext(
+        task_id="task-id",
+        run_id="run-id",
+        team_id=1,
+        team_uuid="team-uuid",
+        organization_id="organization-id",
+        github_integration_id=123,
+        repository="posthog/posthog",
+        distinct_id="distinct-id",
+        agent_boot_blobless_clone_enabled=True,
+    )
+    sandbox = mocker.Mock()
+    sandbox.clone_repository.return_value = ExecutionResult(stdout="", stderr="", exit_code=0)
+    mocker.patch(
+        "products.tasks.backend.temporal.process_task.activities.provision_sandbox.get_sandbox_class_for_sandbox_id",
+        return_value=mocker.Mock(get_by_id=mocker.Mock(return_value=sandbox)),
+    )
+
+    result = async_to_sync(activity_environment.run)(
+        clone_repository_in_sandbox,
+        CloneRepositoryInSandboxInput(
+            context=context,
+            sandbox_id="sandbox-id",
+            repository="posthog/posthog",
+            github_token="github-token",
+            shallow_clone=True,
+        ),
+    )
+
+    sandbox.clone_repository.assert_called_once_with(
+        "posthog/posthog",
+        github_token="github-token",
+        shallow=True,
+        branch=None,
+        blobless=True,
+    )
+    assert result.clone_strategy == "shallow_blobless"
+
+
 def test_resume_clone_falls_back_to_default_branch_when_saved_branch_is_missing(mocker, activity_environment):
     context = TaskProcessingContext(
         task_id="task-id",

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -34,6 +34,7 @@ from products.tasks.backend.temporal.process_task import workflow as process_tas
 from products.tasks.backend.temporal.process_task.activities import (
     STEER_DECLINED_OUTCOME,
     CleanupSandboxInput,
+    CloneRepositoryInSandboxOutput,
     CompleteRunStreamInput,
     CreateSandboxForRepositoryInput,
     CreateSandboxForRepositoryOutput,
@@ -2401,7 +2402,7 @@ class TestProcessTaskWorkflowUnit:
             if activity_fn is clone_repository_in_sandbox:
                 cloned.append(args[0].repository)
                 clone_options[args[0].repository] = kwargs
-                return None
+                return CloneRepositoryInSandboxOutput(clone_ms=10, clone_strategy="shallow_blobless")
             if activity_fn is emit_progress_activity:
                 return None
             raise AssertionError(f"Unexpected activity call: {activity_fn}")
@@ -2416,7 +2417,8 @@ class TestProcessTaskWorkflowUnit:
         assert clone_options["posthog/posthog"]["retry_policy"].maximum_attempts == 3
         assert clone_options["posthog/code"]["start_to_close_timeout"] == timedelta(minutes=5)
         assert clone_options["posthog/code"]["retry_policy"].maximum_attempts == 3
-        assert result.clone_ms is None
+        assert result.clone_ms == 20
+        assert result.clone_strategy == "shallow_blobless"
 
     async def test_get_sandbox_for_repository_uses_desktop_budget_for_snapshot_checkout(self, monkeypatch):
         workflow = ProcessTaskWorkflow()

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1739,6 +1739,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 "boot_total_ms": agent_server_output.boot_total_ms,
                 "sandbox_create_ms": sandbox_output.create_ms,
                 "repo_clone_ms": sandbox_output.clone_ms,
+                "repo_clone_strategy": sandbox_output.clone_strategy,
                 "branch_checkout_ms": sandbox_output.checkout_ms,
                 "agent_launch_ms": sandbox_output.launch_ms,
                 "agent_prepare_ms": (
@@ -2044,6 +2045,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             self._agent_shadow_launched = bool(launch_output and launch_output.shadow_launched)
 
         clone_ms: int | None = None
+        clone_strategy: str | None = None
         failed_repositories: set[str] = set()
         materialized_failed_repositories: set[str] = set()
         repo_ready_released = False
@@ -2105,6 +2107,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 *(clone_repository(repository) for repository in repositories_to_clone)
             )
             clone_durations: list[int] = []
+            clone_strategies: set[str] = set()
             for repository, (clone_output, clone_failed, released_after_clone) in zip(
                 repositories_to_clone, clone_outputs
             ):
@@ -2115,7 +2118,11 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 repo_ready_released = repo_ready_released or released_after_clone
                 if (duration := getattr(clone_output, "clone_ms", None)) is not None:
                     clone_durations.append(duration)
+                if (strategy := getattr(clone_output, "clone_strategy", None)) is not None:
+                    clone_strategies.add(strategy)
             clone_ms = sum(clone_durations) if clone_durations else None
+            if clone_strategies:
+                clone_strategy = next(iter(clone_strategies)) if len(clone_strategies) == 1 else "mixed"
             if failed_repositories:
                 failed_list = ", ".join(sorted(failed_repositories))
                 remaining_failed_repositories = sorted(failed_repositories - materialized_failed_repositories)
@@ -2194,6 +2201,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             image_source=prepared.image_source,
             create_ms=created.create_ms,
             clone_ms=clone_ms,
+            clone_strategy=clone_strategy,
             checkout_ms=checkout_ms,
             launch_ms=launch_ms,
             agent_prepare_ms=agent_prepare_ms,

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -151,6 +151,7 @@ Tracked after sandbox and agent server are provisioned.
 | `boot_total_ms`                 | `int`  | Infrastructure boot time, excluding setup agent execution |
 | `sandbox_create_ms`             | `int`  | Sandbox creation time                                     |
 | `repo_clone_ms`                 | `int`  | Repository clone time                                     |
+| `repo_clone_strategy`           | `str`  | Clone strategy selected for the run                       |
 | `branch_checkout_ms`            | `int`  | Branch checkout time                                      |
 | `agent_launch_ms`               | `int`  | Agent server launch time                                  |
 | `agent_prepare_ms`              | `int`  | Backend launch configuration time                         |
@@ -208,6 +209,10 @@ Both first-interaction events include:
 | `provider`             | `str` | Model provider                    |
 | `sandbox_backend`      | `str` | Sandbox provider                  |
 | `transport`            | `str` | SSE or sequenced event ingest     |
+
+### Clone strategy rollout
+
+`tasks-agent-boot-blobless-clone` compares the current shallow clone with a shallow blobless clone. The flag is evaluated on the server and fails closed to the current strategy. Use `repo_clone_strategy` to compare boot latency and failure rates between cohorts.
 
 ### Modal VM rollout payload
 


### PR DESCRIPTION
## Problem

Repository clone latency dominates the slow boot tail, but the current path has no controlled strategy comparison.

## Changes

- Gate shallow blobless clones behind an internal server-side holdout.
- Record the selected clone strategy on `sandbox_started`.
