### PR TITLE
fix(notebooks): make the variables bar as wide as the notebook

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1308,6 +1308,10 @@ snapshots:
         hash: v1.k794b7964.b933911885203330331bde8bd799fd74fcd4e5964ba7fba4538dd075f07e32dc.QhPFXSfVCoIMya1xKmHLdyh3P9dJf-zNL4_zLUNqgqU
     components-markdown-editor-rich--with-markdown--light:
         hash: v1.k794b7964.98bef7667e05e7a86864149a5db5c24b3d4733bcef7d413ab6faf3053c79fba8.evR63xGwLPTzXw6Hi35ROggl2AHmH_y5lT5p05kFGTg
+    components-markdown-notebook--canvas-header--dark:
+        hash: v1.k794b7964.608a0ac08314f9ca439ce83d605b5b7068699aefcdc3ec64d2ea9850b78383a5.6uhW10xIiflrvLM9jcnT-l6on-ERqLyloX1KosD6EnA
+    components-markdown-notebook--canvas-header--light:
+        hash: v1.k794b7964.16b2968666f9d437cd7a6563d7e5c729a63c312b6d45e19763676adb10be5d50.XdkGvKh9l6Osw19D13Y_VwwD_dhRQl9TUIS257ov4CY
     components-markdown-notebook--component-catalog--dark:
         hash: v1.k794b7964.8d4bc1ec68c46621e7f0fa8d9ab9c83fc4a5c214fbba1dec162e9bb086643758.kBJyYgTMXU0MN-WCD6K4BcTw4Dne_Y5LCut3zY83OuU
     components-markdown-notebook--component-catalog--light:

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.scss
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.scss
@@ -275,6 +275,16 @@
     margin: 0 auto;
 }
 
+// Takes the canvas's own column, then steps in by the offset the blocks leave for their hover
+// controls, so anything pinned above the canvas lines up with the blocks below it at any width.
+.MarkdownNotebook__canvas-header {
+    width: 100%;
+    max-width: var(--markdown-notebook-canvas-max-width);
+    padding-right: var(--markdown-notebook-gutter-reserve);
+    padding-left: calc(var(--markdown-notebook-gutter-reserve) + var(--markdown-notebook-content-offset));
+    margin: 0 auto;
+}
+
 .MarkdownNotebook--edit .MarkdownNotebook__canvas {
     padding-bottom: 18rem;
 }
