### PR TITLE
fix(engineering-analytics): scope PR-list CI rollups to visible PRs

### DIFF
--- a/products/engineering_analytics/backend/logic/queries/_curated.py
+++ b/products/engineering_analytics/backend/logic/queries/_curated.py
@@ -311,24 +311,25 @@ class CuratedGitHubSource:
         """
         return f"runs AS {self.run_source()}"
 
-    def _pr_scope_set(self, column: str, pr_scope_where: str) -> str:
-        """IN-subquery over the curated PR source: the ``column`` values of PRs matching
-        ``pr_scope_where`` (a predicate over unqualified curated PR columns).
+    def _pr_scope_cte(self, pr_scope_where: str) -> str:
+        """CTE: the number and head SHA of PRs matching ``pr_scope_where`` (a predicate over
+        unqualified curated PR columns), read once and shared by both runs rollups below —
+        the same one-scan-per-query reasoning as ``runs_cte``, applied to the PR source.
 
         The runs rollups only ever join back to PRs the consuming query keeps, so they
-        prefilter the runs scan to that set. Unscoped, they aggregate the team's whole
+        prefilter the runs scan to this set. Unscoped, they aggregate the team's whole
         run history — millions of ``(head_sha, workflow)`` groups on a busy repo — and
         the query runs out of memory before the join discards almost all of it.
         """
-        return f"(SELECT {column} FROM {self.pr_source()} AS scope_pr WHERE {pr_scope_where})"
+        return f"pr_scope AS (SELECT number, head_sha FROM {self.pr_source()} AS scope_pr WHERE {pr_scope_where})"
 
-    def ci_rollup_cte(self, *, pr_scope_where: str) -> str:
+    def ci_rollup_cte(self) -> str:
         """CTE collapsing each head SHA's workflow runs into pass/fail/pending counts.
 
         Takes the latest run per ``(head_sha, workflow_name)`` via ``argMax`` (a PR's CI status
         is its newest run per workflow), then aggregates per SHA. Reads the shared ``runs`` CTE
         (see ``runs_cte``); ``head_sha`` is the only link between a PR and its CI. Scoped to the
-        head SHAs of PRs matching ``pr_scope_where`` (see ``_pr_scope_set``).
+        ``pr_scope`` CTE the composing query adds (see ``_pr_scope_cte``).
         """
         return f"""
             ci_rollup AS (
@@ -350,7 +351,7 @@ class CuratedGitHubSource:
                         argMax(status, run_started_at) AS s,
                         argMax(conclusion, run_started_at) AS c
                     FROM runs AS r
-                    WHERE r.head_sha IN {self._pr_scope_set("head_sha", pr_scope_where)}
+                    WHERE head_sha IN (SELECT head_sha FROM pr_scope)
                     GROUP BY head_sha, workflow_name
                 )
                 GROUP BY head_sha
@@ -360,16 +361,19 @@ class CuratedGitHubSource:
     def pr_rollup_query(self, select: str, *, pr_scope_where: str) -> str:
         """Compose a pull-requests query that reads ``FROM __PR_SOURCE__ AS pr LEFT JOIN ci_rollup``.
 
-        Prefixes ``select`` with the CI rollup CTE and fills its ``__PR_SOURCE__`` placeholder
-        with the curated pull-requests source — the two steps the cards and PR-list queries always
-        do together. ``pr_scope_where`` must keep every PR the ``select`` reads CI for (it prunes
-        the rollup scan, see ``_pr_scope_set``); a PR outside it joins as if it had no runs.
+        Prefixes ``select`` with the ``pr_scope`` and CI rollup CTEs and fills its
+        ``__PR_SOURCE__`` placeholder with the curated pull-requests source — the steps the
+        cards and PR-list queries always do together. ``pr_scope_where`` must keep every PR the
+        ``select`` reads CI for (it prunes the rollup scan, see ``_pr_scope_cte``); a PR outside
+        it joins as if it had no runs.
         """
-        return self._compose_pr_query([self.runs_cte(), self.ci_rollup_cte(pr_scope_where=pr_scope_where)], select)
+        return self._compose_pr_query(
+            [self.runs_cte(), self._pr_scope_cte(pr_scope_where), self.ci_rollup_cte()], select
+        )
 
-    def runs_by_pr_cte(self, *, pr_scope_where: str) -> str:
+    def runs_by_pr_cte(self) -> str:
         """CTE: per-PR activity from the workflow runs attributed to each PR. Scoped to the
