### PR TITLE
feat(auth): six-slot verification code input

### DIFF
--- a/frontend/src/lib/utils/localStorageSlot.ts
+++ b/frontend/src/lib/utils/localStorageSlot.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 export interface LocalStorageSlot<T> {
     get: () => T | null
     set: (value: T) => void
+    clear: () => void
 }
 
 // Stored data outlives deploys and can be edited by hand, so reads validate
@@ -28,6 +29,13 @@ export function localStorageSlot<T>(key: string | (() => string), schema: z.ZodT
                 localStorage.setItem(resolveKey(), JSON.stringify(value))
             } catch {
                 // localStorage can be unavailable. Losing the value is fine
+            }
+        },
+        clear: (): void => {
+            try {
+                localStorage.removeItem(resolveKey())
+            } catch {
+                // Same as above: an unavailable localStorage has nothing to remove
             }
         },
     }

--- a/frontend/src/scenes/authentication/invite-signup/inviteSignupLogic.ts
+++ b/frontend/src/scenes/authentication/invite-signup/inviteSignupLogic.ts
@@ -8,6 +8,7 @@ import posthog from 'posthog-js'
 
 import api from 'lib/api'
 import { ValidatedPasswordResult, validatePassword } from 'lib/components/PasswordStrength'
+import { rememberPendingVerificationEmail } from 'scenes/authentication/shared/pendingVerificationEmail'
 import { getPasskeyErrorMessage } from 'scenes/settings/user/passkeys/utils'
 import type { RegistrationBeginResponse } from 'scenes/settings/user/passkeySettingsLogic'
 
