### PR TITLE
feat(warehouse_sources): add Tally folders and form analytics metrics tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS_APPENDIX.md
@@ -8333,6 +8333,21 @@ Diffed against: <https://api.tailscale.com/api/v2?outputOpenapiSchema=true>
 
 Note: Fetched the live OpenAPI 3.1 schema (58 paths). Static 4-endpoint config in sources/tailscale/settings.py, no dynamic discovery. Coverage of the tailnet-level list endpoints is reasonable; the notable miss is network flow logs, which sit on the same /logging prefix as the audit logs already synced and are by far the largest analytical dataset the API exposes. ACL, DNS, contacts, settings, webhooks and OAuth apps are all config and correctly out of scope.
 
+## Tally — gaps
+
+Today (7): `workspaces`, `forms`, `folders`, `questions`, `submissions`, `form_analytics_metrics`, `webhooks`
+
+Diffed against: <https://developers.tally.so/api-reference/changelog>
+
+- [x] `GET /workspaces/{workspaceId}/folders` — Folders that organize a workspace's forms; fanned out per workspace (added)
+- [x] `GET /forms/{formId}/analytics/metrics` — Aggregate per-form metrics (visits, submissions, completion rate); fanned out per form with `period=all` (added)
+- [ ] `GET /forms/{formId}/analytics/visits` — Form visits over time; a time series, not a table row per resource, so it needs a bucketed shape before it is worth syncing (low)
+- [ ] `GET /forms/{formId}/analytics/submissions` — Completed and partial submissions over time; same time-series shape caveat as visits (low)
+- [ ] `GET /forms/{formId}/analytics/dimensions` — Visitor breakdowns by source, browser, OS, device, and location (low)
+- [ ] `GET /forms/{formId}/analytics/drop-off` — Per-question drop-off statistics (low)
+
+Note: The folders and form-analytics endpoints were announced in the June 2026 releases (v0.8.0, v0.9.0) and are additive, so they are reachable with the source's pinned `tally-version: 2025-02-01`. Folders returns a bare JSON array; the metrics endpoint returns a single aggregate object per form. The remaining analytics endpoints are time series rather than one-row-per-resource tables, so they are deferred until a bucketed table shape is designed for them.
+
 ## Tavus — gaps
 
 Today (4): `conversations`, `personas`, `replicas`, `videos`

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tally/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tally/canonical_descriptions.py
@@ -52,6 +52,38 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "updatedAt": "When the question was last updated.",
         },
     },
