### PR TITLE
fix(warehouse_sources): fetch the latest completed job per source with one index probe

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1100,11 +1100,15 @@ class Database(BaseModel):
         warehouse_table_names = self.get_warehouse_table_names()
         views = [] if self._is_direct_query() else self.get_view_names()
 
+        direct_query_source_ids = [self._connection_id] if self._is_direct_query() and self._connection_id else None
         warehouse_tables_query = (
             DataWarehouseTable.raw_objects.select_related("credential", "external_data_source")
             .prefetch_related(
                 latest_completed_job_prefetch(
-                    context.team_id, "external_data_source__jobs", to_attr="latest_completed_job"
+                    context.team_id,
+                    "external_data_source__jobs",
+                    to_attr="latest_completed_job",
+                    source_ids=direct_query_source_ids,
                 )
             )
             # `queryable()` drops soft-deleted tables and orphans of a soft-deleted source, so an

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1030,7 +1030,6 @@ class Database(BaseModel):
         include_hidden_posthog_tables: bool = False,
         include_fields: bool = True,
     ) -> dict[str, DatabaseSchemaTable]:
-        from django.db.models import Prefetch  # noqa: PLC0415
 
         from posthog.schema import (  # noqa: PLC0415
             DatabaseSchemaDataWarehouseTable,
@@ -1048,8 +1047,8 @@ class Database(BaseModel):
         from products.revenue_analytics.backend.views import RevenueAnalyticsBaseView  # noqa: PLC0415
         from products.warehouse_sources.backend.facade.models import (  # noqa: PLC0415
             DataWarehouseTable,
-            ExternalDataJob,
             ExternalDataSource,
+            latest_completed_job_prefetch,
         )
 
         tables: dict[str, DatabaseSchemaTable] = {}
@@ -1104,13 +1103,9 @@ class Database(BaseModel):
         warehouse_tables_query = (
             DataWarehouseTable.raw_objects.select_related("credential", "external_data_source")
             .prefetch_related(
-                Prefetch(
-                    "external_data_source__jobs",
-                    queryset=ExternalDataJob.objects.filter(status="Completed", team_id=context.team_id).order_by(
-                        "-created_at"
-                    )[:1],
-                    to_attr="latest_completed_job",
-                ),
+                latest_completed_job_prefetch(
+                    context.team_id, "external_data_source__jobs", to_attr="latest_completed_job"
+                )
             )
             # `queryable()` drops soft-deleted tables and orphans of a soft-deleted source, so an
             # orphan can't shadow the live table sharing its name in the SQL editor catalog.

--- a/products/model_crossing_uses_baseline.txt
+++ b/products/model_crossing_uses_baseline.txt
@@ -161,7 +161,6 @@ warehouse_sources.DataWarehouseTable products.marketing_analytics.backend.manage
 warehouse_sources.DataWarehouseTable products.posthog_ai.evals.data_warehouse.seeder construct 1
 warehouse_sources.DataWarehouseTable products.posthog_ai.evals.data_warehouse.seeder write(bulk_create) 1
 warehouse_sources.DataWarehouseTable products.posthog_ai.evals.data_warehouse.seeder write(create) 1
-warehouse_sources.ExternalDataJob posthog.hogql.database.database prefetch 1
 warehouse_sources.ExternalDataJob posthog.tasks.usage_report instance-many(annotate) 4
 warehouse_sources.ExternalDataJob products.data_warehouse.backend.logic.data_load.source_templates instance-single 2
 warehouse_sources.ExternalDataJob products.data_warehouse.backend.logic.external_data_source.jobs lock 1

--- a/products/warehouse_sources/backend/facade/models.py
+++ b/products/warehouse_sources/backend/facade/models.py
@@ -18,7 +18,11 @@ from products.warehouse_sources.backend.models.credential import (
     DataWarehouseCredential,
     get_or_create_datawarehouse_credential,
 )
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob, get_latest_run_if_exists
+from products.warehouse_sources.backend.models.external_data_job import (
+    ExternalDataJob,
+    get_latest_run_if_exists,
+    latest_completed_job_prefetch,
+)
 from products.warehouse_sources.backend.models.external_data_schema import (
     ExternalDataSchema,
     auto_enable_new_schemas,
@@ -90,6 +94,7 @@ __all__ = [
     "get_direct_external_data_source_for_connection",
     "is_managed_warehouse_connection_ready",
     "get_latest_run_if_exists",
+    "latest_completed_job_prefetch",
     "get_or_create_datawarehouse_credential",
     "clickhouse_column_to_dwh_column",
     "clickhouse_columns_to_dwh_columns",

--- a/products/warehouse_sources/backend/models/external_data_job.py
+++ b/products/warehouse_sources/backend/models/external_data_job.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from uuid import UUID
 
 from django.conf import settings
@@ -80,15 +81,23 @@ def get_external_data_job(job_id: UUID) -> ExternalDataJob:
     ).get(pk=job_id)
 
 
-def latest_completed_job_prefetch(team_id: int, lookup: str, to_attr: str) -> Prefetch:
+def latest_completed_job_prefetch(
+    team_id: int, lookup: str, to_attr: str, source_ids: Collection[UUID | str] | None = None
+) -> Prefetch:
     """Prefetch each source's newest completed job as a one-element list on `to_attr`.
 
     Do not replace this with a sliced prefetch queryset (`order_by("-created_at")[:1]`). Django
     compiles that to a ROW_NUMBER window over every completed job of every listed source, so
     Postgres reads and sorts the team's whole job history to keep one row per source. Selecting
     each source's newest job id in a correlated subquery costs one index probe per source.
+
+    The probes run for every live source of the team unless `source_ids` narrows them, because a
+    prefetch queryset cannot see which parent rows it is loaded for.
     """
-    latest_job_ids = ExternalDataSource.objects.filter(team_id=team_id).values(
+    sources = ExternalDataSource.objects.filter(team_id=team_id).exclude(deleted=True)
+    if source_ids is not None:
+        sources = sources.filter(id__in=source_ids)
+    latest_job_ids = sources.values(
         latest_job_id=Subquery(
             ExternalDataJob.objects.filter(
                 pipeline=OuterRef("pk"), team_id=team_id, status=ExternalDataJobStatus.COMPLETED

--- a/products/warehouse_sources/backend/models/external_data_job.py
+++ b/products/warehouse_sources/backend/models/external_data_job.py
@@ -2,11 +2,12 @@ from uuid import UUID
 
 from django.conf import settings
 from django.db import models
-from django.db.models import Prefetch
+from django.db.models import OuterRef, Prefetch, Subquery
 
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 from posthog.sync import database_sync_to_async
 
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.types import ExternalDataJobPipelineVersion, ExternalDataJobStatus
 
 
@@ -77,6 +78,26 @@ def get_external_data_job(job_id: UUID) -> ExternalDataJob:
     return ExternalDataJob.objects.prefetch_related(
         "pipeline", Prefetch("schema", queryset=ExternalDataSchema.objects.prefetch_related("source"))
     ).get(pk=job_id)
+
+
+def latest_completed_job_prefetch(team_id: int, lookup: str, to_attr: str) -> Prefetch:
+    """Prefetch each source's newest completed job as a one-element list on `to_attr`.
+
+    Do not replace this with a sliced prefetch queryset (`order_by("-created_at")[:1]`). Django
+    compiles that to a ROW_NUMBER window over every completed job of every listed source, so
+    Postgres reads and sorts the team's whole job history to keep one row per source. Selecting
+    each source's newest job id in a correlated subquery costs one index probe per source.
+    """
+    latest_job_ids = ExternalDataSource.objects.filter(team_id=team_id).values(
+        latest_job_id=Subquery(
+            ExternalDataJob.objects.filter(
+                pipeline=OuterRef("pk"), team_id=team_id, status=ExternalDataJobStatus.COMPLETED
+            )
+            .order_by("-created_at")
+            .values("id")[:1]
+        )
+    )
+    return Prefetch(lookup, queryset=ExternalDataJob.objects.filter(id__in=latest_job_ids), to_attr=to_attr)
 
 
 @database_sync_to_async

--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -113,6 +113,7 @@ from products.warehouse_sources.backend.facade.models import (
     ExternalDataSource,
     PendingSourceCredential,
     auto_enable_new_schemas,
+    latest_completed_job_prefetch,
     sync_old_schemas_with_new_schemas,
     update_sync_type_config_keys,
 )
@@ -2143,13 +2144,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             # list load (up to one query, and a get_or_create write, per source).
             .select_related("created_by", "revenue_analytics_config")
             .prefetch_related(
-                Prefetch(
-                    "jobs",
-                    queryset=ExternalDataJob.objects.filter(status="Completed", team_id=self.team_id).order_by(
-                        "-created_at"
-                    )[:1],
-                    to_attr="ordered_jobs",
-                ),
+                latest_completed_job_prefetch(self.team_id, "jobs", to_attr="ordered_jobs"),
                 # The one place schemas are read during serialization. `active_schemas` used to be a
                 # second prefetch over the same rows — it's now derived in Python from this one (see
                 # `_active_schemas`), so the schema table is scanned once.

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -5582,6 +5582,28 @@ class TestExternalDataSource(APIBaseTest):
                 ExternalDataSource.objects.filter(team=self.team, source_type="Postgres").exists(),
             )
 
+    def test_list_last_run_at_is_newest_completed_job(self):
+        source = self._create_external_data_source()
+        schema = self._create_external_data_schema(source.pk)
+        never_completed = self._create_external_data_source()
+        for created_at, job_status in [
+            ("2024-07-01T12:00:00.000Z", ExternalDataJob.Status.COMPLETED),
+            ("2024-07-01T18:00:00.000Z", ExternalDataJob.Status.COMPLETED),
+            ("2024-07-02T06:00:00.000Z", ExternalDataJob.Status.FAILED),
+        ]:
+            with freeze_time(created_at):
+                ExternalDataJob.objects.create(team=self.team, pipeline=source, schema=schema, status=job_status)
+        with freeze_time("2024-07-02T06:00:00.000Z"):
+            ExternalDataJob.objects.create(
+                team=self.team, pipeline=never_completed, status=ExternalDataJob.Status.RUNNING
+            )
+
+        response = self.client.get(f"/api/environments/{self.team.pk}/external_data_sources/")
+
+        assert response.status_code == status.HTTP_200_OK
+        last_run_at = {row["id"]: row["last_run_at"] for row in response.json()["results"]}
+        assert last_run_at == {str(source.pk): "2024-07-01T18:00:00+00:00", str(never_completed.pk): None}
+
     def test_source_jobs(self):
         source = self._create_external_data_source()
         schema = self._create_external_data_schema(source.pk)


### PR DESCRIPTION
## Problem

Listing data warehouse sources, and building the HogQL database for warehouse-backed queries, both look up each source's newest completed sync job.
Both used a sliced prefetch (`order_by("-created_at")[:1]`), which Django compiles to a `ROW_NUMBER() OVER (PARTITION BY pipeline_id)` window filtered to row 1.
Postgres has to read and sort every completed job of every listed source before it can number them, so each call costs the team's whole job history to return one row per source.
pganalyze flagged the query as one of the heaviest on `posthog_externaldatajob`.

<details>
<summary>Query before this change</summary>

```sql
SELECT "col1", ..., "col17" FROM (
  SELECT * FROM (
    SELECT "posthog_externaldatajob".*,
           ROW_NUMBER() OVER (PARTITION BY "posthog_externaldatajob"."pipeline_id"
                              ORDER BY "posthog_externaldatajob"."created_at" DESC) AS "qual0"
      FROM "posthog_externaldatajob"
     WHERE "posthog_externaldatajob"."status" = $1
       AND "posthog_externaldatajob"."team_id" = $2
       AND "posthog_externaldatajob"."pipeline_id" IN ($3::uuid, ..., $67::uuid)
  )
) WHERE "qual0" <= 1
```

</details>

## Changes

- `latest_completed_job_prefetch` builds the prefetch from a correlated subquery that selects each source's newest completed job id, then loads those jobs by primary key. Postgres runs it as one `LIMIT 1` probe of `idx_extdatajob_latest_run` per source.
- The sources list view and the HogQL database build use the helper instead of their own sliced prefetch. The attribute names (`ordered_jobs`, `latest_completed_job`) and the one-element list shape are unchanged, so serializers and the database builder are untouched.
- The helper is exported through the `warehouse_sources` facade, since `posthog/hogql` is outside the product.
- Nothing user-visible changes.

## How did you test this code?

- `EXPLAIN (ANALYZE, BUFFERS)` on a production replica for a team with 155 sources, same predicates:

| | Before (window) | After (correlated subquery) |
| --- | --- | --- |
| Job rows read | 2,003,224 | 155 |
| Buffers | 2.0M | 2.6k |
| Execution time | 2,248 ms | 270 ms cold, dominated by primary key page reads |

- The SQL Django emits for the new queryset was printed from a shell and matches the profiled shape.
- Adds `test_list_last_run_at_is_newest_completed_job`: two sources, one with an older completed job, a newer completed job, and a newest failed job, one with only a running job. It catches a lookup that returns the newest job regardless of status, or more than one job per source. No existing test asserted `last_run_at` against more than one job.


## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code traced the pganalyze query to the two sliced prefetches, profiled the window query and two replacements on a production replica, and wrote the helper and test.
Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
A raw `LATERAL` join was measured first (1.3 ms for the same team) but needs `RawSQL`; the correlated subquery is pure ORM and reads the same number of rows, so it was preferred.
