### PR TITLE
fix(customer-analytics): clarify relationship unassignment

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AGENTS.md
+++ b/products/customer_analytics/frontend/components/Accounts/AGENTS.md
@@ -28,7 +28,7 @@ AccountsTabContent  ── binds dataNodeLogic(ACCOUNTS_TABLE_DATA_NODE_KEY, acc
     └── AccountNotebooksExpansion   expanded row: sidebar (Useful links + active-relationships summary) + LemonTabs(Notes/Users/Relationships/Feature requests/Usage/Spend/Opportunities/Conversations/Meetings/Event stream)
         ├── (notes)         paginated/searchable/sortable LemonTable + "New note" button  (accountNotebooksLogic, keyed by accountId)
         ├── (users)         AccountRelatedUsersExpansion             (accountRelatedUsersLogic, keyed by externalId; staff get a compact, region-aware admin link)
-        ├── (relationships) AccountRelationshipsExpansion            (accountRelationshipsLogic, keyed by accountId — full assignment timeline, paginated; assign/end controls + definition filter, admin-only hard-delete controls with confirmation, current assignments sorted on top)
+        ├── (relationships) AccountRelationshipsExpansion            (accountRelationshipsLogic, keyed by accountId — full assignment timeline, paginated; assign/unassign controls + definition filter, admin-only hard-delete controls with confirmation, current assignments sorted on top)
         ├── (feature requests) AccountFeatureRequestsExpansion        (accountFeatureRequestsLogic, keyed by accountId — linked requests and link-existing flow)
         ├── (usage)         AccountBillingExpansion kind="usage"     (accountBillingLogic — a saved billing-usage insight)
         ├── (spend)         AccountBillingExpansion kind="spend"     (accountBillingLogic — saved billing-spend insights)

--- a/products/customer_analytics/frontend/components/Accounts/AccountRelationshipsExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountRelationshipsExpansion.tsx
@@ -95,7 +95,7 @@ export function AccountRelationshipsExpansion({ accountId }: { accountId: string
                                 data-attr="account-relationships-unassign-button"
                                 onClick={() => endRelationship(relationship)}
                             >
-                                Unassigned
+                                Unassign
                             </LemonButton>
                         )}
                         {canDeleteRelationships && (

--- a/products/customer_analytics/frontend/components/Accounts/AccountRelationshipsExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountRelationshipsExpansion.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconTrash, IconX } from '@posthog/icons'
+import { IconTrash } from '@posthog/icons'
 import {
     LemonButton,
     LemonModal,
@@ -88,12 +88,15 @@ export function AccountRelationshipsExpansion({ accountId }: { accountId: string
                     <div className="flex justify-end gap-1">
                         {!relationship.ended_at && (
                             <LemonButton
+                                type="secondary"
                                 size="xsmall"
-                                icon={<IconX />}
                                 tooltip={`End this ${relationship.definition.name} assignment`}
                                 disabledReason={relationshipSaving ? 'Saving…' : undefined}
+                                data-attr="account-relationships-unassign-button"
                                 onClick={() => endRelationship(relationship)}
-                            />
+                            >
+                                Unassigned
+                            </LemonButton>
                         )}
                         {canDeleteRelationships && (
                             <LemonButton


### PR DESCRIPTION
## Problem

The Relationships tab shows an X for ending an assignment, which is ambiguous beside the admin hard-delete control.

## Changes

- Current assignments now show an `Unassign` secondary button instead of an X icon.
- The button keeps the existing end-assignment behavior and save-state guard.
- The existing hard-delete confirmation remains unchanged.
- Screenshot not captured because browser tooling is unavailable in this environment.

## How did you test this code?

- Ran `hogli test products/customer_analytics/frontend/components/Accounts/accountRelationshipsLogic.test.ts`.
- Ran `pnpm --filter=@posthog/frontend fix`.
- Ran `hogli ci:preflight --strict`.
- The full TypeScript check reports existing unrelated missing Quill package exports.

## Automatic notifications

- [ ] Publish to changelog

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop used the `ship-it` workflow. Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and `/ship-it`.

The change keeps hard deletion separate from normal unassignment and only updates the normal assignment-ending control.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
