### PR TITLE
docs(warehouse_sources): record Zuora meters as out of scope

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -9543,6 +9543,8 @@ Diffed against: <https://developer.zuora.com/yaml/apis/zuora-openapi-full-compac
 
 Note: The connector already uses Zuora's Object Query API (/object-query/<segment>, filtered on updateddate), so every gap listed is a same-shape, same-pagination addition - the spec exposes ~50 object-query collections and the source wires up 8. Also unsynced but lower value: payment-applications, refund-applications, payment-methods, taxation-items, billing-runs, payment-runs, prepaid-balances/prepaid-balance-transactions, invoice-schedules, ramps, summarystatements. Zuora also serves the spec as zuora-openapi-for-otc.yaml (order-to-cash only); I used the full compact build, version 2026-07-24.
 
+Out of scope — the Metering/meters API (`/meters/*`): despite the "Metering/meters endpoints" changelog note, this family exposes no Object Query collection and no plain list-of-meters endpoint. Every path is either an operational action (run/stop/debug a meter, import a definition, truncate or query event stores) or a per-resource fetch (meter summary, run status, audit-trail entries), none of which supports the `updateddate` filter and cursor pagination this source is built on, so there is no incremental table to add.
+
 ## Zylo — gaps
 
 Today (12): `ActivityHistory`, `ApplicationBudgets`, `ApplicationLicenses`, `ApplicationUsers`, `Applications`, `ContractLineItems`, `Contracts`, `POLineItems`, `Payments`, `PurchaseOrders`, `SavingsEvents`, `Suppliers`


### PR DESCRIPTION
## Problem

The Zuora warehouse source syncs 8 Object Query collections. A changelog sweep flagged the v1 API's "Metering/meters endpoints" as a missing table for the source. Verification against Zuora's OpenAPI spec and the v1 API changelog shows there is nothing warehouse-table material to add, so the gap tracking should say so.

## Changes

- Records `meters` as out of scope in the Zuora section of the warehouse-source coverage appendix, so future sweeps do not re-triage it.
- The Zuora source is built entirely on the Object Query API (`/object-query/<segment>`, filtered on `updateddate`, cursor-paginated). Zuora exposes no `object-query/meters` collection.
- The `/meters/*` family is operational actions (run, stop, debug a meter, import a definition, truncate or query event stores) and per-resource fetches (meter summary, run status, audit-trail entries). None is a listable collection of meter records.
- No `/meters/*` path supports the `updateddate` filter or cursor pagination this source relies on, so no incremental table can be wired the way the existing endpoints are.

No source code changes. The only edit is documentation.

## How did you test this code?

Documentation-only change, so no automated tests were added or run. The skip decision was verified against two public sources:

- Zuora's full compact OpenAPI spec (`zuora-openapi-full-compact.yaml`): its `object-query` path list contains no `meters` collection, and the `/meters/*` paths are all POST actions or per-resource GETs.
- The v1 API changelog: every announced meters endpoint is an action or per-resource fetch, none a queryable collection of meter records.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This is an internal engineering appendix, not a posthog.com doc.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Automated warehouse-source coverage sweep. The task was to add a table for the Zuora `meters` endpoint from a changelog note, verify it against the vendor's official API reference first, and skip it if it was not warehouse-table material.

Skills invoked: `/implementing-warehouse-sources`, `/writing-pr-descriptions`.

Verification found the announced endpoint over-claimed: the Metering API has no Object Query collection and no list-of-meters endpoint, so no table survives. Per the task's skip path, no source code was written; the outcome is recorded in the coverage appendix instead.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
