### PR TITLE
feat(cymbal): persist changed frame snapshots

### DIFF
--- a/rust/cymbal/src/core/config.rs
+++ b/rust/cymbal/src/core/config.rs
@@ -67,6 +67,9 @@ pub struct ResolverConfig {
     #[envconfig(default = "300")]
     pub frame_unresolved_ttl_seconds: u64,
 
+    #[envconfig(default = "false")]
+    pub frame_change_only_persistence_enabled: bool,
+
     // TTL for the in-memory negative cache of symbol-set lookup failures in the `Saving` layer.
     // Like `frame_unresolved_ttl_seconds`, this is kept short: a failure record can become
     // resolvable the moment a user uploads the missing symbols, so a cached negative result

--- a/rust/cymbal/src/core/symbolication/symbol/local.rs
+++ b/rust/cymbal/src/core/symbolication/symbol/local.rs
@@ -53,6 +53,7 @@ pub struct LocalSymbolResolver {
     release_id_cache: Cache<(TeamId, Vec<String>), Option<Uuid>>,
     pool: PgPool,
     ttl_policy: FrameResultTtlPolicy,
+    frame_change_only_persistence_enabled: bool,
     // Lines of pre/post source context to attach per resolved frame.
     context_lines: usize,
 }
@@ -120,6 +121,7 @@ impl LocalSymbolResolver {
             cache,
             release_id_cache,
             ttl_policy,
+            frame_change_only_persistence_enabled: config.frame_change_only_persistence_enabled,
             context_lines: config.context_line_count,
         }
     }
@@ -201,17 +203,40 @@ impl LocalSymbolResolver {
             records.push(record);
         }
 
