### PR TITLE
fix(tasks): stop stalled pi cloud turns with the turn stall watchdog

### DIFF
--- a/docs/published/handbook/engineering/ai/sandboxed-agents.md
+++ b/docs/published/handbook/engineering/ai/sandboxed-agents.md
@@ -362,8 +362,8 @@ A sandbox that is starved rather than dead keeps its Modal handle but stops answ
 never return, heartbeats stop, and the run looks alive until the inactivity timeout ends it. Two
 detectors shorten that window:
 
-- The agent-server runs a turn stall watchdog (`turn-stall-watchdog.ts`). When the adapter has
-  produced no output for `POSTHOG_TURN_STALL_SOFT_TIMEOUT_MS` (10 minutes) it probes the box by
+- The agent-server (both the ACP `AgentServer` and `PiAgentServer`) runs a turn stall watchdog
+  (`turn-stall-watchdog.ts`). When the runtime has produced no output for `POSTHOG_TURN_STALL_SOFT_TIMEOUT_MS` (10 minutes) it probes the box by
   spawning a trivial process; a probe that fails, or silence past
   `POSTHOG_TURN_STALL_HARD_TIMEOUT_MS` (45 minutes), interrupts the turn, emits a
   `sandbox_unresponsive` or `turn_silent` error to the stream, waits up to a minute for that turn

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -125,10 +125,11 @@ import { resolveRtkSavings } from "./rtk-savings";
 import { RunUsageAccumulator } from "./run-usage";
 import { jsonRpcRequestSchema, validateCommandParams } from "./schemas";
 import {
-  DEFAULT_TURN_STALL_HARD_TIMEOUT_MS,
-  DEFAULT_TURN_STALL_SOFT_TIMEOUT_MS,
   probeSandboxResponsive,
-  readTurnStallTimeoutMs,
+  readTurnStallTimeoutsFromEnv,
+  TURN_STALL_CANCEL_GRACE_MS,
+  TURN_STALL_DRAIN_POLL_MS,
+  TURN_STALL_MESSAGES,
   type TurnStallReason,
   TurnStallWatchdog,
 } from "./turn-stall-watchdog";
@@ -145,15 +146,6 @@ const agentErrorClassificationSchema = z.enum([
   "turn_ended_without_response",
   "agent_error",
 ]) satisfies z.ZodType<AgentErrorClassification>;
-
-const TURN_STALL_CANCEL_GRACE_MS = 60_000;
-const TURN_STALL_DRAIN_POLL_MS = 500;
-export const TURN_STALL_MESSAGES: Record<TurnStallReason, string> = {
-  sandbox_unresponsive:
-    "The sandbox stopped responding while the agent was working. Resume the task to continue.",
-  turn_silent:
-    "The agent produced no output for a long time and the turn was stopped. Resume the task to continue.",
-};
 
 const INITIAL_TASK_RUN_REFRESH_TIMEOUT_MS = 5_000;
 