+    "folders": {
+        "description": "A folder used to organize a workspace's forms. Folders can nest under a parent folder.",
+        "docs_url": "https://developers.tally.so/api-reference/endpoint/workspaces/folders/list",
+        "columns": {
+            "id": "Unique identifier for the folder within its workspace.",
+            "name": "Name of the folder.",
+            "workspaceId": "Identifier of the workspace the folder belongs to.",
+            "parentId": "Identifier of the parent folder, or null for a top-level folder.",
+            "createdByUserId": "Identifier of the user who created the folder.",
+            "createdAt": "When the folder was created.",
+            "updatedAt": "When the folder was last updated.",
+        },
+    },
+    "form_analytics_metrics": {
+        "description": (
+            "Aggregate performance metrics for a form over its whole history. One row per form, "
+            "recomputed on every sync."
+        ),
+        "docs_url": "https://developers.tally.so/api-reference/endpoint/forms/analytics/metrics",
+        "columns": {
+            "formId": "Identifier of the form the metrics are for.",
+            "visits": "Number of visits to the form.",
+            "visitDuration": "Average time spent on the form, in seconds.",
+            "submissions": "Number of submissions the form received.",
+            "uniqueRespondents": "Number of distinct respondents who submitted the form.",
+            "totalViews": "Total number of times the form was viewed.",
+            "starts": "Number of respondents who began filling in the form.",
+            "completions": "Number of respondents who completed the form.",
+            "completionDuration": "Average time to complete the form, in seconds.",
+            "completionRate": "Share of starts that resulted in a completion.",
+        },
+    },
     "submissions": {
         "description": (
             "A single submission of a form, with every answer nested under `responses`. Answers are "

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tally/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tally/settings.py
@@ -28,6 +28,11 @@ WEBHOOKS_PAGE_SIZE = 100
 SUBMISSION_FILTER_COMPLETED: Literal["completed"] = "completed"
 SUBMISSION_FILTER_ALL: Literal["all"] = "all"
 
+# /forms/{formId}/analytics/metrics requires a `period`. It returns one aggregate row per form, so
+# the whole-lifetime window is the only one that makes the row self-contained rather than a moving
+# slice — every sync recomputes it in full.
+FORM_METRICS_PERIOD = "all"
+
 
 @dataclass
 class TallyEndpointConfig:
@@ -55,7 +60,10 @@ class TallyEndpointConfig:
     capture_samples: bool = True
 
 
-def _forms_fanout(parent_params: Optional[dict[str, object]] = None) -> DependentEndpointConfig:
+def _forms_fanout(
+    parent_params: Optional[dict[str, object]] = None,
+    child_params: Optional[dict[str, object]] = None,
+) -> DependentEndpointConfig:
     # Child rows already carry `formId`, but injecting the parent id guarantees the composite
     # primary key's column exists even if a future response shape drops it.
     return DependentEndpointConfig(
@@ -65,6 +73,20 @@ def _forms_fanout(parent_params: Optional[dict[str, object]] = None) -> Dependen
         include_from_parent=["id"],
         parent_field_renames={"id": "formId"},
         parent_params=dict(parent_params or {}),
+        child_params=dict(child_params or {}),
+    )
+
+
+def _workspaces_fanout() -> DependentEndpointConfig:
+    # Folders are listed per workspace, and a folder id is only documented as unique within its
+    # workspace, so the parent workspace is part of the key. The row already carries `workspaceId`,
+    # but injecting the parent id guarantees the key column exists even if the shape drops it.
+    return DependentEndpointConfig(
+        parent_name="workspaces",
+        resolve_param="workspaceId",
+        resolve_field="id",
+        include_from_parent=["id"],
+        parent_field_renames={"id": "workspaceId"},
     )
 
 
@@ -130,6 +152,33 @@ TALLY_ENDPOINTS: dict[str, TallyEndpointConfig] = {
         partition_key="createdAt",
         redact_fields=("signingSecret", "httpHeaders"),
         capture_samples=False,
+    ),
+    # One request per workspace. Folders organize a workspace's forms; the endpoint returns the
+    # whole set as a bare JSON array with no wrapper key and no pagination.
+    "folders": TallyEndpointConfig(
+        name="folders",
+        path="/workspaces/{workspaceId}/folders",
+        data_selector="$",
+        page_size_param=None,
+        paginated=False,
+        primary_keys=["workspaceId", "id"],
+        partition_key="createdAt",
+        fanout=_workspaces_fanout(),
+    ),
+    # One request per form. Returns a single aggregate object (visits, submissions, completion rate)
+    # with no wrapper, no array, and no id of its own — one row per form, recomputed every sync.
+    "form_analytics_metrics": TallyEndpointConfig(
+        name="form_analytics_metrics",
+        path="/forms/{formId}/analytics/metrics",
+        data_selector="$",
+        page_size_param=None,
+        paginated=False,
+        primary_keys=["formId"],
+        # The aggregate carries no timestamp, so there is no stable field to partition it by.
+        fanout=_forms_fanout(
+            parent_params={"limit": FORMS_PAGE_SIZE},
+            child_params={"period": FORM_METRICS_PERIOD},
+        ),
     ),
 }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tally/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tally/source.py
@@ -61,7 +61,7 @@ class TallySource(ResumableSource[TallySourceConfig, TallyResumeConfig]):
             keywords=["forms", "surveys", "tally.so"],
             iconPath="/static/services/tally.png",
             docsUrl="https://posthog.com/docs/cdp/sources/tally",
-            caption="""Enter a Tally API key to sync your workspaces, forms, questions, submissions, and webhooks.
+            caption="""Enter a Tally API key to sync your workspaces, forms, folders, questions, submissions, form analytics, and webhooks.
 
 You can create an API key in your [Tally settings](https://tally.so/settings/api-keys). No extra scopes are needed.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tally/tests/test_tally.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tally/tests/test_tally.py
@@ -113,6 +113,7 @@ class TestSourceResponseShape:
             ("questions", ["formId", "id"], "createdAt", "asc"),
             ("submissions", ["formId", "id"], "submittedAt", "desc"),
             ("webhooks", ["id"], "createdAt", "asc"),
+            ("folders", ["workspaceId", "id"], "createdAt", "asc"),
         ]
     )
     @mock.patch(CLIENT_SESSION_PATCH)
@@ -140,6 +141,22 @@ class TestSourceResponseShape:
         # Submissions interleave one form's history after another's, so the stream is not globally
         # ascending and the watermark must only advance once the whole sync finishes.
         assert response.sort_mode == expected_sort_mode
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_metrics_has_no_partition_and_is_keyed_by_form(self, _MockSession: Any) -> None:
+        # The metrics aggregate carries no timestamp, so it must not be partitioned; it is one row
+        # per form, keyed by the injected parent form id (the object has no id of its own).
+        response = tally_source(
+            api_key="key",
+            api_version=TALLY_API_VERSION,
+            endpoint="form_analytics_metrics",
+            team_id=1,
+            job_id="job",
+            resumable_source_manager=_make_manager(),
+        )
+        assert response.primary_keys == ["formId"]
+        assert response.partition_mode is None
+        assert response.partition_keys is None
 
 
 class TestPagination:
@@ -256,6 +273,36 @@ class TestFanOut:
         }
         _rows, params, _session = _run("submissions", responses, submission_filter=submission_filter)
         assert params[1]["filter"] == submission_filter
