### PR TITLE
feat(desktop): rework Skills view with enable toggle and popular skills

### DIFF
--- a/products/desktop/packages/host-router/src/routers/skills.router.ts
+++ b/products/desktop/packages/host-router/src/routers/skills.router.ts
@@ -18,6 +18,7 @@ import {
   resolveSkillDependenciesOutput,
   saveSkillFileInput,
   saveSkillManifestInput,
+  setSkillEnabledInput,
   skillContentsInput,
   skillContentsOutput,
   skillPathOutput,
@@ -111,6 +112,13 @@ export const skillsRouter = router({
         .get<SkillsService>(SKILLS_SERVICE)
         .deleteSkill(input.skillPath),
     ),
+  setEnabled: publicProcedure
+    .input(setSkillEnabledInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<SkillsService>(SKILLS_SERVICE)
+        .setSkillEnabled(input.skillPath, input.enabled),
+    ),
   export: publicProcedure
     .input(exportSkillInput)
     .output(exportSkillOutput)
@@ -140,6 +148,13 @@ export const skillsRouter = router({
     }
   }),
   marketplace: router({
+    popular: publicProcedure
+      .output(marketplaceSearchOutput)
+      .query(({ ctx }) =>
+        ctx.container
+          .get<SkillsMarketplaceService>(SKILLS_MARKETPLACE_SERVICE)
+          .popular(),
+      ),
     search: publicProcedure
       .input(marketplaceSearchInput)
       .output(marketplaceSearchOutput)

--- a/products/desktop/packages/shared/src/skills.ts
+++ b/products/desktop/packages/shared/src/skills.ts
@@ -13,6 +13,7 @@ export interface SkillInfo {
   skillMdBytes: number;
   /** Frontmatter `disable-model-invocation: true`: only an explicit user invocation runs the skill, never the agent on its own. */
   disableModelInvocation?: boolean;
+  enabled?: boolean;
 }
 
 export interface SkillFileEntry {

--- a/products/desktop/packages/ui/src/features/skills/InlineEdit.tsx
+++ b/products/desktop/packages/ui/src/features/skills/InlineEdit.tsx
@@ -1,0 +1,145 @@
+import { CheckIcon, PencilSimpleIcon, XIcon } from "@phosphor-icons/react";
+import { Button } from "@posthog/quill";
+import { useState } from "react";
+
+const CLAMP_AT_CHARS = 190;
+
+interface InlineEditProps {
+  value: string;
+  placeholder: string;
+  ariaLabel: string;
+  textClass: string;
+  multiline?: boolean;
+  clamp?: boolean;
+  editable?: boolean;
+  saving?: boolean;
+  onSave: (value: string) => void;
+}
+
+export function InlineEdit({
+  value,
+  placeholder,
+  ariaLabel,
+  textClass,
+  multiline,
+  clamp,
+  editable = true,
+  saving,
+  onSave,
+}: InlineEditProps) {
+  const [draft, setDraft] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  if (draft === null) {
+    const isLong = clamp === true && value.length > CLAMP_AT_CHARS;
+    const text = (
+      <span
+        className={`${isLong && !expanded ? "line-clamp-3" : "block"} ${
+          value ? textClass : "text-[12px] text-gray-9 italic"
+        }`}
+      >
+        {value || placeholder}
+      </span>
+    );
+
+    return (
+      <div className="flex min-w-0 flex-col items-start">
+        {editable ? (
+          <button
+            type="button"
+            aria-label={`Edit ${ariaLabel}`}
+            className="group -mx-1 flex w-[calc(100%+0.5rem)] items-start gap-1 rounded px-1 py-0.5 text-left transition-colors hover:bg-gray-3"
+            onClick={() => setDraft(value)}
+          >
+            <span className="min-w-0 flex-1">{text}</span>
+            <PencilSimpleIcon
+              size={11}
+              className="mt-1 shrink-0 text-gray-9 opacity-0 transition-opacity group-hover:opacity-100"
+            />
+          </button>
+        ) : value ? (
+          <div className="min-w-0 py-0.5">{text}</div>
+        ) : null}
+        {isLong ? (
+          <button
+            type="button"
+            className="py-0.5 text-[11px] text-gray-9 transition-colors hover:text-gray-11"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  const commit = () => {
+    const next = draft.trim();
+    setDraft(null);
+    if (next !== value.trim()) onSave(next);
+  };
+
+  const fieldClass = `w-full rounded border border-accent-7 bg-gray-1 px-1.5 py-1 outline-none ${textClass}`;
+
+  return (
+    <div className="flex w-full flex-col gap-1">
+      {multiline ? (
+        <textarea
+          // biome-ignore lint/a11y/noAutofocus: the field opens on an explicit click
+          autoFocus
+          rows={4}
+          aria-label={ariaLabel}
+          className={`${fieldClass} resize-none`}
+          value={draft}
+          placeholder={placeholder}
+          onChange={(event) => setDraft(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") setDraft(null);
+            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+              commit();
+            }
+          }}
+        />
+      ) : (
+        <input
+          // biome-ignore lint/a11y/noAutofocus: the field opens on an explicit click
+          autoFocus
+          aria-label={ariaLabel}
+          className={fieldClass}
+          value={draft}
+          placeholder={placeholder}
+          onChange={(event) => setDraft(event.currentTarget.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") setDraft(null);
+            if (event.key === "Enter") commit();
+          }}
+        />
+      )}
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          variant="primary"
+          size="icon-sm"
+          aria-label={`Save ${ariaLabel}`}
+          loading={saving}
+          disabled={saving}
+          onClick={commit}
+        >
+          <CheckIcon size={12} weight="bold" />
+        </Button>
+        <Button
+          type="button"
+          variant="link-muted"
+          size="icon-sm"
+          aria-label="Cancel"
+          onClick={() => setDraft(null)}
+        >
+          <XIcon size={12} />
+        </Button>
+        <span className="text-[11px] text-gray-9">
+          {multiline ? "⌘ + Enter saves" : "Enter saves"}, Esc cancels
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/skills/MarketplaceBrowse.tsx
+++ b/products/desktop/packages/ui/src/features/skills/MarketplaceBrowse.tsx
@@ -1,21 +1,17 @@
-import { MagnifyingGlass, Storefront } from "@phosphor-icons/react";
+import { DownloadSimpleIcon, StorefrontIcon } from "@phosphor-icons/react";
 import { useDebouncedValue } from "@posthog/ui/primitives/hooks/useDebouncedValue";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
-import {
-  Badge,
-  Box,
-  Flex,
-  ScrollArea,
-  Text,
-  TextField,
-} from "@radix-ui/themes";
 import { useState } from "react";
 import { MarketplaceSkillPanel } from "./MarketplaceSkillPanel";
 import { SkillListCard } from "./SkillListCard";
+import { SkillChip } from "./SkillPanelHeader";
+import { SkillListSkeleton } from "./SkillSkeletons";
+import { SkillsToolbar } from "./SkillsToolbar";
 import { useSkillsSidebarStore } from "./skillsSidebarStore";
 import {
   installsFormatter,
   type MarketplaceSkillSummary,
+  useMarketplacePopular,
   useMarketplaceSearch,
 } from "./useMarketplace";
 
@@ -26,8 +22,11 @@ export function MarketplaceBrowse() {
     null,
   );
 
-  const { data, isLoading, error } = useMarketplaceSearch(debouncedQuery);
-  const results = data?.results ?? [];
+  const isSearching = debouncedQuery.trim().length >= 2;
+  const search = useMarketplaceSearch(debouncedQuery);
+  const popular = useMarketplacePopular(!isSearching);
+  const active = isSearching ? search : popular;
+  const results = active.data?.results ?? [];
 
   const {
     width: sidebarWidth,
@@ -37,44 +36,33 @@ export function MarketplaceBrowse() {
   } = useSkillsSidebarStore();
 
   return (
-    <Flex className="min-h-0 flex-1">
-      <Box flexGrow="1" className="min-w-0">
-        <ScrollArea type="auto" className="scroll-area-constrain-width h-full">
-          <Box px="4" py="3">
-            <Box pb="3">
-              <TextField.Root
-                size="2"
-                placeholder="Search community skills..."
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                className="text-[13px]"
-              >
-                <TextField.Slot>
-                  <MagnifyingGlass size={14} />
-                </TextField.Slot>
-              </TextField.Root>
-            </Box>
+    <div className="flex min-h-0 flex-1">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <SkillsToolbar
+          placeholder="Search community skills"
+          value={query}
+          onChange={setQuery}
+        />
 
-            {debouncedQuery.trim().length < 2 ? (
-              <BrowseEmptyState message="Search the community skills index from skills.sh" />
-            ) : error ? (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="mx-auto w-full max-w-5xl px-4 py-3">
+            {active.error ? (
               <BrowseEmptyState message="Could not reach the skills index. Check your connection and try again." />
-            ) : isLoading ? (
-              <Text className="text-[12px] text-gray-9">Searching...</Text>
+            ) : active.isLoading ? (
+              <SkillListSkeleton rows={6} />
             ) : results.length === 0 ? (
               <BrowseEmptyState message="No skills found" />
             ) : (
-              <Flex direction="column" gap="1">
+              <div className="flex flex-col gap-0.5">
+                {isSearching ? null : (
+                  <p className="pb-1 font-medium text-[12px] text-gray-9 uppercase tracking-wider">
+                    Most installed
+                  </p>
+                )}
                 {results.map((result) => (
                   <SkillListCard
                     key={result.id}
-                    icon={
-                      <Storefront
-                        size={14}
-                        weight="duotone"
-                        className="text-gray-11"
-                      />
-                    }
+                    icon={<StorefrontIcon size={12} weight="duotone" />}
                     title={result.name}
                     subtitle={result.source}
                     isSelected={selected?.id === result.id}
@@ -86,27 +74,24 @@ export function MarketplaceBrowse() {
                     trailing={
                       <>
                         {result.installed && (
-                          <Badge
-                            size="1"
-                            variant="soft"
-                            color="green"
-                            className="shrink-0"
-                          >
-                            Installed
-                          </Badge>
+                          <SkillChip tone="positive">Installed</SkillChip>
                         )}
-                        <Text className="shrink-0 text-[12px] text-gray-9 tabular-nums">
+                        <span
+                          className="flex shrink-0 items-center gap-1 text-[11px] text-gray-9 tabular-nums"
+                          title={`${installsFormatter.format(result.installs)} installs`}
+                        >
+                          <DownloadSimpleIcon size={12} />
                           {installsFormatter.format(result.installs)}
-                        </Text>
+                        </span>
                       </>
                     }
                   />
                 ))}
-              </Flex>
+              </div>
             )}
-          </Box>
-        </ScrollArea>
-      </Box>
+          </div>
+        </div>
+      </div>
 
       <ResizableSidebar
         open={!!selected}
@@ -124,25 +109,19 @@ export function MarketplaceBrowse() {
           />
         )}
       </ResizableSidebar>
-    </Flex>
+    </div>
   );
 }
 
 function BrowseEmptyState({ message }: { message: string }) {
   return (
-    <Flex
-      align="center"
-      justify="center"
-      direction="column"
-      gap="3"
-      className="py-12"
-    >
-      <Box className="rounded-lg border border-gray-6 border-dashed p-4">
-        <Storefront size={24} className="text-gray-8" />
-      </Box>
-      <Text className="max-w-[360px] text-center text-[13px] text-gray-10">
+    <div className="flex flex-col items-center justify-center gap-3 py-12">
+      <div className="rounded-lg border border-gray-6 border-dashed p-4">
+        <StorefrontIcon size={24} className="text-gray-8" />
+      </div>
+      <p className="max-w-[360px] text-center text-[13px] text-gray-10">
         {message}
-      </Text>
-    </Flex>
+      </p>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/MarketplaceSkillPanel.tsx
+++ b/products/desktop/packages/ui/src/features/skills/MarketplaceSkillPanel.tsx
@@ -16,6 +16,7 @@ import {
 import { useState } from "react";
 import { ReplaceSkillDialog } from "./ReplaceSkillDialog";
 import { SkillFileTree } from "./SkillFileTree";
+import { SkillBodySkeleton } from "./SkillSkeletons";
 import { isSkillExistsError, skillErrorDescription } from "./skillErrors";
 import {
   installsFormatter,
@@ -144,9 +145,7 @@ export function MarketplaceSkillPanel({
 
       <Box className="min-h-0 flex-1">
         {isLoading ? (
-          <Box p="3">
-            <Text className="text-[12px] text-gray-9">Loading...</Text>
-          </Box>
+          <SkillBodySkeleton />
         ) : selected?.content == null ? (
           <Box p="3">
             <Text className="text-[12px] text-gray-9">

--- a/products/desktop/packages/ui/src/features/skills/SkillCard.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillCard.tsx
@@ -1,42 +1,75 @@
 import {
-  Folder,
-  Package,
-  Robot,
-  Storefront,
-  User,
-  Warning,
+  FolderIcon,
+  LightbulbIcon,
+  PackageIcon,
+  RobotIcon,
+  StorefrontIcon,
+  WarningIcon,
 } from "@phosphor-icons/react";
-import type {
-  SkillAnalysis,
-  SkillIssue,
-} from "@posthog/core/skills/analyzeSkills";
+import type { SkillIssue } from "@posthog/core/skills/analyzeSkills";
+import {
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@posthog/quill";
 import type { SkillInfo, SkillSource } from "@posthog/shared";
-import { Badge, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useEffect, useRef } from "react";
 import { SkillListCard } from "./SkillListCard";
+import { SkillChip } from "./SkillPanelHeader";
+import { useSetSkillEnabled } from "./useSkillMutations";
 
 export const SOURCE_CONFIG: Record<
   SkillSource,
-  { icon: typeof Package; label: string; sectionTitle: string }
+  {
+    icon: typeof PackageIcon;
+    label: string;
+    sectionTitle: string;
+    chipClass: string;
+    dotClass: string;
+  }
 > = {
-  user: { icon: User, label: "User", sectionTitle: "Your skills" },
+  user: {
+    icon: LightbulbIcon,
+    label: "User",
+    sectionTitle: "Your skills",
+    chipClass: "bg-amber-3 text-amber-11",
+    dotClass: "bg-amber-9",
+  },
   bundled: {
-    icon: Package,
+    icon: PackageIcon,
     label: "PostHog",
     sectionTitle: "PostHog",
+    chipClass: "bg-orange-3 text-orange-11",
+    dotClass: "bg-orange-9",
   },
-  repo: { icon: Folder, label: "Repo", sectionTitle: "Repository" },
+  repo: {
+    icon: FolderIcon,
+    label: "Repo",
+    sectionTitle: "Repository",
+    chipClass: "bg-green-3 text-green-11",
+    dotClass: "bg-green-9",
+  },
   marketplace: {
-    icon: Storefront,
+    icon: StorefrontIcon,
     label: "Marketplace",
     sectionTitle: "Marketplace",
+    chipClass: "bg-blue-3 text-blue-11",
+    dotClass: "bg-blue-9",
   },
-  codex: { icon: Robot, label: "Codex", sectionTitle: "Codex" },
+  codex: {
+    icon: RobotIcon,
+    label: "Codex",
+    sectionTitle: "Codex",
+    chipClass: "bg-violet-3 text-violet-11",
+    dotClass: "bg-violet-9",
+  },
 };
 
 interface SkillCardProps {
   skill: SkillInfo;
   isSelected: boolean;
+  showRepoBadge?: boolean;
   onClick: () => void;
   /** When true, scroll this card into view once (used for deep-linked skills). */
   scrollIntoView?: boolean;
@@ -47,13 +80,16 @@ interface SkillCardProps {
 export function SkillCard({
   skill,
   isSelected,
+  showRepoBadge = true,
   onClick,
   scrollIntoView,
   onScrolledIntoView,
   issues = [],
 }: SkillCardProps) {
   const config = SOURCE_CONFIG[skill.source];
-  const Icon = config?.icon ?? Package;
+  const Icon = config?.icon ?? PackageIcon;
+  const setEnabled = useSetSkillEnabled();
+  const isEnabled = skill.enabled !== false;
 
   const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -65,83 +101,56 @@ export function SkillCard({
   return (
     <SkillListCard
       cardRef={ref}
-      icon={<Icon size={14} weight="duotone" className="text-gray-11" />}
+      icon={<Icon size={12} weight="duotone" />}
+      iconClass={config?.chipClass}
       title={skill.name}
-      subtitle={skill.description || undefined}
+      subtitle={
+        skill.description && skill.description !== skill.name
+          ? skill.description
+          : undefined
+      }
       isSelected={isSelected}
+      dimmed={!isEnabled}
       onClick={onClick}
       trailing={
         <>
           {issues.length > 0 && (
-            <Tooltip
-              content={
-                <Flex direction="column" gap="1">
-                  {issues.map((issue) => (
-                    <Text key={issue.message} size="1">
-                      {issue.message}
-                    </Text>
-                  ))}
-                </Flex>
-              }
-            >
-              <Warning size={14} className="shrink-0 text-amber-11" />
-            </Tooltip>
+            <WarningIcon
+              size={13}
+              className="shrink-0 text-amber-11"
+              aria-label="This skill has issues"
+            />
           )}
-          {skill.repoName && (
-            <Badge size="1" variant="soft" color="gray" className="shrink-0">
-              {skill.repoName}
-            </Badge>
+          {skill.repoName && showRepoBadge && (
+            <SkillChip>{skill.repoName}</SkillChip>
           )}
-          {skill.disableModelInvocation && (
-            <Tooltip content="The agent won't use this skill on its own. It runs only when you invoke it">
-              <Badge size="1" variant="soft" color="gray" className="shrink-0">
-                Manual
-              </Badge>
+          {skill.disableModelInvocation && <SkillChip>Manual</SkillChip>}
+          {skill.editable && skill.source !== "repo" && (
+            <Tooltip>
+              <TooltipTrigger
+                render={<span className="flex shrink-0 items-center" />}
+              >
+                <Switch
+                  checked={isEnabled}
+                  disabled={setEnabled.isPending}
+                  aria-label={`Turn ${skill.name} ${isEnabled ? "off" : "on"}`}
+                  onCheckedChange={(checked) =>
+                    setEnabled.mutate({
+                      skillPath: skill.path,
+                      enabled: checked,
+                    })
+                  }
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                {isEnabled
+                  ? "On. Agents can discover and use this skill."
+                  : "Off. Agents do not see this skill."}
+              </TooltipContent>
             </Tooltip>
           )}
         </>
       }
     />
-  );
-}
-
-interface SkillSectionProps {
-  title: string;
-  skills: SkillInfo[];
-  selectedPath: string | null;
-  onSelect: (path: string) => void;
-  scrollToPath: string | null;
-  onScrolledIntoView: () => void;
-  analysis?: SkillAnalysis;
-}
-
-export function SkillSection({
-  title,
-  skills,
-  selectedPath,
-  onSelect,
-  scrollToPath,
-  onScrolledIntoView,
-  analysis,
-}: SkillSectionProps) {
-  return (
-    <Flex direction="column" gap="1">
-      <Text className="mb-1 font-medium text-[12px] text-gray-9 uppercase tracking-wider">
-        {title}
-      </Text>
-      <Flex direction="column" gap="1">
-        {skills.map((skill) => (
-          <SkillCard
-            key={skill.path}
-            skill={skill}
-            isSelected={selectedPath === skill.path}
-            onClick={() => onSelect(skill.path)}
-            scrollIntoView={scrollToPath === skill.path}
-            onScrolledIntoView={onScrolledIntoView}
-            issues={analysis?.[skill.path]}
-          />
-        ))}
-      </Flex>
-    </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -1,40 +1,39 @@
-import {
-  CloudArrowUp,
-  DownloadSimple,
-  FilePlus,
-  Folder,
-  HandTap,
-  LockSimple,
-  PencilSimple,
-  Trash,
-  Warning,
-  X,
-} from "@phosphor-icons/react";
+import { DownloadSimpleIcon, WarningIcon } from "@phosphor-icons/react";
 import type { SkillIssue } from "@posthog/core/skills/analyzeSkills";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenuCheckboxItem,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  Input,
+} from "@posthog/quill";
 import type { SkillInfo } from "@posthog/shared";
 import { stripFrontmatter } from "@posthog/shared";
 import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { toast } from "@posthog/ui/primitives/toast";
-import {
-  AlertDialog,
-  Badge,
-  Box,
-  Button,
-  Callout,
-  Dialog,
-  Flex,
-  ScrollArea,
-  Text,
-  TextField,
-  Tooltip,
-} from "@radix-ui/themes";
 import { useState } from "react";
 import { ReplaceSkillDialog } from "./ReplaceSkillDialog";
 import { SOURCE_CONFIG } from "./SkillCard";
 import { SkillFileEditor } from "./SkillFileEditor";
 import { SkillFileTree } from "./SkillFileTree";
 import { SkillManifestEditor } from "./SkillManifestEditor";
+import { SkillChip, SkillPanelHeader } from "./SkillPanelHeader";
+import { SkillBodySkeleton } from "./SkillSkeletons";
 import { isSkillExistsError, skillErrorDescription } from "./skillErrors";
 import { useSkillContents, useSkillFile } from "./useSkillContents";
 import {
@@ -43,6 +42,7 @@ import {
   useImportCodexSkill,
   useRenameSkillFile,
   useSaveSkillFile,
+  useSaveSkillManifest,
 } from "./useSkillMutations";
 import { usePublishSkill } from "./useTeamSkillMutations";
 
@@ -80,6 +80,7 @@ export function SkillDetailPanel({
   );
 
   const saveFile = useSaveSkillFile();
+  const saveManifest = useSaveSkillManifest();
   const renameFile = useRenameSkillFile();
   const deleteFile = useDeleteSkillFile();
   const deleteSkill = useDeleteSkill();
@@ -89,6 +90,33 @@ export function SkillDetailPanel({
   const files = contents?.files ?? [];
   const isSkillMd = selectedFile === "SKILL.md";
   const body = isSkillMd && fileContent ? stripFrontmatter(fileContent) : null;
+  const isMarkdown = selectedFile.toLowerCase().endsWith(".md");
+  const preview = isSkillMd ? body : fileContent;
+  const canEditManifest = skill.editable && body !== null && !isEditing;
+
+  const writeManifest = async (fields: {
+    name?: string;
+    description?: string;
+    disableModelInvocation?: boolean;
+  }) => {
+    if (body === null) return;
+    try {
+      await saveManifest.mutateAsync({
+        skillPath: skill.path,
+        name: fields.name ?? skill.name,
+        description: fields.description ?? skill.description,
+        body,
+        disableModelInvocation:
+          fields.disableModelInvocation ??
+          skill.disableModelInvocation ??
+          false,
+      });
+    } catch (error) {
+      toast.error("Failed to save the skill", {
+        description: skillErrorDescription(error),
+      });
+    }
+  };
 
   const handleAddFile = async () => {
     const filePath = newFilePath.trim();
@@ -198,162 +226,104 @@ export function SkillDetailPanel({
   };
 
   return (
-    <>
-      <Flex
-        direction="column"
-        gap="2"
-        px="3"
-        py="2"
-        className="shrink-0 border-b border-b-(--gray-5)"
-      >
-        <Flex align="start" justify="between" gap="2">
-          <Text className="block min-w-0 break-words font-medium text-[13px]">
-            {skill.name}
-          </Text>
-          <Flex align="center" gap="1" className="shrink-0">
-            {skill.editable && !isEditing && (
-              <>
-                {canPublish && (
-                  <Tooltip content="Publish to team">
-                    <button
-                      type="button"
-                      aria-label="Publish to team"
-                      onClick={() => setPublishOpen(true)}
-                      className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
-                    >
-                      <CloudArrowUp size={14} />
-                    </button>
-                  </Tooltip>
-                )}
-                <Tooltip content="Edit skill">
-                  <button
-                    type="button"
-                    aria-label="Edit skill"
-                    onClick={() => setIsEditing(true)}
-                    disabled={isLoading || fileContent == null}
-                    className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
-                  >
-                    <PencilSimple size={14} />
-                  </button>
-                </Tooltip>
-                <Tooltip content="Add file">
-                  <button
-                    type="button"
-                    aria-label="Add file"
-                    onClick={() => setAddFileOpen(true)}
-                    className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
-                  >
-                    <FilePlus size={14} />
-                  </button>
-                </Tooltip>
-                <Tooltip content="Delete skill">
-                  <button
-                    type="button"
-                    aria-label="Delete skill"
-                    onClick={() => setDeleteSkillOpen(true)}
-                    className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-red-11"
-                  >
-                    <Trash size={14} />
-                  </button>
-                </Tooltip>
-              </>
-            )}
-            <Tooltip content="Close">
-              <button
-                type="button"
-                aria-label="Close"
-                onClick={onClose}
-                className="rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
-              >
-                <X size={14} />
-              </button>
-            </Tooltip>
-          </Flex>
-        </Flex>
-
-        <Flex align="center" gap="2" wrap="wrap">
-          <Badge size="1" variant="soft" color="gray">
-            {config?.label ?? skill.source}
-          </Badge>
-          {skill.repoName && (
-            <Badge size="1" variant="soft" color="gray">
-              <Folder size={10} className="text-gray-9" />
-              {skill.repoName}
-            </Badge>
-          )}
-          {!skill.editable && (
-            <Badge size="1" variant="soft" color="gray">
-              <LockSimple size={10} className="text-gray-9" />
-              Read-only
-            </Badge>
-          )}
-          {skill.disableModelInvocation && (
-            <Tooltip content="The agent won't use this skill on its own. It runs only when you invoke it">
-              <Badge size="1" variant="soft" color="gray">
-                <HandTap size={10} className="text-gray-9" />
-                Manual-only
-              </Badge>
-            </Tooltip>
-          )}
-          {skill.source === "codex" && (
+    <div className="flex h-full min-h-0 flex-col">
+      <SkillPanelHeader
+        name={skill.name}
+        description={skill.description}
+        onEdit={
+          canEditManifest ? (fields) => void writeManifest(fields) : undefined
+        }
+        saving={saveManifest.isPending}
+        onClose={onClose}
+        actions={
+          skill.source === "codex" ? (
             <Button
-              size="1"
-              variant="solid"
-              onClick={() => void handleImport(false)}
+              type="button"
+              variant="primary"
+              size="sm"
+              loading={importCodexSkill.isPending}
               disabled={importCodexSkill.isPending}
+              onClick={() => void handleImport(false)}
             >
-              <DownloadSimple size={12} />
+              <DownloadSimpleIcon size={12} />
               Import
             </Button>
-          )}
-        </Flex>
-
-        {issues.length > 0 && (
-          <Flex direction="column" gap="1">
-            {issues.map((issue) => (
-              <Callout.Root
-                key={issue.type}
-                size="1"
-                color="amber"
-                variant="surface"
+          ) : null
+        }
+        menuItems={
+          skill.editable && !isEditing ? (
+            <>
+              <DropdownMenuCheckboxItem
+                checked={skill.disableModelInvocation ?? false}
+                disabled={body === null}
+                onCheckedChange={(checked: boolean) =>
+                  void writeManifest({ disableModelInvocation: checked })
+                }
               >
-                <Callout.Icon>
-                  <Warning size={12} />
-                </Callout.Icon>
-                <Callout.Text className="text-[12px]">
-                  {issue.message}
-                </Callout.Text>
-              </Callout.Root>
-            ))}
-          </Flex>
-        )}
-      </Flex>
+                Manual invocation only
+              </DropdownMenuCheckboxItem>
+              {canPublish ? (
+                <DropdownMenuItem onClick={() => setPublishOpen(true)}>
+                  Publish to team
+                </DropdownMenuItem>
+              ) : null}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => setDeleteSkillOpen(true)}>
+                Delete skill
+              </DropdownMenuItem>
+            </>
+          ) : null
+        }
+        badges={
+          <>
+            <SkillChip>
+              <span
+                className={`size-1.5 rounded-full ${config?.dotClass ?? "bg-gray-9"}`}
+              />
+              {config?.label ?? skill.source}
+            </SkillChip>
+            {skill.repoName ? <SkillChip>{skill.repoName}</SkillChip> : null}
+            {skill.editable ? null : <SkillChip>Read-only</SkillChip>}
+            {skill.disableModelInvocation ? (
+              <SkillChip>Manual only</SkillChip>
+            ) : null}
+            {skill.enabled === false ? <SkillChip>Off</SkillChip> : null}
+          </>
+        }
+      />
 
-      {files.length > 1 && (
-        <Box className="max-h-[40%] shrink-0 overflow-y-auto border-b border-b-(--gray-5) py-1">
-          <SkillFileTree
-            files={files}
-            selectedPath={selectedFile}
-            onSelect={(path) => {
-              setSelectedFile(path);
-              setIsEditing(false);
-            }}
-            onRenameFile={
-              skill.editable
-                ? (path) => {
-                    setRenameFrom(path);
-                    setRenameTo(path);
-                  }
-                : undefined
-            }
-            onDeleteFile={
-              skill.editable ? (path) => setDeleteFileTarget(path) : undefined
-            }
-          />
-        </Box>
-      )}
+      <div className="max-h-[40%] shrink-0 overflow-y-auto border-gray-4 border-b">
+        <SkillFileTree
+          files={files}
+          selectedPath={selectedFile}
+          onSelect={(path) => {
+            setSelectedFile(path);
+            setIsEditing(false);
+          }}
+          onEditFile={
+            skill.editable
+              ? (path) => {
+                  setSelectedFile(path);
+                  setIsEditing(true);
+                }
+              : undefined
+          }
+          onRenameFile={
+            skill.editable
+              ? (path) => {
+                  setRenameFrom(path);
+                  setRenameTo(path);
+                }
+              : undefined
+          }
+          onDeleteFile={
+            skill.editable ? (path) => setDeleteFileTarget(path) : undefined
+          }
+          onAddFile={skill.editable ? () => setAddFileOpen(true) : undefined}
+        />
+      </div>
 
-      <Box className="min-h-0 flex-1">
+      <div className="min-h-0 flex-1">
         {isEditing && isSkillMd ? (
           <SkillManifestEditor
             skill={skill}
@@ -370,155 +340,147 @@ export function SkillDetailPanel({
             onCancel={() => setIsEditing(false)}
             onSaved={() => setIsEditing(false)}
           />
-        ) : isSkillMd ? (
-          <ScrollArea
-            type="auto"
-            scrollbars="vertical"
-            className="scroll-area-constrain-width h-full"
-          >
-            <Flex direction="column" gap="3" p="3">
-              {skill.description && (
-                <Text className="text-[12px] text-gray-10">
-                  {skill.description}
-                </Text>
-              )}
-
-              {isLoading ? (
-                <Text className="text-[12px] text-gray-9">Loading...</Text>
-              ) : body ? (
-                <Box className="rounded border border-gray-5 bg-gray-1 px-4 py-3 text-[13px]">
-                  <MarkdownRenderer content={body} />
-                </Box>
-              ) : (
-                <Text className="text-[12px] text-gray-9">
-                  No content in SKILL.md
-                </Text>
-              )}
-            </Flex>
-          </ScrollArea>
+        ) : isMarkdown ? (
+          <div className="flex h-full flex-col gap-2 overflow-y-auto px-3 py-2.5">
+            {issues.map((issue) => (
+              <div
+                key={issue.type}
+                className="flex items-start gap-1.5 rounded-md bg-amber-3 px-2 py-1.5 text-[12px] text-amber-11"
+              >
+                <WarningIcon size={13} className="mt-0.5 shrink-0" />
+                {issue.message}
+              </div>
+            ))}
+            {isLoading ? (
+              <SkillBodySkeleton />
+            ) : preview ? (
+              <div className="text-[13px]">
+                <MarkdownRenderer content={preview} />
+              </div>
+            ) : (
+              <p className="text-[12px] text-gray-9">{selectedFile} is empty</p>
+            )}
+          </div>
         ) : isLoading ? (
-          <Box p="3">
-            <Text className="text-[12px] text-gray-9">Loading...</Text>
-          </Box>
+          <SkillBodySkeleton />
         ) : fileContent != null ? (
           <CodeMirrorEditor
             content={fileContent}
             filePath={`${skill.path}/${selectedFile}`}
-            relativePath={selectedFile}
             readOnly
           />
         ) : (
-          <Box p="3">
-            <Text className="text-[12px] text-gray-9">
-              Unable to display this file
-            </Text>
-          </Box>
+          <p className="p-3 text-[12px] text-gray-9">
+            Unable to display this file
+          </p>
         )}
-      </Box>
+      </div>
 
-      <Dialog.Root open={addFileOpen} onOpenChange={setAddFileOpen}>
-        <Dialog.Content maxWidth="380px" size="2">
-          <Dialog.Title size="3">Add file</Dialog.Title>
-          <Dialog.Description size="1" color="gray">
-            Path relative to the skill directory
-          </Dialog.Description>
-          <Flex direction="column" gap="3" mt="3">
-            <TextField.Root
-              size="2"
+      <Dialog open={addFileOpen} onOpenChange={setAddFileOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Add file</DialogTitle>
+            <DialogDescription>
+              Path relative to the skill directory
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <Input
               autoFocus
               value={newFilePath}
-              onChange={(e) => setNewFilePath(e.target.value)}
+              onChange={(event) => setNewFilePath(event.currentTarget.value)}
               placeholder="references/guide.md"
-              onKeyDown={(e) => {
-                if (e.key === "Enter") void handleAddFile();
+              aria-label="File path"
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void handleAddFile();
               }}
             />
-            <Flex justify="end" gap="2">
-              <Dialog.Close>
-                <Button size="1" variant="soft" color="gray">
-                  Cancel
-                </Button>
-              </Dialog.Close>
-              <Button
-                size="1"
-                variant="solid"
-                onClick={handleAddFile}
-                disabled={saveFile.isPending || !newFilePath.trim()}
-              >
-                Add
-              </Button>
-            </Flex>
-          </Flex>
-        </Dialog.Content>
-      </Dialog.Root>
+          </DialogBody>
+          <DialogFooter>
+            <DialogClose render={<Button type="button" variant="outline" />}>
+              Cancel
+            </DialogClose>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={() => void handleAddFile()}
+              disabled={saveFile.isPending || !newFilePath.trim()}
+            >
+              Add
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-      <Dialog.Root
+      <Dialog
         open={renameFrom !== null}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!open) setRenameFrom(null);
         }}
       >
-        <Dialog.Content maxWidth="380px" size="2">
-          <Dialog.Title size="3">Rename file</Dialog.Title>
-          <Flex direction="column" gap="3" mt="3">
-            <TextField.Root
-              size="2"
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Rename file</DialogTitle>
+          </DialogHeader>
+          <DialogBody>
+            <Input
               autoFocus
               value={renameTo}
-              onChange={(e) => setRenameTo(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") void handleRenameFile();
+              aria-label="New file path"
+              onChange={(event) => setRenameTo(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void handleRenameFile();
               }}
             />
-            <Flex justify="end" gap="2">
-              <Dialog.Close>
-                <Button size="1" variant="soft" color="gray">
-                  Cancel
-                </Button>
-              </Dialog.Close>
-              <Button
-                size="1"
-                variant="solid"
-                onClick={handleRenameFile}
-                disabled={renameFile.isPending || !renameTo.trim()}
-              >
-                Rename
-              </Button>
-            </Flex>
-          </Flex>
-        </Dialog.Content>
-      </Dialog.Root>
+          </DialogBody>
+          <DialogFooter>
+            <DialogClose render={<Button type="button" variant="outline" />}>
+              Cancel
+            </DialogClose>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={() => void handleRenameFile()}
+              disabled={renameFile.isPending || !renameTo.trim()}
+            >
+              Rename
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-      <AlertDialog.Root
+      <AlertDialog
         open={deleteFileTarget !== null}
-        onOpenChange={(open) => {
+        onOpenChange={(open: boolean) => {
           if (!open) setDeleteFileTarget(null);
         }}
       >
-        <AlertDialog.Content maxWidth="420px" size="2">
-          <AlertDialog.Title size="3">Delete file</AlertDialog.Title>
-          <AlertDialog.Description size="1">
-            Delete "{deleteFileTarget}" from this skill? This cannot be undone.
-          </AlertDialog.Description>
-          <Flex justify="end" gap="2" mt="4">
-            <AlertDialog.Cancel>
-              <Button size="1" variant="soft" color="gray">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-            <AlertDialog.Action>
-              <Button
-                size="1"
-                variant="solid"
-                color="red"
-                onClick={handleDeleteFile}
-              >
-                Delete
-              </Button>
-            </AlertDialog.Action>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete file</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete "{deleteFileTarget}" from this skill? This cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setDeleteFileTarget(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => void handleDeleteFile()}
+            >
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <ReplaceSkillDialog
         open={confirmImportOverwrite}
@@ -528,59 +490,64 @@ export function SkillDetailPanel({
         onConfirm={() => void handleImport(true)}
       />
 
-      <AlertDialog.Root open={publishOpen} onOpenChange={setPublishOpen}>
-        <AlertDialog.Content maxWidth="420px" size="2">
-          <AlertDialog.Title size="3">Publish to team</AlertDialog.Title>
-          <AlertDialog.Description size="1">
-            Publish "{skill.name}" to your team? Teammates will be able to view
-            and install it. Re-publishing creates a new version.
-          </AlertDialog.Description>
-          <Flex justify="end" gap="2" mt="4">
-            <AlertDialog.Cancel>
-              <Button size="1" variant="soft" color="gray">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
+      <AlertDialog open={publishOpen} onOpenChange={setPublishOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Publish to team</AlertDialogTitle>
+            <AlertDialogDescription>
+              Publish "{skill.name}" to your team? Teammates will be able to
+              view and install it. Re-publishing creates a new version.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
             <Button
-              size="1"
-              variant="solid"
-              onClick={handlePublish}
+              type="button"
+              variant="outline"
+              onClick={() => setPublishOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              loading={publishSkill.isPending}
               disabled={publishSkill.isPending}
+              onClick={() => void handlePublish()}
             >
               Publish
             </Button>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
-      <AlertDialog.Root
-        open={deleteSkillOpen}
-        onOpenChange={setDeleteSkillOpen}
-      >
-        <AlertDialog.Content maxWidth="420px" size="2">
-          <AlertDialog.Title size="3">Delete skill</AlertDialog.Title>
-          <AlertDialog.Description size="1">
-            Delete "{skill.name}" and all of its files? This cannot be undone.
-          </AlertDialog.Description>
-          <Flex justify="end" gap="2" mt="4">
-            <AlertDialog.Cancel>
-              <Button size="1" variant="soft" color="gray">
-                Cancel
-              </Button>
-            </AlertDialog.Cancel>
-            <AlertDialog.Action>
-              <Button
-                size="1"
-                variant="solid"
-                color="red"
-                onClick={handleDeleteSkill}
-              >
-                Delete
-              </Button>
-            </AlertDialog.Action>
-          </Flex>
-        </AlertDialog.Content>
-      </AlertDialog.Root>
-    </>
+      <AlertDialog open={deleteSkillOpen} onOpenChange={setDeleteSkillOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete skill</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete "{skill.name}" and all of its files? This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setDeleteSkillOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              loading={deleteSkill.isPending}
+              disabled={deleteSkill.isPending}
+              onClick={() => void handleDeleteSkill()}
+            >
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/SkillFileEditor.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillFileEditor.tsx
@@ -1,6 +1,6 @@
+import { Button } from "@posthog/quill";
 import type { SkillInfo } from "@posthog/shared";
 import { toast } from "@posthog/ui/primitives/toast";
-import { Box, Button, Flex } from "@radix-ui/themes";
 import { useRef, useState } from "react";
 import { SkillCodeEditor } from "./SkillCodeEditor";
 import { skillErrorDescription } from "./skillErrors";
@@ -43,8 +43,8 @@ export function SkillFileEditor({
   };
 
   return (
-    <Flex direction="column" height="100%">
-      <Box className="min-h-0 flex-1">
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1">
         <SkillCodeEditor
           initialContent={mountedContent}
           filePath={`${skill.path}/${filePath}`}
@@ -52,25 +52,22 @@ export function SkillFileEditor({
             contentRef.current = doc;
           }}
         />
-      </Box>
-      <Flex
-        justify="end"
-        gap="2"
-        p="2"
-        className="shrink-0 border-t border-t-(--gray-5)"
-      >
-        <Button size="1" variant="soft" color="gray" onClick={onCancel}>
+      </div>
+      <div className="flex shrink-0 justify-end gap-1.5 border-gray-5 border-t p-2">
+        <Button type="button" variant="outline" size="sm" onClick={onCancel}>
           Cancel
         </Button>
         <Button
-          size="1"
-          variant="solid"
-          onClick={handleSave}
+          type="button"
+          variant="primary"
+          size="sm"
+          loading={saveFile.isPending}
           disabled={saveFile.isPending}
+          onClick={() => void handleSave()}
         >
           Save
         </Button>
-      </Flex>
-    </Flex>
+      </div>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/SkillFileTree.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillFileTree.tsx
@@ -1,11 +1,15 @@
-import { PencilSimple, Trash } from "@phosphor-icons/react";
+import {
+  CursorTextIcon,
+  NotePencilIcon,
+  PlusIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
 import type { SkillFileEntry } from "@posthog/shared";
 import {
   TreeDirectoryRow,
   TreeFileRow,
 } from "@posthog/ui/primitives/TreeDirectoryRow";
-import { Flex, Tooltip } from "@radix-ui/themes";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 
 interface TreeDir {
   name: string;
@@ -33,21 +37,49 @@ function buildTree(files: SkillFileEntry[]): TreeDir {
   return root;
 }
 
+function RowAction({
+  label,
+  icon,
+  onClick,
+}: {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className="rounded p-0.5 text-gray-9 transition-colors hover:bg-gray-4 hover:text-gray-12"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+    >
+      {icon}
+    </button>
+  );
+}
+
 interface SkillFileTreeProps {
   files: SkillFileEntry[];
   selectedPath: string | null;
   onSelect: (path: string) => void;
-  /** When set, file rows (except SKILL.md) get rename/delete actions. */
+  onEditFile?: (path: string) => void;
   onRenameFile?: (path: string) => void;
   onDeleteFile?: (path: string) => void;
+  onAddFile?: () => void;
 }
 
 export function SkillFileTree({
   files,
   selectedPath,
   onSelect,
+  onEditFile,
   onRenameFile,
   onDeleteFile,
+  onAddFile,
 }: SkillFileTreeProps) {
   const tree = useMemo(() => buildTree(files), [files]);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
@@ -64,12 +96,12 @@ export function SkillFileTree({
     });
   };
 
-  const renderDir = (dir: TreeDir, depth: number): React.ReactNode => (
-    <Flex direction="column" key={dir.path || "__root"}>
+  const renderDir = (dir: TreeDir, depth: number): ReactNode => (
+    <div className="flex flex-col" key={dir.path || "__root"}>
       {dir.dirs.map((child) => {
         const isExpanded = !collapsed.has(child.path);
         return (
-          <Flex direction="column" key={child.path}>
+          <div className="flex flex-col" key={child.path}>
             <TreeDirectoryRow
               name={child.name}
               depth={depth}
@@ -77,12 +109,38 @@ export function SkillFileTree({
               onToggle={() => toggleDir(child.path)}
             />
             {isExpanded && renderDir(child, depth + 1)}
-          </Flex>
+          </div>
         );
       })}
       {dir.files.map((file) => {
-        const showActions =
-          (onRenameFile || onDeleteFile) && file.path !== "SKILL.md";
+        const isManifest = file.path === "SKILL.md";
+        const actions = [
+          onEditFile ? (
+            <RowAction
+              key="edit"
+              label={isManifest ? "Edit the instructions" : "Edit this file"}
+              icon={<NotePencilIcon size={12} />}
+              onClick={() => onEditFile(file.path)}
+            />
+          ) : null,
+          onRenameFile && !isManifest ? (
+            <RowAction
+              key="rename"
+              label="Rename this file"
+              icon={<CursorTextIcon size={12} />}
+              onClick={() => onRenameFile(file.path)}
+            />
+          ) : null,
+          onDeleteFile && !isManifest ? (
+            <RowAction
+              key="delete"
+              label="Delete this file"
+              icon={<TrashIcon size={12} />}
+              onClick={() => onDeleteFile(file.path)}
+            />
+          ) : null,
+        ].filter(Boolean);
+
         return (
           <TreeFileRow
             key={file.path}
@@ -92,46 +150,31 @@ export function SkillFileTree({
             title={file.path}
             onClick={() => onSelect(file.path)}
             trailing={
-              showActions ? (
-                <Flex gap="1" className="shrink-0">
-                  {onRenameFile && (
-                    <Tooltip content="Rename file">
-                      <button
-                        type="button"
-                        aria-label="Rename file"
-                        className="rounded p-0.5 text-gray-9 hover:bg-gray-4 hover:text-gray-12"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onRenameFile(file.path);
-                        }}
-                      >
-                        <PencilSimple size={12} />
-                      </button>
-                    </Tooltip>
-                  )}
-                  {onDeleteFile && (
-                    <Tooltip content="Delete file">
-                      <button
-                        type="button"
-                        aria-label="Delete file"
-                        className="rounded p-0.5 text-gray-9 hover:bg-gray-4 hover:text-gray-12"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onDeleteFile(file.path);
-                        }}
-                      >
-                        <Trash size={12} />
-                      </button>
-                    </Tooltip>
-                  )}
-                </Flex>
+              actions.length > 0 ? (
+                <div className="flex shrink-0 items-center gap-0.5">
+                  {actions}
+                </div>
               ) : undefined
             }
           />
         );
       })}
-    </Flex>
+    </div>
   );
 
-  return renderDir(tree, 0);
+  return (
+    <div className="flex flex-col py-1">
+      {renderDir(tree, 0)}
+      {onAddFile ? (
+        <button
+          type="button"
+          className="flex h-[22px] items-center gap-1.5 pl-[24px] text-[13px] text-gray-9 transition-colors hover:bg-gray-3 hover:text-gray-11"
+          onClick={onAddFile}
+        >
+          <PlusIcon size={12} />
+          Add file
+        </button>
+      ) : null}
+    </div>
+  );
 }

--- a/products/desktop/packages/ui/src/features/skills/SkillListCard.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillListCard.tsx
@@ -1,56 +1,60 @@
-import { Box, Flex, Text } from "@radix-ui/themes";
 import type { ReactNode, Ref } from "react";
 
 interface SkillListCardProps {
   /** Forwarded to the row element (e.g. for scroll-into-view). */
   cardRef?: Ref<HTMLDivElement>;
   icon: ReactNode;
+  iconClass?: string;
   title: string;
   subtitle?: string;
   isSelected: boolean;
+  dimmed?: boolean;
   onClick: () => void;
   /** Badges or counts rendered after the text block. */
   trailing?: ReactNode;
 }
 
-/** Shared card row for every skills list (local, team, marketplace). */
 export function SkillListCard({
   cardRef,
   icon,
+  iconClass,
   title,
   subtitle,
   isSelected,
+  dimmed,
   onClick,
   trailing,
 }: SkillListCardProps) {
   return (
-    <Flex
+    <div
       ref={cardRef}
-      align="center"
-      gap="2"
-      px="3"
-      py="2"
-      className={`cursor-pointer rounded-lg border transition-colors ${
+      className={`flex items-center gap-2 rounded-md border px-2 py-1 transition-colors ${
         isSelected
           ? "border-accent-8 bg-accent-3"
-          : "border-gray-6 bg-gray-2 hover:border-gray-8 hover:bg-gray-3"
+          : "border-transparent hover:border-gray-5 hover:bg-gray-3"
       }`}
-      onClick={onClick}
     >
-      <Box className="flex shrink-0 items-center justify-center rounded bg-gray-4 p-1.5">
-        {icon}
-      </Box>
-
-      <Flex direction="column" gap="0" className="min-w-0 flex-1">
-        <Text className="truncate font-medium text-[13px] text-gray-12">
+      <button
+        type="button"
+        className={`flex min-w-0 flex-1 cursor-pointer items-baseline gap-2 text-left ${dimmed ? "opacity-40" : ""}`}
+        onClick={onClick}
+      >
+        <span
+          className={`flex size-5 shrink-0 translate-y-0.5 items-center justify-center rounded ${iconClass ?? "bg-gray-4 text-gray-11"}`}
+        >
+          {icon}
+        </span>
+        <span className="min-w-0 max-w-[55%] truncate font-medium text-[13px] text-gray-12">
           {title}
-        </Text>
-        {subtitle && (
-          <Text className="truncate text-[12px] text-gray-10">{subtitle}</Text>
-        )}
-      </Flex>
+        </span>
+        {subtitle ? (
+          <span className="min-w-0 flex-1 truncate text-[12px] text-gray-10">
+            {subtitle}
+          </span>
+        ) : null}
+      </button>
 
       {trailing}
-    </Flex>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/SkillManifestEditor.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillManifestEditor.tsx
@@ -1,14 +1,6 @@
+import { Button } from "@posthog/quill";
 import type { SkillInfo } from "@posthog/shared";
 import { toast } from "@posthog/ui/primitives/toast";
-import {
-  Box,
-  Button,
-  Flex,
-  Switch,
-  Text,
-  TextArea,
-  TextField,
-} from "@radix-ui/themes";
 import { useRef, useState } from "react";
 import { SkillCodeEditor } from "./SkillCodeEditor";
 import { skillErrorDescription } from "./skillErrors";
@@ -21,21 +13,12 @@ interface SkillManifestEditorProps {
   onSaved: () => void;
 }
 
-/**
- * Edit mode for SKILL.md: a small form for the frontmatter (users never
- * hand-edit YAML) plus a markdown editor for the body.
- */
 export function SkillManifestEditor({
   skill,
   initialBody,
   onCancel,
   onSaved,
 }: SkillManifestEditorProps) {
-  const [name, setName] = useState(skill.name);
-  const [description, setDescription] = useState(skill.description);
-  const [disableModelInvocation, setDisableModelInvocation] = useState(
-    skill.disableModelInvocation ?? false,
-  );
   // Captured at mount: background refetches must not reset in-flight edits.
   const [mountedBody] = useState(initialBody);
   const bodyRef = useRef(mountedBody);
@@ -45,10 +28,10 @@ export function SkillManifestEditor({
     try {
       await saveManifest.mutateAsync({
         skillPath: skill.path,
-        name,
-        description,
+        name: skill.name,
+        description: skill.description,
         body: bodyRef.current,
-        disableModelInvocation,
+        disableModelInvocation: skill.disableModelInvocation ?? false,
       });
       onSaved();
     } catch (error) {
@@ -59,50 +42,8 @@ export function SkillManifestEditor({
   };
 
   return (
-    <Flex direction="column" height="100%">
-      <Flex direction="column" gap="2" p="3" className="shrink-0">
-        <Box>
-          <Text as="label" className="mb-1 block text-[12px] text-gray-10">
-            Name
-          </Text>
-          <TextField.Root
-            size="1"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="skill-name"
-          />
-        </Box>
-        <Box>
-          <Text as="label" className="mb-1 block text-[12px] text-gray-10">
-            Description
-          </Text>
-          <TextArea
-            size="1"
-            rows={3}
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="When should an agent use this skill?"
-          />
-        </Box>
-        <Flex align="center" justify="between" gap="2">
-          <Box>
-            <Text className="block text-[12px] text-gray-12">
-              Manual invocation only
-            </Text>
-            <Text className="block text-[11px] text-gray-10">
-              The agent won't use this skill on its own. It runs only when you
-              invoke it
-            </Text>
-          </Box>
-          <Switch
-            size="1"
-            checked={disableModelInvocation}
-            onCheckedChange={setDisableModelInvocation}
-          />
-        </Flex>
-      </Flex>
-
-      <Box className="min-h-0 flex-1 border-t border-t-(--gray-5)">
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1">
         <SkillCodeEditor
           initialContent={mountedBody}
           filePath={`${skill.path}/SKILL.md`}
@@ -110,26 +51,23 @@ export function SkillManifestEditor({
             bodyRef.current = doc;
           }}
         />
-      </Box>
+      </div>
 
-      <Flex
-        justify="end"
-        gap="2"
-        p="2"
-        className="shrink-0 border-t border-t-(--gray-5)"
-      >
-        <Button size="1" variant="soft" color="gray" onClick={onCancel}>
+      <div className="flex shrink-0 justify-end gap-1.5 border-gray-5 border-t p-2">
+        <Button type="button" variant="outline" size="sm" onClick={onCancel}>
           Cancel
         </Button>
         <Button
-          size="1"
-          variant="solid"
-          onClick={handleSave}
-          disabled={saveManifest.isPending || !name.trim()}
+          type="button"
+          variant="primary"
+          size="sm"
+          loading={saveManifest.isPending}
+          disabled={saveManifest.isPending}
+          onClick={() => void handleSave()}
         >
           Save
         </Button>
-      </Flex>
-    </Flex>
+      </div>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/SkillPanelHeader.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillPanelHeader.tsx
@@ -1,0 +1,114 @@
+import { DotsThreeIcon, XIcon } from "@phosphor-icons/react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@posthog/quill";
+import type { ReactNode } from "react";
+import { InlineEdit } from "./InlineEdit";
+
+export function SkillChip({
+  children,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "positive";
+}) {
+  const toneClass =
+    tone === "positive" ? "bg-green-3 text-green-11" : "bg-gray-3 text-gray-11";
+  return (
+    <span
+      className={`flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[11px] ${toneClass}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+interface SkillPanelHeaderProps {
+  name: string;
+  description?: string;
+  onEdit?: (fields: { name?: string; description?: string }) => void;
+  saving?: boolean;
+  badges?: ReactNode;
+  actions?: ReactNode;
+  menuItems?: ReactNode;
+  onClose: () => void;
+}
+
+export function SkillPanelHeader({
+  name,
+  description,
+  onEdit,
+  saving,
+  badges,
+  actions,
+  menuItems,
+  onClose,
+}: SkillPanelHeaderProps) {
+  return (
+    <div className="flex shrink-0 flex-col gap-1.5 border-gray-4 border-b px-3 py-2">
+      <div className="flex items-center gap-1">
+        <div className="min-w-0 flex-1">
+          <InlineEdit
+            value={name}
+            placeholder="Name this skill"
+            ariaLabel="skill name"
+            textClass="truncate font-semibold text-[13px] text-gray-12"
+            editable={!!onEdit}
+            saving={saving}
+            onSave={(next) => onEdit?.({ name: next })}
+          />
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5">
+          {actions}
+          {menuItems ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="link-muted"
+                    size="icon-sm"
+                    aria-label="More actions"
+                  >
+                    <DotsThreeIcon size={16} weight="bold" />
+                  </Button>
+                }
+              />
+              <DropdownMenuContent align="end" className="min-w-[200px]">
+                {menuItems}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+          <Button
+            type="button"
+            variant="link-muted"
+            size="icon-sm"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            <XIcon size={14} />
+          </Button>
+        </div>
+      </div>
+
+      <InlineEdit
+        value={description ?? ""}
+        placeholder="Say when an agent must use this skill"
+        ariaLabel="skill description"
+        textClass="text-[12px] text-gray-10 leading-relaxed"
+        multiline
+        clamp
+        editable={!!onEdit}
+        saving={saving}
+        onSave={(next) => onEdit?.({ description: next })}
+      />
+
+      {badges ? (
+        <div className="flex flex-wrap items-center gap-1">{badges}</div>
+      ) : null}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/skills/SkillSkeletons.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillSkeletons.tsx
@@ -1,0 +1,49 @@
+import { Skeleton } from "@posthog/quill";
+
+export function SkillListSkeleton({ rows = 8 }: { rows?: number }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      {Array.from({ length: rows }, (_, index) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length placeholder
+          key={index}
+          className="flex items-center gap-2 rounded-md border border-transparent px-2 py-1"
+        >
+          <Skeleton className="size-5 shrink-0 rounded" />
+          <Skeleton
+            className="h-3 rounded"
+            style={{ width: `${[110, 90, 140, 120][index % 4]}px` }}
+          />
+          <Skeleton
+            className="h-3 min-w-0 flex-1 rounded"
+            style={{ maxWidth: `${[420, 300, 520, 360][index % 4]}px` }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function SkillBodySkeleton() {
+  return (
+    <div className="flex flex-col gap-4 px-3 py-2.5">
+      {[3, 4, 2].map((lines, index) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length placeholder
+          key={index}
+          className="flex flex-col gap-2"
+        >
+          <Skeleton className="h-3.5 w-32 rounded" />
+          {Array.from({ length: lines }, (_, line) => (
+            <Skeleton
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length placeholder
+              key={line}
+              className="h-2.5 rounded"
+              style={{ width: line === lines - 1 ? "62%" : "100%" }}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/skills/SkillsToolbar.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillsToolbar.tsx
@@ -1,0 +1,46 @@
+import { MagnifyingGlassIcon } from "@phosphor-icons/react";
+import { Input } from "@posthog/quill";
+import type { ReactNode, Ref } from "react";
+
+export function SkillsToolbar({
+  placeholder,
+  value,
+  onChange,
+  inputRef,
+  actions,
+  filters,
+}: {
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  inputRef?: Ref<HTMLInputElement>;
+  actions?: ReactNode;
+  filters?: ReactNode;
+}) {
+  return (
+    <div className="shrink-0 border-gray-4 border-b">
+      <div className="mx-auto w-full max-w-5xl px-4 pt-3">
+        <div className={`flex items-center gap-2 ${filters ? "pb-2" : "pb-3"}`}>
+          <div className="relative flex-1">
+            <MagnifyingGlassIcon
+              size={14}
+              className="-translate-y-1/2 absolute top-1/2 left-2.5 text-gray-9"
+            />
+            <Input
+              ref={inputRef}
+              className="h-8 pl-7 text-[13px]"
+              placeholder={placeholder}
+              aria-label={placeholder}
+              value={value}
+              onChange={(event) => onChange(event.currentTarget.value)}
+            />
+          </div>
+          {actions}
+        </div>
+        {filters ? (
+          <div className="flex flex-wrap gap-1 pb-2.5">{filters}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/skills/SkillsView.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillsView.tsx
@@ -1,27 +1,38 @@
-import { Lightbulb, MagnifyingGlass, Plus } from "@phosphor-icons/react";
-import { analyzeSkills } from "@posthog/core/skills/analyzeSkills";
-import { Tabs, TabsList, TabsTrigger } from "@posthog/quill";
-import type { SkillInfo, SkillSource } from "@posthog/shared";
 import {
-  Box,
+  CaretDownIcon,
+  CaretRightIcon,
+  LightbulbIcon,
+  PlusIcon,
+} from "@phosphor-icons/react";
+import { analyzeSkills } from "@posthog/core/skills/analyzeSkills";
+import {
   Button,
-  Flex,
-  ScrollArea,
-  Text,
-  TextField,
-} from "@radix-ui/themes";
-import { useCallback, useEffect, useMemo, useState } from "react";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@posthog/quill";
+import type { SkillInfo, SkillSource } from "@posthog/shared";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ResizableSidebar } from "../../primitives/ResizableSidebar";
 import { MarketplaceBrowse } from "./MarketplaceBrowse";
 import { NewSkillDialog } from "./NewSkillDialog";
-import { SkillSection, SOURCE_CONFIG } from "./SkillCard";
+import { SkillCard, SOURCE_CONFIG } from "./SkillCard";
 import { SkillDetailPanel } from "./SkillDetailPanel";
+import { SkillListSkeleton } from "./SkillSkeletons";
+import { SkillsToolbar } from "./SkillsToolbar";
 import {
   useRequestedSkillName,
   useSkillsSelectionActions,
 } from "./skillsSelectionStore";
 import { useSkillsSidebarStore } from "./skillsSidebarStore";
 import { TeamSkillsTab } from "./TeamSkillsTab";
+import { useMarketplacePopular } from "./useMarketplace";
 import { useSkills } from "./useSkills";
 import { useSkillsWatcher } from "./useSkillsWatcher";
 import { useTeamSkills } from "./useTeamSkills";
@@ -37,6 +48,19 @@ const SOURCE_ORDER: SkillSource[] = [
 // Installed = on disk, usable by agents right now. Team and Marketplace are
 // remote catalogs; installing materializes a skill into Installed.
 type SkillsTab = "installed" | "team" | "marketplace";
+type StatusFilter = "all" | "on" | "off";
+
+interface SkillRow {
+  path: string;
+  skill: SkillInfo;
+  showRepoBadge: boolean;
+}
+
+interface SkillsSection {
+  key: string;
+  title: string;
+  rows: SkillRow[];
+}
 
 export function SkillsView() {
   const { data: skills = [], isLoading } = useSkills();
@@ -46,9 +70,14 @@ export function SkillsView() {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [scrollToPath, setScrollToPath] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SkillSource | "all">("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [collapsed, setCollapsed] = useState<string[]>([]);
   const [newSkillOpen, setNewSkillOpen] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
 
-  const { data: teamListing } = useTeamSkills(skills);
+  const { data: teamListing, isLoading: teamLoading } = useTeamSkills(skills);
+  useMarketplacePopular(true);
   const teamAvailable = teamListing?.available ?? false;
   // Team access revoked mid-session: fall back to Installed.
   const activeTab: SkillsTab =
@@ -92,31 +121,118 @@ export function SkillsView() {
 
   const analysis = useMemo(() => analyzeSkills(skills), [skills]);
 
-  const grouped = useMemo(() => {
-    const map = new Map<SkillSource, SkillInfo[]>();
-    for (const source of SOURCE_ORDER) {
-      map.set(source, []);
-    }
+  const matchedSkills = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
-    for (const skill of skills) {
-      if (
-        query &&
-        !skill.name.toLowerCase().includes(query) &&
-        !(skill.description?.toLowerCase().includes(query) ?? false)
-      ) {
-        continue;
-      }
-      const list = map.get(skill.source);
-      if (list) {
-        list.push(skill);
-      }
+    return skills.filter((skill) => {
+      if (statusFilter === "on" && skill.enabled === false) return false;
+      if (statusFilter === "off" && skill.enabled !== false) return false;
+      if (!query) return true;
+      return (
+        skill.name.toLowerCase().includes(query) ||
+        (skill.description?.toLowerCase().includes(query) ?? false)
+      );
+    });
+  }, [skills, searchQuery, statusFilter]);
+
+  const sourceCounts = useMemo(() => {
+    const counts = new Map<SkillSource, number>();
+    for (const source of SOURCE_ORDER) {
+      counts.set(
+        source,
+        matchedSkills.filter((skill) => skill.source === source).length,
+      );
     }
-    return map;
-  }, [skills, searchQuery]);
+    return counts;
+  }, [matchedSkills]);
+
+  const sections = useMemo<SkillsSection[]>(() => {
+    const result: SkillsSection[] = [];
+    for (const source of SOURCE_ORDER) {
+      if (sourceFilter !== "all" && sourceFilter !== source) continue;
+      const items = matchedSkills.filter((skill) => skill.source === source);
+      if (items.length === 0) continue;
+      const repoNames = new Set(
+        items.map((skill) => skill.repoName).filter(Boolean),
+      );
+      const sharedRepo = repoNames.size === 1 ? [...repoNames][0] : undefined;
+      result.push({
+        key: source,
+        title: sharedRepo
+          ? `${SOURCE_CONFIG[source].sectionTitle} · ${sharedRepo}`
+          : SOURCE_CONFIG[source].sectionTitle,
+        rows: items.map((skill) => ({
+          path: skill.path,
+          skill,
+          showRepoBadge: !sharedRepo,
+        })),
+      });
+    }
+    return result;
+  }, [matchedSkills, sourceFilter]);
+
+  const visibleRows = useMemo(
+    () =>
+      sections
+        .filter((section) => !collapsed.includes(section.key))
+        .flatMap((section) => section.rows),
+    [sections, collapsed],
+  );
+  const totalRows = sections.reduce(
+    (sum, section) => sum + section.rows.length,
+    0,
+  );
+
+  useEffect(() => {
+    if (activeTab !== "installed") return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const typing =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable;
+      if (event.key === "/" && !typing) {
+        event.preventDefault();
+        searchRef.current?.focus();
+        return;
+      }
+      if (typing) return;
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      if (visibleRows.length === 0) return;
+      event.preventDefault();
+      const current = visibleRows.findIndex((row) => row.path === selectedPath);
+      const step = event.key === "ArrowDown" ? 1 : -1;
+      const nextIndex =
+        current === -1
+          ? step === 1
+            ? 0
+            : visibleRows.length - 1
+          : Math.min(Math.max(current + step, 0), visibleRows.length - 1);
+      const next = visibleRows[nextIndex];
+      setScrollToPath(next.path);
+      setSelectedPath(next.path);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [activeTab, visibleRows, selectedPath]);
+
+  const filterChips: Array<[SkillSource | "all", string, number]> = [
+    [
+      "all",
+      "All",
+      [...sourceCounts.values()].reduce((sum, item) => sum + item, 0),
+    ],
+    ...SOURCE_ORDER.filter((source) => (sourceCounts.get(source) ?? 0) > 0).map<
+      [SkillSource, string, number]
+    >((source) => [
+      source,
+      SOURCE_CONFIG[source].sectionTitle,
+      sourceCounts.get(source) ?? 0,
+    ]),
+  ];
 
   return (
-    <Flex direction="column" height="100%" className="overflow-hidden">
-      <Box px="4" className="shrink-0 border-b border-b-(--gray-5)">
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="shrink-0 border-gray-5 border-b px-4">
         <Tabs
           value={activeTab}
           onValueChange={(value: string) => setTab(value as SkillsTab)}
@@ -135,83 +251,174 @@ export function SkillsView() {
             </TabsTrigger>
           </TabsList>
         </Tabs>
-      </Box>
+      </div>
 
       {activeTab === "marketplace" ? (
         <MarketplaceBrowse />
       ) : activeTab === "team" ? (
-        <TeamSkillsTab skills={teamListing?.skills ?? []} />
+        <TeamSkillsTab
+          skills={teamListing?.skills ?? []}
+          loading={teamLoading}
+        />
       ) : (
-        <Flex className="min-h-0 flex-1">
-          <Box flexGrow="1" className="min-w-0">
-            <ScrollArea
-              type="auto"
-              className="scroll-area-constrain-width h-full"
-            >
-              <Box px="4" py="3">
-                <Flex pb="3" gap="2" align="center">
-                  <Box flexGrow="1">
-                    <TextField.Root
-                      size="2"
-                      placeholder="Search skills..."
-                      value={searchQuery}
-                      onChange={(e) => setSearchQuery(e.target.value)}
-                      className="text-[13px]"
+        <div className="flex min-h-0 flex-1">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <SkillsToolbar
+              placeholder="Search skills, or press /"
+              value={searchQuery}
+              onChange={setSearchQuery}
+              inputRef={searchRef}
+              actions={
+                <>
+                  <ToggleGroup
+                    value={[statusFilter]}
+                    onValueChange={(values: string[]) => {
+                      const next = values[0];
+                      if (next === "all" || next === "on" || next === "off") {
+                        setStatusFilter(next);
+                      }
+                    }}
+                    aria-label="Filter by state"
+                    className="h-8 shrink-0"
+                  >
+                    <ToggleGroupItem value="all" className="h-8 px-2.5">
+                      All
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="on" className="h-8 px-2.5">
+                      On
+                    </ToggleGroupItem>
+                    <ToggleGroupItem value="off" className="h-8 px-2.5">
+                      Off
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <Button
+                          type="button"
+                          variant="primary"
+                          size="sm"
+                          className="h-8"
+                        >
+                          <PlusIcon size={14} />
+                          New
+                        </Button>
+                      }
+                    />
+                    <DropdownMenuContent align="end" className="min-w-[220px]">
+                      <DropdownMenuItem onClick={() => setNewSkillOpen(true)}>
+                        Blank skill
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </>
+              }
+              filters={filterChips.map(([value, label, count]) => {
+                const isActive = sourceFilter === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    className={`rounded-full border px-2.5 py-0.5 text-[12px] transition-colors ${
+                      isActive
+                        ? "border-accent-8 bg-accent-3 text-accent-11"
+                        : "border-gray-5 bg-gray-1 text-gray-11 hover:bg-gray-3"
+                    }`}
+                    onClick={() => setSourceFilter(value)}
+                  >
+                    {label}
+                    <span
+                      className={`ml-1 ${isActive ? "text-accent-10" : "text-gray-8"}`}
                     >
-                      <TextField.Slot>
-                        <MagnifyingGlass size={14} />
-                      </TextField.Slot>
-                    </TextField.Root>
-                  </Box>
-                  <Button
-                    size="2"
-                    variant="soft"
-                    onClick={() => setNewSkillOpen(true)}
-                  >
-                    <Plus size={14} />
-                    New skill
-                  </Button>
-                </Flex>
-                {skills.length === 0 && !isLoading ? (
-                  <Flex
-                    align="center"
-                    justify="center"
-                    direction="column"
-                    gap="3"
-                    className="py-12"
-                  >
-                    <Box className="rounded-lg border border-gray-6 border-dashed p-4">
-                      <Lightbulb size={24} className="text-gray-8" />
-                    </Box>
-                    <Text className="text-[13px] text-gray-10">
-                      No skills found
-                    </Text>
-                  </Flex>
-                ) : (
-                  <Flex direction="column" gap="5">
-                    {SOURCE_ORDER.map((source) => {
-                      const items = grouped.get(source);
-                      if (!items || items.length === 0) return null;
-                      const config = SOURCE_CONFIG[source];
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            />
 
-                      return (
-                        <SkillSection
-                          key={source}
-                          title={config.sectionTitle}
-                          skills={items}
-                          selectedPath={selectedSkill?.path ?? null}
-                          onSelect={handleSelect}
-                          scrollToPath={scrollToPath}
-                          onScrolledIntoView={handleScrolledIntoView}
-                          analysis={analysis}
-                        />
-                      );
-                    })}
-                  </Flex>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="mx-auto w-full max-w-5xl px-4 pb-3">
+                {isLoading && skills.length === 0 ? (
+                  <div className="pt-2">
+                    <SkillListSkeleton />
+                  </div>
+                ) : skills.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center gap-3 py-12">
+                    <div className="rounded-lg border border-gray-6 border-dashed p-4">
+                      <LightbulbIcon size={24} className="text-gray-8" />
+                    </div>
+                    <p className="text-[13px] text-gray-10">No skills found</p>
+                  </div>
+                ) : totalRows === 0 ? (
+                  <div className="mt-3 flex flex-col items-center gap-2 rounded-lg border border-gray-5 border-dashed py-8">
+                    <p className="text-[13px] text-gray-10">
+                      No skills match your search.
+                    </p>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        setSearchQuery("");
+                        setSourceFilter("all");
+                        setStatusFilter("all");
+                      }}
+                    >
+                      Clear search and filters
+                    </Button>
+                  </div>
+                ) : (
+                  sections.map((section) => {
+                    const isCollapsed = collapsed.includes(section.key);
+                    return (
+                      <div key={section.key} className="flex flex-col">
+                        <button
+                          type="button"
+                          className="sticky top-0 z-10 flex items-center gap-1.5 bg-gray-1 py-1.5 text-left"
+                          onClick={() =>
+                            setCollapsed((current) =>
+                              current.includes(section.key)
+                                ? current.filter((key) => key !== section.key)
+                                : [...current, section.key],
+                            )
+                          }
+                        >
+                          {isCollapsed ? (
+                            <CaretRightIcon size={10} className="text-gray-9" />
+                          ) : (
+                            <CaretDownIcon size={10} className="text-gray-9" />
+                          )}
+                          <span className="font-medium text-[12px] text-gray-9 uppercase tracking-wider">
+                            {section.title}
+                          </span>
+                          <span className="text-[11px] text-gray-8">
+                            {section.rows.length}
+                          </span>
+                        </button>
+                        {isCollapsed ? null : (
+                          <div className="flex flex-col gap-0.5 pb-2">
+                            {section.rows.map((row) => (
+                              <SkillCard
+                                key={row.path}
+                                skill={row.skill}
+                                showRepoBadge={row.showRepoBadge}
+                                isSelected={selectedPath === row.path}
+                                onClick={() => handleSelect(row.path)}
+                                scrollIntoView={scrollToPath === row.path}
+                                onScrolledIntoView={handleScrolledIntoView}
+                                issues={analysis[row.path]}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })
                 )}
-              </Box>
-            </ScrollArea>
-          </Box>
+              </div>
+            </div>
+          </div>
 
           <ResizableSidebar
             open={!!selectedSkill}
@@ -221,7 +428,7 @@ export function SkillsView() {
             setIsResizing={setIsResizing}
             side="right"
           >
-            {selectedSkill && (
+            {selectedSkill ? (
               <SkillDetailPanel
                 key={selectedSkill.path}
                 skill={selectedSkill}
@@ -229,9 +436,9 @@ export function SkillsView() {
                 canPublish={!!teamListing?.available}
                 onClose={handleCloseSidebar}
               />
-            )}
+            ) : null}
           </ResizableSidebar>
-        </Flex>
+        </div>
       )}
 
       <NewSkillDialog
@@ -239,6 +446,6 @@ export function SkillsView() {
         onOpenChange={setNewSkillOpen}
         onCreated={(path) => setSelectedPath(path)}
       />
-    </Flex>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/SkillsView.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillsView.tsx
@@ -337,7 +337,7 @@ export function SkillsView() {
               })}
             />
 
-            <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="ph-dotted-surface min-h-0 flex-1 overflow-y-auto">
               <div className="mx-auto w-full max-w-5xl px-4 pb-3">
                 {isLoading && skills.length === 0 ? (
                   <div className="pt-2">
@@ -375,7 +375,7 @@ export function SkillsView() {
                       <div key={section.key} className="flex flex-col">
                         <button
                           type="button"
-                          className="sticky top-0 z-10 flex items-center gap-1.5 bg-gray-1 py-1.5 text-left"
+                          className="ph-dotted-surface sticky top-0 z-10 flex items-center gap-1.5 py-1.5 text-left"
                           onClick={() =>
                             setCollapsed((current) =>
                               current.includes(section.key)

--- a/products/desktop/packages/ui/src/features/skills/TeamSkillDetailPanel.tsx
+++ b/products/desktop/packages/ui/src/features/skills/TeamSkillDetailPanel.tsx
@@ -1,21 +1,15 @@
-import { DownloadSimple, UsersThree, X } from "@phosphor-icons/react";
+import { DownloadSimpleIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
+import { Button } from "@posthog/quill";
 import { stripFrontmatter } from "@posthog/shared";
 import { CodeMirrorEditor } from "@posthog/ui/features/code-editor/components/CodeMirrorEditor";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { toast } from "@posthog/ui/primitives/toast";
-import {
-  Badge,
-  Box,
-  Button,
-  Flex,
-  ScrollArea,
-  Text,
-  Tooltip,
-} from "@radix-ui/themes";
 import { useState } from "react";
 import { ReplaceSkillDialog } from "./ReplaceSkillDialog";
 import { SkillFileTree } from "./SkillFileTree";
+import { SkillChip, SkillPanelHeader } from "./SkillPanelHeader";
+import { SkillBodySkeleton } from "./SkillSkeletons";
 import { isSkillExistsError, skillErrorDescription } from "./skillErrors";
 import { useInstallTeamSkill } from "./useTeamSkillMutations";
 import { useTeamSkillDetail, useTeamSkillFile } from "./useTeamSkills";
@@ -64,115 +58,82 @@ export function TeamSkillDetailPanel({
   ];
 
   return (
-    <>
-      <Flex
-        direction="column"
-        gap="2"
-        px="3"
-        py="2"
-        className="shrink-0 border-b border-b-(--gray-5)"
-      >
-        <Flex align="start" justify="between" gap="2">
-          <Text className="block min-w-0 break-words font-medium text-[13px]">
-            {skill.name}
-          </Text>
-          <Tooltip content="Close">
-            <button
-              type="button"
-              aria-label="Close"
-              onClick={onClose}
-              className="shrink-0 rounded p-0.5 text-gray-11 hover:bg-gray-3 hover:text-gray-12"
-            >
-              <X size={14} />
-            </button>
-          </Tooltip>
-        </Flex>
-
-        <Flex align="center" gap="2" wrap="wrap">
-          <Badge size="1" variant="soft" color="gray">
-            <UsersThree size={10} className="text-gray-9" />
-            Team
-          </Badge>
-          <Badge size="1" variant="soft" color="gray">
-            v{skill.version}
-          </Badge>
-          {skill.createdByEmail && (
-            <Badge size="1" variant="soft" color="gray">
-              {skill.createdByEmail}
-            </Badge>
-          )}
-          {skill.installedLocally && (
-            <Badge size="1" variant="soft" color="green">
-              Installed
-            </Badge>
-          )}
+    <div className="flex h-full min-h-0 flex-col">
+      <SkillPanelHeader
+        name={skill.name}
+        description={skill.description || undefined}
+        onClose={onClose}
+        actions={
           <Button
-            size="1"
-            variant="solid"
-            onClick={() => void handleInstall(false)}
+            type="button"
+            variant="primary"
+            size="sm"
             disabled={install.isPending || isLoading}
+            loading={install.isPending}
+            onClick={() => void handleInstall(false)}
           >
-            <DownloadSimple size={12} />
+            <DownloadSimpleIcon size={12} />
             {skill.installedLocally ? "Reinstall" : "Install"}
           </Button>
-        </Flex>
-      </Flex>
+        }
+        badges={
+          <>
+            <SkillChip>
+              <UsersThreeIcon size={10} />
+              Team
+            </SkillChip>
+            <SkillChip>v{skill.version}</SkillChip>
+            {skill.createdByEmail ? (
+              <SkillChip>{skill.createdByEmail}</SkillChip>
+            ) : null}
+            {skill.installedLocally ? (
+              <SkillChip tone="positive">Installed</SkillChip>
+            ) : null}
+          </>
+        }
+      />
 
-      {treeFiles.length > 1 && (
-        <Box className="max-h-[40%] shrink-0 overflow-y-auto border-b border-b-(--gray-5) py-1">
+      {treeFiles.length > 1 ? (
+        <div className="max-h-[40%] shrink-0 overflow-y-auto border-gray-4 border-b">
           <SkillFileTree
             files={treeFiles}
             selectedPath={selectedFile}
             onSelect={setSelectedFile}
           />
-        </Box>
-      )}
+        </div>
+      ) : null}
 
-      <Box className="min-h-0 flex-1">
+      <div className="min-h-0 flex-1">
         {isSkillMd ? (
-          <ScrollArea
-            type="auto"
-            scrollbars="vertical"
-            className="scroll-area-constrain-width h-full"
-          >
-            <Flex direction="column" gap="3" p="3">
-              {skill.description && (
-                <Text className="text-[12px] text-gray-10">
-                  {skill.description}
-                </Text>
-              )}
-              {isLoading ? (
-                <Text className="text-[12px] text-gray-9">Loading...</Text>
-              ) : detail?.body ? (
-                <Box className="rounded border border-gray-5 bg-gray-1 px-4 py-3 text-[13px]">
-                  <MarkdownRenderer content={stripFrontmatter(detail.body)} />
-                </Box>
-              ) : (
-                <Text className="text-[12px] text-gray-9">
-                  No content in SKILL.md
-                </Text>
-              )}
-            </Flex>
-          </ScrollArea>
+          <div className="flex h-full flex-col gap-2 overflow-y-auto px-3 py-2.5">
+            {isLoading ? (
+              <SkillBodySkeleton />
+            ) : detail?.body ? (
+              <div className="text-[13px]">
+                <MarkdownRenderer content={stripFrontmatter(detail.body)} />
+              </div>
+            ) : (
+              <p className="text-[12px] text-gray-9">No content in SKILL.md</p>
+            )}
+          </div>
         ) : isFileLoading ? (
-          <Box p="3">
-            <Text className="text-[12px] text-gray-9">Loading...</Text>
-          </Box>
+          <SkillBodySkeleton />
+        ) : file && selectedFile.toLowerCase().endsWith(".md") ? (
+          <div className="h-full overflow-y-auto px-3 py-2.5 text-[13px]">
+            <MarkdownRenderer content={file.content} />
+          </div>
         ) : file ? (
           <CodeMirrorEditor
             content={file.content}
             filePath={selectedFile}
-            relativePath={selectedFile}
             readOnly
           />
         ) : (
-          <Box p="3">
-            <Text className="text-[12px] text-gray-9">
-              Unable to display this file
-            </Text>
-          </Box>
+          <p className="p-3 text-[12px] text-gray-9">
+            Unable to display this file
+          </p>
         )}
-      </Box>
+      </div>
 
       <ReplaceSkillDialog
         open={confirmOverwrite}
@@ -181,6 +142,6 @@ export function TeamSkillDetailPanel({
         verb="Reinstalling"
         onConfirm={() => void handleInstall(true)}
       />
-    </>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/TeamSkillsSection.tsx
+++ b/products/desktop/packages/ui/src/features/skills/TeamSkillsSection.tsx
@@ -1,7 +1,7 @@
-import { UsersThree } from "@phosphor-icons/react";
+import { UsersThreeIcon } from "@phosphor-icons/react";
 import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
-import { Badge, Flex } from "@radix-ui/themes";
 import { SkillListCard } from "./SkillListCard";
+import { SkillChip } from "./SkillPanelHeader";
 
 interface TeamSkillsSectionProps {
   skills: TeamSkillInfo[];
@@ -16,13 +16,11 @@ export function TeamSkillsSection({
   onSelect,
 }: TeamSkillsSectionProps) {
   return (
-    <Flex direction="column" gap="1">
+    <div className="flex flex-col gap-0.5">
       {skills.map((skill) => (
         <SkillListCard
           key={skill.id}
-          icon={
-            <UsersThree size={14} weight="duotone" className="text-gray-11" />
-          }
+          icon={<UsersThreeIcon size={12} weight="duotone" />}
           title={skill.name}
           subtitle={skill.description || undefined}
           isSelected={selectedName === skill.name}
@@ -30,22 +28,13 @@ export function TeamSkillsSection({
           trailing={
             <>
               {skill.installedLocally && (
-                <Badge
-                  size="1"
-                  variant="soft"
-                  color="green"
-                  className="shrink-0"
-                >
-                  Installed
-                </Badge>
+                <SkillChip tone="positive">Installed</SkillChip>
               )}
-              <Badge size="1" variant="soft" color="gray" className="shrink-0">
-                v{skill.version}
-              </Badge>
+              <SkillChip>v{skill.version}</SkillChip>
             </>
           }
         />
       ))}
-    </Flex>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/TeamSkillsTab.tsx
+++ b/products/desktop/packages/ui/src/features/skills/TeamSkillsTab.tsx
@@ -1,8 +1,9 @@
-import { MagnifyingGlass, UsersThree } from "@phosphor-icons/react";
+import { UsersThreeIcon } from "@phosphor-icons/react";
 import type { TeamSkillInfo } from "@posthog/core/skills/teamSkillsService";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
-import { Box, Flex, ScrollArea, Text, TextField } from "@radix-ui/themes";
 import { useMemo, useState } from "react";
+import { SkillListSkeleton } from "./SkillSkeletons";
+import { SkillsToolbar } from "./SkillsToolbar";
 import { useSkillsSidebarStore } from "./skillsSidebarStore";
 import { TeamSkillDetailPanel } from "./TeamSkillDetailPanel";
 import { TeamSkillsSection } from "./TeamSkillsSection";
@@ -10,10 +11,11 @@ import { TeamSkillsSection } from "./TeamSkillsSection";
 interface TeamSkillsTabProps {
   /** Latest team skills, already merged with the local listing. */
   skills: TeamSkillInfo[];
+  loading?: boolean;
 }
 
 /** Skills your team published to PostHog cloud; install to use locally. */
-export function TeamSkillsTab({ skills }: TeamSkillsTabProps) {
+export function TeamSkillsTab({ skills, loading }: TeamSkillsTabProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [selected, setSelected] = useState<TeamSkillInfo | null>(null);
 
@@ -35,41 +37,29 @@ export function TeamSkillsTab({ skills }: TeamSkillsTabProps) {
   }, [skills, searchQuery]);
 
   return (
-    <Flex className="min-h-0 flex-1">
-      <Box flexGrow="1" className="min-w-0">
-        <ScrollArea type="auto" className="scroll-area-constrain-width h-full">
-          <Box px="4" py="3">
-            <Box pb="3">
-              <TextField.Root
-                size="2"
-                placeholder="Search team skills..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="text-[13px]"
-              >
-                <TextField.Slot>
-                  <MagnifyingGlass size={14} />
-                </TextField.Slot>
-              </TextField.Root>
-            </Box>
+    <div className="flex min-h-0 flex-1">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <SkillsToolbar
+          placeholder="Search team skills"
+          value={searchQuery}
+          onChange={setSearchQuery}
+        />
 
-            {filtered.length === 0 ? (
-              <Flex
-                align="center"
-                justify="center"
-                direction="column"
-                gap="3"
-                className="py-12"
-              >
-                <Box className="rounded-lg border border-gray-6 border-dashed p-4">
-                  <UsersThree size={24} className="text-gray-8" />
-                </Box>
-                <Text className="max-w-[360px] text-center text-[13px] text-gray-10">
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="mx-auto w-full max-w-5xl px-4 py-3">
+            {loading && skills.length === 0 ? (
+              <SkillListSkeleton rows={5} />
+            ) : filtered.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-12">
+                <div className="rounded-lg border border-gray-6 border-dashed p-4">
+                  <UsersThreeIcon size={24} className="text-gray-8" />
+                </div>
+                <p className="max-w-[360px] text-center text-[13px] text-gray-10">
                   {skills.length === 0
                     ? "No team skills yet. Publish one of your skills to share it with your team."
                     : "No team skills match your search"}
-                </Text>
-              </Flex>
+                </p>
+              </div>
             ) : (
               <TeamSkillsSection
                 skills={filtered}
@@ -79,9 +69,9 @@ export function TeamSkillsTab({ skills }: TeamSkillsTabProps) {
                 }
               />
             )}
-          </Box>
-        </ScrollArea>
-      </Box>
+          </div>
+        </div>
+      </div>
 
       <ResizableSidebar
         open={!!selected}
@@ -99,6 +89,6 @@ export function TeamSkillsTab({ skills }: TeamSkillsTabProps) {
           />
         )}
       </ResizableSidebar>
-    </Flex>
+    </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/skills/useMarketplace.ts
+++ b/products/desktop/packages/ui/src/features/skills/useMarketplace.ts
@@ -25,6 +25,17 @@ export function useMarketplaceSearch(query: string) {
   );
 }
 
+export function useMarketplacePopular(enabled: boolean) {
+  const trpc = useHostTRPC();
+  return useQuery(
+    trpc.skills.marketplace.popular.queryOptions(undefined, {
+      enabled,
+      staleTime: 30 * 60_000,
+      retry: false,
+    }),
+  );
+}
+
 export function useMarketplacePreview(
   ref: { source: string; skillId: string } | null,
 ) {

--- a/products/desktop/packages/ui/src/features/skills/useSkillMutations.ts
+++ b/products/desktop/packages/ui/src/features/skills/useSkillMutations.ts
@@ -18,6 +18,14 @@ export function useCreateSkill() {
   );
 }
 
+export function useSetSkillEnabled() {
+  const trpc = useHostTRPC();
+  const invalidate = useInvalidateSkills();
+  return useMutation(
+    trpc.skills.setEnabled.mutationOptions({ onSuccess: invalidate }),
+  );
+}
+
 export function useSaveSkillManifest() {
   const trpc = useHostTRPC();
   const invalidate = useInvalidateSkills();

--- a/products/desktop/packages/ui/src/styles/globals.css
+++ b/products/desktop/packages/ui/src/styles/globals.css
@@ -1522,3 +1522,12 @@ body.ph-window-blurred .app-fade-in {
     background-position-x: 6px;
   }
 }
+
+/* Dotted backdrop for scrollable lists. The pattern is anchored to the window,
+   so a sticky header that uses the same class stays aligned while scrolling. */
+.ph-dotted-surface {
+  background-color: var(--gray-2);
+  background-image: radial-gradient(circle, var(--gray-5) 1px, transparent 1px);
+  background-size: 14px 14px;
+  background-attachment: fixed;
+}

--- a/products/desktop/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills-marketplace/skills-marketplace.ts
@@ -25,6 +25,9 @@ const MAX_PREVIEW_FILE_BYTES = 256 * 1024;
 const ARCHIVE_CACHE_TTL_MS = 5 * 60_000;
 const ARCHIVE_CACHE_MAX_ENTRIES = 4;
 const SEARCH_TIMEOUT_MS = 10_000;
+const POPULAR_SEED_QUERIES = ["code", "git", "review", "test", "docs", "web"];
+const POPULAR_LIMIT = 40;
+const POPULAR_CACHE_TTL_MS = 30 * 60_000;
 const ARCHIVE_DOWNLOAD_TIMEOUT_MS = 60_000;
 
 interface InstalledSkillsFile {
@@ -110,6 +113,39 @@ export function collectSkillFiles(
 @injectable()
 export class SkillsMarketplaceService {
   private archives = new Map<string, CachedArchive>();
+  private popularCache: {
+    fetchedAt: number;
+    output: MarketplaceSearchOutput;
+  } | null = null;
+
+  async popular(): Promise<MarketplaceSearchOutput> {
+    const cached = this.popularCache;
+    if (cached && Date.now() - cached.fetchedAt < POPULAR_CACHE_TTL_MS) {
+      return cached.output;
+    }
+
+    const batches = await Promise.allSettled(
+      POPULAR_SEED_QUERIES.map((query) => this.search(query)),
+    );
+    const byId = new Map<string, MarketplaceSearchOutput["results"][number]>();
+    for (const batch of batches) {
+      if (batch.status !== "fulfilled") continue;
+      for (const result of batch.value.results) {
+        byId.set(result.id, result);
+      }
+    }
+    if (byId.size === 0) {
+      throw new Error("skills.sh search failed for every seed query");
+    }
+
+    const output = {
+      results: [...byId.values()]
+        .sort((a, b) => b.installs - a.installs)
+        .slice(0, POPULAR_LIMIT),
+    };
+    this.popularCache = { fetchedAt: Date.now(), output };
+    return output;
+  }
 
   async search(query: string): Promise<MarketplaceSearchOutput> {
     const trimmed = query.trim();

--- a/products/desktop/packages/workspace-server/src/services/skills/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/schemas.ts
@@ -18,6 +18,7 @@ export const skillInfo = z.object({
   editable: z.boolean(),
   skillMdBytes: z.number(),
   disableModelInvocation: z.boolean().optional(),
+  enabled: z.boolean().optional(),
 });
 
 export const listSkillsOutput = z.array(skillInfo);
@@ -82,6 +83,11 @@ export const deleteSkillFileInput = z.object({
 
 export const deleteSkillInput = z.object({
   skillPath: z.string(),
+});
+
+export const setSkillEnabledInput = z.object({
+  skillPath: z.string(),
+  enabled: z.boolean(),
 });
 
 export const exportSkillInput = z.object({

--- a/products/desktop/packages/workspace-server/src/services/skills/skill-discovery.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/skill-discovery.ts
@@ -48,6 +48,8 @@ export function isProbablyText(bytes: Uint8Array): boolean {
   return !bytes.subarray(0, 4096).includes(0);
 }
 
+export const DISABLED_SKILL_MD = "SKILL.md.disabled";
+
 export async function findSkillDirs(
   sourceSkillsDir: string,
 ): Promise<string[]> {
@@ -62,10 +64,10 @@ export async function findSkillDirs(
   return entries
     .filter(
       (e) =>
-        (e.isDirectory() || e.isSymbolicLink()) &&
-        // Hidden dirs are never skills (also hides install staging dirs).
-        !e.name.startsWith(".") &&
-        fs.existsSync(path.join(sourceSkillsDir, e.name, "SKILL.md")),
+        ((e.isDirectory() || e.isSymbolicLink()) &&
+          !e.name.startsWith(".") &&
+          fs.existsSync(path.join(sourceSkillsDir, e.name, "SKILL.md"))) ||
+        fs.existsSync(path.join(sourceSkillsDir, e.name, DISABLED_SKILL_MD)),
     )
     .map((e) => e.name);
 }
@@ -190,10 +192,20 @@ export async function readSkillMetadataFromDir(
     skillNames.map(async (skillName): Promise<SkillInfo | null> => {
       const skillPath = path.join(skillsDir, skillName);
       try {
-        const content = await fs.promises.readFile(
-          path.join(skillPath, "SKILL.md"),
-          "utf-8",
-        );
+        let enabled = true;
+        let content: string;
+        try {
+          content = await fs.promises.readFile(
+            path.join(skillPath, "SKILL.md"),
+            "utf-8",
+          );
+        } catch {
+          content = await fs.promises.readFile(
+            path.join(skillPath, DISABLED_SKILL_MD),
+            "utf-8",
+          );
+          enabled = false;
+        }
         const frontmatter = parseSkillFrontmatter(content);
         return {
           name: frontmatter?.name ?? skillName,
@@ -206,6 +218,7 @@ export async function readSkillMetadataFromDir(
           ...(frontmatter?.disableModelInvocation
             ? { disableModelInvocation: true }
             : {}),
+          ...(enabled ? {} : { enabled: false }),
         } satisfies SkillInfo;
       } catch {
         return null;

--- a/products/desktop/packages/workspace-server/src/services/skills/skills.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/skills.ts
@@ -35,6 +35,7 @@ import type {
 } from "./schemas";
 import { bundleLocalSkill } from "./skill-bundler";
 import {
+  DISABLED_SKILL_MD,
   getMarketplaceInstallPaths,
   getUserSkillsDir,
   isProbablyText,
@@ -84,6 +85,17 @@ export class SkillsService {
     const skills = results.flat();
     const mirrorState = await readCodexMirrorState(getCodexSkillsDir());
     return dedupeCodexSkills(skills, new Set(mirrorState.mirrored));
+  }
+
+  async setSkillEnabled(skillPath: string, enabled: boolean): Promise<void> {
+    const skillDir = await this.resolveWritableSkillDir(skillPath);
+    const activePath = path.join(skillDir, "SKILL.md");
+    const disabledPath = path.join(skillDir, DISABLED_SKILL_MD);
+    if (enabled && fs.existsSync(disabledPath)) {
+      await fs.promises.rename(disabledPath, activePath);
+    } else if (!enabled && fs.existsSync(activePath)) {
+      await fs.promises.rename(activePath, disabledPath);
+    }
   }
 
   async getSkillContents(skillPath: string): Promise<SkillContents> {
@@ -521,7 +533,10 @@ export class SkillsService {
     if (!roots.some((root) => path.resolve(root) === parent)) {
       throw new Error("Access denied: skill is not in a writable location");
     }
-    if (!fs.existsSync(path.join(resolved, "SKILL.md"))) {
+    if (
+      !fs.existsSync(path.join(resolved, "SKILL.md")) &&
+      !fs.existsSync(path.join(resolved, DISABLED_SKILL_MD))
+    ) {
       throw new Error("Access denied: not a known skill directory");
     }
     return resolved;


### PR DESCRIPTION
## Problem

A desktop user managing their skills gets a flat list with no way to switch a skill off without deleting it, and the marketplace opens empty until they search. This PR reworks the Skills view so installed, team, and marketplace skills each get a clear surface.

<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/632ae4e5-c046-44fa-9293-d775bed2785a" />


## Changes

- The Skills view now has three tabs: Installed, Team, and Marketplace.
- Installed groups skills by source under collapsible section headers with per-source counts.
- A unified toolbar holds search (with a `/` shortcut), source filter chips, and an All/On/Off state filter.
- A skill can now be switched off: the app renames `SKILL.md` to `SKILL.md.disabled`, so the files stay on disk but agents no longer discover the skill.
- The Marketplace tab opens on a popular-skills list, backed by a new cached `popular` endpoint that aggregates seed searches on skills.sh.
- The detail panel, team skill panel, and marketplace panel now share one header component with chips, a file tree, and loading skeletons.
- The new-skill flow keeps its dialog; the "New" button becomes a dropdown so more entry points can join it later.
- Mechanical: `enabled` flag on `SkillInfo`, a `setEnabled` tRPC mutation, `SkillsService.setSkillEnabled`, and disabled-skill discovery in the workspace server.

## How did you test this code?

- `tsc --noEmit` passes for `@posthog/ui`, `@posthog/workspace-server`, and `@posthog/host-router` (run through turbo with dependencies built).
- `vitest run src/services/skills src/services/skills-marketplace` in `@posthog/workspace-server` passes (7 files).
- `vitest run src/features/skills` in `@posthog/ui` passes.
- `biome check` on the changed files is clean.
- Not done: no manual run of the desktop app, and no Storybook render, so there are no screenshots. The extraction removed the flows parts of `SkillsView` and `TeamSkillDetailPanel` by hand; a visual pass on the Skills view is worth doing before merge.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The human authored this work on `feat/desktop-agent-flows` and asked for the skills UI/UX parts as a standalone PR. The agent located the skills commits on that branch, extracted the 24 skills files onto current master, and rewrote `SkillsView.tsx` and `TeamSkillDetailPanel.tsx` to remove the agent-flows integration (flow rows, flow editor panel, flow badges). Everything else is the human's code unchanged.

- Skills invoked: `/writing-ui-components`, `/writing-pr-descriptions`.
- Verified: no `agent-flows` imports remain in the extracted files, and all `@posthog/shared` imports resolve on master.
- Not verified: runtime behavior of the enable toggle and the popular endpoint against a running backend.