### PR TITLE
fix(tasks): report whether a Pi steer landed

### DIFF
--- a/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.test.ts
@@ -402,7 +402,7 @@ describe("PiAgentServer", () => {
     await rm(repositoryPath, { recursive: true });
   });
 
-  it("aborts the streaming run and re-prompts when a steer arrives", async () => {
+  it("steers the streaming run in place instead of aborting it", async () => {
     const sendCommand = vi.fn(async (_command: Record<string, unknown>) => ({
       success: true,
     }));
@@ -430,25 +430,27 @@ describe("PiAgentServer", () => {
       },
     };
 
-    await server.executeCommand("user_message", {
+    const result = await server.executeCommand("user_message", {
       content: "stop, do this instead",
       messageId: "message-1",
       steer: true,
     });
 
-    expect(order).toEqual(["abort", "sendCommand"]);
+    expect(result).toMatchObject({ steered: true });
+    expect(order).toEqual(["sendCommand"]);
+    expect(abort).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledTimes(1);
     expect(sendCommand).toHaveBeenCalledWith({
       id: "message-1",
-      type: "prompt",
+      type: "steer",
       message: "stop, do this instead",
       images: [],
     });
   });
 
-  it("queues a steer that pi rejects because another run took the idle slot", async () => {
+  it("queues a steer that pi refuses while the run is still streaming", async () => {
     const sendCommand = vi.fn(async (command: Record<string, unknown>) => {
-      if (command.type === "prompt") {
+      if (command.type === "steer") {
         return { success: false, error: "Agent is already processing." };
       }
       return { success: true };
@@ -483,11 +485,12 @@ describe("PiAgentServer", () => {
       images: [],
     });
     expect(result).toMatchObject({ success: true });
+    expect(result).not.toHaveProperty("steered");
   });
 
-  it("declines a steer whose re-prompt fails while pi stays idle so the host redelivers", async () => {
+  it("declines a steer pi refuses while it stays idle so the host redelivers", async () => {
     const sendCommand = vi.fn(async (command: Record<string, unknown>) => {
-      if (command.type === "prompt") {
+      if (command.type === "steer") {
         return {
           success: false,
           error: "Cannot submit a prompt while compaction is in progress.",
@@ -525,11 +528,53 @@ describe("PiAgentServer", () => {
     expect(sendCommand).toHaveBeenCalledTimes(1);
     expect(sendCommand).toHaveBeenCalledWith({
       id: "message-4",
+      type: "steer",
+      message: "stop, do this instead",
+      images: [],
+    });
+    expect(result).toMatchObject({
+      success: false,
+      steered: false,
+      reason: "pi_delivery_failed",
+    });
+  });
+
+  it("sends a steer that arrives while pi is idle as a prompt, without asking for redelivery", async () => {
+    const sendCommand = vi.fn(async (_command: Record<string, unknown>) => ({
+      success: true,
+    }));
+    const abort = vi.fn(async () => {});
+    const server = new PiAgentServer(config()) as unknown as {
+      session: unknown;
+      executeCommand(
+        method: string,
+        params: Record<string, unknown>,
+      ): Promise<unknown>;
+    };
+    server.session = {
+      runtime: {
+        client: {
+          getState: vi.fn(async () => ({ isStreaming: false })),
+          abort,
+        },
+        sendCommand,
+      },
+    };
+
+    const result = await server.executeCommand("user_message", {
+      content: "stop, do this instead",
+      messageId: "message-5",
+      steer: true,
+    });
+
+    expect(abort).not.toHaveBeenCalled();
+    expect(sendCommand).toHaveBeenCalledWith({
+      id: "message-5",
       type: "prompt",
       message: "stop, do this instead",
       images: [],
     });
-    expect(result).toMatchObject({ success: false });
+    expect(result).not.toHaveProperty("steered");
   });
 
   it("queues a mid-turn message that is not a steer instead of aborting", async () => {
@@ -554,11 +599,12 @@ describe("PiAgentServer", () => {
       },
     };
 
-    await server.executeCommand("user_message", {
+    const result = await server.executeCommand("user_message", {
       content: "when you are done, also update the docs",
       messageId: "message-2",
     });
 
+    expect(result).not.toHaveProperty("steered");
     expect(abort).not.toHaveBeenCalled();
     expect(sendCommand).toHaveBeenCalledWith({
       id: "message-2",

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -846,7 +846,7 @@ export class PiAgentServer {
     id: string,
     steer: boolean,
   ): Promise<unknown> {
-    const send = (type: "prompt" | "follow_up") =>
+    const send = (type: "prompt" | "follow_up" | "steer") =>
       runtime.sendCommand({ id, type, message: content, images });
     const state = await runtime.client.getState();
     if (!state.isStreaming) {
@@ -855,13 +855,15 @@ export class PiAgentServer {
     if (!steer) {
       return send("follow_up");
     }
-    await runtime.client.abort();
-    const prompted = await send("prompt");
-    if (prompted.success) {
-      return prompted;
+    const steered = await send("steer");
+    if (steered.success) {
+      return { ...steered, steered: true };
     }
-    const afterPrompt = await runtime.client.getState();
-    return afterPrompt.isStreaming ? send("follow_up") : prompted;
+    const afterSteer = await runtime.client.getState();
+    if (afterSteer.isStreaming) {
+      return send("follow_up");
+    }
+    return { ...steered, steered: false, reason: "pi_delivery_failed" };
   }
 
   private installSseController(sseController: SseController | null): void {


### PR DESCRIPTION
## Problem

- A user who steers a cloud run on the Pi runtime can lose the message outright, and a steer that does work makes the client show the turn as finished while the agent is still working.
- Both follow from one gap: Pi never tells the backend whether a steer landed. The activity reads `steered` off the sandbox response; Pi returns its raw RPC result, which has no such field.
- When Pi refuses the steer and is no longer streaming, nothing reaches the agent, but the activity logs `send_followup_delivered` and the workflow does not re-queue. The message is dropped. The test covering that path is named "so the host redelivers", which is the one thing it does not do.
- When Pi does fold the steer in, the client is told the turn finished, twice over. The sandbox path steered by aborting the run and re-prompting: the abort settles the agent, the translator turns `agent_settled` into a `turn_completed`, and the server broadcasts it unfiltered. The activity then writes a second, synthetic `_posthog/turn_complete`, which the other two runtimes avoid by reporting `steered: true`.

## Changes

- A steer that lands no longer ends the turn in the client. Pi steers the running turn in place through its native command and never aborts, so nothing settles the run mid-steer, and it reports `steered: true` so the activity also skips the synthetic turn-complete.
- The native command is what Pi already uses everywhere else. `piSessionController.ts:576` and `:1310` call `session.client.steer(...)` for local sessions, and `runtime.sendCommand` already tracks `type: "steer"` as a pending user message. Only the sandbox path aborted and re-prompted.
- A steer Pi cannot deliver is no longer dropped. Pi reports `steered: false` with the reason `pi_delivery_failed`, so the workflow re-queues the message as a plain follow-up.
- `steered: false` keeps meaning what the other runtimes make it mean, and what the re-queue rule depends on: nothing reached the agent. The two paths where Pi delivers the message without steering it keep their previous response, so no backend can read them as a decline and re-queue a duplicate.
- No backend change. The activity already reads both values, so this needs nothing on the Python side and carries no deploy-order risk between the agent package and the backend.
- A steer now reaches the model inside the running turn rather than restarting the run with it. That is what steering means on the other two runtimes and in local Pi sessions.
- The refusal paths keep their shape. A steer Pi refuses while it is still streaming queues as a follow-up, and a message that arrives while Pi is idle is still sent as a fresh prompt.
- A follow-up sent without `steer` gets no verdict field, exactly as before.

> [!NOTE]
> Two gaps this PR leaves open, both pre-existing. A runtime that reports a failed delivery inside an HTTP 200 is still read as delivered outside the steer branch, on all three runtimes, so a refused plain follow-up is still logged as delivered and dropped. And Pi's two deliver-without-steering paths stay absent from the decline panel: labelling them would assert a delivery that Pi's own `success` does not guarantee on the fallback path.

## How did you test this code?

- Two existing Pi tests now assert the verdict the backend reads, one per bug: a lost message when nothing was delivered, and a turn-complete on a steer that landed.
- The steer test also asserts that `abort` is never called and that the command sent is `type: "steer"`. Re-introducing abort-and-re-prompt fails it, which is the regression that produced the native completion.
- Three Pi tests assert the absence of a verdict, on the two paths where Pi delivers without steering and on a plain follow-up. A stray `steered: false` on any of them would re-queue a message Pi has already sent, which is the duplicate the review flagged.
- One of those three is new, covering a steer that arrives while Pi is idle.
- Not checked: a real Pi cloud run. Every path is covered only by the fakes in `pi-agent-server.test.ts`, including the switch to the native steer command.
- Not measured: how much prod traffic uses the Pi runtime. The worker logs do not carry the runtime, so the volume behind these two bugs is unknown.
- The `test / e2e` failure on the first push is `session-lifecycle.e2e.test.ts` "interrupts an in-flight turn", which cancels on the first chunk and expects `cancelled`. It is a live-model race in a file with no Pi involvement.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) wrote this, directed by @tatoalo, as a follow-up to [#90886](https://github.com/PostHog/posthog/pull/90886), which flagged the Pi runtime as a blind spot in the same decline metric.
- Skills invoked: `/writing-tests`, `/simplify`, `/writing-pr-descriptions`.
- The two bugs were found by tracing what the activity does with Pi's current return value, not from a report. Both were verified by reading the code path, not by reproducing them in a run.
- The first version also reported the two deliver-without-steering paths, using a new `delivered` field the activity honoured. Review pointed out that overloading `steered: false` on a delivered path breaks the re-queue rule for any backend that predates the field, and that the fallback path's `success` means "queued" rather than "processed". Both threads are addressed by not sending a verdict on those paths at all, which also removed the backend change.
- The first version also kept abort-and-re-prompt, declaring delivery out of scope. Review showed the turn-complete half of the fix does not hold while the abort remains, since the abort settles the run and the client acts on that. Delivery moved to the native steer command as a result, so the claim in Problem is now true.
- Public artifact: nothing here draws on anything outside this repository.
