### PR TITLE
chore(health): drop beta banners from health pages

### DIFF
--- a/frontend/src/scenes/health/HealthScene.tsx
+++ b/frontend/src/scenes/health/HealthScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconBell, IconCheck, IconEllipsis, IconRefresh, IconSparkles, IconSupport } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonMenu } from '@posthog/lemon-ui'
+import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
 
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -111,14 +111,6 @@ export const HealthScene = (): JSX.Element => {
             </div>
 
             <div className="flex flex-col gap-6">
-                <LemonBanner
-                    type="info"
-                    className="mb-2"
-                    dismissKey="unified-health-page-feedback-banner"
-                    action={{ children: 'Send feedback', id: 'unified-health-page-feedback-button' }}
-                >
-                    We'd love your feedback on the new Health page. Let us know what's working and what could be better!
-                </LemonBanner>
                 <PlatformStatusBanner />
                 <HealthIssueSummaryCards />
                 <HealthIssueList />

--- a/frontend/src/scenes/onboarding/shared/sdkHealth/SdkHealthScene.tsx
+++ b/frontend/src/scenes/onboarding/shared/sdkHealth/SdkHealthScene.tsx
@@ -94,12 +94,6 @@ export function SdkHealthScene(): JSX.Element {
                 </div>
             )}
 
-            {/* Beta feedback banner */}
-            <LemonBanner type="info">
-                <strong>SDK Health is in Beta!</strong> Help us improve by sharing your feedback?{' '}
-                <Link to="#panel=support%3Asupport%3Asdk%3Alow%3Atrue">Send feedback</Link>
-            </LemonBanner>
-
             <div className="p-3">
                 {loading ? null : hasErrors ? (
                     <div className="text-center text-muted p-4">


### PR DESCRIPTION
## Problem

Health checks and SDK health are out of beta and working as expected, but both pages still tell people they're using a beta feature. The Health overview banner also pointed at a feedback survey that is no longer running, so its "Send feedback" button did nothing.

## Changes

- The Health page no longer shows the "We'd love your feedback on the new Health page" banner.
- The SDK health page no longer shows the "SDK Health is in Beta!" banner.
- Mechanical: dropped the now-unused `LemonBanner` import from `HealthScene.tsx`.

Docs on posthog.com are updated in a companion PR.

## How did you test this code?

No automated tests cover these banners, and none were added — deleting a static banner has no regression an assertion would catch. Oxlint passes on both changed files. The app was not run manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Handled in the companion posthog.com PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude in PostHog Desktop. The request was to remove every "health page is in beta" mention across the app and the website, and to stop the survey attached to it.

Searching the repo for beta wording near health surfaced exactly two banners. The Health overview banner is not worded as beta, but it is the trigger element for the "Health Overview Survey" widget (`#unified-health-page-feedback-button`); that survey is already stopped, so the banner was removed rather than left as a dead button.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
