### PR TITLE
fix(tasks): make hogli start defer to the backend dev-stack boot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
   - Frontend: `pnpm --filter=@posthog/frontend build`
   - Start dev: `./bin/start` or `hogli start` (interactive TUI). Detached mode: `hogli up -d` paired with `hogli wait` / `hogli down`
     - Cloud task VMs (prebaked dev-stack image): run `bootstrap-dev-stack` first (restores compose host aliases, starts dockerd), then `uv sync`, `source .venv/bin/activate`, `hogli start -y -d`, and `hogli wait` (the detached start returns while the stack is still booting; `hogli wait` blocks until every process is ready) — always detached: the sandbox has no TTY, and phrocs under a pseudo-TTY balloons in memory until OOM-killed
-    - Cloud task VMs: on user-created runs the backend may already be starting the stack; check `curl -sf localhost:8010/_health` and `/tmp/posthog-preview/status.json` before running `hogli start`
+    - Cloud task VMs: on user-created runs the backend usually starts the stack itself. While it does, `hogli start` exits without starting anything. Poll `/tmp/posthog-preview/status.json` until `state` is `ready` or `failed`. On `ready`, run `hogli wait`; it reports `not reachable` until the backend reaches the phrocs step, so retry it rather than forcing a second start. On `failed` (the backend does not retry), start the stack yourself with `hogli start -y -d`
     - Cloud task VMs, frontend work: `pnpm install --frozen-lockfile --prefer-offline` links from the prebaked pnpm store, and Playwright Chromium is preinstalled; product/Storybook builds still run from source
 - OpenAPI/types: `hogli build:openapi` (regenerate after changing serializers/viewsets)
 - LSP: Pyright is configured against the flox venv. Prefer LSP (`goToDefinition`, `findReferences`, `hover`) over grep when navigating or refactoring Python code.