@@ -2112,7 +2122,8 @@ button.MarkdownNotebook__component-title:focus-visible {
 
 /* With comment threads present and enough room, the canvas reserves a right gutter wide
    enough for the whole thread column, pushing the text content left. */
-.MarkdownNotebook--comments-margin .MarkdownNotebook__canvas {
+.MarkdownNotebook--comments-margin .MarkdownNotebook__canvas,
+.MarkdownNotebook--comments-margin .MarkdownNotebook__canvas-header {
     max-width: calc(
         var(--markdown-notebook-canvas-max-width) + var(--markdown-notebook-comment-gutter) +
             var(--markdown-notebook-gutter-reserve)

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.stories.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.stories.tsx
@@ -187,6 +187,17 @@ export const TextOnlyNotebook: Story = {
     },
 }
 
+export const CanvasHeader: Story = {
+    args: {
+        value: textNotebook,
+        canvasHeader: (
+            <div className="mb-2 w-full rounded border border-primary bg-surface-secondary p-2">
+                A panel in the canvas header takes the same left and right edges as the blocks below it.
+            </div>
+        ),
+    },
+}
+
 export const HeadingsAndInlineFormatting: Story = {
     args: {
         value: `# Heading 1

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.tsx
@@ -280,6 +280,10 @@ export type MarkdownNotebookProps = {
      * resolve against the viewer's project rather than the author's. */
     hideResourceLinks?: boolean
     placeholder?: string
+    /** Content pinned above the canvas, laid out on the canvas's own column so it lines up with
+     * the blocks below it at any width. For a caller whose panel belongs to the notebook rather
+     * than to the document, e.g. its variables. */
+    canvasHeader?: ReactNode
     className?: string
     autoFocus?: boolean
     showDebug?: boolean
@@ -602,6 +606,7 @@ function MarkdownNotebookEditor({
     allowViewModeFilters = false,
     hideResourceLinks = false,
     placeholder = 'Start writing...',
+    canvasHeader,
     className,
     autoFocus = false,
     showDebug = false,
@@ -6022,6 +6027,7 @@ function MarkdownNotebookEditor({
                             ))}
                         </div>
                     ) : null}
+                    {canvasHeader ? <div className="MarkdownNotebook__canvas-header">{canvasHeader}</div> : null}
                     <div
                         className="MarkdownNotebook__canvas"
                         ref={canvasRef}

--- a/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2Renderer.tsx
@@ -69,6 +69,7 @@ import {
     NOTEBOOK_AI_PRESENCE_NAME,
 } from './notebookPresence'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
+import { NotebookVariablesBar } from './NotebookVariablesBar'
 
 const NOTEBOOK_AI_FOLLOW_UP_PROMPT_MARKDOWN = '<Prompt question="" />'
 const NOTEBOOK_AI_PRESENCE_DEPARTURE_IDLE_MS = 5_000
@@ -707,6 +708,7 @@ export function MarkdownNotebookV2({ debugOpen, onDebugOpenChange }: MarkdownNot
                     deferRemoteValue={markdownEditorInteractionActive}
                     onInteractionStateChange={setMarkdownEditorInteractionActive}
                     allowViewModeFilters={mountedNotebookLogic.props.mode === 'canvas'}
+                    canvasHeader={<NotebookVariablesBar />}
                     className="Notebook__markdown-v2"
                     data-attr="notebook-markdown-v2"
                     autoFocus={isEditable}

--- a/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2RendererUI.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/MarkdownNotebookV2RendererUI.test.tsx
@@ -130,6 +130,21 @@ describe('MarkdownNotebookV2Renderer UI', () => {
         expect(notebookElement?.classList.contains('Notebook--expanded')).toBe(false)
     })
 
+    it('puts the variables bar in the notebook column, above the blocks', () => {
+        // The bar takes its width from the column it sits in. Rendered anywhere else it either
+        // disappears from the notebook or stops lining up with the blocks below it.
+        act(() => {
+            settingsLogic.actions.setShowVariables(true)
+        })
+
+        const { container } = render(<Notebook shortId={SHORT_ID} mode="notebook" cachedNotebook={cachedNotebook} />)
+        const header = container.querySelector('.MarkdownNotebook__canvas-header')
+        const canvas = container.querySelector('.MarkdownNotebook__canvas')
+
+        expect(header?.querySelector('.NotebookVariables')).toBeInstanceOf(HTMLElement)
+        expect(header?.compareDocumentPosition(canvas as Node)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    })
+
     it('collapses markdown content width', () => {
         const { container } = render(<NotebookExpandButton type="secondary" size="small" inPanel={false} />)
         const button = container.querySelector('button')

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.scss
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.scss
@@ -719,7 +719,8 @@ body[theme='dark'].has-markdown-v2-notebook .main-content-container > main {
         .Notebook__markdown-v2,
         .MarkdownNotebook__debug-layout,
         .MarkdownNotebook__main,
-        .MarkdownNotebook__canvas {
+        .MarkdownNotebook__canvas,
+        .MarkdownNotebook__canvas-header {
             width: 100%;
             max-width: none;
         }

--- a/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/Notebook.tsx
@@ -21,7 +21,6 @@ import { NotebookHistoryWarning } from './NotebookHistory'
 import { NotebookLoadingState } from './NotebookLoadingState'
 import { NotebookMergeConflictDetails } from './NotebookMergeConflictDetails'
 import { notebookSettingsLogic } from './notebookSettingsLogic'
-import { NotebookVariablesBar } from './NotebookVariablesBar'
 
 // Counts mounted notebooks so the <body> marker class survives overlapping mounts
 // (e.g. one in the scene and one in the side panel)
@@ -145,8 +144,6 @@ export function Notebook({
                             It's a great place to gather ideas before turning into a saved Notebook!
                         </LemonBanner>
                     ) : null}
-
-                    <NotebookVariablesBar />
 
                     <div className="Notebook_content">
                         <NotebookColumnLeft />

--- a/frontend/src/scenes/notebooks/Notebook/NotebookVariablesBar.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/NotebookVariablesBar.tsx
@@ -94,7 +94,7 @@ function NotebookVariableValueInput({
 
 /**
  * The notebook's variables, one row each: name, type, value, delete. A property of the notebook
- * rather than a block in the document, so it hangs under the header and cannot be reordered,
+ * rather than a block in the document, so it sits above the first block and cannot be reordered,
  * duplicated, or deleted as content.
  */
 export function NotebookVariablesPanel({
@@ -116,7 +116,7 @@ export function NotebookVariablesPanel({
         onChange(variables.map((variable, i) => (i === index ? { ...variable, ...patch } : variable)))
 
     return (
-        <div className="NotebookVariables mx-auto flex w-[70%] min-w-0 flex-col gap-2 rounded border border-primary bg-surface-secondary p-2">
+        <div className="NotebookVariables flex w-full min-w-0 flex-col gap-2 rounded border border-primary bg-surface-secondary p-2">
             {variables.length === 0 ? (
                 <p className="m-0 text-xs text-secondary">
                     No variables yet. Add one, then read it as <code>{'{name}'}</code> in a SQL cell or as a plain


### PR DESCRIPTION
## Problem

The notebook variables bar does not line up with the notebook. It sits at 70% of the notebook width and centers on its own, so its left and right edges miss the blocks below it in both width settings.

- At full width the bar is much narrower than the blocks, and the value field is cramped for no reason.
- In compact width the bar is wider than the blocks and overhangs them on both sides.

The bar rendered above `Notebook_content`, outside the component that owns the notebook column, so it could not read that column's width.

## Changes

- The variables bar now takes the same left and right edges as the blocks below it, at any notebook width.
- `MarkdownNotebook` gains a `canvasHeader` slot. The slot renders above the canvas and copies the canvas box, so the bar tracks the column instead of guessing at it.
- The notebook scene passes the bar into that slot, and the panel drops its `w-[70%]` and `mx-auto`.
- Mechanical: the panel's placement comment, and one line each in the expanded and comment-gutter width rules so the header follows the canvas there too.

Before:

![variables-bar-before](https://raw.githubusercontent.com/PostHog/pr-assets/3671b0cd720cae7e267d42fbcc43fd32685f451f/2026/08/ee95c08a-01e8-4453-8095-f211a1e3cff7.png)

After:

![variables-bar-after](https://raw.githubusercontent.com/PostHog/pr-assets/112095f53a355095c25e1e6e0c3f23ce727f6fc2/2026/08/fbe8da52-1785-448a-8c3a-81314b1ecec9.png)

## How did you test this code?

Rendered the notebook in Storybook at both width settings and measured the boxes. The bar and the first block report the same left and right edges in each: 58 to 2101 at full width, 725 to 1435 in compact. Repeated at a 520px scene width, where the bar still aligns and nothing overflows.

One new Jest case in `MarkdownNotebookV2RendererUI.test.tsx` asserts the bar renders inside the canvas header, above the canvas. Removing the `canvasHeader` prop fails it. No existing test covered where the bar renders, so a change that drops it would have shipped silently.

A `CanvasHeader` story on `MarkdownNotebook` gives the slot visual-regression coverage.

Not checked: the comment-gutter layout, and the notebook in the side panel.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-ui-components`, `/writing-pr-descriptions`.

The first approach copied the canvas geometry into `Notebook.scss` with duplicated constants. That version drifts as soon as `MarkdownNotebook` changes its gutter, and it misses the comment-gutter layout, so the slot replaced it: the geometry stays in one file.

The screenshots come from a throwaway story that reproduced the old placement next to the new one. That story is not in this PR.

Nothing here comes from a customer conversation, a ticket, or a log. The sample notebook and the variable names are invented.
