### PR TITLE
fix(oauth): check third-party access from the user's tokens

### DIFF
--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -409,6 +409,7 @@ class TestUserAPI(APIBaseTest):
             ("live_refresh_token_only", -1, True, False, True),
             ("expired_access_token_only", -1, False, False, False),
             ("live_access_token_first_party", 1, False, True, False),
+            ("live_refresh_token_only_first_party", -1, True, True, False),
         ]
     )
     def test_requires_credential_review_for_oauth_access(

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -705,12 +705,15 @@ def has_live_third_party_oauth_access(user: "User") -> bool:
 
     First-party applications are excluded because they are PostHog's own surfaces, so a token from
     one is not the third-party access this answers about.
+
+    The check starts from the user's tokens, not from the application table. An `id IN (...)`
+    filter on applications makes Postgres scan every application row even when the user has no
+    tokens at all, and this runs on every load of the current user.
     """
-    return OAuthApplication.objects.filter(
-        Q(id__in=live_oauth_access_tokens(user).values("application_id"))
-        | Q(id__in=live_oauth_refresh_tokens(user).values("application_id")),
-        is_first_party=False,
-    ).exists()
+    return (
+        live_oauth_access_tokens(user).filter(application__is_first_party=False).exists()
+        or live_oauth_refresh_tokens(user).filter(application__is_first_party=False).exists()
+    )
 
 
 def lock_oauth_connection(*, user_id: int, application_id: uuid.UUID) -> None:

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -9,7 +9,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import ValidationError
 from django.db import connection, models, transaction
-from django.db.models import Q
+from django.db.models import Exists, Q
 from django.dispatch import receiver
 from django.utils import timezone
 
@@ -26,6 +26,7 @@ from oauth2_provider.settings import oauth2_settings
 from oauth2_provider.validators import AllowedURIValidator
 
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
+from posthog.models.user import User
 from posthog.models.utils import UUIDT, generate_random_token, hash_key_value, mask_key_value
 
 if TYPE_CHECKING:
@@ -709,11 +710,14 @@ def has_live_third_party_oauth_access(user: "User") -> bool:
     The check starts from the user's tokens, not from the application table. An `id IN (...)`
     filter on applications makes Postgres scan every application row even when the user has no
     tokens at all, and this runs on every load of the current user.
+
+    Both lookups go in one query as `EXISTS(...) OR EXISTS(...)` on the user row. Postgres runs
+    the second subplan only when the first finds nothing, so refresh tokens go first: a partner
+    holds one for the life of the connection, while its access token is usually expired.
     """
-    return (
-        live_oauth_access_tokens(user).filter(application__is_first_party=False).exists()
-        or live_oauth_refresh_tokens(user).filter(application__is_first_party=False).exists()
-    )
+    has_refresh_token = Exists(live_oauth_refresh_tokens(user).filter(application__is_first_party=False))
+    has_access_token = Exists(live_oauth_access_tokens(user).filter(application__is_first_party=False))
+    return User.objects.filter(pk=user.pk).filter(has_refresh_token | has_access_token).exists()
 
 
 def lock_oauth_connection(*, user_id: int, application_id: uuid.UUID) -> None:


### PR DESCRIPTION
## Problem

Loading the current user (`/api/users/@me`) runs a check for whether a third-party OAuth application can still act as that user, to decide if the credential review screen should show.
The check filtered `posthog_oauthapplication` by two `id IN (...)` subqueries over the user's access and refresh tokens.
Postgres cannot drive that shape from the token side, so it sequentially scans the whole application table on every call, even when the user has no tokens at all.
The application table is large enough that this shows up as sustained CPU load on the main Postgres.

<details>
<summary>Query before this change</summary>

```sql
SELECT 1 AS "a"
  FROM "posthog_oauthapplication"
 WHERE (("posthog_oauthapplication"."id" IN (
          SELECT U0."application_id" FROM "posthog_oauthaccesstoken" U0
           WHERE U0."application_id" IS NOT NULL AND U0."expires" > $1 AND U0."user_id" = $2)
      OR "posthog_oauthapplication"."id" IN (
          SELECT U0."application_id" FROM "posthog_oauthrefreshtoken" U0
           WHERE U0."revoked" IS NULL AND U0."user_id" = $3))
   AND NOT "posthog_oauthapplication"."is_first_party")
 LIMIT 1
```

Plan shape on a production replica: `Seq Scan on posthog_oauthapplication` with `Filter: (NOT is_first_party) AND ((hashed SubPlan 1) OR (hashed SubPlan 2))`, removing every row, for a user with no tokens.

</details>

## Changes

- `has_live_third_party_oauth_access` now starts from the user's tokens: one query on the user row with `EXISTS(unrevoked refresh tokens) OR EXISTS(live access tokens)`, each joined to a non-first-party application.
- Each `EXISTS` is an index scan on `user_id` plus a primary key probe into applications, and the application table is never scanned.
- Refresh tokens are checked first. Postgres runs the second `EXISTS` only when the first finds nothing, and a provisioning partner holds a refresh token for the life of the connection while its access token is usually expired.
- The answer is unchanged for every case: live third-party access token, unrevoked refresh token, expired token, and first-party tokens of either kind.
- Nothing user-visible changes.

## How did you test this code?

- `EXPLAIN (ANALYZE, BUFFERS)` on a production replica, same two users, before and after:

| Case | Before | After |
| --- | --- | --- |
| User with no tokens (the common case) | 530 ms, 406k buffers, seq scan of every application | 0.04 ms, 3 buffers, application probe never executed |
| User with the most live tokens | 205 ms, 124k buffers | 0.06 ms, 13 buffers, access token subplan never executed |

- The after plan is an `Index Scan` on the token table's `user_id` index and a primary key probe into applications; the application table is not scanned in either case. The SQL Django emits was printed from a shell and matches the profiled statement.
- Extends `test_requires_credential_review_for_oauth_access` with a first-party refresh token case, which catches a rewrite that drops the `is_first_party` filter from the refresh token branch. The existing cases cover the other three branches.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code identified the plan shape from `EXPLAIN ANALYZE` on a production replica and rewrote the check.
Skills invoked: `/writing-pr-descriptions`, `/writing-tests`.
The first version considered was adding an index; the plans showed no index on `posthog_oauthapplication` helps a hashed subplan filter, so the query was inverted instead.


