### PR TITLE
feat(logs): point the empty logs state at drop rules

### DIFF
--- a/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
+++ b/products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList.tsx
@@ -29,6 +29,7 @@ import { LogRow } from 'products/logs/frontend/components/VirtualizedLogsList/Lo
 import { LogRowHeader } from 'products/logs/frontend/components/VirtualizedLogsList/LogRowHeader'
 import { VirtualizedTableColumn } from 'products/logs/frontend/components/VirtualizedLogsList/types'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
+import { logsDropRulesSettingsUrl } from 'products/logs/frontend/logsDropRulesSettingsUrl'
 import { LogsOrderBy, ParsedLogMessage } from 'products/logs/frontend/types'
 
 const HedgehogMagnifyingGlass = pngHoggie(magnifyingGlassPng)
@@ -349,10 +350,16 @@ export function VirtualizedLogsList({
                     <h4 className="font-semibold m-0">No logs found</h4>
                     <p className="text-muted text-sm mt-1 mb-0 max-w-80">
                         Try adjusting your filters, expanding the time range, or checking that your app is sending logs.
+                        Drop rules can also remove logs before they are stored.
                     </p>
-                    <Link to="https://posthog.com/docs/logs/" target="_blank">
-                        View documentation
-                    </Link>
+                    <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+                        <Link to={logsDropRulesSettingsUrl()} data-attr="logs-empty-state-drop-rules">
+                            Check drop rules
+                        </Link>
+                        <Link to="https://posthog.com/docs/logs/" target="_blank">
+                            View documentation
+                        </Link>
+                    </div>
                 </div>
                 {onExpandTimeRange && (
                     <LemonButton type="secondary" size="small" onClick={onExpandTimeRange}>


### PR DESCRIPTION
## Problem

Someone searching the logs viewer sees "No logs found" and concludes their app is not sending logs, when a drop rule removed the lines before storage. The empty state names three causes (filters, time range, the app itself) and leaves that one out, so the user has no reason to open Logs → Configuration → Drop rules.

## Changes

- The empty state now says drop rules can remove logs before storage, and links to Logs → Configuration → Drop rules.
- The link reuses the existing `logsDropRulesSettingsUrl()` helper, so it lands with the Drop rules item already selected.
- The two links sit in a wrapping flex row next to "View documentation". Nothing else in the state changed.

Before and after:

![before](https://raw.githubusercontent.com/PostHog/pr-assets/ede221b243aaea3d4755b7548fe5dccd182f0b0d/2026/08/fd218ab9-ef06-4646-ae75-2a6b5dd4dfb8.png)

![after](https://raw.githubusercontent.com/PostHog/pr-assets/00a9acfb681ded2f484a1d9779d66a590c5d5c9b/2026/08/1beccf81-01c1-4893-95c0-fa434562f8a3.png)

Where the link lands:

![drop rules](https://raw.githubusercontent.com/PostHog/pr-assets/b7c85e5e306380cbadf5382664a26198885fd58b/2026/08/efed4e0c-2eed-4664-a129-5db596b5fa2a.png)

## How did you test this code?

Rendered the empty state in Storybook behind a temporary story that answers `logs/query` with no results, then clicked the new link and confirmed it opens the Configuration tab with Drop rules selected. The three screenshots above come from that run. The temporary story is not part of this PR.

No tests added: the change is a static string and a link built by a helper that other call sites already cover.

Not checked: `pnpm typescript:check` reports 422 pre-existing errors from the unbuilt quill workspace on master, none of them in `products/logs`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested in Slack by a PostHog engineer after a dev-environment log lookup came up empty and turned out to be a drop rule. The PostHog Slack app made the change.

Skills invoked: `/writing-user-facing-copy`, `/writing-ui-components`, `/writing-pr-descriptions`.

Two decisions worth flagging. The hint always renders rather than loading the team's drop rules first: `logsSamplingSectionLogic` polls HogQL every 30 seconds, and mounting it from an empty state would fire that in every embedded logs viewer. The copy adds one sentence to the existing paragraph instead of a `LemonBanner`, which would outweigh the state it sits in.

The committed diff contains no session material: one sentence of product copy and a helper call.