+
+    def test_folders_fan_out_per_workspace_from_a_bare_array(self) -> None:
+        # /workspaces/{id}/folders returns a bare JSON array with no wrapper key, and a folder id is
+        # only unique within its workspace — so each row must be tagged with its parent workspace.
+        responses = {
+            f"{BASE}/workspaces?page=1": [_page([{"id": "W1"}, {"id": "W2"}], key="items")],
+            f"{BASE}/workspaces/W1/folders": [_resp([{"id": "D1", "workspaceId": "W1", "name": "A"}])],
+            f"{BASE}/workspaces/W2/folders": [_resp([{"id": "D2", "workspaceId": "W2", "name": "B"}])],
+        }
+        rows, _params, _session = _run("folders", responses)
+        assert rows == [
+            {"id": "D1", "workspaceId": "W1", "name": "A"},
+            {"id": "D2", "workspaceId": "W2", "name": "B"},
+        ]
+
+    def test_form_metrics_wrap_a_single_object_and_tag_the_form(self) -> None:
+        # The metrics endpoint returns one aggregate object per form (no wrapper, no array, no id of
+        # its own), so each becomes a single row keyed by the parent form id, and `period` is
+        # required on every child request.
+        responses = {
+            FORMS_PAGE_1: [_page([{"id": "F1"}, {"id": "F2"}])],
+            f"{BASE}/forms/F1/analytics/metrics?period=all": [_resp({"visits": 10, "submissions": 3})],
+            f"{BASE}/forms/F2/analytics/metrics?period=all": [_resp({"visits": 5, "submissions": 1})],
+        }
+        rows, params, _session = _run("form_analytics_metrics", responses)
+        assert rows == [
+            {"visits": 10, "submissions": 3, "formId": "F1"},
+            {"visits": 5, "submissions": 1, "formId": "F2"},
+        ]
+        assert params[1]["period"] == "all"
 
     def test_form_deleted_mid_sync_is_skipped(self) -> None:
         responses = {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tally/tests/test_tally_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tally/tests/test_tally_source.py
@@ -62,7 +62,7 @@ class TestTallySource:
         assert [field["field"] for field in by_name["submissions"].incremental_fields] == ["submittedAt"]
         # `startDate` is inclusive, so append mode would re-write the watermark's own rows.
         assert by_name["submissions"].supports_append is False
-        for name in ("workspaces", "forms", "questions", "webhooks"):
+        for name in ("workspaces", "forms", "questions", "webhooks", "folders", "form_analytics_metrics"):
             assert by_name[name].supports_incremental is False
             assert by_name[name].incremental_fields == []
 


### PR DESCRIPTION
## Problem

A Tally warehouse source user can sync forms and submissions, but two tables Tally's API exposes have no home: the folders that organize a workspace's forms, and each form's aggregate analytics. Tally announced both in its June 2026 releases (folders in v0.9.0, form analytics in v0.8.0).

## Changes

- Users can now sync a `folders` table: one row per folder, with the workspace it belongs to and its parent folder. Fanned out one request per workspace over `/workspaces/{workspaceId}/folders`, which returns a bare JSON array.
- Users can now sync a `form_analytics_metrics` table: one row per form with visits, submissions, completion rate, and related aggregates. Fanned out one request per form over `/forms/{formId}/analytics/metrics`, which returns a single object with no id of its own, so the row is keyed by the parent form id.
- The metrics endpoint requires a `period`; the source sends `period=all` so each row is a self-contained lifetime aggregate, recomputed on every full-refresh sync. It carries no timestamp, so it is left unpartitioned.
- Both endpoints are additive on Tally's date-versioned API, so they are reachable with the source's existing pinned `tally-version: 2025-02-01` — the version pin is unchanged.
- Mechanical: canonical column descriptions for both tables, a `Tally` entry in the coverage appendix, and the source caption now lists the new tables.

Verified against Tally's official API reference: [folders list](https://developers.tally.so/api-reference/endpoint/workspaces/folders/list) and [analytics metrics](https://developers.tally.so/api-reference/endpoint/forms/analytics/metrics). Both endpoints exist on the current API. No endpoints were skipped.

## How did you test this code?

The endpoint additions ride the source's existing REST fan-out framework, so testing is automated. New tests, all run locally:

- `folders` fans out per workspace and extracts rows from a bare array, tagging each with its workspace id — catches a wrong `data_selector` or missing parent-id injection.
- `form_analytics_metrics` wraps a single-object response into one row, tags it with the parent form id, and sends `period=all` — catches broken single-object extraction or a dropped required param.
- `form_analytics_metrics` is left unpartitioned and keyed by `formId` — catches a partition key mistakenly set on a fieldless aggregate.
- both new endpoints report as non-incremental.

Not run: no live Tally account was available, so the endpoints were not exercised against the real API; correctness rests on the vendor reference above and the framework tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com Supported tables section renders from the API (`lists_tables_without_credentials` is on), so the two tables appear there once merged. No in-repo doc change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (Claude, via the PostHog Desktop task runner). Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/writing-pr-descriptions`.

Both endpoint names came from automated changelog research and were verified against Tally's official API reference before building. The metrics endpoint returns a point-in-time aggregate rather than a list; `period=all` with full-refresh was chosen so the table stays a stable one-row-per-form dimension. The pinned API version was deliberately left untouched, since the new endpoints are additive and re-pinning would re-verify every existing endpoint's shape contract.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