@@ -129,6 +129,7 @@ The check fails open (missing `gh` or `trunk`, not logged in, offline, API error
 
 A pre-push hook runs `hogli ci:preflight --strict`, failing the push on deterministic CI breakage reachable from your diff (lint, lockfiles, migration conflicts). Never bypass it (`--no-verify`).
 If it blocks the push, run `hogli ci:preflight --fix`, resolve the remaining `✗ fail` lines, act on the `→ advisory` ones (regenerate OpenAPI types, merge master in), and push again.
+Advisories never block the push; in a cloud task sandbox, do not boot the dev stack only to clear one.
 In environments without hooks (no `node_modules`), run `hogli ci:preflight --fix` yourself before pushing or reporting a task done. If the command reports it is disabled, that's intentional — proceed.
 
 ### Merging PRs

--- a/bin/start
+++ b/bin/start
@@ -35,6 +35,27 @@ cleanup_lock() {
     rm -f "$LOCK_FILE"
 }
 
+PREVIEW_STATE_DIR=/tmp/posthog-preview
+PREVIEW_LOCK_FILE="$PREVIEW_STATE_DIR/lock"
+launched_by_preview() {
+    [[ "$(readlink /proc/self/fd/9 2>/dev/null)" == "$PREVIEW_LOCK_FILE" ]]
+}
+if [[ -z "${HOGLI_SKIP_PREVIEW_CHECK:-}" && -e "$PREVIEW_LOCK_FILE" ]] && ! launched_by_preview; then
+    if ! flock -n "$PREVIEW_LOCK_FILE" true 2>/dev/null; then
+        echo "ℹ️  The sandbox backend is already starting the dev stack."
+        echo "   Poll $PREVIEW_STATE_DIR/status.json until \"state\" is \"ready\" (or \"failed\"), then run 'hogli wait'."
+        echo "   'hogli wait' reports 'not reachable' while the backend is still installing dependencies; that is expected, retry it."
+        echo "   To force a start anyway: HOGLI_SKIP_PREVIEW_CHECK=1 hogli start -y -d"
+        exit 0
+    fi
+    if grep -qE '"state"[[:space:]]*:[[:space:]]*"ready"' "$PREVIEW_STATE_DIR/status.json" 2>/dev/null \
+        && curl -sf --max-time 5 http://localhost:8010/_health >/dev/null 2>&1; then
+        echo "ℹ️  The dev stack started by the sandbox backend is already running. Run 'hogli wait' to confirm it is ready."
+        echo "   To force a start anyway: HOGLI_SKIP_PREVIEW_CHECK=1 hogli start -y -d"
+        exit 0
+    fi
+fi
+
 # Acquire exclusive lock using flock (atomic, no race condition)
 exec 9>"$LOCK_FILE"
 if ! flock -n 9; then

--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -349,7 +349,13 @@ burstable 0.5 floor (a fallback to the plain base image keeps the plain floor), 
 `sandbox_resources` override still wins. The launcher starts with a scrubbed
 environment (`env -i`, fixed PATH), so the stack and its containers never inherit the run's
 GitHub token or personal API key. Relaunching is safe: the script takes an `flock` and reports
-`ready` straight away when the stack is already serving.
+`ready` straight away when the stack is already serving. While that lock is held, or once the
+stack it started answers `/_health`, `bin/start` (so `hogli start`) exits 0 without starting a
+second stack and tells the agent to poll `status.json` for `ready` or `failed`; `hogli wait`
+returns `not reachable` (exit 3) until the launcher reaches the phrocs step, so the agent retries
+it rather than forcing a start. The backend does not retry a `failed` preview; the agent then
+starts the stack itself. `HOGLI_SKIP_PREVIEW_CHECK=1` bypasses the guard, and the launcher sets it
+for its own `hogli start`.
 
 A Modal tunnel cannot reach the 127.0.0.1 listeners the dev compose stack publishes, and a
 two-origin setup breaks ES module loading, so the script puts one host-network Caddy container on

--- a/products/tasks/backend/sandbox/images/start-dev-stack-preview.sh
+++ b/products/tasks/backend/sandbox/images/start-dev-stack-preview.sh
@@ -147,7 +147,7 @@ CADDY
 
 echo "== bootstrap-dev-stack =="
 if [ -x /usr/local/bin/bootstrap-dev-stack ]; then
-	/usr/local/bin/bootstrap-dev-stack || fail "bootstrap-dev-stack failed"
+	/usr/local/bin/bootstrap-dev-stack 9>&- || fail "bootstrap-dev-stack failed"
 fi
 
 echo "== preview proxy =="
@@ -184,9 +184,16 @@ export TRUST_ALL_PROXIES=1
 export DEBUG=1
 export COMPOSE_PROJECT_NAME=posthog
 export HOGLI_SKIP_ZOMBIE_CHECK=1
+export HOGLI_SKIP_PREVIEW_CHECK=1
 
 echo "== hogli start =="
-hogli start -y -d || fail "hogli start failed"
+start_lock_deadline=$((SECONDS + 120))
+until flock -n "$REPO_PATH/bin/start.lock" true 2>/dev/null; do
+	[ "$SECONDS" -lt "$start_lock_deadline" ] || break
+	echo "another bin/start is running; waiting for it"
+	sleep 2
+done
+hogli start -y -d || echo "hogli start did not start a new stack; waiting for the existing one"
 
 echo "== hogli wait =="
 hogli wait --timeout "$HEALTH_TIMEOUT_SECONDS" || fail "a dev stack process crashed or did not become ready within ${HEALTH_TIMEOUT_SECONDS}s"


### PR DESCRIPTION
## Problem

- On a user-created cloud run the backend already boots the dev stack for the run's preview, and the agent then runs `hogli start -y -d` a second time to get Postgres for `hogli build:openapi`.
- Two stacks on one VM starve it, and `AGENTS.md` only asked the agent to check first, which it did not.

## Changes

- `hogli start` (through `bin/start`) now exits 0 with "run `hogli wait`" while the preview launcher holds `/tmp/posthog-preview/lock`, or while the stack it started answers `/_health` and `status.json` says `ready`.
- The lock check cannot go stale: the kernel drops the `flock` when the launcher dies, so a crashed boot lets the next `hogli start` through.
- `HOGLI_SKIP_PREVIEW_CHECK=1` forces a start, matching the existing `HOGLI_SKIP_ZOMBIE_CHECK` seam. The preview launcher exports it for its own `hogli start`.
- `AGENTS.md` tells the agent that `hogli start` is a no-op in that state, and that a `ci:preflight` advisory never needs the stack. Docs text only.
- Local developers are unaffected: the guard is one `-e` test on a path that only exists inside a sandbox.

