### PR TITLE
feat(aio): link the empty-output notice to its troubleshooting docs

### DIFF
--- a/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.test.tsx
@@ -608,6 +608,11 @@ describe('ConversationMessagesDisplay', () => {
             const explanation = container.querySelector('[data-attr="ai-empty-output-explanation"]')
             if (expected !== null) {
                 expect(explanation).toHaveTextContent(expected)
+                // The notice names a cause and the link carries the fix. A typo'd anchor dead-ends there.
+                expect(explanation!.querySelector('a')).toHaveAttribute(
+                    'href',
+                    'https://posthog.com/docs/ai-observability/troubleshooting#why-does-my-generation-show-no-output'
+                )
             } else {
                 expect(explanation).toBeNull()
             }

--- a/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import React from 'react'
 
 import { IconCode, IconEye, IconMarkdown, IconMarkdownFilled, IconWrench } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
 import { HighlightedJSONViewer } from 'lib/components/HighlightedJSONViewer'
@@ -385,7 +385,13 @@ export function ConversationMessagesDisplay({
                                 <div className="italic">No output</div>
                                 {emptyOutputExplanation && (
                                     <div className="mt-1 text-xs" data-attr="ai-empty-output-explanation">
-                                        {emptyOutputExplanation}
+                                        {emptyOutputExplanation}{' '}
+                                        <Link
+                                            to="https://posthog.com/docs/ai-observability/troubleshooting#why-does-my-generation-show-no-output"
+                                            target="_blank"
+                                        >
+                                            Learn more
+                                        </Link>
                                     </div>
                                 )}
                             </div>


### PR DESCRIPTION
## Problem

The empty-output notice ([#90159](https://github.com/PostHog/posthog/pull/90159)) names why a generation rendered nothing, but not what to do about it. Review feedback on that PR asked exactly that: "okay, so how do I fix this?"

## Changes

- Every sentence the notice shows now ends with a "Learn more" link to the troubleshooting section that documents each cause and its fix ([PostHog/posthog.com#19793](https://github.com/PostHog/posthog.com/pull/19793)).
- Stacked on #90159, since the notice this links from ships there. The docs PR should merge first so the anchor resolves.

## How did you test this code?

Extended the existing notice assertions: every explained row now also pins the link's href to the documented anchor, so dropping the link or typo'ing the anchor fails 13 rows. 62 tests pass. Not run: the visual review baselines will show the link appended to the four notice stories.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The docs are the other half of this change: [PostHog/posthog.com#19793](https://github.com/PostHog/posthog.com/pull/19793).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A person directed this work in a PostHog Desktop session; the requester should claim it. Created together with the posthog.com troubleshooting entry in response to review feedback on #90159. The alternative of expanding the guidance in-app was rejected as duplicating the doc and going stale independently.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
