### PR TITLE
fix(access-control): scope org-wide access control query by team ids

### DIFF
--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -559,6 +559,7 @@ class UserAccessControl:
         """
         Adds the 3 main filter options to the query
         """
+        filters = self._db_filters(filters)
         return (
             Q(  # Access controls applying to this team
                 **filters, organization_member=None, role=None
@@ -576,6 +577,18 @@ class UserAccessControl:
                 **filters, organization_member=None, role__in=self._user_role_ids
             )
         )
+
+    @staticmethod
+    def _db_filters(filters: dict[str, Any]) -> dict[str, Any]:
+        """Replace `team__organization_id` with `team_id__in` (the org's teams) for the DB query.
+        The org id is a posthog_team column, so as a join predicate it forces a scan over every
+        org's rows. A team_id predicate uses the index on ee_accesscontrol."""
+        organization_id = filters.get("team__organization_id")
+        if organization_id is None:
+            return filters
+        db_filters = {k: v for k, v in filters.items() if k != "team__organization_id"}
+        db_filters["team_id__in"] = Team.objects.filter(organization_id=organization_id).values("id")
+        return db_filters
 
     def _can_serve_from_preload(self, filters: dict) -> bool:
         """The preloaded set is `WHERE team_id = self._team.id` (+ the OR-3 precedence), so it

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -328,8 +328,8 @@ class TestUserAccessControl(BaseUserAccessControlTest):
     def test_filters_project_queryset_based_on_acs(self):
         team2 = Team.objects.create(organization=self.organization)
         team3 = Team.objects.create(organization=self.organization)
-        # No default access
-        self._create_access_control(resource="project", resource_id=team2.id, access_level="none")
+        # No default access, stored on the project's own team rather than self.team
+        AccessControl.objects.create(team=team2, resource="project", resource_id=team2.id, access_level="none")
         # No default access
         self._create_access_control(resource="project", resource_id=team3.id, access_level="none")
         # This user access


### PR DESCRIPTION
## Problem

Every API request that checks access to a team resource runs one access control query that scans every organization's project rules, not just the caller's.

- `preload_access_levels` filters the `project` resource by `team__organization_id`.
- That column lives on the joined `posthog_team` row, so Postgres cannot apply it to the `ee_accesscontrol` index.
- The plan scans every object-level `project` row in the instance, joins each to `posthog_team` and `posthog_organizationmembership`, then drops all but a handful.
- The cost grows with the global number of project rules, so it gets worse for everyone as more organizations adopt access control.
- On the production US replica, this query was one of the top contributors to Postgres load.

## Changes

- The org-scoped lookup now filters by `team_id IN (the org's teams)` instead of `team__organization_id`.
- `_filter_options` translates the filter key before building the queryset; the cache keys and the in-memory `_row_matches` path are unchanged.
- No user-visible change.

### Affected query

Only the two org-scoped branches of the `WHERE` clause change. The other branches (team-scoped object and resource lookups) already hit the `unique resource per target` index.

Before:

```sql
SELECT "ee_accesscontrol".*, "posthog_team"."organization_id" AS "_team_organization_id"
FROM "ee_accesscontrol"
INNER JOIN "posthog_team" ON ("ee_accesscontrol"."team_id" = "posthog_team"."id")
LEFT OUTER JOIN "posthog_organizationmembership" ON ("ee_accesscontrol"."organization_member_id" = "posthog_organizationmembership"."id")
WHERE (
  ... -- team-scoped branches, unchanged
  OR ("ee_accesscontrol"."organization_member_id" IS NULL
      AND "ee_accesscontrol"."resource" = 'project' AND "ee_accesscontrol"."resource_id" IS NOT NULL
      AND "ee_accesscontrol"."role_id" IS NULL
      AND "posthog_team"."organization_id" = $org::uuid)
  OR ("posthog_organizationmembership"."organization_id" = $org::uuid AND "posthog_organizationmembership"."user_id" = $user
      AND "ee_accesscontrol"."resource" = 'project' AND "ee_accesscontrol"."resource_id" IS NOT NULL
      AND "ee_accesscontrol"."role_id" IS NULL
      AND "posthog_team"."organization_id" = $org::uuid)
)
```

After:

```sql
  ...
  OR ("ee_accesscontrol"."organization_member_id" IS NULL
      AND "ee_accesscontrol"."resource" = 'project' AND "ee_accesscontrol"."resource_id" IS NOT NULL
      AND "ee_accesscontrol"."role_id" IS NULL
      AND "ee_accesscontrol"."team_id" IN (SELECT "id" FROM "posthog_team" WHERE "organization_id" = $org::uuid))
  OR ("posthog_organizationmembership"."organization_id" = $org::uuid AND "posthog_organizationmembership"."user_id" = $user
      AND "ee_accesscontrol"."resource" = 'project' AND "ee_accesscontrol"."resource_id" IS NOT NULL
      AND "ee_accesscontrol"."role_id" IS NULL
      AND "ee_accesscontrol"."team_id" IN (SELECT "id" FROM "posthog_team" WHERE "organization_id" = $org::uuid))
```

### Performance impact

`EXPLAIN (ANALYZE, BUFFERS)` on the production US replica, for the organization with the most access control rules. Both plans return the same 7 rows.

| | Before | After |
| --- | --- | --- |
| Execution time | 70 to 140 ms | 7 ms |
| Shared buffers | 85,000 | 1,400 |
| Rows joined to `posthog_team` and `posthog_organizationmembership` | every project rule in the instance | 81 |
| `Rows Removed by Filter` after the joins | all but 7 | 74 |

The before plan cannot use an index for the org predicate, so it bitmap-scans every `project` rule of every organization and evaluates the org id on the joined row. The after plan hashes the org's team ids and applies them during the scan of `ee_accesscontrol`, so only that org's rows reach the joins.

<details>
<summary>Plans (ids redacted)</summary>

Before:

```text
Nested Loop Left Join  (actual time=14.498..139.431 rows=7 loops=1)
  Filter: (... OR (ac.resource = 'project' AND ac.resource_id IS NOT NULL AND t.organization_id = $org) ...)
  Rows Removed by Filter: 18085
  Buffers: shared hit=85105 read=69
  ->  Nested Loop  (actual rows=18092 loops=1)
        ->  Bitmap Heap Scan on ee_accesscontrol ac  (actual rows=18092 loops=1)
              ->  BitmapOr
                    ->  Bitmap Index Scan on "unique resource per target"  (resource = 'project' AND resource_id IS NOT NULL AND role_id IS NULL)  (actual rows=18076)
                    ...
        ->  Memoize (Index Scan using posthog_team_pkey on posthog_team t)  (loops=18092)
  ->  Index Scan using posthog_organizationmembership_pkey on posthog_organizationmembership m  (loops=18092)
        Buffers: shared hit=64863
Execution Time: 139.504 ms
```

After:

```text
Nested Loop  (actual time=2.656..6.607 rows=7 loops=1)
  Buffers: shared hit=1366
  ->  Nested Loop Left Join  (actual rows=7 loops=1)
        Rows Removed by Filter: 74
        ->  Bitmap Heap Scan on ee_accesscontrol ac  (actual rows=81 loops=1)
              Filter: (... AND (hashed SubPlan 1)) OR (... AND (hashed SubPlan 2))
              Rows Removed by Filter: 18011
              SubPlan 1 / 2
                ->  Index Scan using posthog_team_organization_id_41bbc1d0 on posthog_team  (actual rows=4 loops=2)
        ->  Index Scan using posthog_organizationmembership_pkey on posthog_organizationmembership m  (loops=81)
  ->  Index Scan using posthog_team_pkey on posthog_team t  (loops=7)
Execution Time: 6.685 ms
```

</details>

## How did you test this code?

- `test_filters_project_queryset_based_on_acs` now stores one project rule on the project's own team rather than the test's default team, which is how production rows are stored. It catches a rewrite that narrows the org scope to the current team only.
- The plans above were measured by hand on the production US read replica with literal parameters.
- Not run locally: the Django test suite, because the local test database was in a broken state. Relying on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. The investigation started from a pganalyze index suggestion on a different table; `EXPLAIN (ANALYZE, BUFFERS)` on production showed this query needed a predicate change, not an index. A tighter rewrite using `resource_id IN (team ids)` was considered and rejected because it relies on a data invariant rather than the model.
