### PR TITLE
feat(batch-exports): require an integration for S3 batch exports

### DIFF
--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -50,7 +50,6 @@ from posthog.utils import relative_date_parse, str_to_bool
 from products.batch_exports.backend.api.destination_tests import get_destination_test
 from products.batch_exports.backend.models.batch_export import (
     BATCH_EXPORT_INTERVALS,
-    S3_CREATABLE_TYPES,
     S3_FAMILY_TYPES,
     TIMEZONES,
     BatchExport,
@@ -697,7 +696,7 @@ class AwsS3DestinationRequestSerializer(serializers.Serializer):
     type = serializers.ChoiceField(choices=["AwsS3"])
     integration_id = serializers.IntegerField(
         help_text=(
-            "ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. "
+            "ID of an aws-s3-kind Integration providing AWS credentials. "
             "Use the integrations-list MCP tool to find one."
         ),
     )
@@ -711,7 +710,7 @@ class S3CompatibleDestinationRequestSerializer(serializers.Serializer):
     integration_id = serializers.IntegerField(
         help_text=(
             "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. "
-            "Required when creating a batch export. Use the integrations-list MCP tool to find one."
+            "Use the integrations-list MCP tool to find one."
         ),
     )
     config = S3CompatibleDestinationConfigSerializer()
@@ -839,6 +838,11 @@ S3_DESTINATION_TO_INTEGRATION_KIND: dict[str, Integration.IntegrationKind] = {
     BatchExportDestination.Destination.S3_COMPATIBLE: Integration.IntegrationKind.S3_COMPATIBLE,
 }
 
+# Fields an S3-family export reads from its integration at run time. Rows migrated off inline
+# credentials still hold them in stored config, but no write may set them. Any other credential
+# field is already rejected as unknown, because the input dataclasses never declared it.
+S3_INTEGRATION_OWNED_FIELDS = frozenset({"aws_access_key_id", "aws_secret_access_key", "endpoint_url"})
+
 
 def _coerce_integration_id(value: typing.Any) -> int | None:
     """Return the integration id encoded in a Redshift COPY credential value, if any.
@@ -885,9 +889,9 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
         help_text=(
-            "ID of a team-scoped Integration providing credentials. Required when creating Databricks, "
-            "AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake "
-            "and Redshift (inline credentials remain supported); unused for other types."
+            "ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible "
+            "destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; "
+            "optional for Snowflake and Redshift (inline credentials remain supported); unused for other types."
         ),
     )
 
@@ -927,19 +931,13 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
 
         # Some credential/connection fields are optional on the dataclass (integration-backed exports
         # resolve them at run time), so they must be required here only when no Integration is linked.
-        # For the S3 family this is only possible when updating an export that predates integrations:
-        # creating one without an Integration is rejected in `validate_destination`. Redshift is
-        # absent for the same reason, and because this check runs first: leaving it in would report a
-        # missing 'user' instead of the missing integration that is the actual problem.
-        # TODO: remove this code once inline credentials are gone for S3 and integrations are enforced
-        # for Snowflake
+        # Only Snowflake needs this. Every other destination requires an Integration, so
+        # `validate_destination` reports a missing one. Listing them here would report a missing
+        # credential field instead, because this check runs first.
+        # TODO: remove this code once integrations are enforced for Snowflake
         conditionally_required: set[str] = set()
         if attrs.get("integration") is None:
-            if export_type in S3_FAMILY_TYPES:
-                conditionally_required = {"aws_access_key_id", "aws_secret_access_key"}
-                if export_type == BatchExportDestination.Destination.S3_COMPATIBLE:
-                    conditionally_required.add("endpoint_url")
-            elif export_type == BatchExportDestination.Destination.SNOWFLAKE:
+            if export_type == BatchExportDestination.Destination.SNOWFLAKE:
                 conditionally_required = {"account", "user"}
 
         for destination_field in destination_fields:
@@ -1433,11 +1431,11 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 "Delete this batch export and create a new one with the new destination type."
             )
 
-        # The legacy `S3` type is retained only for existing rows; new destinations must use the
-        # refined `AwsS3` or `S3Compatible` types. `instance is None` means we're creating.
-        if instance is None and destination_type == BatchExportDestination.Destination.S3:
+        # The legacy `S3` type predates both the AwsS3/S3Compatible split and integration-backed
+        # credentials. Every row has been migrated off it, so it accepts no writes at all.
+        if destination_type == BatchExportDestination.Destination.S3:
             raise serializers.ValidationError(
-                "The 'S3' destination type is deprecated and can no longer be created. "
+                "The 'S3' destination type is deprecated and can no longer be used. "
                 "Use 'AwsS3' for AWS S3, or 'S3Compatible' for S3-compatible storage."
             )
 
@@ -1473,26 +1471,27 @@ class BatchExportSerializer(serializers.ModelSerializer):
 
         if destination_type in S3_FAMILY_TYPES:
             integration = destination_attrs.get("integration")
+            if integration is None and "integration" not in destination_attrs and instance is not None:
+                # A PATCH may send config alone, which keeps the export's existing integration.
+                # An explicit `integration: null` is a removal, and is rejected below.
+                integration = instance.destination.integration
 
-            # TODO: remove this guard once integrations are mandatory for S3 and inline credentials are gone.
-            if instance is not None and instance.destination.integration is not None and integration is None:
-                raise serializers.ValidationError(
-                    "Cannot remove the integration from an S3 batch export that uses one. "
-                    "Re-send its `integration` to keep it (or a different one to swap)."
-                )
-
-            # New S3 exports must use an Integration for credentials. Exports created before
-            # integrations existed keep their inline credentials, so only require it on create
-            # (`instance is None`); existing inline-credential exports stay valid when edited.
-            if integration is None and instance is None and destination_type in S3_CREATABLE_TYPES:
+            if integration is None:
                 raise serializers.ValidationError(f"Integration is required for {destination_type} batch exports")
+
+            # Credentials and the provider endpoint live in the integration. Only the submitted
+            # config is checked: rows migrated off inline credentials still hold these keys in
+            # stored config, and patching one must not resurface them as an error.
+            submitted_credential_fields = sorted(S3_INTEGRATION_OWNED_FIELDS & config.keys())
+            if submitted_credential_fields:
+                raise serializers.ValidationError(
+                    f"{destination_type} batch exports authenticate through their integration. "
+                    f"Remove these fields from the configuration: {submitted_credential_fields}"
+                )
 
             # we already validate the required inputs in BatchExportDestinationSerializer::validate
             # so here we just ensure that the inputs are not empty
             required_non_empty_inputs = ["bucket_name", "region", "prefix"]
-            # Credentials are only required inline when no Integration provides them.
-            if integration is None:
-                required_non_empty_inputs += ["aws_access_key_id", "aws_secret_access_key", "aws_role_arn"]
 
             empty_inputs = []
 
@@ -1504,24 +1503,13 @@ class BatchExportSerializer(serializers.ModelSerializer):
             if empty_inputs:
                 raise serializers.ValidationError(f"The following inputs are empty: {empty_inputs}")
 
-            # When an Integration is supplied it must match the destination kind. (Team ownership is
-            # already enforced by the team-scoped `integration` field, which can only resolve
-            # integrations belonging to the request's team.)
-            if integration is not None:
-                # An Integration only makes sense for the integration-backed S3 types. Reject it on the
-                # legacy "S3" type
-                # TODO: remove this branch once the legacy "S3" destination type is fully removed
-                try:
-                    kind = S3_DESTINATION_TO_INTEGRATION_KIND[destination_type]
-                except KeyError:
-                    raise serializers.ValidationError(
-                        f"{destination_type} destinations do not support integration-based credentials."
-                    )
-
-                if not integration.kind == kind:
-                    raise serializers.ValidationError(
-                        f"Integration provided is not an AWS S3 integration (got kind='{integration.kind}')"
-                    )
+            # The integration must match the destination kind. (Team ownership is already enforced
+            # by the team-scoped `integration` field, which can only resolve integrations belonging
+            # to the request's team.)
+            if integration.kind != S3_DESTINATION_TO_INTEGRATION_KIND[destination_type]:
+                raise serializers.ValidationError(
+                    f"Integration provided is not an AWS S3 integration (got kind='{integration.kind}')"
+                )
 
             # JSONLines is the default file format for S3 exports for legacy reasons
             file_format = merged_config.get("file_format", "JSONLines")
@@ -1535,16 +1523,6 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     f"Compression {compression} is not supported for file format {file_format}. Supported compressions are {S3_SUPPORTED_COMPRESSIONS[file_format]}"
                 )
-
-            # if someone is trying to reset the endpoint url, then we need to convert empty string to None
-            if merged_config.get("endpoint_url") == "":
-                destination_attrs["config"]["endpoint_url"] = None
-
-            if merged_config.get("endpoint_url") is not None:
-                try:
-                    resolve_and_validate_url(merged_config["endpoint_url"])
-                except ValueError:
-                    raise serializers.ValidationError(f"Invalid endpoint_url: '{merged_config['endpoint_url']}'")
 
         if destination_type == BatchExportDestination.Destination.DATABRICKS:
             # validate the Integration is valid (this is mandatory for Databricks batch exports)

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -1480,11 +1480,11 @@ class BatchExportSerializer(serializers.ModelSerializer):
             # credential field is already rejected as unknown, since the input dataclasses never
             # declared it.
             integration_owned_fields = {"aws_access_key_id", "aws_secret_access_key", "endpoint_url"}
-            submitted_credential_fields = sorted(integration_owned_fields & config.keys())
-            if submitted_credential_fields:
+            submitted_owned_fields = sorted(integration_owned_fields & config.keys())
+            if submitted_owned_fields:
                 raise serializers.ValidationError(
                     f"{destination_type} batch exports authenticate through their integration. "
-                    f"Remove these fields from the configuration: {submitted_credential_fields}"
+                    f"Remove these fields from the configuration: {submitted_owned_fields}"
                 )
 
             # we already validate the required inputs in BatchExportDestinationSerializer::validate

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -838,11 +838,6 @@ S3_DESTINATION_TO_INTEGRATION_KIND: dict[str, Integration.IntegrationKind] = {
     BatchExportDestination.Destination.S3_COMPATIBLE: Integration.IntegrationKind.S3_COMPATIBLE,
 }
 
-# Fields an S3-family export reads from its integration at run time. Rows migrated off inline
-# credentials still hold them in stored config, but no write may set them. Any other credential
-# field is already rejected as unknown, because the input dataclasses never declared it.
-S3_INTEGRATION_OWNED_FIELDS = frozenset({"aws_access_key_id", "aws_secret_access_key", "endpoint_url"})
-
 
 def _coerce_integration_id(value: typing.Any) -> int | None:
     """Return the integration id encoded in a Redshift COPY credential value, if any.
@@ -889,9 +884,9 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
         help_text=(
-            "ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible "
-            "destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; "
-            "optional for Snowflake and Redshift (inline credentials remain supported); unused for other types."
+            "ID of a team-scoped Integration providing credentials, for destinations that authenticate "
+            "through one. Required for all of those except Snowflake and Redshift, which still support "
+            "inline credentials."
         ),
     )
 
