### PR TITLE
fix(event-definitions): sort the event definitions select column list

### DIFF
--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -73,6 +73,10 @@ def create_event_definitions_sql(
     }
     # Django relies on PK being present in the result set to tell if it's a saved instance
     event_definition_fields.add("id as pk")
+    # Sorted because a set iterates in an order that depends on the process hash seed. Unsorted,
+    # every worker emits a different statement text, so pg_stat_statements and Performance Insights
+    # split this query's load across hundreds of fingerprints and none of them looks expensive.
+    selected_fields = sorted(event_definition_fields)
 
     enterprise_join = (
         "FULL OUTER JOIN ee_enterpriseeventdefinition ON posthog_eventdefinition.id=ee_enterpriseeventdefinition.eventdefinition_ptr_id"
@@ -97,7 +101,7 @@ def create_event_definitions_sql(
     # for any `name` equality in `conditions`. The equivalent form
     # `project_id = X OR (project_id IS NULL AND team_id = X)` matches no index at all.
     return f"""
-            SELECT {",".join(event_definition_fields)}
+            SELECT {",".join(selected_fields)}
             FROM posthog_eventdefinition
             {enterprise_join}
             WHERE COALESCE(project_id, team_id) = %(project_id)s

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -7,15 +7,18 @@ from freezegun.api import freeze_time
 from posthog.test.base import APIBaseTest
 from unittest.mock import ANY, patch
 
+from django.test import SimpleTestCase
 from django.utils import timezone
 
 import dateutil.parser
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.api.event_definition import create_event_definitions_sql
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
+from posthog.constants import EventDefinitionType
 from posthog.models import ActivityLog, EventDefinition, Organization, Tag, Team
 
 from products.actions.backend.models.action import Action
@@ -626,6 +629,15 @@ class TestEventDefinitionAPI(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert not ActivityLog.objects.filter(scope="EventDefinition", item_id=str(ed.id)).exists()
+
+
+class TestCreateEventDefinitionsSql(SimpleTestCase):
+    @parameterized.expand([("enterprise", True), ("open source", False)])
+    def test_selects_columns_in_a_stable_order(self, _name: str, is_enterprise: bool):
+        sql = create_event_definitions_sql(EventDefinitionType.EVENT, is_enterprise=is_enterprise)
+        select_clause = sql.split("SELECT ", 1)[1].split("FROM", 1)[0]
+        columns = [column.strip() for column in select_clause.split(",")]
+        assert columns == sorted(columns)
 
 
 class TestEventDefinitionExcludeStale(APIBaseTest):


### PR DESCRIPTION
## Problem

The event definitions list query is invisible in query statistics. It renders its `SELECT` column list by iterating a Python set, and a set's iteration order depends on the process hash seed — which is per process. Every gunicorn worker therefore emits a different statement text for the same query.

Surfaces that group by statement text split that one query across hundreds of entries. Each entry looks cheap. Nothing points at the query, even while it is the most expensive thing on the writer.

That is not hypothetical: this query recently drove a large amount of extra CPU on a production writer and could not be found by looking at the top queries, because its load was smeared across variants.

## Changes

The query now reports as a single entry, so the next time it misbehaves it shows up where people look.

- The column list is sorted before it is joined into the SQL. Identical text across workers, so statistics aggregate it.
- No change to which columns are selected, their values, or the rows returned. Sorting only changes their order in the `SELECT` clause, and every consumer reads columns by name.

## How did you test this code?

One new test, `test_selects_columns_in_a_stable_order`, parameterized over the enterprise and open-source column sets. It catches a revert to unsorted set iteration, which no existing test covers — and the consequence of that revert is specifically that the query disappears from statistics when someone is looking for it.

It runs in a `SimpleTestCase` with no database, since the function under test builds a string.

Ran `posthog/api/test/test_event_definition.py` and `ee/api/test/test_event_definition.py`.

Not run: no manual testing in a browser. There is no UI in this change.

> [!NOTE]
> Split out of [#90387](https://github.com/PostHog/posthog/pull/90387) at review request — that PR also changed the join type, which is a separate question with a separate risk profile. It now sits on top of this one. This half is the uncontroversial half.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus 5). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Split from [#90387](https://github.com/PostHog/posthog/pull/90387) after review asked for the two changes to be dealt with separately.

No customer data, logs, or thread contents reached this diff.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09KUMHT64A/p1787845895091329?thread_ts=1787845895.091329&cid=C09KUMHT64A)*
