### PR TITLE
fix(mssql): suppress transient EOF-from-server errors from error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -61,6 +61,15 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.MSSQL
 
+    def get_retryable_errors(self) -> set[str]:
+        return {
+            # DB-Lib error 20017 — the SQL Server closed the TCP connection during query
+            # execution (server restart, query timeout, or a brief network interruption).
+            # A fresh connection from the next Temporal retry resolves it; keep it out of
+            # error tracking so it doesn't surface as noise.
+            "Unexpected EOF from the server",
+        }
+
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
             # Azure SQL error 40615 — the server-level firewall rejected PostHog's client IP. This

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -730,6 +730,26 @@ class TestMSSQLSourceNonRetryableErrors:
         assert any(pattern in str(exc_info.value) for pattern in non_retryable.keys())
 
 
+class TestMSSQLSourceRetryableErrors:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            # Real pymssql shape: DB-Lib error 20017 carried as (code, bytes) args.
+            pymssql.OperationalError(
+                20017, b"DB-Lib error message 20017, severity 9:\nUnexpected EOF from the server\n"
+            ),
+            # The SQL-Server-message rendering of the same EOF.
+            pymssql.OperationalError(
+                "SQL Server message 20017, severity 9, state 0, procedure b'\\x00', line 0:\n"
+                "b'DB-Lib error message 20017, severity 9:\\nUnexpected EOF from the server\\n'"
+            ),
+        ],
+    )
+    def test_unexpected_eof_is_retryable(self, error):
+        retryable = MSSQLSource().get_retryable_errors()
+        assert any(pattern.lower() in str(error).lower() for pattern in retryable), str(error)
+
+
 class TestMSSQLSourceValidateCredentials:
     @pytest.fixture
     def source(self):


### PR DESCRIPTION
## Problem

MSSQL syncs that hit a transient server-side connection drop (SQL Server DB-Lib error 20017, "Unexpected EOF from the server") are captured in error tracking as exceptions. The error is a transient connection blip — server restart, query timeout, or brief network interruption — that the next Temporal retry resolves. No customer action is needed.

Without a `get_retryable_errors` entry, error 20017 fell through `_handle_import_error` to `logger.aexception`, creating error-tracking noise on every occurrence.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/01a048dc-35bb-7a00-9665-e59e8ce55db3

## Changes

- `MSSQLSource.get_retryable_errors()` now includes `"Unexpected EOF from the server"`. The error is logged at warning level and re-raised as `NonReportableError`, keeping Temporal's retry loop intact while removing it from error tracking. This mirrors the same pattern `SnowflakeSource` uses for its transient connection blips.

Mechanical: two new parameterized test cases, no pipeline or timeout changes.

## How did you test this code?

- `TestMSSQLSourceRetryableErrors::test_unexpected_eof_is_retryable` (2 parameterized cases) catches the regression where the pattern is removed or stops matching the actual pymssql error string.
- Full MSSQL test suite: 97/97 passed locally.
- Not checked: the Temporal activity path end-to-end; the suppression relies on `_handle_import_error`'s existing `get_retryable_errors` branch, which is tested by shared pipeline tests.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a PostHog error-tracking alert for MSSQL error 20017 via the error-tracking MCP and source-code analysis. Traced the exception through `_handle_import_error` to confirm it fell through to `logger.aexception` rather than the `get_retryable_errors` warning-and-suppress path. Confirmed no open PRs address this error. Classified as a transient connection drop following the same pattern as `SnowflakeSource.get_retryable_errors`. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*