### PR TITLE
feat(tasks): report why an adapter refused a steer

### DIFF
--- a/products/desktop/packages/agent/src/acp-extensions.ts
+++ b/products/desktop/packages/agent/src/acp-extensions.ts
@@ -100,6 +100,27 @@ export const POSTHOG_NOTIFICATIONS = {
   MCP_RESPONSE: "_posthog/mcp_response",
 } as const;
 
+export type SteerDeclineCause =
+  | "cancelled"
+  | "compacting"
+  | "continuation_failed"
+  | "no_in_flight_turn"
+  | "no_owner_turn"
+  | "steer_in_flight"
+  | "turn_ended_first"
+  | "turn_failed"
+  | "turn_not_steerable";
+
+export function steerDeclined(cause: SteerDeclineCause): {
+  stopReason: "end_turn";
+  _meta: { steer: false; steerDeclineCause: SteerDeclineCause };
+} {
+  return {
+    stopReason: "end_turn",
+    _meta: { steer: false, steerDeclineCause: cause },
+  };
+}
+
 export type NativeGoalState = {
   objective: string;
   status:

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.streamed-text.test.ts
@@ -473,7 +473,7 @@ describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {
     await send(query, resultSuccess(sessionId));
 
     await expect(steerPromise).resolves.toMatchObject({
-      _meta: { steer: false },
+      _meta: { steer: false, steerDeclineCause: "turn_ended_first" },
     });
     await expect(promptPromise).resolves.toMatchObject({
       stopReason: "end_turn",
@@ -572,7 +572,7 @@ describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {
     await agent.cancel({ sessionId });
 
     await expect(steerPromise).resolves.toMatchObject({
-      _meta: { steer: false },
+      _meta: { steer: false, steerDeclineCause: "cancelled" },
     });
     await expect(promptPromise).resolves.toMatchObject({
       stopReason: "cancelled",
@@ -606,7 +606,7 @@ describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {
 
     await expect(outcome).resolves.toBe("rejected");
     await expect(steerPromise).resolves.toMatchObject({
-      _meta: { steer: false },
+      _meta: { steer: false, steerDeclineCause: "turn_failed" },
     });
   });
 
@@ -663,7 +663,9 @@ describe("ClaudeAcpAgent.prompt — streamed assistant text wiring", () => {
         prompt: [{ type: "text", text: "too late" }],
         _meta: { steer: true },
       }),
-    ).resolves.toMatchObject({ _meta: { steer: false } });
+    ).resolves.toMatchObject({
+      _meta: { steer: false, steerDeclineCause: "no_in_flight_turn" },
+    });
 
     const session = (agent as unknown as { session: { turnQueue: unknown[] } })
       .session;

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -51,6 +51,8 @@ import {
   isMethod,
   POSTHOG_METHODS,
   POSTHOG_NOTIFICATIONS,
+  type SteerDeclineCause,
+  steerDeclined,
 } from "../../acp-extensions";
 import {
   createEnrichment,
@@ -242,13 +244,13 @@ function confirmConsumedSteers(turn: Turn): void {
 }
 
 /** Report every steer left on a finishing turn as undelivered so callers redeliver it. */
-function declinePendingSteers(turn: Turn): void {
+function declinePendingSteers(turn: Turn, cause: SteerDeclineCause): void {
   if (turn.steerTimer) {
     clearTimeout(turn.steerTimer);
     turn.steerTimer = undefined;
   }
   for (const steer of turn.pendingSteers.values()) {
-    steer.settle(false);
+    steer.settle(false, cause);
   }
   turn.pendingSteers.clear();
 }
@@ -605,15 +607,19 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       // Decline before pushing, so the message is redelivered rather than also
       // applied by a later turn.
       if (!owner) {
-        return { stopReason: "end_turn", _meta: { steer: false } };
+        return steerDeclined("no_owner_turn");
       }
       // Only a declined steer is redelivered, so acking on submission loses any
       // steer the SDK never folds in. Wait for the model to act on it instead.
       const ack = new Promise<PromptResponse>((resolve) => {
         owner.pendingSteers.set(promptUuid, {
           consumed: false,
-          settle: (reachedModel) =>
-            resolve({ stopReason: "end_turn", _meta: { steer: reachedModel } }),
+          settle: (reachedModel, cause) =>
+            resolve(
+              reachedModel
+                ? { stopReason: "end_turn", _meta: { steer: true } }
+                : steerDeclined(cause ?? "turn_ended_first"),
+            ),
         });
       });
       this.session.input.push(userMessage);
@@ -621,7 +627,9 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       return ack;
     }
     if (isSteer) {
-      return { stopReason: "end_turn", _meta: { steer: false } };
+      return steerDeclined(
+        this.session.compacting ? "compacting" : "no_in_flight_turn",
+      );
     }
 
     if (!hasInFlightTurns && !isLocalOnlyCommand) {
@@ -875,7 +883,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         return;
       }
       turn.settled = true;
-      declinePendingSteers(turn);
+      declinePendingSteers(
+        turn,
+        session.cancelled ? "cancelled" : "turn_ended_first",
+      );
       if (session.forceCancelTimer) {
         clearTimeout(session.forceCancelTimer);
         session.forceCancelTimer = undefined;
@@ -897,7 +908,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         return;
       }
       turn.settled = true;
-      declinePendingSteers(turn);
+      declinePendingSteers(turn, "turn_failed");
       session.turnQueue = session.turnQueue.filter((t) => t !== turn);
       session.activeTurn = null;
       this.toolUseStreamCache.clear();
@@ -923,7 +934,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       for (const turn of turns) {
         if (!turn.settled) {
           turn.settled = true;
-          declinePendingSteers(turn);
+          declinePendingSteers(turn, "turn_failed");
           turn.reject(error);
         }
       }
@@ -968,7 +979,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           for (const queued of [...session.turnQueue]) {
             if (!queued.settled) {
               queued.settled = true;
-              declinePendingSteers(queued);
+              declinePendingSteers(
+                queued,
+                session.cancelled ? "cancelled" : "turn_failed",
+              );
               queued.reject(
                 RequestError.internalError(undefined, SESSION_ENDED_MESSAGE),
               );
@@ -1132,7 +1146,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
                   },
                 });
                 head.settled = true;
-                declinePendingSteers(head);
+                declinePendingSteers(head, "turn_failed");
                 session.turnQueue = session.turnQueue.filter((t) => t !== head);
                 this.dispatchQueuedInput(session);
                 head.resolve({ stopReason: "end_turn" });
@@ -1623,7 +1637,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         continue;
       }
       turn.settled = true;
-      declinePendingSteers(turn);
+      declinePendingSteers(turn, "cancelled");
       session.turnQueue = session.turnQueue.filter((t) => t !== turn);
       if (!turn.pendingInput) {
         session.pendingOrphanResults += 1;

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.turn-queue.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.turn-queue.test.ts
@@ -182,7 +182,9 @@ describe("ClaudeAcpAgent turn queue input dispatch", () => {
       _meta: { steer: true },
     });
 
-    await expect(steer).resolves.toMatchObject({ _meta: { steer: false } });
+    await expect(steer).resolves.toMatchObject({
+      _meta: { steer: false, steerDeclineCause: "compacting" },
+    });
     expect(harness.pushed).toHaveLength(1);
 
     harness.query._mockHelpers.sendMessage(createSuccessResult());

--- a/products/desktop/packages/agent/src/adapters/claude/types.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/types.ts
@@ -12,6 +12,7 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 import type { BedrockGatewayVariant } from "@posthog/shared";
 import type { EffortLevel } from "@posthog/shared/domain-types";
+import type { SteerDeclineCause } from "../../acp-extensions";
 import type { PostHogProductId } from "../../posthog-products";
 import type { AgentMode } from "../../types";
 import type { Pushable } from "../../utils/streams";
@@ -46,7 +47,7 @@ export type BackgroundTerminal =
 export type PendingSteer = {
   /** Set when the SDK echoes the message back, i.e. it entered the turn. */
   consumed: boolean;
-  settle: (reachedModel: boolean) => void;
+  settle: (reachedModel: boolean, cause?: SteerDeclineCause) => void;
 };
 
 /** One in-flight `prompt()` call, settled by the session's consumer. */

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -644,6 +644,33 @@ describe("CodexAppServerAgent", () => {
     });
   });
 
+  it("reports a steered goal command as accepted so the host does not redeliver it", async () => {
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "thr_1" } },
+      "thread/goal/get": {
+        goal: { objective: "Ship the fix", status: "active" },
+      },
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/bundle/codex" },
+      rpcFactory: stub.factory,
+    });
+    await agent.newSession({ cwd: "/repo" } as unknown as NewSessionRequest);
+
+    const result = await agent.prompt({
+      sessionId: "thr_1",
+      prompt: [{ type: "text", text: "/goal" }],
+      _meta: { steer: true },
+    } as unknown as PromptRequest);
+
+    expect(result).toMatchObject({ _meta: { steer: true } });
+    expect(stub.requests).toContainEqual({
+      method: "thread/goal/get",
+      params: { threadId: "thr_1" },
+    });
+  });
+
   it("restores a persisted goal when starting a replacement thread", async () => {
     const restoredGoal = { objective: "Ship the fix", status: "paused" };
     const stub = makeStubRpc({
@@ -2944,12 +2971,62 @@ describe("CodexAppServerAgent", () => {
     } as unknown as PromptRequest);
     await agent.cancel({ sessionId: "t" } as unknown as CancelNotification);
     await expect(first).resolves.toMatchObject({ stopReason: "cancelled" });
-    await expect(steer).resolves.toMatchObject({ _meta: { steer: false } });
+    await expect(steer).resolves.toMatchObject({
+      _meta: { steer: false, steerDeclineCause: "cancelled" },
+    });
 
     const interrupted = stub.requests
       .filter((r) => r.method === "turn/interrupt")
       .map((r) => (r.params as { turnId?: string }).turnId);
     expect(interrupted).toContain("turn_2");
+  });
+
+  it("declines a steer that arrives while a cancel is still interrupting", async () => {
+    let starts = 0;
+    let releaseInterrupt: (() => void) | undefined;
+    const stub = makeStubRpc({
+      "thread/start": { thread: { id: "t" } },
+      "turn/start": () => {
+        starts += 1;
+        return { turn: { id: `turn_${starts}` } };
+      },
+      "turn/interrupt": () =>
+        new Promise((resolve) => {
+          releaseInterrupt = () => resolve({});
+        }),
+    });
+    const { client } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const first = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "write a long poem" }],
+    } as unknown as PromptRequest);
+    stub.emit("turn/started", { threadId: "t", turn: { id: "turn_1" } });
+
+    const cancelling = agent.cancel({
+      sessionId: "t",
+    } as unknown as CancelNotification);
+    await vi.waitFor(() => expect(releaseInterrupt).toBeDefined());
+
+    await expect(
+      agent.prompt({
+        sessionId: "t",
+        prompt: [{ type: "text", text: "do this instead" }],
+        _meta: { steer: true },
+      } as unknown as PromptRequest),
+    ).resolves.toMatchObject({
+      _meta: { steer: false, steerDeclineCause: "cancelled" },
+    });
+    expect(starts).toBe(1);
+
+    releaseInterrupt?.();
+    await cancelling;
+    await expect(first).resolves.toMatchObject({ stopReason: "cancelled" });
   });
 
   it("declines a second steer that overlaps the first's interrupt window", async () => {
@@ -2982,7 +3059,9 @@ describe("CodexAppServerAgent", () => {
     } as unknown as PromptRequest);
 
     await expect(steerA).resolves.toMatchObject({ _meta: { steer: true } });
-    await expect(steerB).resolves.toMatchObject({ _meta: { steer: false } });
+    await expect(steerB).resolves.toMatchObject({
+      _meta: { steer: false, steerDeclineCause: "steer_in_flight" },
+    });
     expect(stub.requests.filter((r) => r.method === "turn/start")).toHaveLength(
       2,
     );
@@ -3131,7 +3210,9 @@ describe("CodexAppServerAgent", () => {
         prompt: [{ type: "text", text: "lost steer" }],
         _meta: { steer: true },
       } as unknown as PromptRequest),
-    ).resolves.toMatchObject({ _meta: { steer: false } });
+    ).resolves.toMatchObject({
+      _meta: { steer: false, steerDeclineCause: "continuation_failed" },
+    });
     expect(sessionUpdates).not.toContainEqual(
       expect.objectContaining({
         update: expect.objectContaining({
@@ -3234,7 +3315,9 @@ describe("CodexAppServerAgent", () => {
         prompt: [{ type: "text", text: "too late" }],
         _meta: { steer: true },
       } as unknown as PromptRequest),
-    ).resolves.toMatchObject({ _meta: { steer: false } });
+    ).resolves.toMatchObject({
+      _meta: { steer: false, steerDeclineCause: "no_in_flight_turn" },
+    });
     expect(
       stub.requests.filter((request) => request.method === "turn/start"),
     ).toHaveLength(0);

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -33,6 +33,7 @@ import {
   type NativeGoalState,
   POSTHOG_METHODS,
   POSTHOG_NOTIFICATIONS,
+  steerDeclined,
 } from "../../acp-extensions";
 import {
   buildContextWikiInstructions,
@@ -185,10 +186,6 @@ function parseGoalCommand(prompt: PromptRequest["prompt"]): GoalCommand | null {
     default:
       return { kind: "set", objective: argument };
   }
-}
-
-function steerDeclined(): PromptResponse {
-  return { stopReason: "end_turn", _meta: { steer: false } };
 }
 
 function mergePromptResponses(
@@ -803,15 +800,24 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     if (!this.threadId) {
       throw new Error("prompt() called before newSession()");
     }
+    const isSteer =
+      (params._meta as { steer?: unknown } | undefined)?.steer === true;
+    if (isSteer && this.session.cancelled) {
+      return steerDeclined("cancelled");
+    }
     const goalCommand = parseGoalCommand(params.prompt);
     if (goalCommand) {
       this.broadcastUserInput(visiblePromptBlocks(params.prompt));
       await this.handleGoalCommand(goalCommand);
-      return { stopReason: "end_turn" };
+      return isSteer
+        ? { stopReason: "end_turn", _meta: { steer: true } }
+        : { stopReason: "end_turn" };
     }
     this.cancelNextGoalTurn = false;
     // Reopen the notification gate (a prior interrupt may have left session.cancelled set).
-    this.session.cancelled = false;
+    if (!isSteer) {
+      this.session.cancelled = false;
+    }
     // A new prompt while the plan handoff awaits approval implicitly declines it:
     // settle the race so the previous prompt() returns and this one owns the turn.
     this.planHandoffCancel?.();
@@ -876,8 +882,6 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     if (dropped > 0) {
       this.logger.warn("Dropped non-text/non-image prompt blocks", { dropped });
     }
-    const isSteer =
-      (params._meta as { steer?: unknown } | undefined)?.steer === true;
     if (this.turns.isRunning) {
       if (isSteer) {
         return await this.steerRunningTurn(input, params.prompt);
@@ -895,7 +899,9 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       return { stopReason: "end_turn", _meta: { steer: true } };
     }
     if (isSteer) {
-      return steerDeclined();
+      return steerDeclined(
+        this.turns.isPending ? "turn_not_steerable" : "no_in_flight_turn",
+      );
     }
     if (this.turns.isPending) {
       // A turn is pending but has no turnId yet, so we can't steer; fail fast.
@@ -1059,7 +1065,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     prompt: PromptRequest["prompt"],
   ): Promise<PromptResponse> {
     if (this.steering) {
-      return steerDeclined();
+      return steerDeclined("steer_in_flight");
     }
     this.steering = true;
     try {
@@ -1067,7 +1073,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
         ? undefined
         : this.turns.markInterrupted();
       if (!turnId) {
-        return steerDeclined();
+        return steerDeclined("cancelled");
       }
       await this.interruptTurn(turnId, "steer turn/interrupt failed");
       this.planProposal = undefined;
@@ -1083,7 +1089,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
         if (!this.turns.clearInterrupted(turnId)) {
           await this.finalizeTurn("cancelled");
         }
-        return steerDeclined();
+        return steerDeclined("continuation_failed");
       }
       this.usage.carryForNativeTurn();
       if (this.session.cancelled) {
@@ -1100,7 +1106,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
             "orphan continuation interrupt failed",
           );
         }
-        return steerDeclined();
+        return steerDeclined("cancelled");
       }
       this.broadcastUserInput(prompt);
       return { stopReason: "end_turn", _meta: { steer: true } };

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -3056,60 +3056,67 @@ describe("AgentServer HTTP Mode", () => {
       await activeTurn;
     }, 20000);
 
-    it("declines steering without blocking on a fallback normal turn", async () => {
-      const s = createServer();
-      await s.start();
-      const prompt = vi.fn();
-      const broadcastTurnComplete = vi.fn();
-      const resetTurnMessages = vi.fn();
-      const serverInternals = s as unknown as {
-        activeOwnedTurnCount: number;
-        broadcastTurnComplete: typeof broadcastTurnComplete;
-        session: {
-          clientConnection: { prompt: typeof prompt };
-          logWriter: { resetTurnMessages: typeof resetTurnMessages };
+    it.each([
+      [{ steer: false }, "adapter_rejected"],
+      [{ steer: false, steerDeclineCause: "compacting" }, "adapter_compacting"],
+    ])(
+      "declines steering without blocking on a fallback normal turn (%o)",
+      async (adapterMeta, expectedReason) => {
+        const s = createServer();
+        await s.start();
+        const prompt = vi.fn();
+        const broadcastTurnComplete = vi.fn();
+        const resetTurnMessages = vi.fn();
+        const serverInternals = s as unknown as {
+          activeOwnedTurnCount: number;
+          broadcastTurnComplete: typeof broadcastTurnComplete;
+          session: {
+            clientConnection: { prompt: typeof prompt };
+            logWriter: { resetTurnMessages: typeof resetTurnMessages };
+          };
         };
-      };
-      serverInternals.activeOwnedTurnCount = 1;
-      prompt.mockImplementationOnce(async () => {
-        serverInternals.activeOwnedTurnCount = 0;
-        return { stopReason: "end_turn", _meta: { steer: false } };
-      });
-      serverInternals.broadcastTurnComplete = broadcastTurnComplete;
-      serverInternals.session.clientConnection.prompt = prompt;
-      serverInternals.session.logWriter.resetTurnMessages = resetTurnMessages;
+        serverInternals.activeOwnedTurnCount = 1;
+        prompt.mockImplementationOnce(async () => {
+          serverInternals.activeOwnedTurnCount = 0;
+          return { stopReason: "end_turn", _meta: adapterMeta };
+        });
+        serverInternals.broadcastTurnComplete = broadcastTurnComplete;
+        serverInternals.session.clientConnection.prompt = prompt;
+        serverInternals.session.logWriter.resetTurnMessages = resetTurnMessages;
 
-      const response = await fetch(`http://localhost:${port}/command`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${createToken()}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: "steer-race",
-          method: "user_message",
-          params: { content: "continue normally", steer: true },
-        }),
-      });
+        const response = await fetch(`http://localhost:${port}/command`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${createToken()}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: "steer-race",
+            method: "user_message",
+            params: { content: "continue normally", steer: true },
+          }),
+        });
 
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toMatchObject({
-        result: {
-          stopReason: "steer_declined",
-          steered: false,
-          reason: "adapter_rejected",
-        },
-      });
-      expect(prompt).toHaveBeenCalledTimes(1);
-      expect(prompt.mock.calls[0]?.[0]).toEqual(
-        expect.objectContaining({
-          _meta: expect.objectContaining({ steer: true }),
-        }),
-      );
-      expect(resetTurnMessages).not.toHaveBeenCalled();
-      expect(broadcastTurnComplete).not.toHaveBeenCalled();
-    }, 20000);
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({
+          result: {
+            stopReason: "steer_declined",
+            steered: false,
+            reason: expectedReason,
+          },
+        });
+        expect(prompt).toHaveBeenCalledTimes(1);
+        expect(prompt.mock.calls[0]?.[0]).toEqual(
+          expect.objectContaining({
+            _meta: expect.objectContaining({ steer: true }),
+          }),
+        );
+        expect(resetTurnMessages).not.toHaveBeenCalled();
+        expect(broadcastTurnComplete).not.toHaveBeenCalled();
+      },
+      20000,
+    );
 
     it("redelivers a messageId whose first delivery failed before producing a turn", async () => {
       const s = createServer();

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -44,7 +44,11 @@ import { unzipSync } from "fflate";
 import { Hono } from "hono";
 import { z } from "zod";
 import packageJson from "../../package.json" with { type: "json" };
-import { POSTHOG_METHODS, POSTHOG_NOTIFICATIONS } from "../acp-extensions";
+import {
+  POSTHOG_METHODS,
+  POSTHOG_NOTIFICATIONS,
+  type SteerDeclineCause,
+} from "../acp-extensions";
 import {
   createAcpConnection,
   type InProcessAcpConnection,
@@ -388,7 +392,8 @@ function getTaskRunStateString(
 type SteerDeclineReason =
   | "startup_turn"
   | "no_active_turn"
-  | "adapter_rejected";
+  | "adapter_rejected"
+  | `adapter_${SteerDeclineCause}`;
 
 /** Which delivery routes a Slack run has, as resolved by the backend from flags and Slack scopes. */
 type SlackArtifactDelivery = "none" | "message" | "canvas_file";
@@ -1320,7 +1325,13 @@ export class AgentServer {
                 resolveDelivery(outcome);
                 return outcome;
               }
-              declineReason = "adapter_rejected";
+              const cause = (
+                result._meta as { steerDeclineCause?: unknown } | undefined
+              )?.steerDeclineCause;
+              declineReason =
+                typeof cause === "string"
+                  ? (`adapter_${cause}` as SteerDeclineReason)
+                  : "adapter_rejected";
             }
             const outcome = {
               stopReason: "steer_declined",


### PR DESCRIPTION
## Problem

- A user who steers a cloud run mid-turn is refused about half the time, and the biggest bucket of refusals says nothing about why. The message waits out the turn instead, and the user is not told.
- [#90168](https://github.com/PostHog/posthog/pull/90168) split the decline rate into `startup_turn`, `no_active_turn` and `adapter_rejected`. The first two are the host's own gates, so they are actionable. The third is not.
- `adapter_rejected` is 5 of the 12 labeled declines prod has logged since that deploy, and it hides at least eight conditions across the two runtimes.
- Those conditions need opposite responses. Claude refuses for the whole of a compaction, which is fixable. Claude also reports a steer it accepted but the model never folded in before the turn ended, which is not a defect. Codex refuses when `turn/start` has gone out and `turn/started` has not come back, which is a race at turn start. One number cannot separate them, so no fix can be scoped.

## Changes

- The reason breakdown on the cloud-runs dashboard now splits the adapter bucket, so the next fix can be aimed at the largest cause. The panel groups on the log field, so it picks the new values up with no dashboard change.
- Each adapter names its own cause in the prompt response `_meta`, and the host composes the log reason as `adapter_<cause>`.
- Claude reports `compacting`, `no_owner_turn`, `turn_ended_first`, `turn_failed`, `cancelled` and `no_in_flight_turn`.
- Codex reports `turn_not_steerable`, `no_in_flight_turn`, `steer_in_flight`, `continuation_failed` and `cancelled`.
- An adapter that reports no cause still logs `adapter_rejected`, so an older sandbox image degrades to today's value rather than dropping the field.
- The backend needs no change. `_steer_decline_reason` already forwards any string it finds.
- Two pre-existing refusals turned out to be bugs, both inside the paths this PR reworks, and both are fixed here.
- A `/goal` command sent as a steer ran, reported nothing, and was re-delivered and run again: the user saw their own line twice and two contradictory confirmations. Codex now reads the steer flag before the goal branch and reports acceptance, so the host commits delivery and the workflow does not re-insert the message.
- A steer arriving inside a cancel's interrupt window cleared the cancelled flag before anything read it, so both guards in `steerRunningTurn` missed, work restarted after Stop, and the adapter held a codex turn it could no longer interrupt. The flag is read first now and survives a steer.
- Claude reported every unconsumed steer as a turn-end race, so pressing Stop landed in the same bucket as a benign end-of-turn miss, and the two adapters labelled that one action differently. The cause travels with the decline now, through `declinePendingSteers`.
- Otherwise nothing a user sees changes. Every steer refused before is still refused, on the same condition, and the accept path is untouched.
- One flat reason string keeps the backend and the panel as they are. Logging the layer and the cause as two fields reads better but costs a backend change and a dashboard migration, so it is a follow-up.
- Mechanical: the Codex adapter drops its local declined-steer helper for the shared one, and the test file's churn is indentation from parameterizing one existing case.