-        let write_outcome = classify_frame_snapshot(&stored.records, &records);
-        for record in &records {
-            let rows_affected = match record.save(&self.pool).await {
-                Ok(rows_affected) => rows_affected,
+        if self.frame_change_only_persistence_enabled {
+            let persistence = match ErrorTrackingStackFrame::persist_snapshot(
+                &self.pool,
+                &stored.records,
+                &records,
+            )
+            .await
+            {
+                Ok(persistence) => persistence,
                 Err(error) => {
-                    record_frame_write(FrameWriteOutcome::Error, 0);
+                    record_frame_write(FrameWriteOutcome::Error, 0, 0);
                     return Err(error);
                 }
             };
-            record_frame_write(write_outcome, rows_affected);
+            record_frame_write(
+                persistence.outcome,
+                persistence.upserted_rows,
+                persistence.deleted_rows,
+            );
+        } else {
+            let write_outcome = classify_frame_snapshot(&stored.records, &records);
+            for record in &records {
+                let rows_affected = match record.save(&self.pool).await {
+                    Ok(rows_affected) => rows_affected,
+                    Err(error) => {
+                        record_frame_write(FrameWriteOutcome::Error, 0, 0);
+                        return Err(error);
+                    }
+                };
+                record_frame_write(write_outcome, rows_affected, 0);
+            }
+        }
 
+        for record in &records {
             let r_frame = &record.contents;
             if r_frame.suspicious {
                 metrics::counter!(SUSPICIOUS_FRAMES_DETECTED, "frame_type" => "resolved")

--- a/rust/cymbal/src/core/symbolication/symbol/records.rs
+++ b/rust/cymbal/src/core/symbolication/symbol/records.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Duration, Utc};
 use common_types::error_tracking::{FrameId, RawFrameId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sqlx::Executor;
+use sqlx::{Executor, PgPool};
 use uuid::Uuid;
 
 use crate::core::write_attribution::FrameWriteOutcome;
@@ -88,6 +88,13 @@ pub(crate) struct StoredFrameSnapshot {
     pub fresh: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct FrameSnapshotPersistence {
+    pub outcome: FrameWriteOutcome,
+    pub upserted_rows: u64,
+    pub deleted_rows: u64,
+}
+
 pub(crate) fn classify_frame_snapshot(
     existing: &[ErrorTrackingStackFrame],
     current: &[ErrorTrackingStackFrame],
@@ -162,6 +169,61 @@ impl ErrorTrackingStackFrame {
         .execute(e)
         .await?;
         Ok(result.rows_affected())
+    }
+
+    pub(crate) async fn persist_snapshot(
+        pool: &PgPool,
+        existing: &[Self],
+        current: &[Self],
+    ) -> Result<FrameSnapshotPersistence, UnhandledError> {
+        let outcome = classify_frame_snapshot(existing, current);
+        if outcome == FrameWriteOutcome::Unchanged {
+            return Ok(FrameSnapshotPersistence {
+                outcome,
+                upserted_rows: 0,
+                deleted_rows: 0,
+            });
+        }
+
+        let first = current
+            .first()
+            .ok_or_else(|| UnhandledError::Other("frame snapshot cannot be empty".to_string()))?;
+        if current.iter().any(|record| {
+            record.id.hash_id != first.id.hash_id || record.id.team_id != first.id.team_id
+        }) {
+            return Err(UnhandledError::Other(
+                "frame snapshot records must share an identity".to_string(),
+            ));
+        }
+
+        let mut transaction = pool.begin().await?;
+        let mut upserted_rows = 0;
+        for record in current {
+            upserted_rows += record.save(&mut *transaction).await?;
+        }
+
+        let parts = current
+            .iter()
+            .map(|record| record.id.part)
+            .collect::<Vec<_>>();
+        let deleted_rows = sqlx::query(
+            "DELETE FROM posthog_errortrackingstackframe
+             WHERE raw_id = $1 AND team_id = $2 AND NOT (part = ANY($3))",
+        )
+        .bind(&first.id.hash_id)
+        .bind(first.id.team_id)
+        .bind(&parts)
+        .execute(&mut *transaction)
+        .await?
+        .rows_affected();
+
+        transaction.commit().await?;
+
+        Ok(FrameSnapshotPersistence {
+            outcome,
+            upserted_rows,
+            deleted_rows,
+        })
     }
 
     pub async fn load_all<'c, E>(
@@ -375,6 +437,185 @@ mod tests {
                 "{field}"
             );
         }
+    }
+
+    async fn load_stored_snapshot(
+        pool: &sqlx::PgPool,
+        raw_id: &RawFrameId,
+    ) -> Vec<ErrorTrackingStackFrame> {
+        ErrorTrackingStackFrame::load_snapshot(
+            pool,
+            raw_id,
+            FrameResultTtlPolicy::new(Duration::hours(1), Duration::hours(1)),
+        )
+        .await
+        .unwrap()
+        .records
+    }
+
+    fn snapshot_record(raw_id: &RawFrameId, part: i32) -> ErrorTrackingStackFrame {
+        let id = FrameId::new(raw_id.hash_id.clone(), raw_id.team_id, part);
+        let frame = frame_with_part(id.clone(), part);
+        ErrorTrackingStackFrame::new(id, None, frame, true, None)
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn persist_snapshot_inserts_then_skips_an_unchanged_refresh(pool: sqlx::PgPool) {
+        let raw_id = RawFrameId::new("unchanged-frame".to_string(), 1);
+        let current = vec![snapshot_record(&raw_id, 0)];
+
+        let inserted = ErrorTrackingStackFrame::persist_snapshot(&pool, &[], &current)
+            .await
+            .unwrap();
+        assert_eq!(inserted.outcome, FrameWriteOutcome::Insert);
+        assert_eq!(inserted.upserted_rows, 1);
+        assert_eq!(inserted.deleted_rows, 0);
+
+        let stored = load_stored_snapshot(&pool, &raw_id).await;
+        let original_created_at = stored[0].created_at;
+        let mut refreshed = stored.clone();
+        refreshed[0].created_at += Duration::minutes(10);
+
+        let unchanged = ErrorTrackingStackFrame::persist_snapshot(&pool, &stored, &refreshed)
+            .await
+            .unwrap();
+        assert_eq!(unchanged.outcome, FrameWriteOutcome::Unchanged);
+        assert_eq!(unchanged.upserted_rows, 0);
+        assert_eq!(unchanged.deleted_rows, 0);
+
+        let reloaded = load_stored_snapshot(&pool, &raw_id).await;
+        assert_eq!(reloaded[0].created_at, original_created_at);
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn persist_snapshot_writes_each_durable_change(pool: sqlx::PgPool) {
+        let raw_id = RawFrameId::new("changed-frame".to_string(), 1);
+        let initial = vec![snapshot_record(&raw_id, 0)];
+        ErrorTrackingStackFrame::persist_snapshot(&pool, &[], &initial)
+            .await
+            .unwrap();
+
+        let mut stored = load_stored_snapshot(&pool, &raw_id).await;
+        let context = Context {
+            before: Vec::new(),
+            line: crate::frames::ContextLine {
+                number: 1,
+                line: "changed context".to_string(),
+            },
+            after: Vec::new(),
+        };
+        let mut changed_context = stored.clone();
+        changed_context[0].context = Some(context.clone());
+        changed_context[0].contents.context = Some(context);
+        let result = ErrorTrackingStackFrame::persist_snapshot(&pool, &stored, &changed_context)
+            .await
+            .unwrap();
+        assert_eq!(result.outcome, FrameWriteOutcome::Changed);
+        stored = load_stored_snapshot(&pool, &raw_id).await;
+        assert_eq!(stored[0].context, changed_context[0].context);
+
+        let mut changed_resolution = stored.clone();
+        changed_resolution[0].resolved = false;
+        changed_resolution[0].contents.resolved = false;
+        let result = ErrorTrackingStackFrame::persist_snapshot(&pool, &stored, &changed_resolution)
+            .await
+            .unwrap();
+        assert_eq!(result.outcome, FrameWriteOutcome::Changed);
+        stored = load_stored_snapshot(&pool, &raw_id).await;
+        assert!(!stored[0].resolved);
+
+        let mut changed_symbol_set = stored.clone();
+        changed_symbol_set[0].symbol_set_id = Some(Uuid::now_v7());
+        let result = ErrorTrackingStackFrame::persist_snapshot(&pool, &stored, &changed_symbol_set)
+            .await
+            .unwrap();
+        assert_eq!(result.outcome, FrameWriteOutcome::Changed);
+        stored = load_stored_snapshot(&pool, &raw_id).await;
+        assert_eq!(stored[0].symbol_set_id, changed_symbol_set[0].symbol_set_id);
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn persist_snapshot_replaces_expanded_and_contracted_parts(pool: sqlx::PgPool) {
+        let raw_id = RawFrameId::new("multipart-frame".to_string(), 1);
+        let initial = vec![snapshot_record(&raw_id, 0)];
+        ErrorTrackingStackFrame::persist_snapshot(&pool, &[], &initial)
+            .await
+            .unwrap();
+
+        let stored = load_stored_snapshot(&pool, &raw_id).await;
+        let expanded = vec![snapshot_record(&raw_id, 0), snapshot_record(&raw_id, 1)];
+        let result = ErrorTrackingStackFrame::persist_snapshot(&pool, &stored, &expanded)
+            .await
+            .unwrap();
+        assert_eq!(result.outcome, FrameWriteOutcome::Changed);
+        assert_eq!(result.upserted_rows, 2);
+        assert_eq!(result.deleted_rows, 0);
+        let stored = load_stored_snapshot(&pool, &raw_id).await;
+        assert_eq!(
+            stored
+                .iter()
+                .map(|record| record.id.part)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+
+        let contracted = vec![snapshot_record(&raw_id, 0)];
+        let result = ErrorTrackingStackFrame::persist_snapshot(&pool, &stored, &contracted)
+            .await
+            .unwrap();
+        assert_eq!(result.outcome, FrameWriteOutcome::Changed);
+        assert_eq!(result.upserted_rows, 1);
+        assert_eq!(result.deleted_rows, 1);
+        let stored = load_stored_snapshot(&pool, &raw_id).await;
+        assert_eq!(
+            stored
+                .iter()
+                .map(|record| record.id.part)
+                .collect::<Vec<_>>(),
+            vec![0]
+        );
+    }
+
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn persist_snapshot_rolls_back_upserts_when_obsolete_deletion_fails(pool: sqlx::PgPool) {
+        let raw_id = RawFrameId::new("rollback-frame".to_string(), 1);
+        let initial = vec![snapshot_record(&raw_id, 0)];
+        ErrorTrackingStackFrame::persist_snapshot(&pool, &[], &initial)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "CREATE FUNCTION reject_frame_delete() RETURNS trigger AS $$
+             BEGIN
+                 RAISE EXCEPTION 'delete rejected';
+             END;
+             $$ LANGUAGE plpgsql",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TRIGGER reject_frame_delete
+             BEFORE DELETE ON posthog_errortrackingstackframe
+             FOR EACH ROW EXECUTE FUNCTION reject_frame_delete()",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let stored = load_stored_snapshot(&pool, &raw_id).await;
+        let replacement = vec![snapshot_record(&raw_id, 1)];
+        let result = ErrorTrackingStackFrame::persist_snapshot(&pool, &stored, &replacement).await;
+        assert!(result.is_err());
+
+        let stored = load_stored_snapshot(&pool, &raw_id).await;
+        assert_eq!(
+            stored
+                .iter()
+                .map(|record| record.id.part)
+                .collect::<Vec<_>>(),
+            vec![0]
+        );
     }
 
     #[test]

--- a/rust/cymbal/src/core/write_attribution.rs
+++ b/rust/cymbal/src/core/write_attribution.rs
@@ -81,7 +81,11 @@ impl PostgresMutation {
     }
 }
 
-pub(crate) fn record_frame_write(outcome: FrameWriteOutcome, rows_affected: u64) {
+pub(crate) fn record_frame_write(
+    outcome: FrameWriteOutcome,
+    upserted_rows: u64,
+    deleted_rows: u64,
+) {
     metrics::counter!(
         POSTGRES_WRITE_ATTEMPTS,
         "table" => "stack_frame",
@@ -94,7 +98,13 @@ pub(crate) fn record_frame_write(outcome: FrameWriteOutcome, rows_affected: u64)
         "stack_frame",
         "frame_snapshot",
         PostgresMutation::Upsert,
-        rows_affected,
+        upserted_rows,
+    );
+    record_rows_affected(
+        "stack_frame",
+        "frame_snapshot",
+        PostgresMutation::Delete,
+        deleted_rows,
     );
 }
 
@@ -157,7 +167,11 @@ mod tests {
                 FrameWriteOutcome::Unchanged,
                 FrameWriteOutcome::Error,
             ] {
-                record_frame_write(outcome, u64::from(outcome != FrameWriteOutcome::Error));
+                record_frame_write(
+                    outcome,
+                    u64::from(outcome != FrameWriteOutcome::Error),
+                    u64::from(outcome == FrameWriteOutcome::Changed),
+                );
             }
 
             for purpose in [
@@ -201,7 +215,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(attempts.len(), 19);
-        assert_eq!(rows.len(), 6);
+        assert_eq!(rows.len(), 7);
 
         let allowed_label_keys = HashSet::from(["table", "purpose", "outcome"]);
         let allowed_tables = HashSet::from(["stack_frame", "symbol_set"]);

--- a/rust/cymbal/src/modes/resolution/README.md
+++ b/rust/cymbal/src/modes/resolution/README.md
@@ -121,6 +121,7 @@ All variables are prefixed `CYMBAL_REMOTE_RESOLUTION_` and live on `cymbal::conf
 | `INTERNAL_API_SECRET` | _empty_ | Shared secret required as `X-Internal-Api-Secret` metadata on every gRPC request. Empty configuration rejects all RPCs. |
 | `MAX_CONCURRENT_REQUESTS` | `256` | Hard cap on in-flight gRPC streams. Excess returns `UNAVAILABLE` from the gRPC load-shed layer. `0` disables the cap. |
 | `SYMBOL_RESOLUTION_CONCURRENCY` | `64` | Cap on concurrent symbol-resolution operations across all in-flight items. |
+| `FRAME_CHANGE_ONLY_PERSISTENCE_ENABLED` | `false` | Persist new and changed frame snapshots atomically while leaving unchanged snapshots untouched. Keep disabled until snapshot freshness consumers are decoupled from timestamp refreshes. |
 | `MAX_ITEM_CONCURRENCY` | `64` | Process-wide cap on concurrently processed exception items. Excess items receive `ERROR_KIND_OVERLOADED`. |
 | `SERVICE_INSTANCE_ID` | random UUID | Identifier surfaced to callers via `LoadEvent` on the Subscribe stream. |
 | `SUBSCRIBE_TICK_INTERVAL_MS` | `1000` | Default `LoadEvent` heartbeat cadence when callers do not suggest one. Load events may be emitted earlier when draining changes or in-flight load crosses coarse thresholds. |


### PR DESCRIPTION
## Problem

Error tracking rewrites identical frame snapshots after cache expiry, adding Postgres churn without changing durable source context.

Multipart updates also upsert current parts without removing obsolete parts when an expanded stack contracts.

## Changes

- Cymbal can skip identical snapshots and atomically replace changed multipart snapshots behind a default-off rollback setting.
- The default path keeps unconditional writes until the rollout prerequisites finish.
- Frame attribution now distinguishes upserted and deleted rows with bounded labels.
- This draft causes no user-visible behavior change while the setting remains disabled.

```diff
+ FRAME_CHANGE_ONLY_PERSISTENCE_ENABLED=false
```

## How did you test this code?

- Added database cases covering inserts, unchanged timestamps, durable field changes, multipart contraction, and transaction rollback.
- Ran `SQLX_OFFLINE=true bin/hogli test rust/cymbal`.
- Ran Cargo formatting and Clippy with warnings denied.
- Ran `bin/hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the resolution-mode operator documentation for the default-off persistence setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi coding agent implemented this change. The session link is unavailable.

Skills invoked: `/openspec-apply-change`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and `/pr`.
