### PR TITLE
fix(batch-exports): bump Snowflake login timeout from 5s to 20s

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -634,7 +634,9 @@ class SnowflakeClient:
                     # wrap role in quotes in case it contains lowercase or special characters
                     role=f'"{self.role}"' if self.role is not None else None,
                     private_key=self.private_key,
-                    login_timeout=5,
+                    # Logins can be slow, and a login timeout raises a
+                    # non-retryable connection error, so allow extra time.
+                    login_timeout=20,
                     # Pin Snowflake's per-session statement count to 1 to block
                     # multi-statement execution. This is already the connector default,
                     # but setting it explicitly means an account-level override cannot


### PR DESCRIPTION
## Problem

Snowflake batch export runs intermittently fail at the connection step with a non-retryable error when the Snowflake login handshake takes longer than 5 seconds. Affected runs fail instead of retrying, so exports stop until someone intervenes.

## Changes

- Snowflake batch exports now allow up to 20s for the login handshake before timing out (was 5s), so slow logins no longer surface as non-retryable connection errors.

## How did you test this code?

Single connector parameter change (`login_timeout` passed to `snowflake.connector.connect`). Ran `ruff check` and `ruff format --check` on the changed file — both pass. Did not run the Snowflake destination test suites locally: the temporal activity tests hang in this environment, and the E2E suites require a real Snowflake account. No test asserts on the timeout value.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal timeout value, not user-configurable or documented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Change requested directly by the human driver: increase the login timeout for the Snowflake connector used in batch exports from 5s to 20s, as connection errors raised at login are non-retryable. Located the single production call site in `products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py`, applied the bump, and verified lint/format. A test fixture (`conftest.py`) also sets `login_timeout=5` for E2E test setup connections; left unchanged as it only affects tests. No repo skills matched this one-line connector parameter change. Nothing from the session beyond the request itself is included in this PR.