-        numbers of PRs matching ``pr_scope_where`` (see ``_pr_scope_set``); the scope is a
+        ``pr_scope`` CTE the composing query adds (see ``_pr_scope_cte``); the scope is a
         prefilter — the repo-qualified join below still decides correctness.
 
         A run records the PR(s) it ran for in ``pull_requests``; the curated run source surfaces
@@ -400,7 +404,7 @@ class CuratedGitHubSource:
                     countIf(run_attempt > 1) AS rerun_cycles
                 FROM runs AS r
                 WHERE pr_number > 0 AND NOT is_merge_queue
-                    AND pr_number IN {self._pr_scope_set("number", pr_scope_where)}
+                    AND pr_number IN (SELECT number FROM pr_scope)
                 GROUP BY repo_owner, repo_name, pr_number
             )
         """
@@ -408,11 +412,12 @@ class CuratedGitHubSource:
     def pr_list_rollup_query(self, select: str, *, pr_scope_where: str) -> str:
         """``pr_rollup_query`` plus the per-PR runs rollup and, when it is observable, the
         ``ready_by_pr`` rollup ``ready_to_merge_sql`` reads. ``pr_scope_where`` scopes both
-        runs rollups (see ``pr_rollup_query``)."""
+        runs rollups via the shared ``pr_scope`` CTE (see ``pr_rollup_query``)."""
         ctes = [
             self.runs_cte(),
-            self.ci_rollup_cte(pr_scope_where=pr_scope_where),
-            self.runs_by_pr_cte(pr_scope_where=pr_scope_where),
+            self._pr_scope_cte(pr_scope_where),
+            self.ci_rollup_cte(),
+            self.runs_by_pr_cte(),
         ]
         ready_cte = self.ready_to_merge_sql().cte
         if ready_cte:

--- a/products/engineering_analytics/backend/logic/queries/_curated.py
+++ b/products/engineering_analytics/backend/logic/queries/_curated.py
@@ -311,12 +311,24 @@ class CuratedGitHubSource:
         """
         return f"runs AS {self.run_source()}"
 
-    def ci_rollup_cte(self) -> str:
+    def _pr_scope_set(self, column: str, pr_scope_where: str) -> str:
+        """IN-subquery over the curated PR source: the ``column`` values of PRs matching
+        ``pr_scope_where`` (a predicate over unqualified curated PR columns).
+
+        The runs rollups only ever join back to PRs the consuming query keeps, so they
+        prefilter the runs scan to that set. Unscoped, they aggregate the team's whole
+        run history — millions of ``(head_sha, workflow)`` groups on a busy repo — and
+        the query runs out of memory before the join discards almost all of it.
+        """
+        return f"(SELECT {column} FROM {self.pr_source()} AS scope_pr WHERE {pr_scope_where})"
+
+    def ci_rollup_cte(self, *, pr_scope_where: str) -> str:
         """CTE collapsing each head SHA's workflow runs into pass/fail/pending counts.
 
         Takes the latest run per ``(head_sha, workflow_name)`` via ``argMax`` (a PR's CI status
         is its newest run per workflow), then aggregates per SHA. Reads the shared ``runs`` CTE
-        (see ``runs_cte``); ``head_sha`` is the only link between a PR and its CI.
+        (see ``runs_cte``); ``head_sha`` is the only link between a PR and its CI. Scoped to the
+        head SHAs of PRs matching ``pr_scope_where`` (see ``_pr_scope_set``).
         """
         return f"""
             ci_rollup AS (
@@ -338,23 +350,27 @@ class CuratedGitHubSource:
                         argMax(status, run_started_at) AS s,
                         argMax(conclusion, run_started_at) AS c
                     FROM runs AS r
+                    WHERE r.head_sha IN {self._pr_scope_set("head_sha", pr_scope_where)}
                     GROUP BY head_sha, workflow_name
                 )
                 GROUP BY head_sha
             )
         """
 
-    def pr_rollup_query(self, select: str) -> str:
+    def pr_rollup_query(self, select: str, *, pr_scope_where: str) -> str:
         """Compose a pull-requests query that reads ``FROM __PR_SOURCE__ AS pr LEFT JOIN ci_rollup``.
 
         Prefixes ``select`` with the CI rollup CTE and fills its ``__PR_SOURCE__`` placeholder
         with the curated pull-requests source — the two steps the cards and PR-list queries always
