### PR TITLE
fix(desktop): always include task attribution

### DIFF
--- a/products/desktop/packages/agent/src/pi/task-system-prompt.test.ts
+++ b/products/desktop/packages/agent/src/pi/task-system-prompt.test.ts
@@ -24,7 +24,7 @@ describe("buildTaskSystemPrompt", () => {
     expect(prompt).toContain("## Channel task");
   });
 
-  it("includes attribution instructions for cloud tasks", () => {
+  it("includes signed commit attribution instructions for cloud tasks", () => {
     const prompt = buildTaskSystemPrompt({
       projectId: 42,
       apiHost: "https://us.posthog.com",
@@ -34,8 +34,10 @@ describe("buildTaskSystemPrompt", () => {
       additionalInstructions: "Use the existing pull request.",
     });
 
+    expect(prompt).toContain("git_signed_commit");
     expect(prompt).toContain("Generated-By: PostHog Desktop");
     expect(prompt).toContain("Task-Id: task-123");
+    expect(prompt).not.toContain('git commit -m "$(cat');
     expect(prompt).toContain("Use the existing pull request.");
   });
 });

--- a/products/desktop/packages/agent/src/pi/task-system-prompt.test.ts
+++ b/products/desktop/packages/agent/src/pi/task-system-prompt.test.ts
@@ -24,7 +24,7 @@ describe("buildTaskSystemPrompt", () => {
     expect(prompt).toContain("## Channel task");
   });
 
-  it("does not give local source-control instructions to cloud tasks", () => {
+  it("includes attribution instructions for cloud tasks", () => {
     const prompt = buildTaskSystemPrompt({
       projectId: 42,
       apiHost: "https://us.posthog.com",
@@ -34,7 +34,8 @@ describe("buildTaskSystemPrompt", () => {
       additionalInstructions: "Use the existing pull request.",
     });
 
-    expect(prompt).not.toContain("Generated-By: PostHog Desktop");
+    expect(prompt).toContain("Generated-By: PostHog Desktop");
+    expect(prompt).toContain("Task-Id: task-123");
     expect(prompt).toContain("Use the existing pull request.");
   });
 });

--- a/products/desktop/packages/agent/src/pi/task-system-prompt.ts
+++ b/products/desktop/packages/agent/src/pi/task-system-prompt.ts
@@ -134,11 +134,8 @@ export function buildTaskSystemPrompt(
     buildTaskContextPrompt(context.taskId),
   ];
 
-  if (context.environment === "local") {
-    sections.push(buildLocalAttributionPrompt(context.taskId));
-  }
-
   sections.push(
+    buildLocalAttributionPrompt(context.taskId),
     buildQuestionsPrompt(capabilities.structuredInput === true),
     buildPullRequestLinksPrompt(),
     buildShellEfficiencyPrompt(),

--- a/products/desktop/packages/agent/src/pi/task-system-prompt.ts
+++ b/products/desktop/packages/agent/src/pi/task-system-prompt.ts
@@ -36,11 +36,16 @@ export function buildTaskContextPrompt(taskId: string): string {
 This is task ${taskId}. Keep material provided as task context, including customer conversations, support tickets, logs, and internal threads, out of code, tests, comments, commit messages, and pull request text. Rewriting or anonymizing that material does not make it safe to publish.`;
 }
 
-export function buildLocalAttributionPrompt(taskId: string): string {
-  return `## Attribution
-Do NOT use Claude Code's default attribution (no "Co-Authored-By" trailers, no "Generated with [Claude Code]" lines).
-
-Instead, add the following trailers to EVERY commit message (after a blank line at the end):
+export function buildAttributionPrompt(
+  taskId: string,
+  environment: TaskContext["environment"],
+): string {
+  const commitInstructions =
+    environment === "cloud"
+      ? `In cloud tasks, call \`git_signed_commit\` to create commits. It automatically adds these trailers:
+  Generated-By: PostHog Desktop
+  Task-Id: ${taskId}`
+      : `Add the following trailers to every commit message after a blank line:
   Generated-By: PostHog Desktop
   Task-Id: ${taskId}
 
@@ -53,7 +58,12 @@ Generated-By: PostHog Desktop
 Task-Id: ${taskId}
 EOF
 )"
-\`\`\`
+\`\`\``;
+
+  return `## Attribution
+Do NOT use Claude Code's default attribution (no "Co-Authored-By" trailers, no "Generated with [Claude Code]" lines).
+
+${commitInstructions}
 
 When creating new branches, prefix them with \`posthog/\` (e.g. \`posthog/fix-login-redirect\`).
 
@@ -62,6 +72,10 @@ When creating pull requests, add the following footer at the end of the PR descr
 ---
 *Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
 \`\`\``;
+}
+
+export function buildLocalAttributionPrompt(taskId: string): string {
+  return buildAttributionPrompt(taskId, "local");
 }
 
 export function buildQuestionsPrompt(
@@ -135,7 +149,7 @@ export function buildTaskSystemPrompt(
   ];
 
   sections.push(
-    buildLocalAttributionPrompt(context.taskId),
+    buildAttributionPrompt(context.taskId, context.environment),
     buildQuestionsPrompt(capabilities.structuredInput === true),
     buildPullRequestLinksPrompt(),
     buildShellEfficiencyPrompt(),


### PR DESCRIPTION
## Problem

Cloud task runs did not receive commit attribution instructions, so their commits and pull requests could omit PostHog Desktop attribution.

## Changes

- Cloud task runs now receive attribution instructions through `git_signed_commit`, which appends the required commit trailers.
- Local task runs retain the existing commit-message example.
- The prompt test prevents cloud tasks from receiving the blocked raw `git commit` command.

## How did you test this code?

- Ran `pnpm --filter @posthog/agent test`.
- Ran `pnpm --filter @posthog/agent typecheck`.
- Ran `pnpm exec biome check packages/agent/src/pi/task-system-prompt.ts packages/agent/src/pi/task-system-prompt.test.ts`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change only affects agent instructions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An agent created this PR with the `posthog-desktop`, `writing-tests`, and `writing-pr-descriptions` skills. The revision preserves attribution in cloud tasks without suggesting blocked commands.