### PR TITLE
feat(warehouse_sources): add pipeline/status/finished_at index on external data jobs

### DIFF
--- a/products/warehouse_sources/backend/migrations/0156_externaldatajob_pipeline_status_finished_idx.py
+++ b/products/warehouse_sources/backend/migrations/0156_externaldatajob_pipeline_status_finished_idx.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # Concurrent index builds cannot run inside a transaction.
+    atomic = False
+    dependencies = [("warehouse_sources", "0155_repin_github_api_version")]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="externaldatajob",
+            index=models.Index(
+                fields=["pipeline", "status", "finished_at"],
+                name="idx_extdatajob_pipe_stat_fin",
+            ),
+        ),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0155_repin_github_api_version
+0156_externaldatajob_pipeline_status_finished_idx

--- a/products/warehouse_sources/backend/models/external_data_job.py
+++ b/products/warehouse_sources/backend/models/external_data_job.py
@@ -55,6 +55,13 @@ class ExternalDataJob(CreatedMetaFields, UpdatedMetaFields, UUIDTModel):
                 fields=["updated_at"],
                 name="idx_extdatajob_updated_at",
             ),
+            # Serves the rows-synced aggregates (usage report, source health): equality on
+            # pipeline/status with a finished_at range. Without it the FK index walks every
+            # job for the pipeline and filters most of them out.
+            models.Index(
+                fields=["pipeline", "status", "finished_at"],
+                name="idx_extdatajob_pipe_stat_fin",
+            ),
         ]
 
     def folder_path(self) -> str:


### PR DESCRIPTION
## Problem

The usage report and the marketing analytics source health check both sum `rows_synced` over completed external data jobs for a pipeline within a `finished_at` window.
The only index that serves those queries is the foreign key index on `pipeline_id`.
Postgres walks every job a pipeline ever ran and discards the ones outside the status and time range on the heap, which is nearly all of them.
pganalyze flagged both queries and recommends this index.

<details>
<summary>Affected queries</summary>

Usage report, from `get_teams_with_rows_synced_in_period` in `posthog/tasks/usage_report.py`:

```sql
SELECT "posthog_externaldatajob"."team_id" AS "team_id", SUM("posthog_externaldatajob"."rows_synced") AS "total"
  FROM "posthog_externaldatajob"
 INNER JOIN "posthog_externaldatasource" ON ("posthog_externaldatajob"."pipeline_id" = "posthog_externaldatasource"."id")
 WHERE (NOT ("posthog_externaldatasource"."created_at" >= $1::timestamptz)
   AND "posthog_externaldatajob"."billable"
   AND "posthog_externaldatajob"."finished_at" >= $2::timestamptz
   AND "posthog_externaldatajob"."finished_at" <= $3::timestamptz
   AND "posthog_externaldatajob"."status" = $4)
 GROUP BY 1
```

Source health, from `_get_rows_synced` in `products/marketing_analytics/backend/services/data_source_health.py`:

```sql
SELECT SUM("posthog_externaldatajob"."rows_synced") AS "total"
  FROM "posthog_externaldatajob"
 WHERE ("posthog_externaldatajob"."finished_at" >= $1::timestamptz
   AND "posthog_externaldatajob"."pipeline_id" = $2::uuid
   AND "posthog_externaldatajob"."status" = $3)
```

</details>

## Changes

- Adds the composite index `(pipeline_id, status, finished_at)` on `posthog_externaldatajob`, so both predicates move into the index condition and each probe returns only the matching rows.
- The usage report query already runs as a nested loop from sources into jobs through the `pipeline_id` index. The new index has the same leading column, so the planner takes it as a direct replacement rather than a plan change.
- The migration builds the index concurrently through `SafeAddIndexConcurrently`, which disables the statement timeout for the build and is idempotent under deploy retries.
- Nothing user-visible changes.

## How did you test this code?

- `makemigrations --check` reports no drift and `sqlmigrate` emits `CREATE INDEX CONCURRENTLY "idx_extdatajob_pipe_stat_fin" ON "posthog_externaldatajob" ("pipeline_id", "status", "finished_at")`, matching the pganalyze recommendation.
- `EXPLAIN (ANALYZE, BUFFERS)` on a production read replica confirmed both queries spend their time in the `Rows Removed by Filter` step of the `pipeline_id` index scan.
- Not run: the migration against a local database, and the risk analyzer CI job.
- No tests added: an index adds no behavior to assert.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored the model change and migration after a review of the pganalyze recommendation.
Skills invoked: `/django-migrations`, `/writing-pr-descriptions`.
The queries' plans were checked on a production replica before deciding the index was worth adding; the index column order follows the pganalyze suggestion unchanged.