-        do together.
+        do together. ``pr_scope_where`` must keep every PR the ``select`` reads CI for (it prunes
+        the rollup scan, see ``_pr_scope_set``); a PR outside it joins as if it had no runs.
         """
-        return self._compose_pr_query([self.runs_cte(), self.ci_rollup_cte()], select)
+        return self._compose_pr_query([self.runs_cte(), self.ci_rollup_cte(pr_scope_where=pr_scope_where)], select)
 
-    def runs_by_pr_cte(self) -> str:
-        """CTE: per-PR activity from the workflow runs attributed to each PR.
+    def runs_by_pr_cte(self, *, pr_scope_where: str) -> str:
+        """CTE: per-PR activity from the workflow runs attributed to each PR. Scoped to the
+        numbers of PRs matching ``pr_scope_where`` (see ``_pr_scope_set``); the scope is a
+        prefilter — the repo-qualified join below still decides correctness.
 
         A run records the PR(s) it ran for in ``pull_requests``; the curated run source surfaces
         the first as ``pr_number``. ``pushes`` counts the distinct head SHAs that triggered CI
@@ -384,14 +400,20 @@ class CuratedGitHubSource:
                     countIf(run_attempt > 1) AS rerun_cycles
                 FROM runs AS r
                 WHERE pr_number > 0 AND NOT is_merge_queue
+                    AND pr_number IN {self._pr_scope_set("number", pr_scope_where)}
                 GROUP BY repo_owner, repo_name, pr_number
             )
         """
 
-    def pr_list_rollup_query(self, select: str) -> str:
+    def pr_list_rollup_query(self, select: str, *, pr_scope_where: str) -> str:
         """``pr_rollup_query`` plus the per-PR runs rollup and, when it is observable, the
-        ``ready_by_pr`` rollup ``ready_to_merge_sql`` reads."""
-        ctes = [self.runs_cte(), self.ci_rollup_cte(), self.runs_by_pr_cte()]
+        ``ready_by_pr`` rollup ``ready_to_merge_sql`` reads. ``pr_scope_where`` scopes both
+        runs rollups (see ``pr_rollup_query``)."""
+        ctes = [
+            self.runs_cte(),
+            self.ci_rollup_cte(pr_scope_where=pr_scope_where),
+            self.runs_by_pr_cte(pr_scope_where=pr_scope_where),
+        ]
         ready_cte = self.ready_to_merge_sql().cte
         if ready_cte:
             ctes.append(ready_cte)

--- a/products/engineering_analytics/backend/logic/queries/ci_cards.py
+++ b/products/engineering_analytics/backend/logic/queries/ci_cards.py
@@ -10,14 +10,18 @@ from products.engineering_analytics.backend.logic.queries._curated import Curate
 
 _EMPTY = CICardSummary(open_prs=0, repos=0, stuck=0, failing_ci=0)
 
-_SELECT = """
+# Every _SELECT metric below is gated on this, and it also scopes the rollup CTEs to the
+# same PRs (see query_ci_cards) — one definition so the two can never drift apart.
+_OPEN = "state = 'open'"
+
+_SELECT = f"""
     SELECT
-        countIf(pr.state = 'open') AS open_prs,
-        count(DISTINCT if(pr.state = 'open', concat(pr.repo_owner, '/', pr.repo_name), NULL)) AS repos,
+        countIf(pr.{_OPEN}) AS open_prs,
+        count(DISTINCT if(pr.{_OPEN}, concat(pr.repo_owner, '/', pr.repo_name), NULL)) AS repos,
         countIf(
-            pr.state = 'open' AND NOT pr.is_draft AND NOT pr.is_bot AND pr.created_at < now() - INTERVAL 7 DAY
+            pr.{_OPEN} AND NOT pr.is_draft AND NOT pr.is_bot AND pr.created_at < now() - INTERVAL 7 DAY
         ) AS stuck,
-        countIf(pr.state = 'open' AND coalesce(ci.failing, 0) > 0) AS failing_ci
+        countIf(pr.{_OPEN} AND coalesce(ci.failing, 0) > 0) AS failing_ci
     FROM __PR_SOURCE__ AS pr
     LEFT JOIN ci_rollup AS ci ON ci.head_sha = pr.head_sha
 """