@@ -663,14 +655,7 @@ export class AgentServer {
     );
     this.logger = new Logger({ debug: true, prefix: "[AgentServer]" });
     this.turnStallWatchdog = new TurnStallWatchdog({
-      softTimeoutMs: readTurnStallTimeoutMs(
-        process.env.POSTHOG_TURN_STALL_SOFT_TIMEOUT_MS,
-        DEFAULT_TURN_STALL_SOFT_TIMEOUT_MS,
-      ),
-      hardTimeoutMs: readTurnStallTimeoutMs(
-        process.env.POSTHOG_TURN_STALL_HARD_TIMEOUT_MS,
-        DEFAULT_TURN_STALL_HARD_TIMEOUT_MS,
-      ),
+      ...readTurnStallTimeoutsFromEnv(),
       probe: () => probeSandboxResponsive(),
       isWaitingOnUser: () => this.pendingPermissions.size > 0,
       onStall: (reason, silentMs) => this.handleTurnStall(reason, silentMs),

--- a/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
@@ -22,6 +22,50 @@ function config(overrides: Partial<AgentServerConfig> = {}): AgentServerConfig {
 }
 
 describe("PiAgentServer", () => {
+  it("interrupts a stalled Pi turn and fails the run", async () => {
+    vi.useFakeTimers();
+    try {
+      const abort = vi.fn(async () => {});
+      const getState = vi.fn(async () => ({ isStreaming: false }));
+      const updateTaskRun = vi.fn(async () => ({}));
+      const broadcast = vi.fn();
+      const server = new PiAgentServer(config()) as unknown as {
+        session: unknown;
+        posthogAPI: { updateTaskRun: typeof updateTaskRun };
+        broadcast: typeof broadcast;
+        handleTurnStall(reason: string, silentMs: number): Promise<void>;
+      };
+      server.posthogAPI.updateTaskRun = updateTaskRun;
+      server.broadcast = broadcast;
+      server.session = {
+        payload: { task_id: "task-1", run_id: "run-1" },
+        runtime: { client: { abort, getState } },
+      };
+
+      const stall = server.handleTurnStall("sandbox_unresponsive", 600_000);
+      await vi.runAllTimersAsync();
+      await stall;
+
+      expect(abort).toHaveBeenCalledOnce();
+      expect(broadcast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "pi_event",
+          event: expect.objectContaining({
+            type: "runtime_error",
+            errorType: "sandbox_unresponsive",
+          }),
+        }),
+      );
+      expect(updateTaskRun).toHaveBeenCalledWith(
+        "task-1",
+        "run-1",
+        expect.objectContaining({ status: "failed" }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("logs session initialization diagnostics when setup fails", async () => {
     const payload = { task_id: "task-1", run_id: "run-1" };
     const server = new PiAgentServer(

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -37,6 +37,15 @@ import { Logger } from "../utils/logger";
 import { TaskRunEventStreamSender } from "./event-stream-sender";
 import { type JwtPayload, JwtValidationError, validateJwt } from "./jwt";
 import { jsonRpcRequestSchema } from "./schemas";
+import {
+  probeSandboxResponsive,
+  readTurnStallTimeoutsFromEnv,
+  TURN_STALL_CANCEL_GRACE_MS,
+  TURN_STALL_DRAIN_POLL_MS,
+  TURN_STALL_MESSAGES,
+  type TurnStallReason,
+  TurnStallWatchdog,
+} from "./turn-stall-watchdog";
 import type { AgentServerConfig } from "./types";
 
 interface SseController {
@@ -136,8 +145,19 @@ export class PiAgentServer {
     string,
     McpToolPermissionRequest
   >();
+  private readonly turnStallWatchdog: TurnStallWatchdog;
 
   constructor(private readonly config: AgentServerConfig) {
+    this.turnStallWatchdog = new TurnStallWatchdog({
+      ...readTurnStallTimeoutsFromEnv(),
+      probe: () => probeSandboxResponsive(),
+      isWaitingOnUser: () => this.pendingMcpPermissions.size > 0,
+      onStall: (reason, silentMs) => this.handleTurnStall(reason, silentMs),
+      logger: {
+        debug: (message, data) => this.logger.debug(message, data),
+        warn: (message, data) => this.logger.warn(message, data),
+      },
+    });
     this.posthogAPI = new PostHogAPIClient({
       apiUrl: config.apiUrl,
       projectId: config.projectId,
@@ -211,6 +231,7 @@ export class PiAgentServer {
   }
 
   async stop(): Promise<void> {
+    this.turnStallWatchdog.stop();
     const session = this.session;
     if (session) {
       await session.runtime.client
@@ -619,7 +640,12 @@ export class PiAgentServer {
       this.handleEvent(event),
     );
     const unsubscribeRuntime = runtime.onRuntimeEvent((event) => {
+      if (event.type === "agent_start") {
+        this.turnStallWatchdog.start();
+      }
+      this.turnStallWatchdog.recordActivity();
       if (event.type === "agent_settled") {
+        this.turnStallWatchdog.stop();
         this.settledPersistenceQueue = this.settledPersistenceQueue
           .then(() => this.persistSettledTurn())
           .catch((error) => {
@@ -662,6 +688,7 @@ export class PiAgentServer {
   }
 
   private handleEvent(event: AgentConversationEvent): void {
+    this.turnStallWatchdog.recordActivity();
     const id = randomUUID();
     this.broadcast({
       id,
@@ -674,6 +701,47 @@ export class PiAgentServer {
         this.logger.error("Failed to persist Pi queue state", error),
       );
     }
+  }
+
+  private async handleTurnStall(
+    reason: TurnStallReason,
+    silentMs: number,
+  ): Promise<void> {
+    const session = this.session;
+    if (!session) return;
+    const message = TURN_STALL_MESSAGES[reason];
+    this.logger.error("turn_stalled", { reason, silentMs });
+    this.broadcast({
+      type: "pi_event",
+      timestamp: new Date().toISOString(),
+      event: {
+        type: "runtime_error",
+        timestamp: Date.now(),
+        errorType: reason,
+        message,
+      } satisfies AgentConversationEvent,
+    });
+    await session.runtime.client.abort().catch((error: unknown) => {
+      this.logger.warn("Turn stall abort failed", { error });
+    });
+    const deadline = Date.now() + TURN_STALL_CANCEL_GRACE_MS;
+    while (Date.now() < deadline) {
+      const state = await session.runtime.client.getState().catch(() => null);
+      if (state && !state.isStreaming) break;
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, TURN_STALL_DRAIN_POLL_MS),
+      );
+    }
+    if (this.session !== session) return;
+    await this.settledPersistenceQueue.catch(() => undefined);
+    await this.posthogAPI
+      .updateTaskRun(session.payload.task_id, session.payload.run_id, {
+        status: "failed",
+        error_message: message,
+      })
+      .catch((error) =>
+        this.logger.error("Failed to mark stalled Pi run as failed", error),
+      );
   }
 
   private handleMcpToolPermissionRequest(

--- a/products/desktop/packages/agent/src/server/turn-stall-watchdog.ts
+++ b/products/desktop/packages/agent/src/server/turn-stall-watchdog.ts
@@ -10,6 +10,31 @@ export const DEFAULT_TURN_STALL_PROBE_TIMEOUT_MS = 15 * 1000;
 
 export type TurnStallReason = "sandbox_unresponsive" | "turn_silent";
 
+export const TURN_STALL_CANCEL_GRACE_MS = 60_000;
+export const TURN_STALL_DRAIN_POLL_MS = 500;
+export const TURN_STALL_MESSAGES: Record<TurnStallReason, string> = {
+  sandbox_unresponsive:
+    "The sandbox stopped responding while the agent was working. Resume the task to continue.",
+  turn_silent:
+    "The agent produced no output for a long time and the turn was stopped. Resume the task to continue.",
+};
+
+export function readTurnStallTimeoutsFromEnv(): {
+  softTimeoutMs: number;
+  hardTimeoutMs: number;
+} {
+  return {
+    softTimeoutMs: readTurnStallTimeoutMs(
+      process.env.POSTHOG_TURN_STALL_SOFT_TIMEOUT_MS,
+      DEFAULT_TURN_STALL_SOFT_TIMEOUT_MS,
+    ),
+    hardTimeoutMs: readTurnStallTimeoutMs(
+      process.env.POSTHOG_TURN_STALL_HARD_TIMEOUT_MS,
+      DEFAULT_TURN_STALL_HARD_TIMEOUT_MS,
+    ),
+  };
+}
+
 export interface TurnStallWatchdogLogger {
   debug(message: string, data?: unknown): void;
   warn(message: string, data?: unknown): void;


### PR DESCRIPTION
## Problem

- A Pi cloud run whose turn hangs (a wedged tool call, a starved VM) keeps spinning until the 1-hour inactivity timeout ends it.
- #90858 added the turn stall watchdog to the ACP `AgentServer` only. `bin.ts` starts `PiAgentServer` when `POSTHOG_AGENT_RUNTIME` is `pi`, and that server had no stall detection. Its `/health` also answers `ok` while a turn hangs, so the workflow probe from #90858 saw a healthy server.
- Pi cloud runs sit behind the fail-closed `pi_cloud_runtime_enabled` flag, so this affects the rollout path, not the default runtime.

## Changes

- A stalled Pi turn now ends the same way as an ACP one: the stream gets a `runtime_error` event (`sandbox_unresponsive` or `turn_silent`), the Pi runtime is aborted, and the run is marked failed with "Resume the task to continue" once the turn drains or a minute passes.
- `PiAgentServer` owns a `TurnStallWatchdog`: it starts on the runtime's `agent_start`, records activity on every runtime and conversation event, stops on `agent_settled`, and treats a pending MCP permission request as waiting on the user, not silence. The same `POSTHOG_TURN_STALL_{SOFT,HARD}_TIMEOUT_MS` variables apply.
- Mechanical: the stall messages, grace constants, and the env-var reader move from `agent-server.ts` into `turn-stall-watchdog.ts` so both servers share them.

## How did you test this code?

- New `PiAgentServer` test: a stall aborts the runtime, broadcasts the `runtime_error`, and fails the run. Existing `AgentServer` and watchdog tests keep passing after the constant move.
- Not run: a real Pi cloud run on Modal.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/published/handbook/engineering/ai/sandboxed-agents.md` now names both servers under "Wedged sandboxes".

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, directed by the assignee. Follow-up to a review finding on #90858 that the watchdog did not cover the Pi runtime. Skills invoked: `/writing-pr-descriptions`, `/stacking-prs`. Turn boundaries come from the Pi runtime's `agent_start` / `agent_settled` events rather than a counter around prompt calls, because Pi queues follow-ups inside the runtime and the server never sees a per-turn promise.
