### PR TITLE
feat(personhog): merge traffic in the test harness gate

### DIFF
--- a/.agents/skills/extending-personhog-test-harness/SKILL.md
+++ b/.agents/skills/extending-personhog-test-harness/SKILL.md
@@ -44,9 +44,9 @@ logic here: the harness is for whole-stack behavior only.
   kill, etcd lease revocation, per-service env. New disruptions are new
   methods here.
 - `src/scenarios/merge.rs` — the merge lane (`--merge-concurrency`): MergePersons
-  calls against pairs of live persons while the other lanes write to them.
-  Merged sources fold into the survivor's journal and are retired from the
-  shared `src/pool.rs` target pool.
+  calls with one or more sources (`--merge-sources`) against live persons while
+  the other lanes write to them. Merged sources hang off the survivor in the
+  journal tree and are retired from the shared `src/pool.rs` target pool.
 - `src/state.rs` — the acked-write journal and its verifiers. New invariants go
   here, and their decision tables get unit tests: a false-negative verifier
   looks identical to a healthy stack, so e2e runs cannot reveal it.

--- a/.agents/skills/extending-personhog-test-harness/SKILL.md
+++ b/.agents/skills/extending-personhog-test-harness/SKILL.md
@@ -43,6 +43,10 @@ logic here: the harness is for whole-stack behavior only.
   SIGTERM drain, SIGSTOP/SIGCONT zombie), writer crash/pause, coordinator
   kill, etcd lease revocation, per-service env. New disruptions are new
   methods here.
+- `src/scenarios/merge.rs` — the merge lane (`--merge-concurrency`): MergePersons
+  calls against pairs of live persons while the other lanes write to them.
+  Merged sources fold into the survivor's journal and are retired from the
+  shared `src/pool.rs` target pool.
 - `src/state.rs` — the acked-write journal and its verifiers. New invariants go
   here, and their decision tables get unit tests: a false-negative verifier
   looks identical to a healthy stack, so e2e runs cannot reveal it.

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -642,14 +642,13 @@ jobs:
             # The merge saga under load and chaos: MergePersons calls against
             # live persons while blast writes race each source's fence and
             # each target's fold, through a leader kill and a scale-up. Two
-            # sources per call exercise the fold's request-order precedence,
-            # and the wide persons make the flip repoint a thousand
-            # mappings per source. The gate asserts the sources' acked
-            # writes on the survivor under the fold rule, the merge event's
-            # $set and $set_once tiers, that each source is gone (not-found
-            # reads, a Postgres tombstone above every acked version, no
-            # mapping left behind), and that the delete leg answers
-            # not_found for merged sources.
+            # sources per call exercise the fold's request order. The wide
+            # persons make the flip repoint a thousand mappings per source.
+            # The gate asserts the folded survivor document, the merge
+            # event's $set and $set_once, that each source is gone (not-found
+            # reads, a tombstone above every acked version, no mapping left
+            # behind), and that the delete leg answers not_found for merged
+            # sources.
             - name: Run the e2e gate merging persons under chaos (kill + scale-up)
               run: |
                   ./target/debug/personhog-test-harness gate \

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -640,18 +640,24 @@ jobs:
                     --concurrency 10 --duration 15s --kill-after 5s --scale-up-after 8s
 
             # The merge saga under load and chaos: MergePersons calls against
-            # pairs of live persons while blast writes race each source's
-            # fence and each target's fold, through a leader kill and a
-            # scale-up. The gate asserts the source's acked writes on the
-            # survivor, that the source is gone (not-found reads, a
-            # Postgres tombstone above every acked version), and that the
-            # delete leg answers not_found for merged sources.
+            # live persons while blast writes race each source's fence and
+            # each target's fold, through a leader kill and a scale-up. Two
+            # sources per call exercise the fold's request-order precedence,
+            # and the wide persons make the flip repoint a thousand
+            # mappings per source. The gate asserts the sources' acked
+            # writes on the survivor under the fold rule, the merge event's
+            # $set and $set_once tiers, that each source is gone (not-found
+            # reads, a Postgres tombstone above every acked version, no
+            # mapping left behind), and that the delete leg answers
+            # not_found for merged sources.
             - name: Run the e2e gate merging persons under chaos (kill + scale-up)
               run: |
                   ./target/debug/personhog-test-harness gate \
                     --pg-target-table posthog_person \
                     --leaders 3 --partitions 8 --persons 200 \
                     --concurrency 10 --duration 15s --merge-concurrency 4 --merge-rate 5 \
+                    --merge-sources 2 \
+                    --merge-wide-persons 3 --merge-wide-distinct-ids 1000 --merge-wide-role source \
                     --kill-after 5s --scale-up-after 8s
 
             # Regression gate for eviction under writer lag: the cache is

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -639,6 +639,21 @@ jobs:
                     --leaders 3 --partitions 8 --persons 100 \
                     --concurrency 10 --duration 15s --kill-after 5s --scale-up-after 8s
 
+            # The merge saga under load and chaos: MergePersons calls against
+            # pairs of live persons while blast writes race each source's
+            # fence and each target's fold, through a leader kill and a
+            # scale-up. The gate asserts the source's acked writes on the
+            # survivor, that the source is gone (not-found reads, a
+            # Postgres tombstone above every acked version), and that the
+            # delete leg answers not_found for merged sources.
+            - name: Run the e2e gate merging persons under chaos (kill + scale-up)
+              run: |
+                  ./target/debug/personhog-test-harness gate \
+                    --pg-target-table posthog_person \
+                    --leaders 3 --partitions 8 --persons 200 \
+                    --concurrency 10 --duration 15s --merge-concurrency 4 --merge-rate 5 \
+                    --kill-after 5s --scale-up-after 8s
+
             # Regression gate for eviction under writer lag: the cache is
             # sized far below the person count so dirty entries evict while
             # the paused writer guarantees their PG rows are stale. Before

--- a/rust/personhog-test-harness/README.md
+++ b/rust/personhog-test-harness/README.md
@@ -64,14 +64,17 @@ Multiple local leaders work because each registers with a `host:port` pod name, 
 
 ### Merging persons under load
 
-`--merge-concurrency N` adds a merge lane: N workers repeatedly pick two live persons and merge one into the other through `MergePersons` on the identity service, while the blast writers and probers keep writing to both.
-Every pair is two distinct live persons, so each call that settles as `merged` ran the durable saga end to end (fence, seal, fold, flip, release) with writes racing the source's fence and the target's fold.
+`--merge-concurrency N` adds a merge lane: N workers repeatedly pick live persons and merge one or more sources into a target through `MergePersons` on the identity service, while the blast writers and probers keep writing to all of them.
+Every source is a distinct live person, so each source that settles as `merged` ran the durable saga end to end (fence, seal, fold, flip, release) with writes racing the source's fence and the target's fold.
 A source distinct id is reserved for one in-flight call and never reused once merged; targets are shared, so concurrent calls can contend for a person and settle as `skipped_conflict`.
+`--merge-sources K` puts K sources on each call (default 1, the shape ingestion sends); the leader folds sealed sources in request order, and the journal holds the survivor to that order.
 The lane implies `--create-via-identity` (merges need distinct ids) and merges identified sources by default (`--merge-identified-sources false` for `$identify` semantics, under which a survivor can never be a source again).
 
 The invariant extends to the fold rather than stopping at it:
 
-- The source's acked writes are asserted on the survivor under the leader's fold rule (the survivor wins every key it has, the source fills the rest), the merge event's own `$set` key must be in the acked survivor document and afterwards, and the folded version is claimed like any other ack.
+- The sources' acked writes are asserted on the survivor under the leader's fold rule (the survivor wins every key it has, the sources fill the rest in request order), and the folded version is claimed like any other ack.
+- The merge event's own writes are asserted in the acked survivor document and afterwards: its `$set` key must be present, its `$set_once` must fill a fresh key, lose to the same event's `$set` on a shared key, and leave the seed property every person holds untouched.
+- The journal is a tree: a merged source keeps its own keys and hangs off the survivor its ack named, and a live person's expected document is folded from that tree. So a source write whose ack lands after the merge was journaled still counts, even for a key an earlier fold already carried, and a survivor that merges on carries everything with it.
 - A merged source must be gone: a strong read right after the ack and at end of run must answer not-found, its Postgres row must be a tombstone whose death version sits above every version the leader acked for it, and no acked version may exceed the sealed version the saga recorded on its `lifecycle_op_person` row — an ack above the seal means a write got through the fence.
 - Two merges into one survivor are ordered by the folded version, not by ack arrival: the earlier fold fills a key and the later fold finds it present, which is what the journal expects.
 - A merge the crash window abandons mid-saga is re-driven by the identity sweeper (the spawned identity runs it on a 3s cadence), and the delete leg waits for those ops to settle before it asserts.
@@ -89,7 +92,7 @@ target/debug/personhog-test-harness gate --merge-concurrency 2 --merge-rate 2 \
   --persons 100 --duration 15s
 ```
 
-Each merge retires one person, so size `--persons` for rate × duration; the report says when the lane ran the pool dry.
+Each merged source retires one person, so size `--persons` for sources × rate × duration; the report says when the lane ran the pool dry.
 The `merges` row in the report is the baseline: one call is one saga, so its latency is the end-to-end merge cost and its RPS the merge throughput.
 
 ```bash