@@ -26,7 +30,7 @@ _SELECT = """
 def query_ci_cards(*, curated: CuratedGitHubSource) -> CICardSummary:
     # Every count only reads CI for open PRs, so the rollup scan is scoped to their head SHAs.
     response = curated.run(
-        curated.pr_rollup_query(_SELECT, pr_scope_where="state = 'open'"),
+        curated.pr_rollup_query(_SELECT, pr_scope_where=_OPEN),
         query_type="engineering_analytics.ci_cards",
     )
     if not response.results:

--- a/products/engineering_analytics/backend/logic/queries/ci_cards.py
+++ b/products/engineering_analytics/backend/logic/queries/ci_cards.py
@@ -24,7 +24,11 @@ _SELECT = """
 
 
 def query_ci_cards(*, curated: CuratedGitHubSource) -> CICardSummary:
-    response = curated.run(curated.pr_rollup_query(_SELECT), query_type="engineering_analytics.ci_cards")
+    # Every count only reads CI for open PRs, so the rollup scan is scoped to their head SHAs.
+    response = curated.run(
+        curated.pr_rollup_query(_SELECT, pr_scope_where="state = 'open'"),
+        query_type="engineering_analytics.ci_cards",
+    )
     if not response.results:
         return _EMPTY
     open_prs, repos, stuck, failing_ci = response.results[0]

--- a/products/engineering_analytics/backend/logic/queries/pull_request_list.py
+++ b/products/engineering_analytics/backend/logic/queries/pull_request_list.py
@@ -29,10 +29,11 @@ _LIMIT = 1000
 _PUSH_HISTORY_LIMIT = 20
 
 
-def _visible_prs_where(prefix: str, author_clause: str) -> str:
+def _visible_prs_where(prefix: str, author: str | None) -> str:
     """The list's row predicate, buildable against the ``pr`` alias (outer WHERE) or
     unqualified curated PR columns (the runs-rollup scope) — one definition so the
     rollup scope can never drift narrower than the rows it must serve."""
+    author_clause = f"AND {prefix}author_handle = {{author}}" if author else ""
     return f"""(
             {prefix}state = 'open'
             OR {prefix}merged_at >= {{date_from}}
@@ -144,18 +145,14 @@ def query_pull_request_list(
     if author:
         placeholders["author"] = ast.Constant(value=author)
 
-    def visible_where(prefix: str) -> str:
-        author_clause = f"AND {prefix}author_handle = {{author}}" if author else ""
-        return _visible_prs_where(prefix, author_clause)
-
     ready = curated.ready_to_merge_sql()
     select = (
         _SELECT.replace("__READY_TO_MERGE__", f"{ready.expr} AS ready_to_merge_seconds")
         .replace("__READY_JOIN__", ready.join)
-        .replace("__VISIBLE_PRS__", visible_where("pr."))
+        .replace("__VISIBLE_PRS__", _visible_prs_where("pr.", author))
     )
     response = curated.run(
-        curated.pr_list_rollup_query(select, pr_scope_where=visible_where("")),
+        curated.pr_list_rollup_query(select, pr_scope_where=_visible_prs_where("", author)),
         query_type="engineering_analytics.pull_request_list",
         placeholders=placeholders,
     )

--- a/products/engineering_analytics/backend/logic/queries/pull_request_list.py
+++ b/products/engineering_analytics/backend/logic/queries/pull_request_list.py
@@ -28,6 +28,18 @@ _LIMIT = 1000
 # Sparkline cap: enough to read a PR's CI history at a glance without bloating a 1000-row page.
 _PUSH_HISTORY_LIMIT = 20
 
+
+def _visible_prs_where(prefix: str, author_clause: str) -> str:
+    """The list's row predicate, buildable against the ``pr`` alias (outer WHERE) or
+    unqualified curated PR columns (the runs-rollup scope) — one definition so the
+    rollup scope can never drift narrower than the rows it must serve."""
+    return f"""(
+            {prefix}state = 'open'
+            OR {prefix}merged_at >= {{date_from}}
+            OR {prefix}closed_at >= {{date_from}}
+        ) {author_clause}"""
+
+
 _SELECT = f"""
     SELECT
         pr.number, pr.title, pr.repo_owner, pr.repo_name,