@@ -313,6 +314,12 @@ export const inviteSignupLogic = kea<inviteSignupLogicType>([
                     }
 
                     const res = await api.create(`api/signup/${values.invite.id}/`, submitPayload)
+                    if (res.uuid && res.email) {
+                        // An invitee with an unverified email is redirected to the verification
+                        // page. That page loads without a session, so store the address for it
+                        // to show.
+                        rememberPendingVerificationEmail(res.uuid, res.email)
+                    }
                     location.href = res.redirect_url || '/' // hard refresh because the current_organization changed
                 } catch (e) {
                     const error = e as Record<string, any>

--- a/frontend/src/scenes/authentication/login/loginLogic.ts
+++ b/frontend/src/scenes/authentication/login/loginLogic.ts
@@ -16,7 +16,7 @@ import { isWebKitBrowser } from 'lib/utils/dom'
 import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
 import { getRelativeNextPath } from 'lib/utils/url'
 import { devLoginLogic } from 'scenes/authentication/shared/devLoginLogic'
-import { pendingVerificationEmailStorage } from 'scenes/authentication/shared/pendingVerificationEmail'
+import { rememberPendingVerificationEmail } from 'scenes/authentication/shared/pendingVerificationEmail'
 import { normalizeVerificationCode } from 'scenes/authentication/shared/verificationCode'
 import { twoFactorResetLogic } from 'scenes/authentication/two-factor-reset/twoFactorResetLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -576,8 +576,9 @@ export const loginLogic = kea<loginLogicType>([
                     if (code === 'verify_email_pending' && typeof detail === 'string') {
                         // detail carries the user uuid; the verification page has the code entry form
                         lemonToast.info('Verify your email to continue. We just sent you a new code.')
-                        // The page has no session to read the address from, so leave it behind.
-                        pendingVerificationEmailStorage.set(email)
+                        // The verification page has no session, so store the address for it to
+                        // show.
+                        rememberPendingVerificationEmail(detail, email)
                         const next: string | undefined = router.values.searchParams.next
                         router.actions.push(urls.verifyEmail(detail), next ? { next } : {})
                         throw e

--- a/frontend/src/scenes/authentication/login/loginLogic.ts
+++ b/frontend/src/scenes/authentication/login/loginLogic.ts
@@ -16,6 +16,7 @@ import { isWebKitBrowser } from 'lib/utils/dom'
 import { getCurrentTeamIdOrNone } from 'lib/utils/getAppContext'
 import { getRelativeNextPath } from 'lib/utils/url'
 import { devLoginLogic } from 'scenes/authentication/shared/devLoginLogic'
+import { pendingVerificationEmailStorage } from 'scenes/authentication/shared/pendingVerificationEmail'
 import { normalizeVerificationCode } from 'scenes/authentication/shared/verificationCode'
 import { twoFactorResetLogic } from 'scenes/authentication/two-factor-reset/twoFactorResetLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
@@ -575,6 +576,8 @@ export const loginLogic = kea<loginLogicType>([
                     if (code === 'verify_email_pending' && typeof detail === 'string') {
                         // detail carries the user uuid; the verification page has the code entry form
                         lemonToast.info('Verify your email to continue. We just sent you a new code.')
+                        // The page has no session to read the address from, so leave it behind.
+                        pendingVerificationEmailStorage.set(email)
                         const next: string | undefined = router.values.searchParams.next
                         router.actions.push(urls.verifyEmail(detail), next ? { next } : {})
                         throw e

--- a/frontend/src/scenes/authentication/shared/VerificationCodeInput.stories.tsx
+++ b/frontend/src/scenes/authentication/shared/VerificationCodeInput.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryFn } from '@storybook/react'
+import { useState } from 'react'
+
+import { VerificationCodeInput } from './VerificationCodeInput'
+
+type StoryArgs = {
+    initialValue: string
+    error: string | null
+    disabled: boolean
+    width: number
+}
+
+const meta: Meta<StoryArgs> = {
+    title: 'Scenes-Other/Authentication/VerificationCodeInput',
+    parameters: {
+        viewMode: 'story',
+    },
+    argTypes: {
+        initialValue: { control: 'text', name: 'Value' },
+        error: { control: 'text', name: 'Error' },
+        disabled: { control: 'boolean', name: 'Disabled' },
+        width: { control: 'number', name: 'Container width' },
+    },
+    args: {
+        initialValue: '',
+        error: null,
+        disabled: false,
+        // The verification card is 27rem wide, minus its padding.
+        width: 360,
+    },
+}
+export default meta
+
+const Template: StoryFn<StoryArgs> = ({ initialValue, error, disabled, width }) => {
+    const [value, setValue] = useState(initialValue)
+
+    return (
+        <div className="p-4" style={{ width }}>
+            <VerificationCodeInput value={value} onChange={setValue} error={error} disabled={disabled} />
+        </div>
+    )
+}
+
+export const Empty: StoryFn<StoryArgs> = Template.bind({})
+
+export const Filled: StoryFn<StoryArgs> = Template.bind({})
+Filled.args = { initialValue: '123456' }
+
+export const Rejected: StoryFn<StoryArgs> = Template.bind({})
+Rejected.args = { error: 'This code is invalid or has expired.' }
+
+export const Verifying: StoryFn<StoryArgs> = Template.bind({})
+Verifying.args = { initialValue: '123456', disabled: true }
+
+/** Six slots still have to fit where a settings modal or a docked panel is narrow. */
+export const Narrow: StoryFn<StoryArgs> = Template.bind({})
+Narrow.args = { initialValue: '1234', width: 320 }

--- a/frontend/src/scenes/authentication/shared/VerificationCodeInput.stories.tsx
+++ b/frontend/src/scenes/authentication/shared/VerificationCodeInput.stories.tsx
@@ -1,13 +1,18 @@
-import type { Meta, StoryFn } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
 
 import { VerificationCodeInput } from './VerificationCodeInput'
 
 type StoryArgs = {
-    initialValue: string
-    error: string | null
-    disabled: boolean
-    width: number
+    initialValue?: string
+    error?: string | null
+    disabled?: boolean
+}
+
+function InteractiveCode({ initialValue = '', error = null, disabled = false }: StoryArgs): JSX.Element {
+    const [value, setValue] = useState(initialValue)
+
+    return <VerificationCodeInput value={value} onChange={setValue} error={error} disabled={disabled} />
 }
 
 const meta: Meta<StoryArgs> = {
@@ -15,43 +20,30 @@ const meta: Meta<StoryArgs> = {
     parameters: {
         viewMode: 'story',
     },
-    argTypes: {
-        initialValue: { control: 'text', name: 'Value' },
-        error: { control: 'text', name: 'Error' },
-        disabled: { control: 'boolean', name: 'Disabled' },
-        width: { control: 'number', name: 'Container width' },
-    },
-    args: {
-        initialValue: '',
-        error: null,
-        disabled: false,
+    render: (args) => (
         // The verification card is 27rem wide, minus its padding.
-        width: 360,
-    },
+        <div className="w-90 p-4">
+            <InteractiveCode {...args} />
+        </div>
+    ),
 }
 export default meta
+type Story = StoryObj<StoryArgs>
 
-const Template: StoryFn<StoryArgs> = ({ initialValue, error, disabled, width }) => {
-    const [value, setValue] = useState(initialValue)
+export const Empty: Story = {}
 
-    return (
-        <div className="p-4" style={{ width }}>
-            <VerificationCodeInput value={value} onChange={setValue} error={error} disabled={disabled} />
+export const Filled: Story = { args: { initialValue: '123456' } }
+
+export const Rejected: Story = { args: { error: 'This code is invalid or has expired.' } }
+
+export const Verifying: Story = { args: { initialValue: '123456', disabled: true } }
+
+/** Six slots must also fit where a settings modal or a docked panel is narrow. */
+export const Narrow: Story = {
+    args: { initialValue: '1234' },
+    render: (args) => (
+        <div className="w-80 p-4">
+            <InteractiveCode {...args} />
         </div>
-    )
+    ),
 }
-
-export const Empty: StoryFn<StoryArgs> = Template.bind({})
-
-export const Filled: StoryFn<StoryArgs> = Template.bind({})
-Filled.args = { initialValue: '123456' }
-
-export const Rejected: StoryFn<StoryArgs> = Template.bind({})
-Rejected.args = { error: 'This code is invalid or has expired.' }
-
-export const Verifying: StoryFn<StoryArgs> = Template.bind({})
-Verifying.args = { initialValue: '123456', disabled: true }
-
-/** Six slots still have to fit where a settings modal or a docked panel is narrow. */
-export const Narrow: StoryFn<StoryArgs> = Template.bind({})
-Narrow.args = { initialValue: '1234', width: 320 }

--- a/frontend/src/scenes/authentication/shared/VerificationCodeInput.tsx
+++ b/frontend/src/scenes/authentication/shared/VerificationCodeInput.tsx
@@ -3,13 +3,12 @@ import { useEffect, useRef } from 'react'
 
 import { cn } from 'lib/utils/css-classes'
 
-import { normalizeVerificationCode } from './verificationCode'
+import { VERIFICATION_CODE_LENGTH, normalizeVerificationCode } from './verificationCode'
 
-export const VERIFICATION_CODE_LENGTH = 6
-
-// Base UI's built-in `numeric` validation strips everything `\d` rejects *before* our normalizer
-// runs, which would throw away the fullwidth digits and separators an email client can hand us on
-// paste. So we opt out of its validation and normalize ourselves: fold to ASCII first, keep digits.
+// Base UI's built-in `numeric` validation strips non-digits before our normalizer runs. That order
+// would discard the fullwidth digits and separators that email clients can add to a pasted code.
+// So the field opts out of the built-in validation, folds the input to ASCII first, and then keeps
+// only digits.
 function normalizeToDigits(value: string): string {
     return normalizeVerificationCode(value).replace(/\D/g, '')
 }
@@ -17,36 +16,30 @@ function normalizeToDigits(value: string): string {
 export interface VerificationCodeInputProps {
     value: string
     onChange: (value: string) => void
-    /** Fired once all slots are filled, by typing or paste — wire this to submit. */
-    onComplete?: (value: string) => void
     /** Message to show under the slots. Setting it also returns focus to the first slot. */
     error?: string | null
     disabled?: boolean
     autoFocus?: boolean
-    label?: string
     'data-attr'?: string
-    className?: string
 }
 
 /**
- * One slot per digit of an emailed verification code, on top of Base UI's OTP field — which is what
- * gives us auto-advance, backspace-to-previous, arrow keys, and paste-anywhere-fills-everything.
+ * One slot per digit of an emailed verification code. Base UI's OTP field supplies the interaction
+ * model: typing advances, backspace steps back, arrow keys move, and a paste fills all slots.
+ * The field submits the owning form when the last digit arrives.
  */
 export function VerificationCodeInput({
     value,
     onChange,
-    onComplete,
     error,
     disabled,
     autoFocus,
-    label = 'Email verification code',
     'data-attr': dataAttr,
-    className,
 }: VerificationCodeInputProps): JSX.Element {
     const firstSlotRef = useRef<HTMLInputElement>(null)
 
-    // A rejected code is cleared by the logic, so put the cursor back where the retype starts. Wait
-    // for the request to finish: a disabled slot cannot take focus.
+    // The logic clears a rejected code, so return the cursor to the slot where the retype starts.
+    // Wait until the request finishes, because a disabled slot cannot take focus.
     useEffect(() => {
         if (error && !disabled) {
             firstSlotRef.current?.focus()
@@ -54,18 +47,18 @@ export function VerificationCodeInput({
     }, [error, disabled])
 
     return (
-        <div className={cn('flex w-full flex-col gap-2', className)} data-attr={dataAttr}>
+        <div className="flex w-full flex-col gap-2" data-attr={dataAttr}>
             <OTPField.Root
                 length={VERIFICATION_CODE_LENGTH}
                 value={value}
                 onValueChange={onChange}
-                onValueComplete={(completed) => onComplete?.(completed)}
+                autoSubmit
                 validationType="none"
                 normalizeValue={normalizeToDigits}
                 inputMode="numeric"
                 autoComplete="one-time-code"
                 disabled={disabled}
-                // Codes are as sensitive as passwords — keep them out of session recordings.
+                // Codes are as sensitive as passwords, so keep them out of session recordings.
                 className="ph-replay-block flex w-full items-center justify-center gap-2"
             >
                 {Array.from({ length: VERIFICATION_CODE_LENGTH }, (_, index) => (
@@ -73,7 +66,11 @@ export function VerificationCodeInput({
                         key={index}
                         ref={index === 0 ? firstSlotRef : undefined}
                         autoFocus={autoFocus && index === 0}
-                        aria-label={index === 0 ? label : `Digit ${index + 1} of ${VERIFICATION_CODE_LENGTH}`}
+                        aria-label={
+                            index === 0
+                                ? 'Email verification code'
+                                : `Digit ${index + 1} of ${VERIFICATION_CODE_LENGTH}`
+                        }
                         aria-invalid={error ? true : undefined}
                         className={cn(
                             'h-14 min-w-0 max-w-14 flex-1 rounded-md border p-0 text-center text-xl font-semibold tabular-nums',

--- a/frontend/src/scenes/authentication/shared/VerificationCodeInput.tsx
+++ b/frontend/src/scenes/authentication/shared/VerificationCodeInput.tsx
@@ -1,0 +1,97 @@
+import { OTPField } from '@base-ui/react/otp-field'
+import { useEffect, useRef } from 'react'
+
+import { cn } from 'lib/utils/css-classes'
+
+import { normalizeVerificationCode } from './verificationCode'
+
+export const VERIFICATION_CODE_LENGTH = 6
+
+// Base UI's built-in `numeric` validation strips everything `\d` rejects *before* our normalizer
+// runs, which would throw away the fullwidth digits and separators an email client can hand us on
+// paste. So we opt out of its validation and normalize ourselves: fold to ASCII first, keep digits.
+function normalizeToDigits(value: string): string {
+    return normalizeVerificationCode(value).replace(/\D/g, '')
+}
+
+export interface VerificationCodeInputProps {
+    value: string
+    onChange: (value: string) => void
+    /** Fired once all slots are filled, by typing or paste — wire this to submit. */
+    onComplete?: (value: string) => void
+    /** Message to show under the slots. Setting it also returns focus to the first slot. */
+    error?: string | null
+    disabled?: boolean
+    autoFocus?: boolean
+    label?: string
+    'data-attr'?: string
+    className?: string
+}
+
+/**
+ * One slot per digit of an emailed verification code, on top of Base UI's OTP field — which is what
+ * gives us auto-advance, backspace-to-previous, arrow keys, and paste-anywhere-fills-everything.
+ */
+export function VerificationCodeInput({
+    value,
+    onChange,
+    onComplete,
+    error,
+    disabled,
+    autoFocus,
+    label = 'Email verification code',
+    'data-attr': dataAttr,
+    className,
+}: VerificationCodeInputProps): JSX.Element {
+    const firstSlotRef = useRef<HTMLInputElement>(null)
+
+    // A rejected code is cleared by the logic, so put the cursor back where the retype starts. Wait
+    // for the request to finish: a disabled slot cannot take focus.
+    useEffect(() => {
+        if (error && !disabled) {
+            firstSlotRef.current?.focus()
+        }
+    }, [error, disabled])
+
+    return (
+        <div className={cn('flex w-full flex-col gap-2', className)} data-attr={dataAttr}>
+            <OTPField.Root
+                length={VERIFICATION_CODE_LENGTH}
+                value={value}
+                onValueChange={onChange}
+                onValueComplete={(completed) => onComplete?.(completed)}
+                validationType="none"
+                normalizeValue={normalizeToDigits}
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                disabled={disabled}
+                // Codes are as sensitive as passwords — keep them out of session recordings.
+                className="ph-replay-block flex w-full items-center justify-center gap-2"
+            >
+                {Array.from({ length: VERIFICATION_CODE_LENGTH }, (_, index) => (
+                    <OTPField.Input
+                        key={index}
+                        ref={index === 0 ? firstSlotRef : undefined}
+                        autoFocus={autoFocus && index === 0}
+                        aria-label={index === 0 ? label : `Digit ${index + 1} of ${VERIFICATION_CODE_LENGTH}`}
+                        aria-invalid={error ? true : undefined}
+                        className={cn(
+                            'h-14 min-w-0 max-w-14 flex-1 rounded-md border p-0 text-center text-xl font-semibold tabular-nums',
+                            'bg-surface-primary text-primary caret-accent selection:bg-accent/25 transition-colors duration-100',
+                            'focus:z-10 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30',
+                            'disabled:cursor-not-allowed disabled:opacity-[var(--opacity-disabled)]',
+                            error
+                                ? 'border-danger focus:border-danger focus:ring-danger/30'
+                                : 'border-primary hover:border-secondary data-[filled]:border-secondary'
+                        )}
+                    />
+                ))}
+            </OTPField.Root>
+            {error && (
+                <p className="m-0 text-sm text-danger" role="alert">
+                    {error}
+                </p>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/authentication/shared/pendingVerificationEmail.ts
+++ b/frontend/src/scenes/authentication/shared/pendingVerificationEmail.ts
@@ -2,7 +2,25 @@ import { z } from 'zod'
 
 import { localStorageSlot } from 'lib/utils/localStorageSlot'
 
-// An unverified user has no session, so the verification page cannot ask the API which address it is
-// waiting on. The device that signed up leaves the address here, so the page can name it. Absent
-// when the person opens the page somewhere else — the copy falls back to not naming an address.
-export const pendingVerificationEmailStorage = localStorageSlot('ph_pending_verification_email', z.email())
+// The verification page loads without a session, so it cannot ask the API which address the code
+// went to. The page that starts verification stores the address here, together with the user uuid.
+// The verification page shows the address only when the stored uuid matches the uuid in its URL.
+// This match prevents one problem: a value left behind by an earlier signup on the same device
+// must not name the wrong account.
+const pendingVerificationEmailSlot = localStorageSlot(
+    'ph_pending_verification_email',
+    z.object({ uuid: z.string(), email: z.email() })
+)
+
+export function rememberPendingVerificationEmail(uuid: string, email: string): void {
+    pendingVerificationEmailSlot.set({ uuid, email })
+}
+
+export function pendingVerificationEmailFor(uuid: string | null): string | null {
+    const stored = pendingVerificationEmailSlot.get()
+    return stored && stored.uuid === uuid ? stored.email : null
+}
+
+export function clearPendingVerificationEmail(): void {
+    pendingVerificationEmailSlot.clear()
+}

--- a/frontend/src/scenes/authentication/shared/pendingVerificationEmail.ts
+++ b/frontend/src/scenes/authentication/shared/pendingVerificationEmail.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+import { localStorageSlot } from 'lib/utils/localStorageSlot'
+
+// An unverified user has no session, so the verification page cannot ask the API which address it is
+// waiting on. The device that signed up leaves the address here, so the page can name it. Absent
+// when the person opens the page somewhere else — the copy falls back to not naming an address.
+export const pendingVerificationEmailStorage = localStorageSlot('ph_pending_verification_email', z.email())

--- a/frontend/src/scenes/authentication/shared/verificationCode.ts
+++ b/frontend/src/scenes/authentication/shared/verificationCode.ts
@@ -7,8 +7,10 @@ export function normalizeVerificationCode(code: string): string {
     return (code ?? '').normalize('NFKC').replace(CODE_NOISE_RE, '')
 }
 
+export const VERIFICATION_CODE_LENGTH = 6
+
 export function isValidVerificationCode(code: string): boolean {
-    return /^\d{6}$/.test(code)
+    return code.length === VERIFICATION_CODE_LENGTH && /^\d+$/.test(code)
 }
 
 export function verificationCodeErrorMessage(e: { code?: string; detail?: string }): string {

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -13,6 +13,7 @@ import { CLOUD_HOSTNAMES, FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { splitFullName } from 'lib/utils/strings'
 import { getRelativeNextPath } from 'lib/utils/url'
+import { pendingVerificationEmailStorage } from 'scenes/authentication/shared/pendingVerificationEmail'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { getPasskeyErrorMessage, isWebAuthnCancellation } from 'scenes/settings/user/passkeys/utils'
 import { RegistrationBeginResponse } from 'scenes/settings/user/passkeySettingsLogic'
@@ -527,6 +528,10 @@ export const signupLogic = kea<signupLogicType>([
                     if (values.passkeyRegistered) {
                         posthog.capture('signup completed with passkey')
                     }
+
+                    // The verification page loads without a session, so it can only name the
+                    // address if we leave it behind here.
+                    pendingVerificationEmailStorage.set(signupData.email)
 
                     // it's ok to trust the url sent from the server
                     // nosemgrep: javascript.browser.security.open-redirect.js-open-redirect

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -13,7 +13,7 @@ import { CLOUD_HOSTNAMES, FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { splitFullName } from 'lib/utils/strings'
 import { getRelativeNextPath } from 'lib/utils/url'
-import { pendingVerificationEmailStorage } from 'scenes/authentication/shared/pendingVerificationEmail'
+import { rememberPendingVerificationEmail } from 'scenes/authentication/shared/pendingVerificationEmail'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { getPasskeyErrorMessage, isWebAuthnCancellation } from 'scenes/settings/user/passkeys/utils'
 import { RegistrationBeginResponse } from 'scenes/settings/user/passkeySettingsLogic'
@@ -529,9 +529,9 @@ export const signupLogic = kea<signupLogicType>([
                         posthog.capture('signup completed with passkey')
                     }
 
-                    // The verification page loads without a session, so it can only name the
-                    // address if we leave it behind here.
-                    pendingVerificationEmailStorage.set(signupData.email)
+                    // The verification page loads without a session, so store the address for
+                    // it to show.
+                    rememberPendingVerificationEmail(res.uuid, signupData.email)
 
                     // it's ok to trust the url sent from the server
                     // nosemgrep: javascript.browser.security.open-redirect.js-open-redirect

--- a/frontend/src/scenes/authentication/verify-email/VerifyEmailForm.tsx
+++ b/frontend/src/scenes/authentication/verify-email/VerifyEmailForm.tsx
@@ -7,10 +7,10 @@ import { pngHoggie } from 'lib/brand/hoggies'
 import { ExplorerHog, SleepingHog } from 'lib/components/hedgehogs'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { AuthScene, AuthSceneCard } from 'scenes/authentication/shared/authScene/AuthScene'
+import { VERIFICATION_CODE_LENGTH, VerificationCodeInput } from 'scenes/authentication/shared/VerificationCodeInput'
 import { urls } from 'scenes/urls'
 
 import { verifyEmailLogic } from './verifyEmailLogic'
@@ -120,24 +120,19 @@ function VerificationCodeEntry(): JSX.Element {
                 }
             }}
         >
-            <LemonInput
+            <VerificationCodeInput
                 autoFocus
                 value={verificationCode}
                 onChange={setVerificationCode}
-                placeholder="123456"
-                aria-label="Email verification code"
-                inputMode="numeric"
-                autoComplete="one-time-code"
-                size="large"
-                className="text-center ph-replay-block"
+                onComplete={() => {
+                    if (!validatedEmailTokenLoading) {
+                        submitVerificationCode()
+                    }
+                }}
+                error={verificationCodeError}
+                disabled={validatedEmailTokenLoading}
                 data-attr="verify-email-code"
-                status={verificationCodeError ? 'danger' : 'default'}
             />
-            {verificationCodeError && (
-                <p className="m-0 text-sm text-danger" role="alert">
-                    {verificationCodeError}
-                </p>
-            )}
             <LemonButton
                 type="primary"
                 size="large"
@@ -145,7 +140,11 @@ function VerificationCodeEntry(): JSX.Element {
                 fullWidth
                 htmlType="submit"
                 loading={validatedEmailTokenLoading}
-                disabledReason={verificationCode ? undefined : 'Enter the code from your email'}
+                disabledReason={
+                    verificationCode.length === VERIFICATION_CODE_LENGTH
+                        ? undefined
+                        : 'Enter the 6-digit code from your email'
+                }
                 data-attr="verify-email-code-submit"
             >
                 Verify email
@@ -155,7 +154,7 @@ function VerificationCodeEntry(): JSX.Element {
 }
 
 export function VerifyEmailForm(): JSX.Element {
-    const { view, uuid, newlyRequestedVerificationLinkLoading } = useValues(verifyEmailLogic)
+    const { view, uuid, pendingEmail, newlyRequestedVerificationLinkLoading } = useValues(verifyEmailLogic)
     const { requestVerificationLink } = useActions(verifyEmailLogic)
     const { openSupportForm } = useActions(supportLogic)
 
@@ -277,8 +276,14 @@ export function VerifyEmailForm(): JSX.Element {
                         Check your inbox
                     </h1>
                     <p className="AuthScene__sub mt-2 mb-4 text-sm text-secondary text-center text-pretty">
-                        We emailed you a 6-digit code. Enter it below to verify your email address. The code is valid
-                        for 30 minutes.
+                        {pendingEmail ? (
+                            <>
+                                We emailed a 6-digit code to <strong>{pendingEmail}</strong>. The code is valid for 30
+                                minutes.
+                            </>
+                        ) : (
+                            'We emailed you a 6-digit code. The code is valid for 30 minutes.'
+                        )}
                     </p>
                     <VerificationCodeEntry />
                     <div className="mt-3">

--- a/frontend/src/scenes/authentication/verify-email/VerifyEmailForm.tsx
+++ b/frontend/src/scenes/authentication/verify-email/VerifyEmailForm.tsx
@@ -10,7 +10,8 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { AuthScene, AuthSceneCard } from 'scenes/authentication/shared/authScene/AuthScene'
-import { VERIFICATION_CODE_LENGTH, VerificationCodeInput } from 'scenes/authentication/shared/VerificationCodeInput'
+import { isValidVerificationCode } from 'scenes/authentication/shared/verificationCode'
+import { VerificationCodeInput } from 'scenes/authentication/shared/VerificationCodeInput'
 import { urls } from 'scenes/urls'
 
 import { verifyEmailLogic } from './verifyEmailLogic'
@@ -124,11 +125,6 @@ function VerificationCodeEntry(): JSX.Element {
                 autoFocus
                 value={verificationCode}
                 onChange={setVerificationCode}
-                onComplete={() => {
-                    if (!validatedEmailTokenLoading) {
-                        submitVerificationCode()
-                    }
-                }}
                 error={verificationCodeError}
                 disabled={validatedEmailTokenLoading}
                 data-attr="verify-email-code"
@@ -141,9 +137,7 @@ function VerificationCodeEntry(): JSX.Element {
                 htmlType="submit"
                 loading={validatedEmailTokenLoading}
                 disabledReason={
-                    verificationCode.length === VERIFICATION_CODE_LENGTH
-                        ? undefined
-                        : 'Enter the 6-digit code from your email'
+                    isValidVerificationCode(verificationCode) ? undefined : 'Enter the 6-digit code from your email'
                 }
                 data-attr="verify-email-code-submit"
             >

--- a/frontend/src/scenes/authentication/verify-email/verifyEmailLogic.test.ts
+++ b/frontend/src/scenes/authentication/verify-email/verifyEmailLogic.test.ts
@@ -30,6 +30,17 @@ describe('verifyEmailLogic', () => {
             .toMatchValues({ verificationCode: '', verificationCodeError: 'That code is wrong.' })
     })
 
+    it('names the stored address only when its uuid matches the page uuid', () => {
+        localStorage.setItem(
+            'ph_pending_verification_email',
+            JSON.stringify({ uuid: '12345678', email: 'signup@example.com' })
+        )
+        expect(logic.values.pendingEmail).toEqual('signup@example.com')
+
+        logic.actions.setUuid('another-account')
+        expect(logic.values.pendingEmail).toEqual(null)
+    })
+
     it('keeps a partial code when it is too short to send', async () => {
         logic.actions.setVerificationCode('123')
 

--- a/frontend/src/scenes/authentication/verify-email/verifyEmailLogic.test.ts
+++ b/frontend/src/scenes/authentication/verify-email/verifyEmailLogic.test.ts
@@ -1,0 +1,43 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { verifyEmailLogic } from 'scenes/authentication/verify-email/verifyEmailLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+describe('verifyEmailLogic', () => {
+    let logic: ReturnType<typeof verifyEmailLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = verifyEmailLogic()
+        logic.mount()
+        logic.actions.setUuid('12345678')
+    })
+
+    afterEach(() => logic.unmount())
+
+    it('empties the code and reports the error when the server rejects it', async () => {
+        useMocks({
+            post: {
+                '/api/users/verify_email/': () => [400, { code: 'invalid_code', detail: 'That code is wrong.' }],
+            },
+        })
+        logic.actions.setVerificationCode('123456')
+
+        await expectLogic(logic, () => logic.actions.submitVerificationCode())
+            .toFinishAllListeners()
+            .toMatchValues({ verificationCode: '', verificationCodeError: 'That code is wrong.' })
+    })
+
+    it('keeps a partial code when it is too short to send', async () => {
+        logic.actions.setVerificationCode('123')
+
+        await expectLogic(logic, () => logic.actions.submitVerificationCode())
+            .toFinishAllListeners()
+            .toMatchValues({
+                verificationCode: '123',
+                verificationCodeError: 'Enter the 6-digit code from your email.',
+            })
+    })
+})

--- a/frontend/src/scenes/authentication/verify-email/verifyEmailLogic.ts
+++ b/frontend/src/scenes/authentication/verify-email/verifyEmailLogic.ts
@@ -1,11 +1,14 @@
-import { MakeLogicType, actions, connect, kea, path, reducers } from 'kea'
+import { MakeLogicType, actions, connect, kea, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { getRelativeNextPath } from 'lib/utils/url'
-import { pendingVerificationEmailStorage } from 'scenes/authentication/shared/pendingVerificationEmail'
+import {
+    clearPendingVerificationEmail,
+    pendingVerificationEmailFor,
+} from 'scenes/authentication/shared/pendingVerificationEmail'
 import {
     isValidVerificationCode,
     normalizeVerificationCode,
@@ -43,8 +46,8 @@ const redirectAfterVerification = (
     response: PostVerifyResponse,
     values: Parameters<typeof resolvePostVerifyDefault>[0]
 ): void => {
-    // The address has served its purpose once the account is verified.
-    pendingVerificationEmailStorage.clear()
+    // Verification is complete, so the stored address is no longer necessary.
+    clearPendingVerificationEmail()
     const nextUrl = getRelativeNextPath(new URLSearchParams(location.search).get('next'), location)
     const loginMessage = response.requires_2fa
         ? 'Email verified! Please log in with your password to complete two-factor authentication.'
@@ -119,6 +122,9 @@ export interface verifyEmailLogicActions {
     }
     setVerificationCodeError: (error: string | null) => {
         error: string | null
+    }
+    verificationCodeRejected: (error: string) => {
+        error: string
     }
     setView: (view: 'invalid' | 'pending' | 'success' | 'verify' | null) => {
         view: 'invalid' | 'pending' | 'success' | 'verify' | null
@@ -209,6 +215,7 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
         requestVerificationLink: (uuid: string) => ({ uuid }),
         setVerificationCode: (code: string) => ({ code }),
         setVerificationCodeError: (error: string | null) => ({ error }),
+        verificationCodeRejected: (error: string) => ({ error }),
         submitVerificationCode: true,
     }),
     loaders(({ actions, values }) => ({
@@ -230,13 +237,7 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
                         if (user?.is_email_verified) {
                             actions.setView('success')
                             await breakpoint(VERIFY_EMAIL_REDIRECT_DELAY_MS)
-                            const nextUrl = getRelativeNextPath(
-                                new URLSearchParams(location.search).get('next'),
-                                location
-                            )
-                            // this url is validated in getRelativeNextPath as either being relative or on the same origin
-                            // nosemgrep: javascript.browser.security.open-redirect.js-open-redirect
-                            location.href = nextUrl || resolvePostVerifyDefault(values)
+                            redirectAfterVerification({ success: true }, values)
                             return { success: true, token, uuid }
                         }
                         actions.setView('invalid')
@@ -263,10 +264,7 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
                         redirectAfterVerification(response, values)
                         return { success: true, uuid }
                     } catch (e: any) {
-                        // Empty the slots so the retype starts clean. Clear before you set the
-                        // error, because setVerificationCode also resets the error.
-                        actions.setVerificationCode('')
-                        actions.setVerificationCodeError(verificationCodeErrorMessage(e))
+                        actions.verificationCodeRejected(verificationCodeErrorMessage(e))
                         return values.validatedEmailToken
                     }
                 },
@@ -281,9 +279,8 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
                         lemonToast.success(
                             'A new verification email has been sent to the associated email address. Please check your inbox.'
                         )
-                        // A resend invalidates the previous code, so drop it and its error (the
-                        // setVerificationCode reducer clears the error too). The 6-char field is
-                        // otherwise full and blocks typing the freshly sent code.
+                        // A resend invalidates the previous code. Clear it so the slots are
+                        // empty for the new code; the reducer also clears the error.
                         actions.setVerificationCode('')
                         // Show the pending view after a resend - it has the code entry form.
                         actions.setView('pending')
@@ -317,11 +314,11 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
                 setUuid: (_, { uuid }) => uuid,
             },
         ],
-        pendingEmail: [pendingVerificationEmailStorage.get(), {}],
         verificationCode: [
             '',
             {
                 setVerificationCode: (_, { code }) => code,
+                verificationCodeRejected: () => '',
             },
         ],
         verificationCodeError: [
@@ -330,7 +327,19 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
                 setVerificationCode: () => null,
                 submitVerificationCode: () => null,
                 setVerificationCodeError: (_, { error }) => error,
+                verificationCodeRejected: (_, { error }) => error,
             },
+        ],
+    }),
+    selectors({
+        pendingEmail: [
+            (s) => [s.uuid, s.user],
+            (uuid, user): string | null =>
+                // The stored address wins because it also covers users without a session. The user
+                // fallback covers a signed-in but unverified user on a device that has no stored
+                // address. Both sources must match the uuid from the URL, so the page never names
+                // a different account.
+                pendingVerificationEmailFor(uuid) ?? (user && user.uuid === uuid ? user.email : null),
         ],
     }),
     urlToAction(({ actions }) => ({

--- a/frontend/src/scenes/authentication/verify-email/verifyEmailLogic.ts
+++ b/frontend/src/scenes/authentication/verify-email/verifyEmailLogic.ts
@@ -5,6 +5,7 @@ import { router, urlToAction } from 'kea-router'
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { getRelativeNextPath } from 'lib/utils/url'
+import { pendingVerificationEmailStorage } from 'scenes/authentication/shared/pendingVerificationEmail'
 import {
     isValidVerificationCode,
     normalizeVerificationCode,
@@ -42,6 +43,8 @@ const redirectAfterVerification = (
     response: PostVerifyResponse,
     values: Parameters<typeof resolvePostVerifyDefault>[0]
 ): void => {
+    // The address has served its purpose once the account is verified.
+    pendingVerificationEmailStorage.clear()
     const nextUrl = getRelativeNextPath(new URLSearchParams(location.search).get('next'), location)
     const loginMessage = response.requires_2fa
         ? 'Email verified! Please log in with your password to complete two-factor authentication.'
@@ -76,6 +79,7 @@ export interface verifyEmailLogicValues {
     user: UserType | null // userLogic
     newlyRequestedVerificationLink: boolean | null
     newlyRequestedVerificationLinkLoading: boolean
+    pendingEmail: string | null
     uuid: string | null
     validatedEmailToken: ValidatedTokenResponseType | null
     validatedEmailTokenLoading: boolean
@@ -259,6 +263,9 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
                         redirectAfterVerification(response, values)
                         return { success: true, uuid }
                     } catch (e: any) {
+                        // Empty the slots so the retype starts clean. Clear before you set the
+                        // error, because setVerificationCode also resets the error.
+                        actions.setVerificationCode('')
                         actions.setVerificationCodeError(verificationCodeErrorMessage(e))
                         return values.validatedEmailToken
                     }
@@ -310,6 +317,7 @@ export const verifyEmailLogic = kea<verifyEmailLogicType>([
                 setUuid: (_, { uuid }) => uuid,
             },
         ],
+        pendingEmail: [pendingVerificationEmailStorage.get(), {}],
         verificationCode: [
             '',
             {

--- a/frontend/src/scenes/settings/user/EmailChangeVerificationModal.tsx
+++ b/frontend/src/scenes/settings/user/EmailChangeVerificationModal.tsx
@@ -5,8 +5,8 @@ import * as magnifyingGlassPng from '@posthog/brand/hoggies/png/magnifying-glass
 import { pngHoggie } from 'lib/brand/hoggies'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { VERIFICATION_CODE_LENGTH, VerificationCodeInput } from 'scenes/authentication/shared/VerificationCodeInput'
 import { userLogic } from 'scenes/userLogic'
 
 import { MAX_RESENDS, emailChangeVerificationLogic } from './emailChangeVerificationLogic'
@@ -42,28 +42,22 @@ export function EmailChangeVerificationModal(): JSX.Element {
                 <HedgehogMagnifyingGlass className="block w-auto mx-auto h-28" />
                 <h2 className="m-0 text-2xl font-bold">Check your inbox</h2>
                 <p className="m-0 mb-2 text-secondary text-pretty">
-                    We emailed a 6-digit code to <strong>{user?.pending_email}</strong>. Enter it below to verify your
-                    new address. The code is valid for 30 minutes.
+                    We emailed a 6-digit code to <strong>{user?.pending_email}</strong>. The code is valid for 30
+                    minutes.
                 </p>
-                <LemonInput
+                <VerificationCodeInput
                     autoFocus
                     value={verificationCode}
                     onChange={setVerificationCode}
-                    placeholder="123456"
-                    aria-label="Email verification code"
-                    inputMode="numeric"
-                    autoComplete="one-time-code"
-                    size="large"
-                    fullWidth
+                    onComplete={() => {
+                        if (!verificationResultLoading) {
+                            submitVerificationCode()
+                        }
+                    }}
+                    error={verificationCodeError}
+                    disabled={verificationResultLoading}
                     data-attr="email-change-verification-code"
-                    className="ph-replay-block"
-                    status={verificationCodeError ? 'danger' : 'default'}
                 />
-                {verificationCodeError && (
-                    <p className="m-0 text-sm text-danger" role="alert">
-                        {verificationCodeError}
-                    </p>
-                )}
                 <LemonButton
                     type="primary"
                     size="large"
@@ -71,7 +65,11 @@ export function EmailChangeVerificationModal(): JSX.Element {
                     fullWidth
                     htmlType="submit"
                     loading={verificationResultLoading}
-                    disabledReason={verificationCode ? undefined : 'Enter the code from your email'}
+                    disabledReason={
+                        verificationCode.length === VERIFICATION_CODE_LENGTH
+                            ? undefined
+                            : 'Enter the 6-digit code from your email'
+                    }
                     data-attr="email-change-verification-submit"
                 >
                     Verify email

--- a/frontend/src/scenes/settings/user/EmailChangeVerificationModal.tsx
+++ b/frontend/src/scenes/settings/user/EmailChangeVerificationModal.tsx
@@ -6,7 +6,8 @@ import { pngHoggie } from 'lib/brand/hoggies'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
-import { VERIFICATION_CODE_LENGTH, VerificationCodeInput } from 'scenes/authentication/shared/VerificationCodeInput'
+import { isValidVerificationCode } from 'scenes/authentication/shared/verificationCode'
+import { VerificationCodeInput } from 'scenes/authentication/shared/VerificationCodeInput'
 import { userLogic } from 'scenes/userLogic'
 
 import { MAX_RESENDS, emailChangeVerificationLogic } from './emailChangeVerificationLogic'
@@ -49,11 +50,6 @@ export function EmailChangeVerificationModal(): JSX.Element {
                     autoFocus
                     value={verificationCode}
                     onChange={setVerificationCode}
-                    onComplete={() => {
-                        if (!verificationResultLoading) {
-                            submitVerificationCode()
-                        }
-                    }}
                     error={verificationCodeError}
                     disabled={verificationResultLoading}
                     data-attr="email-change-verification-code"
@@ -66,9 +62,7 @@ export function EmailChangeVerificationModal(): JSX.Element {
                     htmlType="submit"
                     loading={verificationResultLoading}
                     disabledReason={
-                        verificationCode.length === VERIFICATION_CODE_LENGTH
-                            ? undefined
-                            : 'Enter the 6-digit code from your email'
+                        isValidVerificationCode(verificationCode) ? undefined : 'Enter the 6-digit code from your email'
                     }
                     data-attr="email-change-verification-submit"
                 >

--- a/frontend/src/scenes/settings/user/emailChangeVerificationLogic.ts
+++ b/frontend/src/scenes/settings/user/emailChangeVerificationLogic.ts
@@ -197,6 +197,9 @@ export const emailChangeVerificationLogic = kea<emailChangeVerificationLogicType
                         actions.loadUser()
                         return { success: true }
                     } catch (e: any) {
+                        // Empty the slots so the retype starts clean. Clear before you set the
+                        // error, because setVerificationCode also resets the error.
+                        actions.setVerificationCode('')
                         actions.setVerificationCodeError(verificationCodeErrorMessage(e))
                         return null
                     }

--- a/frontend/src/scenes/settings/user/emailChangeVerificationLogic.ts
+++ b/frontend/src/scenes/settings/user/emailChangeVerificationLogic.ts
@@ -78,6 +78,9 @@ export interface emailChangeVerificationLogicActions {
     setVerificationCodeError: (error: string | null) => {
         error: string | null
     }
+    verificationCodeRejected: (error: string) => {
+        error: string
+    }
     startResendCooldown: (seconds: number) => {
         seconds: number
     }
@@ -128,6 +131,7 @@ export const emailChangeVerificationLogic = kea<emailChangeVerificationLogicType
         emailChangeStaged: true,
         setVerificationCode: (code: string) => ({ code }),
         setVerificationCodeError: (error: string | null) => ({ error }),
+        verificationCodeRejected: (error: string) => ({ error }),
         submitVerificationCode: true,
         resendCode: true,
         resendLimitReached: true,
@@ -146,6 +150,7 @@ export const emailChangeVerificationLogic = kea<emailChangeVerificationLogicType
             '',
             {
                 setVerificationCode: (_, { code }) => code,
+                verificationCodeRejected: () => '',
                 openModal: () => '',
             },
         ],
@@ -155,6 +160,7 @@ export const emailChangeVerificationLogic = kea<emailChangeVerificationLogicType
                 setVerificationCode: () => null,
                 submitVerificationCode: () => null,
                 setVerificationCodeError: (_, { error }) => error,
+                verificationCodeRejected: (_, { error }) => error,
                 openModal: () => null,
             },
         ],
@@ -197,10 +203,7 @@ export const emailChangeVerificationLogic = kea<emailChangeVerificationLogicType
                         actions.loadUser()
                         return { success: true }
                     } catch (e: any) {
-                        // Empty the slots so the retype starts clean. Clear before you set the
-                        // error, because setVerificationCode also resets the error.
-                        actions.setVerificationCode('')
-                        actions.setVerificationCodeError(verificationCodeErrorMessage(e))
+                        actions.verificationCodeRejected(verificationCodeErrorMessage(e))
                         return null
                     }
                 },


### PR DESCRIPTION
## Problem

Someone verifying their email after signup types the 6-digit code into a single text box, and that box does not behave like a code field: nothing shows how many digits it wants, and a rejected code stays on screen until they clear it by hand before retrying. The same box is in the email change modal in settings.

Requested in the Slack thread on the switch from verification links to codes, with a [reference screenshot](https://posthog.slack.com/files/U0963BAULSD/F0BT9LN2W2Y/screenshot_2026-08-27_at_17.42.50.png).

## Changes

- The code field is now six slots, one per digit. Typing advances, backspace steps back, arrows move between slots, and letters are refused.

  ![verification code slots](https://raw.githubusercontent.com/PostHog/pr-assets/30bd97de727d85ed24acb0879b37840dc164a383/2026/08/6b8b5a5a-00ea-451e-a6f3-78d7b33f5a21.png)

- Pasting fills every slot at once, including a code that arrives as `123-456`, wrapped in spaces, or with the fullwidth digits some email clients produce.
- Entering the last digit submits the form, so a complete code no longer needs the button.
- A rejected code empties the slots and puts the cursor back in the first one, ready for the retype. One `verificationCodeRejected` action owns "empty the code, show the error" in both logics.

  ![rejected code](https://raw.githubusercontent.com/PostHog/pr-assets/30bd97de727d85ed24acb0879b37840dc164a383/2026/08/b9e7f56c-a15a-48df-8699-7af5afecf9dd.png)

- The page names the address it wrote to: "We emailed a 6-digit code to marius@example.com." The verification page has no session, so signup, invite signup, and the login redirect store the address in `localStorage` together with the user uuid, and the page shows it only when the uuid matches its URL. A signed-in but unverified user with the same uuid gets the address from their session instead. Without either source the copy falls back to "We emailed you a 6-digit code."
- Both surfaces drop the sentence "Enter it below to verify your email address."
- The slots are Base UI's OTP field, already a dependency of this repo. Hand-rolled slot inputs are where paste, IME, and backspace behavior usually break. Completion submits through Base UI's `autoSubmit`, so the form's existing submit guard stays the single submit path.
- Mechanical: one shared `VerificationCodeInput` replaces the `LemonInput` in the verify-email scene and the settings modal; `localStorageSlot` gains `clear()`; `VERIFICATION_CODE_LENGTH` lives beside `isValidVerificationCode` and both buttons gate on that helper.

## How did you test this code?

- `verifyEmailLogic` tests cover: a rejected code empties the field and shows the error; a too-short code stays in place; the stored address is shown only when its uuid matches the page uuid (so a leftover value from an earlier signup on the same device never names the wrong account).
- Drove the component in headless Chromium against Storybook: typing, backspace, arrows, refused letters, pasting ` 987-654 ` and `１２３４５６`, auto-submit on the sixth digit, and a rejected code emptying the slots and refocusing the first one. Verified the named-address copy for a matching uuid and the fallback copy for a mismatched one. Also checked dark theme and a narrow width.
- New stories cover empty, filled, rejected, verifying, and narrow.
- Not checked: a real signup and verification round trip against the backend, the invite signup path, and the settings email change modal in the running app. The modal is covered only through the shared component's stories.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills consulted: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/simplify`, `/writing-code-comments`.
- The first attempt kept the single input and only styled it. It moved to Base UI's OTP field once the paste and retype cases were written down, since those are the ones a styled input still gets wrong.
- Naming the address needed somewhere to keep it, because the verification page loads without a session. A backend lookup keyed on the verification uuid was rejected as it would hand out an address to anyone holding a uuid.
- A `/simplify` review pass reworked the first version: the stored address became uuid-keyed after the review flagged that a leftover value could name the wrong account, the read moved from a module-import-time reducer default (stale across the login redirect, which is a client-side navigation) to a selector, the `is_email_verified` fallback branch was routed through `redirectAfterVerification` so it also clears the stored address, an order-dependent clear-then-error action pair became one action, and an `onComplete` prop was replaced by Base UI's `autoSubmit`.
- Commits were created through GitHub's `createCommitOnBranch` API: this workspace has no reachable signing key, and the repository requires verified signatures.