--- a/rust/personhog-test-harness/README.md
+++ b/rust/personhog-test-harness/README.md
@@ -3,7 +3,7 @@
 Load, consistency, and e2e correctness harness for the personhog leader path.
 Revived from the original personhog-cannon draft (#55581) and extended with stack orchestration, Postgres seeding, and an acked-write journal so it can gate CI, not just generate load.
 
-The core invariant it checks: **every write acked by the leader path is visible afterwards** — in strong reads once coordination has converged (post-chaos handoffs re-driven; an already-settled run waits zero time, and failing to converge within 30s fails the gate), and in Postgres (at or above the highest acked version) once the writer drains.
+The core invariant it checks: **every write acked by the leader path is visible afterwards** — on the person it was written to, or on the survivor once a merge folded that person away — in strong reads once coordination has converged (post-chaos handoffs re-driven; an already-settled run waits zero time, and failing to converge within 30s fails the gate), and in Postgres (at or above the highest acked version) once the writer drains.
 Every acked update is journaled under a unique property key, so the final state must contain all of them regardless of how concurrent writers interleaved.
 Version assignment is asserted throughout: the leader assigns each version of a person to at most one acked write, so a duplicated acked version (two writes served from the same base state), or a strong read observing a version below the highest ack, is a violation.
 Read-your-write recency is asserted live: `--probers` (default 2) workers run write-then-strong-read cycles alongside the blast traffic, so a staleness window during a chaos event trips a probe even if it heals before the end-of-run verification.
@@ -61,6 +61,51 @@ target/debug/personhog-test-harness gate --create-via-identity \
 ```
 
 Multiple local leaders work because each registers with a `host:port` pod name, which the router's address resolver dials as-is (bare pod names still resolve via DNS on the fleet-wide leader port).
+
+### Merging persons under load
+
+`--merge-concurrency N` adds a merge lane: N workers repeatedly pick two live persons and merge one into the other through `MergePersons` on the identity service, while the blast writers and probers keep writing to both.
+Every pair is two distinct live persons, so each call that settles as `merged` ran the durable saga end to end (fence, seal, fold, flip, release) with writes racing the source's fence and the target's fold.
+A source distinct id is reserved for one in-flight call and never reused once merged; targets are shared, so concurrent calls can contend for a person and settle as `skipped_conflict`.
+The lane implies `--create-via-identity` (merges need distinct ids) and merges identified sources by default (`--merge-identified-sources false` for `$identify` semantics, under which a survivor can never be a source again).
+
+The invariant extends to the fold rather than stopping at it:
+
+- The source's acked writes are asserted on the survivor under the leader's fold rule (the survivor wins every key it has, the source fills the rest), the merge event's own `$set` key must be in the acked survivor document and afterwards, and the folded version is claimed like any other ack.
+- A merged source must be gone: a strong read right after the ack and at end of run must answer not-found, its Postgres row must be a tombstone whose death version sits above every version the leader acked for it, and no acked version may exceed the sealed version the saga recorded on its `lifecycle_op_person` row — an ack above the seal means a write got through the fence.
+- Two merges into one survivor are ordered by the folded version, not by ack arrival: the earlier fold fills a key and the later fold finds it present, which is what the journal expects.
+- A merge the crash window abandons mid-saga is re-driven by the identity sweeper (the spawned identity runs it on a 3s cadence), and the delete leg waits for those ops to settle before it asserts.
+- A call that loses every response (retried under the same op id) is settled after traffic from the saga's own `lifecycle_op` record: a completed merge is journaled late (safe, because folds are ordered by version), an aborted or never-started one leaves the source live, and one that never settles is a violation. Writes refused for a fenced or destroyed person are counted as lifecycle rejections, not failures.
+- The delete leg expects merged sources to answer `not_found` on the first attempt.
+
+Pathological merges — a person carrying thousands of distinct ids, every one of which the flip must repoint — get their own lane: `--merge-fat-persons N` creates N extra persons with `--merge-fat-distinct-ids K` extra mappings each (identity caps a create entry at 5000), and `--merge-fat-role source|target|both` decides which side they take.
+Workers prefer a fat pair while one is available, and calls involving a fat person report as a separate `merges_fat` row so their cost does not hide in the ordinary median.
+Merged sources are additionally checked for leftover mappings (`__merged_source_dids_left`): every distinct id of a destroyed person must point at the survivor.
+
+```bash
+# 5 fat sources with 2000 distinct ids each, merged into ordinary targets
+target/debug/personhog-test-harness gate --merge-concurrency 2 --merge-rate 2 \
+  --merge-fat-persons 5 --merge-fat-distinct-ids 2000 --merge-fat-role source \
+  --persons 100 --duration 15s
+```
+
+Each merge retires one person, so size `--persons` for rate × duration; the report says when the lane ran the pool dry.
+The `merges` row in the report is the baseline: one call is one saga, so its latency is the end-to-end merge cost and its RPS the merge throughput.
+
+```bash
+# Paced: 5 merges/s alongside the blast traffic
+target/debug/personhog-test-harness gate --merge-concurrency 4 --merge-rate 5 \
+  --persons 200 --concurrency 10 --duration 15s
+
+# Throughput ceiling: unpaced workers, pool sized for a 10s burn
+target/debug/personhog-test-harness gate --merge-concurrency 8 --persons 400 --duration 10s
+
+# Merges through a leader kill and a scale-up: fences, folds, and death
+# documents must survive the handoffs
+target/debug/personhog-test-harness gate --leaders 3 --partitions 8 \
+  --merge-concurrency 4 --merge-rate 5 --persons 200 --duration 15s \
+  --kill-after 5s --scale-up-after 8s
+```
 
 ### Chaos disruptions
 
@@ -232,10 +277,15 @@ target/debug/personhog-test-harness consistency \
   Operation     Total  Success  Failed      p50      p95      p99       RPS
   writes          970      970       0   23.3ms   45.4ms   56.4ms     160.1
   reads            20       20       0    753us    1.2ms    1.3ms       3.3
+  merges           80       80       0   80.6ms  197.0ms  697.3ms       5.0
+
+  Lifecycle rejections (counted in Total, not Failed): 17 writes refused for a fenced or destroyed person
+  Merge outcomes per source: merged=79 skipped_conflict=1
 
   Consistency violations: 0
 ```
 
 Violations are printed per person/key with expected vs actual; `__version` rows mean Postgres settled at a different version than the last ack, `__row` rows mean the person never reached Postgres at all.
+Merge runs add `__merged_source_alive` (a destroyed person still reads), `__merged_source_tombstone` / `__merged_source_death_version` (the source row is not a tombstone, or its death version does not sit above every acked write), `__merged_source_ack_above_seal` (the leader acked a source write above the sealed version the saga recorded — the fence failed open), `__merged_source_seal_record` (the saga left no deleted source row for a merged person), `__merged_twice` (one person destroyed by two merges), and `__merge_unsettled` (a merge that lost every response never reached a terminal step).
 
 Set `RUST_LOG=personhog_test_harness=debug` for per-request logging.

--- a/rust/personhog-test-harness/README.md
+++ b/rust/personhog-test-harness/README.md
@@ -78,14 +78,14 @@ The invariant extends to the fold rather than stopping at it:
 - A call that loses every response (retried under the same op id) is settled after traffic from the saga's own `lifecycle_op` record: a completed merge is journaled late (safe, because folds are ordered by version), an aborted or never-started one leaves the source live, and one that never settles is a violation. Writes refused for a fenced or destroyed person are counted as lifecycle rejections, not failures.
 - The delete leg expects merged sources to answer `not_found` on the first attempt.
 
-Pathological merges — a person carrying thousands of distinct ids, every one of which the flip must repoint — get their own lane: `--merge-fat-persons N` creates N extra persons with `--merge-fat-distinct-ids K` extra mappings each (identity caps a create entry at 5000), and `--merge-fat-role source|target|both` decides which side they take.
-Workers prefer a fat pair while one is available, and calls involving a fat person report as a separate `merges_fat` row so their cost does not hide in the ordinary median.
+Pathological merges — a person carrying thousands of distinct ids, every one of which the flip must repoint — get their own lane: `--merge-wide-persons N` creates N extra persons with `--merge-wide-distinct-ids K` extra mappings each (identity caps a create entry at 5000), and `--merge-wide-role source|target|both` decides which side they take.
+Workers prefer a wide pair while one is available, and calls involving a wide person report as a separate `merges_wide` row so their cost does not hide in the ordinary median.
 Merged sources are additionally checked for leftover mappings (`__merged_source_dids_left`): every distinct id of a destroyed person must point at the survivor.
 
 ```bash
-# 5 fat sources with 2000 distinct ids each, merged into ordinary targets
+# 5 wide sources with 2000 distinct ids each, merged into ordinary targets
 target/debug/personhog-test-harness gate --merge-concurrency 2 --merge-rate 2 \
-  --merge-fat-persons 5 --merge-fat-distinct-ids 2000 --merge-fat-role source \
+  --merge-wide-persons 5 --merge-wide-distinct-ids 2000 --merge-wide-role source \
   --persons 100 --duration 15s
 ```
 

--- a/rust/personhog-test-harness/src/cli.rs
+++ b/rust/personhog-test-harness/src/cli.rs
@@ -352,6 +352,14 @@ pub struct GateArgs {
     #[arg(long)]
     pub merge_rate: Option<f64>,
 
+    /// Sources per merge call. Ingestion sends one, and one is the
+    /// default. With more, the leader folds the sealed sources in
+    /// request order, and the journal holds the survivor to that order.
+    /// Every merged source retires a person, so size --persons for
+    /// sources x rate x duration.
+    #[arg(long, default_value_t = 1)]
+    pub merge_sources: usize,
+
     /// Persons created with --merge-wide-distinct-ids extra distinct ids
     /// each, on top of --persons. The merge lane pairs them per
     /// --merge-wide-role. The expensive merges, where the flip must

--- a/rust/personhog-test-harness/src/cli.rs
+++ b/rust/personhog-test-harness/src/cli.rs
@@ -333,38 +333,31 @@ pub struct GateArgs {
     #[arg(long)]
     pub external_identity_url: Option<String>,
 
-    /// Concurrent merge workers running alongside the blast traffic and
-    /// probers. Each worker repeatedly picks two live persons and merges
-    /// one into the other through MergePersons on the identity service,
-    /// so every merged pair runs the durable saga under concurrent
-    /// writes to both. Merged sources leave the traffic pool. Their
-    /// acked writes are asserted on the survivor, and their rows must
-    /// end as tombstones above every acked version. Implies
-    /// --create-via-identity, because persons need distinct ids. 0
+    /// Merge workers that run next to the blast traffic and probers.
+    /// Each worker picks live persons and merges them through
+    /// MergePersons on the identity service while writes to them
+    /// continue. Merged sources leave the traffic pool. Implies
+    /// --create-via-identity, because merges need distinct ids. 0
     /// disables.
     #[arg(long, default_value_t = 0)]
     pub merge_concurrency: usize,
 
-    /// Combined merge rate across the merge workers (merges/second).
-    /// Unset runs them flat out, which measures the throughput ceiling
-    /// but drains the pool fast. Every merge retires one person, so
-    /// size --persons for rate x duration.
+    /// Total merge calls per second across the merge workers. Unset
+    /// runs them flat out. Each merged source retires one person, so
+    /// size --persons for sources x rate x duration.
     #[arg(long)]
     pub merge_rate: Option<f64>,
 
-    /// Sources per merge call. Ingestion sends one, and one is the
-    /// default. With more, the leader folds the sealed sources in
-    /// request order, and the journal holds the survivor to that order.
-    /// Every merged source retires a person, so size --persons for
-    /// sources x rate x duration.
+    /// Sources per merge call. Ingestion sends one. With more, the
+    /// leader folds the sources in request order, and the gate asserts
+    /// that order.
     #[arg(long, default_value_t = 1)]
     pub merge_sources: usize,
 
-    /// Persons created with --merge-wide-distinct-ids extra distinct ids
-    /// each, on top of --persons. The merge lane pairs them per
-    /// --merge-wide-role. The expensive merges, where the flip must
-    /// repoint a source's every mapping, then report on their own
-    /// `merges_wide` latency row. Requires --merge-concurrency.
+    /// Extra persons, each created with --merge-wide-distinct-ids
+    /// distinct ids. The merge lane uses them per --merge-wide-role and
+    /// reports their calls on the `merges_wide` row. Requires
+    /// --merge-concurrency.
     #[arg(long, default_value_t = 0)]
     pub merge_wide_persons: u32,
 
@@ -373,18 +366,16 @@ pub struct GateArgs {
     #[arg(long, default_value_t = 1000)]
     pub merge_wide_distinct_ids: u32,
 
-    /// Which side of a merge the wide persons take. With `source`, the
-    /// flip repoints every mapping, which is the expensive case. With
-    /// `target`, the flip is cheap but the survivor keeps growing.
+    /// Which side of a merge the wide persons take. `source` makes the
+    /// flip repoint every mapping. `target` makes the survivor grow.
     /// `both` merges wide into wide.
     #[arg(long, default_value = "source", value_parser = ["source", "target", "both"])]
     pub merge_wide_role: String,
 
-    /// Merge identified sources ($merge_dangerously semantics). A
-    /// survivor becomes identified. With this off it can never be a
-    /// source again, and the lane degrades to
-    /// skipped_already_identified once every live person has survived a
-    /// merge.
+    /// Merge identified sources, as $merge_dangerously does. A survivor
+    /// becomes identified. With this off, a survivor can never be a
+    /// source again, and the lane ends in skipped_already_identified
+    /// once every live person survived a merge.
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub merge_identified_sources: bool,
 

--- a/rust/personhog-test-harness/src/cli.rs
+++ b/rust/personhog-test-harness/src/cli.rs
@@ -334,47 +334,49 @@ pub struct GateArgs {
     pub external_identity_url: Option<String>,
 
     /// Concurrent merge workers running alongside the blast traffic and
-    /// probers: each repeatedly picks two live persons and merges one
-    /// into the other through MergePersons on the identity service, so
-    /// every merged pair runs the durable saga under concurrent writes
-    /// to both. Merged sources are retired from the traffic pool; their
+    /// probers. Each worker repeatedly picks two live persons and merges
+    /// one into the other through MergePersons on the identity service,
+    /// so every merged pair runs the durable saga under concurrent
+    /// writes to both. Merged sources leave the traffic pool. Their
     /// acked writes are asserted on the survivor, and their rows must
     /// end as tombstones above every acked version. Implies
-    /// --create-via-identity (persons need distinct ids). 0 disables.
+    /// --create-via-identity, because persons need distinct ids. 0
+    /// disables.
     #[arg(long, default_value_t = 0)]
     pub merge_concurrency: usize,
 
     /// Combined merge rate across the merge workers (merges/second).
-    /// Unset runs them flat out — the throughput ceiling — at the cost of
-    /// draining the pool fast: every merge retires one person, so size
-    /// --persons for rate × duration.
+    /// Unset runs them flat out, which measures the throughput ceiling
+    /// but drains the pool fast. Every merge retires one person, so
+    /// size --persons for rate x duration.
     #[arg(long)]
     pub merge_rate: Option<f64>,
 
     /// Persons created with --merge-wide-distinct-ids extra distinct ids
     /// each, on top of --persons. The merge lane pairs them per
-    /// --merge-wide-role, so the pathological merges — a source whose
-    /// every mapping the flip must repoint — get their own latency row
-    /// (`merges_wide`). Requires --merge-concurrency.
+    /// --merge-wide-role. The expensive merges, where the flip must
+    /// repoint a source's every mapping, then report on their own
+    /// `merges_wide` latency row. Requires --merge-concurrency.
     #[arg(long, default_value_t = 0)]
     pub merge_wide_persons: u32,
 
-    /// Extra distinct ids per wide person (the identity service caps a
-    /// create entry at 5000).
+    /// Extra distinct ids per wide person. The identity service caps a
+    /// create entry at 5000.
     #[arg(long, default_value_t = 1000)]
     pub merge_wide_distinct_ids: u32,
 
-    /// Which side of a merge the wide persons take: `source` (every
-    /// mapping repoints — the expensive flip), `target` (the survivor
-    /// is wide; the flip is cheap but the survivor keeps growing), or
-    /// `both` (wide into wide).
+    /// Which side of a merge the wide persons take. With `source`, the
+    /// flip repoints every mapping, which is the expensive case. With
+    /// `target`, the flip is cheap but the survivor keeps growing.
+    /// `both` merges wide into wide.
     #[arg(long, default_value = "source", value_parser = ["source", "target", "both"])]
     pub merge_wide_role: String,
 
     /// Merge identified sources ($merge_dangerously semantics). A
-    /// survivor becomes identified, so with this off it can never be a
-    /// source again and the lane degrades to skipped_already_identified
-    /// once every live person has survived a merge.
+    /// survivor becomes identified. With this off it can never be a
+    /// source again, and the lane degrades to
+    /// skipped_already_identified once every live person has survived a
+    /// merge.
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub merge_identified_sources: bool,
 

--- a/rust/personhog-test-harness/src/cli.rs
+++ b/rust/personhog-test-harness/src/cli.rs
@@ -351,25 +351,25 @@ pub struct GateArgs {
     #[arg(long)]
     pub merge_rate: Option<f64>,
 
-    /// Persons created with --merge-fat-distinct-ids extra distinct ids
+    /// Persons created with --merge-wide-distinct-ids extra distinct ids
     /// each, on top of --persons. The merge lane pairs them per
-    /// --merge-fat-role, so the pathological merges — a source whose
+    /// --merge-wide-role, so the pathological merges — a source whose
     /// every mapping the flip must repoint — get their own latency row
-    /// (`merges_fat`). Requires --merge-concurrency.
+    /// (`merges_wide`). Requires --merge-concurrency.
     #[arg(long, default_value_t = 0)]
-    pub merge_fat_persons: u32,
+    pub merge_wide_persons: u32,
 
-    /// Extra distinct ids per fat person (the identity service caps a
+    /// Extra distinct ids per wide person (the identity service caps a
     /// create entry at 5000).
     #[arg(long, default_value_t = 1000)]
-    pub merge_fat_distinct_ids: u32,
+    pub merge_wide_distinct_ids: u32,
 
-    /// Which side of a merge the fat persons take: `source` (every
+    /// Which side of a merge the wide persons take: `source` (every
     /// mapping repoints — the expensive flip), `target` (the survivor
-    /// is fat; the flip is cheap but the survivor keeps growing), or
-    /// `both` (fat into fat).
+    /// is wide; the flip is cheap but the survivor keeps growing), or
+    /// `both` (wide into wide).
     #[arg(long, default_value = "source", value_parser = ["source", "target", "both"])]
-    pub merge_fat_role: String,
+    pub merge_wide_role: String,
 
     /// Merge identified sources ($merge_dangerously semantics). A
     /// survivor becomes identified, so with this off it can never be a

--- a/rust/personhog-test-harness/src/cli.rs
+++ b/rust/personhog-test-harness/src/cli.rs
@@ -333,6 +333,51 @@ pub struct GateArgs {
     #[arg(long)]
     pub external_identity_url: Option<String>,
 
+    /// Concurrent merge workers running alongside the blast traffic and
+    /// probers: each repeatedly picks two live persons and merges one
+    /// into the other through MergePersons on the identity service, so
+    /// every merged pair runs the durable saga under concurrent writes
+    /// to both. Merged sources are retired from the traffic pool; their
+    /// acked writes are asserted on the survivor, and their rows must
+    /// end as tombstones above every acked version. Implies
+    /// --create-via-identity (persons need distinct ids). 0 disables.
+    #[arg(long, default_value_t = 0)]
+    pub merge_concurrency: usize,
+
+    /// Combined merge rate across the merge workers (merges/second).
+    /// Unset runs them flat out — the throughput ceiling — at the cost of
+    /// draining the pool fast: every merge retires one person, so size
+    /// --persons for rate × duration.
+    #[arg(long)]
+    pub merge_rate: Option<f64>,
+
+    /// Persons created with --merge-fat-distinct-ids extra distinct ids
+    /// each, on top of --persons. The merge lane pairs them per
+    /// --merge-fat-role, so the pathological merges — a source whose
+    /// every mapping the flip must repoint — get their own latency row
+    /// (`merges_fat`). Requires --merge-concurrency.
+    #[arg(long, default_value_t = 0)]
+    pub merge_fat_persons: u32,
+
+    /// Extra distinct ids per fat person (the identity service caps a
+    /// create entry at 5000).
+    #[arg(long, default_value_t = 1000)]
+    pub merge_fat_distinct_ids: u32,
+
+    /// Which side of a merge the fat persons take: `source` (every
+    /// mapping repoints — the expensive flip), `target` (the survivor
+    /// is fat; the flip is cheap but the survivor keeps growing), or
+    /// `both` (fat into fat).
+    #[arg(long, default_value = "source", value_parser = ["source", "target", "both"])]
+    pub merge_fat_role: String,
+
+    /// Merge identified sources ($merge_dangerously semantics). A
+    /// survivor becomes identified, so with this off it can never be a
+    /// source again and the lane degrades to skipped_already_identified
+    /// once every live person has survived a merge.
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    pub merge_identified_sources: bool,
+
     /// Leave the spawned stack running after the gate finishes (for
     /// poking at it manually). Ignored with --external-router-url.
     #[arg(long, default_value_t = false)]

--- a/rust/personhog-test-harness/src/client.rs
+++ b/rust/personhog-test-harness/src/client.rs
@@ -157,10 +157,9 @@ impl IdentityClient {
         Ok(resp.into_inner().results)
     }
 
-    /// Merge `source_distinct_ids` into the person `target_distinct_id`
-    /// resolves to, and apply `event_set` and `event_set_once` to the
-    /// survivor. A retry under the same op id returns the recorded
-    /// outcome and does not merge again.
+    /// Merge `source_distinct_ids` into the person that
+    /// `target_distinct_id` resolves to. A retry with the same op id
+    /// returns the recorded outcome and does not merge again.
     #[allow(clippy::too_many_arguments)]
     pub async fn merge_persons(
         &self,

--- a/rust/personhog-test-harness/src/client.rs
+++ b/rust/personhog-test-harness/src/client.rs
@@ -158,9 +158,9 @@ impl IdentityClient {
     }
 
     /// Merge `source_distinct_ids` into the person `target_distinct_id`
-    /// resolves to, and apply `event_set` to the survivor. A retry under
-    /// the same op id returns the recorded outcome and does not merge
-    /// again.
+    /// resolves to, and apply `event_set` and `event_set_once` to the
+    /// survivor. A retry under the same op id returns the recorded
+    /// outcome and does not merge again.
     #[allow(clippy::too_many_arguments)]
     pub async fn merge_persons(
         &self,
@@ -168,6 +168,7 @@ impl IdentityClient {
         target_distinct_id: &str,
         source_distinct_ids: &[String],
         event_set: serde_json::Value,
+        event_set_once: serde_json::Value,
         op_id: &uuid::Uuid,
         allow_identified_sources: bool,
         move_limit: i64,
@@ -186,7 +187,7 @@ impl IdentityClient {
                     })
                     .collect(),
                 event_set: serde_json::to_vec(&event_set)?,
-                event_set_once: Vec::new(),
+                event_set_once: serde_json::to_vec(&event_set_once)?,
                 op_id: op_id.to_string(),
                 allow_identified_sources,
                 move_limit: Some(move_limit),

--- a/rust/personhog-test-harness/src/client.rs
+++ b/rust/personhog-test-harness/src/client.rs
@@ -5,7 +5,8 @@ use personhog_common::client::RouterClient;
 use personhog_proto::personhog::{
     identity::v1::{
         person_hog_identity_client::PersonHogIdentityClient, GetOrCreatePersonEntry,
-        GetOrCreatePersonResult, GetOrCreatePersonsByDistinctIdsRequest,
+        GetOrCreatePersonResult, GetOrCreatePersonsByDistinctIdsRequest, MergePersonsRequest,
+        MergePersonsResponse, MergeSource,
     },
     lifecycle::v1::{
         person_hog_lifecycle_client::PersonHogLifecycleClient, DeletePersonOutcome,
@@ -154,6 +155,46 @@ impl IdentityClient {
             .await
             .context("GetOrCreatePersonsByDistinctIds failed")?;
         Ok(resp.into_inner().results)
+    }
+
+    /// Merge `source_distinct_ids` into the person `target_distinct_id`
+    /// resolves to, applying `event_set` to the survivor. The op id is
+    /// scoped to one attempt: a retry under the same id returns the
+    /// recorded outcome instead of merging again.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn merge_persons(
+        &self,
+        team_id: i64,
+        target_distinct_id: &str,
+        source_distinct_ids: &[String],
+        event_set: serde_json::Value,
+        op_id: &uuid::Uuid,
+        allow_identified_sources: bool,
+        move_limit: i64,
+    ) -> Result<MergePersonsResponse> {
+        let resp = self
+            .inner
+            .clone()
+            .merge_persons(Request::new(MergePersonsRequest {
+                team_id,
+                target_distinct_id: target_distinct_id.to_string(),
+                sources: source_distinct_ids
+                    .iter()
+                    .map(|did| MergeSource {
+                        source_distinct_id: did.clone(),
+                        event_uuid: uuid::Uuid::new_v4().to_string(),
+                    })
+                    .collect(),
+                event_set: serde_json::to_vec(&event_set)?,
+                event_set_once: Vec::new(),
+                op_id: op_id.to_string(),
+                allow_identified_sources,
+                move_limit: Some(move_limit),
+                created_at: 0,
+            }))
+            .await
+            .context("MergePersons failed")?;
+        Ok(resp.into_inner())
     }
 }
 

--- a/rust/personhog-test-harness/src/client.rs
+++ b/rust/personhog-test-harness/src/client.rs
@@ -158,9 +158,9 @@ impl IdentityClient {
     }
 
     /// Merge `source_distinct_ids` into the person `target_distinct_id`
-    /// resolves to, applying `event_set` to the survivor. The op id is
-    /// scoped to one attempt: a retry under the same id returns the
-    /// recorded outcome instead of merging again.
+    /// resolves to, and apply `event_set` to the survivor. A retry under
+    /// the same op id returns the recorded outcome and does not merge
+    /// again.
     #[allow(clippy::too_many_arguments)]
     pub async fn merge_persons(
         &self,

--- a/rust/personhog-test-harness/src/main.rs
+++ b/rust/personhog-test-harness/src/main.rs
@@ -4,6 +4,7 @@ use tracing_subscriber::EnvFilter;
 
 mod cli;
 mod client;
+mod pool;
 mod report;
 mod scenarios;
 mod seed;

--- a/rust/personhog-test-harness/src/pool.rs
+++ b/rust/personhog-test-harness/src/pool.rs
@@ -2,13 +2,10 @@ use std::sync::RwLock;
 
 use rand::Rng;
 
-/// The live traffic targets. Every lane picks from it. The merge lane
-/// removes a person once the saga destroyed it, because a dead person
-/// refuses every write and would only add expected failures.
-///
-/// Removal is deliberately late. A source keeps taking traffic until the
-/// merge acks, so writes race the fence, the fold, and the flip. That
-/// race is the point of merging under load.
+/// The live traffic targets. The merge lane removes a source after the
+/// merge ack, not before the call. The source keeps taking writes during
+/// the merge, so the writes race the fence and the fold. That race is
+/// the point of merging under load.
 pub struct TargetPool {
     ids: RwLock<Vec<i64>>,
 }
@@ -36,8 +33,8 @@ impl TargetPool {
         Some(ids[rng.gen_range(0..ids.len())])
     }
 
-    /// The person at `n` modulo the live count, for the probers'
-    /// round-robin walk. None once the pool is empty.
+    /// The person at `n` modulo the live count. None when the pool is
+    /// empty.
     pub fn pick_nth(&self, n: usize) -> Option<i64> {
         let ids = self.ids.read().unwrap();
         if ids.is_empty() {

--- a/rust/personhog-test-harness/src/pool.rs
+++ b/rust/personhog-test-harness/src/pool.rs
@@ -1,0 +1,89 @@
+use std::sync::RwLock;
+
+use rand::Rng;
+
+/// The live traffic targets. Every lane picks from it, and the merge lane
+/// removes a person once the saga destroyed it — a dead person answers
+/// not-found to every write, so leaving it in the pool would only turn
+/// the remaining run into expected failures.
+///
+/// Removal is deliberately late: a source keeps taking traffic until the
+/// merge acks, so writes race the fence, the fold, and the flip. That
+/// race is the whole point of merging under load.
+pub struct TargetPool {
+    ids: RwLock<Vec<i64>>,
+}
+
+impl TargetPool {
+    pub fn new(ids: Vec<i64>) -> Self {
+        Self {
+            ids: RwLock::new(ids),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.ids.read().unwrap().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// A uniformly random live person, or None once the pool is empty.
+    pub fn pick_random(&self, rng: &mut impl Rng) -> Option<i64> {
+        let ids = self.ids.read().unwrap();
+        if ids.is_empty() {
+            return None;
+        }
+        Some(ids[rng.gen_range(0..ids.len())])
+    }
+
+    /// The person at `n` modulo the live count — the probers' round-robin
+    /// walk. None once the pool is empty.
+    pub fn pick_nth(&self, n: usize) -> Option<i64> {
+        let ids = self.ids.read().unwrap();
+        if ids.is_empty() {
+            return None;
+        }
+        Some(ids[n % ids.len()])
+    }
+
+    /// Retire a person. Returns false if it was already gone.
+    pub fn remove(&self, person_id: i64) -> bool {
+        let mut ids = self.ids.write().unwrap();
+        match ids.iter().position(|&id| id == person_id) {
+            Some(index) => {
+                ids.swap_remove(index);
+                true
+            }
+            None => false,
+        }
+    }
+
+    pub fn snapshot(&self) -> Vec<i64> {
+        self.ids.read().unwrap().clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picks_only_live_persons_and_empties_cleanly() {
+        let pool = TargetPool::new(vec![1, 2, 3]);
+        let mut rng = rand::thread_rng();
+        assert!(pool.remove(2));
+        assert!(!pool.remove(2));
+        for _ in 0..100 {
+            let picked = pool.pick_random(&mut rng).unwrap();
+            assert!(picked == 1 || picked == 3);
+        }
+        assert_eq!(pool.pick_nth(1), Some(pool.snapshot()[1]));
+        assert!(pool.remove(1));
+        assert!(pool.remove(3));
+        assert!(pool.is_empty());
+        assert_eq!(pool.pick_random(&mut rng), None);
+        assert_eq!(pool.pick_nth(7), None);
+    }
+}

--- a/rust/personhog-test-harness/src/pool.rs
+++ b/rust/personhog-test-harness/src/pool.rs
@@ -2,14 +2,13 @@ use std::sync::RwLock;
 
 use rand::Rng;
 
-/// The live traffic targets. Every lane picks from it, and the merge lane
-/// removes a person once the saga destroyed it — a dead person answers
-/// not-found to every write, so leaving it in the pool would only turn
-/// the remaining run into expected failures.
+/// The live traffic targets. Every lane picks from it. The merge lane
+/// removes a person once the saga destroyed it, because a dead person
+/// refuses every write and would only add expected failures.
 ///
-/// Removal is deliberately late: a source keeps taking traffic until the
+/// Removal is deliberately late. A source keeps taking traffic until the
 /// merge acks, so writes race the fence, the fold, and the flip. That
-/// race is the whole point of merging under load.
+/// race is the point of merging under load.
 pub struct TargetPool {
     ids: RwLock<Vec<i64>>,
 }
@@ -29,7 +28,6 @@ impl TargetPool {
         self.len() == 0
     }
 
-    /// A uniformly random live person, or None once the pool is empty.
     pub fn pick_random(&self, rng: &mut impl Rng) -> Option<i64> {
         let ids = self.ids.read().unwrap();
         if ids.is_empty() {
@@ -38,8 +36,8 @@ impl TargetPool {
         Some(ids[rng.gen_range(0..ids.len())])
     }
 
-    /// The person at `n` modulo the live count — the probers' round-robin
-    /// walk. None once the pool is empty.
+    /// The person at `n` modulo the live count, for the probers'
+    /// round-robin walk. None once the pool is empty.
     pub fn pick_nth(&self, n: usize) -> Option<i64> {
         let ids = self.ids.read().unwrap();
         if ids.is_empty() {
@@ -48,7 +46,6 @@ impl TargetPool {
         Some(ids[n % ids.len()])
     }
 
-    /// Retire a person. Returns false if it was already gone.
     pub fn remove(&self, person_id: i64) -> bool {
         let mut ids = self.ids.write().unwrap();
         match ids.iter().position(|&id| id == person_id) {

--- a/rust/personhog-test-harness/src/report.rs
+++ b/rust/personhog-test-harness/src/report.rs
@@ -58,9 +58,9 @@ pub fn print_report(
     if merge_snap.total > 0 {
         print_stats_row("merges", &merge_snap);
     }
-    let fat_snap = collector.fat_merges.snapshot();
-    if fat_snap.total > 0 {
-        print_stats_row("merges_fat", &fat_snap);
+    let wide_snap = collector.wide_merges.snapshot();
+    if wide_snap.total > 0 {
+        print_stats_row("merges_wide", &wide_snap);
     }
     println!();
     let rejected = write_snap.lifecycle_rejections + read_snap.lifecycle_rejections;

--- a/rust/personhog-test-harness/src/report.rs
+++ b/rust/personhog-test-harness/src/report.rs
@@ -54,7 +54,33 @@ pub fn print_report(
     if read_snap.total > 0 {
         print_stats_row("reads", &read_snap);
     }
+    let merge_snap = collector.merges.snapshot();
+    if merge_snap.total > 0 {
+        print_stats_row("merges", &merge_snap);
+    }
+    let fat_snap = collector.fat_merges.snapshot();
+    if fat_snap.total > 0 {
+        print_stats_row("merges_fat", &fat_snap);
+    }
     println!();
+    let rejected = write_snap.lifecycle_rejections + read_snap.lifecycle_rejections;
+    if rejected > 0 {
+        println!(
+            "  Lifecycle rejections (counted in Total, not Failed): {rejected} writes refused \
+             for a fenced or destroyed person"
+        );
+    }
+    let outcomes = collector.merge_outcomes();
+    if !outcomes.is_empty() {
+        let rendered: Vec<String> = outcomes
+            .iter()
+            .map(|(outcome, count)| format!("{outcome}={count}"))
+            .collect();
+        println!("  Merge outcomes per source: {}", rendered.join(" "));
+    }
+    if rejected > 0 || !outcomes.is_empty() {
+        println!();
+    }
 
     if violations.is_empty() {
         println!("  Consistency violations: 0");

--- a/rust/personhog-test-harness/src/scenarios/blast.rs
+++ b/rust/personhog-test-harness/src/scenarios/blast.rs
@@ -152,8 +152,8 @@ pub async fn run_traffic(
                 if let Some(pacer) = pacer.as_mut() {
                     pacer.tick().await;
                 }
-                // The merge lane retires destroyed persons. An emptied
-                // pool ends the worker instead of letting it spin.
+                // The merge lane can empty the pool. Stop instead of
+                // spinning.
                 let Some(person_id) = person_ids.pick_random(&mut rng) else {
                     break;
                 };
@@ -189,8 +189,8 @@ pub async fn run_traffic(
                     }
                     Err(e) => {
                         if is_lifecycle_rejection(&e) {
-                            // The refusal means nothing applied, so the
-                            // key needs no uncertainty taint.
+                            // The write did not apply, so the key stays
+                            // certain.
                             collector.writes.record_lifecycle_rejection();
                             continue;
                         }
@@ -212,12 +212,10 @@ pub async fn run_traffic(
     Ok(())
 }
 
-/// Whether a write error is the typed refusal a lifecycle op requires:
-/// FAILED_PRECONDITION with the leader's fenced header for a fenced
-/// person, or NOT_FOUND for a destroyed one. Both mean the write did
-/// not apply. The header separates the fence from every other
-/// FAILED_PRECONDITION, such as a partition mid-handoff or a stale
-/// owner, which stay real failures.
+/// True for the refusals a lifecycle op causes: FAILED_PRECONDITION
+/// with the leader's fenced header, or NOT_FOUND for a destroyed
+/// person. Both mean the write did not apply. Other FAILED_PRECONDITION
+/// causes, such as a handoff, stay failures.
 pub fn is_lifecycle_rejection(err: &anyhow::Error) -> bool {
     let Some(status) = err.downcast_ref::<tonic::Status>() else {
         return false;
@@ -229,7 +227,6 @@ pub fn is_lifecycle_rejection(err: &anyhow::Error) -> bool {
     }
 }
 
-/// Whether a read error is the leader's NOT_FOUND for a destroyed person.
 pub fn is_not_found(err: &anyhow::Error) -> bool {
     err.downcast_ref::<tonic::Status>()
         .is_some_and(|status| status.code() == tonic::Code::NotFound)
@@ -248,8 +245,7 @@ pub fn per_worker_tick(rate_per_sec: f64, concurrency: usize) -> Duration {
 /// violation, not a skip: NotFound for a person with acked writes means the
 /// person is gone, and a read error (retried once, since verification can
 /// race a settling handoff) means visibility cannot be asserted at all.
-/// Persons a merge destroyed are held to the opposite rule: a strong
-/// read must not find them alive. Their acked writes are verified on
+/// A merged source must not read as alive. Its writes are verified on
 /// the survivor.
 pub async fn verify_strong(
     client: &HarnessClient,
@@ -263,8 +259,7 @@ pub async fn verify_strong(
     for person_id in state.merged_source_ids().await {
         let start = Instant::now();
         match strong_read_with_retry(client, team_id, person_id).await {
-            // A destroyed person answers NOT_FOUND. That is the expected
-            // shape, not a read failure.
+            // NOT_FOUND is the expected answer for a merged source.
             Err(e) if is_not_found(&e) => collector.reads.record_success(start.elapsed()),
             Ok(Some(person)) if !person.is_deleted => {
                 collector.reads.record_success(start.elapsed());

--- a/rust/personhog-test-harness/src/scenarios/blast.rs
+++ b/rust/personhog-test-harness/src/scenarios/blast.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 
 use crate::cli::BlastArgs;
 use crate::client::HarnessClient;
+use crate::pool::TargetPool;
 use crate::report::{print_report, ConsistencyViolation};
 use crate::state::PersonState;
 use crate::stats::StatsCollector;
@@ -20,7 +21,7 @@ use crate::traffic_metrics;
 pub async fn run(args: BlastArgs) -> Result<()> {
     let client =
         HarnessClient::connect_with_channels(&args.router_url, args.router_channels).await?;
-    let person_ids = Arc::new(args.person_ids.clone());
+    let person_ids = Arc::new(TargetPool::new(args.person_ids.clone()));
 
     println!(
         "Blasting {} persons for {} with concurrency {}...",
@@ -115,7 +116,7 @@ impl PropertyPlan {
 pub async fn run_traffic(
     client: &HarnessClient,
     team_id: i64,
-    person_ids: Arc<Vec<i64>>,
+    person_ids: Arc<TargetPool>,
     duration: Duration,
     concurrency: usize,
     rate_per_sec: Option<f64>,
@@ -124,6 +125,9 @@ pub async fn run_traffic(
     state: &PersonState,
     stop: Arc<AtomicBool>,
 ) -> Result<()> {
+    if person_ids.is_empty() {
+        bail!("no traffic targets: the pool is empty");
+    }
     let deadline = Instant::now() + duration;
     let worker_tick = rate_per_sec.map(|rate| per_worker_tick(rate, concurrency));
 
@@ -148,7 +152,11 @@ pub async fn run_traffic(
                 if let Some(pacer) = pacer.as_mut() {
                     pacer.tick().await;
                 }
-                let person_id = person_ids[rng.gen_range(0..person_ids.len())];
+                // The merge lane retires destroyed persons; an emptied
+                // pool ends the worker early rather than spinning.
+                let Some(person_id) = person_ids.pick_random(&mut rng) else {
+                    break;
+                };
 
                 let key = plan.key(worker_id, &mut rng);
                 let value = Uuid::new_v4().to_string();
@@ -180,6 +188,13 @@ pub async fn run_traffic(
                         }
                     }
                     Err(e) => {
+                        if is_lifecycle_rejection(&e) {
+                            // A fenced or destroyed person must refuse the
+                            // write; that refusal is the stack doing its
+                            // job, and nothing applied.
+                            collector.writes.record_lifecycle_rejection();
+                            continue;
+                        }
                         collector.writes.record_failure();
                         traffic_metrics::record_write_failed(traffic_metrics::LANE_BLAST, &e);
                         state.record_write_uncertain(person_id, &key).await;
@@ -198,6 +213,29 @@ pub async fn run_traffic(
     Ok(())
 }
 
+/// Whether a write error is the typed refusal a lifecycle op requires:
+/// a person fenced by a live saga (FAILED_PRECONDITION carrying the
+/// leader's fenced header) or one it already destroyed (NOT_FOUND). Both
+/// mean the write did not apply. The header is what separates the fence
+/// from every other FAILED_PRECONDITION (a partition mid-handoff, a
+/// stale owner), which stay real failures.
+pub fn is_lifecycle_rejection(err: &anyhow::Error) -> bool {
+    let Some(status) = err.downcast_ref::<tonic::Status>() else {
+        return false;
+    };
+    match status.code() {
+        tonic::Code::NotFound => true,
+        tonic::Code::FailedPrecondition => status.metadata().contains_key("x-person-fenced"),
+        _ => false,
+    }
+}
+
+/// Whether a read error is the leader's NOT_FOUND for a destroyed person.
+pub fn is_not_found(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<tonic::Status>()
+        .is_some_and(|status| status.code() == tonic::Code::NotFound)
+}
+
 /// The tick interval each of `concurrency` workers needs so their
 /// combined rate hits `rate_per_sec`. Rates too low to represent tick at
 /// most once per hour rather than dividing by zero.
@@ -211,6 +249,8 @@ pub fn per_worker_tick(rate_per_sec: f64, concurrency: usize) -> Duration {
 /// violation, not a skip: NotFound for a person with acked writes means the
 /// person is gone, and a read error (retried once, since verification can
 /// race a settling handoff) means visibility cannot be asserted at all.
+/// Persons a merge destroyed are held to the opposite: a strong read must
+/// not find them alive — their acked writes are verified on the survivor.
 pub async fn verify_strong(
     client: &HarnessClient,
     collector: &StatsCollector,
@@ -220,17 +260,37 @@ pub async fn verify_strong(
     let person_ids = state.person_ids().await;
     let mut all_violations = Vec::new();
 
+    for person_id in state.merged_source_ids().await {
+        let start = Instant::now();
+        match strong_read_with_retry(client, team_id, person_id).await {
+            // A destroyed person answers NOT_FOUND: that is the expected
+            // shape, not a read failure.
+            Err(e) if is_not_found(&e) => collector.reads.record_success(start.elapsed()),
+            Ok(Some(person)) if !person.is_deleted => {
+                collector.reads.record_success(start.elapsed());
+                all_violations.push(ConsistencyViolation {
+                    person_id,
+                    key: "__merged_source_alive".to_string(),
+                    expected: json!("not found after the merge"),
+                    actual: json!({ "version": person.version }),
+                });
+            }
+            Ok(_) => collector.reads.record_success(start.elapsed()),
+            Err(e) => {
+                collector.reads.record_failure();
+                all_violations.push(ConsistencyViolation {
+                    person_id,
+                    key: "__strong_read_failed".to_string(),
+                    expected: json!("readable"),
+                    actual: json!(e.to_string()),
+                });
+            }
+        }
+    }
+
     for person_id in person_ids {
         let start = Instant::now();
-        let mut result = client
-            .get_person(team_id, person_id, ConsistencyLevel::Strong)
-            .await;
-        if result.is_err() {
-            sleep(Duration::from_secs(2)).await;
-            result = client
-                .get_person(team_id, person_id, ConsistencyLevel::Strong)
-                .await;
-        }
+        let result = strong_read_with_retry(client, team_id, person_id).await;
 
         match result {
             Ok(Some(person)) => {
@@ -271,6 +331,23 @@ pub async fn verify_strong(
     }
 
     Ok(all_violations)
+}
+
+async fn strong_read_with_retry(
+    client: &HarnessClient,
+    team_id: i64,
+    person_id: i64,
+) -> Result<Option<personhog_proto::personhog::types::v1::Person>> {
+    let mut result = client
+        .get_person(team_id, person_id, ConsistencyLevel::Strong)
+        .await;
+    if result.as_ref().is_err_and(|e| !is_not_found(e)) {
+        sleep(Duration::from_secs(2)).await;
+        result = client
+            .get_person(team_id, person_id, ConsistencyLevel::Strong)
+            .await;
+    }
+    result
 }
 
 #[cfg(test)]

--- a/rust/personhog-test-harness/src/scenarios/blast.rs
+++ b/rust/personhog-test-harness/src/scenarios/blast.rs
@@ -152,8 +152,8 @@ pub async fn run_traffic(
                 if let Some(pacer) = pacer.as_mut() {
                     pacer.tick().await;
                 }
-                // The merge lane retires destroyed persons; an emptied
-                // pool ends the worker early rather than spinning.
+                // The merge lane retires destroyed persons. An emptied
+                // pool ends the worker instead of letting it spin.
                 let Some(person_id) = person_ids.pick_random(&mut rng) else {
                     break;
                 };
@@ -189,9 +189,8 @@ pub async fn run_traffic(
                     }
                     Err(e) => {
                         if is_lifecycle_rejection(&e) {
-                            // A fenced or destroyed person must refuse the
-                            // write; that refusal is the stack doing its
-                            // job, and nothing applied.
+                            // The refusal means nothing applied, so the
+                            // key needs no uncertainty taint.
                             collector.writes.record_lifecycle_rejection();
                             continue;
                         }
@@ -214,11 +213,11 @@ pub async fn run_traffic(
 }
 
 /// Whether a write error is the typed refusal a lifecycle op requires:
-/// a person fenced by a live saga (FAILED_PRECONDITION carrying the
-/// leader's fenced header) or one it already destroyed (NOT_FOUND). Both
-/// mean the write did not apply. The header is what separates the fence
-/// from every other FAILED_PRECONDITION (a partition mid-handoff, a
-/// stale owner), which stay real failures.
+/// FAILED_PRECONDITION with the leader's fenced header for a fenced
+/// person, or NOT_FOUND for a destroyed one. Both mean the write did
+/// not apply. The header separates the fence from every other
+/// FAILED_PRECONDITION, such as a partition mid-handoff or a stale
+/// owner, which stay real failures.
 pub fn is_lifecycle_rejection(err: &anyhow::Error) -> bool {
     let Some(status) = err.downcast_ref::<tonic::Status>() else {
         return false;
@@ -249,8 +248,9 @@ pub fn per_worker_tick(rate_per_sec: f64, concurrency: usize) -> Duration {
 /// violation, not a skip: NotFound for a person with acked writes means the
 /// person is gone, and a read error (retried once, since verification can
 /// race a settling handoff) means visibility cannot be asserted at all.
-/// Persons a merge destroyed are held to the opposite: a strong read must
-/// not find them alive — their acked writes are verified on the survivor.
+/// Persons a merge destroyed are held to the opposite rule: a strong
+/// read must not find them alive. Their acked writes are verified on
+/// the survivor.
 pub async fn verify_strong(
     client: &HarnessClient,
     collector: &StatsCollector,
@@ -263,7 +263,7 @@ pub async fn verify_strong(
     for person_id in state.merged_source_ids().await {
         let start = Instant::now();
         match strong_read_with_retry(client, team_id, person_id).await {
-            // A destroyed person answers NOT_FOUND: that is the expected
+            // A destroyed person answers NOT_FOUND. That is the expected
             // shape, not a read failure.
             Err(e) if is_not_found(&e) => collector.reads.record_success(start.elapsed()),
             Ok(Some(person)) if !person.is_deleted => {

--- a/rust/personhog-test-harness/src/scenarios/consistency.rs
+++ b/rust/personhog-test-harness/src/scenarios/consistency.rs
@@ -283,10 +283,9 @@ pub async fn run_probers(
                     Ok(None) => {
                         // A served read that cannot see a person with an
                         // acked write is a violation, not an availability
-                        // blip. The exception is a merge destroying the
-                        // person: the write landed before the seal and
-                        // folded into the survivor, where end-of-run
-                        // verification asserts it.
+                        // blip. The exception is a merged person: its
+                        // writes folded into the survivor, and end-of-run
+                        // verification asserts them there.
                         if state.is_merge_pending_or_merged(person_id).await {
                             collector.reads.record_success(read_start.elapsed());
                             continue;

--- a/rust/personhog-test-harness/src/scenarios/consistency.rs
+++ b/rust/personhog-test-harness/src/scenarios/consistency.rs
@@ -8,6 +8,7 @@ use personhog_proto::personhog::types::v1::ConsistencyLevel;
 
 use crate::cli::ConsistencyArgs;
 use crate::client::HarnessClient;
+use crate::pool::TargetPool;
 use crate::report::{print_report, ConsistencyViolation};
 use crate::state::PersonState;
 use crate::stats::StatsCollector;
@@ -178,7 +179,7 @@ pub async fn run(args: ConsistencyArgs) -> Result<()> {
 pub async fn run_probers(
     client: &HarnessClient,
     team_id: i64,
-    person_ids: Arc<Vec<i64>>,
+    person_ids: Arc<TargetPool>,
     probers: usize,
     duration: Duration,
     collector: &Arc<StatsCollector>,
@@ -200,7 +201,9 @@ pub async fn run_probers(
             let mut iteration: usize = 0;
 
             while Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
-                let person_id = person_ids[(worker_id + iteration) % person_ids.len()];
+                let Some(person_id) = person_ids.pick_nth(worker_id + iteration) else {
+                    break;
+                };
                 iteration += 1;
                 let marker = uuid::Uuid::new_v4().to_string();
                 let key = format!("harness_probe_{worker_id}_{iteration}");
@@ -225,6 +228,10 @@ pub async fn run_probers(
                         response
                     }
                     Err(e) => {
+                        if super::blast::is_lifecycle_rejection(&e) {
+                            collector.writes.record_lifecycle_rejection();
+                            continue;
+                        }
                         collector.writes.record_failure();
                         traffic_metrics::record_write_failed(traffic_metrics::LANE_PROBER, &e);
                         tracing::warn!(person_id, error = %e, "probe write failed");
@@ -276,7 +283,14 @@ pub async fn run_probers(
                     Ok(None) => {
                         // A served read that cannot see a person with an
                         // acked write is a violation, not an availability
-                        // blip.
+                        // blip — unless a merge is destroying the person:
+                        // the write landed before the seal and folded
+                        // into the survivor, where end-of-run verification
+                        // asserts it.
+                        if state.is_merge_pending_or_merged(person_id).await {
+                            collector.reads.record_success(read_start.elapsed());
+                            continue;
+                        }
                         collector.reads.record_failure();
                         traffic_metrics::record_read_failed(
                             traffic_metrics::LANE_PROBER,

--- a/rust/personhog-test-harness/src/scenarios/consistency.rs
+++ b/rust/personhog-test-harness/src/scenarios/consistency.rs
@@ -283,10 +283,10 @@ pub async fn run_probers(
                     Ok(None) => {
                         // A served read that cannot see a person with an
                         // acked write is a violation, not an availability
-                        // blip — unless a merge is destroying the person:
-                        // the write landed before the seal and folded
-                        // into the survivor, where end-of-run verification
-                        // asserts it.
+                        // blip. The exception is a merge destroying the
+                        // person: the write landed before the seal and
+                        // folded into the survivor, where end-of-run
+                        // verification asserts it.
                         if state.is_merge_pending_or_merged(person_id).await {
                             collector.reads.record_success(read_start.elapsed());
                             continue;

--- a/rust/personhog-test-harness/src/scenarios/gate.rs
+++ b/rust/personhog-test-harness/src/scenarios/gate.rs
@@ -22,9 +22,8 @@ use crate::state::PersonState;
 use crate::stats::StatsCollector;
 use crate::verify::verify_postgres;
 
-/// The property every person created through the identity service
-/// carries from birth. The merge lane relies on it being present on
-/// every survivor.
+/// The property set on every person the identity service creates. The
+/// merge lane expects it on every survivor.
 pub const SEED_KEY: &str = "harness_seed";
 
 /// A chaos disruption scheduled relative to the start of the traffic phase.
@@ -157,8 +156,8 @@ pub async fn run(args: GateArgs) -> Result<()> {
     if args.external_router_url.is_some() && !args.leader_env.is_empty() {
         bail!("--leader-env requires a spawned stack; it cannot target --external-router-url");
     }
-    // Merges need persons with distinct ids, which only the identity
-    // create path provides.
+    // Merges need distinct ids. Only the identity create path provides
+    // them.
     let create_via_identity = args.create_via_identity || args.merge_concurrency > 0;
     if create_via_identity
         && args.external_router_url.is_some()
@@ -366,8 +365,6 @@ pub async fn run(args: GateArgs) -> Result<()> {
         })
     };
 
-    // The merge lane shares the traffic window, so the saga runs under
-    // the blast and prober writes above.
     let merges = identity_url
         .as_ref()
         .filter(|_| args.merge_concurrency > 0)
@@ -384,8 +381,8 @@ pub async fn run(args: GateArgs) -> Result<()> {
                 rate_per_sec: args.merge_rate,
                 sources_per_call: args.merge_sources,
                 allow_identified_sources: args.merge_identified_sources,
-                // A survivor collects every distinct id of every merged
-                // source. The pool bounds that total, so no source ever
+                // A survivor collects the distinct ids of every merged
+                // source. This limit covers the whole pool, so no source
                 // trips the move guard.
                 move_limit: i64::from(args.persons)
                     + i64::from(args.merge_wide_persons)
@@ -615,9 +612,8 @@ pub async fn run(args: GateArgs) -> Result<()> {
     }
 
     // Merges that lost every response settle from their op records
-    // before anything is asserted. The sweeper claims an abandoned op
-    // once its lease (15s) lapses, then re-drives it on the converged
-    // stack.
+    // first. The sweeper re-drives an abandoned op only after its 15s
+    // lease lapses, which is why the deadline is long.
     let mut violations = prober_violations;
     violations.extend(
         merge::settle_unresolved(&pool, &state, unresolved_merges, Duration::from_secs(90)).await?,
@@ -667,9 +663,8 @@ pub async fn run(args: GateArgs) -> Result<()> {
     // get-or-create leave through the lifecycle saga, and both the
     // outcomes and the saga's idempotence are gate assertions — every
     // created person deletes exactly once, and a second attempt under a
-    // fresh op id answers not_found for all of them. Persons a merge
-    // destroyed are tombstones already, so they answer not_found on
-    // the first attempt.
+    // fresh op id answers not_found for all of them. A merged source is
+    // a tombstone already, so it answers not_found on the first attempt.
     if let Some(url) = &identity_url {
         if !args.keep_data {
             println!("Deleting persons through the lifecycle saga...");
@@ -720,16 +715,15 @@ pub async fn run(args: GateArgs) -> Result<()> {
 /// to the gate's standard: every id deleted on the first attempt, every
 /// id not_found on a second attempt under a fresh op id (deleting a
 /// tombstone is a no-op, never an error, never a false success).
-/// The merge saga destroyed `merged_ids`, so they must answer not_found
-/// on the first attempt. A "deleted" there means the merge left a
-/// living row behind. `uncertain_ids` had a merge call that never
-/// answered, so either outcome is accepted for them.
+/// `merged_ids` must answer not_found on the first attempt. A `deleted`
+/// there means the merge left a living row. `uncertain_ids` had a merge
+/// call that never answered, so either answer is accepted.
 ///
 /// A `skipped_conflict` means another lifecycle op still holds the
-/// person, usually a merge that chaos interrupted mid-saga. The sweeper
-/// must re-drive that op, so conflicts are retried under fresh op ids
-/// until the op settles. One that never settles fails the gate, because
-/// nobody can ever merge or delete that person again.
+/// person, usually a merge that chaos interrupted. The delete is retried
+/// under fresh op ids until the sweeper settles that op. An op that
+/// never settles fails the gate, because nobody can merge or delete
+/// that person again.
 async fn verify_lifecycle_delete(
     lifecycle: &crate::client::LifecycleClient,
     team_id: i64,
@@ -739,13 +733,10 @@ async fn verify_lifecycle_delete(
 ) -> Result<()> {
     use personhog_proto::personhog::lifecycle::v1::DeletePersonOutcome;
 
-    /// The sweeper claims an abandoned op once its lease (15s) lapses,
-    /// on its own cadence. A re-driven merge then needs its leader
-    /// calls to succeed on a converged stack.
+    /// The sweeper claims an abandoned op only after its 15s lease
+    /// lapses, then re-drives it. Sized for a few of those in sequence.
     const SETTLE_DEADLINE: Duration = Duration::from_secs(90);
 
-    // Everything answers on the first attempt. Conflicts are asked
-    // again until the holding op settles.
     let mut expected: HashMap<i64, Vec<DeletePersonOutcome>> = HashMap::new();
     for &id in person_ids {
         expected.insert(id, vec![DeletePersonOutcome::Deleted]);
@@ -801,9 +792,8 @@ async fn verify_lifecycle_delete(
         pending = conflicts;
     }
 
-    // Idempotence: a second attempt under a fresh op id answers
-    // not_found for everything. Deleting a tombstone is a no-op, never
-    // an error, and never a false success.
+    // A second attempt under a fresh op id must answer not_found for
+    // everything. Deleting a tombstone is a no-op, not an error.
     let mut all: Vec<i64> = expected.keys().copied().collect();
     all.sort_unstable();
     for chunk in all.chunks(200) {
@@ -890,9 +880,8 @@ async fn create_persons_via_identity(
     Ok(person_ids)
 }
 
-/// Create persons that carry `extra_distinct_ids` extra mappings each.
-/// A merge of this shape makes the flip repoint every mapping. The
-/// journaling is the same as on the ordinary create path.
+/// Create persons with `extra_distinct_ids` extra distinct ids each, so
+/// a merge makes the flip repoint many mappings.
 async fn create_wide_persons_via_identity(
     identity_url: &str,
     team_id: i64,

--- a/rust/personhog-test-harness/src/scenarios/gate.rs
+++ b/rust/personhog-test-harness/src/scenarios/gate.rs
@@ -22,6 +22,11 @@ use crate::state::PersonState;
 use crate::stats::StatsCollector;
 use crate::verify::verify_postgres;
 
+/// The property every person created through the identity service
+/// carries from birth. The merge lane relies on it being present on
+/// every survivor.
+pub const SEED_KEY: &str = "harness_seed";
+
 /// A chaos disruption scheduled relative to the start of the traffic phase.
 enum ChaosEvent {
     Kill { fast: bool },
@@ -166,6 +171,9 @@ pub async fn run(args: GateArgs) -> Result<()> {
     }
     if args.merge_rate.is_some_and(|rate| rate <= 0.0) {
         bail!("--merge-rate must be positive; omit it to run the merge workers flat out");
+    }
+    if args.merge_sources == 0 {
+        bail!("--merge-sources must be at least 1");
     }
     if args.merge_wide_persons > 0 && args.merge_concurrency == 0 {
         bail!("--merge-wide-persons needs --merge-concurrency");
@@ -374,6 +382,7 @@ pub async fn run(args: GateArgs) -> Result<()> {
                 team_id: args.team_id,
                 concurrency: args.merge_concurrency,
                 rate_per_sec: args.merge_rate,
+                sources_per_call: args.merge_sources,
                 allow_identified_sources: args.merge_identified_sources,
                 // A survivor collects every distinct id of every merged
                 // source. The pool bounds that total, so no source ever
@@ -387,11 +396,12 @@ pub async fn run(args: GateArgs) -> Result<()> {
             };
             let duration = args.duration;
             println!(
-                "Merging with {} workers{}...",
+                "Merging with {} workers{}, {} source(s) per call...",
                 args.merge_concurrency,
                 args.merge_rate
                     .map(|rate| format!(" at {rate} merges/s"))
-                    .unwrap_or_default()
+                    .unwrap_or_default(),
+                args.merge_sources
             );
             tokio::spawn(async move {
                 let identity = IdentityClient::connect(&url).await?;
@@ -842,7 +852,7 @@ async fn create_persons_via_identity(
                     extra_distinct_ids: vec![],
                     event_name: "$set".to_string(),
                     set_properties: serde_json::to_vec(
-                        &serde_json::json!({ "harness_seed": distinct_id }),
+                        &serde_json::json!({ SEED_KEY: distinct_id }),
                     )
                     .expect("seed properties serialize"),
                     set_once_properties: Vec::new(),
@@ -868,10 +878,8 @@ async fn create_persons_via_identity(
                     result.distinct_id
                 );
             }
-            let seed_properties = HashMap::from([(
-                "harness_seed".to_string(),
-                serde_json::json!(result.distinct_id),
-            )]);
+            let seed_properties =
+                HashMap::from([(SEED_KEY.to_string(), serde_json::json!(result.distinct_id))]);
             state
                 .record_write(person.id, person.version, seed_properties)
                 .await;
@@ -903,7 +911,7 @@ async fn create_wide_persons_via_identity(
                 .map(|j| format!("{distinct_id}-{j}"))
                 .collect(),
             event_name: "$set".to_string(),
-            set_properties: serde_json::to_vec(&serde_json::json!({ "harness_seed": distinct_id }))
+            set_properties: serde_json::to_vec(&serde_json::json!({ SEED_KEY: distinct_id }))
                 .expect("seed properties serialize"),
             set_once_properties: Vec::new(),
             created_at: 0,
@@ -926,10 +934,7 @@ async fn create_wide_persons_via_identity(
             .record_write(
                 person.id,
                 person.version,
-                HashMap::from([(
-                    "harness_seed".to_string(),
-                    serde_json::json!(result.distinct_id),
-                )]),
+                HashMap::from([(SEED_KEY.to_string(), serde_json::json!(result.distinct_id))]),
             )
             .await;
         persons.push((person.id, result.distinct_id));

--- a/rust/personhog-test-harness/src/scenarios/gate.rs
+++ b/rust/personhog-test-harness/src/scenarios/gate.rs
@@ -12,7 +12,9 @@ use personhog_proto::personhog::identity::v1::GetOrCreatePersonEntry;
 
 use crate::cli::{GateArgs, DEFAULT_KEYS_PER_PERSON};
 use crate::client::{HarnessClient, IdentityClient};
+use crate::pool::TargetPool;
 use crate::report::print_report;
+use crate::scenarios::merge::{self, FatRole, MergeLane};
 use crate::scenarios::{blast, consistency};
 use crate::seed;
 use crate::stack::{Stack, StackConfig};
@@ -150,12 +152,26 @@ pub async fn run(args: GateArgs) -> Result<()> {
     if args.external_router_url.is_some() && !args.leader_env.is_empty() {
         bail!("--leader-env requires a spawned stack; it cannot target --external-router-url");
     }
-    if args.create_via_identity
+    // Merges need persons with distinct ids, which only the identity
+    // create path provides.
+    let create_via_identity = args.create_via_identity || args.merge_concurrency > 0;
+    if create_via_identity
         && args.external_router_url.is_some()
         && args.external_identity_url.is_none()
     {
-        bail!("--create-via-identity with --external-router-url needs --external-identity-url");
+        bail!("--create-via-identity (or --merge-concurrency) with --external-router-url needs --external-identity-url");
     }
+    if args.merge_concurrency > 0 && args.persons < 2 {
+        bail!("--merge-concurrency needs at least 2 persons to pair");
+    }
+    if args.merge_rate.is_some_and(|rate| rate <= 0.0) {
+        bail!("--merge-rate must be positive; omit it to run the merge workers flat out");
+    }
+    if args.merge_fat_persons > 0 && args.merge_concurrency == 0 {
+        bail!("--merge-fat-persons needs --merge-concurrency");
+    }
+    let fat_role = FatRole::parse(&args.merge_fat_role)
+        .ok_or_else(|| anyhow::anyhow!("unknown --merge-fat-role {:?}", args.merge_fat_role))?;
     // The spawned identity derives its whole table set (person, distinct id,
     // hash-key overrides) from --pg-target-table, so any known table set
     // works; Stack::up rejects person tables without a known companion set.
@@ -203,7 +219,7 @@ pub async fn run(args: GateArgs) -> Result<()> {
                     extra_leader_env: args.leader_env.clone(),
                     recovery_pool_size: args.recovery_pool_size,
                     leader_lease_ttl: args.leader_lease_ttl,
-                    spawn_identity: args.create_via_identity,
+                    spawn_identity: create_via_identity,
                 })
                 .await?,
             )
@@ -236,28 +252,58 @@ pub async fn run(args: GateArgs) -> Result<()> {
     // assertions target that stack, so an external identity service pointed
     // elsewhere would only produce confusing failures.
     let identity_url = match (&args.external_identity_url, &stack) {
-        _ if !args.create_via_identity => None,
+        _ if !create_via_identity => None,
         (_, Some(stack)) => stack.identity_url.clone(),
         (Some(url), None) => Some(url.clone()),
         (None, None) => unreachable!("validated above"),
     };
+    // Each created person's distinct id, for the merge lane's requests.
+    let mut distinct_ids: HashMap<i64, String> = HashMap::new();
     let person_ids = match &identity_url {
         Some(url) => {
-            let ids = create_persons_via_identity(url, args.team_id, args.persons, &state).await?;
+            let created =
+                create_persons_via_identity(url, args.team_id, args.persons, &state).await?;
             println!(
                 "Created {} persons via identity for team {}",
-                ids.len(),
+                created.len(),
                 args.team_id
             );
-            Arc::new(ids)
+            let ids = created.iter().map(|(id, _)| *id).collect();
+            distinct_ids.extend(created);
+            ids
         }
         None => {
             let ids = seed::seed_persons(&pool, &args.pg_target_table, args.team_id, args.persons)
                 .await?;
             println!("Seeded {} persons for team {}", ids.len(), args.team_id);
-            Arc::new(ids)
+            ids
         }
     };
+    let mut person_ids = person_ids;
+    let mut fat_persons = Vec::new();
+    if let (Some(url), true) = (&identity_url, args.merge_fat_persons > 0) {
+        let created = create_fat_persons_via_identity(
+            url,
+            args.team_id,
+            args.merge_fat_persons,
+            args.merge_fat_distinct_ids,
+            &state,
+        )
+        .await?;
+        println!(
+            "Created {} fat persons with {} extra distinct ids each",
+            created.len(),
+            args.merge_fat_distinct_ids
+        );
+        fat_persons.extend(created.iter().map(|(id, _)| *id));
+        person_ids.extend(created.iter().map(|(id, _)| *id));
+        distinct_ids.extend(created);
+    }
+    let created_count = person_ids.len();
+    // The live pool: every lane picks from it, and the merge lane retires
+    // the persons it destroys.
+    let person_ids = Arc::new(TargetPool::new(person_ids));
+    let distinct_ids = Arc::new(distinct_ids);
 
     println!(
         "Driving traffic for {} with concurrency {}...",
@@ -315,6 +361,58 @@ pub async fn run(args: GateArgs) -> Result<()> {
         })
     };
 
+    // The merge lane runs the durable saga against pairs of live persons
+    // for the same window, under the blast and prober writes above.
+    let merges = identity_url
+        .as_ref()
+        .filter(|_| args.merge_concurrency > 0)
+        .map(|url| {
+            let url = url.clone();
+            let router = client.clone();
+            let person_ids = person_ids.clone();
+            let distinct_ids = distinct_ids.clone();
+            let collector = collector.clone();
+            let state = state.clone();
+            let lane = MergeLane {
+                team_id: args.team_id,
+                concurrency: args.merge_concurrency,
+                rate_per_sec: args.merge_rate,
+                allow_identified_sources: args.merge_identified_sources,
+                // A survivor collects every distinct id of every merged
+                // source; the pool bounds that, so no source ever trips
+                // the move guard.
+                move_limit: i64::from(args.persons)
+                    + i64::from(args.merge_fat_persons)
+                        * (i64::from(args.merge_fat_distinct_ids) + 1)
+                    + 1,
+                fat_persons: fat_persons.clone(),
+                fat_role,
+            };
+            let duration = args.duration;
+            println!(
+                "Merging with {} workers{}...",
+                args.merge_concurrency,
+                args.merge_rate
+                    .map(|rate| format!(" at {rate} merges/s"))
+                    .unwrap_or_default()
+            );
+            tokio::spawn(async move {
+                let identity = IdentityClient::connect(&url).await?;
+                merge::run_merges(
+                    &identity,
+                    &router,
+                    lane,
+                    person_ids,
+                    distinct_ids,
+                    duration,
+                    &collector,
+                    &state,
+                    Arc::new(AtomicBool::new(false)),
+                )
+                .await
+            })
+        });
+
     // Fire scheduled disruptions while traffic flows. Failures aren't
     // journaled, so the invariant is untouched: whatever the leader acked
     // through the disruption must still be visible afterwards.
@@ -344,7 +442,7 @@ pub async fn run(args: GateArgs) -> Result<()> {
                 .execute(&pool)
                 .await
                 .context("inserting fence op row")?;
-                for &person_id in person_ids.iter().take(args.fence_count) {
+                for &person_id in person_ids.snapshot().iter().take(args.fence_count) {
                     sqlx::query(
                         "INSERT INTO lifecycle_op_person \
                          (op_id, team_id, person_id, person_uuid, role, status) \
@@ -357,7 +455,7 @@ pub async fn run(args: GateArgs) -> Result<()> {
                     .await
                     .context("inserting fence mark")?;
                 }
-                for &person_id in person_ids.iter().take(args.fence_count) {
+                for &person_id in person_ids.snapshot().iter().take(args.fence_count) {
                     match client
                         .fence_person(args.team_id, person_id, &fence_op)
                         .await
@@ -476,7 +574,13 @@ pub async fn run(args: GateArgs) -> Result<()> {
     }
 
     traffic.await.context("traffic task panicked")??;
-    let prober_violations = probers.await.context("prober task panicked")??;
+    let mut prober_violations = probers.await.context("prober task panicked")??;
+    let mut unresolved_merges = Vec::new();
+    if let Some(merges) = merges {
+        let result = merges.await.context("merge task panicked")??;
+        prober_violations.extend(result.violations);
+        unresolved_merges = result.unresolved;
+    }
 
     // Verification asserts data visibility on a converged topology, not
     // recovery speed: chaos legitimately leaves handoffs to re-drive. The
@@ -503,33 +607,74 @@ pub async fn run(args: GateArgs) -> Result<()> {
         );
     }
 
-    println!("Verifying strong reads...");
+    // Merges that lost every response settle from their op records
+    // before anything is asserted: the sweeper claims an abandoned op
+    // once its lease (15s) lapses, then re-drives it on the converged
+    // stack.
     let mut violations = prober_violations;
+    violations.extend(
+        merge::settle_unresolved(&pool, &state, unresolved_merges, Duration::from_secs(90)).await?,
+    );
+
+    println!("Verifying strong reads...");
     violations.extend(state.take_anomalies().await);
     violations.extend(blast::verify_strong(&client, &collector, &state, args.team_id).await?);
 
     println!("Waiting for the writer to drain, then verifying Postgres...");
+    let merged_ids = state.merged_source_ids().await;
     let journal = state.snapshot().await;
-    violations.extend(verify_postgres(&pool, &args.pg_target_table, args.team_id, &journal).await?);
-
-    print_report(
-        "gate",
-        &collector,
-        args.team_id,
-        person_ids.len(),
-        &violations,
+    let merged = state.snapshot_merged().await;
+    violations.extend(
+        verify_postgres(
+            &pool,
+            &args.pg_target_table,
+            args.team_id,
+            &journal,
+            &merged,
+        )
+        .await?,
     );
+
+    print_report("gate", &collector, args.team_id, created_count, &violations);
+    // Where the journal's expectations came from, for every violated
+    // person: which acks and which folds set the disputed keys.
+    let mut disputed: HashMap<i64, Vec<String>> = HashMap::new();
+    for violation in &violations {
+        let keys = disputed.entry(violation.person_id).or_default();
+        if !keys.contains(&violation.key) {
+            keys.push(violation.key.clone());
+        }
+    }
+    for (person_id, keys) in disputed {
+        println!("{}", state.describe(person_id, &keys).await);
+    }
+    if !merged_ids.is_empty() {
+        println!(
+            "  Merged {} of {} persons; {} live at the end",
+            merged_ids.len(),
+            created_count,
+            person_ids.len()
+        );
+        println!();
+    }
 
     // The delete leg of the identity path: persons created through
     // get-or-create leave through the lifecycle saga, and both the
     // outcomes and the saga's idempotence are gate assertions — every
     // created person deletes exactly once, and a second attempt under a
-    // fresh op id answers not_found for all of them.
+    // fresh op id answers not_found for all of them. Persons a merge
+    // destroyed are tombstones already, so they answer not_found from
+    // the first attempt.
     if let Some(url) = &identity_url {
         if !args.keep_data {
             println!("Deleting persons through the lifecycle saga...");
             let lifecycle = crate::client::LifecycleClient::connect(url).await?;
-            verify_lifecycle_delete(&lifecycle, args.team_id, &person_ids).await?;
+            let uncertain = state.merge_uncertain_ids().await;
+            let mut live: Vec<i64> = distinct_ids.keys().copied().collect();
+            live.retain(|id| !merged_ids.contains(id) && !uncertain.contains(id));
+            live.sort_unstable();
+            verify_lifecycle_delete(&lifecycle, args.team_id, &live, &merged_ids, &uncertain)
+                .await?;
             println!("Lifecycle delete verified: all deleted, re-delete answers not_found");
         }
     }
@@ -570,30 +715,102 @@ pub async fn run(args: GateArgs) -> Result<()> {
 /// to the gate's standard: every id deleted on the first attempt, every
 /// id not_found on a second attempt under a fresh op id (deleting a
 /// tombstone is a no-op, never an error, never a false success).
+/// `merged_ids` were destroyed by the merge saga and must answer
+/// not_found on the first attempt already — a "deleted" there means the
+/// merge left a living row behind. `uncertain_ids` had a merge call that
+/// never answered, so either outcome is accepted for them.
+///
+/// A `skipped_conflict` means another lifecycle op still holds the
+/// person — a merge that chaos interrupted mid-saga, which the sweeper
+/// must re-drive to completion. Those are retried under fresh op ids
+/// until the op settles; one that never does fails the gate, because an
+/// op abandoned forever is a person nobody can ever merge or delete.
 async fn verify_lifecycle_delete(
     lifecycle: &crate::client::LifecycleClient,
     team_id: i64,
     person_ids: &[i64],
+    merged_ids: &[i64],
+    uncertain_ids: &[i64],
 ) -> Result<()> {
     use personhog_proto::personhog::lifecycle::v1::DeletePersonOutcome;
 
-    for (attempt, expected) in [
-        (1, DeletePersonOutcome::Deleted),
-        (2, DeletePersonOutcome::NotFound),
-    ] {
+    /// The sweeper claims abandoned ops once their lease lapses (15s)
+    /// on its own cadence, and a re-driven merge then needs its leader
+    /// calls to succeed on a converged stack.
+    const SETTLE_DEADLINE: Duration = Duration::from_secs(90);
+
+    // Everything answers on the first attempt except conflicts, which
+    // are re-asked until the holding op settles.
+    let mut expected: HashMap<i64, Vec<DeletePersonOutcome>> = HashMap::new();
+    for &id in person_ids {
+        expected.insert(id, vec![DeletePersonOutcome::Deleted]);
+    }
+    for &id in merged_ids {
+        expected.insert(id, vec![DeletePersonOutcome::NotFound]);
+    }
+    for &id in uncertain_ids {
+        expected.insert(
+            id,
+            vec![DeletePersonOutcome::Deleted, DeletePersonOutcome::NotFound],
+        );
+    }
+    let mut pending: Vec<i64> = expected.keys().copied().collect();
+    pending.sort_unstable();
+    let deadline = Instant::now() + SETTLE_DEADLINE;
+    while !pending.is_empty() {
+        let mut conflicts = Vec::new();
         // The lifecycle service caps batches at 250 person ids.
-        for chunk in person_ids.chunks(200) {
+        for chunk in pending.chunks(200) {
             let op_id = uuid::Uuid::new_v4();
-            let outcomes = lifecycle
+            for (person_id, outcome) in lifecycle
                 .delete_persons(team_id, chunk.to_vec(), &op_id)
-                .await?;
-            for (person_id, outcome) in outcomes {
-                if outcome != expected {
+                .await?
+            {
+                let accepted = &expected[&person_id];
+                if outcome == DeletePersonOutcome::SkippedConflict {
+                    conflicts.push(person_id);
+                } else if !accepted.contains(&outcome) {
                     bail!(
-                        "lifecycle delete attempt {attempt}: person {person_id} answered \
-                         {outcome:?}, expected {expected:?}"
+                        "lifecycle delete: person {person_id} answered {outcome:?}, \
+                         expected one of {accepted:?}"
                     );
                 }
+            }
+        }
+        if conflicts.is_empty() {
+            break;
+        }
+        if Instant::now() > deadline {
+            bail!(
+                "lifecycle delete: {} persons still held by another lifecycle op after {:?}: {:?}",
+                conflicts.len(),
+                SETTLE_DEADLINE,
+                &conflicts[..conflicts.len().min(10)]
+            );
+        }
+        println!(
+            "  {} persons held by an unsettled lifecycle op; waiting for the sweeper...",
+            conflicts.len()
+        );
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        pending = conflicts;
+    }
+
+    // Idempotence: a second attempt under a fresh op id answers
+    // not_found for everything (deleting a tombstone is a no-op, never an
+    // error, never a false success).
+    let mut all: Vec<i64> = expected.keys().copied().collect();
+    all.sort_unstable();
+    for chunk in all.chunks(200) {
+        let op_id = uuid::Uuid::new_v4();
+        for (person_id, outcome) in lifecycle
+            .delete_persons(team_id, chunk.to_vec(), &op_id)
+            .await?
+        {
+            if outcome != DeletePersonOutcome::NotFound {
+                bail!(
+                    "lifecycle re-delete: person {person_id} answered {outcome:?}, expected NotFound"
+                );
             }
         }
     }
@@ -601,9 +818,10 @@ async fn verify_lifecycle_delete(
 }
 
 /// Create the traffic-target persons through the identity service's batch
-/// get-or-create, with one seed property per person. The create ack covers
-/// both planes (stub committed in Postgres, initial properties durable in
-/// the changelog), so each ack is journaled like any other write — the
+/// get-or-create, with one seed property per person, returning each
+/// person's id with its distinct id. The create ack covers both planes
+/// (stub committed in Postgres, initial properties durable in the
+/// changelog), so each ack is journaled like any other write — the
 /// end-of-run strong reads and the Postgres check then hold create
 /// visibility to the same invariant as update visibility.
 async fn create_persons_via_identity(
@@ -611,7 +829,7 @@ async fn create_persons_via_identity(
     team_id: i64,
     count: u32,
     state: &PersonState,
-) -> Result<Vec<i64>> {
+) -> Result<Vec<(i64, String)>> {
     /// The identity service caps batches at 250 entries by default.
     const CREATE_BATCH_SIZE: u32 = 250;
 
@@ -662,11 +880,66 @@ async fn create_persons_via_identity(
             state
                 .record_write(person.id, person.version, seed_properties)
                 .await;
-            person_ids.push(person.id);
+            person_ids.push((person.id, result.distinct_id));
         }
         start = end;
     }
     Ok(person_ids)
+}
+
+/// Create persons that carry `extra_distinct_ids` extra mappings each —
+/// the shape whose merge the flip must repoint mapping by mapping. Same
+/// journaling as the ordinary create path.
+async fn create_fat_persons_via_identity(
+    identity_url: &str,
+    team_id: i64,
+    count: u32,
+    extra_distinct_ids: u32,
+    state: &PersonState,
+) -> Result<Vec<(i64, String)>> {
+    let client = IdentityClient::connect(identity_url).await?;
+    let mut persons = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        let distinct_id = format!("harness-gate-{team_id}-fat{i}");
+        let entry = GetOrCreatePersonEntry {
+            team_id,
+            distinct_id: distinct_id.clone(),
+            extra_distinct_ids: (0..extra_distinct_ids)
+                .map(|j| format!("{distinct_id}-{j}"))
+                .collect(),
+            event_name: "$set".to_string(),
+            set_properties: serde_json::to_vec(&serde_json::json!({ "harness_seed": distinct_id }))
+                .expect("seed properties serialize"),
+            set_once_properties: Vec::new(),
+            created_at: 0,
+            is_identified: false,
+        };
+        let mut results = client.get_or_create_persons(vec![entry]).await?;
+        let result = results
+            .pop()
+            .context("identity returned no result for a fat person")?;
+        if let Some(error) = &result.error {
+            bail!("identity create failed for fat person {distinct_id}: {error}");
+        }
+        let person = result
+            .person
+            .with_context(|| format!("no person for fat distinct id {distinct_id}"))?;
+        if !result.created {
+            bail!("distinct id {distinct_id} already existed — the harness team must start clean");
+        }
+        state
+            .record_write(
+                person.id,
+                person.version,
+                HashMap::from([(
+                    "harness_seed".to_string(),
+                    serde_json::json!(result.distinct_id),
+                )]),
+            )
+            .await;
+        persons.push((person.id, result.distinct_id));
+    }
+    Ok(persons)
 }
 
 #[cfg(test)]

--- a/rust/personhog-test-harness/src/scenarios/gate.rs
+++ b/rust/personhog-test-harness/src/scenarios/gate.rs
@@ -257,7 +257,6 @@ pub async fn run(args: GateArgs) -> Result<()> {
         (Some(url), None) => Some(url.clone()),
         (None, None) => unreachable!("validated above"),
     };
-    // Each created person's distinct id, for the merge lane's requests.
     let mut distinct_ids: HashMap<i64, String> = HashMap::new();
     let person_ids = match &identity_url {
         Some(url) => {
@@ -300,8 +299,6 @@ pub async fn run(args: GateArgs) -> Result<()> {
         distinct_ids.extend(created);
     }
     let created_count = person_ids.len();
-    // The live pool: every lane picks from it, and the merge lane retires
-    // the persons it destroys.
     let person_ids = Arc::new(TargetPool::new(person_ids));
     let distinct_ids = Arc::new(distinct_ids);
 
@@ -361,8 +358,8 @@ pub async fn run(args: GateArgs) -> Result<()> {
         })
     };
 
-    // The merge lane runs the durable saga against pairs of live persons
-    // for the same window, under the blast and prober writes above.
+    // The merge lane shares the traffic window, so the saga runs under
+    // the blast and prober writes above.
     let merges = identity_url
         .as_ref()
         .filter(|_| args.merge_concurrency > 0)
@@ -379,8 +376,8 @@ pub async fn run(args: GateArgs) -> Result<()> {
                 rate_per_sec: args.merge_rate,
                 allow_identified_sources: args.merge_identified_sources,
                 // A survivor collects every distinct id of every merged
-                // source; the pool bounds that, so no source ever trips
-                // the move guard.
+                // source. The pool bounds that total, so no source ever
+                // trips the move guard.
                 move_limit: i64::from(args.persons)
                     + i64::from(args.merge_wide_persons)
                         * (i64::from(args.merge_wide_distinct_ids) + 1)
@@ -608,7 +605,7 @@ pub async fn run(args: GateArgs) -> Result<()> {
     }
 
     // Merges that lost every response settle from their op records
-    // before anything is asserted: the sweeper claims an abandoned op
+    // before anything is asserted. The sweeper claims an abandoned op
     // once its lease (15s) lapses, then re-drives it on the converged
     // stack.
     let mut violations = prober_violations;
@@ -636,8 +633,6 @@ pub async fn run(args: GateArgs) -> Result<()> {
     );
 
     print_report("gate", &collector, args.team_id, created_count, &violations);
-    // Where the journal's expectations came from, for every violated
-    // person: which acks and which folds set the disputed keys.
     let mut disputed: HashMap<i64, Vec<String>> = HashMap::new();
     for violation in &violations {
         let keys = disputed.entry(violation.person_id).or_default();
@@ -663,7 +658,7 @@ pub async fn run(args: GateArgs) -> Result<()> {
     // outcomes and the saga's idempotence are gate assertions — every
     // created person deletes exactly once, and a second attempt under a
     // fresh op id answers not_found for all of them. Persons a merge
-    // destroyed are tombstones already, so they answer not_found from
+    // destroyed are tombstones already, so they answer not_found on
     // the first attempt.
     if let Some(url) = &identity_url {
         if !args.keep_data {
@@ -715,16 +710,16 @@ pub async fn run(args: GateArgs) -> Result<()> {
 /// to the gate's standard: every id deleted on the first attempt, every
 /// id not_found on a second attempt under a fresh op id (deleting a
 /// tombstone is a no-op, never an error, never a false success).
-/// `merged_ids` were destroyed by the merge saga and must answer
-/// not_found on the first attempt already — a "deleted" there means the
-/// merge left a living row behind. `uncertain_ids` had a merge call that
-/// never answered, so either outcome is accepted for them.
+/// The merge saga destroyed `merged_ids`, so they must answer not_found
+/// on the first attempt. A "deleted" there means the merge left a
+/// living row behind. `uncertain_ids` had a merge call that never
+/// answered, so either outcome is accepted for them.
 ///
 /// A `skipped_conflict` means another lifecycle op still holds the
-/// person — a merge that chaos interrupted mid-saga, which the sweeper
-/// must re-drive to completion. Those are retried under fresh op ids
-/// until the op settles; one that never does fails the gate, because an
-/// op abandoned forever is a person nobody can ever merge or delete.
+/// person, usually a merge that chaos interrupted mid-saga. The sweeper
+/// must re-drive that op, so conflicts are retried under fresh op ids
+/// until the op settles. One that never settles fails the gate, because
+/// nobody can ever merge or delete that person again.
 async fn verify_lifecycle_delete(
     lifecycle: &crate::client::LifecycleClient,
     team_id: i64,
@@ -734,13 +729,13 @@ async fn verify_lifecycle_delete(
 ) -> Result<()> {
     use personhog_proto::personhog::lifecycle::v1::DeletePersonOutcome;
 
-    /// The sweeper claims abandoned ops once their lease lapses (15s)
-    /// on its own cadence, and a re-driven merge then needs its leader
+    /// The sweeper claims an abandoned op once its lease (15s) lapses,
+    /// on its own cadence. A re-driven merge then needs its leader
     /// calls to succeed on a converged stack.
     const SETTLE_DEADLINE: Duration = Duration::from_secs(90);
 
-    // Everything answers on the first attempt except conflicts, which
-    // are re-asked until the holding op settles.
+    // Everything answers on the first attempt. Conflicts are asked
+    // again until the holding op settles.
     let mut expected: HashMap<i64, Vec<DeletePersonOutcome>> = HashMap::new();
     for &id in person_ids {
         expected.insert(id, vec![DeletePersonOutcome::Deleted]);
@@ -797,8 +792,8 @@ async fn verify_lifecycle_delete(
     }
 
     // Idempotence: a second attempt under a fresh op id answers
-    // not_found for everything (deleting a tombstone is a no-op, never an
-    // error, never a false success).
+    // not_found for everything. Deleting a tombstone is a no-op, never
+    // an error, and never a false success.
     let mut all: Vec<i64> = expected.keys().copied().collect();
     all.sort_unstable();
     for chunk in all.chunks(200) {
@@ -821,7 +816,7 @@ async fn verify_lifecycle_delete(
 /// get-or-create, with one seed property per person, returning each
 /// person's id with its distinct id. The create ack covers both planes
 /// (stub committed in Postgres, initial properties durable in the
-/// changelog), so each ack is journaled like any other write — the
+/// changelog), so each ack is journaled like any other write. The
 /// end-of-run strong reads and the Postgres check then hold create
 /// visibility to the same invariant as update visibility.
 async fn create_persons_via_identity(
@@ -869,7 +864,7 @@ async fn create_persons_via_identity(
                 .with_context(|| format!("no person for distinct id {}", result.distinct_id))?;
             if !result.created {
                 bail!(
-                    "distinct id {} already existed — the harness team must start clean",
+                    "distinct id {} already existed; the harness team must start clean",
                     result.distinct_id
                 );
             }
@@ -887,9 +882,9 @@ async fn create_persons_via_identity(
     Ok(person_ids)
 }
 
-/// Create persons that carry `extra_distinct_ids` extra mappings each —
-/// the shape whose merge the flip must repoint mapping by mapping. Same
-/// journaling as the ordinary create path.
+/// Create persons that carry `extra_distinct_ids` extra mappings each.
+/// A merge of this shape makes the flip repoint every mapping. The
+/// journaling is the same as on the ordinary create path.
 async fn create_wide_persons_via_identity(
     identity_url: &str,
     team_id: i64,
@@ -925,7 +920,7 @@ async fn create_wide_persons_via_identity(
             .person
             .with_context(|| format!("no person for wide distinct id {distinct_id}"))?;
         if !result.created {
-            bail!("distinct id {distinct_id} already existed — the harness team must start clean");
+            bail!("distinct id {distinct_id} already existed; the harness team must start clean");
         }
         state
             .record_write(

--- a/rust/personhog-test-harness/src/scenarios/gate.rs
+++ b/rust/personhog-test-harness/src/scenarios/gate.rs
@@ -14,7 +14,7 @@ use crate::cli::{GateArgs, DEFAULT_KEYS_PER_PERSON};
 use crate::client::{HarnessClient, IdentityClient};
 use crate::pool::TargetPool;
 use crate::report::print_report;
-use crate::scenarios::merge::{self, FatRole, MergeLane};
+use crate::scenarios::merge::{self, MergeLane, WideRole};
 use crate::scenarios::{blast, consistency};
 use crate::seed;
 use crate::stack::{Stack, StackConfig};
@@ -167,11 +167,11 @@ pub async fn run(args: GateArgs) -> Result<()> {
     if args.merge_rate.is_some_and(|rate| rate <= 0.0) {
         bail!("--merge-rate must be positive; omit it to run the merge workers flat out");
     }
-    if args.merge_fat_persons > 0 && args.merge_concurrency == 0 {
-        bail!("--merge-fat-persons needs --merge-concurrency");
+    if args.merge_wide_persons > 0 && args.merge_concurrency == 0 {
+        bail!("--merge-wide-persons needs --merge-concurrency");
     }
-    let fat_role = FatRole::parse(&args.merge_fat_role)
-        .ok_or_else(|| anyhow::anyhow!("unknown --merge-fat-role {:?}", args.merge_fat_role))?;
+    let wide_role = WideRole::parse(&args.merge_wide_role)
+        .ok_or_else(|| anyhow::anyhow!("unknown --merge-wide-role {:?}", args.merge_wide_role))?;
     // The spawned identity derives its whole table set (person, distinct id,
     // hash-key overrides) from --pg-target-table, so any known table set
     // works; Stack::up rejects person tables without a known companion set.
@@ -280,22 +280,22 @@ pub async fn run(args: GateArgs) -> Result<()> {
         }
     };
     let mut person_ids = person_ids;
-    let mut fat_persons = Vec::new();
-    if let (Some(url), true) = (&identity_url, args.merge_fat_persons > 0) {
-        let created = create_fat_persons_via_identity(
+    let mut wide_persons = Vec::new();
+    if let (Some(url), true) = (&identity_url, args.merge_wide_persons > 0) {
+        let created = create_wide_persons_via_identity(
             url,
             args.team_id,
-            args.merge_fat_persons,
-            args.merge_fat_distinct_ids,
+            args.merge_wide_persons,
+            args.merge_wide_distinct_ids,
             &state,
         )
         .await?;
         println!(
-            "Created {} fat persons with {} extra distinct ids each",
+            "Created {} wide persons with {} extra distinct ids each",
             created.len(),
-            args.merge_fat_distinct_ids
+            args.merge_wide_distinct_ids
         );
-        fat_persons.extend(created.iter().map(|(id, _)| *id));
+        wide_persons.extend(created.iter().map(|(id, _)| *id));
         person_ids.extend(created.iter().map(|(id, _)| *id));
         distinct_ids.extend(created);
     }
@@ -382,11 +382,11 @@ pub async fn run(args: GateArgs) -> Result<()> {
                 // source; the pool bounds that, so no source ever trips
                 // the move guard.
                 move_limit: i64::from(args.persons)
-                    + i64::from(args.merge_fat_persons)
-                        * (i64::from(args.merge_fat_distinct_ids) + 1)
+                    + i64::from(args.merge_wide_persons)
+                        * (i64::from(args.merge_wide_distinct_ids) + 1)
                     + 1,
-                fat_persons: fat_persons.clone(),
-                fat_role,
+                wide_persons: wide_persons.clone(),
+                wide_role,
             };
             let duration = args.duration;
             println!(
@@ -890,7 +890,7 @@ async fn create_persons_via_identity(
 /// Create persons that carry `extra_distinct_ids` extra mappings each —
 /// the shape whose merge the flip must repoint mapping by mapping. Same
 /// journaling as the ordinary create path.
-async fn create_fat_persons_via_identity(
+async fn create_wide_persons_via_identity(
     identity_url: &str,
     team_id: i64,
     count: u32,
@@ -900,7 +900,7 @@ async fn create_fat_persons_via_identity(
     let client = IdentityClient::connect(identity_url).await?;
     let mut persons = Vec::with_capacity(count as usize);
     for i in 0..count {
-        let distinct_id = format!("harness-gate-{team_id}-fat{i}");
+        let distinct_id = format!("harness-gate-{team_id}-wide{i}");
         let entry = GetOrCreatePersonEntry {
             team_id,
             distinct_id: distinct_id.clone(),
@@ -917,13 +917,13 @@ async fn create_fat_persons_via_identity(
         let mut results = client.get_or_create_persons(vec![entry]).await?;
         let result = results
             .pop()
-            .context("identity returned no result for a fat person")?;
+            .context("identity returned no result for a wide person")?;
         if let Some(error) = &result.error {
-            bail!("identity create failed for fat person {distinct_id}: {error}");
+            bail!("identity create failed for wide person {distinct_id}: {error}");
         }
         let person = result
             .person
-            .with_context(|| format!("no person for fat distinct id {distinct_id}"))?;
+            .with_context(|| format!("no person for wide distinct id {distinct_id}"))?;
         if !result.created {
             bail!("distinct id {distinct_id} already existed — the harness team must start clean");
         }

--- a/rust/personhog-test-harness/src/scenarios/merge.rs
+++ b/rust/personhog-test-harness/src/scenarios/merge.rs
@@ -1,14 +1,12 @@
-//! The merge lane: MergePersons calls against random live persons while
-//! the blast writers and probers keep writing to all of them.
+//! The merge lane: MergePersons calls against live persons while the
+//! blast writers and probers keep writing to them.
 //!
-//! Every call names one target and one or more distinct live sources.
-//! Thus every source that settles as `merged` ran the durable saga end
-//! to end (fence, seal, fold, flip, release) with writes racing the
-//! source's fence and the target's fold. A source distinct id is reserved
-//! for one in-flight call and is never reused after a merge, so the
-//! journal always knows which person died. Targets are shared, so two
-//! calls can contend for one person and exercise the saga's conflict
-//! settlements.
+//! Each call names one target and one or more live sources. A source
+//! that settles as `merged` ran the durable saga end to end, with writes
+//! racing its fence and the target's fold. A source is reserved for one
+//! call at a time and is never reused after a merge, so the journal
+//! always knows which person died. Targets are shared, so two calls can
+//! contend for one person.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -32,15 +30,13 @@ use crate::scenarios::gate::SEED_KEY;
 use crate::state::{MergeAck, PersonState};
 use crate::stats::StatsCollector;
 
-/// Attempts per merge call under one op id. A retry under the same op id
-/// returns the recorded outcome, so a lost response is asked again, not
-/// guessed at.
+/// Attempts per call, all under one op id. A retry with the same op id
+/// returns the recorded outcome and does not merge again.
 const MERGE_ATTEMPTS: u32 = 3;
 const MERGE_RETRY_BACKOFF: Duration = Duration::from_millis(500);
 
-/// The `$set_once` value that must never land: it is sent for keys the
-/// survivor already holds, so the fold's set-once tier has to leave
-/// them alone.
+/// The `$set_once` value sent for keys the survivor already holds. It
+/// must never land.
 const SET_ONCE_LOSER: &str = "harness_set_once_must_not_win";
 
 pub struct MergeLane {
@@ -48,15 +44,13 @@ pub struct MergeLane {
     pub concurrency: usize,
     /// Combined target rate across the workers. Unset runs flat out.
     pub rate_per_sec: Option<f64>,
-    /// Sources per call. The leader folds several sealed sources in
-    /// request order, and only a call with more than one source
-    /// exercises that ordering.
+    /// Sources per call. Only a call with more than one source exercises
+    /// the leader's request-order fold.
     pub sources_per_call: usize,
     pub allow_identified_sources: bool,
     pub move_limit: i64,
-    /// Persons created with many distinct ids. Workers prefer a wide
-    /// pair while one is available, so the expensive merges happen
-    /// before the pool thins. Their latency is recorded apart.
+    /// Persons with many distinct ids. Workers prefer them while one is
+    /// available, so the expensive merges happen before the pool thins.
     pub wide_persons: Vec<i64>,
     pub wide_role: WideRole,
 }
@@ -83,10 +77,9 @@ impl WideRole {
 /// run anyway. The op record decides, see [`settle_unresolved`].
 pub struct UnresolvedMerge {
     pub op_id: uuid::Uuid,
-    /// The sources, as person id and distinct id, in request order.
+    /// Person id and distinct id per source, in request order.
     pub sources: Vec<(i64, String)>,
-    /// The merge event's `$set` and `$set_once`. Journaled on the
-    /// survivor if the op record says the merge ran.
+    /// Journaled on the survivor if the op record says the merge ran.
     pub set: HashMap<String, serde_json::Value>,
     pub set_once: HashMap<String, serde_json::Value>,
 }
@@ -96,10 +89,9 @@ pub struct MergeLaneResult {
     pub unresolved: Vec<UnresolvedMerge>,
 }
 
-/// The merge event's property writes for one call. Three `$set_once`
-/// keys cover the fold's set-once tier: a fresh key it must fill, the
-/// `$set` key it must lose to, and the seed key every person holds, which
-/// it must leave alone.
+/// The merge event's writes for one call. The three `$set_once` keys
+/// test the fold: a fresh key it must fill, the `$set` key it must lose
+/// to, and the seed key it must not change.
 struct MergeEvent {
     set: HashMap<String, serde_json::Value>,
     set_once: HashMap<String, serde_json::Value>,
@@ -119,8 +111,7 @@ impl MergeEvent {
         }
     }
 
-    /// The keys the survivor document must carry after the fold, with
-    /// their values.
+    /// The keys and values the survivor must carry after the fold.
     fn expected(&self) -> impl Iterator<Item = (&String, &serde_json::Value)> {
         self.set.iter().chain(
             self.set_once
@@ -130,10 +121,8 @@ impl MergeEvent {
     }
 }
 
-/// Drive merges until the deadline. Every `merged` ack is journaled into
-/// `state` and the destroyed sources leave `pool`. Returns the violations
-/// observed live: a survivor without the merge event's writes, a merged
-/// source that still reads as alive, or an ack with no survivor.
+/// Drive merges until the deadline. Merged acks go into `state`, and
+/// merged sources leave `pool`. Returns the violations seen live.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_merges(
     identity: &IdentityClient,
@@ -151,8 +140,7 @@ pub async fn run_merges(
         .rate_per_sec
         .map(|rate| per_worker_tick(rate, lane.concurrency));
     let wide: Arc<HashSet<i64>> = Arc::new(lane.wide_persons.iter().copied().collect());
-    // The eligible set excludes the wide persons so an ordinary pick
-    // cannot spend a wide source.
+    // An ordinary pick must not spend a wide source.
     let eligible = Arc::new(Mutex::new(
         pool.snapshot()
             .into_iter()
@@ -200,8 +188,6 @@ pub async fn run_merges(
             });
             let mut violations = Vec::new();
             let mut unresolved = Vec::new();
-            // A source goes back to the set it was reserved from when the
-            // call leaves it alive.
             let release = |source: i64| {
                 if wide.contains(&source) {
                     wide_sources.lock().unwrap().push(source);
@@ -218,8 +204,8 @@ pub async fn run_merges(
                     pick_wide_pair(&wide_sources, &wide_targets, &eligible, &pool, &mut rng)
                         .or_else(|| pick_pair(&eligible, &pool, &mut rng));
                 let Some((first_source, target)) = picked else {
-                    // Fewer than two live persons remain, or every
-                    // source is reserved.
+                    // The pool is almost empty, or every source is
+                    // reserved.
                     if pool.len() < 2 {
                         note_dry(&dry_at, started.elapsed());
                     }
@@ -294,11 +280,10 @@ pub async fn run_merges(
                 };
                 let Some(response) = response else {
                     recorder.record_failure();
-                    // The saga is durable, and the sweeper re-drives
-                    // abandoned ops. The call can still destroy the
-                    // sources after this failure. The op record settles
-                    // them after traffic. Until then every source stays
-                    // reserved and takes no more traffic.
+                    // The saga can still destroy the sources after this
+                    // failure. The op record settles them after traffic.
+                    // Until then the sources stay reserved and take no
+                    // traffic.
                     for &source in &sources {
                         state.record_merge_uncertain(source).await;
                         pool.remove(source);
@@ -335,9 +320,9 @@ pub async fn run_merges(
                 }
 
                 let Some(survivor) = response.survivor else {
-                    // The sources are destroyed but the survivor is
-                    // unknown. Keep the reservations so reads tolerate
-                    // their absence, and stop asserting on them.
+                    // The sources are destroyed, but the survivor is
+                    // unknown. Keep them reserved, so reads tolerate
+                    // their absence.
                     for &source in &merged {
                         violations.push(ConsistencyViolation {
                             person_id: source,
@@ -352,8 +337,8 @@ pub async fn run_merges(
                 };
                 let survivor_props: serde_json::Value =
                     serde_json::from_slice(&survivor.properties).unwrap_or_else(|_| json!({}));
-                // The fold applies the merge event's writes last. The
-                // folded document in the ack must already carry them.
+                // The ack carries the folded document, so the merge
+                // event's writes must already be in it.
                 for (key, value) in event.expected() {
                     if survivor_props.get(key) != Some(value) {
                         violations.push(ConsistencyViolation {
@@ -390,9 +375,8 @@ pub async fn run_merges(
                     pool.remove(source);
                 }
 
-                // Read-your-merge check. The release produced each
-                // source's death document before the saga completed. A
-                // strong read served now must not find a living person.
+                // A strong read after the ack must not find a living
+                // source.
                 for &source in &merged {
                     let read_start = Instant::now();
                     match router
@@ -445,15 +429,11 @@ pub async fn run_merges(
     })
 }
 
-/// Settle every unresolved merge from the saga's own record. A
-/// `completed` op is journaled as the merge it was, with the sources the
-/// record says merged. That is safe after later merges' acks, because
-/// the journal orders folds by the recorded survivor version. An aborted
-/// op means every source lived on. So does a missing op row, because the
-/// call failed before the saga froze its request. An op still in flight
-/// is polled until `deadline` elapses, which gives the sweeper time to
-/// re-drive it. An op that never settles is a violation: no lifecycle
-/// op can ever touch those persons again.
+/// Settle each unresolved merge from its op record. A `completed` op is
+/// journaled as a merge with the sources the record says merged. An
+/// aborted op, or a missing op row, means every source lived on. An op
+/// still in flight is polled until `deadline`, which gives the sweeper
+/// time to re-drive it. An op that never settles is a violation.
 pub async fn settle_unresolved(
     pool: &PgPool,
     state: &PersonState,
@@ -479,8 +459,7 @@ pub async fn settle_unresolved(
                 .await
                 .context("reading an unresolved merge op")?;
             let Some(row) = row else {
-                // No op row means the saga never froze the request, so
-                // nothing destructive started.
+                // No op row means the saga never started.
                 for (source, _) in &merge.sources {
                     state.clear_merge_pending(*source).await;
                 }
@@ -567,8 +546,7 @@ pub async fn settle_unresolved(
 }
 
 /// A pair with a wide person on the configured side. None when no wide
-/// source is left to reserve and no wide target is live. With wide
-/// targets only, the source comes from the ordinary eligible set.
+/// source is free and no wide target is live.
 fn pick_wide_pair(
     wide_sources: &Mutex<Vec<i64>>,
     wide_targets: &[i64],
@@ -643,9 +621,8 @@ fn pick_pair(
     }
     let index = rng.gen_range(0..eligible.len());
     let source = eligible.swap_remove(index);
-    // The pool holds at least two persons, so a different target exists
-    // and a few random draws almost always find one. A miss only puts
-    // the source back.
+    // A few random draws almost always find a different target. A miss
+    // puts the source back.
     for _ in 0..16 {
         match pool.pick_random(rng) {
             Some(target) if target != source => return Some((source, target)),
@@ -703,9 +680,8 @@ pub fn outcome_name(outcome: MergeSourceOutcome) -> &'static str {
 mod tests {
     use super::*;
 
-    /// A call with several sources must not double-book a person: the
-    /// target is never one of its own sources, and every source comes
-    /// out of the eligible set exactly once.
+    /// The target is never one of its own sources, and each source
+    /// leaves the eligible set exactly once.
     #[test]
     fn extra_sources_are_reserved_apart_from_the_target() {
         let mut rng = rand::rngs::StdRng::seed_from_u64(7);
@@ -716,8 +692,7 @@ mod tests {
         assert_eq!(sources, vec![1, 2, 4]);
         assert_eq!(*eligible.lock().unwrap(), vec![3]);
 
-        // The eligible set running out caps the call, and does not
-        // spend the target.
+        // An empty eligible set caps the call. The target stays.
         reserve_more_sources(&eligible, &mut sources, 3, 10, &mut rng);
         assert_eq!(sources.len(), 3);
         assert_eq!(*eligible.lock().unwrap(), vec![3]);

--- a/rust/personhog-test-harness/src/scenarios/merge.rs
+++ b/rust/personhog-test-harness/src/scenarios/merge.rs
@@ -1,15 +1,16 @@
-//! The merge lane: MergePersons calls against random pairs of live
-//! persons while the blast writers and probers keep writing to both.
+//! The merge lane: MergePersons calls against random live persons while
+//! the blast writers and probers keep writing to all of them.
 //!
-//! Every pair is two distinct live persons. Thus every call that settles
-//! as `merged` ran the durable saga end to end (fence, seal, fold, flip,
-//! release) with writes racing the source's fence and the target's fold.
-//! A source distinct id is reserved for one in-flight call and is never
-//! reused after a merge, so the journal always knows which person died.
-//! Targets are shared, so two calls can contend for one person and
-//! exercise the saga's conflict settlements.
+//! Every call names one target and one or more distinct live sources.
+//! Thus every source that settles as `merged` ran the durable saga end
+//! to end (fence, seal, fold, flip, release) with writes racing the
+//! source's fence and the target's fold. A source distinct id is reserved
+//! for one in-flight call and is never reused after a merge, so the
+//! journal always knows which person died. Targets are shared, so two
+//! calls can contend for one person and exercise the saga's conflict
+//! settlements.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -27,7 +28,8 @@ use crate::client::{HarnessClient, IdentityClient};
 use crate::pool::TargetPool;
 use crate::report::ConsistencyViolation;
 use crate::scenarios::blast::{is_not_found, per_worker_tick};
-use crate::state::PersonState;
+use crate::scenarios::gate::SEED_KEY;
+use crate::state::{MergeAck, PersonState};
 use crate::stats::StatsCollector;
 
 /// Attempts per merge call under one op id. A retry under the same op id
@@ -36,11 +38,20 @@ use crate::stats::StatsCollector;
 const MERGE_ATTEMPTS: u32 = 3;
 const MERGE_RETRY_BACKOFF: Duration = Duration::from_millis(500);
 
+/// The `$set_once` value that must never land: it is sent for keys the
+/// survivor already holds, so the fold's set-once tier has to leave
+/// them alone.
+const SET_ONCE_LOSER: &str = "harness_set_once_must_not_win";
+
 pub struct MergeLane {
     pub team_id: i64,
     pub concurrency: usize,
     /// Combined target rate across the workers. Unset runs flat out.
     pub rate_per_sec: Option<f64>,
+    /// Sources per call. The leader folds several sealed sources in
+    /// request order, and only a call with more than one source
+    /// exercises that ordering.
+    pub sources_per_call: usize,
     pub allow_identified_sources: bool,
     pub move_limit: i64,
     /// Persons created with many distinct ids. Workers prefer a wide
@@ -72,11 +83,12 @@ impl WideRole {
 /// run anyway. The op record decides, see [`settle_unresolved`].
 pub struct UnresolvedMerge {
     pub op_id: uuid::Uuid,
-    pub source: i64,
-    /// The merge event's `$set` key and value. Journaled on the survivor
-    /// if the op record says the merge ran.
-    pub key: String,
-    pub value: serde_json::Value,
+    /// The sources, as person id and distinct id, in request order.
+    pub sources: Vec<(i64, String)>,
+    /// The merge event's `$set` and `$set_once`. Journaled on the
+    /// survivor if the op record says the merge ran.
+    pub set: HashMap<String, serde_json::Value>,
+    pub set_once: HashMap<String, serde_json::Value>,
 }
 
 pub struct MergeLaneResult {
@@ -84,9 +96,43 @@ pub struct MergeLaneResult {
     pub unresolved: Vec<UnresolvedMerge>,
 }
 
+/// The merge event's property writes for one call. Three `$set_once`
+/// keys cover the fold's set-once tier: a fresh key it must fill, the
+/// `$set` key it must lose to, and the seed key every person holds, which
+/// it must leave alone.
+struct MergeEvent {
+    set: HashMap<String, serde_json::Value>,
+    set_once: HashMap<String, serde_json::Value>,
+}
+
+impl MergeEvent {
+    fn new(op_id: &uuid::Uuid) -> Self {
+        let op = json!(op_id.to_string());
+        let loser = json!(SET_ONCE_LOSER);
+        Self {
+            set: HashMap::from([(format!("harness_merge_{op_id}"), op.clone())]),
+            set_once: HashMap::from([
+                (format!("harness_merge_once_{op_id}"), op),
+                (format!("harness_merge_{op_id}"), loser.clone()),
+                (SEED_KEY.to_string(), loser),
+            ]),
+        }
+    }
+
+    /// The keys the survivor document must carry after the fold, with
+    /// their values.
+    fn expected(&self) -> impl Iterator<Item = (&String, &serde_json::Value)> {
+        self.set.iter().chain(
+            self.set_once
+                .iter()
+                .filter(|(_, value)| value.as_str() != Some(SET_ONCE_LOSER)),
+        )
+    }
+}
+
 /// Drive merges until the deadline. Every `merged` ack is journaled into
-/// `state` and the destroyed source leaves `pool`. Returns the violations
-/// observed live: a survivor without the merge's own write, a merged
+/// `state` and the destroyed sources leave `pool`. Returns the violations
+/// observed live: a survivor without the merge event's writes, a merged
 /// source that still reads as alive, or an ack with no survivor.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_merges(
@@ -104,9 +150,8 @@ pub async fn run_merges(
     let worker_tick = lane
         .rate_per_sec
         .map(|rate| per_worker_tick(rate, lane.concurrency));
-    let wide: Arc<std::collections::HashSet<i64>> =
-        Arc::new(lane.wide_persons.iter().copied().collect());
-    // The eligible set excludes the wide persons so an ordinary pair
+    let wide: Arc<HashSet<i64>> = Arc::new(lane.wide_persons.iter().copied().collect());
+    // The eligible set excludes the wide persons so an ordinary pick
     // cannot spend a wide source.
     let eligible = Arc::new(Mutex::new(
         pool.snapshot()
@@ -139,8 +184,12 @@ pub async fn run_merges(
         let collector = collector.clone();
         let state = state.clone();
         let stop = stop.clone();
-        let (team_id, allow_identified_sources, move_limit) =
-            (lane.team_id, lane.allow_identified_sources, lane.move_limit);
+        let (team_id, allow_identified_sources, move_limit, sources_per_call) = (
+            lane.team_id,
+            lane.allow_identified_sources,
+            lane.move_limit,
+            lane.sources_per_call.max(1),
+        );
 
         handles.push(tokio::spawn(async move {
             let mut rng = rand::rngs::StdRng::from_entropy();
@@ -151,6 +200,15 @@ pub async fn run_merges(
             });
             let mut violations = Vec::new();
             let mut unresolved = Vec::new();
+            // A source goes back to the set it was reserved from when the
+            // call leaves it alive.
+            let release = |source: i64| {
+                if wide.contains(&source) {
+                    wide_sources.lock().unwrap().push(source);
+                } else {
+                    eligible.lock().unwrap().push(source);
+                }
+            };
 
             while Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
                 if let Some(pacer) = pacer.as_mut() {
@@ -159,7 +217,7 @@ pub async fn run_merges(
                 let picked =
                     pick_wide_pair(&wide_sources, &wide_targets, &eligible, &pool, &mut rng)
                         .or_else(|| pick_pair(&eligible, &pool, &mut rng));
-                let Some((source, target)) = picked else {
+                let Some((first_source, target)) = picked else {
                     // Fewer than two live persons remain, or every
                     // source is reserved.
                     if pool.len() < 2 {
@@ -168,16 +226,25 @@ pub async fn run_merges(
                     sleep(Duration::from_millis(200)).await;
                     continue;
                 };
-                let (Some(source_did), Some(target_did)) =
-                    (distinct_ids.get(&source), distinct_ids.get(&target))
-                else {
+                let mut sources = vec![first_source];
+                reserve_more_sources(&eligible, &mut sources, target, sources_per_call, &mut rng);
+                let Some(target_did) = distinct_ids.get(&target) else {
                     unreachable!("every pooled person was created with a distinct id");
                 };
+                let source_dids: Vec<String> = sources
+                    .iter()
+                    .map(|source| {
+                        distinct_ids.get(source).cloned().unwrap_or_else(|| {
+                            unreachable!("every pooled person was created with a distinct id")
+                        })
+                    })
+                    .collect();
 
-                state.mark_merge_pending(source).await;
+                for &source in &sources {
+                    state.mark_merge_pending(source).await;
+                }
                 let op_id = uuid::Uuid::new_v4();
-                let key = format!("harness_merge_{op_id}");
-                let value = serde_json::Value::String(op_id.to_string());
+                let event = MergeEvent::new(&op_id);
 
                 let start = Instant::now();
                 let mut attempt = 0;
@@ -187,8 +254,9 @@ pub async fn run_merges(
                         .merge_persons(
                             team_id,
                             target_did,
-                            std::slice::from_ref(source_did),
-                            json!({ &key: &value }),
+                            &source_dids,
+                            json!(event.set),
+                            json!(event.set_once),
                             &op_id,
                             allow_identified_sources,
                             move_limit,
@@ -198,7 +266,7 @@ pub async fn run_merges(
                         Ok(response) => break Some(response),
                         Err(e) if attempt < MERGE_ATTEMPTS => {
                             tracing::warn!(
-                                source,
+                                ?sources,
                                 target,
                                 attempt,
                                 error = format!("{e:#}"),
@@ -208,17 +276,18 @@ pub async fn run_merges(
                         }
                         Err(e) => {
                             tracing::warn!(
-                                source,
+                                ?sources,
                                 target,
                                 error = format!("{e:#}"),
-                                "merge call failed on every attempt; source outcome unknown"
+                                "merge call failed on every attempt; source outcomes unknown"
                             );
                             break None;
                         }
                     }
                 };
 
-                let recorder = if wide.contains(&source) || wide.contains(&target) {
+                let recorder = if wide.contains(&target) || sources.iter().any(|s| wide.contains(s))
+                {
                     &collector.wide_merges
                 } else {
                     &collector.merges
@@ -227,104 +296,127 @@ pub async fn run_merges(
                     recorder.record_failure();
                     // The saga is durable, and the sweeper re-drives
                     // abandoned ops. The call can still destroy the
-                    // source after this failure. The op record settles
-                    // it after traffic. Until then the source stays
+                    // sources after this failure. The op record settles
+                    // them after traffic. Until then every source stays
                     // reserved and takes no more traffic.
-                    state.record_merge_uncertain(source).await;
-                    pool.remove(source);
+                    for &source in &sources {
+                        state.record_merge_uncertain(source).await;
+                        pool.remove(source);
+                    }
                     unresolved.push(UnresolvedMerge {
                         op_id,
-                        source,
-                        key,
-                        value,
+                        sources: sources.iter().copied().zip(source_dids).collect(),
+                        set: event.set,
+                        set_once: event.set_once,
                     });
                     continue;
                 };
                 recorder.record_success(start.elapsed());
 
-                let source_outcome = response
-                    .results
-                    .iter()
-                    .find(|r| r.source_distinct_id == *source_did)
-                    .map(|r| r.outcome())
-                    .unwrap_or(MergeSourceOutcome::Unspecified);
-                collector.record_merge_outcome(outcome_name(source_outcome));
-
-                if source_outcome != MergeSourceOutcome::Merged {
-                    // Every outcome except merged leaves the source alive.
-                    state.clear_merge_pending(source).await;
-                    if wide.contains(&source) {
-                        wide_sources.lock().unwrap().push(source);
+                let mut merged = Vec::new();
+                for (&source, source_did) in sources.iter().zip(&source_dids) {
+                    let outcome = response
+                        .results
+                        .iter()
+                        .find(|r| r.source_distinct_id == *source_did)
+                        .map(|r| r.outcome())
+                        .unwrap_or(MergeSourceOutcome::Unspecified);
+                    collector.record_merge_outcome(outcome_name(outcome));
+                    if outcome == MergeSourceOutcome::Merged {
+                        merged.push(source);
                     } else {
-                        eligible.lock().unwrap().push(source);
+                        // Every outcome except merged leaves the source alive.
+                        state.clear_merge_pending(source).await;
+                        release(source);
                     }
+                }
+                if merged.is_empty() {
                     continue;
                 }
 
                 let Some(survivor) = response.survivor else {
-                    violations.push(ConsistencyViolation {
-                        person_id: source,
-                        key: "__merge_ack_missing_survivor".to_string(),
-                        expected: json!("a merged ack carries the survivor document"),
-                        actual: serde_json::Value::Null,
-                    });
-                    // The source is destroyed but the survivor is
-                    // unknown. Keep the reservation so reads tolerate
-                    // its absence, and stop asserting on it.
-                    state.record_merge_uncertain(source).await;
-                    pool.remove(source);
+                    // The sources are destroyed but the survivor is
+                    // unknown. Keep the reservations so reads tolerate
+                    // their absence, and stop asserting on them.
+                    for &source in &merged {
+                        violations.push(ConsistencyViolation {
+                            person_id: source,
+                            key: "__merge_ack_missing_survivor".to_string(),
+                            expected: json!("a merged ack carries the survivor document"),
+                            actual: serde_json::Value::Null,
+                        });
+                        state.record_merge_uncertain(source).await;
+                        pool.remove(source);
+                    }
                     continue;
                 };
                 let survivor_props: serde_json::Value =
                     serde_json::from_slice(&survivor.properties).unwrap_or_else(|_| json!({}));
-                if survivor_props.get(&key) != Some(&value) {
-                    // The fold applies the merge event's $set last. The
-                    // folded document in the ack must already carry it.
+                // The fold applies the merge event's writes last. The
+                // folded document in the ack must already carry them.
+                for (key, value) in event.expected() {
+                    if survivor_props.get(key) != Some(value) {
+                        violations.push(ConsistencyViolation {
+                            person_id: survivor.id,
+                            key: key.clone(),
+                            expected: value.clone(),
+                            actual: survivor_props
+                                .get(key)
+                                .cloned()
+                                .unwrap_or(serde_json::Value::Null),
+                        });
+                    }
+                }
+                if survivor_props.get(SEED_KEY) == Some(&json!(SET_ONCE_LOSER)) {
                     violations.push(ConsistencyViolation {
                         person_id: survivor.id,
-                        key: key.clone(),
-                        expected: value.clone(),
-                        actual: survivor_props
-                            .get(&key)
-                            .cloned()
-                            .unwrap_or(serde_json::Value::Null),
+                        key: SEED_KEY.to_string(),
+                        expected: json!(
+                            "the value the fold carried; $set_once must not replace it"
+                        ),
+                        actual: json!(SET_ONCE_LOSER),
                     });
                 }
                 state
-                    .record_merge(
-                        source,
-                        survivor.id,
-                        survivor.version,
-                        HashMap::from([(key, value)]),
-                    )
+                    .record_merge(MergeAck {
+                        survivor: survivor.id,
+                        survivor_version: survivor.version,
+                        sources: merged.clone(),
+                        set: event.set,
+                        set_once: event.set_once,
+                    })
                     .await;
-                pool.remove(source);
+                for &source in &merged {
+                    pool.remove(source);
+                }
 
-                // Read-your-merge check. The release produced the
+                // Read-your-merge check. The release produced each
                 // source's death document before the saga completed. A
                 // strong read served now must not find a living person.
-                let read_start = Instant::now();
-                match router
-                    .get_person(team_id, source, ConsistencyLevel::Strong)
-                    .await
-                {
-                    Ok(Some(person)) if !person.is_deleted => {
-                        collector.reads.record_success(read_start.elapsed());
-                        violations.push(ConsistencyViolation {
-                            person_id: source,
-                            key: "__merged_source_alive".to_string(),
-                            expected: json!("not found after the merge ack"),
-                            actual: json!({ "version": person.version }),
-                        });
-                    }
-                    Ok(_) => collector.reads.record_success(read_start.elapsed()),
-                    Err(e) if is_not_found(&e) => {
-                        collector.reads.record_success(read_start.elapsed())
-                    }
-                    Err(e) => {
-                        // Readability is end-of-run verification's job.
-                        collector.reads.record_failure();
-                        tracing::warn!(source, error = %e, "post-merge read failed");
+                for &source in &merged {
+                    let read_start = Instant::now();
+                    match router
+                        .get_person(team_id, source, ConsistencyLevel::Strong)
+                        .await
+                    {
+                        Ok(Some(person)) if !person.is_deleted => {
+                            collector.reads.record_success(read_start.elapsed());
+                            violations.push(ConsistencyViolation {
+                                person_id: source,
+                                key: "__merged_source_alive".to_string(),
+                                expected: json!("not found after the merge ack"),
+                                actual: json!({ "version": person.version }),
+                            });
+                        }
+                        Ok(_) => collector.reads.record_success(read_start.elapsed()),
+                        Err(e) if is_not_found(&e) => {
+                            collector.reads.record_success(read_start.elapsed())
+                        }
+                        Err(e) => {
+                            // Readability is end-of-run verification's job.
+                            collector.reads.record_failure();
+                            tracing::warn!(source, error = %e, "post-merge read failed");
+                        }
                     }
                 }
             }
@@ -354,14 +446,14 @@ pub async fn run_merges(
 }
 
 /// Settle every unresolved merge from the saga's own record. A
-/// `completed` op with the source `merged` is journaled as the merge it
-/// was. That is safe after later merges' acks, because the journal
-/// orders folds by the recorded survivor version. An aborted op means
-/// the source lived on. So does a missing op row, because the call
-/// failed before the saga froze its request. An op still in flight is
-/// polled until `deadline` elapses, which gives the sweeper time to
+/// `completed` op is journaled as the merge it was, with the sources the
+/// record says merged. That is safe after later merges' acks, because
+/// the journal orders folds by the recorded survivor version. An aborted
+/// op means every source lived on. So does a missing op row, because the
+/// call failed before the saga froze its request. An op still in flight
+/// is polled until `deadline` elapses, which gives the sweeper time to
 /// re-drive it. An op that never settles is a violation: no lifecycle
-/// op can ever touch that person again.
+/// op can ever touch those persons again.
 pub async fn settle_unresolved(
     pool: &PgPool,
     state: &PersonState,
@@ -389,7 +481,9 @@ pub async fn settle_unresolved(
             let Some(row) = row else {
                 // No op row means the saga never froze the request, so
                 // nothing destructive started.
-                state.clear_merge_pending(merge.source).await;
+                for (source, _) in &merge.sources {
+                    state.clear_merge_pending(*source).await;
+                }
                 continue;
             };
             let step: String = row.get("step");
@@ -397,35 +491,57 @@ pub async fn settle_unresolved(
             match step.as_str() {
                 "completed" => {
                     let outcome = outcome.unwrap_or_default();
-                    let merged = outcome["results"]
+                    let merged_dids: HashSet<&str> = outcome["results"]
                         .as_array()
-                        .is_some_and(|results| results.iter().any(|r| r["outcome"] == "merged"));
+                        .map(|results| {
+                            results
+                                .iter()
+                                .filter(|r| r["outcome"] == "merged")
+                                .filter_map(|r| r["distinct_id"].as_str())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let mut merged = Vec::new();
+                    for (source, did) in &merge.sources {
+                        if merged_dids.contains(did.as_str()) {
+                            merged.push(*source);
+                        } else {
+                            state.clear_merge_pending(*source).await;
+                        }
+                    }
+                    if merged.is_empty() {
+                        continue;
+                    }
                     let survivor = &outcome["survivor"];
-                    match (
-                        merged,
-                        survivor["id"].as_i64(),
-                        survivor["version"].as_i64(),
-                    ) {
-                        (true, Some(id), Some(version)) => {
+                    match (survivor["id"].as_i64(), survivor["version"].as_i64()) {
+                        (Some(id), Some(version)) => {
                             state
-                                .record_merge(
-                                    merge.source,
-                                    id,
-                                    version,
-                                    HashMap::from([(merge.key, merge.value)]),
-                                )
+                                .record_merge(MergeAck {
+                                    survivor: id,
+                                    survivor_version: version,
+                                    sources: merged,
+                                    set: merge.set,
+                                    set_once: merge.set_once,
+                                })
                                 .await;
                         }
-                        (true, _, _) => violations.push(ConsistencyViolation {
-                            person_id: merge.source,
-                            key: "__merge_record_missing_survivor".to_string(),
-                            expected: json!("a completed merge records its survivor"),
-                            actual: outcome,
-                        }),
-                        (false, _, _) => state.clear_merge_pending(merge.source).await,
+                        _ => {
+                            for source in merged {
+                                violations.push(ConsistencyViolation {
+                                    person_id: source,
+                                    key: "__merge_record_missing_survivor".to_string(),
+                                    expected: json!("a completed merge records its survivor"),
+                                    actual: outcome.clone(),
+                                });
+                            }
+                        }
                     }
                 }
-                "aborted" => state.clear_merge_pending(merge.source).await,
+                "aborted" => {
+                    for (source, _) in &merge.sources {
+                        state.clear_merge_pending(*source).await;
+                    }
+                }
                 _ => still_pending.push(merge),
             }
         }
@@ -434,12 +550,14 @@ pub async fn settle_unresolved(
         }
         if started.elapsed() > deadline {
             for merge in still_pending {
-                violations.push(ConsistencyViolation {
-                    person_id: merge.source,
-                    key: "__merge_unsettled".to_string(),
-                    expected: json!(format!("op {} terminal within {deadline:?}", merge.op_id)),
-                    actual: json!("in flight"),
-                });
+                for (source, _) in merge.sources {
+                    violations.push(ConsistencyViolation {
+                        person_id: source,
+                        key: "__merge_unsettled".to_string(),
+                        expected: json!(format!("op {} terminal within {deadline:?}", merge.op_id)),
+                        actual: json!("in flight"),
+                    });
+                }
             }
             return Ok(violations);
         }
@@ -458,10 +576,11 @@ fn pick_wide_pair(
     pool: &TargetPool,
     rng: &mut impl Rng,
 ) -> Option<(i64, i64)> {
+    let live = pool.snapshot();
     let live_wide_targets: Vec<i64> = wide_targets
         .iter()
         .copied()
-        .filter(|id| pool.snapshot().contains(id))
+        .filter(|id| live.contains(id))
         .collect();
     let source = {
         let mut wide_sources = wide_sources.lock().unwrap();
@@ -537,6 +656,28 @@ fn pick_pair(
     None
 }
 
+/// Reserve ordinary sources until the call carries `wanted`, or the
+/// eligible set runs out. The target is never a source of its own call.
+fn reserve_more_sources(
+    eligible: &Mutex<Vec<i64>>,
+    sources: &mut Vec<i64>,
+    target: i64,
+    wanted: usize,
+    rng: &mut impl Rng,
+) {
+    let mut eligible = eligible.lock().unwrap();
+    while sources.len() < wanted {
+        let candidates: Vec<usize> = (0..eligible.len())
+            .filter(|&i| eligible[i] != target)
+            .collect();
+        if candidates.is_empty() {
+            return;
+        }
+        let source = eligible.swap_remove(candidates[rng.gen_range(0..candidates.len())]);
+        sources.push(source);
+    }
+}
+
 fn note_dry(dry_at: &Mutex<Option<Duration>>, at: Duration) {
     let mut dry = dry_at.lock().unwrap();
     if dry.is_none() {
@@ -555,5 +696,30 @@ pub fn outcome_name(outcome: MergeSourceOutcome) -> &'static str {
         MergeSourceOutcome::SkippedMoveLimit => "skipped_move_limit",
         MergeSourceOutcome::Error => "error",
         MergeSourceOutcome::Unspecified => "unspecified",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A call with several sources must not double-book a person: the
+    /// target is never one of its own sources, and every source comes
+    /// out of the eligible set exactly once.
+    #[test]
+    fn extra_sources_are_reserved_apart_from_the_target() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(7);
+        let eligible = Mutex::new(vec![2, 3, 4]);
+        let mut sources = vec![1];
+        reserve_more_sources(&eligible, &mut sources, 3, 3, &mut rng);
+        sources.sort_unstable();
+        assert_eq!(sources, vec![1, 2, 4]);
+        assert_eq!(*eligible.lock().unwrap(), vec![3]);
+
+        // The eligible set running out caps the call, and does not
+        // spend the target.
+        reserve_more_sources(&eligible, &mut sources, 3, 10, &mut rng);
+        assert_eq!(sources.len(), 3);
+        assert_eq!(*eligible.lock().unwrap(), vec![3]);
     }
 }

--- a/rust/personhog-test-harness/src/scenarios/merge.rs
+++ b/rust/personhog-test-harness/src/scenarios/merge.rs
@@ -45,21 +45,21 @@ pub struct MergeLane {
     pub allow_identified_sources: bool,
     pub move_limit: i64,
     /// Persons created with many distinct ids, and the side they take.
-    /// Workers prefer a fat pair while one is available, so the
+    /// Workers prefer a wide pair while one is available, so the
     /// pathological merges happen early instead of after the pool has
     /// thinned; their latency is recorded apart.
-    pub fat_persons: Vec<i64>,
-    pub fat_role: FatRole,
+    pub wide_persons: Vec<i64>,
+    pub wide_role: WideRole,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub enum FatRole {
+pub enum WideRole {
     Source,
     Target,
     Both,
 }
 
-impl FatRole {
+impl WideRole {
     pub fn parse(role: &str) -> Option<Self> {
         match role {
             "source" => Some(Self::Source),
@@ -106,24 +106,24 @@ pub async fn run_merges(
     let worker_tick = lane
         .rate_per_sec
         .map(|rate| per_worker_tick(rate, lane.concurrency));
-    let fat: Arc<std::collections::HashSet<i64>> =
-        Arc::new(lane.fat_persons.iter().copied().collect());
-    // Fat sources are reserved like any other source; fat targets are
+    let wide: Arc<std::collections::HashSet<i64>> =
+        Arc::new(lane.wide_persons.iter().copied().collect());
+    // Wide sources are reserved like any other source; wide targets are
     // shared like any other target. The normal eligible set excludes the
-    // fat persons so a fat source is never spent on an ordinary pair.
+    // wide persons so a wide source is never spent on an ordinary pair.
     let eligible = Arc::new(Mutex::new(
         pool.snapshot()
             .into_iter()
-            .filter(|id| !fat.contains(id))
+            .filter(|id| !wide.contains(id))
             .collect::<Vec<_>>(),
     ));
-    let fat_sources = Arc::new(Mutex::new(match lane.fat_role {
-        FatRole::Source | FatRole::Both => lane.fat_persons.clone(),
-        FatRole::Target => Vec::new(),
+    let wide_sources = Arc::new(Mutex::new(match lane.wide_role {
+        WideRole::Source | WideRole::Both => lane.wide_persons.clone(),
+        WideRole::Target => Vec::new(),
     }));
-    let fat_targets: Arc<Vec<i64>> = Arc::new(match lane.fat_role {
-        FatRole::Target | FatRole::Both => lane.fat_persons.clone(),
-        FatRole::Source => Vec::new(),
+    let wide_targets: Arc<Vec<i64>> = Arc::new(match lane.wide_role {
+        WideRole::Target | WideRole::Both => lane.wide_persons.clone(),
+        WideRole::Source => Vec::new(),
     });
     let dry_at: Arc<Mutex<Option<Duration>>> = Arc::new(Mutex::new(None));
     let started = Instant::now();
@@ -135,9 +135,9 @@ pub async fn run_merges(
         let pool = pool.clone();
         let distinct_ids = distinct_ids.clone();
         let eligible = eligible.clone();
-        let fat = fat.clone();
-        let fat_sources = fat_sources.clone();
-        let fat_targets = fat_targets.clone();
+        let wide = wide.clone();
+        let wide_sources = wide_sources.clone();
+        let wide_targets = wide_targets.clone();
         let dry_at = dry_at.clone();
         let collector = collector.clone();
         let state = state.clone();
@@ -159,8 +159,9 @@ pub async fn run_merges(
                 if let Some(pacer) = pacer.as_mut() {
                     pacer.tick().await;
                 }
-                let picked = pick_fat_pair(&fat_sources, &fat_targets, &eligible, &pool, &mut rng)
-                    .or_else(|| pick_pair(&eligible, &pool, &mut rng));
+                let picked =
+                    pick_wide_pair(&wide_sources, &wide_targets, &eligible, &pool, &mut rng)
+                        .or_else(|| pick_pair(&eligible, &pool, &mut rng));
                 let Some((source, target)) = picked else {
                     // The pool has shrunk to one live person (or every
                     // source is reserved): nothing left to merge.
@@ -220,8 +221,8 @@ pub async fn run_merges(
                     }
                 };
 
-                let recorder = if fat.contains(&source) || fat.contains(&target) {
-                    &collector.fat_merges
+                let recorder = if wide.contains(&source) || wide.contains(&target) {
+                    &collector.wide_merges
                 } else {
                     &collector.merges
                 };
@@ -256,8 +257,8 @@ pub async fn run_merges(
                     // Settled without destroying the source: it is live
                     // and eligible again.
                     state.clear_merge_pending(source).await;
-                    if fat.contains(&source) {
-                        fat_sources.lock().unwrap().push(source);
+                    if wide.contains(&source) {
+                        wide_sources.lock().unwrap().push(source);
                     } else {
                         eligible.lock().unwrap().push(source);
                     }
@@ -450,54 +451,54 @@ pub async fn settle_unresolved(
     }
 }
 
-/// A pair with a fat person on the configured side, or None when no fat
-/// source is left to reserve and no fat target is live. With fat targets
+/// A pair with a wide person on the configured side, or None when no wide
+/// source is left to reserve and no wide target is live. With wide targets
 /// only, the source comes from the ordinary eligible set.
-fn pick_fat_pair(
-    fat_sources: &Mutex<Vec<i64>>,
-    fat_targets: &[i64],
+fn pick_wide_pair(
+    wide_sources: &Mutex<Vec<i64>>,
+    wide_targets: &[i64],
     eligible: &Mutex<Vec<i64>>,
     pool: &TargetPool,
     rng: &mut impl Rng,
 ) -> Option<(i64, i64)> {
-    let live_fat_targets: Vec<i64> = fat_targets
+    let live_wide_targets: Vec<i64> = wide_targets
         .iter()
         .copied()
         .filter(|id| pool.snapshot().contains(id))
         .collect();
     let source = {
-        let mut fat_sources = fat_sources.lock().unwrap();
-        if fat_sources.is_empty() {
+        let mut wide_sources = wide_sources.lock().unwrap();
+        if wide_sources.is_empty() {
             None
         } else {
-            let index = rng.gen_range(0..fat_sources.len());
-            Some(fat_sources.swap_remove(index))
+            let index = rng.gen_range(0..wide_sources.len());
+            Some(wide_sources.swap_remove(index))
         }
     };
     match source {
         Some(source) => {
-            let target = if live_fat_targets.is_empty() {
+            let target = if live_wide_targets.is_empty() {
                 (0..16)
                     .filter_map(|_| pool.pick_random(rng))
                     .find(|&target| target != source)
             } else {
-                live_fat_targets
+                live_wide_targets
                     .iter()
                     .copied()
                     .filter(|&target| target != source)
-                    .nth(rng.gen_range(0..live_fat_targets.len().max(1)))
-                    .or_else(|| live_fat_targets.iter().copied().find(|&t| t != source))
+                    .nth(rng.gen_range(0..live_wide_targets.len().max(1)))
+                    .or_else(|| live_wide_targets.iter().copied().find(|&t| t != source))
             };
             match target {
                 Some(target) => Some((source, target)),
                 None => {
-                    fat_sources.lock().unwrap().push(source);
+                    wide_sources.lock().unwrap().push(source);
                     None
                 }
             }
         }
-        None if !live_fat_targets.is_empty() => {
-            let target = live_fat_targets[rng.gen_range(0..live_fat_targets.len())];
+        None if !live_wide_targets.is_empty() => {
+            let target = live_wide_targets[rng.gen_range(0..live_wide_targets.len())];
             let mut eligible = eligible.lock().unwrap();
             let candidates: Vec<usize> = (0..eligible.len())
                 .filter(|&i| eligible[i] != target)

--- a/rust/personhog-test-harness/src/scenarios/merge.rs
+++ b/rust/personhog-test-harness/src/scenarios/merge.rs
@@ -1,14 +1,13 @@
 //! The merge lane: MergePersons calls against random pairs of live
 //! persons while the blast writers and probers keep writing to both.
 //!
-//! Every pair is two distinct live persons, so every call that settles as
-//! `merged` ran the durable saga end to end — fence, seal, fold, flip,
-//! release — under concurrent writes to the source (racing the fence) and
-//! the target (racing the fold). A source distinct id is reserved for one
-//! in-flight call at a time and never reused once merged, which is what
-//! keeps the journal's view of *which* person died unambiguous; targets
-//! are shared, so two calls can contend for one person and exercise the
-//! saga's conflict settlements.
+//! Every pair is two distinct live persons. Thus every call that settles
+//! as `merged` ran the durable saga end to end (fence, seal, fold, flip,
+//! release) with writes racing the source's fence and the target's fold.
+//! A source distinct id is reserved for one in-flight call and is never
+//! reused after a merge, so the journal always knows which person died.
+//! Targets are shared, so two calls can contend for one person and
+//! exercise the saga's conflict settlements.
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -31,23 +30,22 @@ use crate::scenarios::blast::{is_not_found, per_worker_tick};
 use crate::state::PersonState;
 use crate::stats::StatsCollector;
 
-/// Attempts per merge call under one op id. The contract makes a retry
-/// return the recorded outcome, so a call whose response was lost (a
-/// timeout, a router blip) is re-asked rather than guessed at.
+/// Attempts per merge call under one op id. A retry under the same op id
+/// returns the recorded outcome, so a lost response is asked again, not
+/// guessed at.
 const MERGE_ATTEMPTS: u32 = 3;
 const MERGE_RETRY_BACKOFF: Duration = Duration::from_millis(500);
 
 pub struct MergeLane {
     pub team_id: i64,
     pub concurrency: usize,
-    /// Combined target rate across the workers; unset runs flat out.
+    /// Combined target rate across the workers. Unset runs flat out.
     pub rate_per_sec: Option<f64>,
     pub allow_identified_sources: bool,
     pub move_limit: i64,
-    /// Persons created with many distinct ids, and the side they take.
-    /// Workers prefer a wide pair while one is available, so the
-    /// pathological merges happen early instead of after the pool has
-    /// thinned; their latency is recorded apart.
+    /// Persons created with many distinct ids. Workers prefer a wide
+    /// pair while one is available, so the expensive merges happen
+    /// before the pool thins. Their latency is recorded apart.
     pub wide_persons: Vec<i64>,
     pub wide_role: WideRole,
 }
@@ -71,12 +69,12 @@ impl WideRole {
 }
 
 /// A merge call whose every attempt lost its response. The saga may have
-/// run anyway — the op record decides, see [`settle_unresolved`].
+/// run anyway. The op record decides, see [`settle_unresolved`].
 pub struct UnresolvedMerge {
     pub op_id: uuid::Uuid,
     pub source: i64,
-    /// The merge event's `$set` key and value, journaled on the survivor
-    /// if the op turns out to have merged.
+    /// The merge event's `$set` key and value. Journaled on the survivor
+    /// if the op record says the merge ran.
     pub key: String,
     pub value: serde_json::Value,
 }
@@ -86,10 +84,10 @@ pub struct MergeLaneResult {
     pub unresolved: Vec<UnresolvedMerge>,
 }
 
-/// Drive merges until the deadline, journaling every `merged` ack into
-/// `state` and retiring the destroyed source from `pool`. Returns the
-/// violations observed live: a survivor missing the merge's own write, a
-/// merged source that still reads as alive, or an ack with no survivor.
+/// Drive merges until the deadline. Every `merged` ack is journaled into
+/// `state` and the destroyed source leaves `pool`. Returns the violations
+/// observed live: a survivor without the merge's own write, a merged
+/// source that still reads as alive, or an ack with no survivor.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_merges(
     identity: &IdentityClient,
@@ -108,9 +106,8 @@ pub async fn run_merges(
         .map(|rate| per_worker_tick(rate, lane.concurrency));
     let wide: Arc<std::collections::HashSet<i64>> =
         Arc::new(lane.wide_persons.iter().copied().collect());
-    // Wide sources are reserved like any other source; wide targets are
-    // shared like any other target. The normal eligible set excludes the
-    // wide persons so a wide source is never spent on an ordinary pair.
+    // The eligible set excludes the wide persons so an ordinary pair
+    // cannot spend a wide source.
     let eligible = Arc::new(Mutex::new(
         pool.snapshot()
             .into_iter()
@@ -163,8 +160,8 @@ pub async fn run_merges(
                     pick_wide_pair(&wide_sources, &wide_targets, &eligible, &pool, &mut rng)
                         .or_else(|| pick_pair(&eligible, &pool, &mut rng));
                 let Some((source, target)) = picked else {
-                    // The pool has shrunk to one live person (or every
-                    // source is reserved): nothing left to merge.
+                    // Fewer than two live persons remain, or every
+                    // source is reserved.
                     if pool.len() < 2 {
                         note_dry(&dry_at, started.elapsed());
                     }
@@ -228,11 +225,11 @@ pub async fn run_merges(
                 };
                 let Some(response) = response else {
                     recorder.record_failure();
-                    // The saga is durable: a call whose every response was
-                    // lost may still have destroyed the source, or may
-                    // yet (the sweeper re-drives abandoned ops). The op
-                    // record settles it after traffic; until then the
-                    // source is reserved and takes no more traffic.
+                    // The saga is durable, and the sweeper re-drives
+                    // abandoned ops. The call can still destroy the
+                    // source after this failure. The op record settles
+                    // it after traffic. Until then the source stays
+                    // reserved and takes no more traffic.
                     state.record_merge_uncertain(source).await;
                     pool.remove(source);
                     unresolved.push(UnresolvedMerge {
@@ -254,8 +251,7 @@ pub async fn run_merges(
                 collector.record_merge_outcome(outcome_name(source_outcome));
 
                 if source_outcome != MergeSourceOutcome::Merged {
-                    // Settled without destroying the source: it is live
-                    // and eligible again.
+                    // Every outcome except merged leaves the source alive.
                     state.clear_merge_pending(source).await;
                     if wide.contains(&source) {
                         wide_sources.lock().unwrap().push(source);
@@ -272,9 +268,9 @@ pub async fn run_merges(
                         expected: json!("a merged ack carries the survivor document"),
                         actual: serde_json::Value::Null,
                     });
-                    // Destroyed, but into whom is unknown: keep the
-                    // reservation so reads tolerate its absence, and stop
-                    // asserting on it.
+                    // The source is destroyed but the survivor is
+                    // unknown. Keep the reservation so reads tolerate
+                    // its absence, and stop asserting on it.
                     state.record_merge_uncertain(source).await;
                     pool.remove(source);
                     continue;
@@ -282,7 +278,7 @@ pub async fn run_merges(
                 let survivor_props: serde_json::Value =
                     serde_json::from_slice(&survivor.properties).unwrap_or_else(|_| json!({}));
                 if survivor_props.get(&key) != Some(&value) {
-                    // The fold applies the merge event's $set last, so the
+                    // The fold applies the merge event's $set last. The
                     // folded document in the ack must already carry it.
                     violations.push(ConsistencyViolation {
                         person_id: survivor.id,
@@ -304,9 +300,9 @@ pub async fn run_merges(
                     .await;
                 pool.remove(source);
 
-                // Read-your-merge: the release produced the source's
-                // death document before the saga completed, so a strong
-                // read served now must not find a living person.
+                // Read-your-merge check. The release produced the
+                // source's death document before the saga completed. A
+                // strong read served now must not find a living person.
                 let read_start = Instant::now();
                 match router
                     .get_person(team_id, source, ConsistencyLevel::Strong)
@@ -357,15 +353,15 @@ pub async fn run_merges(
     })
 }
 
-/// Settle every unresolved merge from the saga's own record. An op row
-/// that reaches `completed` with the source `merged` is journaled as the
-/// merge it was — the fold is ordered by the survivor version it
-/// records, so landing it after later merges' acks is safe. An aborted
-/// op, or no op row at all (the call failed before the saga froze its
-/// request), means the source lived on. An op still in flight is polled
-/// until `deadline` elapses — the sweeper re-drives abandoned ops — and
-/// one that never settles is a violation: a person no lifecycle op can
-/// ever touch again.
+/// Settle every unresolved merge from the saga's own record. A
+/// `completed` op with the source `merged` is journaled as the merge it
+/// was. That is safe after later merges' acks, because the journal
+/// orders folds by the recorded survivor version. An aborted op means
+/// the source lived on. So does a missing op row, because the call
+/// failed before the saga froze its request. An op still in flight is
+/// polled until `deadline` elapses, which gives the sweeper time to
+/// re-drive it. An op that never settles is a violation: no lifecycle
+/// op can ever touch that person again.
 pub async fn settle_unresolved(
     pool: &PgPool,
     state: &PersonState,
@@ -391,7 +387,8 @@ pub async fn settle_unresolved(
                 .await
                 .context("reading an unresolved merge op")?;
             let Some(row) = row else {
-                // No frozen request: nothing destructive ever started.
+                // No op row means the saga never froze the request, so
+                // nothing destructive started.
                 state.clear_merge_pending(merge.source).await;
                 continue;
             };
@@ -451,9 +448,9 @@ pub async fn settle_unresolved(
     }
 }
 
-/// A pair with a wide person on the configured side, or None when no wide
-/// source is left to reserve and no wide target is live. With wide targets
-/// only, the source comes from the ordinary eligible set.
+/// A pair with a wide person on the configured side. None when no wide
+/// source is left to reserve and no wide target is live. With wide
+/// targets only, the source comes from the ordinary eligible set.
 fn pick_wide_pair(
     wide_sources: &Mutex<Vec<i64>>,
     wide_targets: &[i64],
@@ -513,7 +510,7 @@ fn pick_wide_pair(
     }
 }
 
-/// Reserve a random eligible source and pick a distinct live target.
+/// Reserve a random eligible source and pick a different live target.
 /// None when fewer than two live persons remain or every source is
 /// reserved.
 fn pick_pair(
@@ -527,9 +524,9 @@ fn pick_pair(
     }
     let index = rng.gen_range(0..eligible.len());
     let source = eligible.swap_remove(index);
-    // The pool holds at least two persons, so a distinct target exists;
-    // a handful of draws finds one with overwhelming probability, and a
-    // miss just returns the source.
+    // The pool holds at least two persons, so a different target exists
+    // and a few random draws almost always find one. A miss only puts
+    // the source back.
     for _ in 0..16 {
         match pool.pick_random(rng) {
             Some(target) if target != source => return Some((source, target)),
@@ -540,7 +537,6 @@ fn pick_pair(
     None
 }
 
-/// Record the first moment the lane found nothing left to merge.
 fn note_dry(dry_at: &Mutex<Option<Duration>>, at: Duration) {
     let mut dry = dry_at.lock().unwrap();
     if dry.is_none() {

--- a/rust/personhog-test-harness/src/scenarios/merge.rs
+++ b/rust/personhog-test-harness/src/scenarios/merge.rs
@@ -1,0 +1,562 @@
+//! The merge lane: MergePersons calls against random pairs of live
+//! persons while the blast writers and probers keep writing to both.
+//!
+//! Every pair is two distinct live persons, so every call that settles as
+//! `merged` ran the durable saga end to end — fence, seal, fold, flip,
+//! release — under concurrent writes to the source (racing the fence) and
+//! the target (racing the fold). A source distinct id is reserved for one
+//! in-flight call at a time and never reused once merged, which is what
+//! keeps the journal's view of *which* person died unambiguous; targets
+//! are shared, so two calls can contend for one person and exercise the
+//! saga's conflict settlements.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use personhog_proto::personhog::identity::v1::MergeSourceOutcome;
+use personhog_proto::personhog::types::v1::ConsistencyLevel;
+use rand::{Rng, SeedableRng};
+use serde_json::json;
+use sqlx::postgres::PgPool;
+use sqlx::Row;
+use tokio::time::{interval, sleep, MissedTickBehavior};
+
+use crate::client::{HarnessClient, IdentityClient};
+use crate::pool::TargetPool;
+use crate::report::ConsistencyViolation;
+use crate::scenarios::blast::{is_not_found, per_worker_tick};
+use crate::state::PersonState;
+use crate::stats::StatsCollector;
+
+/// Attempts per merge call under one op id. The contract makes a retry
+/// return the recorded outcome, so a call whose response was lost (a
+/// timeout, a router blip) is re-asked rather than guessed at.
+const MERGE_ATTEMPTS: u32 = 3;
+const MERGE_RETRY_BACKOFF: Duration = Duration::from_millis(500);
+
+pub struct MergeLane {
+    pub team_id: i64,
+    pub concurrency: usize,
+    /// Combined target rate across the workers; unset runs flat out.
+    pub rate_per_sec: Option<f64>,
+    pub allow_identified_sources: bool,
+    pub move_limit: i64,
+    /// Persons created with many distinct ids, and the side they take.
+    /// Workers prefer a fat pair while one is available, so the
+    /// pathological merges happen early instead of after the pool has
+    /// thinned; their latency is recorded apart.
+    pub fat_persons: Vec<i64>,
+    pub fat_role: FatRole,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FatRole {
+    Source,
+    Target,
+    Both,
+}
+
+impl FatRole {
+    pub fn parse(role: &str) -> Option<Self> {
+        match role {
+            "source" => Some(Self::Source),
+            "target" => Some(Self::Target),
+            "both" => Some(Self::Both),
+            _ => None,
+        }
+    }
+}
+
+/// A merge call whose every attempt lost its response. The saga may have
+/// run anyway — the op record decides, see [`settle_unresolved`].
+pub struct UnresolvedMerge {
+    pub op_id: uuid::Uuid,
+    pub source: i64,
+    /// The merge event's `$set` key and value, journaled on the survivor
+    /// if the op turns out to have merged.
+    pub key: String,
+    pub value: serde_json::Value,
+}
+
+pub struct MergeLaneResult {
+    pub violations: Vec<ConsistencyViolation>,
+    pub unresolved: Vec<UnresolvedMerge>,
+}
+
+/// Drive merges until the deadline, journaling every `merged` ack into
+/// `state` and retiring the destroyed source from `pool`. Returns the
+/// violations observed live: a survivor missing the merge's own write, a
+/// merged source that still reads as alive, or an ack with no survivor.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_merges(
+    identity: &IdentityClient,
+    router: &HarnessClient,
+    lane: MergeLane,
+    pool: Arc<TargetPool>,
+    distinct_ids: Arc<HashMap<i64, String>>,
+    duration: Duration,
+    collector: &Arc<StatsCollector>,
+    state: &PersonState,
+    stop: Arc<AtomicBool>,
+) -> Result<MergeLaneResult> {
+    let deadline = Instant::now() + duration;
+    let worker_tick = lane
+        .rate_per_sec
+        .map(|rate| per_worker_tick(rate, lane.concurrency));
+    let fat: Arc<std::collections::HashSet<i64>> =
+        Arc::new(lane.fat_persons.iter().copied().collect());
+    // Fat sources are reserved like any other source; fat targets are
+    // shared like any other target. The normal eligible set excludes the
+    // fat persons so a fat source is never spent on an ordinary pair.
+    let eligible = Arc::new(Mutex::new(
+        pool.snapshot()
+            .into_iter()
+            .filter(|id| !fat.contains(id))
+            .collect::<Vec<_>>(),
+    ));
+    let fat_sources = Arc::new(Mutex::new(match lane.fat_role {
+        FatRole::Source | FatRole::Both => lane.fat_persons.clone(),
+        FatRole::Target => Vec::new(),
+    }));
+    let fat_targets: Arc<Vec<i64>> = Arc::new(match lane.fat_role {
+        FatRole::Target | FatRole::Both => lane.fat_persons.clone(),
+        FatRole::Source => Vec::new(),
+    });
+    let dry_at: Arc<Mutex<Option<Duration>>> = Arc::new(Mutex::new(None));
+    let started = Instant::now();
+
+    let mut handles = Vec::new();
+    for _ in 0..lane.concurrency {
+        let identity = identity.clone();
+        let router = router.clone();
+        let pool = pool.clone();
+        let distinct_ids = distinct_ids.clone();
+        let eligible = eligible.clone();
+        let fat = fat.clone();
+        let fat_sources = fat_sources.clone();
+        let fat_targets = fat_targets.clone();
+        let dry_at = dry_at.clone();
+        let collector = collector.clone();
+        let state = state.clone();
+        let stop = stop.clone();
+        let (team_id, allow_identified_sources, move_limit) =
+            (lane.team_id, lane.allow_identified_sources, lane.move_limit);
+
+        handles.push(tokio::spawn(async move {
+            let mut rng = rand::rngs::StdRng::from_entropy();
+            let mut pacer = worker_tick.map(|tick| {
+                let mut ticker = interval(tick);
+                ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                ticker
+            });
+            let mut violations = Vec::new();
+            let mut unresolved = Vec::new();
+
+            while Instant::now() < deadline && !stop.load(Ordering::Relaxed) {
+                if let Some(pacer) = pacer.as_mut() {
+                    pacer.tick().await;
+                }
+                let picked = pick_fat_pair(&fat_sources, &fat_targets, &eligible, &pool, &mut rng)
+                    .or_else(|| pick_pair(&eligible, &pool, &mut rng));
+                let Some((source, target)) = picked else {
+                    // The pool has shrunk to one live person (or every
+                    // source is reserved): nothing left to merge.
+                    if pool.len() < 2 {
+                        note_dry(&dry_at, started.elapsed());
+                    }
+                    sleep(Duration::from_millis(200)).await;
+                    continue;
+                };
+                let (Some(source_did), Some(target_did)) =
+                    (distinct_ids.get(&source), distinct_ids.get(&target))
+                else {
+                    unreachable!("every pooled person was created with a distinct id");
+                };
+
+                state.mark_merge_pending(source).await;
+                let op_id = uuid::Uuid::new_v4();
+                let key = format!("harness_merge_{op_id}");
+                let value = serde_json::Value::String(op_id.to_string());
+
+                let start = Instant::now();
+                let mut attempt = 0;
+                let response = loop {
+                    attempt += 1;
+                    let result = identity
+                        .merge_persons(
+                            team_id,
+                            target_did,
+                            std::slice::from_ref(source_did),
+                            json!({ &key: &value }),
+                            &op_id,
+                            allow_identified_sources,
+                            move_limit,
+                        )
+                        .await;
+                    match result {
+                        Ok(response) => break Some(response),
+                        Err(e) if attempt < MERGE_ATTEMPTS => {
+                            tracing::warn!(
+                                source,
+                                target,
+                                attempt,
+                                error = format!("{e:#}"),
+                                "merge call failed; retrying under the same op id"
+                            );
+                            sleep(MERGE_RETRY_BACKOFF).await;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                source,
+                                target,
+                                error = format!("{e:#}"),
+                                "merge call failed on every attempt; source outcome unknown"
+                            );
+                            break None;
+                        }
+                    }
+                };
+
+                let recorder = if fat.contains(&source) || fat.contains(&target) {
+                    &collector.fat_merges
+                } else {
+                    &collector.merges
+                };
+                let Some(response) = response else {
+                    recorder.record_failure();
+                    // The saga is durable: a call whose every response was
+                    // lost may still have destroyed the source, or may
+                    // yet (the sweeper re-drives abandoned ops). The op
+                    // record settles it after traffic; until then the
+                    // source is reserved and takes no more traffic.
+                    state.record_merge_uncertain(source).await;
+                    pool.remove(source);
+                    unresolved.push(UnresolvedMerge {
+                        op_id,
+                        source,
+                        key,
+                        value,
+                    });
+                    continue;
+                };
+                recorder.record_success(start.elapsed());
+
+                let source_outcome = response
+                    .results
+                    .iter()
+                    .find(|r| r.source_distinct_id == *source_did)
+                    .map(|r| r.outcome())
+                    .unwrap_or(MergeSourceOutcome::Unspecified);
+                collector.record_merge_outcome(outcome_name(source_outcome));
+
+                if source_outcome != MergeSourceOutcome::Merged {
+                    // Settled without destroying the source: it is live
+                    // and eligible again.
+                    state.clear_merge_pending(source).await;
+                    if fat.contains(&source) {
+                        fat_sources.lock().unwrap().push(source);
+                    } else {
+                        eligible.lock().unwrap().push(source);
+                    }
+                    continue;
+                }
+
+                let Some(survivor) = response.survivor else {
+                    violations.push(ConsistencyViolation {
+                        person_id: source,
+                        key: "__merge_ack_missing_survivor".to_string(),
+                        expected: json!("a merged ack carries the survivor document"),
+                        actual: serde_json::Value::Null,
+                    });
+                    // Destroyed, but into whom is unknown: keep the
+                    // reservation so reads tolerate its absence, and stop
+                    // asserting on it.
+                    state.record_merge_uncertain(source).await;
+                    pool.remove(source);
+                    continue;
+                };
+                let survivor_props: serde_json::Value =
+                    serde_json::from_slice(&survivor.properties).unwrap_or_else(|_| json!({}));
+                if survivor_props.get(&key) != Some(&value) {
+                    // The fold applies the merge event's $set last, so the
+                    // folded document in the ack must already carry it.
+                    violations.push(ConsistencyViolation {
+                        person_id: survivor.id,
+                        key: key.clone(),
+                        expected: value.clone(),
+                        actual: survivor_props
+                            .get(&key)
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null),
+                    });
+                }
+                state
+                    .record_merge(
+                        source,
+                        survivor.id,
+                        survivor.version,
+                        HashMap::from([(key, value)]),
+                    )
+                    .await;
+                pool.remove(source);
+
+                // Read-your-merge: the release produced the source's
+                // death document before the saga completed, so a strong
+                // read served now must not find a living person.
+                let read_start = Instant::now();
+                match router
+                    .get_person(team_id, source, ConsistencyLevel::Strong)
+                    .await
+                {
+                    Ok(Some(person)) if !person.is_deleted => {
+                        collector.reads.record_success(read_start.elapsed());
+                        violations.push(ConsistencyViolation {
+                            person_id: source,
+                            key: "__merged_source_alive".to_string(),
+                            expected: json!("not found after the merge ack"),
+                            actual: json!({ "version": person.version }),
+                        });
+                    }
+                    Ok(_) => collector.reads.record_success(read_start.elapsed()),
+                    Err(e) if is_not_found(&e) => {
+                        collector.reads.record_success(read_start.elapsed())
+                    }
+                    Err(e) => {
+                        // Readability is end-of-run verification's job.
+                        collector.reads.record_failure();
+                        tracing::warn!(source, error = %e, "post-merge read failed");
+                    }
+                }
+            }
+            (violations, unresolved)
+        }));
+    }
+
+    let mut violations = Vec::new();
+    let mut unresolved = Vec::new();
+    for handle in handles {
+        let (worker_violations, worker_unresolved) =
+            handle.await.context("merge worker panicked")?;
+        violations.extend(worker_violations);
+        unresolved.extend(worker_unresolved);
+    }
+    if let Some(at) = *dry_at.lock().unwrap() {
+        println!(
+            "Merge lane ran the pool dry {:.1}s into traffic; size --persons up or the rate down \
+             for a longer merge window",
+            at.as_secs_f64()
+        );
+    }
+    Ok(MergeLaneResult {
+        violations,
+        unresolved,
+    })
+}
+
+/// Settle every unresolved merge from the saga's own record. An op row
+/// that reaches `completed` with the source `merged` is journaled as the
+/// merge it was — the fold is ordered by the survivor version it
+/// records, so landing it after later merges' acks is safe. An aborted
+/// op, or no op row at all (the call failed before the saga froze its
+/// request), means the source lived on. An op still in flight is polled
+/// until `deadline` elapses — the sweeper re-drives abandoned ops — and
+/// one that never settles is a violation: a person no lifecycle op can
+/// ever touch again.
+pub async fn settle_unresolved(
+    pool: &PgPool,
+    state: &PersonState,
+    unresolved: Vec<UnresolvedMerge>,
+    deadline: Duration,
+) -> Result<Vec<ConsistencyViolation>> {
+    if unresolved.is_empty() {
+        return Ok(Vec::new());
+    }
+    println!(
+        "Settling {} merge calls that lost every response from the saga's op records...",
+        unresolved.len()
+    );
+    let mut violations = Vec::new();
+    let mut pending = unresolved;
+    let started = Instant::now();
+    loop {
+        let mut still_pending = Vec::new();
+        for merge in pending {
+            let row = sqlx::query("SELECT step, outcome FROM lifecycle_op WHERE op_id = $1")
+                .bind(merge.op_id)
+                .fetch_optional(pool)
+                .await
+                .context("reading an unresolved merge op")?;
+            let Some(row) = row else {
+                // No frozen request: nothing destructive ever started.
+                state.clear_merge_pending(merge.source).await;
+                continue;
+            };
+            let step: String = row.get("step");
+            let outcome: Option<serde_json::Value> = row.get("outcome");
+            match step.as_str() {
+                "completed" => {
+                    let outcome = outcome.unwrap_or_default();
+                    let merged = outcome["results"]
+                        .as_array()
+                        .is_some_and(|results| results.iter().any(|r| r["outcome"] == "merged"));
+                    let survivor = &outcome["survivor"];
+                    match (
+                        merged,
+                        survivor["id"].as_i64(),
+                        survivor["version"].as_i64(),
+                    ) {
+                        (true, Some(id), Some(version)) => {
+                            state
+                                .record_merge(
+                                    merge.source,
+                                    id,
+                                    version,
+                                    HashMap::from([(merge.key, merge.value)]),
+                                )
+                                .await;
+                        }
+                        (true, _, _) => violations.push(ConsistencyViolation {
+                            person_id: merge.source,
+                            key: "__merge_record_missing_survivor".to_string(),
+                            expected: json!("a completed merge records its survivor"),
+                            actual: outcome,
+                        }),
+                        (false, _, _) => state.clear_merge_pending(merge.source).await,
+                    }
+                }
+                "aborted" => state.clear_merge_pending(merge.source).await,
+                _ => still_pending.push(merge),
+            }
+        }
+        if still_pending.is_empty() {
+            return Ok(violations);
+        }
+        if started.elapsed() > deadline {
+            for merge in still_pending {
+                violations.push(ConsistencyViolation {
+                    person_id: merge.source,
+                    key: "__merge_unsettled".to_string(),
+                    expected: json!(format!("op {} terminal within {deadline:?}", merge.op_id)),
+                    actual: json!("in flight"),
+                });
+            }
+            return Ok(violations);
+        }
+        sleep(Duration::from_secs(2)).await;
+        pending = still_pending;
+    }
+}
+
+/// A pair with a fat person on the configured side, or None when no fat
+/// source is left to reserve and no fat target is live. With fat targets
+/// only, the source comes from the ordinary eligible set.
+fn pick_fat_pair(
+    fat_sources: &Mutex<Vec<i64>>,
+    fat_targets: &[i64],
+    eligible: &Mutex<Vec<i64>>,
+    pool: &TargetPool,
+    rng: &mut impl Rng,
+) -> Option<(i64, i64)> {
+    let live_fat_targets: Vec<i64> = fat_targets
+        .iter()
+        .copied()
+        .filter(|id| pool.snapshot().contains(id))
+        .collect();
+    let source = {
+        let mut fat_sources = fat_sources.lock().unwrap();
+        if fat_sources.is_empty() {
+            None
+        } else {
+            let index = rng.gen_range(0..fat_sources.len());
+            Some(fat_sources.swap_remove(index))
+        }
+    };
+    match source {
+        Some(source) => {
+            let target = if live_fat_targets.is_empty() {
+                (0..16)
+                    .filter_map(|_| pool.pick_random(rng))
+                    .find(|&target| target != source)
+            } else {
+                live_fat_targets
+                    .iter()
+                    .copied()
+                    .filter(|&target| target != source)
+                    .nth(rng.gen_range(0..live_fat_targets.len().max(1)))
+                    .or_else(|| live_fat_targets.iter().copied().find(|&t| t != source))
+            };
+            match target {
+                Some(target) => Some((source, target)),
+                None => {
+                    fat_sources.lock().unwrap().push(source);
+                    None
+                }
+            }
+        }
+        None if !live_fat_targets.is_empty() => {
+            let target = live_fat_targets[rng.gen_range(0..live_fat_targets.len())];
+            let mut eligible = eligible.lock().unwrap();
+            let candidates: Vec<usize> = (0..eligible.len())
+                .filter(|&i| eligible[i] != target)
+                .collect();
+            if candidates.is_empty() {
+                return None;
+            }
+            let source = eligible.swap_remove(candidates[rng.gen_range(0..candidates.len())]);
+            Some((source, target))
+        }
+        None => None,
+    }
+}
+
+/// Reserve a random eligible source and pick a distinct live target.
+/// None when fewer than two live persons remain or every source is
+/// reserved.
+fn pick_pair(
+    eligible: &Mutex<Vec<i64>>,
+    pool: &TargetPool,
+    rng: &mut impl Rng,
+) -> Option<(i64, i64)> {
+    let mut eligible = eligible.lock().unwrap();
+    if eligible.is_empty() || pool.len() < 2 {
+        return None;
+    }
+    let index = rng.gen_range(0..eligible.len());
+    let source = eligible.swap_remove(index);
+    // The pool holds at least two persons, so a distinct target exists;
+    // a handful of draws finds one with overwhelming probability, and a
+    // miss just returns the source.
+    for _ in 0..16 {
+        match pool.pick_random(rng) {
+            Some(target) if target != source => return Some((source, target)),
+            _ => {}
+        }
+    }
+    eligible.push(source);
+    None
+}
+
+/// Record the first moment the lane found nothing left to merge.
+fn note_dry(dry_at: &Mutex<Option<Duration>>, at: Duration) {
+    let mut dry = dry_at.lock().unwrap();
+    if dry.is_none() {
+        *dry = Some(at);
+    }
+}
+
+pub fn outcome_name(outcome: MergeSourceOutcome) -> &'static str {
+    match outcome {
+        MergeSourceOutcome::Merged => "merged",
+        MergeSourceOutcome::NoopSamePerson => "noop_same_person",
+        MergeSourceOutcome::Attached => "attached",
+        MergeSourceOutcome::SkippedIllegal => "skipped_illegal",
+        MergeSourceOutcome::SkippedAlreadyIdentified => "skipped_already_identified",
+        MergeSourceOutcome::SkippedConflict => "skipped_conflict",
+        MergeSourceOutcome::SkippedMoveLimit => "skipped_move_limit",
+        MergeSourceOutcome::Error => "error",
+        MergeSourceOutcome::Unspecified => "unspecified",
+    }
+}

--- a/rust/personhog-test-harness/src/scenarios/mod.rs
+++ b/rust/personhog-test-harness/src/scenarios/mod.rs
@@ -2,5 +2,6 @@ pub mod blast;
 pub mod chaos;
 pub mod consistency;
 pub mod gate;
+pub mod merge;
 pub mod seed_cmd;
 pub mod traffic;

--- a/rust/personhog-test-harness/src/scenarios/traffic.rs
+++ b/rust/personhog-test-harness/src/scenarios/traffic.rs
@@ -263,8 +263,6 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
             let collector = Arc::new(StatsCollector::new());
             let state = PersonState::new();
 
-            // Traffic mode has no merge lane, so nothing retires
-            // persons and the pool stays the seeded set.
             let pool = Arc::new(TargetPool::new(person_ids.as_ref().clone()));
             let traffic = {
                 let client = client.clone();

--- a/rust/personhog-test-harness/src/scenarios/traffic.rs
+++ b/rust/personhog-test-harness/src/scenarios/traffic.rs
@@ -27,6 +27,7 @@
 //! epoch's load short and runs the normal close-out (verify what was
 //! acked, record, clean up) inside the termination grace window.
 
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -47,6 +48,7 @@ use uuid::Uuid;
 use crate::cli::TrafficArgs;
 use crate::client::HarnessClient;
 use crate::client::{IdentityClient, LifecycleClient};
+use crate::pool::TargetPool;
 use crate::report::ConsistencyViolation;
 use crate::scenarios::chaos::{self, ChaosConfig, TargetKind, TargetSpec};
 use crate::scenarios::{blast, consistency};
@@ -261,9 +263,12 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
             let collector = Arc::new(StatsCollector::new());
             let state = PersonState::new();
 
+            // The lanes share one live pool; nothing retires persons here
+            // (no merge lane in traffic mode), so it is the seeded set.
+            let pool = Arc::new(TargetPool::new(person_ids.as_ref().clone()));
             let traffic = {
                 let client = client.clone();
-                let person_ids = person_ids.clone();
+                let person_ids = pool.clone();
                 let collector = collector.clone();
                 let state = state.clone();
                 let (duration, concurrency) = (args.epoch, args.concurrency);
@@ -291,7 +296,7 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
             };
             let probers = {
                 let client = client.clone();
-                let person_ids = person_ids.clone();
+                let person_ids = pool.clone();
                 let collector = collector.clone();
                 let state = state.clone();
                 let duration = args.epoch;
@@ -357,7 +362,9 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
                         blast::verify_strong(client, &lane.collector, &lane.state, team_id).await?,
                     );
                     let journal = lane.state.snapshot().await;
-                    lane_violations.extend(verify_postgres(pool, table, team_id, &journal).await?);
+                    lane_violations.extend(
+                        verify_postgres(pool, table, team_id, &journal, &HashMap::new()).await?,
+                    );
                     anyhow::Ok((team_id, lane_violations, lane.collector.writes.snapshot()))
                 };
                 close

--- a/rust/personhog-test-harness/src/scenarios/traffic.rs
+++ b/rust/personhog-test-harness/src/scenarios/traffic.rs
@@ -263,8 +263,8 @@ pub async fn run(args: TrafficArgs) -> Result<()> {
             let collector = Arc::new(StatsCollector::new());
             let state = PersonState::new();
 
-            // The lanes share one live pool; nothing retires persons here
-            // (no merge lane in traffic mode), so it is the seeded set.
+            // Traffic mode has no merge lane, so nothing retires
+            // persons and the pool stays the seeded set.
             let pool = Arc::new(TargetPool::new(person_ids.as_ref().clone()));
             let traffic = {
                 let client = client.clone();

--- a/rust/personhog-test-harness/src/seed.rs
+++ b/rust/personhog-test-harness/src/seed.rs
@@ -54,7 +54,7 @@ pub async fn seed_persons(
 /// writes and whose FK blocks the person delete. Cleanup stays inside
 /// the person table's own namespace: targeting the validation set must
 /// never delete from the real tables.
-fn distinct_id_tables_for(person_table: &str) -> &'static [&'static str] {
+pub fn distinct_id_tables_for(person_table: &str) -> &'static [&'static str] {
     if person_table == "personhog_person_tmp" {
         &["personhog_persondistinctid_tmp"]
     } else {

--- a/rust/personhog-test-harness/src/stack/mod.rs
+++ b/rust/personhog-test-harness/src/stack/mod.rs
@@ -259,11 +259,10 @@ impl Stack {
                     ("PERSON_TABLE", config.pg_target_table.clone()),
                     ("PERSON_DISTINCT_ID_TABLE", pdi_table.to_string()),
                     ("FF_HASH_KEY_OVERRIDE_TABLE", ffhko_table.to_string()),
-                    // A merge whose leader calls die with a killed
-                    // leader is abandoned mid-saga. Only the sweeper
-                    // re-drives it, and the gate's delete leg waits for
-                    // that. The service default is off, so turn it on
-                    // here, on a cadence that fits a short run.
+                    // The service default is off. The gate needs the
+                    // sweeper: a leader kill abandons a merge mid-saga,
+                    // and only the sweeper re-drives it. The short
+                    // interval fits a short run.
                     ("LIFECYCLE_SWEEPER_ENABLED", "true".to_string()),
                     ("LIFECYCLE_SWEEP_INTERVAL_SECS", "3".to_string()),
                 ],

--- a/rust/personhog-test-harness/src/stack/mod.rs
+++ b/rust/personhog-test-harness/src/stack/mod.rs
@@ -259,6 +259,13 @@ impl Stack {
                     ("PERSON_TABLE", config.pg_target_table.clone()),
                     ("PERSON_DISTINCT_ID_TABLE", pdi_table.to_string()),
                     ("FF_HASH_KEY_OVERRIDE_TABLE", ffhko_table.to_string()),
+                    // A merge whose leader calls die with a killed leader
+                    // is abandoned mid-saga; only the sweeper re-drives
+                    // it, and the gate's delete leg waits for exactly
+                    // that. Off by default in the service, so on here,
+                    // on a cadence that fits a short run.
+                    ("LIFECYCLE_SWEEPER_ENABLED", "true".to_string()),
+                    ("LIFECYCLE_SWEEP_INTERVAL_SECS", "3".to_string()),
                 ],
                 &log_dir,
             )?);

--- a/rust/personhog-test-harness/src/stack/mod.rs
+++ b/rust/personhog-test-harness/src/stack/mod.rs
@@ -259,11 +259,11 @@ impl Stack {
                     ("PERSON_TABLE", config.pg_target_table.clone()),
                     ("PERSON_DISTINCT_ID_TABLE", pdi_table.to_string()),
                     ("FF_HASH_KEY_OVERRIDE_TABLE", ffhko_table.to_string()),
-                    // A merge whose leader calls die with a killed leader
-                    // is abandoned mid-saga; only the sweeper re-drives
-                    // it, and the gate's delete leg waits for exactly
-                    // that. Off by default in the service, so on here,
-                    // on a cadence that fits a short run.
+                    // A merge whose leader calls die with a killed
+                    // leader is abandoned mid-saga. Only the sweeper
+                    // re-drives it, and the gate's delete leg waits for
+                    // that. The service default is off, so turn it on
+                    // here, on a cadence that fits a short run.
                     ("LIFECYCLE_SWEEPER_ENABLED", "true".to_string()),
                     ("LIFECYCLE_SWEEP_INTERVAL_SECS", "3".to_string()),
                 ],

--- a/rust/personhog-test-harness/src/state.rs
+++ b/rust/personhog-test-harness/src/state.rs
@@ -13,6 +13,12 @@ use crate::report::ConsistencyViolation;
 /// belongs to one worker and workers write sequentially. A write whose
 /// outcome is unknown breaks that and drops its key — see
 /// [`PersonState::record_write_uncertain`].
+///
+/// Merges make the journal a tree. Each person keeps the keys its own
+/// acks set, and a merged source hangs off the survivor its ack named.
+/// A live person's expected document is computed from that tree under
+/// the leader's fold rule, so an ack that lands late, for a person the
+/// journal already merged, only has to update that person's own keys.
 #[derive(Clone)]
 pub struct PersonState {
     inner: Arc<RwLock<Journal>>,
@@ -20,7 +26,10 @@ pub struct PersonState {
 
 #[derive(Default)]
 struct Journal {
-    persons: HashMap<i64, ExpectedPerson>,
+    /// Every person the harness journaled, alive or merged. A merged
+    /// person keeps its node because its keys still fold into the
+    /// survivor, and a late ack can still add to them.
+    persons: HashMap<i64, PersonNode>,
     /// Persons currently frozen by a lifecycle fence, mapped to their
     /// sealed version. While a person is here, no write above the sealed
     /// version may be acked — the fence's whole guarantee. Writes acked at
@@ -36,21 +45,34 @@ struct Journal {
     /// in whatever order the responses land, so a lower version arriving
     /// after a higher one is normal.
     anomalies: Vec<ConsistencyViolation>,
-    /// Persons the merge saga destroyed, keyed by the dead source. A
-    /// pre-fence write can ack after the merge was journaled. This map
-    /// routes such acks to the survivor, and its high-water mark is
-    /// what the Postgres tombstone's death version must sit above.
-    merged: HashMap<i64, MergedSource>,
+    /// The merge tree's edges, keyed by the dead source. The survivor a
+    /// merge ack names can be dead in the journal already, when its own
+    /// merge acked first. The edge still points at the named survivor,
+    /// because the fold happened into that person's document, at that
+    /// person's version.
+    merged: HashMap<i64, MergeEdge>,
+    /// The reverse of `merged`: the sources folded into each person.
+    children: HashMap<i64, Vec<i64>>,
     /// Sources with a merge call in flight. A read that cannot find one
     /// of these is the saga at work, not lost data.
     merge_pending: HashSet<i64>,
 }
 
+struct MergeEdge {
+    survivor: i64,
+    /// The survivor version the fold produced. Folds into one survivor
+    /// fill keys in this order: the earlier fold filled a key and every
+    /// later fold found it present.
+    fold_version: i64,
+    /// Position among the sources of one merge call. The leader fills
+    /// from the sealed snapshots in request order.
+    ordinal: usize,
+}
+
 /// What the journal keeps about a person after a merge destroyed it.
 pub struct MergedSource {
     /// The person the source folded into, as answered by the merge ack.
-    /// A later merge can destroy it too. [`Journal::resolve`] follows
-    /// the chain.
+    /// A later merge can destroy it too.
     pub survivor: i64,
     /// Highest version the leader acked for the source, before or after
     /// the merge was journaled. The fence seals the source at its
@@ -58,9 +80,6 @@ pub struct MergedSource {
     /// version the saga recorded. An ack above the seal means the fence
     /// failed open.
     pub max_acked_version: i64,
-    /// The survivor version the fold produced. This is the point in the
-    /// survivor's history at which the source's keys entered it.
-    fold_version: i64,
 }
 
 impl MergedSource {
@@ -69,11 +88,23 @@ impl MergedSource {
         Self {
             survivor,
             max_acked_version,
-            fold_version: 0,
         }
     }
 }
 
+/// A merged ack of MergePersons: the sources it destroyed, in request
+/// order, and the survivor document's version. The merge event's `$set`
+/// overrides on the survivor after the fold, and its `$set_once` fills
+/// only keys still absent then.
+pub struct MergeAck {
+    pub survivor: i64,
+    pub survivor_version: i64,
+    pub sources: Vec<i64>,
+    pub set: HashMap<String, serde_json::Value>,
+    pub set_once: HashMap<String, serde_json::Value>,
+}
+
+/// A live person's expected document, for verification.
 #[derive(Clone)]
 pub struct ExpectedPerson {
     /// Only tracks keys the harness wrote — other properties are ignored
@@ -81,6 +112,13 @@ pub struct ExpectedPerson {
     pub written_properties: HashMap<String, serde_json::Value>,
     /// Highest version the leader acked for this person.
     pub last_version: i64,
+}
+
+/// The keys a person's own acks set. What a merge folds from it is
+/// computed from this node and the nodes merged into it.
+struct PersonNode {
+    own: HashMap<String, serde_json::Value>,
+    last_version: i64,
     /// Every version the leader acked for this person, for duplicate
     /// detection.
     acked_versions: HashSet<i64>,
@@ -90,27 +128,19 @@ pub struct ExpectedPerson {
     /// the target wins every key it actually has, known to the journal
     /// or not. The next ack for the key clears it.
     uncertain_keys: HashSet<String>,
-    /// The ack version that last set each key the person's own writes
-    /// hold. Diagnostics only: the report uses it to say how the
-    /// journal came by its expectation.
+    /// The ack version that last set each key. Diagnostics only: the
+    /// report uses it to say how the journal came by its expectation.
     own_origins: HashMap<String, i64>,
-    /// Keys a fold filled, mapped to the survivor version of that fold.
-    /// Merge acks land in response order, not fold order, so the journal
-    /// orders folds into one survivor by version: the earlier fold
-    /// filled the key and every later fold found it present. Absent for
-    /// keys the person's own writes set, which win over any fold.
-    fold_origins: HashMap<String, i64>,
 }
 
-impl ExpectedPerson {
+impl PersonNode {
     fn empty() -> Self {
         Self {
-            written_properties: HashMap::new(),
+            own: HashMap::new(),
             last_version: 0,
             acked_versions: HashSet::new(),
             uncertain_keys: HashSet::new(),
             own_origins: HashMap::new(),
-            fold_origins: HashMap::new(),
         }
     }
 
@@ -125,7 +155,6 @@ impl ExpectedPerson {
     ) {
         for (k, v) in properties {
             self.uncertain_keys.remove(&k);
-            self.fold_origins.remove(&k);
             match version {
                 Some(version) => {
                     self.own_origins.insert(k.clone(), version);
@@ -134,51 +163,34 @@ impl ExpectedPerson {
                     self.own_origins.remove(&k);
                 }
             }
-            self.written_properties.insert(k, v);
+            self.own.insert(k, v);
         }
     }
 
-    /// How the journal came by its expectation for `key`.
-    fn origin_of(&self, key: &str) -> String {
-        if let Some(version) = self.fold_origins.get(key) {
-            return format!("fold at survivor v{version}");
-        }
-        match self.own_origins.get(key) {
-            Some(version) => format!("own ack v{version}"),
-            None => "own no-change ack".to_string(),
-        }
+    /// Claim `version` as an applied ack of this person. Two applied
+    /// acks sharing one version is the split-brain signature.
+    fn claim_version(&mut self, version: i64) -> bool {
+        self.last_version = self.last_version.max(version);
+        self.acked_versions.insert(version)
     }
+}
 
-    /// The leader's fold rule: the survivor wins every key it has, and
-    /// the source fills the rest. A key the survivor can hold from an
-    /// uncertain write is neither asserted nor filled. A key an earlier
-    /// fold filled stays: among folds, the lowest survivor version
-    /// wins, in whatever order their acks arrived.
-    fn fold_from_source(
-        &mut self,
-        properties: HashMap<String, serde_json::Value>,
-        fold_version: i64,
-    ) {
-        for (k, v) in properties {
-            if self.uncertain_keys.contains(&k) {
-                continue;
-            }
-            match self.fold_origins.get(&k) {
-                // The person's own write set it: the survivor wins.
-                None if self.written_properties.contains_key(&k) => continue,
-                // An earlier fold filled it first. Equal versions meet
-                // only through a chain: a late fold into an
-                // already-merged survivor enters the final survivor at
-                // the same hop as that survivor's own document, and the
-                // leader let that document win.
-                Some(&origin) if origin <= fold_version => continue,
-                _ => {}
-            }
-            self.own_origins.remove(&k);
-            self.fold_origins.insert(k.clone(), fold_version);
-            self.written_properties.insert(k, v);
-        }
-    }
+/// How the journal came by its expectation for a key.
+enum Origin {
+    Own(Option<i64>),
+    Fold { source: i64, fold_version: i64 },
+}
+
+/// A person's document as the fold rule builds it from the journal
+/// tree: the person's own keys, then each merged source's document in
+/// fold order, filling only absent keys.
+#[derive(Default)]
+struct Folded {
+    properties: HashMap<String, serde_json::Value>,
+    /// Keys the person can hold from a write the journal cannot vouch
+    /// for. Neither asserted nor filled from a later source.
+    uncertain: HashSet<String>,
+    origins: HashMap<String, Origin>,
 }
 
 impl Journal {
@@ -186,8 +198,8 @@ impl Journal {
     /// document now.
     fn resolve(&self, mut person_id: i64) -> i64 {
         let mut hops = 0;
-        while let Some(merged) = self.merged.get(&person_id) {
-            person_id = merged.survivor;
+        while let Some(edge) = self.merged.get(&person_id) {
+            person_id = edge.survivor;
             hops += 1;
             if hops > self.merged.len() {
                 unreachable!("merge chain cycles: a person cannot survive its own merge");
@@ -196,24 +208,68 @@ impl Journal {
         person_id
     }
 
-    /// Where a document named by a merge ack lives now, and the version
-    /// at which it entered there. For a live named survivor this is the
-    /// survivor itself. For a dead one it is the final survivor and the
-    /// fold version of the chain's last hop.
-    fn entry_point(&self, named: i64) -> (i64, Option<i64>) {
-        let mut person_id = named;
-        let mut hop = None;
-        while let Some(merged) = self.merged.get(&person_id) {
-            person_id = merged.survivor;
-            hop = Some(merged.fold_version);
-        }
-        (person_id, hop)
-    }
-
-    fn live_entry(&mut self, person_id: i64) -> &mut ExpectedPerson {
+    fn node(&mut self, person_id: i64) -> &mut PersonNode {
         self.persons
             .entry(person_id)
-            .or_insert_with(ExpectedPerson::empty)
+            .or_insert_with(PersonNode::empty)
+    }
+
+    fn is_live(&self, person_id: i64) -> bool {
+        !self.merged.contains_key(&person_id)
+    }
+
+    /// The leader's fold rule over the journal tree: a person wins every
+    /// key its own acks set, and the sources merged into it fill the
+    /// rest in fold order. A source's own document is folded the same
+    /// way first, because that is the document its seal carried. A key
+    /// a person can hold from an uncertain write is neither asserted nor
+    /// filled from a later source.
+    fn fold(&self, person_id: i64) -> Folded {
+        let mut doc = Folded::default();
+        if let Some(node) = self.persons.get(&person_id) {
+            for (k, v) in &node.own {
+                doc.origins
+                    .insert(k.clone(), Origin::Own(node.own_origins.get(k).copied()));
+                doc.properties.insert(k.clone(), v.clone());
+            }
+            doc.uncertain = node.uncertain_keys.clone();
+        }
+        let mut sources: Vec<(i64, usize, i64)> = self
+            .children
+            .get(&person_id)
+            .map(|children| {
+                children
+                    .iter()
+                    .map(|&source| {
+                        let edge = &self.merged[&source];
+                        (edge.fold_version, edge.ordinal, source)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        sources.sort_unstable();
+        for (fold_version, _, source) in sources {
+            let folded = self.fold(source);
+            for (k, v) in folded.properties {
+                if doc.properties.contains_key(&k) || doc.uncertain.contains(&k) {
+                    continue;
+                }
+                doc.origins.insert(
+                    k.clone(),
+                    Origin::Fold {
+                        source,
+                        fold_version,
+                    },
+                );
+                doc.properties.insert(k, v);
+            }
+            for k in folded.uncertain {
+                if !doc.properties.contains_key(&k) {
+                    doc.uncertain.insert(k);
+                }
+            }
+        }
+        doc
     }
 }
 
@@ -228,7 +284,11 @@ impl PersonState {
     /// version: the leader assigns each applied update a fresh version
     /// under the per-person lock, so two applied acks sharing one version
     /// means two writes served from the same base state — the split-brain
-    /// signature the duplicate check exists to catch.
+    /// signature the duplicate check exists to catch. An ack for a person
+    /// the journal already merged is a pre-seal write whose response
+    /// landed late: it joins that person's own keys and folds on from
+    /// there, and it raises the high-water mark the tombstone's death
+    /// version must sit above.
     pub async fn record_write(
         &self,
         person_id: i64,
@@ -236,21 +296,8 @@ impl PersonState {
         properties: HashMap<String, serde_json::Value>,
     ) {
         let mut journal = self.inner.write().await;
-        if let Some(merged) = journal.merged.get_mut(&person_id) {
-            // A dead source's ack. The write landed before the seal and
-            // folded into the survivor, unless the fence failed open,
-            // which the seal check on the op record catches.
-            merged.max_acked_version = merged.max_acked_version.max(version);
-            let fold_version = merged.fold_version;
-            let survivor = journal.resolve(person_id);
-            journal
-                .live_entry(survivor)
-                .fold_from_source(properties, fold_version);
-            return;
-        }
-        let entry = journal.live_entry(person_id);
-        let duplicate = !entry.acked_versions.insert(version);
-        entry.last_version = entry.last_version.max(version);
+        let entry = journal.node(person_id);
+        let duplicate = !entry.claim_version(version);
         entry.insert_acked_at(properties, Some(version));
         if duplicate {
             journal.anomalies.push(ConsistencyViolation {
@@ -306,28 +353,22 @@ impl PersonState {
         person_id: i64,
         properties: HashMap<String, serde_json::Value>,
     ) {
-        let mut journal = self.inner.write().await;
-        if let Some(merged) = journal.merged.get(&person_id) {
-            let fold_version = merged.fold_version;
-            let survivor = journal.resolve(person_id);
-            journal
-                .live_entry(survivor)
-                .fold_from_source(properties, fold_version);
-            return;
-        }
-        journal.live_entry(person_id).insert_acked(properties);
+        self.inner
+            .write()
+            .await
+            .node(person_id)
+            .insert_acked(properties);
     }
 
     /// Drop a key whose write errored: the write can still apply, so the
     /// journalled value could be superseded and asserting it would fail
     /// a correct stack. The next ack for the key restores coverage. For
-    /// a dead source the taint goes to the survivor instead, because
-    /// the write can have landed before the seal and folded.
+    /// a merged source the taint folds on to the survivor, because the
+    /// write can have landed before the seal.
     pub async fn record_write_uncertain(&self, person_id: i64, key: &str) {
         let mut journal = self.inner.write().await;
-        let holder = journal.resolve(person_id);
-        if let Some(entry) = journal.persons.get_mut(&holder) {
-            entry.written_properties.remove(key);
+        if let Some(entry) = journal.persons.get_mut(&person_id) {
+            entry.own.remove(key);
             entry.uncertain_keys.insert(key.to_string());
         }
     }
@@ -349,15 +390,7 @@ impl PersonState {
             expected: serde_json::json!("update response carries the person"),
             actual: serde_json::Value::Null,
         });
-        if let Some(merged) = journal.merged.get(&person_id) {
-            let fold_version = merged.fold_version;
-            let survivor = journal.resolve(person_id);
-            journal
-                .live_entry(survivor)
-                .fold_from_source(properties, fold_version);
-            return;
-        }
-        journal.live_entry(person_id).insert_acked(properties);
+        journal.node(person_id).insert_acked(properties);
     }
 
     /// Reserve a source for an in-flight merge call. Until
@@ -379,73 +412,68 @@ impl PersonState {
         journal.merge_pending.contains(&person_id) || journal.merged.contains_key(&person_id)
     }
 
-    /// Journal a merge ack that destroyed `source_id` into `survivor_id`.
-    /// The source's acked keys fold into the survivor under the leader's
-    /// rule: the survivor wins every key it has. `merge_properties`, the
-    /// merge event's own `$set`, override on the survivor. The folded
-    /// version is claimed like any other ack. From here the source must
-    /// be gone: strong reads must not find it, and its Postgres row
-    /// must be a tombstone above every acked version.
-    pub async fn record_merge(
-        &self,
-        source_id: i64,
-        survivor_id: i64,
-        survivor_version: i64,
-        merge_properties: HashMap<String, serde_json::Value>,
-    ) {
+    /// Journal a merge ack. Each destroyed source hangs off the named
+    /// survivor from here, so the survivor's expected document folds the
+    /// source's keys under the leader's rule: the survivor wins every key
+    /// it has, and the sources fill the rest in request order. Then the
+    /// merge event's `$set` overrides on the survivor and its `$set_once`
+    /// fills the keys still absent. The folded version is claimed on the
+    /// named survivor like any other ack, whether the journal still
+    /// holds it live or a later merge's ack already destroyed it. From
+    /// here every source must be gone: strong reads must not find it,
+    /// and its Postgres row must be a tombstone above every acked
+    /// version.
+    pub async fn record_merge(&self, ack: MergeAck) {
         let mut journal = self.inner.write().await;
-        journal.merge_pending.remove(&source_id);
-        // The ack names the person the fold landed on. A merge
-        // journaled since can have moved that document on again. The
-        // source's keys then entered the final survivor with it, at
-        // that hop's version. The folded version belongs to a dead
-        // person in that case, so nothing claims it.
-        let (survivor, hop) = journal.entry_point(survivor_id);
-        let fold_version = hop.unwrap_or(survivor_version);
-        if journal.merged.contains_key(&source_id) || survivor == source_id {
-            journal.anomalies.push(ConsistencyViolation {
-                person_id: source_id,
-                key: "__merged_twice".to_string(),
-                expected: serde_json::json!("a person is destroyed by at most one merge"),
-                actual: serde_json::json!(survivor_id),
-            });
-            return;
-        }
-        let source = journal
-            .persons
-            .remove(&source_id)
-            .unwrap_or_else(ExpectedPerson::empty);
-        journal.merged.insert(
-            source_id,
-            MergedSource {
-                survivor,
-                max_acked_version: source.last_version,
-                fold_version,
-            },
-        );
-        let entry = journal.live_entry(survivor);
-        entry.fold_from_source(source.written_properties, fold_version);
-        for key in source.uncertain_keys {
-            if !entry.written_properties.contains_key(&key) {
-                entry.uncertain_keys.insert(key);
+        let mut ordinal = 0;
+        for source in ack.sources {
+            journal.merge_pending.remove(&source);
+            let survives_itself = source == ack.survivor || journal.resolve(ack.survivor) == source;
+            if journal.merged.contains_key(&source) || survives_itself {
+                journal.anomalies.push(ConsistencyViolation {
+                    person_id: source,
+                    key: "__merged_twice".to_string(),
+                    expected: serde_json::json!("a person is destroyed by at most one merge"),
+                    actual: serde_json::json!(ack.survivor),
+                });
+                continue;
             }
+            journal.node(source);
+            journal.merged.insert(
+                source,
+                MergeEdge {
+                    survivor: ack.survivor,
+                    fold_version: ack.survivor_version,
+                    ordinal,
+                },
+            );
+            journal
+                .children
+                .entry(ack.survivor)
+                .or_default()
+                .push(source);
+            ordinal += 1;
         }
-        if hop.is_some() {
-            // The merge event's $set landed on the dead named survivor
-            // and travelled on with its document, so it is a
-            // fold-origin key like the rest.
-            entry.fold_from_source(merge_properties, fold_version);
-            return;
+        // $set_once fills only what the fold left absent, and the fold
+        // includes the sources just attached.
+        let folded = journal.fold(ack.survivor);
+        let entry = journal.node(ack.survivor);
+        entry.insert_acked_at(ack.set, Some(ack.survivor_version));
+        for (key, value) in ack.set_once {
+            let present = entry.own.contains_key(&key)
+                || folded.properties.contains_key(&key)
+                || folded.uncertain.contains(&key);
+            if present {
+                continue;
+            }
+            entry.insert_acked_at(HashMap::from([(key, value)]), Some(ack.survivor_version));
         }
-        entry.insert_acked_at(merge_properties, Some(survivor_version));
-        let duplicate = !entry.acked_versions.insert(survivor_version);
-        entry.last_version = entry.last_version.max(survivor_version);
-        if duplicate {
+        if !entry.claim_version(ack.survivor_version) {
             journal.anomalies.push(ConsistencyViolation {
-                person_id: survivor,
+                person_id: ack.survivor,
                 key: "__ack_version_duplicate".to_string(),
                 expected: serde_json::json!("each version acked at most once"),
-                actual: serde_json::json!(survivor_version),
+                actual: serde_json::json!(ack.survivor_version),
             });
         }
     }
@@ -478,18 +506,20 @@ impl PersonState {
 
     /// The merged-source records for offline (Postgres) verification.
     pub async fn snapshot_merged(&self) -> HashMap<i64, MergedSource> {
-        self.inner
-            .read()
-            .await
+        let journal = self.inner.read().await;
+        journal
             .merged
             .iter()
-            .map(|(id, m)| {
+            .map(|(id, edge)| {
                 (
                     *id,
                     MergedSource {
-                        survivor: m.survivor,
-                        max_acked_version: m.max_acked_version,
-                        fold_version: m.fold_version,
+                        survivor: edge.survivor,
+                        max_acked_version: journal
+                            .persons
+                            .get(id)
+                            .map(|node| node.last_version)
+                            .unwrap_or_default(),
                     },
                 )
             })
@@ -503,7 +533,8 @@ impl PersonState {
 
     /// Verify a strong read against the journal: every acked property must
     /// be present, and the observed version must not sit below the highest
-    /// acked version.
+    /// acked version. A merged person has nothing to verify: its document
+    /// lives on in the survivor.
     pub async fn verify(
         &self,
         person_id: i64,
@@ -511,16 +542,19 @@ impl PersonState {
         observed_version: i64,
     ) -> Vec<ConsistencyViolation> {
         let journal = self.inner.read().await;
-        let Some(expected) = journal.persons.get(&person_id) else {
+        if !journal.is_live(person_id) {
+            return vec![];
+        }
+        let Some(node) = journal.persons.get(&person_id) else {
             return vec![];
         };
-        let mut violations =
-            verify_properties(person_id, &expected.written_properties, actual_properties);
-        if observed_version < expected.last_version {
+        let folded = journal.fold(person_id);
+        let mut violations = verify_properties(person_id, &folded.properties, actual_properties);
+        if observed_version < node.last_version {
             violations.push(ConsistencyViolation {
                 person_id,
                 key: "__strong_read_version".to_string(),
-                expected: serde_json::json!(format!(">= {}", expected.last_version)),
+                expected: serde_json::json!(format!(">= {}", node.last_version)),
                 actual: serde_json::json!(observed_version),
             });
         }
@@ -532,41 +566,82 @@ impl PersonState {
     pub async fn describe(&self, person_id: i64, keys: &[String]) -> String {
         let journal = self.inner.read().await;
         let mut lines = Vec::new();
-        let sources: Vec<String> = journal
+        let mut sources: Vec<String> = journal
             .merged
             .iter()
-            .filter(|(_, m)| journal.resolve(m.survivor) == person_id)
-            .map(|(source, m)| {
+            .filter(|(_, edge)| journal.resolve(edge.survivor) == person_id)
+            .map(|(source, edge)| {
+                let max_acked = journal
+                    .persons
+                    .get(source)
+                    .map(|node| node.last_version)
+                    .unwrap_or_default();
                 format!(
-                    "{source} (fold v{}, max acked v{})",
-                    m.fold_version, m.max_acked_version
+                    "{source} (into {} at v{}, max acked v{max_acked})",
+                    edge.survivor, edge.fold_version
                 )
             })
             .collect();
+        sources.sort();
         match journal.persons.get(&person_id) {
-            Some(entry) => {
+            Some(node) => {
+                let folded = journal.fold(person_id);
                 lines.push(format!(
                     "person {person_id}: last acked v{}, {} keys, merged sources: [{}]",
-                    entry.last_version,
-                    entry.written_properties.len(),
+                    node.last_version,
+                    folded.properties.len(),
                     sources.join(", ")
                 ));
                 for key in keys {
-                    lines.push(format!("  {key}: {}", entry.origin_of(key)));
+                    let origin = match folded.origins.get(key) {
+                        Some(Origin::Own(Some(version))) => format!("own ack v{version}"),
+                        Some(Origin::Own(None)) => "own no-change ack".to_string(),
+                        Some(Origin::Fold {
+                            source,
+                            fold_version,
+                        }) => format!("fold from person {source} at v{fold_version}"),
+                        None if folded.uncertain.contains(key) => {
+                            "uncertain: the last write errored".to_string()
+                        }
+                        None => "not journaled".to_string(),
+                    };
+                    lines.push(format!("  {key}: {origin}"));
                 }
             }
-            None => lines.push(format!("person {person_id}: not in the live journal")),
+            None => lines.push(format!("person {person_id}: not in the journal")),
         }
         lines.join("\n")
     }
 
+    /// The live persons: everything journaled that no merge destroyed.
     pub async fn person_ids(&self) -> Vec<i64> {
-        self.inner.read().await.persons.keys().copied().collect()
+        let journal = self.inner.read().await;
+        journal
+            .persons
+            .keys()
+            .copied()
+            .filter(|&id| journal.is_live(id))
+            .collect()
     }
 
-    /// The journal as a plain map for offline (Postgres) verification.
+    /// The live persons' expected documents, for offline (Postgres)
+    /// verification.
     pub async fn snapshot(&self) -> HashMap<i64, ExpectedPerson> {
-        self.inner.read().await.persons.clone()
+        let journal = self.inner.read().await;
+        journal
+            .persons
+            .iter()
+            .filter(|(&id, _)| journal.is_live(id))
+            .map(|(&id, node)| {
+                (
+                    id,
+                    ExpectedPerson {
+                        written_properties: journal.fold(id).properties,
+                        last_version: node.last_version,
+                    },
+                )
+            })
+            .collect()
     }
 }
 
@@ -624,6 +699,17 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), json!(v)))
             .collect()
+    }
+
+    /// A single-source merge with a `$set` and no `$set_once`.
+    fn merge(source: i64, survivor: i64, survivor_version: i64, set: &[(&str, &str)]) -> MergeAck {
+        MergeAck {
+            survivor,
+            survivor_version,
+            sources: vec![source],
+            set: props(set),
+            set_once: HashMap::new(),
+        }
     }
 
     #[test]
@@ -820,6 +906,7 @@ mod tests {
         // Unjournaled persons have nothing to verify against.
         assert!(state.verify(2, &actual, 0).await.is_empty());
     }
+
     /// The fold rule the survivor's journal must mirror: the survivor
     /// keeps every key it has, the source fills the rest, the merge
     /// event's own $set overrides, and the folded version is claimed. A
@@ -839,7 +926,7 @@ mod tests {
         state.mark_merge_pending(2).await;
         assert!(state.is_merge_pending_or_merged(2).await);
         state
-            .record_merge(2, 1, 8, props(&[("harness_merge", "op")]))
+            .record_merge(merge(2, 1, 8, &[("harness_merge", "op")]))
             .await;
         assert!(state.take_anomalies().await.is_empty());
         assert!(state.is_merge_pending_or_merged(2).await);
@@ -852,6 +939,7 @@ mod tests {
             "shared": "target", "t_only": "t", "s_only": "s", "harness_merge": "op"
         });
         assert!(state.verify(1, &folded, 8).await.is_empty());
+        assert!(state.verify(2, &json!({}), 0).await.is_empty());
         assert_eq!(
             violation_keys(
                 state
@@ -876,10 +964,14 @@ mod tests {
     }
 
     /// A pre-seal source write can ack after the merge was journaled.
-    /// Such an ack folds into the survivor under the same rule and
-    /// raises the source's high-water mark, which the Postgres
-    /// tombstone check holds the death version above. A source write
-    /// that errored taints the survivor's key instead of asserting it.
+    /// Such an ack is part of the document the seal carried, so it folds
+    /// into the survivor under the same rule: it fills a key the survivor
+    /// lacks, and it replaces the value the journal folded from the
+    /// source earlier, because the source's own later write superseded
+    /// that value before the seal. It also raises the source's high-water
+    /// mark, which the Postgres tombstone check holds the death version
+    /// above. A source write that errored taints the survivor's key
+    /// instead of asserting it.
     #[tokio::test]
     async fn late_source_acks_route_to_the_survivor() {
         let state = PersonState::new();
@@ -887,10 +979,14 @@ mod tests {
             .record_write(1, 3, props(&[("shared", "target")]))
             .await;
         state.record_write(2, 5, props(&[("a", "1")])).await;
-        state.record_merge(2, 1, 6, HashMap::new()).await;
+        state.record_merge(merge(2, 1, 6, &[])).await;
 
         state
-            .record_write(2, 6, props(&[("shared", "late"), ("late", "v")]))
+            .record_write(
+                2,
+                6,
+                props(&[("shared", "late"), ("late", "v"), ("a", "2")]),
+            )
             .await;
         state
             .record_write_no_change(2, props(&[("echo", "v")]))
@@ -898,8 +994,20 @@ mod tests {
         state.record_write_uncertain(2, "lost").await;
         assert!(state.take_anomalies().await.is_empty());
 
-        let survivor = json!({"shared": "target", "a": "1", "late": "v", "echo": "v"});
+        let survivor = json!({"shared": "target", "a": "2", "late": "v", "echo": "v"});
         assert!(state.verify(1, &survivor, 6).await.is_empty());
+        assert_eq!(
+            violation_keys(
+                state
+                    .verify(
+                        1,
+                        &json!({"shared": "target", "a": "1", "late": "v", "echo": "v"}),
+                        6
+                    )
+                    .await
+            ),
+            vec!["a"]
+        );
         // A later survivor ack for the tainted key restores coverage.
         state.record_write(1, 9, props(&[("lost", "found")])).await;
         assert_eq!(
@@ -920,7 +1028,7 @@ mod tests {
         state.record_write(1, 3, props(&[("k", "target")])).await;
         state.record_write_uncertain(1, "k").await;
         state.record_write(2, 5, props(&[("k", "source")])).await;
-        state.record_merge(2, 1, 6, HashMap::new()).await;
+        state.record_merge(merge(2, 1, 6, &[])).await;
 
         // Either value is acceptable: the key is not asserted.
         assert!(state.verify(1, &json!({"k": "target"}), 6).await.is_empty());
@@ -930,7 +1038,7 @@ mod tests {
         let state = PersonState::new();
         state.record_write(3, 2, props(&[("u", "s")])).await;
         state.record_write_uncertain(3, "u").await;
-        state.record_merge(3, 4, 3, HashMap::new()).await;
+        state.record_merge(merge(3, 4, 3, &[])).await;
         assert!(state.verify(4, &json!({}), 3).await.is_empty());
         state.record_write(4, 4, props(&[("u", "t")])).await;
         assert_eq!(
@@ -939,25 +1047,28 @@ mod tests {
         );
     }
 
-    /// Survivors merge on. The chain resolves through every hop, so a
+    /// Survivors merge on. The tree resolves through every hop, so a
     /// merge ack that names an already-merged survivor and a late ack
-    /// for the first source both land on the final person.
+    /// for the first source both land on the final person, and each
+    /// hop's fold keeps the leader's precedence: a person's own keys
+    /// beat what merged into it, and what merged into it beats nothing
+    /// its own survivor already had.
     #[tokio::test]
     async fn merge_chains_resolve_to_the_final_survivor() {
         let state = PersonState::new();
         state.record_write(1, 1, props(&[("a", "1")])).await;
         state.record_write(2, 1, props(&[("b", "2")])).await;
         state.record_write(3, 1, props(&[("c", "3")])).await;
-        state.record_merge(1, 2, 2, HashMap::new()).await;
-        state.record_merge(2, 3, 2, HashMap::new()).await;
-        // Acks that name the dead intermediate survivor resolve onward.
-        // The folded version 3 belongs to person 2, not person 3, so it
-        // is not claimed on 3. Person 4's keys enter 3 at the hop 2
-        // took (v2), where 2's own document wins ties.
+        state.record_merge(merge(1, 2, 2, &[])).await;
+        state.record_merge(merge(2, 3, 2, &[])).await;
+        // Person 4 merged into 2 while 2 was alive, at 2's version 3, but
+        // the ack lands after 2's own merge did. 4's keys entered 2, so
+        // 2's own document wins them; the merge event's $set overrode
+        // 2's own key; and 2's document entered 3 with both.
         state
-            .record_merge(4, 2, 3, props(&[("d", "4"), ("b", "late-4")]))
+            .record_merge(merge(4, 2, 3, &[("d", "4"), ("b", "set-4")]))
             .await;
-        state.record_write(1, 1, props(&[("late", "1")])).await;
+        state.record_write(1, 2, props(&[("late", "1")])).await;
         state.record_write(3, 3, props(&[("own", "3")])).await;
         assert!(state.take_anomalies().await.is_empty());
 
@@ -968,7 +1079,7 @@ mod tests {
         assert!(state
             .verify(
                 3,
-                &json!({"a": "1", "b": "2", "c": "3", "d": "4", "late": "1", "own": "3"}),
+                &json!({"a": "1", "b": "set-4", "c": "3", "d": "4", "late": "1", "own": "3"}),
                 3
             )
             .await
@@ -977,14 +1088,38 @@ mod tests {
             violation_keys(state.verify(3, &json!({"c": "3"}), 3).await),
             vec!["a", "b", "d", "late", "own"]
         );
+        // The fold into the dead intermediate raised its high-water mark:
+        // its tombstone must sit above the version that fold produced.
+        assert_eq!(state.snapshot_merged().await[&2].max_acked_version, 3);
 
         // A person cannot die twice, and a merge cannot survive itself.
-        state.record_merge(1, 3, 4, HashMap::new()).await;
-        state.record_merge(3, 1, 5, HashMap::new()).await;
+        state.record_merge(merge(1, 3, 4, &[])).await;
+        state.record_merge(merge(3, 1, 5, &[])).await;
         assert_eq!(
             violation_keys(state.take_anomalies().await),
             vec!["__merged_twice", "__merged_twice"]
         );
+    }
+
+    /// A key a source filled into its target is beaten by the target's
+    /// own write for that key, whichever of the two acks the journal
+    /// sees first. Before the fold the target already held it; after
+    /// the fold the target's `$set` overwrote the fill.
+    #[tokio::test]
+    async fn a_late_own_ack_of_a_dead_target_beats_what_merged_into_it() {
+        let state = PersonState::new();
+        state.record_write(4, 1, props(&[("k", "from-4")])).await;
+        state.record_merge(merge(4, 2, 3, &[])).await;
+        state.record_merge(merge(2, 3, 2, &[])).await;
+        assert!(state.verify(3, &json!({"k": "from-4"}), 2).await.is_empty());
+
+        state.record_write(2, 2, props(&[("k", "own-2")])).await;
+        assert!(state.verify(3, &json!({"k": "own-2"}), 2).await.is_empty());
+        assert_eq!(
+            violation_keys(state.verify(3, &json!({"k": "from-4"}), 2).await),
+            vec!["k"]
+        );
+        assert!(state.take_anomalies().await.is_empty());
     }
 
     /// Two merges into one survivor can ack in the opposite order to
@@ -999,8 +1134,8 @@ mod tests {
         state.record_write(2, 1, props(&[("k", "second")])).await;
         // Person 2's merge folded at survivor version 21. Person 1's
         // folded at 18, but its ack lands second.
-        state.record_merge(2, 3, 21, HashMap::new()).await;
-        state.record_merge(1, 3, 18, HashMap::new()).await;
+        state.record_merge(merge(2, 3, 21, &[])).await;
+        state.record_merge(merge(1, 3, 18, &[])).await;
         assert!(state.verify(3, &json!({"k": "first"}), 21).await.is_empty());
         assert_eq!(
             violation_keys(state.verify(3, &json!({"k": "second"}), 21).await),
@@ -1008,8 +1143,8 @@ mod tests {
         );
         // A late ack for the earlier source folds at its own version and
         // still beats the later fold.
-        state.record_write(1, 1, props(&[("k2", "first")])).await;
-        state.record_write(2, 1, props(&[("k2", "second")])).await;
+        state.record_write(1, 2, props(&[("k2", "first")])).await;
+        state.record_write(2, 2, props(&[("k2", "second")])).await;
         assert!(state
             .verify(3, &json!({"k": "first", "k2": "first"}), 21)
             .await
@@ -1018,12 +1153,106 @@ mod tests {
         // order.
         state.record_write(3, 22, props(&[("k", "own")])).await;
         state.record_write(4, 1, props(&[("k", "late")])).await;
-        state.record_merge(4, 3, 17, HashMap::new()).await;
+        state.record_merge(merge(4, 3, 17, &[])).await;
         assert!(state
             .verify(3, &json!({"k": "own", "k2": "first"}), 22)
             .await
             .is_empty());
         assert!(state.take_anomalies().await.is_empty());
+    }
+
+    /// One call with several sources folds them in request order: the
+    /// first source fills a key and the later ones find it present. The
+    /// folded version is claimed once for the call, not once per
+    /// source.
+    #[tokio::test]
+    async fn sources_of_one_merge_fill_in_request_order() {
+        let state = PersonState::new();
+        state
+            .record_write(1, 1, props(&[("k", "first"), ("a", "1")]))
+            .await;
+        state
+            .record_write(2, 1, props(&[("k", "second"), ("b", "2")]))
+            .await;
+        state.record_write(3, 1, props(&[("k", "third")])).await;
+        state.record_write(9, 4, props(&[("t", "9")])).await;
+        state
+            .record_merge(MergeAck {
+                survivor: 9,
+                survivor_version: 5,
+                sources: vec![2, 1, 3],
+                set: props(&[("harness_merge", "op")]),
+                set_once: HashMap::new(),
+            })
+            .await;
+        assert!(state.take_anomalies().await.is_empty());
+        let mut merged = state.merged_source_ids().await;
+        merged.sort_unstable();
+        assert_eq!(merged, vec![1, 2, 3]);
+        assert!(state
+            .verify(
+                9,
+                &json!({"t": "9", "k": "second", "a": "1", "b": "2", "harness_merge": "op"}),
+                5
+            )
+            .await
+            .is_empty());
+        assert_eq!(
+            violation_keys(state.verify(9, &json!({"k": "first"}), 5).await),
+            vec!["a", "b", "harness_merge", "k", "t"]
+        );
+    }
+
+    /// The merge event's `$set_once` fills only keys the fold left
+    /// absent: not a key the survivor or a source holds, not a key the
+    /// same event's `$set` writes, and not a key the survivor can hold
+    /// from an uncertain write.
+    #[tokio::test]
+    async fn merge_set_once_fills_only_absent_keys() {
+        let state = PersonState::new();
+        state
+            .record_write(1, 3, props(&[("own", "t"), ("raced", "t")]))
+            .await;
+        state.record_write_uncertain(1, "raced").await;
+        state.record_write(2, 5, props(&[("folded", "s")])).await;
+        state
+            .record_merge(MergeAck {
+                survivor: 1,
+                survivor_version: 6,
+                sources: vec![2],
+                set: props(&[("set", "set")]),
+                set_once: props(&[
+                    ("own", "once"),
+                    ("folded", "once"),
+                    ("set", "once"),
+                    ("raced", "once"),
+                    ("fresh", "once"),
+                ]),
+            })
+            .await;
+        assert!(state.take_anomalies().await.is_empty());
+        let survivor = json!({"own": "t", "folded": "s", "set": "set", "fresh": "once"});
+        assert!(state.verify(1, &survivor, 6).await.is_empty());
+        assert!(state
+            .verify(
+                1,
+                &json!({"own": "t", "folded": "s", "set": "set", "fresh": "once", "raced": "once"}),
+                6
+            )
+            .await
+            .is_empty());
+        assert_eq!(
+            violation_keys(
+                state
+                    .verify(
+                        1,
+                        &json!({"own": "once", "folded": "once", "set": "once", "fresh": "once"}),
+                        6
+                    )
+                    .await
+            ),
+            vec!["folded", "own", "set"]
+        );
     }
 
     /// A merge that lost every response keeps its journal and stays
@@ -1038,7 +1267,7 @@ mod tests {
         assert_eq!(state.merge_uncertain_ids().await, vec![1]);
         assert!(state.is_merge_pending_or_merged(1).await);
         // Settled as merged: the late fold lands like any other.
-        state.record_merge(1, 5, 3, HashMap::new()).await;
+        state.record_merge(merge(1, 5, 3, &[])).await;
         assert!(state.merge_uncertain_ids().await.is_empty());
         assert!(state.verify(5, &json!({"a": "1"}), 3).await.is_empty());
         // A call that settled without a merge releases the reservation.

--- a/rust/personhog-test-harness/src/state.rs
+++ b/rust/personhog-test-harness/src/state.rs
@@ -15,10 +15,9 @@ use crate::report::ConsistencyViolation;
 /// [`PersonState::record_write_uncertain`].
 ///
 /// Merges make the journal a tree. Each person keeps the keys its own
-/// acks set, and a merged source hangs off the survivor its ack named.
-/// A live person's expected document is computed from that tree under
-/// the leader's fold rule, so an ack that lands late, for a person the
-/// journal already merged, only has to update that person's own keys.
+/// acks set. A merged source hangs off the survivor its ack named. A
+/// live person's expected document is folded from that tree, so a late
+/// ack for a merged person only updates that person's own keys.
 #[derive(Clone)]
 pub struct PersonState {
     inner: Arc<RwLock<Journal>>,
@@ -26,9 +25,8 @@ pub struct PersonState {
 
 #[derive(Default)]
 struct Journal {
-    /// Every person the harness journaled, alive or merged. A merged
-    /// person keeps its node because its keys still fold into the
-    /// survivor, and a late ack can still add to them.
+    /// Every journaled person, alive or merged. A merged person keeps
+    /// its node because its keys fold into the survivor.
     persons: HashMap<i64, PersonNode>,
     /// Persons currently frozen by a lifecycle fence, mapped to their
     /// sealed version. While a person is here, no write above the sealed
@@ -45,11 +43,10 @@ struct Journal {
     /// in whatever order the responses land, so a lower version arriving
     /// after a higher one is normal.
     anomalies: Vec<ConsistencyViolation>,
-    /// The merge tree's edges, keyed by the dead source. The survivor a
-    /// merge ack names can be dead in the journal already, when its own
-    /// merge acked first. The edge still points at the named survivor,
-    /// because the fold happened into that person's document, at that
-    /// person's version.
+    /// The tree's edges, keyed by the merged source. An edge points at
+    /// the survivor the ack named, even when that survivor is merged
+    /// already, because the fold happened into that person's document
+    /// at that person's version.
     merged: HashMap<i64, MergeEdge>,
     /// The reverse of `merged`: the sources folded into each person.
     children: HashMap<i64, Vec<i64>>,
@@ -61,11 +58,10 @@ struct Journal {
 struct MergeEdge {
     survivor: i64,
     /// The survivor version the fold produced. Folds into one survivor
-    /// fill keys in this order: the earlier fold filled a key and every
-    /// later fold found it present.
+    /// fill keys in this order.
     fold_version: i64,
-    /// Position among the sources of one merge call. The leader fills
-    /// from the sealed snapshots in request order.
+    /// Position among the sources of one call. The leader fills from
+    /// them in request order.
     ordinal: usize,
 }
 
@@ -92,10 +88,9 @@ impl MergedSource {
     }
 }
 
-/// A merged ack of MergePersons: the sources it destroyed, in request
-/// order, and the survivor document's version. The merge event's `$set`
-/// overrides on the survivor after the fold, and its `$set_once` fills
-/// only keys still absent then.
+/// A MergePersons ack: the sources it merged, in request order, and the
+/// survivor's version. `set` overrides on the survivor after the fold.
+/// `set_once` fills only keys still absent after that.
 pub struct MergeAck {
     pub survivor: i64,
     pub survivor_version: i64,
@@ -114,8 +109,7 @@ pub struct ExpectedPerson {
     pub last_version: i64,
 }
 
-/// The keys a person's own acks set. What a merge folds from it is
-/// computed from this node and the nodes merged into it.
+/// The keys a person's own acks set.
 struct PersonNode {
     own: HashMap<String, serde_json::Value>,
     last_version: i64,
@@ -128,8 +122,7 @@ struct PersonNode {
     /// the target wins every key it actually has, known to the journal
     /// or not. The next ack for the key clears it.
     uncertain_keys: HashSet<String>,
-    /// The ack version that last set each key. Diagnostics only: the
-    /// report uses it to say how the journal came by its expectation.
+    /// The ack version that last set each key. Diagnostics only.
     own_origins: HashMap<String, i64>,
 }
 
@@ -167,8 +160,7 @@ impl PersonNode {
         }
     }
 
-    /// Claim `version` as an applied ack of this person. Two applied
-    /// acks sharing one version is the split-brain signature.
+    /// Claim `version`. False when an earlier ack already claimed it.
     fn claim_version(&mut self, version: i64) -> bool {
         self.last_version = self.last_version.max(version);
         self.acked_versions.insert(version)
@@ -181,14 +173,13 @@ enum Origin {
     Fold { source: i64, fold_version: i64 },
 }
 
-/// A person's document as the fold rule builds it from the journal
-/// tree: the person's own keys, then each merged source's document in
-/// fold order, filling only absent keys.
+/// A person's document as the fold builds it: own keys first, then each
+/// merged source in fold order, filling only absent keys.
 #[derive(Default)]
 struct Folded {
     properties: HashMap<String, serde_json::Value>,
-    /// Keys the person can hold from a write the journal cannot vouch
-    /// for. Neither asserted nor filled from a later source.
+    /// Keys the person can hold from an errored write. Neither asserted
+    /// nor filled from a source.
     uncertain: HashSet<String>,
     origins: HashMap<String, Origin>,
 }
@@ -218,12 +209,10 @@ impl Journal {
         !self.merged.contains_key(&person_id)
     }
 
-    /// The leader's fold rule over the journal tree: a person wins every
-    /// key its own acks set, and the sources merged into it fill the
-    /// rest in fold order. A source's own document is folded the same
-    /// way first, because that is the document its seal carried. A key
-    /// a person can hold from an uncertain write is neither asserted nor
-    /// filled from a later source.
+    /// The leader's fold rule: a person wins every key its own acks set,
+    /// and merged sources fill the rest in fold order. A source is
+    /// folded the same way first, because that is the document its seal
+    /// carried.
     fn fold(&self, person_id: i64) -> Folded {
         let mut doc = Folded::default();
         if let Some(node) = self.persons.get(&person_id) {
@@ -284,11 +273,10 @@ impl PersonState {
     /// version: the leader assigns each applied update a fresh version
     /// under the per-person lock, so two applied acks sharing one version
     /// means two writes served from the same base state — the split-brain
-    /// signature the duplicate check exists to catch. An ack for a person
-    /// the journal already merged is a pre-seal write whose response
-    /// landed late: it joins that person's own keys and folds on from
-    /// there, and it raises the high-water mark the tombstone's death
-    /// version must sit above.
+    /// signature the duplicate check exists to catch. An ack for a merged
+    /// person is a pre-seal write whose response landed late. It joins
+    /// that person's own keys and raises the version its tombstone must
+    /// sit above.
     pub async fn record_write(
         &self,
         person_id: i64,
@@ -363,7 +351,7 @@ impl PersonState {
     /// Drop a key whose write errored: the write can still apply, so the
     /// journalled value could be superseded and asserting it would fail
     /// a correct stack. The next ack for the key restores coverage. For
-    /// a merged source the taint folds on to the survivor, because the
+    /// a merged source the taint folds into the survivor, because the
     /// write can have landed before the seal.
     pub async fn record_write_uncertain(&self, person_id: i64, key: &str) {
         let mut journal = self.inner.write().await;
@@ -412,17 +400,13 @@ impl PersonState {
         journal.merge_pending.contains(&person_id) || journal.merged.contains_key(&person_id)
     }
 
-    /// Journal a merge ack. Each destroyed source hangs off the named
-    /// survivor from here, so the survivor's expected document folds the
-    /// source's keys under the leader's rule: the survivor wins every key
-    /// it has, and the sources fill the rest in request order. Then the
-    /// merge event's `$set` overrides on the survivor and its `$set_once`
-    /// fills the keys still absent. The folded version is claimed on the
-    /// named survivor like any other ack, whether the journal still
-    /// holds it live or a later merge's ack already destroyed it. From
-    /// here every source must be gone: strong reads must not find it,
-    /// and its Postgres row must be a tombstone above every acked
-    /// version.
+    /// Journal a merge ack. Each source hangs off the named survivor from
+    /// here, so the survivor's document folds the sources' keys: the
+    /// survivor wins every key it has, and the sources fill the rest in
+    /// request order. Then `set` overrides and `set_once` fills the keys
+    /// still absent. The folded version is claimed on the named
+    /// survivor, even when a later merge's ack already merged that
+    /// person. From here every source must be gone.
     pub async fn record_merge(&self, ack: MergeAck) {
         let mut journal = self.inner.write().await;
         let mut ordinal = 0;
@@ -454,8 +438,8 @@ impl PersonState {
                 .push(source);
             ordinal += 1;
         }
-        // $set_once fills only what the fold left absent, and the fold
-        // includes the sources just attached.
+        // The fold must include the sources attached above before
+        // `set_once` is checked.
         let folded = journal.fold(ack.survivor);
         let entry = journal.node(ack.survivor);
         entry.insert_acked_at(ack.set, Some(ack.survivor_version));
@@ -479,16 +463,14 @@ impl PersonState {
     }
 
     /// A merge call for `source_id` lost every response. The saga can
-    /// destroy the person, now or later. The person stays reserved, so
-    /// a read that cannot find it is tolerated, and keeps its journal.
-    /// The saga's op record settles it later: `record_merge` when the
-    /// merge ran, `clear_merge_pending` when the person lived on.
+    /// still destroy the person. The person stays reserved until the op
+    /// record settles it: `record_merge` when the merge ran,
+    /// `clear_merge_pending` when it did not.
     pub async fn record_merge_uncertain(&self, source_id: i64) {
         self.inner.write().await.merge_pending.insert(source_id);
     }
 
-    /// Persons whose merge call never answered. The harness cannot know
-    /// whether they are destroyed.
+    /// Persons whose merge call never answered.
     pub async fn merge_uncertain_ids(&self) -> Vec<i64> {
         self.inner
             .read()
@@ -613,7 +595,7 @@ impl PersonState {
         lines.join("\n")
     }
 
-    /// The live persons: everything journaled that no merge destroyed.
+    /// The journaled persons that no merge destroyed.
     pub async fn person_ids(&self) -> Vec<i64> {
         let journal = self.inner.read().await;
         journal
@@ -963,15 +945,11 @@ mod tests {
         assert_eq!(merged[&2].max_acked_version, 7);
     }
 
-    /// A pre-seal source write can ack after the merge was journaled.
-    /// Such an ack is part of the document the seal carried, so it folds
-    /// into the survivor under the same rule: it fills a key the survivor
-    /// lacks, and it replaces the value the journal folded from the
-    /// source earlier, because the source's own later write superseded
-    /// that value before the seal. It also raises the source's high-water
-    /// mark, which the Postgres tombstone check holds the death version
-    /// above. A source write that errored taints the survivor's key
-    /// instead of asserting it.
+    /// A pre-seal source write can ack after the merge was journaled. It
+    /// is part of the sealed document, so it fills a key the survivor
+    /// lacks and replaces an older value the journal folded from the
+    /// source. It also raises the version the tombstone must sit above.
+    /// An errored source write taints the survivor's key.
     #[tokio::test]
     async fn late_source_acks_route_to_the_survivor() {
         let state = PersonState::new();
@@ -1047,12 +1025,10 @@ mod tests {
         );
     }
 
-    /// Survivors merge on. The tree resolves through every hop, so a
-    /// merge ack that names an already-merged survivor and a late ack
-    /// for the first source both land on the final person, and each
-    /// hop's fold keeps the leader's precedence: a person's own keys
-    /// beat what merged into it, and what merged into it beats nothing
-    /// its own survivor already had.
+    /// Survivors merge on. A merge ack that names a merged survivor and
+    /// a late ack for the first source both land on the final person.
+    /// Each hop keeps the leader's precedence: a person's own keys beat
+    /// what merged into it.
     #[tokio::test]
     async fn merge_chains_resolve_to_the_final_survivor() {
         let state = PersonState::new();
@@ -1061,10 +1037,9 @@ mod tests {
         state.record_write(3, 1, props(&[("c", "3")])).await;
         state.record_merge(merge(1, 2, 2, &[])).await;
         state.record_merge(merge(2, 3, 2, &[])).await;
-        // Person 4 merged into 2 while 2 was alive, at 2's version 3, but
-        // the ack lands after 2's own merge did. 4's keys entered 2, so
-        // 2's own document wins them; the merge event's $set overrode
-        // 2's own key; and 2's document entered 3 with both.
+        // Person 4 merged into 2 at 2's version 3, but the ack lands
+        // after 2's own merge did. 2's own keys beat 4's, the merge
+        // event's $set overrode 2's key, and 2's document entered 3.
         state
             .record_merge(merge(4, 2, 3, &[("d", "4"), ("b", "set-4")]))
             .await;
@@ -1088,8 +1063,8 @@ mod tests {
             violation_keys(state.verify(3, &json!({"c": "3"}), 3).await),
             vec!["a", "b", "d", "late", "own"]
         );
-        // The fold into the dead intermediate raised its high-water mark:
-        // its tombstone must sit above the version that fold produced.
+        // The fold into 2 raised the version its tombstone must sit
+        // above.
         assert_eq!(state.snapshot_merged().await[&2].max_acked_version, 3);
 
         // A person cannot die twice, and a merge cannot survive itself.
@@ -1101,10 +1076,9 @@ mod tests {
         );
     }
 
-    /// A key a source filled into its target is beaten by the target's
-    /// own write for that key, whichever of the two acks the journal
-    /// sees first. Before the fold the target already held it; after
-    /// the fold the target's `$set` overwrote the fill.
+    /// A target's own write for a key beats a fill from a source, in
+    /// either ack order. Before the fold the target held the key. After
+    /// the fold the target's write overwrote the fill.
     #[tokio::test]
     async fn a_late_own_ack_of_a_dead_target_beats_what_merged_into_it() {
         let state = PersonState::new();
@@ -1161,10 +1135,8 @@ mod tests {
         assert!(state.take_anomalies().await.is_empty());
     }
 
-    /// One call with several sources folds them in request order: the
-    /// first source fills a key and the later ones find it present. The
-    /// folded version is claimed once for the call, not once per
-    /// source.
+    /// Sources of one call fill in request order. The folded version is
+    /// claimed once per call.
     #[tokio::test]
     async fn sources_of_one_merge_fill_in_request_order() {
         let state = PersonState::new();
@@ -1203,10 +1175,9 @@ mod tests {
         );
     }
 
-    /// The merge event's `$set_once` fills only keys the fold left
-    /// absent: not a key the survivor or a source holds, not a key the
-    /// same event's `$set` writes, and not a key the survivor can hold
-    /// from an uncertain write.
+    /// `$set_once` fills only keys the fold left absent: not a key the
+    /// survivor or a source holds, not the same event's `$set` key, and
+    /// not an uncertain key.
     #[tokio::test]
     async fn merge_set_once_fills_only_absent_keys() {
         let state = PersonState::new();

--- a/rust/personhog-test-harness/src/state.rs
+++ b/rust/personhog-test-harness/src/state.rs
@@ -36,11 +36,10 @@ struct Journal {
     /// in whatever order the responses land, so a lower version arriving
     /// after a higher one is normal.
     anomalies: Vec<ConsistencyViolation>,
-    /// Persons the merge saga destroyed, keyed by the dead source. Acks
-    /// that arrive for a dead source after its merge was journaled (a
-    /// pre-fence write whose response landed late) are folded into the
-    /// survivor through this map, and its high-water mark is what the
-    /// Postgres tombstone's death version must sit above.
+    /// Persons the merge saga destroyed, keyed by the dead source. A
+    /// pre-fence write can ack after the merge was journaled. This map
+    /// routes such acks to the survivor, and its high-water mark is
+    /// what the Postgres tombstone's death version must sit above.
     merged: HashMap<i64, MergedSource>,
     /// Sources with a merge call in flight. A read that cannot find one
     /// of these is the saga at work, not lost data.
@@ -50,16 +49,16 @@ struct Journal {
 /// What the journal keeps about a person after a merge destroyed it.
 pub struct MergedSource {
     /// The person the source folded into, as answered by the merge ack.
-    /// May itself have been merged since; [`Journal::resolve`] follows
+    /// A later merge can destroy it too. [`Journal::resolve`] follows
     /// the chain.
     pub survivor: i64,
     /// Highest version the leader acked for the source, before or after
-    /// the merge was journaled. Every ack must sit at or below the
-    /// sealed version the saga recorded (and so below the death
-    /// version): the fence seals the source at its current version, so
-    /// a later ack means the fence failed open.
+    /// the merge was journaled. The fence seals the source at its
+    /// current version, so every ack must sit at or below the sealed
+    /// version the saga recorded. An ack above the seal means the fence
+    /// failed open.
     pub max_acked_version: i64,
-    /// The survivor version the fold produced: the point in the
+    /// The survivor version the fold produced. This is the point in the
     /// survivor's history at which the source's keys entered it.
     fold_version: i64,
 }
@@ -85,22 +84,21 @@ pub struct ExpectedPerson {
     /// Every version the leader acked for this person, for duplicate
     /// detection.
     acked_versions: HashSet<i64>,
-    /// Keys whose last write errored: the write may still have applied,
-    /// so the person may hold a value the journal does not know. A
-    /// merge fold must not assert a source's value for such a key — the
-    /// target wins every key it actually has, known to the journal or
-    /// not. Cleared by the next ack for the key.
+    /// Keys whose last write errored. Such a write can still apply, so
+    /// the person can hold a value the journal does not know. A merge
+    /// fold must not assert a source's value for such a key, because
+    /// the target wins every key it actually has, known to the journal
+    /// or not. The next ack for the key clears it.
     uncertain_keys: HashSet<String>,
     /// The ack version that last set each key the person's own writes
-    /// hold — diagnostics for a violation, so the report can say how the
+    /// hold. Diagnostics only: the report uses it to say how the
     /// journal came by its expectation.
     own_origins: HashMap<String, i64>,
     /// Keys a fold filled, mapped to the survivor version of that fold.
-    /// Merge acks land in whatever order the responses arrive, not the
-    /// order the folds applied, so two merges into one survivor must be
-    /// ordered by version: the earlier fold filled the key and every
-    /// later fold found it present. Absent for keys the person's own
-    /// writes set, which win over any fold.
+    /// Merge acks land in response order, not fold order, so the journal
+    /// orders folds into one survivor by version: the earlier fold
+    /// filled the key and every later fold found it present. Absent for
+    /// keys the person's own writes set, which win over any fold.
     fold_origins: HashMap<String, i64>,
 }
 
@@ -152,10 +150,10 @@ impl ExpectedPerson {
     }
 
     /// The leader's fold rule: the survivor wins every key it has, and
-    /// the source fills the rest. A key the survivor may hold from an
-    /// uncertain write is neither asserted nor filled, and a key an
-    /// earlier fold filled stays: among folds, the lowest survivor
-    /// version wins, whatever order their acks arrived in.
+    /// the source fills the rest. A key the survivor can hold from an
+    /// uncertain write is neither asserted nor filled. A key an earlier
+    /// fold filled stays: among folds, the lowest survivor version
+    /// wins, in whatever order their acks arrived.
     fn fold_from_source(
         &mut self,
         properties: HashMap<String, serde_json::Value>,
@@ -169,10 +167,10 @@ impl ExpectedPerson {
                 // The person's own write set it: the survivor wins.
                 None if self.written_properties.contains_key(&k) => continue,
                 // An earlier fold filled it first. Equal versions meet
-                // only through a chain (a late fold into a survivor that
-                // was merged on since enters the final survivor at the
-                // same hop as everything that survivor carried), and
-                // there the survivor's own document won.
+                // only through a chain: a late fold into an
+                // already-merged survivor enters the final survivor at
+                // the same hop as that survivor's own document, and the
+                // leader let that document win.
                 Some(&origin) if origin <= fold_version => continue,
                 _ => {}
             }
@@ -199,9 +197,9 @@ impl Journal {
     }
 
     /// Where a document named by a merge ack lives now, and the version
-    /// at which it entered there: the named survivor itself when it is
-    /// still live, else the final survivor and the fold version of the
-    /// chain's last hop.
+    /// at which it entered there. For a live named survivor this is the
+    /// survivor itself. For a dead one it is the final survivor and the
+    /// fold version of the chain's last hop.
     fn entry_point(&self, named: i64) -> (i64, Option<i64>) {
         let mut person_id = named;
         let mut hop = None;
@@ -239,9 +237,9 @@ impl PersonState {
     ) {
         let mut journal = self.inner.write().await;
         if let Some(merged) = journal.merged.get_mut(&person_id) {
-            // A dead source's ack: the write landed before the seal (or
-            // the fence failed open — Postgres decides, via the sealed
-            // version), so it is part of what folded into the survivor.
+            // A dead source's ack. The write landed before the seal and
+            // folded into the survivor, unless the fence failed open,
+            // which the seal check on the op record catches.
             merged.max_acked_version = merged.max_acked_version.max(version);
             let fold_version = merged.fold_version;
             let survivor = journal.resolve(person_id);
@@ -320,11 +318,11 @@ impl PersonState {
         journal.live_entry(person_id).insert_acked(properties);
     }
 
-    /// Drop a key whose write errored: it may still have applied, so the
-    /// journalled value could be superseded and asserting it would fail a
-    /// correct stack. The next ack for the key restores coverage. A dead
-    /// source's uncertain key taints the survivor instead: the write may
-    /// have landed before the seal and folded.
+    /// Drop a key whose write errored: the write can still apply, so the
+    /// journalled value could be superseded and asserting it would fail
+    /// a correct stack. The next ack for the key restores coverage. For
+    /// a dead source the taint goes to the survivor instead, because
+    /// the write can have landed before the seal and folded.
     pub async fn record_write_uncertain(&self, person_id: i64, key: &str) {
         let mut journal = self.inner.write().await;
         let holder = journal.resolve(person_id);
@@ -383,11 +381,11 @@ impl PersonState {
 
     /// Journal a merge ack that destroyed `source_id` into `survivor_id`.
     /// The source's acked keys fold into the survivor under the leader's
-    /// rule (the survivor wins every key it has), `merge_properties` — the
-    /// merge event's own `$set` — override on the survivor, and the
-    /// folded document's version is claimed like any other ack. From here
-    /// the source is expected gone: strong reads must not find it, and
-    /// its Postgres row must be a tombstone above every acked version.
+    /// rule: the survivor wins every key it has. `merge_properties`, the
+    /// merge event's own `$set`, override on the survivor. The folded
+    /// version is claimed like any other ack. From here the source must
+    /// be gone: strong reads must not find it, and its Postgres row
+    /// must be a tombstone above every acked version.
     pub async fn record_merge(
         &self,
         source_id: i64,
@@ -397,11 +395,11 @@ impl PersonState {
     ) {
         let mut journal = self.inner.write().await;
         journal.merge_pending.remove(&source_id);
-        // The ack names the person the fold landed on; a merge journaled
-        // since may have moved that document on again, in which case the
-        // source's keys entered the final survivor with it, at that
-        // hop's version — and the folded version belongs to a dead
-        // person, so nothing claims it.
+        // The ack names the person the fold landed on. A merge
+        // journaled since can have moved that document on again. The
+        // source's keys then entered the final survivor with it, at
+        // that hop's version. The folded version belongs to a dead
+        // person in that case, so nothing claims it.
         let (survivor, hop) = journal.entry_point(survivor_id);
         let fold_version = hop.unwrap_or(survivor_version);
         if journal.merged.contains_key(&source_id) || survivor == source_id {
@@ -434,8 +432,8 @@ impl PersonState {
         }
         if hop.is_some() {
             // The merge event's $set landed on the dead named survivor
-            // and travelled on with its document: a fold-origin key
-            // like the rest.
+            // and travelled on with its document, so it is a
+            // fold-origin key like the rest.
             entry.fold_from_source(merge_properties, fold_version);
             return;
         }
@@ -452,18 +450,17 @@ impl PersonState {
         }
     }
 
-    /// A merge call for `source_id` lost every response: the saga may
-    /// have destroyed it, now or later. The person stays reserved, so a
-    /// read that cannot find it is tolerated, and keeps its journal: the
-    /// saga's own op record settles it later — into a `record_merge`
-    /// (the fold is ordered by version, so applying it late is safe) or
-    /// back to an ordinary live person via `clear_merge_pending`.
+    /// A merge call for `source_id` lost every response. The saga can
+    /// destroy the person, now or later. The person stays reserved, so
+    /// a read that cannot find it is tolerated, and keeps its journal.
+    /// The saga's op record settles it later: `record_merge` when the
+    /// merge ran, `clear_merge_pending` when the person lived on.
     pub async fn record_merge_uncertain(&self, source_id: i64) {
         self.inner.write().await.merge_pending.insert(source_id);
     }
 
-    /// Persons whose merge call never answered: destroyed or not, the
-    /// harness cannot know.
+    /// Persons whose merge call never answered. The harness cannot know
+    /// whether they are destroyed.
     pub async fn merge_uncertain_ids(&self) -> Vec<i64> {
         self.inner
             .read()
@@ -530,8 +527,8 @@ impl PersonState {
         violations
     }
 
-    /// A diagnostic account of a person's journal: its versions, which
-    /// merges fed it, and where each of `keys` came from.
+    /// A diagnostic account of a person's journal: its versions, the
+    /// merges that fed it, and where each of `keys` came from.
     pub async fn describe(&self, person_id: i64, keys: &[String]) -> String {
         let journal = self.inner.read().await;
         let mut lines = Vec::new();
@@ -827,7 +824,7 @@ mod tests {
     /// keeps every key it has, the source fills the rest, the merge
     /// event's own $set overrides, and the folded version is claimed. A
     /// journal that let the source overwrite the survivor's keys would
-    /// flag a correct stack; one that dropped the source's keys would
+    /// flag a correct stack. One that dropped the source's keys would
     /// pass a fold that lost them.
     #[tokio::test]
     async fn a_merge_folds_the_source_into_the_survivor_target_wins() {
@@ -847,7 +844,7 @@ mod tests {
         assert!(state.take_anomalies().await.is_empty());
         assert!(state.is_merge_pending_or_merged(2).await);
 
-        // The source no longer verifies as a live person; the survivor
+        // The source no longer verifies as a live person. The survivor
         // holds the folded document.
         assert_eq!(state.person_ids().await, vec![1]);
         assert_eq!(state.merged_source_ids().await, vec![2]);
@@ -878,9 +875,9 @@ mod tests {
         assert_eq!(merged[&2].max_acked_version, 7);
     }
 
-    /// A source ack whose response lands after the merge was journaled
-    /// (a pre-seal write) folds into the survivor under the same rule
-    /// and raises the source's high-water mark, which the Postgres
+    /// A pre-seal source write can ack after the merge was journaled.
+    /// Such an ack folds into the survivor under the same rule and
+    /// raises the source's high-water mark, which the Postgres
     /// tombstone check holds the death version above. A source write
     /// that errored taints the survivor's key instead of asserting it.
     #[tokio::test]
@@ -914,9 +911,9 @@ mod tests {
         assert_eq!(merged[&2].max_acked_version, 6);
     }
 
-    /// A key the survivor may hold from an uncertain write is never
-    /// filled from the source: the survivor wins every key it actually
-    /// has, known to the journal or not.
+    /// A key the survivor can hold from an uncertain write is never
+    /// filled from the source, because the survivor wins every key it
+    /// actually has, known to the journal or not.
     #[tokio::test]
     async fn an_uncertain_survivor_key_is_not_filled_from_the_source() {
         let state = PersonState::new();
@@ -942,9 +939,9 @@ mod tests {
         );
     }
 
-    /// Survivors merge on: the chain resolves through every hop, so a
-    /// merge ack naming an already-merged survivor and a late ack for
-    /// the first source both land on the final person.
+    /// Survivors merge on. The chain resolves through every hop, so a
+    /// merge ack that names an already-merged survivor and a late ack
+    /// for the first source both land on the final person.
     #[tokio::test]
     async fn merge_chains_resolve_to_the_final_survivor() {
         let state = PersonState::new();
@@ -953,10 +950,10 @@ mod tests {
         state.record_write(3, 1, props(&[("c", "3")])).await;
         state.record_merge(1, 2, 2, HashMap::new()).await;
         state.record_merge(2, 3, 2, HashMap::new()).await;
-        // Acks naming the dead intermediate survivor resolve onward. The
-        // folded version 3 is person 2's, not person 3's: it is not
-        // claimed on 3, and 4's keys enter 3 at the hop 2 took (v2),
-        // where 2's own document wins ties.
+        // Acks that name the dead intermediate survivor resolve onward.
+        // The folded version 3 belongs to person 2, not person 3, so it
+        // is not claimed on 3. Person 4's keys enter 3 at the hop 2
+        // took (v2), where 2's own document wins ties.
         state
             .record_merge(4, 2, 3, props(&[("d", "4"), ("b", "late-4")]))
             .await;
@@ -990,18 +987,18 @@ mod tests {
         );
     }
 
-    /// Two merges into one survivor whose acks arrive in the opposite
-    /// order to their folds: the earlier fold (lower survivor version)
-    /// filled the key, and the later fold found it present. Journaling
-    /// in ack order would expect the later source's value and flag a
-    /// correct stack.
+    /// Two merges into one survivor can ack in the opposite order to
+    /// their folds. The earlier fold (lower survivor version) filled
+    /// the key, and the later fold found it present. A journal that
+    /// applied folds in ack order would expect the later source's value
+    /// and flag a correct stack.
     #[tokio::test]
     async fn folds_into_one_survivor_are_ordered_by_version_not_ack_arrival() {
         let state = PersonState::new();
         state.record_write(1, 1, props(&[("k", "first")])).await;
         state.record_write(2, 1, props(&[("k", "second")])).await;
-        // Person 2's merge folded at survivor version 21; person 1's at
-        // 18, but its ack lands second.
+        // Person 2's merge folded at survivor version 21. Person 1's
+        // folded at 18, but its ack lands second.
         state.record_merge(2, 3, 21, HashMap::new()).await;
         state.record_merge(1, 3, 18, HashMap::new()).await;
         assert!(state.verify(3, &json!({"k": "first"}), 21).await.is_empty());
@@ -1017,8 +1014,8 @@ mod tests {
             .verify(3, &json!({"k": "first", "k2": "first"}), 21)
             .await
             .is_empty());
-        // The survivor's own write wins over every fold, whenever it
-        // arrives.
+        // The survivor's own write wins over every fold, in any arrival
+        // order.
         state.record_write(3, 22, props(&[("k", "own")])).await;
         state.record_write(4, 1, props(&[("k", "late")])).await;
         state.record_merge(4, 3, 17, HashMap::new()).await;
@@ -1029,7 +1026,7 @@ mod tests {
         assert!(state.take_anomalies().await.is_empty());
     }
 
-    /// A merge whose every response was lost keeps its journal and stays
+    /// A merge that lost every response keeps its journal and stays
     /// tolerated as absent until the op record settles it either way.
     #[tokio::test]
     async fn an_uncertain_merge_keeps_the_source_pending_until_settled() {
@@ -1044,7 +1041,7 @@ mod tests {
         state.record_merge(1, 5, 3, HashMap::new()).await;
         assert!(state.merge_uncertain_ids().await.is_empty());
         assert!(state.verify(5, &json!({"a": "1"}), 3).await.is_empty());
-        // A settled-without-merge call releases the reservation.
+        // A call that settled without a merge releases the reservation.
         state.mark_merge_pending(2).await;
         state.clear_merge_pending(2).await;
         assert!(!state.is_merge_pending_or_merged(2).await);

--- a/rust/personhog-test-harness/src/state.rs
+++ b/rust/personhog-test-harness/src/state.rs
@@ -36,8 +36,46 @@ struct Journal {
     /// in whatever order the responses land, so a lower version arriving
     /// after a higher one is normal.
     anomalies: Vec<ConsistencyViolation>,
+    /// Persons the merge saga destroyed, keyed by the dead source. Acks
+    /// that arrive for a dead source after its merge was journaled (a
+    /// pre-fence write whose response landed late) are folded into the
+    /// survivor through this map, and its high-water mark is what the
+    /// Postgres tombstone's death version must sit above.
+    merged: HashMap<i64, MergedSource>,
+    /// Sources with a merge call in flight. A read that cannot find one
+    /// of these is the saga at work, not lost data.
+    merge_pending: HashSet<i64>,
 }
 
+/// What the journal keeps about a person after a merge destroyed it.
+pub struct MergedSource {
+    /// The person the source folded into, as answered by the merge ack.
+    /// May itself have been merged since; [`Journal::resolve`] follows
+    /// the chain.
+    pub survivor: i64,
+    /// Highest version the leader acked for the source, before or after
+    /// the merge was journaled. Every ack must sit at or below the
+    /// sealed version the saga recorded (and so below the death
+    /// version): the fence seals the source at its current version, so
+    /// a later ack means the fence failed open.
+    pub max_acked_version: i64,
+    /// The survivor version the fold produced: the point in the
+    /// survivor's history at which the source's keys entered it.
+    fold_version: i64,
+}
+
+impl MergedSource {
+    #[cfg(test)]
+    pub fn for_test(survivor: i64, max_acked_version: i64) -> Self {
+        Self {
+            survivor,
+            max_acked_version,
+            fold_version: 0,
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct ExpectedPerson {
     /// Only tracks keys the harness wrote — other properties are ignored
     /// during verification.
@@ -47,6 +85,138 @@ pub struct ExpectedPerson {
     /// Every version the leader acked for this person, for duplicate
     /// detection.
     acked_versions: HashSet<i64>,
+    /// Keys whose last write errored: the write may still have applied,
+    /// so the person may hold a value the journal does not know. A
+    /// merge fold must not assert a source's value for such a key — the
+    /// target wins every key it actually has, known to the journal or
+    /// not. Cleared by the next ack for the key.
+    uncertain_keys: HashSet<String>,
+    /// The ack version that last set each key the person's own writes
+    /// hold — diagnostics for a violation, so the report can say how the
+    /// journal came by its expectation.
+    own_origins: HashMap<String, i64>,
+    /// Keys a fold filled, mapped to the survivor version of that fold.
+    /// Merge acks land in whatever order the responses arrive, not the
+    /// order the folds applied, so two merges into one survivor must be
+    /// ordered by version: the earlier fold filled the key and every
+    /// later fold found it present. Absent for keys the person's own
+    /// writes set, which win over any fold.
+    fold_origins: HashMap<String, i64>,
+}
+
+impl ExpectedPerson {
+    fn empty() -> Self {
+        Self {
+            written_properties: HashMap::new(),
+            last_version: 0,
+            acked_versions: HashSet::new(),
+            uncertain_keys: HashSet::new(),
+            own_origins: HashMap::new(),
+            fold_origins: HashMap::new(),
+        }
+    }
+
+    fn insert_acked(&mut self, properties: HashMap<String, serde_json::Value>) {
+        self.insert_acked_at(properties, None);
+    }
+
+    fn insert_acked_at(
+        &mut self,
+        properties: HashMap<String, serde_json::Value>,
+        version: Option<i64>,
+    ) {
+        for (k, v) in properties {
+            self.uncertain_keys.remove(&k);
+            self.fold_origins.remove(&k);
+            match version {
+                Some(version) => {
+                    self.own_origins.insert(k.clone(), version);
+                }
+                None => {
+                    self.own_origins.remove(&k);
+                }
+            }
+            self.written_properties.insert(k, v);
+        }
+    }
+
+    /// How the journal came by its expectation for `key`.
+    fn origin_of(&self, key: &str) -> String {
+        if let Some(version) = self.fold_origins.get(key) {
+            return format!("fold at survivor v{version}");
+        }
+        match self.own_origins.get(key) {
+            Some(version) => format!("own ack v{version}"),
+            None => "own no-change ack".to_string(),
+        }
+    }
+
+    /// The leader's fold rule: the survivor wins every key it has, and
+    /// the source fills the rest. A key the survivor may hold from an
+    /// uncertain write is neither asserted nor filled, and a key an
+    /// earlier fold filled stays: among folds, the lowest survivor
+    /// version wins, whatever order their acks arrived in.
+    fn fold_from_source(
+        &mut self,
+        properties: HashMap<String, serde_json::Value>,
+        fold_version: i64,
+    ) {
+        for (k, v) in properties {
+            if self.uncertain_keys.contains(&k) {
+                continue;
+            }
+            match self.fold_origins.get(&k) {
+                // The person's own write set it: the survivor wins.
+                None if self.written_properties.contains_key(&k) => continue,
+                // An earlier fold filled it first. Equal versions meet
+                // only through a chain (a late fold into a survivor that
+                // was merged on since enters the final survivor at the
+                // same hop as everything that survivor carried), and
+                // there the survivor's own document won.
+                Some(&origin) if origin <= fold_version => continue,
+                _ => {}
+            }
+            self.own_origins.remove(&k);
+            self.fold_origins.insert(k.clone(), fold_version);
+            self.written_properties.insert(k, v);
+        }
+    }
+}
+
+impl Journal {
+    /// Follow the merge chain to the person that holds `person_id`'s
+    /// document now.
+    fn resolve(&self, mut person_id: i64) -> i64 {
+        let mut hops = 0;
+        while let Some(merged) = self.merged.get(&person_id) {
+            person_id = merged.survivor;
+            hops += 1;
+            if hops > self.merged.len() {
+                unreachable!("merge chain cycles: a person cannot survive its own merge");
+            }
+        }
+        person_id
+    }
+
+    /// Where a document named by a merge ack lives now, and the version
+    /// at which it entered there: the named survivor itself when it is
+    /// still live, else the final survivor and the fold version of the
+    /// chain's last hop.
+    fn entry_point(&self, named: i64) -> (i64, Option<i64>) {
+        let mut person_id = named;
+        let mut hop = None;
+        while let Some(merged) = self.merged.get(&person_id) {
+            person_id = merged.survivor;
+            hop = Some(merged.fold_version);
+        }
+        (person_id, hop)
+    }
+
+    fn live_entry(&mut self, person_id: i64) -> &mut ExpectedPerson {
+        self.persons
+            .entry(person_id)
+            .or_insert_with(ExpectedPerson::empty)
+    }
 }
 
 impl PersonState {
@@ -68,19 +238,22 @@ impl PersonState {
         properties: HashMap<String, serde_json::Value>,
     ) {
         let mut journal = self.inner.write().await;
-        let entry = journal
-            .persons
-            .entry(person_id)
-            .or_insert_with(|| ExpectedPerson {
-                written_properties: HashMap::new(),
-                last_version: 0,
-                acked_versions: HashSet::new(),
-            });
+        if let Some(merged) = journal.merged.get_mut(&person_id) {
+            // A dead source's ack: the write landed before the seal (or
+            // the fence failed open — Postgres decides, via the sealed
+            // version), so it is part of what folded into the survivor.
+            merged.max_acked_version = merged.max_acked_version.max(version);
+            let fold_version = merged.fold_version;
+            let survivor = journal.resolve(person_id);
+            journal
+                .live_entry(survivor)
+                .fold_from_source(properties, fold_version);
+            return;
+        }
+        let entry = journal.live_entry(person_id);
         let duplicate = !entry.acked_versions.insert(version);
         entry.last_version = entry.last_version.max(version);
-        for (k, v) in properties {
-            entry.written_properties.insert(k, v);
-        }
+        entry.insert_acked_at(properties, Some(version));
         if duplicate {
             journal.anomalies.push(ConsistencyViolation {
                 person_id,
@@ -136,26 +309,28 @@ impl PersonState {
         properties: HashMap<String, serde_json::Value>,
     ) {
         let mut journal = self.inner.write().await;
-        let entry = journal
-            .persons
-            .entry(person_id)
-            .or_insert_with(|| ExpectedPerson {
-                written_properties: HashMap::new(),
-                last_version: 0,
-                acked_versions: HashSet::new(),
-            });
-        for (k, v) in properties {
-            entry.written_properties.insert(k, v);
+        if let Some(merged) = journal.merged.get(&person_id) {
+            let fold_version = merged.fold_version;
+            let survivor = journal.resolve(person_id);
+            journal
+                .live_entry(survivor)
+                .fold_from_source(properties, fold_version);
+            return;
         }
+        journal.live_entry(person_id).insert_acked(properties);
     }
 
     /// Drop a key whose write errored: it may still have applied, so the
     /// journalled value could be superseded and asserting it would fail a
-    /// correct stack. The next ack for the key restores coverage.
+    /// correct stack. The next ack for the key restores coverage. A dead
+    /// source's uncertain key taints the survivor instead: the write may
+    /// have landed before the seal and folded.
     pub async fn record_write_uncertain(&self, person_id: i64, key: &str) {
         let mut journal = self.inner.write().await;
-        if let Some(entry) = journal.persons.get_mut(&person_id) {
+        let holder = journal.resolve(person_id);
+        if let Some(entry) = journal.persons.get_mut(&holder) {
             entry.written_properties.remove(key);
+            entry.uncertain_keys.insert(key.to_string());
         }
     }
 
@@ -176,17 +351,152 @@ impl PersonState {
             expected: serde_json::json!("update response carries the person"),
             actual: serde_json::Value::Null,
         });
-        let entry = journal
-            .persons
-            .entry(person_id)
-            .or_insert_with(|| ExpectedPerson {
-                written_properties: HashMap::new(),
-                last_version: 0,
-                acked_versions: HashSet::new(),
-            });
-        for (k, v) in properties {
-            entry.written_properties.insert(k, v);
+        if let Some(merged) = journal.merged.get(&person_id) {
+            let fold_version = merged.fold_version;
+            let survivor = journal.resolve(person_id);
+            journal
+                .live_entry(survivor)
+                .fold_from_source(properties, fold_version);
+            return;
         }
+        journal.live_entry(person_id).insert_acked(properties);
+    }
+
+    /// Reserve a source for an in-flight merge call. Until
+    /// [`PersonState::record_merge`] or [`PersonState::clear_merge_pending`],
+    /// a read that cannot find the person is the saga's doing.
+    pub async fn mark_merge_pending(&self, source_id: i64) {
+        self.inner.write().await.merge_pending.insert(source_id);
+    }
+
+    /// The merge call settled without destroying the source.
+    pub async fn clear_merge_pending(&self, source_id: i64) {
+        self.inner.write().await.merge_pending.remove(&source_id);
+    }
+
+    /// Whether a not-found for this person is expected: a merge is in
+    /// flight for it, or one already destroyed it.
+    pub async fn is_merge_pending_or_merged(&self, person_id: i64) -> bool {
+        let journal = self.inner.read().await;
+        journal.merge_pending.contains(&person_id) || journal.merged.contains_key(&person_id)
+    }
+
+    /// Journal a merge ack that destroyed `source_id` into `survivor_id`.
+    /// The source's acked keys fold into the survivor under the leader's
+    /// rule (the survivor wins every key it has), `merge_properties` — the
+    /// merge event's own `$set` — override on the survivor, and the
+    /// folded document's version is claimed like any other ack. From here
+    /// the source is expected gone: strong reads must not find it, and
+    /// its Postgres row must be a tombstone above every acked version.
+    pub async fn record_merge(
+        &self,
+        source_id: i64,
+        survivor_id: i64,
+        survivor_version: i64,
+        merge_properties: HashMap<String, serde_json::Value>,
+    ) {
+        let mut journal = self.inner.write().await;
+        journal.merge_pending.remove(&source_id);
+        // The ack names the person the fold landed on; a merge journaled
+        // since may have moved that document on again, in which case the
+        // source's keys entered the final survivor with it, at that
+        // hop's version — and the folded version belongs to a dead
+        // person, so nothing claims it.
+        let (survivor, hop) = journal.entry_point(survivor_id);
+        let fold_version = hop.unwrap_or(survivor_version);
+        if journal.merged.contains_key(&source_id) || survivor == source_id {
+            journal.anomalies.push(ConsistencyViolation {
+                person_id: source_id,
+                key: "__merged_twice".to_string(),
+                expected: serde_json::json!("a person is destroyed by at most one merge"),
+                actual: serde_json::json!(survivor_id),
+            });
+            return;
+        }
+        let source = journal
+            .persons
+            .remove(&source_id)
+            .unwrap_or_else(ExpectedPerson::empty);
+        journal.merged.insert(
+            source_id,
+            MergedSource {
+                survivor,
+                max_acked_version: source.last_version,
+                fold_version,
+            },
+        );
+        let entry = journal.live_entry(survivor);
+        entry.fold_from_source(source.written_properties, fold_version);
+        for key in source.uncertain_keys {
+            if !entry.written_properties.contains_key(&key) {
+                entry.uncertain_keys.insert(key);
+            }
+        }
+        if hop.is_some() {
+            // The merge event's $set landed on the dead named survivor
+            // and travelled on with its document: a fold-origin key
+            // like the rest.
+            entry.fold_from_source(merge_properties, fold_version);
+            return;
+        }
+        entry.insert_acked_at(merge_properties, Some(survivor_version));
+        let duplicate = !entry.acked_versions.insert(survivor_version);
+        entry.last_version = entry.last_version.max(survivor_version);
+        if duplicate {
+            journal.anomalies.push(ConsistencyViolation {
+                person_id: survivor,
+                key: "__ack_version_duplicate".to_string(),
+                expected: serde_json::json!("each version acked at most once"),
+                actual: serde_json::json!(survivor_version),
+            });
+        }
+    }
+
+    /// A merge call for `source_id` lost every response: the saga may
+    /// have destroyed it, now or later. The person stays reserved, so a
+    /// read that cannot find it is tolerated, and keeps its journal: the
+    /// saga's own op record settles it later — into a `record_merge`
+    /// (the fold is ordered by version, so applying it late is safe) or
+    /// back to an ordinary live person via `clear_merge_pending`.
+    pub async fn record_merge_uncertain(&self, source_id: i64) {
+        self.inner.write().await.merge_pending.insert(source_id);
+    }
+
+    /// Persons whose merge call never answered: destroyed or not, the
+    /// harness cannot know.
+    pub async fn merge_uncertain_ids(&self) -> Vec<i64> {
+        self.inner
+            .read()
+            .await
+            .merge_pending
+            .iter()
+            .copied()
+            .collect()
+    }
+
+    /// Persons destroyed by a journaled merge.
+    pub async fn merged_source_ids(&self) -> Vec<i64> {
+        self.inner.read().await.merged.keys().copied().collect()
+    }
+
+    /// The merged-source records for offline (Postgres) verification.
+    pub async fn snapshot_merged(&self) -> HashMap<i64, MergedSource> {
+        self.inner
+            .read()
+            .await
+            .merged
+            .iter()
+            .map(|(id, m)| {
+                (
+                    *id,
+                    MergedSource {
+                        survivor: m.survivor,
+                        max_acked_version: m.max_acked_version,
+                        fold_version: m.fold_version,
+                    },
+                )
+            })
+            .collect()
     }
 
     /// Duplicate-version and response anomalies observed while journaling.
@@ -220,14 +530,46 @@ impl PersonState {
         violations
     }
 
+    /// A diagnostic account of a person's journal: its versions, which
+    /// merges fed it, and where each of `keys` came from.
+    pub async fn describe(&self, person_id: i64, keys: &[String]) -> String {
+        let journal = self.inner.read().await;
+        let mut lines = Vec::new();
+        let sources: Vec<String> = journal
+            .merged
+            .iter()
+            .filter(|(_, m)| journal.resolve(m.survivor) == person_id)
+            .map(|(source, m)| {
+                format!(
+                    "{source} (fold v{}, max acked v{})",
+                    m.fold_version, m.max_acked_version
+                )
+            })
+            .collect();
+        match journal.persons.get(&person_id) {
+            Some(entry) => {
+                lines.push(format!(
+                    "person {person_id}: last acked v{}, {} keys, merged sources: [{}]",
+                    entry.last_version,
+                    entry.written_properties.len(),
+                    sources.join(", ")
+                ));
+                for key in keys {
+                    lines.push(format!("  {key}: {}", entry.origin_of(key)));
+                }
+            }
+            None => lines.push(format!("person {person_id}: not in the live journal")),
+        }
+        lines.join("\n")
+    }
+
     pub async fn person_ids(&self) -> Vec<i64> {
         self.inner.read().await.persons.keys().copied().collect()
     }
 
-    /// Drain the journal into a plain map for offline (Postgres) verification.
+    /// The journal as a plain map for offline (Postgres) verification.
     pub async fn snapshot(&self) -> HashMap<i64, ExpectedPerson> {
-        let mut journal = self.inner.write().await;
-        mem::take(&mut journal.persons)
+        self.inner.read().await.persons.clone()
     }
 }
 
@@ -480,5 +822,231 @@ mod tests {
         );
         // Unjournaled persons have nothing to verify against.
         assert!(state.verify(2, &actual, 0).await.is_empty());
+    }
+    /// The fold rule the survivor's journal must mirror: the survivor
+    /// keeps every key it has, the source fills the rest, the merge
+    /// event's own $set overrides, and the folded version is claimed. A
+    /// journal that let the source overwrite the survivor's keys would
+    /// flag a correct stack; one that dropped the source's keys would
+    /// pass a fold that lost them.
+    #[tokio::test]
+    async fn a_merge_folds_the_source_into_the_survivor_target_wins() {
+        let state = PersonState::new();
+        state
+            .record_write(1, 3, props(&[("shared", "target"), ("t_only", "t")]))
+            .await;
+        state
+            .record_write(2, 7, props(&[("shared", "source"), ("s_only", "s")]))
+            .await;
+
+        state.mark_merge_pending(2).await;
+        assert!(state.is_merge_pending_or_merged(2).await);
+        state
+            .record_merge(2, 1, 8, props(&[("harness_merge", "op")]))
+            .await;
+        assert!(state.take_anomalies().await.is_empty());
+        assert!(state.is_merge_pending_or_merged(2).await);
+
+        // The source no longer verifies as a live person; the survivor
+        // holds the folded document.
+        assert_eq!(state.person_ids().await, vec![1]);
+        assert_eq!(state.merged_source_ids().await, vec![2]);
+        let folded = json!({
+            "shared": "target", "t_only": "t", "s_only": "s", "harness_merge": "op"
+        });
+        assert!(state.verify(1, &folded, 8).await.is_empty());
+        assert_eq!(
+            violation_keys(
+                state
+                    .verify(
+                        1,
+                        &json!({"shared": "source", "t_only": "t", "harness_merge": "op"}),
+                        8
+                    )
+                    .await
+            ),
+            vec!["s_only", "shared"]
+        );
+        // The folded version is an ack of the survivor.
+        assert_eq!(
+            violation_keys(state.verify(1, &folded, 7).await),
+            vec!["__strong_read_version"]
+        );
+
+        let merged = state.snapshot_merged().await;
+        assert_eq!(merged[&2].survivor, 1);
+        assert_eq!(merged[&2].max_acked_version, 7);
+    }
+
+    /// A source ack whose response lands after the merge was journaled
+    /// (a pre-seal write) folds into the survivor under the same rule
+    /// and raises the source's high-water mark, which the Postgres
+    /// tombstone check holds the death version above. A source write
+    /// that errored taints the survivor's key instead of asserting it.
+    #[tokio::test]
+    async fn late_source_acks_route_to_the_survivor() {
+        let state = PersonState::new();
+        state
+            .record_write(1, 3, props(&[("shared", "target")]))
+            .await;
+        state.record_write(2, 5, props(&[("a", "1")])).await;
+        state.record_merge(2, 1, 6, HashMap::new()).await;
+
+        state
+            .record_write(2, 6, props(&[("shared", "late"), ("late", "v")]))
+            .await;
+        state
+            .record_write_no_change(2, props(&[("echo", "v")]))
+            .await;
+        state.record_write_uncertain(2, "lost").await;
+        assert!(state.take_anomalies().await.is_empty());
+
+        let survivor = json!({"shared": "target", "a": "1", "late": "v", "echo": "v"});
+        assert!(state.verify(1, &survivor, 6).await.is_empty());
+        // A later survivor ack for the tainted key restores coverage.
+        state.record_write(1, 9, props(&[("lost", "found")])).await;
+        assert_eq!(
+            violation_keys(state.verify(1, &survivor, 9).await),
+            vec!["lost"]
+        );
+
+        let merged = state.snapshot_merged().await;
+        assert_eq!(merged[&2].max_acked_version, 6);
+    }
+
+    /// A key the survivor may hold from an uncertain write is never
+    /// filled from the source: the survivor wins every key it actually
+    /// has, known to the journal or not.
+    #[tokio::test]
+    async fn an_uncertain_survivor_key_is_not_filled_from_the_source() {
+        let state = PersonState::new();
+        state.record_write(1, 3, props(&[("k", "target")])).await;
+        state.record_write_uncertain(1, "k").await;
+        state.record_write(2, 5, props(&[("k", "source")])).await;
+        state.record_merge(2, 1, 6, HashMap::new()).await;
+
+        // Either value is acceptable: the key is not asserted.
+        assert!(state.verify(1, &json!({"k": "target"}), 6).await.is_empty());
+        assert!(state.verify(1, &json!({"k": "source"}), 6).await.is_empty());
+
+        // The source's own uncertain key taints the survivor too.
+        let state = PersonState::new();
+        state.record_write(3, 2, props(&[("u", "s")])).await;
+        state.record_write_uncertain(3, "u").await;
+        state.record_merge(3, 4, 3, HashMap::new()).await;
+        assert!(state.verify(4, &json!({}), 3).await.is_empty());
+        state.record_write(4, 4, props(&[("u", "t")])).await;
+        assert_eq!(
+            violation_keys(state.verify(4, &json!({}), 4).await),
+            vec!["u"]
+        );
+    }
+
+    /// Survivors merge on: the chain resolves through every hop, so a
+    /// merge ack naming an already-merged survivor and a late ack for
+    /// the first source both land on the final person.
+    #[tokio::test]
+    async fn merge_chains_resolve_to_the_final_survivor() {
+        let state = PersonState::new();
+        state.record_write(1, 1, props(&[("a", "1")])).await;
+        state.record_write(2, 1, props(&[("b", "2")])).await;
+        state.record_write(3, 1, props(&[("c", "3")])).await;
+        state.record_merge(1, 2, 2, HashMap::new()).await;
+        state.record_merge(2, 3, 2, HashMap::new()).await;
+        // Acks naming the dead intermediate survivor resolve onward. The
+        // folded version 3 is person 2's, not person 3's: it is not
+        // claimed on 3, and 4's keys enter 3 at the hop 2 took (v2),
+        // where 2's own document wins ties.
+        state
+            .record_merge(4, 2, 3, props(&[("d", "4"), ("b", "late-4")]))
+            .await;
+        state.record_write(1, 1, props(&[("late", "1")])).await;
+        state.record_write(3, 3, props(&[("own", "3")])).await;
+        assert!(state.take_anomalies().await.is_empty());
+
+        assert_eq!(state.person_ids().await, vec![3]);
+        let mut merged = state.merged_source_ids().await;
+        merged.sort_unstable();
+        assert_eq!(merged, vec![1, 2, 4]);
+        assert!(state
+            .verify(
+                3,
+                &json!({"a": "1", "b": "2", "c": "3", "d": "4", "late": "1", "own": "3"}),
+                3
+            )
+            .await
+            .is_empty());
+        assert_eq!(
+            violation_keys(state.verify(3, &json!({"c": "3"}), 3).await),
+            vec!["a", "b", "d", "late", "own"]
+        );
+
+        // A person cannot die twice, and a merge cannot survive itself.
+        state.record_merge(1, 3, 4, HashMap::new()).await;
+        state.record_merge(3, 1, 5, HashMap::new()).await;
+        assert_eq!(
+            violation_keys(state.take_anomalies().await),
+            vec!["__merged_twice", "__merged_twice"]
+        );
+    }
+
+    /// Two merges into one survivor whose acks arrive in the opposite
+    /// order to their folds: the earlier fold (lower survivor version)
+    /// filled the key, and the later fold found it present. Journaling
+    /// in ack order would expect the later source's value and flag a
+    /// correct stack.
+    #[tokio::test]
+    async fn folds_into_one_survivor_are_ordered_by_version_not_ack_arrival() {
+        let state = PersonState::new();
+        state.record_write(1, 1, props(&[("k", "first")])).await;
+        state.record_write(2, 1, props(&[("k", "second")])).await;
+        // Person 2's merge folded at survivor version 21; person 1's at
+        // 18, but its ack lands second.
+        state.record_merge(2, 3, 21, HashMap::new()).await;
+        state.record_merge(1, 3, 18, HashMap::new()).await;
+        assert!(state.verify(3, &json!({"k": "first"}), 21).await.is_empty());
+        assert_eq!(
+            violation_keys(state.verify(3, &json!({"k": "second"}), 21).await),
+            vec!["k"]
+        );
+        // A late ack for the earlier source folds at its own version and
+        // still beats the later fold.
+        state.record_write(1, 1, props(&[("k2", "first")])).await;
+        state.record_write(2, 1, props(&[("k2", "second")])).await;
+        assert!(state
+            .verify(3, &json!({"k": "first", "k2": "first"}), 21)
+            .await
+            .is_empty());
+        // The survivor's own write wins over every fold, whenever it
+        // arrives.
+        state.record_write(3, 22, props(&[("k", "own")])).await;
+        state.record_write(4, 1, props(&[("k", "late")])).await;
+        state.record_merge(4, 3, 17, HashMap::new()).await;
+        assert!(state
+            .verify(3, &json!({"k": "own", "k2": "first"}), 22)
+            .await
+            .is_empty());
+        assert!(state.take_anomalies().await.is_empty());
+    }
+
+    /// A merge whose every response was lost keeps its journal and stays
+    /// tolerated as absent until the op record settles it either way.
+    #[tokio::test]
+    async fn an_uncertain_merge_keeps_the_source_pending_until_settled() {
+        let state = PersonState::new();
+        state.record_write(1, 1, props(&[("a", "1")])).await;
+        state.mark_merge_pending(1).await;
+        state.record_merge_uncertain(1).await;
+        assert_eq!(state.person_ids().await, vec![1]);
+        assert_eq!(state.merge_uncertain_ids().await, vec![1]);
+        assert!(state.is_merge_pending_or_merged(1).await);
+        // Settled as merged: the late fold lands like any other.
+        state.record_merge(1, 5, 3, HashMap::new()).await;
+        assert!(state.merge_uncertain_ids().await.is_empty());
+        assert!(state.verify(5, &json!({"a": "1"}), 3).await.is_empty());
+        // A settled-without-merge call releases the reservation.
+        state.mark_merge_pending(2).await;
+        state.clear_merge_pending(2).await;
+        assert!(!state.is_merge_pending_or_merged(2).await);
     }
 }

--- a/rust/personhog-test-harness/src/stats.rs
+++ b/rust/personhog-test-harness/src/stats.rs
@@ -9,9 +9,9 @@ pub struct LatencyRecorder {
     histogram: Mutex<Histogram<u64>>,
     successes: AtomicU64,
     failures: AtomicU64,
-    /// Refusals the stack must give: writes to a person a lifecycle op
-    /// fenced or destroyed. Counted apart from failures so a merge
-    /// run's expected rejections do not read as a broken stack.
+    /// Writes refused because a lifecycle op fenced or destroyed the
+    /// person. Counted apart from failures, because a merge run expects
+    /// them.
     lifecycle_rejections: AtomicU64,
     start_time: Instant,
 }
@@ -85,13 +85,13 @@ pub struct StatsSnapshot {
 pub struct StatsCollector {
     pub writes: LatencyRecorder,
     pub reads: LatencyRecorder,
-    /// MergePersons calls. One call is one saga or one inline
-    /// settlement, so its latency is the end-to-end merge cost.
+    /// MergePersons calls. One call is one saga, so its latency is the
+    /// full merge cost.
     pub merges: LatencyRecorder,
-    /// Merge calls that involve a wide person (many distinct ids). Kept
-    /// apart so the expensive calls do not hide in the median.
+    /// Merge calls that involve a wide person. Kept apart so their cost
+    /// does not hide in the median.
     pub wide_merges: LatencyRecorder,
-    /// Per-source merge outcomes, by the wire outcome's name.
+    /// Merge outcomes per source, by name.
     merge_outcomes: Mutex<BTreeMap<&'static str, u64>>,
 }
 

--- a/rust/personhog-test-harness/src/stats.rs
+++ b/rust/personhog-test-harness/src/stats.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -8,6 +9,11 @@ pub struct LatencyRecorder {
     histogram: Mutex<Histogram<u64>>,
     successes: AtomicU64,
     failures: AtomicU64,
+    /// Refusals the stack is required to give: writes to a person a
+    /// lifecycle op has fenced or already destroyed. Counted apart from
+    /// failures so a merge run's expected rejections do not read as a
+    /// broken stack.
+    lifecycle_rejections: AtomicU64,
     start_time: Instant,
 }
 
@@ -17,6 +23,7 @@ impl LatencyRecorder {
             histogram: Mutex::new(Histogram::new_with_max(60_000_000, 3).unwrap()),
             successes: AtomicU64::new(0),
             failures: AtomicU64::new(0),
+            lifecycle_rejections: AtomicU64::new(0),
             start_time: Instant::now(),
         }
     }
@@ -33,11 +40,16 @@ impl LatencyRecorder {
         self.failures.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn record_lifecycle_rejection(&self) {
+        self.lifecycle_rejections.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn snapshot(&self) -> StatsSnapshot {
         let h = self.histogram.lock().unwrap();
         let successes = self.successes.load(Ordering::Relaxed);
         let failures = self.failures.load(Ordering::Relaxed);
-        let total = successes + failures;
+        let lifecycle_rejections = self.lifecycle_rejections.load(Ordering::Relaxed);
+        let total = successes + failures + lifecycle_rejections;
         let elapsed = self.start_time.elapsed();
         let throughput_rps = if elapsed.as_secs_f64() > 0.0 {
             total as f64 / elapsed.as_secs_f64()
@@ -49,6 +61,7 @@ impl LatencyRecorder {
             total,
             successes,
             failures,
+            lifecycle_rejections,
             p50_us: h.value_at_quantile(0.50),
             p95_us: h.value_at_quantile(0.95),
             p99_us: h.value_at_quantile(0.99),
@@ -62,6 +75,7 @@ pub struct StatsSnapshot {
     pub total: u64,
     pub successes: u64,
     pub failures: u64,
+    pub lifecycle_rejections: u64,
     pub p50_us: u64,
     pub p95_us: u64,
     pub p99_us: u64,
@@ -72,6 +86,14 @@ pub struct StatsSnapshot {
 pub struct StatsCollector {
     pub writes: LatencyRecorder,
     pub reads: LatencyRecorder,
+    /// MergePersons calls: one call is one saga (or one inline
+    /// settlement), so its latency is the end-to-end merge cost.
+    pub merges: LatencyRecorder,
+    /// Merge calls involving a fat person (many distinct ids), kept
+    /// apart so the pathological cost does not hide in the median.
+    pub fat_merges: LatencyRecorder,
+    /// Per-source merge outcomes, by the wire outcome's name.
+    merge_outcomes: Mutex<BTreeMap<&'static str, u64>>,
 }
 
 impl StatsCollector {
@@ -79,6 +101,22 @@ impl StatsCollector {
         Self {
             writes: LatencyRecorder::new(),
             reads: LatencyRecorder::new(),
+            merges: LatencyRecorder::new(),
+            fat_merges: LatencyRecorder::new(),
+            merge_outcomes: Mutex::new(BTreeMap::new()),
         }
+    }
+
+    pub fn record_merge_outcome(&self, outcome: &'static str) {
+        if let Ok(mut outcomes) = self.merge_outcomes.lock() {
+            *outcomes.entry(outcome).or_default() += 1;
+        }
+    }
+
+    pub fn merge_outcomes(&self) -> BTreeMap<&'static str, u64> {
+        self.merge_outcomes
+            .lock()
+            .map(|outcomes| outcomes.clone())
+            .unwrap_or_default()
     }
 }

--- a/rust/personhog-test-harness/src/stats.rs
+++ b/rust/personhog-test-harness/src/stats.rs
@@ -9,10 +9,9 @@ pub struct LatencyRecorder {
     histogram: Mutex<Histogram<u64>>,
     successes: AtomicU64,
     failures: AtomicU64,
-    /// Refusals the stack is required to give: writes to a person a
-    /// lifecycle op has fenced or already destroyed. Counted apart from
-    /// failures so a merge run's expected rejections do not read as a
-    /// broken stack.
+    /// Refusals the stack must give: writes to a person a lifecycle op
+    /// fenced or destroyed. Counted apart from failures so a merge
+    /// run's expected rejections do not read as a broken stack.
     lifecycle_rejections: AtomicU64,
     start_time: Instant,
 }
@@ -86,11 +85,11 @@ pub struct StatsSnapshot {
 pub struct StatsCollector {
     pub writes: LatencyRecorder,
     pub reads: LatencyRecorder,
-    /// MergePersons calls: one call is one saga (or one inline
-    /// settlement), so its latency is the end-to-end merge cost.
+    /// MergePersons calls. One call is one saga or one inline
+    /// settlement, so its latency is the end-to-end merge cost.
     pub merges: LatencyRecorder,
-    /// Merge calls involving a wide person (many distinct ids), kept
-    /// apart so the pathological cost does not hide in the median.
+    /// Merge calls that involve a wide person (many distinct ids). Kept
+    /// apart so the expensive calls do not hide in the median.
     pub wide_merges: LatencyRecorder,
     /// Per-source merge outcomes, by the wire outcome's name.
     merge_outcomes: Mutex<BTreeMap<&'static str, u64>>,

--- a/rust/personhog-test-harness/src/stats.rs
+++ b/rust/personhog-test-harness/src/stats.rs
@@ -89,9 +89,9 @@ pub struct StatsCollector {
     /// MergePersons calls: one call is one saga (or one inline
     /// settlement), so its latency is the end-to-end merge cost.
     pub merges: LatencyRecorder,
-    /// Merge calls involving a fat person (many distinct ids), kept
+    /// Merge calls involving a wide person (many distinct ids), kept
     /// apart so the pathological cost does not hide in the median.
-    pub fat_merges: LatencyRecorder,
+    pub wide_merges: LatencyRecorder,
     /// Per-source merge outcomes, by the wire outcome's name.
     merge_outcomes: Mutex<BTreeMap<&'static str, u64>>,
 }
@@ -102,7 +102,7 @@ impl StatsCollector {
             writes: LatencyRecorder::new(),
             reads: LatencyRecorder::new(),
             merges: LatencyRecorder::new(),
-            fat_merges: LatencyRecorder::new(),
+            wide_merges: LatencyRecorder::new(),
             merge_outcomes: Mutex::new(BTreeMap::new()),
         }
     }

--- a/rust/personhog-test-harness/src/verify.rs
+++ b/rust/personhog-test-harness/src/verify.rs
@@ -21,15 +21,12 @@ pub const QUIESCE_DEADLINE: Duration = Duration::from_secs(60);
 /// property writes at the acked version, or the quiesce deadline passes.
 /// Returns the outstanding violations (empty = converged).
 ///
-/// Merged sources are held to the tombstone shape the saga's flip
-/// writes and the writer's death-document projection preserves: the row
-/// is deleted, at a death version above every version the leader acked
-/// for it. The fence itself is checked against the sealed version the
-/// saga recorded on its `lifecycle_op_person` row. The fence seals the
-/// source at its then-current version, so an ack above the seal means a
-/// write got through the fence. The death version alone cannot catch
-/// that, because the leader derives it from its current version as well
-/// as the seal.
+/// A merged source must be a tombstone: the row is deleted, and its
+/// version is above every version the leader acked for it. The fence is
+/// checked against the sealed version on the source's
+/// `lifecycle_op_person` row. An ack above the seal means a write got
+/// through the fence. The death version alone cannot show that, because
+/// the leader derives it from its current version too.
 pub async fn verify_postgres(
     pool: &PgPool,
     table: &str,
@@ -50,9 +47,8 @@ pub async fn verify_postgres(
     );
     let tombstone_query =
         format!("SELECT id, is_deleted, version FROM {table} WHERE team_id = $1 AND id = ANY($2)");
-    // The flip repoints every one of a source's mappings to the survivor
-    // in the destroying transaction. A mapping left on a tombstone would
-    // resolve events to a person that no longer exists.
+    // A mapping left on a tombstone resolves events to a person that no
+    // longer exists.
     let leftover_dids_query = crate::seed::distinct_id_tables_for(table)
         .iter()
         .map(|pdi_table| {
@@ -62,9 +58,8 @@ pub async fn verify_postgres(
             )
         })
         .collect::<Vec<_>>();
-    // The saga's own record of each source's seal. The merge driver
-    // writes the sealed snapshot on the source's op row and settles the
-    // row as deleted when the death document is produced.
+    // The saga records each source's seal on its op row and sets the
+    // row's status to deleted after the flip.
     let sealed_query = "SELECT person_id, (sealed->>'version')::bigint AS sealed_version \
                         FROM lifecycle_op_person \
                         WHERE team_id = $1 AND role = 'source' AND status = 'deleted' \
@@ -199,7 +194,7 @@ pub async fn verify_postgres(
 
 /// The decision table for a merged source's row. `row` is
 /// `(is_deleted, version)`, or None when the row is gone. `sealed` is
-/// the version the saga recorded at the fence, or None when its op row
+/// the version the saga recorded at the fence, or None when the op row
 /// is missing.
 pub fn verify_tombstone(
     person_id: i64,
@@ -263,8 +258,6 @@ mod tests {
         violations.into_iter().map(|v| v.key).collect()
     }
 
-    /// A false negative here passes a run in which a write got through
-    /// the fence or the flip never tombstoned the source.
     #[test]
     fn tombstone_decision_table() {
         let source = MergedSource::for_test(2, 7);
@@ -287,8 +280,8 @@ mod tests {
             keys(verify_tombstone(1, &source, Some((false, 3)), Some(7))),
             vec!["__merged_source_tombstone", "__merged_source_death_version"]
         );
-        // The fence failed open. The ack sits above the recorded seal
-        // even though the leader's death version cleared it.
+        // The fence failed open: the ack sits above the recorded seal,
+        // but the death version cleared it.
         assert_eq!(
             keys(verify_tombstone(1, &source, Some((true, 20)), Some(6))),
             vec!["__merged_source_ack_above_seal"]

--- a/rust/personhog-test-harness/src/verify.rs
+++ b/rust/personhog-test-harness/src/verify.rs
@@ -211,7 +211,10 @@ pub fn verify_tombstone(
         return vec![ConsistencyViolation {
             person_id,
             key: "__merged_source_row".to_string(),
-            expected: json!("tombstone present"),
+            expected: json!(format!(
+                "tombstone present (merged into {})",
+                source.survivor
+            )),
             actual: Value::Null,
         }];
     };

--- a/rust/personhog-test-harness/src/verify.rs
+++ b/rust/personhog-test-harness/src/verify.rs
@@ -11,7 +11,7 @@ use sqlx::Row;
 use tokio::time::sleep;
 
 use crate::report::ConsistencyViolation;
-use crate::state::{verify_properties, ExpectedPerson};
+use crate::state::{verify_properties, ExpectedPerson, MergedSource};
 
 /// How long to wait for the writer to drain acked writes into Postgres
 /// before declaring them lost.
@@ -20,15 +20,26 @@ pub const QUIESCE_DEADLINE: Duration = Duration::from_secs(60);
 /// Poll Postgres until every journaled person row contains all acked
 /// property writes at the acked version, or the quiesce deadline passes.
 /// Returns the outstanding violations (empty = converged).
+///
+/// Merged sources are held to the tombstone shape the saga's flip writes
+/// (and the writer's death-document projection preserves): the row is
+/// deleted, at a death version above every version the leader acked for
+/// it. The fence itself is checked against the sealed version the saga
+/// recorded on its `lifecycle_op_person` row: the fence seals the source
+/// at its then-current version, so an ack above the seal means a write
+/// got through the fence. The death version alone cannot catch that —
+/// the leader derives it from its current version as well as the seal.
 pub async fn verify_postgres(
     pool: &PgPool,
     table: &str,
     team_id: i64,
     journal: &HashMap<i64, ExpectedPerson>,
+    merged: &HashMap<i64, MergedSource>,
 ) -> Result<Vec<ConsistencyViolation>> {
     let team: i32 = team_id.try_into().context("team_id out of i32 range")?;
     let person_ids: Vec<i64> = journal.keys().copied().collect();
-    if person_ids.is_empty() {
+    let merged_ids: Vec<i64> = merged.keys().copied().collect();
+    if person_ids.is_empty() && merged_ids.is_empty() {
         return Ok(Vec::new());
     }
 
@@ -36,6 +47,27 @@ pub async fn verify_postgres(
         "SELECT id, properties::text AS properties, version \
          FROM {table} WHERE team_id = $1 AND id = ANY($2)"
     );
+    let tombstone_query =
+        format!("SELECT id, is_deleted, version FROM {table} WHERE team_id = $1 AND id = ANY($2)");
+    // The flip repoints every one of a source's mappings to the survivor
+    // in the destroying transaction; a mapping left on a tombstone would
+    // resolve events to a person that no longer exists.
+    let leftover_dids_query = crate::seed::distinct_id_tables_for(table)
+        .iter()
+        .map(|pdi_table| {
+            format!(
+                "SELECT person_id, count(*) AS n FROM {pdi_table} \
+                 WHERE team_id = $1 AND person_id = ANY($2) GROUP BY person_id"
+            )
+        })
+        .collect::<Vec<_>>();
+    // The saga's own record of each source's seal. The merge driver
+    // writes the sealed snapshot on the source's op row and settles the
+    // row as deleted when the death document is produced.
+    let sealed_query = "SELECT person_id, (sealed->>'version')::bigint AS sealed_version \
+                        FROM lifecycle_op_person \
+                        WHERE team_id = $1 AND role = 'source' AND status = 'deleted' \
+                          AND person_id = ANY($2)";
     let deadline = Instant::now() + QUIESCE_DEADLINE;
     loop {
         let rows = sqlx::query(&query)
@@ -94,6 +126,62 @@ pub async fn verify_postgres(
             }
         }
 
+        if !merged_ids.is_empty() {
+            let rows = sqlx::query(&tombstone_query)
+                .bind(team)
+                .bind(&merged_ids)
+                .fetch_all(pool)
+                .await
+                .context("reading merged sources from Postgres")?;
+            let mut tombstones: HashMap<i64, (bool, i64)> = HashMap::new();
+            for row in rows {
+                let id: i64 = row.get("id");
+                let is_deleted: bool = row.get("is_deleted");
+                let version: Option<i64> = row.get("version");
+                tombstones.insert(id, (is_deleted, version.unwrap_or(0)));
+            }
+            let mut seals: HashMap<i64, i64> = HashMap::new();
+            for row in sqlx::query(sealed_query)
+                .bind(team)
+                .bind(&merged_ids)
+                .fetch_all(pool)
+                .await
+                .context("reading merge seals from lifecycle_op_person")?
+            {
+                let person_id: i64 = row.get("person_id");
+                let sealed_version: Option<i64> = row.get("sealed_version");
+                if let Some(sealed_version) = sealed_version {
+                    seals.insert(person_id, sealed_version);
+                }
+            }
+            for (person_id, source) in merged {
+                violations.extend(verify_tombstone(
+                    *person_id,
+                    source,
+                    tombstones.get(person_id).copied(),
+                    seals.get(person_id).copied(),
+                ));
+            }
+            for query in &leftover_dids_query {
+                for row in sqlx::query(query)
+                    .bind(team)
+                    .bind(&merged_ids)
+                    .fetch_all(pool)
+                    .await
+                    .context("counting distinct ids left on merged sources")?
+                {
+                    let person_id: i64 = row.get("person_id");
+                    let n: i64 = row.get("n");
+                    violations.push(ConsistencyViolation {
+                        person_id,
+                        key: "__merged_source_dids_left".to_string(),
+                        expected: json!("every mapping repointed to the survivor"),
+                        actual: json!(n),
+                    });
+                }
+            }
+        }
+
         if violations.is_empty() {
             return Ok(violations);
         }
@@ -105,5 +193,105 @@ pub async fn verify_postgres(
             return Ok(violations);
         }
         sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// The decision table for a merged source's row: `row` is
+/// `(is_deleted, version)` or None when the row is gone; `sealed` is the
+/// version the saga recorded at the fence, or None when its op row is
+/// missing.
+pub fn verify_tombstone(
+    person_id: i64,
+    source: &MergedSource,
+    row: Option<(bool, i64)>,
+    sealed: Option<i64>,
+) -> Vec<ConsistencyViolation> {
+    let Some((is_deleted, version)) = row else {
+        return vec![ConsistencyViolation {
+            person_id,
+            key: "__merged_source_row".to_string(),
+            expected: json!("tombstone present"),
+            actual: Value::Null,
+        }];
+    };
+    let mut violations = Vec::new();
+    if !is_deleted {
+        violations.push(ConsistencyViolation {
+            person_id,
+            key: "__merged_source_tombstone".to_string(),
+            expected: json!("is_deleted"),
+            actual: json!(false),
+        });
+    }
+    if version <= source.max_acked_version {
+        violations.push(ConsistencyViolation {
+            person_id,
+            key: "__merged_source_death_version".to_string(),
+            expected: json!(format!("> {} (highest acked)", source.max_acked_version)),
+            actual: json!(version),
+        });
+    }
+    match sealed {
+        Some(sealed) if sealed < source.max_acked_version => {
+            violations.push(ConsistencyViolation {
+                person_id,
+                key: "__merged_source_ack_above_seal".to_string(),
+                expected: json!(format!("no acked version above seal {sealed}")),
+                actual: json!(source.max_acked_version),
+            });
+        }
+        Some(_) => {}
+        None => violations.push(ConsistencyViolation {
+            person_id,
+            key: "__merged_source_seal_record".to_string(),
+            expected: json!("a deleted source row on the merge op"),
+            actual: Value::Null,
+        }),
+    }
+    violations
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys(violations: Vec<ConsistencyViolation>) -> Vec<String> {
+        violations.into_iter().map(|v| v.key).collect()
+    }
+
+    /// A false negative here passes a run in which a write got through
+    /// the fence or the flip never tombstoned the source.
+    #[test]
+    fn tombstone_decision_table() {
+        let source = MergedSource::for_test(2, 7);
+        assert!(verify_tombstone(1, &source, Some((true, 8)), Some(7)).is_empty());
+        assert!(verify_tombstone(1, &source, Some((true, 20)), Some(9)).is_empty());
+        assert_eq!(
+            keys(verify_tombstone(1, &source, None, Some(7))),
+            vec!["__merged_source_row"]
+        );
+        assert_eq!(
+            keys(verify_tombstone(1, &source, Some((false, 8)), Some(7))),
+            vec!["__merged_source_tombstone"]
+        );
+        // Death at the highest acked version: that ack sat above the seal.
+        assert_eq!(
+            keys(verify_tombstone(1, &source, Some((true, 7)), Some(7))),
+            vec!["__merged_source_death_version"]
+        );
+        assert_eq!(
+            keys(verify_tombstone(1, &source, Some((false, 3)), Some(7))),
+            vec!["__merged_source_tombstone", "__merged_source_death_version"]
+        );
+        // The fence failed open: an ack above the recorded seal, even
+        // though the leader's death version cleared it.
+        assert_eq!(
+            keys(verify_tombstone(1, &source, Some((true, 20)), Some(6))),
+            vec!["__merged_source_ack_above_seal"]
+        );
+        assert_eq!(
+            keys(verify_tombstone(1, &source, Some((true, 8)), None)),
+            vec!["__merged_source_seal_record"]
+        );
     }
 }

--- a/rust/personhog-test-harness/src/verify.rs
+++ b/rust/personhog-test-harness/src/verify.rs
@@ -21,14 +21,15 @@ pub const QUIESCE_DEADLINE: Duration = Duration::from_secs(60);
 /// property writes at the acked version, or the quiesce deadline passes.
 /// Returns the outstanding violations (empty = converged).
 ///
-/// Merged sources are held to the tombstone shape the saga's flip writes
-/// (and the writer's death-document projection preserves): the row is
-/// deleted, at a death version above every version the leader acked for
-/// it. The fence itself is checked against the sealed version the saga
-/// recorded on its `lifecycle_op_person` row: the fence seals the source
-/// at its then-current version, so an ack above the seal means a write
-/// got through the fence. The death version alone cannot catch that —
-/// the leader derives it from its current version as well as the seal.
+/// Merged sources are held to the tombstone shape the saga's flip
+/// writes and the writer's death-document projection preserves: the row
+/// is deleted, at a death version above every version the leader acked
+/// for it. The fence itself is checked against the sealed version the
+/// saga recorded on its `lifecycle_op_person` row. The fence seals the
+/// source at its then-current version, so an ack above the seal means a
+/// write got through the fence. The death version alone cannot catch
+/// that, because the leader derives it from its current version as well
+/// as the seal.
 pub async fn verify_postgres(
     pool: &PgPool,
     table: &str,
@@ -50,7 +51,7 @@ pub async fn verify_postgres(
     let tombstone_query =
         format!("SELECT id, is_deleted, version FROM {table} WHERE team_id = $1 AND id = ANY($2)");
     // The flip repoints every one of a source's mappings to the survivor
-    // in the destroying transaction; a mapping left on a tombstone would
+    // in the destroying transaction. A mapping left on a tombstone would
     // resolve events to a person that no longer exists.
     let leftover_dids_query = crate::seed::distinct_id_tables_for(table)
         .iter()
@@ -196,10 +197,10 @@ pub async fn verify_postgres(
     }
 }
 
-/// The decision table for a merged source's row: `row` is
-/// `(is_deleted, version)` or None when the row is gone; `sealed` is the
-/// version the saga recorded at the fence, or None when its op row is
-/// missing.
+/// The decision table for a merged source's row. `row` is
+/// `(is_deleted, version)`, or None when the row is gone. `sealed` is
+/// the version the saga recorded at the fence, or None when its op row
+/// is missing.
 pub fn verify_tombstone(
     person_id: i64,
     source: &MergedSource,
@@ -283,8 +284,8 @@ mod tests {
             keys(verify_tombstone(1, &source, Some((false, 3)), Some(7))),
             vec!["__merged_source_tombstone", "__merged_source_death_version"]
         );
-        // The fence failed open: an ack above the recorded seal, even
-        // though the leader's death version cleared it.
+        // The fence failed open. The ack sits above the recorded seal
+        // even though the leader's death version cleared it.
         assert_eq!(
             keys(verify_tombstone(1, &source, Some((true, 20)), Some(6))),
             vec!["__merged_source_ack_above_seal"]


### PR DESCRIPTION
## Problem

- Nobody can measure what a person merge costs in the personhog leader path, or check that concurrent updates survive one, because the test harness never merges.
- The gate drives property updates through the router and asserts every acked write stays visible, but the durable merge saga (fence, seal, fold, flip, release) has no end-to-end coverage under load or chaos.
- Pathological merges, where a source carries thousands of distinct ids the flip must repoint, have no baseline at all.

## Changes

- `gate --merge-concurrency N [--merge-rate R]` adds a merge lane: workers call `MergePersons` on the identity service against pairs of live persons while blast writers and probers keep writing to both.
- The report gains a `merges` row (p50/p95/p99, RPS), a per-source outcome breakdown, and a count of writes the stack correctly refused for fenced or destroyed persons.
- `--merge-wide-persons N --merge-wide-distinct-ids K --merge-wide-role source|target|both` creates persons with K extra distinct ids and reports their merges on a separate `merges_wide` row.
- The journal folds a merged source into its survivor under the leader's rule (survivor wins every key it has, source fills the rest), ordered by the folded version rather than by ack arrival.
- New invariants: a merged source reads not-found, its row is a tombstone above every acked version, no ack exceeds the sealed version the saga recorded, no distinct id mapping is left on it, and the delete leg answers `not_found` for it.
- A merge call that loses every response settles after traffic from its `lifecycle_op` row by op id; the spawned identity runs the sweeper on a 3s cadence so ops abandoned by a leader kill get re-driven.
- CI runs the merge lane through a leader kill and a scale-up as a new `personhog-gate` step.
- Mechanical: every lane picks from a shared `TargetPool` instead of a fixed id list, so the merge lane can retire destroyed persons.

Rejected alternative: journaling folds in ack order. Two merges into one survivor can ack in the opposite order to their folds, and a late fold into a survivor that was merged on since enters the final survivor at that hop's version. Both showed up as false violations during rehearsal, so the journal records a fold version per key.

## How did you test this code?

New unit tests in `state.rs` and `verify.rs` cover the fold decision table: target wins, tainted keys, out-of-order fold acks, merge chains, late folds into a merged-on survivor, and the tombstone and seal checks. Each was red on the earlier journal shape that produced a false violation.

Local rehearsal against a spawned stack (debug build, docker-compose deps):

- Paced 5 merges/s under a leader kill plus scale-up: six consecutive green runs, including runs where a merge lost every response and settled from its op row.
- Unpaced, 8 workers, 400 persons: ~60 merges/s, zero violations.
- Drain plus writer pause with merges: green.
- Wide persons with 2000 extra distinct ids as source, target, and both: green; a wide source roughly doubles merge latency, and wide-into-wide survivors reach a p95 near 900ms.

Not checked: the continuous `traffic` mode has no merge lane; it only takes the shared pool type.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The harness README documents the new flags, invariants, and violation keys.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) wrote the change with Bash, file edit tools, and background reruns of the gate; skills invoked: `/extending-personhog-test-harness`, `/writing-pr-descriptions`. Every red run during rehearsal traced to a journal-ordering gap rather than the stack, and each became a unit test before the next rehearsal. The second commit renames the many-distinct-id persons from "fat" to "wide" on reviewer request. Two stack observations for follow-up, not changed here: a merge whose target is destroyed concurrently answers `NotFound` instead of re-resolving the target, and the identity sweeper is off by default so an abandoned merge never settles without it.

https://claude.ai/code/session_01GbjKh1uSb51Vp46V3neB2f