@@ -48,11 +60,7 @@ _SELECT = f"""
     LEFT JOIN runs_by_pr AS rp
         ON rp.repo_owner = pr.repo_owner AND rp.repo_name = pr.repo_name AND rp.pr_number = pr.number
     __READY_JOIN__
-    WHERE (
-            pr.state = 'open'
-            OR pr.merged_at >= {{date_from}}
-            OR pr.closed_at >= {{date_from}}
-        ) __AUTHOR__
+    WHERE __VISIBLE_PRS__
     ORDER BY pr.created_at DESC
     LIMIT {_LIMIT + 1}
 """
@@ -133,18 +141,21 @@ def query_pull_request_list(
     *, curated: CuratedGitHubSource, date_from: datetime, author: str | None = None
 ) -> PullRequestList:
     placeholders: dict[str, ast.Expr] = {"date_from": ast.Constant(value=date_from)}
-    author_clause = ""
     if author:
-        author_clause = "AND pr.author_handle = {author}"
         placeholders["author"] = ast.Constant(value=author)
+
+    def visible_where(prefix: str) -> str:
+        author_clause = f"AND {prefix}author_handle = {{author}}" if author else ""
+        return _visible_prs_where(prefix, author_clause)
+
     ready = curated.ready_to_merge_sql()
     select = (
         _SELECT.replace("__READY_TO_MERGE__", f"{ready.expr} AS ready_to_merge_seconds")
         .replace("__READY_JOIN__", ready.join)
-        .replace("__AUTHOR__", author_clause)
+        .replace("__VISIBLE_PRS__", visible_where("pr."))
     )
     response = curated.run(
-        curated.pr_list_rollup_query(select),
+        curated.pr_list_rollup_query(select, pr_scope_where=visible_where("")),
         query_type="engineering_analytics.pull_request_list",
         placeholders=placeholders,
     )


### PR DESCRIPTION
## Problem

Opening the engineering analytics PR list (and its header cards) fails with "This query ran out of memory before it could finish" on repos with a large CI history.

- The list and cards queries aggregate the team's whole workflow-run history into `ci_rollup` / `runs_by_pr` before joining it to at most one page of PRs.
- On PostHog/posthog that is roughly 2.7M run rows collapsing into roughly 2.2M `(head_sha, workflow)` groups.
- The shared `runs` CTE inlines once per reference, so the scan and its aggregation state build twice in one query.

## Changes

- The PR list and the header cards load again on large repos; nothing looks different beyond that.
- Both rollup CTEs now prefilter the runs scan with an `IN`-subquery over the curated PR source, using the same predicate as the consuming query (list: open or merged/closed since `date_from`; cards: open only).
- The aggregation state now tracks the page (about 10^3 head SHAs) instead of all history (about 10^6 groups).
- The list predicate is defined once (`_visible_prs_where`) and reused for the outer `WHERE` and the rollup scope, so the scope cannot drift narrower than the rows it serves.
- Results are unchanged: the rollups only ever joined back to PRs the query keeps, so pruning the rest removes work, not data.

## How did you test this code?

- The scoped query was rendered with production table names and run against live data: it returns the full 1001-row page with CI rollups populated, where the unscoped query exhausts memory.
- Existing warehouse-backed tests cover the changed paths and pass unchanged (91 tests across `test_logic_pull_requests.py`, `test_presentation.py`, and the query tests), run on a devbox.
- No new tests: the change is a scan prefilter with identical results, and the existing fixture assertions are the regression net.
- Not run: the full product suite locally (no dev stack in this sandbox); CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session driven by the PR list OOM report; diagnosis via live warehouse sizing queries, fix verified against production data through the PostHog MCP.
- Skills invoked: /writing-pr-descriptions, /writing-tests (considered; no new tests warranted), /writing-code-comments.
- Design decision: scope the rollups inside the single query with IN-subqueries rather than splitting into follow-up scoped queries (the `query_pr_list_costs` pattern), keeping one round trip and no contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