@@ -1481,8 +1476,11 @@ class BatchExportSerializer(serializers.ModelSerializer):
 
             # Credentials and the provider endpoint live in the integration. Only the submitted
             # config is checked: rows migrated off inline credentials still hold these keys in
-            # stored config, and patching one must not resurface them as an error.
-            submitted_credential_fields = sorted(S3_INTEGRATION_OWNED_FIELDS & config.keys())
+            # stored config, and patching one must not resurface them as an error. Any other
+            # credential field is already rejected as unknown, since the input dataclasses never
+            # declared it.
+            integration_owned_fields = {"aws_access_key_id", "aws_secret_access_key", "endpoint_url"}
+            submitted_credential_fields = sorted(integration_owned_fields & config.keys())
             if submitted_credential_fields:
                 raise serializers.ValidationError(
                     f"{destination_type} batch exports authenticate through their integration. "

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -885,8 +885,8 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text=(
             "ID of a team-scoped Integration providing credentials, for destinations that authenticate "
-            "through one. Required for all of those except Snowflake and Redshift, which still support "
-            "inline credentials."
+            "through one. Required for all of those except Snowflake, which still supports inline "
+            "credentials."
         ),
     )
 

--- a/products/batch_exports/backend/api/destination_tests/__init__.py
+++ b/products/batch_exports/backend/api/destination_tests/__init__.py
@@ -10,7 +10,7 @@ def get_destination_test(
     (databricks, google-cloud-bigquery, snowflake, etc.). Importing them lazily keeps the
     SDKs off the API import path — only the requested destination's SDK loads.
     """
-    if destination in ("S3", "S3Compatible"):
+    if destination == "S3Compatible":
         from products.batch_exports.backend.api.destination_tests.s3 import S3CompatibleDestinationTest  # noqa: PLC0415
 
         return S3CompatibleDestinationTest()

--- a/products/batch_exports/backend/models/batch_export.py
+++ b/products/batch_exports/backend/models/batch_export.py
@@ -28,10 +28,6 @@ TIMEZONES = [(tz, tz) for tz in pytz.all_timezones]
 # Includes the legacy "S3" alias for backwards compatibility.
 S3_FAMILY_TYPES: frozenset[str] = frozenset({"S3", "AwsS3", "S3Compatible"})
 
-# S3-family types that can be created via the API. The legacy "S3" type is excluded:
-# existing rows keep working, but new destinations must use "AwsS3" or "S3Compatible".
-S3_CREATABLE_TYPES: frozenset[str] = frozenset({"AwsS3", "S3Compatible"})
-
 
 class DayOfWeek(IntEnum):
     """Day of the week enum for batch export schedules.
@@ -84,6 +80,9 @@ class BatchExportDestination(UUIDTModel):
         NOOP = "NoOp"
         FILE_DOWNLOAD = "FileDownload"
 
+    # S3-family exports read their credentials from an Integration, but rows migrated off inline
+    # credentials still hold them in `config`. These entries keep those stale values out of API
+    # responses until a follow-up strips them from stored config.
     secret_fields = {
         "S3": {"aws_access_key_id", "aws_secret_access_key"},
         "AwsS3": {"aws_access_key_id", "aws_secret_access_key"},

--- a/products/batch_exports/backend/models/batch_export.py
+++ b/products/batch_exports/backend/models/batch_export.py
@@ -24,9 +24,9 @@ from posthog.models.utils import UUIDTModel
 # (we could use common_timezones instead; this has 433 timezones vs 596 for all_timezones)
 TIMEZONES = [(tz, tz) for tz in pytz.all_timezones]
 
-# All destination types that share the s3-export Temporal workflow.
-# Includes the legacy "S3" alias for backwards compatibility.
-S3_FAMILY_TYPES: frozenset[str] = frozenset({"S3", "AwsS3", "S3Compatible"})
+# S3-family destination types that are in use. Note that this excludes the legacy "S3"
+# type which has now been fully deprecated.
+S3_FAMILY_TYPES: frozenset[str] = frozenset({"AwsS3", "S3Compatible"})
 
 
 class DayOfWeek(IntEnum):
@@ -66,7 +66,7 @@ class BatchExportDestination(UUIDTModel):
     class Destination(models.TextChoices):
         """Enumeration of supported destinations for PostHog BatchExports."""
 
-        S3 = "S3"  # legacy alias; AwsS3 / S3Compatible are the preferred types for new rows
+        S3 = "S3"  # TODO: legacy alias which is no longer used so can be removed
         AWS_S3 = "AwsS3"
         S3_COMPATIBLE = "S3Compatible"
         SNOWFLAKE = "Snowflake"

--- a/products/batch_exports/backend/tests/api/backfills/test_cancel.py
+++ b/products/batch_exports/backend/tests/api/backfills/test_cancel.py
@@ -62,8 +62,6 @@ def test_cancelling_a_batch_export_backfill(client: HttpClient, organization, te
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     batch_export_data = {

--- a/products/batch_exports/backend/tests/api/backfills/test_create.py
+++ b/products/batch_exports/backend/tests/api/backfills/test_create.py
@@ -43,8 +43,6 @@ def _create_batch_export_ok(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     batch_export_data = {

--- a/products/batch_exports/backend/tests/api/conftest.py
+++ b/products/batch_exports/backend/tests/api/conftest.py
@@ -132,6 +132,27 @@ def s3_compatible_integration(team, user):
     )
 
 
+@pytest.fixture
+def s3_batch_export_data(aws_s3_integration) -> dict:
+    """Return the request body for creating a minimal AwsS3 batch export.
+
+    Function scoped, so a test may change the returned dictionary without affecting other tests.
+    """
+    return {
+        "name": "my-production-s3-bucket-destination",
+        "destination": {
+            "type": "AwsS3",
+            "integration": aws_s3_integration.id,
+            "config": {
+                "bucket_name": "my-production-s3-bucket",
+                "region": "us-east-1",
+                "prefix": "posthog-events/",
+            },
+        },
+        "interval": "hour",
+    }
+
+
 def assert_is_daily_schedule(schedule: ScheduleDescription, expected_hour: int):
     """Assert the schedule is a daily schedule."""
     calendars = schedule.schedule.spec.calendars

--- a/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
@@ -120,7 +120,6 @@ async def test_assume_role_step_skips_without_role():
 @pytest.mark.parametrize(
     "destination,expected_test,expected_steps",
     [
-        ("S3", S3CompatibleDestinationTest, [S3EnsureBucketTestStep]),
         ("S3Compatible", S3CompatibleDestinationTest, [S3EnsureBucketTestStep]),
         ("AwsS3", AwsS3DestinationTest, [S3AssumeRoleTestStep, S3EnsureBucketTestStep]),
     ],

--- a/products/batch_exports/backend/tests/api/test_create.py
+++ b/products/batch_exports/backend/tests/api/test_create.py
@@ -54,9 +54,6 @@ def test_create_batch_export_with_interval_schedule(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
-            "endpoint_url": "https://localhost:9000",
             "use_virtual_style_addressing": True,
         },
         "integration": s3_compatible_integration.id,
@@ -80,10 +77,6 @@ def test_create_batch_export_with_interval_schedule(
 
     data = response.json()
 
-    # We should not get the aws_access_key_id or aws_secret_access_key back, so
-    # remove that from the data we expect.
-    batch_export_data["destination"]["config"].pop("aws_access_key_id")
-    batch_export_data["destination"]["config"].pop("aws_secret_access_key")
     assert data["destination"] == batch_export_data["destination"]
 
     # We should match on top level fields.
@@ -114,9 +107,11 @@ def test_create_batch_export_with_interval_schedule(
     assert args["bucket_name"] == "my-production-s3-bucket"
     assert args["region"] == "us-east-1"
     assert args["prefix"] == "posthog-events/"
-    assert args["aws_access_key_id"] == "abc123"
-    assert args["aws_secret_access_key"] == "secret"
     assert args["use_virtual_style_addressing"]
+    # Credentials are resolved from the integration at run time, never carried in the schedule.
+    assert args["integration_id"] == s3_compatible_integration.id
+    assert args.get("aws_access_key_id") is None
+    assert args.get("aws_secret_access_key") is None
 
     # Temporal UI metadata should be set on the schedule's action
     assert schedule.schedule.action.static_summary is not None
@@ -191,8 +186,6 @@ def test_create_batch_export_with_different_intervals_timezones_and_interval_off
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -347,8 +340,6 @@ def test_cannot_create_a_batch_export_for_another_organization(client: HttpClien
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -432,8 +423,6 @@ def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -498,8 +487,6 @@ def test_create_batch_export_with_custom_schema(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -614,8 +601,6 @@ def test_create_batch_export_fails_with_invalid_query(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -661,8 +646,6 @@ def test_create_batch_export_fails_with_invalid_query(
                 "bucket_name": "my-s3-bucket",
                 "region": "us-east-1",
                 "prefix": "posthog-events/",
-                "aws_access_key_id": "abc123",
-                "aws_secret_access_key": "secret",
                 "hello": 123,  # Unknown field
                 "hello2": 123,  # Another unknown field
             },
@@ -726,8 +709,6 @@ _S3_FILTER_TEST_CONFIG = {
     "bucket_name": "my-s3-bucket",
     "region": "us-east-1",
     "prefix": "posthog-events/",
-    "aws_access_key_id": "abc123",
-    "aws_secret_access_key": "secret",
 }
 
 

--- a/products/batch_exports/backend/tests/api/test_create.py
+++ b/products/batch_exports/backend/tests/api/test_create.py
@@ -413,23 +413,9 @@ def test_cannot_create_batch_export_with_integration_from_another_team(
 
 
 def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "every 5 minutes",
-    }
+    batch_export_data = {**s3_batch_export_data, "interval": "every 5 minutes"}
 
     client.force_login(user)
     with mock.patch(
@@ -469,7 +455,7 @@ FROM events
 
 
 def test_create_batch_export_with_custom_schema(
-    client: HttpClient, temporal, encryption_codec, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, encryption_codec, organization, team, user, s3_batch_export_data
 ):
     """Test creating a BatchExport with a custom schema expressed as a HogQL Query.
 
@@ -479,22 +465,7 @@ def test_create_batch_export_with_custom_schema(
     expected inputs.
     """
 
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "hogql_query": TEST_HOGQL_QUERY,
-        "interval": "hour",
-    }
+    batch_export_data = {**s3_batch_export_data, "hogql_query": TEST_HOGQL_QUERY}
 
     client.force_login(user)
 
@@ -589,26 +560,18 @@ def test_create_batch_export_with_custom_schema(
     ],
 )
 def test_create_batch_export_fails_with_invalid_query(
-    client: HttpClient, invalid_query, expected_error_message, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient,
+    invalid_query,
+    expected_error_message,
+    temporal,
+    organization,
+    team,
+    user,
+    s3_batch_export_data,
 ):
     """Test creating a BatchExport should fail with an invalid query."""
 
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-        "hogql_query": invalid_query,
-    }
+    batch_export_data = {**s3_batch_export_data, "hogql_query": invalid_query}
 
     client.force_login(user)
 

--- a/products/batch_exports/backend/tests/api/test_create.py
+++ b/products/batch_exports/backend/tests/api/test_create.py
@@ -6,7 +6,6 @@ from zoneinfo import ZoneInfo
 import pytest
 from unittest import mock
 
-from django.test import override_settings
 from django.test.client import Client as HttpClient
 
 from asgiref.sync import async_to_sync
@@ -772,53 +771,3 @@ def test_creating_batch_export_with_filters(
 
     if expected_error:
         assert expected_error in response.json()["detail"]
-
-
-@pytest.mark.parametrize(
-    "host",
-    [
-        "192.168.1.1",
-        "127.0.0.1",
-        "[::1]",
-        "10.0.0.1",
-        "169.254.0.0",
-        "localhost",
-    ],
-)
-def test_create_redshift_batch_export_fails_with_invalid_host(
-    client: HttpClient, temporal, organization, team, user, host, aws_redshift_integration
-):
-    """Test creating a BatchExport with Redshift destination validates inputs for 'COPY'.
-
-    Postgres host validation is covered separately in test_create_postgres.py, where the host
-    comes from the linked Integration rather than from inline config.
-    """
-
-    destination_data = {
-        "type": "Redshift",
-        "config": {
-            "database": "my-db",
-            "host": host,
-            "schema": "public",
-            "table_name": "my_events",
-        },
-        "integration": aws_redshift_integration.pk,
-    }
-
-    batch_export_data = {
-        "name": "my-production-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
-    client.force_login(user)
-
-    with override_settings(TEST=0, DEBUG=0):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
-
-    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert f"Invalid host: '{host}'" in response.json()["detail"]

--- a/products/batch_exports/backend/tests/api/test_create_redshift.py
+++ b/products/batch_exports/backend/tests/api/test_create_redshift.py
@@ -1,5 +1,6 @@
 import pytest
 
+from django.test import override_settings
 from django.test.client import Client as HttpClient
 
 from rest_framework import status
@@ -196,6 +197,56 @@ def test_create_redshift_batch_export_rejects_invalid_authorization_type(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert "Authorization for 'COPY'" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "192.168.1.1",
+        "127.0.0.1",
+        "[::1]",
+        "10.0.0.1",
+        "169.254.0.0",
+        "localhost",
+    ],
+)
+def test_create_redshift_batch_export_fails_with_invalid_host(
+    client: HttpClient, temporal, organization, team, user, host, aws_redshift_integration
+):
+    """Test creating a BatchExport with a Redshift destination rejects an internal host.
+
+    Postgres host validation is covered separately in test_create_postgres.py, where the host
+    comes from the linked Integration rather than from inline config.
+    """
+
+    destination_data = {
+        "type": "Redshift",
+        "config": {
+            "database": "my-db",
+            "host": host,
+            "schema": "public",
+            "table_name": "my_events",
+        },
+        "integration": aws_redshift_integration.pk,
+    }
+
+    batch_export_data = {
+        "name": "my-production-destination",
+        "destination": destination_data,
+        "interval": "hour",
+    }
+
+    client.force_login(user)
+
+    with override_settings(TEST=0, DEBUG=0):
+        response = create_batch_export(
+            client,
+            team.pk,
+            batch_export_data,
+        )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert f"Invalid host: '{host}'" in response.json()["detail"]
 
 
 def test_create_redshift_batch_export_with_aws_integration(

--- a/products/batch_exports/backend/tests/api/test_create_s3.py
+++ b/products/batch_exports/backend/tests/api/test_create_s3.py
@@ -1,14 +1,10 @@
-import typing as t
-
 import pytest
 
-from django.test import override_settings
 from django.test.client import Client as HttpClient
 
 from rest_framework import status
 from temporalio.client import ScheduleActionStartWorkflow
 
-from products.batch_exports.backend.models.batch_export import S3_CREATABLE_TYPES
 from products.batch_exports.backend.tests.api.conftest import describe_schedule
 from products.batch_exports.backend.tests.api.operations import create_batch_export
 
@@ -17,12 +13,12 @@ pytestmark = [
     pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
 
+_S3_FAMILY_TYPES = ["AwsS3", "S3Compatible"]
+
 _S3_FAMILY_BASE_CONFIG = {
     "bucket_name": "my-bucket",
     "region": "us-east-1",
     "prefix": "events/",
-    "aws_access_key_id": "key",
-    "aws_secret_access_key": "secret",
 }
 
 
@@ -31,8 +27,8 @@ _S3_FAMILY_BASE_CONFIG = {
     [
         # Refined AwsS3 (with AWS-only encryption field)
         ("AwsS3", "aws_s3_integration", {"encryption": "AES256"}, "AwsS3"),
-        # Refined S3Compatible (accepts an inline endpoint_url alongside the integration's)
-        ("S3Compatible", "s3_compatible_integration", {"endpoint_url": "https://localhost:9000"}, "S3Compatible"),
+        # Refined S3Compatible (with its addressing-style field)
+        ("S3Compatible", "s3_compatible_integration", {"use_virtual_style_addressing": True}, "S3Compatible"),
     ],
 )
 def test_create_s3_family_batch_export(
@@ -67,23 +63,19 @@ def test_create_s3_family_batch_export(
     assert response.json()["destination"]["type"] == expected_persisted_type
 
 
-@pytest.mark.parametrize("destination_type", sorted(S3_CREATABLE_TYPES))
+@pytest.mark.parametrize("destination_type", _S3_FAMILY_TYPES)
 def test_create_s3_family_batch_export_requires_an_integration(
     client: HttpClient, temporal, organization, team, user, destination_type
 ):
-    """Inline credentials are no longer enough to create an S3-family export: an Integration is required."""
+    """An S3-family export cannot be created without an Integration to authenticate through."""
     client.force_login(user)
-    config = {**_S3_FAMILY_BASE_CONFIG}
-    if destination_type == "S3Compatible":
-        config["endpoint_url"] = "https://localhost:9000"
-
     response = create_batch_export(
         client,
         team.pk,
         {
             "name": "my-export",
             "interval": "hour",
-            "destination": {"type": destination_type, "config": config},
+            "destination": {"type": destination_type, "config": {**_S3_FAMILY_BASE_CONFIG}},
         },
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
@@ -126,8 +118,6 @@ def test_create_s3_family_batch_export_validates_empty_inputs(
     integration = request.getfixturevalue(integration_fixture)
     client.force_login(user)
     config = {**_S3_FAMILY_BASE_CONFIG, "bucket_name": "", "region": ""}
-    if destination_type == "S3Compatible":
-        config["endpoint_url"] = "https://localhost:9000"
 
     response = create_batch_export(
         client,
@@ -143,43 +133,52 @@ def test_create_s3_family_batch_export_validates_empty_inputs(
 
 
 @pytest.mark.parametrize(
-    "destination_type,missing_field",
+    "destination_type,integration_fixture,credential_field",
     [
-        *((dt, field) for dt in sorted(S3_CREATABLE_TYPES) for field in ("aws_access_key_id", "aws_secret_access_key")),
-        # `endpoint_url` is required only for S3Compatible.
-        ("S3Compatible", "endpoint_url"),
+        ("AwsS3", "aws_s3_integration", "aws_access_key_id"),
+        ("AwsS3", "aws_s3_integration", "aws_secret_access_key"),
+        ("S3Compatible", "s3_compatible_integration", "aws_access_key_id"),
+        ("S3Compatible", "s3_compatible_integration", "aws_secret_access_key"),
+        # `endpoint_url` is an S3Compatible-only field; AwsS3 rejects it as unknown instead.
+        ("S3Compatible", "s3_compatible_integration", "endpoint_url"),
     ],
 )
-def test_create_s3_family_batch_export_validates_missing_required_inputs(
+def test_create_s3_family_batch_export_rejects_inline_credentials(
     client: HttpClient,
     temporal,
     organization,
     team,
     user,
     destination_type,
-    missing_field,
+    integration_fixture,
+    credential_field,
+    request,
 ):
-    """Missing required fields are rejected for every S3-family destination."""
+    """Credentials and the provider endpoint belong to the integration, so config may not carry them.
+
+    An accepted value here would be persisted in `config` and copied into the export's Temporal
+    schedule arguments.
+    """
+    integration = request.getfixturevalue(integration_fixture)
     client.force_login(user)
-    config = {**_S3_FAMILY_BASE_CONFIG}
-    if destination_type == "S3Compatible":
-        # S3Compatible requires `endpoint_url` to be present; include it in the
-        # base so only `missing_field` is missing after the pop below.
-        config["endpoint_url"] = "https://localhost:9000"
-
-    config.pop(missing_field, None)
-
     response = create_batch_export(
         client,
         team.pk,
         {
             "name": "my-export",
             "interval": "hour",
-            "destination": {"type": destination_type, "config": config},
+            "destination": {
+                "type": destination_type,
+                "config": {**_S3_FAMILY_BASE_CONFIG, credential_field: "https://localhost:9000"},
+                "integration": integration.id,
+            },
         },
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert f"missing required field: '{missing_field}'" in response.json()["detail"]
+    assert response.json()["detail"] == (
+        f"{destination_type} batch exports authenticate through their integration. "
+        f"Remove these fields from the configuration: ['{credential_field}']"
+    )
 
 
 @pytest.mark.parametrize(
@@ -293,56 +292,8 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
         assert response.json()["detail"] == expected_error_message
 
 
-@pytest.mark.parametrize(
-    "destination_type",
-    # Only creatable types that accept `endpoint_url` reach the SSRF check.
-    ["S3Compatible"],
-)
-@pytest.mark.parametrize(
-    "endpoint_url",
-    [
-        "https://192.168.1.1",
-        "http://127.0.0.1",
-        "http://[::1]/",
-        "http://10.0.0.1:9000/",
-        "http://169.254.0.0:8080/data",
-        "http://localhost",
-    ],
-)
-def test_creating_s3_family_batch_export_fails_if_using_invalid_endpoint_url(
-    client: HttpClient, temporal, organization, team, user, destination_type, endpoint_url, s3_compatible_integration
-):
-    """Test that creating an S3 batch export fails if passing an internal IP as endpoint URL.
-
-    Last time I checked, we are not S3.
-    """
-
-    destination_data = {
-        "type": destination_type,
-        "config": {
-            **_S3_FAMILY_BASE_CONFIG,
-            "use_virtual_style_addressing": True,
-            "endpoint_url": endpoint_url,
-        },
-        "integration": s3_compatible_integration.id,
-    }
-
-    batch_export_data: dict[str, t.Any] = {
-        "name": "my-export",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-    client.force_login(user)
-
-    with override_settings(TEST=0, DEBUG=0):
-        response = create_batch_export(
-            client,
-            team.pk,
-            batch_export_data,
-        )
-
-    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert f"Invalid endpoint_url: '{endpoint_url}'" in response.json()["detail"]
+# The endpoint URL now lives on the s3-compatible integration, which SSRF-checks it on creation
+# (see `test_create_rejects_invalid_endpoint_url` in posthog/api/test/test_integration.py).
 
 
 @pytest.mark.parametrize(

--- a/products/batch_exports/backend/tests/api/test_create_s3.py
+++ b/products/batch_exports/backend/tests/api/test_create_s3.py
@@ -5,6 +5,7 @@ from django.test.client import Client as HttpClient
 from rest_framework import status
 from temporalio.client import ScheduleActionStartWorkflow
 
+from products.batch_exports.backend.models.batch_export import S3_FAMILY_TYPES
 from products.batch_exports.backend.tests.api.conftest import describe_schedule
 from products.batch_exports.backend.tests.api.operations import create_batch_export
 
@@ -12,8 +13,6 @@ pytestmark = [
     pytest.mark.django_db,
     pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
-
-_S3_FAMILY_TYPES = ["AwsS3", "S3Compatible"]
 
 _S3_FAMILY_BASE_CONFIG = {
     "bucket_name": "my-bucket",
@@ -63,7 +62,7 @@ def test_create_s3_family_batch_export(
     assert response.json()["destination"]["type"] == expected_persisted_type
 
 
-@pytest.mark.parametrize("destination_type", _S3_FAMILY_TYPES)
+@pytest.mark.parametrize("destination_type", sorted(S3_FAMILY_TYPES))
 def test_create_s3_family_batch_export_requires_an_integration(
     client: HttpClient, temporal, organization, team, user, destination_type
 ):

--- a/products/batch_exports/backend/tests/api/test_create_s3.py
+++ b/products/batch_exports/backend/tests/api/test_create_s3.py
@@ -132,7 +132,7 @@ def test_create_s3_family_batch_export_validates_empty_inputs(
 
 
 @pytest.mark.parametrize(
-    "destination_type,integration_fixture,credential_field",
+    "destination_type,integration_fixture,owned_field",
     [
         ("AwsS3", "aws_s3_integration", "aws_access_key_id"),
         ("AwsS3", "aws_s3_integration", "aws_secret_access_key"),
@@ -142,7 +142,7 @@ def test_create_s3_family_batch_export_validates_empty_inputs(
         ("S3Compatible", "s3_compatible_integration", "endpoint_url"),
     ],
 )
-def test_create_s3_family_batch_export_rejects_inline_credentials(
+def test_create_s3_family_batch_export_rejects_integration_owned_fields(
     client: HttpClient,
     temporal,
     organization,
@@ -150,7 +150,7 @@ def test_create_s3_family_batch_export_rejects_inline_credentials(
     user,
     destination_type,
     integration_fixture,
-    credential_field,
+    owned_field,
     request,
 ):
     """Credentials and the provider endpoint belong to the integration, so config may not carry them.
@@ -168,7 +168,7 @@ def test_create_s3_family_batch_export_rejects_inline_credentials(
             "interval": "hour",
             "destination": {
                 "type": destination_type,
-                "config": {**_S3_FAMILY_BASE_CONFIG, credential_field: "https://localhost:9000"},
+                "config": {**_S3_FAMILY_BASE_CONFIG, owned_field: "belongs-in-the-integration"},
                 "integration": integration.id,
             },
         },
@@ -176,7 +176,7 @@ def test_create_s3_family_batch_export_rejects_inline_credentials(
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert response.json()["detail"] == (
         f"{destination_type} batch exports authenticate through their integration. "
-        f"Remove these fields from the configuration: ['{credential_field}']"
+        f"Remove these fields from the configuration: ['{owned_field}']"
     )
 
 
@@ -187,8 +187,8 @@ def test_create_s3_family_batch_export_rejects_inline_credentials(
         ("AwsS3", {"endpoint_url": "https://localhost:9000"}, "endpoint_url"),
         ("AwsS3", {"use_virtual_style_addressing": True}, "use_virtual_style_addressing"),
         # S3Compatible rejects AWS-only fields.
-        ("S3Compatible", {"endpoint_url": "https://localhost:9000", "kms_key_id": "alias/test"}, "kms_key_id"),
-        ("S3Compatible", {"endpoint_url": "https://localhost:9000", "encryption": "aws:kms"}, "encryption"),
+        ("S3Compatible", {"kms_key_id": "alias/test"}, "kms_key_id"),
+        ("S3Compatible", {"encryption": "aws:kms"}, "encryption"),
     ],
 )
 def test_create_s3_family_batch_export_rejects_inapplicable_fields(

--- a/products/batch_exports/backend/tests/api/test_create_s3.py
+++ b/products/batch_exports/backend/tests/api/test_create_s3.py
@@ -291,10 +291,6 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
         assert response.json()["detail"] == expected_error_message
 
 
-# The endpoint URL now lives on the s3-compatible integration, which SSRF-checks it on creation
-# (see `test_create_rejects_invalid_endpoint_url` in posthog/api/test/test_integration.py).
-
-
 @pytest.mark.parametrize(
     "destination_type,integration_fixture",
     [

--- a/products/batch_exports/backend/tests/api/test_delete.py
+++ b/products/batch_exports/backend/tests/api/test_delete.py
@@ -40,8 +40,6 @@ def test_delete_batch_export(client: HttpClient, temporal, organization, team, u
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     batch_export_data = {
@@ -101,8 +99,6 @@ def test_delete_batch_export_cancels_backfills(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     batch_export_data = {
@@ -161,8 +157,6 @@ def test_cannot_delete_export_of_other_organizations(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     batch_export_data = {
@@ -197,8 +191,6 @@ def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organi
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     batch_export_data = {
@@ -234,8 +226,6 @@ def test_delete_batch_export_even_without_underlying_schedule(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     batch_export_data = {

--- a/products/batch_exports/backend/tests/api/test_delete.py
+++ b/products/batch_exports/backend/tests/api/test_delete.py
@@ -31,26 +31,11 @@ pytestmark = [
 ]
 
 
-def test_delete_batch_export(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
+def test_delete_batch_export(client: HttpClient, temporal, organization, team, user, s3_batch_export_data):
     """Test deleting a BatchExport."""
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
 
-    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
     batch_export_id = batch_export["id"]
 
     delete_batch_export_ok(client, team.pk, batch_export_id)
@@ -89,27 +74,12 @@ async def wait_for_workflow_in_status(
 
 @pytest.mark.django_db(transaction=True)
 def test_delete_batch_export_cancels_backfills(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
     """Test deleting a BatchExport cancels ongoing BatchExportBackfill."""
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
 
-    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
     batch_export_id = batch_export["id"]
 
     # ensure there is data to backfill, otherwise validation will fail
@@ -148,29 +118,14 @@ def test_delete_batch_export_cancels_backfills(
 
 
 def test_cannot_delete_export_of_other_organizations(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     another_organization = create_organization("Another Org")
     create_team(another_organization)
     another_user = create_user("another-test@user.com", "Another Test User", another_organization)
 
     client.force_login(user)
-    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
     batch_export_id = batch_export["id"]
 
     client.force_login(another_user)
@@ -183,26 +138,13 @@ def test_cannot_delete_export_of_other_organizations(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
+def test_deletes_are_partitioned_by_team_id(
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
+):
     another_team = create_team(organization)
 
     client.force_login(user)
-    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
     batch_export_id = batch_export["id"]
 
     # Try to delete with the other team
@@ -216,27 +158,12 @@ def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organi
 
 @pytest.mark.django_db(transaction=True)
 def test_delete_batch_export_even_without_underlying_schedule(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
     """Test deleting a BatchExport completes even if underlying Schedule was already deleted."""
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
 
-    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
     batch_export_id = batch_export["id"]
 
     handle = temporal.get_schedule_handle(batch_export_id)

--- a/products/batch_exports/backend/tests/api/test_get.py
+++ b/products/batch_exports/backend/tests/api/test_get.py
@@ -47,8 +47,6 @@ def test_can_get_exports_for_your_organizations(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -106,8 +104,6 @@ def test_cannot_get_exports_for_other_organizations(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -146,8 +142,6 @@ def test_batch_exports_are_partitioned_by_team(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 

--- a/products/batch_exports/backend/tests/api/test_get.py
+++ b/products/batch_exports/backend/tests/api/test_get.py
@@ -95,24 +95,8 @@ def test_can_get_exports_for_your_organizations(
 
 
 def test_cannot_get_exports_for_other_organizations(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     another_organization = create_organization("Another Org")
     another_user = create_user("another-test@user.com", "Another Test User", another_organization)
 
@@ -120,7 +104,7 @@ def test_cannot_get_exports_for_other_organizations(
     response = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     client.force_login(another_user)
@@ -129,28 +113,12 @@ def test_cannot_get_exports_for_other_organizations(
 
 
 def test_batch_exports_are_partitioned_by_team(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
     """
     You shouldn't be able to fetch a BatchExport by id, via a team that it
     doesn't belong to.
     """
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     another_team = create_team(organization)
     # Integrations are team-scoped, so the other team's export needs its own.
     another_team_integration = Integration.objects.create(
@@ -166,7 +134,7 @@ def test_batch_exports_are_partitioned_by_team(
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     response = get_batch_export(client, another_team.pk, batch_export["id"])
@@ -176,7 +144,10 @@ def test_batch_exports_are_partitioned_by_team(
     batch_export = create_batch_export_ok(
         client,
         another_team.pk,
-        {**batch_export_data, "destination": {**destination_data, "integration": another_team_integration.id}},
+        {
+            **s3_batch_export_data,
+            "destination": {**s3_batch_export_data["destination"], "integration": another_team_integration.id},
+        },
     )
 
     response = get_batch_export(client, team.pk, batch_export["id"])

--- a/products/batch_exports/backend/tests/api/test_list.py
+++ b/products/batch_exports/backend/tests/api/test_list.py
@@ -32,8 +32,6 @@ def test_list_batch_exports(client: HttpClient, organization, team, user, aws_s3
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -76,8 +74,6 @@ def test_cannot_list_batch_exports_for_other_organizations(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -113,8 +109,6 @@ def test_list_is_partitioned_by_team(client: HttpClient, organization, team, use
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -173,8 +167,6 @@ def test_list_filters_workflows_destination(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 

--- a/products/batch_exports/backend/tests/api/test_list.py
+++ b/products/batch_exports/backend/tests/api/test_list.py
@@ -19,30 +19,14 @@ pytestmark = [
 ]
 
 
-def test_list_batch_exports(client: HttpClient, organization, team, user, aws_s3_integration):
+def test_list_batch_exports(client: HttpClient, organization, team, user, s3_batch_export_data):
     """
     Should be able to list batch exports.
     """
     client.force_login(user)
 
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
-    first_export = create_batch_export_ok(client, team.pk, batch_export_data)
-    second_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    first_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
+    second_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
 
     response = list_batch_exports_ok(client, team.pk)
     assert len(response["results"]) == 2
@@ -58,7 +42,7 @@ def test_list_batch_exports(client: HttpClient, organization, team, user, aws_s3
 
 
 def test_cannot_list_batch_exports_for_other_organizations(
-    client: HttpClient, organization, team, user, aws_s3_integration
+    client: HttpClient, organization, team, user, s3_batch_export_data
 ):
     """
     Should not be able to list batch exports for other teams.
@@ -67,25 +51,9 @@ def test_cannot_list_batch_exports_for_other_organizations(
     other_team = create_team(other_organization)
     other_user = create_user("another-test@user.com", "Another Test User", other_organization)
 
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
-    create_batch_export_ok(client, team.pk, batch_export_data)
-    create_batch_export_ok(client, team.pk, batch_export_data)
+    create_batch_export_ok(client, team.pk, s3_batch_export_data)
+    create_batch_export_ok(client, team.pk, s3_batch_export_data)
 
     # Make sure we can list batch exports for our own team.
     response = list_batch_exports_ok(client, team.pk)
@@ -96,31 +64,15 @@ def test_cannot_list_batch_exports_for_other_organizations(
     assert len(response["results"]) == 0
 
 
-def test_list_is_partitioned_by_team(client: HttpClient, organization, team, user, aws_s3_integration):
+def test_list_is_partitioned_by_team(client: HttpClient, organization, team, user, s3_batch_export_data):
     """
     Should be able to list batch exports for a specific team.
     """
     another_team = create_team(organization)
 
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
-    create_batch_export_ok(client, team.pk, batch_export_data)
-    create_batch_export_ok(client, team.pk, batch_export_data)
+    create_batch_export_ok(client, team.pk, s3_batch_export_data)
+    create_batch_export_ok(client, team.pk, s3_batch_export_data)
 
     # Make sure we can list batch exports for that team.
     response = list_batch_exports_ok(client, team.pk)
@@ -153,28 +105,12 @@ def enable_backfilling_workflows(team):
 
 
 def test_list_filters_workflows_destination(
-    client: HttpClient, organization, team, user, aws_s3_integration, enable_backfilling_workflows
+    client: HttpClient, organization, team, user, s3_batch_export_data, enable_backfilling_workflows
 ):
     """
     Workflows should be filtered out from the list.
     """
     client.force_login(user)
-
-    s3_destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    s3_batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": s3_destination_data,
-        "interval": "hour",
-    }
 
     realtime_destination_data = {
         "type": "Workflows",

--- a/products/batch_exports/backend/tests/api/test_pause.py
+++ b/products/batch_exports/backend/tests/api/test_pause.py
@@ -35,8 +35,6 @@ def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organizati
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
@@ -85,8 +83,6 @@ def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
@@ -151,8 +147,6 @@ def test_pause_and_unpause_are_partitioned_by_team_id(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
@@ -211,8 +205,6 @@ def test_pause_batch_export_that_is_already_paused(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
@@ -263,8 +255,6 @@ def test_unpause_batch_export_that_is_already_unpaused(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
@@ -304,8 +294,6 @@ def test_pause_non_existent_batch_export(client: HttpClient, temporal, organizat
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
@@ -343,8 +331,6 @@ def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal, organizati
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.

--- a/products/batch_exports/backend/tests/api/test_pause.py
+++ b/products/batch_exports/backend/tests/api/test_pause.py
@@ -25,30 +25,14 @@ pytestmark = [
 ]
 
 
-def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
+def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organization, team, user, s3_batch_export_data):
     """Test pausing and unpausing a BatchExport."""
-
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
 
     client.force_login(user)
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     assert batch_export["paused"] is False
@@ -74,24 +58,8 @@ def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organizati
 
 
 def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     from posthog.api.test.test_team import create_team
     from posthog.api.test.test_user import create_user
 
@@ -104,7 +72,7 @@ def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     batch_export_id = batch_export["id"]
@@ -138,24 +106,8 @@ def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
 
 
 def test_pause_and_unpause_are_partitioned_by_team_id(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     from posthog.api.test.test_team import create_team
 
     other_team = create_team(organization)
@@ -163,7 +115,7 @@ def test_pause_and_unpause_are_partitioned_by_team_id(
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     batch_export_id = batch_export["id"]
@@ -194,31 +146,15 @@ def test_pause_and_unpause_are_partitioned_by_team_id(
 
 
 def test_pause_batch_export_that_is_already_paused(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
     """Test pausing a BatchExport that is already paused doesn't actually do anything."""
-
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
 
     client.force_login(user)
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     assert batch_export["paused"] is False
@@ -244,31 +180,15 @@ def test_pause_batch_export_that_is_already_paused(
 
 
 def test_unpause_batch_export_that_is_already_unpaused(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
     """Test unpausing a BatchExport that is already unpaused doesn't actually do anything."""
-
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
 
     client.force_login(user)
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     assert batch_export["paused"] is False
@@ -284,30 +204,14 @@ def test_unpause_batch_export_that_is_already_unpaused(
     assert last_updated_at == data["last_updated_at"]
 
 
-def test_pause_non_existent_batch_export(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
+def test_pause_non_existent_batch_export(client: HttpClient, temporal, organization, team, user, s3_batch_export_data):
     """Test pausing a BatchExport that doesn't exist."""
-
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
 
     client.force_login(user)
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     assert batch_export["paused"] is False
@@ -321,30 +225,14 @@ def test_pause_non_existent_batch_export(client: HttpClient, temporal, organizat
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
+def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal, organization, team, user, s3_batch_export_data):
     """Test unpausing a BatchExport can trigger a backfill."""
-
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    # We create an empty schedule so nothing will run and we can pause/unpause as much as we want.
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
 
     client.force_login(user)
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     assert batch_export["paused"] is False

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -47,8 +47,6 @@ def test_can_get_export_runs_for_your_organizations(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -79,8 +77,6 @@ def test_cannot_get_exports_for_other_organizations(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -118,8 +114,6 @@ def test_batch_exports_are_partitioned_by_team(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -170,8 +164,6 @@ def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organizatio
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
     batch_export_data = {

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -38,29 +38,13 @@ pytestmark = [
 
 
 def test_can_get_export_runs_for_your_organizations(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
     response = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     response = get_batch_export_runs(client, team.pk, response["id"])
@@ -68,31 +52,15 @@ def test_can_get_export_runs_for_your_organizations(
 
 
 def test_cannot_get_exports_for_other_organizations(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     another_organization = create_organization("Another Org")
     another_user = create_user("another-test@user.com", "Another Test User", another_organization)
     client.force_login(user)
     response = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     client.force_login(another_user)
@@ -101,28 +69,12 @@ def test_cannot_get_exports_for_other_organizations(
 
 
 def test_batch_exports_are_partitioned_by_team(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
     """
     You shouldn't be able to fetch a BatchExport by id, via a team that it
     doesn't belong to.
     """
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     another_team = create_team(organization)
     # Integrations are team-scoped, so the other team's export needs its own.
     another_team_integration = Integration.objects.create(
@@ -137,7 +89,7 @@ def test_batch_exports_are_partitioned_by_team(
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
 
     response = get_batch_export(client, another_team.pk, batch_export["id"])
@@ -147,7 +99,10 @@ def test_batch_exports_are_partitioned_by_team(
     batch_export = create_batch_export_ok(
         client,
         another_team.pk,
-        {**batch_export_data, "destination": {**destination_data, "integration": another_team_integration.id}},
+        {
+            **s3_batch_export_data,
+            "destination": {**s3_batch_export_data["destination"], "integration": another_team_integration.id},
+        },
     )
 
     response = get_batch_export(client, team.pk, batch_export["id"])
@@ -155,23 +110,8 @@ def test_batch_exports_are_partitioned_by_team(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
+def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organization, team, user, s3_batch_export_data):
     """Test cancelling a BatchExportRun."""
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
 
     with patch("products.batch_exports.backend.temporal.pipeline.producer.Producer.start") as mock_producer_start:
@@ -185,7 +125,7 @@ def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organizatio
         batch_export = create_batch_export_ok(
             client,
             team.pk,
-            batch_export_data,
+            s3_batch_export_data,
         )
         batch_export_id = batch_export["id"]
 

--- a/products/batch_exports/backend/tests/api/test_test.py
+++ b/products/batch_exports/backend/tests/api/test_test.py
@@ -99,8 +99,8 @@ async def delete_all_from_s3(object_storage_client, bucket_name: str, key_prefix
 def object_storage_integration(team, user):
     """An s3-compatible Integration pointing at the local object storage used by these tests.
 
-    The shared `s3_compatible_integration` fixture points at a fake provider, and its endpoint and
-    credentials would override the inline ones when running a destination test step.
+    The shared `s3_compatible_integration` fixture points at a fake provider, so a destination test
+    step configured from it could not reach a real bucket.
     """
     return Integration.objects.create(
         team=team,
@@ -125,9 +125,6 @@ def test_can_run_s3_test_step_for_new_destination(
             "bucket_name": bucket_name,
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "object_storage_root_user",
-            "aws_secret_access_key": "object_storage_root_password",
-            "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
         },
     }
 
@@ -170,9 +167,6 @@ def test_can_run_s3_test_step_for_destination(
             "bucket_name": bucket_name,
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "object_storage_root_user",
-            "aws_secret_access_key": "object_storage_root_password",
-            "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
         },
     }
 
@@ -210,8 +204,8 @@ def test_run_test_step_rejects_destination_type_change(
     """A test step must not be able to change the destination type of an existing export.
 
     Otherwise a caller could, for example, switch an "AwsS3" export (no `endpoint_url`) to the
-    legacy "S3" type, supply a `endpoint_url` they control, and have the stored credentials tested
-    against that endpoint.
+    legacy "S3" type, supply an `endpoint_url` they control, and have the integration's credentials
+    tested against that endpoint.
     """
 
     destination_data = {
@@ -221,8 +215,6 @@ def test_run_test_step_rejects_destination_type_change(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -393,9 +385,6 @@ def test_can_run_s3_test_step_with_additional_fields(
             "bucket_name": bucket_name,
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "object_storage_root_user",
-            "aws_secret_access_key": "object_storage_root_password",
-            "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT,
         },
     }
 

--- a/products/batch_exports/backend/tests/api/test_test.py
+++ b/products/batch_exports/backend/tests/api/test_test.py
@@ -199,7 +199,7 @@ def test_can_run_s3_test_step_for_destination(
 
 
 def test_run_test_step_rejects_destination_type_change(
-    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, organization, team, user, s3_batch_export_data
 ):
     """A test step must not be able to change the destination type of an existing export.
 
@@ -208,24 +208,8 @@ def test_run_test_step_rejects_destination_type_change(
     tested against that endpoint.
     """
 
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
-    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
 
     malicious_data = {
         "name": "my-production-s3-bucket-destination",

--- a/products/batch_exports/backend/tests/api/test_update.py
+++ b/products/batch_exports/backend/tests/api/test_update.py
@@ -56,8 +56,6 @@ def test_can_put_config(client: HttpClient, temporal, encryption_codec, organiza
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -91,7 +89,6 @@ def test_can_put_config(client: HttpClient, temporal, encryption_codec, organiza
     # We should be able to update if we specify all fields
     new_destination_data = {**destination_data}
     new_destination_data["config"]["bucket_name"] = "my-new-production-s3-bucket"
-    new_destination_data["config"]["aws_secret_access_key"] = "new-secret"
     new_batch_export_data_2: dict[str, t.Any] = {
         "name": "my-production-s3-bucket-destination",
         "destination": new_destination_data,
@@ -119,7 +116,9 @@ def test_can_put_config(client: HttpClient, temporal, encryption_codec, organiza
     decoded_payload = async_to_sync(encryption_codec.decode)(new_schedule.schedule.action.args)
     args = json.loads(decoded_payload[0].data)
     assert args["bucket_name"] == "my-new-production-s3-bucket"
-    assert args["aws_secret_access_key"] == "new-secret"
+    # Credentials are resolved from the integration at run time, never carried in the schedule.
+    assert args["integration_id"] == aws_s3_integration.id
+    assert args.get("aws_secret_access_key") is None
 
 
 @pytest.mark.parametrize("interval", ["hour", "day"])
@@ -136,8 +135,6 @@ def test_can_patch_config(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -432,8 +429,6 @@ def test_can_patch_schedule_configuration(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -506,16 +501,15 @@ def test_can_patch_schedule_configuration(
 @pytest.mark.django_db
 @pytest.mark.parametrize("interval", ["hour", "day"])
 def test_can_patch_config_with_invalid_old_values(
-    client: HttpClient, encryption_codec, interval, temporal, organization, team, user
+    client: HttpClient, encryption_codec, interval, temporal, organization, team, user, aws_s3_integration
 ):
     destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
+        "integration": aws_s3_integration,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
             "invalid_key": "invalid_value",
         },
     }
@@ -540,7 +534,8 @@ def test_can_patch_config_with_invalid_old_values(
     # We should be able to update the destination config, even if there is an invalid config
     # in the existing keys.
     new_destination_data = {
-        "type": "S3",
+        "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-new-production-s3-bucket",
             "region": "us-east-1",
@@ -587,8 +582,6 @@ def test_patch_rejects_destination_type_change(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -640,8 +633,6 @@ def test_put_rejects_destination_type_change(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -687,8 +678,6 @@ def test_can_patch_hogql_query(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 
@@ -779,8 +768,6 @@ def test_patch_returns_error_on_unsupported_hogql_query(
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
         },
     }
 

--- a/products/batch_exports/backend/tests/api/test_update.py
+++ b/products/batch_exports/backend/tests/api/test_update.py
@@ -571,28 +571,12 @@ def test_patch_rejects_destination_type_change(
     organization,
     team,
     user,
-    aws_s3_integration,
+    s3_batch_export_data,
     bigquery_integration,
 ):
     """Assert PATCH cannot change the destination type — callers must delete and recreate."""
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
-    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
 
     new_destination_data = {
         "type": "BigQuery",
@@ -623,27 +607,11 @@ def test_put_rejects_destination_type_change(
     organization,
     team,
     user,
-    aws_s3_integration,
+    s3_batch_export_data,
 ):
     """Assert PUT cannot change the destination type either — same restriction as PATCH."""
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
-    batch_export = create_batch_export_ok(client, team.pk, batch_export_data)
+    batch_export = create_batch_export_ok(client, team.pk, s3_batch_export_data)
 
     new_batch_export_data = {
         "name": "my-production-s3-bucket-destination",
@@ -668,31 +636,15 @@ def test_put_rejects_destination_type_change(
 
 
 def test_can_patch_hogql_query(
-    client: HttpClient, temporal, encryption_codec, organization, team, user, aws_s3_integration
+    client: HttpClient, temporal, encryption_codec, organization, team, user, s3_batch_export_data
 ):
     """Test we can patch a schema with a HogQL query."""
-    destination_data = {
-        "type": "AwsS3",
-        "integration": aws_s3_integration.id,
-        "config": {
-            "bucket_name": "my-production-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "posthog-events/",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-s3-bucket-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
     client.force_login(user)
 
     batch_export = create_batch_export_ok(
         client,
         team.pk,
-        batch_export_data,
+        s3_batch_export_data,
     )
     old_schedule = describe_schedule(temporal, batch_export["id"])
 

--- a/products/batch_exports/backend/tests/api/test_update_s3.py
+++ b/products/batch_exports/backend/tests/api/test_update_s3.py
@@ -16,44 +16,6 @@ pytestmark = [
 ]
 
 
-def _assert_empty_inputs_rejected(client: HttpClient, team_id: int, batch_export_id, destination_type: str) -> None:
-    response = patch_batch_export(
-        client,
-        team_id,
-        batch_export_id,
-        {
-            "destination": {
-                "type": destination_type,
-                "config": {
-                    "bucket_name": "my-new-bucket",
-                    "aws_access_key_id": "",
-                    "aws_secret_access_key": "",
-                },
-            },
-        },
-    )
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"] == "The following inputs are empty: ['aws_access_key_id', 'aws_secret_access_key']"
-
-
-def test_updating_legacy_s3_batch_export_validates_empty_inputs(client: HttpClient, temporal, organization, team, user):
-    """Legacy `S3` rows can no longer be created, but existing ones must remain patchable and validated."""
-    destination = BatchExportDestination.objects.create(
-        type="S3",
-        config={
-            "bucket_name": "my-s3-bucket",
-            "region": "us-east-1",
-            "prefix": "events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
-        },
-    )
-    batch_export = create_batch_export_orm(team, destination)
-
-    client.force_login(user)
-    _assert_empty_inputs_rejected(client, team.pk, str(batch_export.id), "S3")
-
-
 _S3_FAMILY_INTEGRATIONS = [
     ("AwsS3", Integration.IntegrationKind.AWS_S3, {"name": "prod-aws", "aws_account_id": "123456789012"}),
     (
@@ -93,7 +55,7 @@ def _create_integration_backed_export(client: HttpClient, team, user, destinatio
 
 @pytest.mark.parametrize("destination_type,kind,integration_config", _S3_FAMILY_INTEGRATIONS)
 @pytest.mark.parametrize("integration_value", [None, "omitted"])
-def test_updating_s3_family_batch_export_rejects_removing_integration(
+def test_updating_s3_family_batch_export_requires_an_integration(
     client: HttpClient,
     temporal,
     organization,
@@ -104,21 +66,25 @@ def test_updating_s3_family_batch_export_rejects_removing_integration(
     integration_config,
     integration_value,
 ):
-    """An integration-backed export can't drop back to inline credentials — whether the caller
-    sends `integration: null` or omits it entirely (clients re-send the full destination on update).
+    """An export can't drop its integration: sending `integration: null` is rejected, and omitting
+    it entirely keeps the one already linked.
     """
-    _, batch_export = _create_integration_backed_export(client, team, user, destination_type, kind, integration_config)
+    integration, batch_export = _create_integration_backed_export(
+        client, team, user, destination_type, kind, integration_config
+    )
 
-    destination: dict = {"type": destination_type, "config": {}}
+    destination: dict = {"type": destination_type, "config": {"prefix": "new-prefix/"}}
     if integration_value is None:
         destination["integration"] = None
 
     response = patch_batch_export(client, team.pk, batch_export["id"], {"destination": destination})
-    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert response.json()["detail"] == (
-        "Cannot remove the integration from an S3 batch export that uses one. "
-        "Re-send its `integration` to keep it (or a different one to swap)."
-    )
+
+    if integration_value is None:
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["detail"] == f"Integration is required for {destination_type} batch exports"
+    else:
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["destination"]["integration"] == integration.id
 
 
 @pytest.mark.parametrize("destination_type,kind,integration_config", _S3_FAMILY_INTEGRATIONS)
@@ -141,8 +107,34 @@ def test_updating_integration_backed_s3_export_allows_config_patch_with_integrat
     assert response.json()["destination"]["integration"] == integration.id
 
 
-def test_updating_legacy_s3_batch_export_rejects_integration(client: HttpClient, temporal, organization, team, user):
-    """The legacy `S3` type doesn't support integration-based credentials, so linking one is rejected."""
+@pytest.mark.parametrize("destination_type,kind,integration_config", _S3_FAMILY_INTEGRATIONS)
+def test_updating_migrated_s3_batch_export_ignores_credentials_left_in_stored_config(
+    client: HttpClient, temporal, organization, team, user, destination_type, kind, integration_config
+):
+    """Exports migrated onto an integration still hold their old credentials in stored config.
+
+    Those stale values must not make the export unpatchable: only the submitted config is checked
+    for credential fields.
+    """
+    integration, batch_export = _create_integration_backed_export(
+        client, team, user, destination_type, kind, integration_config
+    )
+    destination = BatchExportDestination.objects.get(batchexport__id=batch_export["id"])
+    destination.config = {**destination.config, "aws_access_key_id": "stale", "aws_secret_access_key": "stale"}
+    destination.save()
+
+    response = patch_batch_export(
+        client,
+        team.pk,
+        batch_export["id"],
+        {"destination": {"type": destination_type, "config": {"prefix": "new-prefix/"}, "integration": integration.id}},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json()["destination"]["config"]["prefix"] == "new-prefix/"
+
+
+def test_updating_legacy_s3_batch_export_is_rejected(client: HttpClient, temporal, organization, team, user):
+    """The legacy `S3` type has been migrated away and accepts no writes."""
     destination = BatchExportDestination.objects.create(
         type="S3",
         config={
@@ -154,21 +146,13 @@ def test_updating_legacy_s3_batch_export_rejects_integration(client: HttpClient,
         },
     )
     batch_export = create_batch_export_orm(team, destination)
-    integration = Integration.objects.create(
-        team=team,
-        kind=Integration.IntegrationKind.AWS_S3,
-        integration_id="prod-aws",
-        config={"name": "prod-aws", "aws_account_id": "123456789012"},
-        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
-        created_by=user,
-    )
 
     client.force_login(user)
     response = patch_batch_export(
         client,
         team.pk,
         str(batch_export.id),
-        {"destination": {"type": "S3", "config": {}, "integration": integration.id}},
+        {"destination": {"type": "S3", "config": {"prefix": "new-prefix/"}}},
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert response.json()["detail"] == "S3 destinations do not support integration-based credentials."
+    assert "deprecated" in response.json()["detail"]

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -477,7 +477,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.
+     * ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.
      * @nullable
      */
     integration_id?: number | null
@@ -1374,7 +1374,7 @@ export const AwsS3DestinationRequestApiType = {
  */
 export interface AwsS3DestinationRequestApi {
     type: AwsS3DestinationRequestApiType
-    /** ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+    /** ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one. */
     integration_id: number
     config: AwsS3DestinationConfigApi
 }
@@ -1391,7 +1391,7 @@ export const S3CompatibleDestinationRequestApiType = {
  */
 export interface S3CompatibleDestinationRequestApi {
     type: S3CompatibleDestinationRequestApiType
-    /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+    /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one. */
     integration_id: number
     config: S3CompatibleDestinationConfigApi
 }

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -477,7 +477,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.
+     * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.
      * @nullable
      */
     integration_id?: number | null

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -477,7 +477,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.
+     * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.
      * @nullable
      */
     integration_id?: number | null

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -192,7 +192,7 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -248,7 +248,7 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -889,7 +889,7 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -945,7 +945,7 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -1341,7 +1341,7 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -1397,7 +1397,7 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -1984,7 +1984,7 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
@@ -2429,7 +2429,7 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
@@ -2863,7 +2863,7 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
@@ -3318,7 +3318,7 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -1984,7 +1984,7 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.'
                     ),
             })
             .describe(
@@ -2429,7 +2429,7 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.'
                     ),
             })
             .describe(
@@ -2863,7 +2863,7 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.'
                     ),
             })
             .describe(
@@ -3318,7 +3318,7 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.'
                     ),
             })
             .describe(

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -1984,7 +1984,7 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.'
                     ),
             })
             .describe(
@@ -2429,7 +2429,7 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.'
                     ),
             })
             .describe(
@@ -2863,7 +2863,7 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.'
                     ),
             })
             .describe(
@@ -3318,7 +3318,7 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.'
                     ),
             })
             .describe(

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12214,7 +12214,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.
+         * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.
          * @nullable
          */
       integration_id?: number | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12214,7 +12214,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.
+         * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake and Redshift, which still support inline credentials.
          * @nullable
          */
       integration_id?: number | null;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11223,7 +11223,7 @@ export namespace Schemas {
      */
     export interface AwsS3DestinationRequest {
       type: AwsS3DestinationRequestType;
-      /** ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+      /** ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one. */
       integration_id: number;
       config: AwsS3DestinationConfig;
     }
@@ -12214,7 +12214,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.
+         * ID of a team-scoped Integration providing credentials. Required for AwsS3 and S3Compatible destinations, and when creating Databricks, AzureBlob, BigQuery and Postgres destinations; optional for Snowflake and Redshift (inline credentials remain supported); unused for other types.
          * @nullable
          */
       integration_id?: number | null;
@@ -13178,7 +13178,7 @@ export namespace Schemas {
      */
     export interface S3CompatibleDestinationRequest {
       type: S3CompatibleDestinationRequestType;
-      /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+      /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one. */
       integration_id: number;
       config: S3CompatibleDestinationConfig;
     }

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -208,7 +208,7 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -263,7 +263,7 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -660,7 +660,7 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -715,7 +715,7 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         integration_id: zod
                             .number()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
@@ -265,7 +265,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {
@@ -334,7 +334,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
@@ -264,7 +264,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {
@@ -333,7 +333,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {


### PR DESCRIPTION
## Problem

We've migrated all `S3` destinations to either `AwsS3` or `S3Compatible` and have also migrated all S3-family exports to use integrations.

We now want to enforce this at the API-level: we don't expect any `S3` destinations to be created or updated, and we don't expect inline credentials to be used.

## Changes

- A write to the deprecated `S3` destination type is rejected. Creating one was already blocked; updating one now is too.
- A request that puts `aws_access_key_id`, `aws_secret_access_key` or `endpoint_url` in an S3 export's configuration is now rejected, with a message naming the fields to remove.
- A `PATCH` that omits the integration now keeps the one already linked. It used to fail, so a caller had to re-send the integration just to change a bucket name.
- Sending `integration: null` is still rejected. An export cannot drop the only thing it can authenticate with.
- Only the *submitted* configuration is checked for credential fields. Exports the migration moved onto an integration still hold their old keys in stored config, and this keeps them patchable.


Most of the diff is test cleanup. One `s3_batch_export_data` fixture replaces 29 copies of the same create payload across 9 files, and the Redshift host test moves to `test_create_redshift.py`.

The `endpoint_url` SSRF check is gone from this serializer, not lost. `S3CompatibleIntegration.integration_from_config` validates the endpoint when the integration is created, and the endpoint can no longer reach an export any other way.

## How did you test this code?

Automated tests run locally.

Not tested manually. No run against a live AWS bucket.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) in PostHog Desktop, directed by @rossgray. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/stacking-prs`.

Bottom layer of a three-PR stack. The layers above remove the matching paths from the Temporal activity, then from the input dataclasses.

Nothing here carries material from the agent session. The work drew only on this repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
