### PR TITLE
feat(signals): split the scout roster's need-you stat into pausing soon and recently paused

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7013,13 +7013,13 @@ snapshots:
     scenes-app-inbox-scoutowners--states--light:
         hash: v1.k794b7964.62cb1889d60cf91cae1d0337da5a9209f4a759a1ccfed6a67dd6d2b238e75f13.qvVHYAWE8wGdD83VE5OOHw6uveEUae2uieDQ6sExrrs
     scenes-app-inbox-scoutsroster--large-fleet--dark:
-        hash: v1.k794b7964.93eef32b387248bc4fb19e860267675bdb55ebd544cf31a4d462db8c27db4c42.LW5WPysIjDR4qLLNitsa4Ba5PORL-Z_psDYcc9pjK2A
+        hash: v1.k794b7964.d3f850509b9a371d4c00c5924a1a2e155f04289a18151d441fb84e222b1a852b.dHr-Gj3Ar63TDyGQKRdm4Bc5neoHiuSa0COc085PElM
     scenes-app-inbox-scoutsroster--large-fleet--light:
-        hash: v1.k794b7964.5559787c8ef2e02afa6df48151b1b8d17fd41fa24c6803720952e4c8fdcab27d.XdEXQe9tPSTtZm4gGNvlIC0lB2FibngNbILHRDQtnEw
+        hash: v1.k794b7964.0d1649bf11cfd25fb3c2a97cb49322f0ec66a860f5730eeb0c0ddc092f800242.icTSsIopncZ0vGf-tP--2i-Lka8KgTw5WbyEfkqsllE
     scenes-app-inbox-scoutsroster--narrow--dark:
-        hash: v1.k794b7964.1feb663b0f7c787baebbb5cb76112af14394d12564bcd84a10f74b4320ce6df7.S20hNzFMJwmUnCS2XnNbS2LL49lgymuQuOUkIWEqeJs
+        hash: v1.k794b7964.18240cfc1a347a0d7cddfe4f15ec43bdae2abfe50cba99ce2af0194b0c44d7f2.BfxJKFbc9Tu9f6sD6XI9vTuqYjEkXjLz-nryfyUoSck
     scenes-app-inbox-scoutsroster--narrow--light:
-        hash: v1.k794b7964.5a75dcc9a78a645e0ca0b5811453e6b975952a00a9ffc6280463b113ad94faea.ulBW3-DilRBC_cyXD6R2MH2g0k_S38zfhKnn3_jWK4I
+        hash: v1.k794b7964.5847e79a80a8853afed7fe2277b22a941f376452496197978a4bf3f9a479b457.QTEj_WDuxJ5v21cCIoSKrf341geSRdAL5ZIlxqfNtLM
     scenes-app-inbox-scoutsroster--roster--dark:
         hash: v1.k794b7964.93f5297e0efc7eb2b3c3f65a27a4a0ed3244dc410d9433f90b48e4ea39d93987.eyirdHer2L8_kERPtGO30CP8DNQfgGx7YF5OeeGWI8M
     scenes-app-inbox-scoutsroster--roster--light:

--- a/products/signals/frontend/inbox/__mocks__/scoutConfigs.ts
+++ b/products/signals/frontend/inbox/__mocks__/scoutConfigs.ts
@@ -165,4 +165,21 @@ export const mockLargeScoutFleet: SignalScoutConfigApi[] = [
         description: 'experiments with unexpected or inconclusive results',
         emit: false,
     }),
+    makeMockScout({
+        id: 'scout-broken',
+        skill_name: 'signals-scout-logs',
+        description: 'error spikes and new failure patterns in application logs',
+        enabled: false,
+        status: 'paused_by_system',
+        pause_reason: 'repeated_failures',
+        consecutive_failure_count: 3,
+        status_changed_at: '2026-06-10T08:00:00Z',
+    }),
+    makeMockScout({
+        id: 'scout-warned',
+        skill_name: 'signals-scout-surveys',
+        description: 'survey responses that point at a product problem',
+        status: 'pending_pause',
+        pause_reason: 'ignored',
+    }),
 ]

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutsRosterStats.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutsRosterStats.tsx
@@ -8,31 +8,38 @@ import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 import { scratchpadLogic } from '../../../logics/scratchpadLogic'
 import { SCOUT_ROSTER_WINDOW_LABEL } from '../../../utils/scoutRunsWindow'
 
+type StatTone = 'muted' | 'warning' | 'danger'
+
+const VALUE_CLASS: Record<StatTone, string> = {
+    muted: 'text-default',
+    warning: 'text-warning',
+    danger: 'text-danger',
+}
+
+const LABEL_CLASS: Record<StatTone, string> = {
+    muted: 'text-muted',
+    warning: 'text-warning',
+    danger: 'text-danger',
+}
+
 function Stat({
     value,
     label,
-    alert = false,
     tooltip,
+    tone = 'muted',
 }: {
     value: string
     label: string
-    alert?: boolean
-    tooltip?: string
+    tooltip: string
+    tone?: StatTone
 }): JSX.Element {
-    const stat = (
-        <span
-            className={cn('flex items-baseline gap-1 whitespace-nowrap text-xs', alert ? 'text-danger' : 'text-muted')}
-        >
-            <span className={cn('font-semibold tabular-nums', alert ? 'text-danger' : 'text-default')}>{value}</span>
-            <span>{label}</span>
-        </span>
-    )
-    return tooltip ? (
+    return (
         <Tooltip title={tooltip}>
-            <span>{stat}</span>
+            <span className={cn('flex items-baseline gap-1 whitespace-nowrap text-xs', LABEL_CLASS[tone])}>
+                <span className={cn('font-semibold tabular-nums', VALUE_CLASS[tone])}>{value}</span>
+                <span>{label}</span>
+            </span>
         </Tooltip>
-    ) : (
-        stat
     )
 }
 
@@ -42,21 +49,40 @@ function Stat({
  * earning its keep.
  */
 export function ScoutsRosterStats(): JSX.Element {
-    const { rosterGroupCounts, enabledCount, emittedFindingsSummary, fleetFindingsSummaryLoadedOnce } =
+    const { pauseAttentionCounts, enabledCount, emittedFindingsSummary, fleetFindingsSummaryLoadedOnce } =
         useValues(scoutFleetLogic)
     // Mounted here rather than by the fleet logic, so the 1,000-entry scratchpad read only happens
     // on the surfaces that show it, not on every inbox tab that mounts the fleet.
-    const { recentlyLearnedCount, entries: scratchpadEntries } = useValues(scratchpadLogic)
+    const { recentlyLearnedCount, recentlyLearnedCountCapped, entries: scratchpadEntries } = useValues(scratchpadLogic)
     // A summary that hasn't landed is not zero runs. The number holds a dash until it does; a failed
     // request keeps the dash rather than claiming a quiet week.
     const summaryValue = (value: number): string => (fleetFindingsSummaryLoadedOnce ? String(value) : '—')
+    const learnedValue =
+        scratchpadEntries === null ? '—' : `${recentlyLearnedCount}${recentlyLearnedCountCapped ? '+' : ''}`
 
     return (
         <div className="ml-auto flex flex-wrap items-center gap-x-3 gap-y-1" data-attr="inbox-scout-stats">
-            {rosterGroupCounts.needs_you > 0 && (
-                <Stat value={String(rosterGroupCounts.needs_you)} label="need you" alert />
+            {pauseAttentionCounts.pausingSoon > 0 && (
+                <Stat
+                    value={String(pauseAttentionCounts.pausingSoon)}
+                    label="pausing soon"
+                    tone="warning"
+                    tooltip="Scouts that will pause themselves: nobody acted on their reports, or they surfaced nothing for a while. They still run. Open one to keep it going."
+                />
             )}
-            <Stat value={String(enabledCount)} label="on patrol" />
+            {pauseAttentionCounts.recentlyPaused > 0 && (
+                <Stat
+                    value={String(pauseAttentionCounts.recentlyPaused)}
+                    label="recently paused"
+                    tone="danger"
+                    tooltip="Scouts that paused themselves: their runs kept failing, nobody acted on their reports, or they surfaced nothing. Open one to turn it back on."
+                />
+            )}
+            <Stat
+                value={String(enabledCount)}
+                label="on patrol"
+                tooltip="Scouts that are turned on and run on their schedule, dry runs included."
+            />
             <Stat
                 value={summaryValue(emittedFindingsSummary.runCount)}
                 label="runs"
@@ -73,9 +99,13 @@ export function ScoutsRosterStats(): JSX.Element {
                 tooltip={`Existing reports your scouts added to in the ${SCOUT_ROSTER_WINDOW_LABEL}.`}
             />
             <Stat
-                value={scratchpadEntries === null ? '—' : String(recentlyLearnedCount)}
+                value={learnedValue}
                 label="learned"
-                tooltip={`Scratchpad entries your scouts wrote or refreshed in the ${SCOUT_ROSTER_WINDOW_LABEL}.`}
+                tooltip={
+                    recentlyLearnedCountCapped
+                        ? `Scratchpad entries your scouts wrote or refreshed in the ${SCOUT_ROSTER_WINDOW_LABEL}. Only the newest 1,000 entries are counted, and all of them fall in this window.`
+                        : `Scratchpad entries your scouts wrote or refreshed in the ${SCOUT_ROSTER_WINDOW_LABEL}.`
+                }
             />
         </div>
     )

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutsRosterStats.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutsRosterStats.tsx
@@ -67,7 +67,7 @@ export function ScoutsRosterStats(): JSX.Element {
                     value={String(pauseAttentionCounts.pausingSoon)}
                     label="pausing soon"
                     tone="warning"
-                    tooltip="Scouts that will pause themselves: nobody acted on their reports, or they surfaced nothing for a while. They still run. Open one to keep it going."
+                    tooltip="Scouts that will pause themselves because nobody acted on their reports. They still run. Open one to keep it going."
                 />
             )}
             {pauseAttentionCounts.recentlyPaused > 0 && (

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
@@ -612,7 +612,7 @@ describe('scoutFleetLogic', () => {
             expect(second?.[1]).toBe(first?.[1])
         })
 
-        it('moves scouts out of cold start when an unchanged runs poll crosses the boundary', async () => {
+        it('advances time-sensitive roster states when an unchanged runs poll crosses a boundary', async () => {
             jest.useFakeTimers()
             try {
                 jest.setSystemTime(Date.UTC(2026, 7, 4))
@@ -624,12 +624,24 @@ describe('scoutFleetLogic', () => {
                 logic = scoutFleetLogic()
                 logic.mount()
                 await expectLogic(logic).toFinishAllListeners()
-                logic.actions.loadScoutConfigsSuccess([BASE_CONFIG])
+                logic.actions.loadScoutConfigsSuccess([
+                    BASE_CONFIG,
+                    {
+                        ...BASE_CONFIG,
+                        id: 'paused',
+                        skill_name: 'signals-scout-paused',
+                        enabled: false,
+                        status: 'paused_by_system',
+                        pause_reason: 'repeated_failures',
+                        status_changed_at: '2026-07-29T00:00:00Z',
+                    },
+                ])
                 logic.actions.loadScoutRuns()
                 await expectLogic(logic).toDispatchActions(['loadScoutRuns', 'loadScoutRunsSuccess'])
                 const firstRuns = logic.values.scoutRuns
 
                 expect(logic.values.rosterScouts[0].group).toBe('settling_in')
+                expect(logic.values.pauseAttentionCounts.recentlyPaused).toBe(1)
 
                 jest.setSystemTime(Date.UTC(2026, 7, 6))
                 logic.actions.loadScoutRuns()
@@ -637,6 +649,7 @@ describe('scoutFleetLogic', () => {
 
                 expect(logic.values.scoutRuns).toBe(firstRuns)
                 expect(logic.values.rosterScouts[0].group).toBe('watching')
+                expect(logic.values.pauseAttentionCounts.recentlyPaused).toBe(0)
             } finally {
                 jest.useRealTimers()
             }

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
@@ -187,6 +187,7 @@ describe('scoutFleetLogic', () => {
     })
 
     it('lists the whole roster A→Z and tags each row with its lifecycle group', () => {
+        logic.actions.setRosterEvaluatedAt(new Date('2026-08-28T12:00:00Z').valueOf())
         logic.actions.loadScoutConfigsSuccess([
             { ...BASE_CONFIG, id: 'quiet', skill_name: 'signals-scout-quiet' },
             { ...BASE_CONFIG, id: 'busy', skill_name: 'signals-scout-busy' },
@@ -204,6 +205,16 @@ describe('scoutFleetLogic', () => {
                 enabled: false,
                 status: 'paused_by_system',
                 pause_reason: 'repeated_failures',
+                status_changed_at: '2026-08-27T12:00:00Z',
+            },
+            {
+                ...BASE_CONFIG,
+                id: 'stale-pause',
+                skill_name: 'signals-scout-stale-pause',
+                enabled: false,
+                status: 'paused_by_system',
+                pause_reason: 'no_output',
+                status_changed_at: '2026-08-20T12:00:00Z',
             },
             {
                 ...BASE_CONFIG,
@@ -222,9 +233,10 @@ describe('scoutFleetLogic', () => {
             ['busy', 'working'],
             ['off', 'off'],
             ['quiet', 'watching'],
+            ['stale-pause', 'needs_you'],
             ['warned', 'needs_you'],
         ])
-        // The stats tell a warning apart from a pause; a human pause is neither.
+        // The stats tell a warning apart from a recent pause; human and stale pauses are neither.
         expect(logic.values.pauseAttentionCounts).toEqual({ pausingSoon: 1, recentlyPaused: 1 })
     })
 

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
@@ -223,6 +223,13 @@ describe('scoutFleetLogic', () => {
                 status: 'pending_pause',
                 pause_reason: 'ignored',
             },
+            {
+                ...BASE_CONFIG,
+                id: 'quiet-warning',
+                skill_name: 'signals-scout-quiet-warning',
+                status: 'pending_pause',
+                pause_reason: 'no_output',
+            },
         ])
         // `busy` filed a report in the window, which is what separates Working from Watching.
         logic.actions.loadScoutRunsSuccess([makeRun({ skill_name: 'signals-scout-busy', emitted_report_ids: ['r-1'] })])
@@ -233,6 +240,7 @@ describe('scoutFleetLogic', () => {
             ['busy', 'working'],
             ['off', 'off'],
             ['quiet', 'watching'],
+            ['quiet-warning', 'needs_you'],
             ['stale-pause', 'needs_you'],
             ['warned', 'needs_you'],
         ])

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.test.ts
@@ -205,6 +205,13 @@ describe('scoutFleetLogic', () => {
                 status: 'paused_by_system',
                 pause_reason: 'repeated_failures',
             },
+            {
+                ...BASE_CONFIG,
+                id: 'warned',
+                skill_name: 'signals-scout-warned',
+                status: 'pending_pause',
+                pause_reason: 'ignored',
+            },
         ])
         // `busy` filed a report in the window, which is what separates Working from Watching.
         logic.actions.loadScoutRunsSuccess([makeRun({ skill_name: 'signals-scout-busy', emitted_report_ids: ['r-1'] })])
@@ -215,7 +222,10 @@ describe('scoutFleetLogic', () => {
             ['busy', 'working'],
             ['off', 'off'],
             ['quiet', 'watching'],
+            ['warned', 'needs_you'],
         ])
+        // The stats tell a warning apart from a pause; a human pause is neither.
+        expect(logic.values.pauseAttentionCounts).toEqual({ pausingSoon: 1, recentlyPaused: 1 })
     })
 
     it('keeps configs unresolved until the current team is available', async () => {

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
@@ -192,7 +192,10 @@ export interface scoutFleetLogicValues {
     fleetSummary: FleetSummary | null
     lastRunAt: string | null
     manualRunScoutIds: string[]
-    pauseAttentionCounts: { pausingSoon: number; recentlyPaused: number }
+    pauseAttentionCounts: {
+        pausingSoon: number
+        recentlyPaused: number
+    }
     rollups: Map<string, ScoutRollup>
     rosterEvaluatedAt: number
     rosterGroupCounts: Record<ScoutGroupKey, number>
@@ -410,15 +413,18 @@ export interface scoutFleetLogicMeta {
             scoutEnabledFilter: ScoutEnabledFilter,
             scoutRosterSort: ScoutRosterSort
         ) => ScoutRosterRow[]
-        pauseAttentionCounts: (scoutConfigs: SignalScoutConfigApi[] | null) => {
-            pausingSoon: number
-            recentlyPaused: number
-        }
         rosterGroupCounts: (
             scoutConfigs: SignalScoutConfigApi[] | null,
             rollups: Map<string, ScoutRollup>,
             rosterEvaluatedAt: number
         ) => Record<ScoutGroupKey, number>
+        pauseAttentionCounts: (
+            scoutConfigs: SignalScoutConfigApi[] | null,
+            rosterEvaluatedAt: number
+        ) => {
+            pausingSoon: number
+            recentlyPaused: number
+        }
         emittedFindingsSummary: (fleetFindingsSummary: FleetFindingsSummaryApi | null) => {
             authoredReportCount: number
             count: number
@@ -879,14 +885,22 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
          * unnarrowed by search, for the same reason as `rosterGroupCounts`.
          */
         pauseAttentionCounts: [
-            (s) => [s.scoutConfigs],
-            (scoutConfigs: SignalScoutConfig[] | null): { pausingSoon: number; recentlyPaused: number } => {
+            (s) => [s.scoutConfigs, s.rosterEvaluatedAt],
+            (
+                scoutConfigs: SignalScoutConfig[] | null,
+                rosterEvaluatedAt: number
+            ): { pausingSoon: number; recentlyPaused: number } => {
                 let pausingSoon = 0
                 let recentlyPaused = 0
+                const windowStart = dayjs(rosterEvaluatedAt).subtract(SCOUT_ROSTER_WINDOW_HOURS, 'hours')
                 for (const config of scoutConfigs ?? []) {
                     if (config.status === 'pending_pause') {
                         pausingSoon += 1
-                    } else if (config.status === 'paused_by_system') {
+                    } else if (
+                        config.status === 'paused_by_system' &&
+                        config.status_changed_at &&
+                        dayjs(config.status_changed_at).isAfter(windowStart)
+                    ) {
                         recentlyPaused += 1
                     }
                 }

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
@@ -192,6 +192,7 @@ export interface scoutFleetLogicValues {
     fleetSummary: FleetSummary | null
     lastRunAt: string | null
     manualRunScoutIds: string[]
+    pauseAttentionCounts: { pausingSoon: number; recentlyPaused: number }
     rollups: Map<string, ScoutRollup>
     rosterEvaluatedAt: number
     rosterGroupCounts: Record<ScoutGroupKey, number>
@@ -409,6 +410,10 @@ export interface scoutFleetLogicMeta {
             scoutEnabledFilter: ScoutEnabledFilter,
             scoutRosterSort: ScoutRosterSort
         ) => ScoutRosterRow[]
+        pauseAttentionCounts: (scoutConfigs: SignalScoutConfigApi[] | null) => {
+            pausingSoon: number
+            recentlyPaused: number
+        }
         rosterGroupCounts: (
             scoutConfigs: SignalScoutConfigApi[] | null,
             rollups: Map<string, ScoutRollup>,
@@ -866,6 +871,26 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                     counts[scoutGroup(config, rollups.get(config.skill_name), now)] += 1
                 }
                 return counts
+            },
+        ],
+        /**
+         * The two scheduler states the stats call out separately: a warned scout still runs and can
+         * be kept, a system-paused one has stopped and needs turning back on. Whole fleet,
+         * unnarrowed by search, for the same reason as `rosterGroupCounts`.
+         */
+        pauseAttentionCounts: [
+            (s) => [s.scoutConfigs],
+            (scoutConfigs: SignalScoutConfig[] | null): { pausingSoon: number; recentlyPaused: number } => {
+                let pausingSoon = 0
+                let recentlyPaused = 0
+                for (const config of scoutConfigs ?? []) {
+                    if (config.status === 'pending_pause') {
+                        pausingSoon += 1
+                    } else if (config.status === 'paused_by_system') {
+                        recentlyPaused += 1
+                    }
+                }
+                return { pausingSoon, recentlyPaused }
             },
         ],
         // Fleet-wide output tally for the "Scout findings" callout, read from the cheap backend

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
@@ -894,7 +894,7 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                 let recentlyPaused = 0
                 const windowStart = dayjs(rosterEvaluatedAt).subtract(SCOUT_ROSTER_WINDOW_HOURS, 'hours')
                 for (const config of scoutConfigs ?? []) {
-                    if (config.status === 'pending_pause') {
+                    if (config.status === 'pending_pause' && config.pause_reason === 'ignored') {
                         pausingSoon += 1
                     } else if (
                         config.status === 'paused_by_system' &&

--- a/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutFleetLogic.ts
@@ -63,6 +63,14 @@ import type { ScoutTagOption } from '../utils/scoutTags'
 export type SignalScoutConfig = SignalScoutConfigApi
 type SignalScoutConfigUpdate = PatchedSignalScoutConfigUpdateApi
 
+function isRecentlySystemPaused(config: SignalScoutConfig, evaluatedAt: Date): boolean {
+    return Boolean(
+        config.status === 'paused_by_system' &&
+        config.status_changed_at &&
+        dayjs(config.status_changed_at).isAfter(dayjs(evaluatedAt).subtract(SCOUT_ROSTER_WINDOW_HOURS, 'hours'))
+    )
+}
+
 /**
  * One `Scout config changed` per field the request carried. A schedule switch patches both
  * `run_interval_minutes` and `run_cron_schedule` at once, and collapsing those into a single event
@@ -892,15 +900,11 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
             ): { pausingSoon: number; recentlyPaused: number } => {
                 let pausingSoon = 0
                 let recentlyPaused = 0
-                const windowStart = dayjs(rosterEvaluatedAt).subtract(SCOUT_ROSTER_WINDOW_HOURS, 'hours')
+                const evaluatedAt = new Date(rosterEvaluatedAt)
                 for (const config of scoutConfigs ?? []) {
                     if (config.status === 'pending_pause' && config.pause_reason === 'ignored') {
                         pausingSoon += 1
-                    } else if (
-                        config.status === 'paused_by_system' &&
-                        config.status_changed_at &&
-                        dayjs(config.status_changed_at).isAfter(windowStart)
-                    ) {
+                    } else if (isRecentlySystemPaused(config, evaluatedAt)) {
                         recentlyPaused += 1
                     }
                 }
@@ -947,7 +951,10 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
                 const rollup = values.rollups.get(config.skill_name)
                 return scoutGroup(config, rollup, evaluatedAt) !== scoutGroup(config, rollup, now)
             })
-            if (groupChanged) {
+            const pauseRecencyChanged = (values.scoutConfigs ?? []).some(
+                (config) => isRecentlySystemPaused(config, evaluatedAt) !== isRecentlySystemPaused(config, now)
+            )
+            if (groupChanged || pauseRecencyChanged) {
                 actions.setRosterEvaluatedAt(now.valueOf())
             }
         },

--- a/products/signals/frontend/inbox/logics/scratchpadLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scratchpadLogic.test.ts
@@ -6,7 +6,7 @@ import { initKeaTests } from '~/test/init'
 
 import type { ScratchpadEntryApi } from 'products/signals/frontend/generated/api.schemas'
 
-import { SCRATCHPAD_PREVIEW_CHARS, scratchpadLogic } from './scratchpadLogic'
+import { SCRATCHPAD_FETCH_LIMIT, SCRATCHPAD_PREVIEW_CHARS, scratchpadLogic } from './scratchpadLogic'
 
 const SCRATCHPAD_URL = '/api/projects/:team_id/signals/scout/scratchpad/'
 
@@ -144,6 +144,26 @@ describe('scratchpadLogic', () => {
         expect(logic.values.visibleEntries).toHaveLength(3)
         // Clearing the box needs no request: the window never went anywhere.
         expect(searchRequests).toHaveLength(1)
+    })
+
+    it('flags the learned count as capped only when a full fetch all falls inside the window', () => {
+        const fresh = (i: number): ScratchpadEntryApi => ({
+            ...entry(`pattern:${i}`, 'note'),
+            updated_at: new Date().toISOString(),
+        })
+        const full = Array.from({ length: SCRATCHPAD_FETCH_LIMIT }, (_, i) => fresh(i))
+
+        logic.actions.loadEntriesSuccess(full)
+        expect(logic.values.recentlyLearnedCount).toBe(SCRATCHPAD_FETCH_LIMIT)
+        expect(logic.values.recentlyLearnedCountCapped).toBe(true)
+
+        // One stale entry in a full fetch means the window ended inside it, so the count is exact.
+        logic.actions.loadEntriesSuccess([...full.slice(1), WHOLE])
+        expect(logic.values.recentlyLearnedCount).toBe(SCRATCHPAD_FETCH_LIMIT - 1)
+        expect(logic.values.recentlyLearnedCountCapped).toBe(false)
+
+        logic.actions.loadEntriesSuccess(full.slice(0, 10))
+        expect(logic.values.recentlyLearnedCountCapped).toBe(false)
     })
 
     it('keeps the card usable when the body lookup fails', async () => {

--- a/products/signals/frontend/inbox/logics/scratchpadLogic.ts
+++ b/products/signals/frontend/inbox/logics/scratchpadLogic.ts
@@ -20,7 +20,7 @@ const SEARCH_DEBOUNCE_MS = 300
 // one read and group/search client-side. The endpoint exposes a `date_to` cursor for
 // walking past the cap; a team that routinely exceeds 1000 wants that wired into a "load
 // more" here, not a bigger single read.
-const SCRATCHPAD_FETCH_LIMIT = 1000
+export const SCRATCHPAD_FETCH_LIMIT = 1000
 // Bodies are an unbounded TextField clamped at 50k chars on write, so a full-fat window of
 // 1000 entries is a payload nobody needs: the card renders a 2-line clamp until you open it.
 // Pull previews for the list and fetch the one body you expand. Sized well past two lines so
@@ -79,6 +79,7 @@ export interface scratchpadLogicValues {
     loadFailed: boolean
     loadingContentKeys: string[]
     recentlyLearnedCount: number
+    recentlyLearnedCountCapped: boolean
     searchFailed: boolean
     searchResults: ScratchpadEntryApi[] | null
     searchResultsLoading: boolean
@@ -151,6 +152,7 @@ export interface scratchpadLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         totalCount: (entries: ScratchpadEntryApi[] | null) => number | null
         recentlyLearnedCount: (entries: ScratchpadEntryApi[] | null) => number
+        recentlyLearnedCountCapped: (entries: ScratchpadEntryApi[] | null, recentlyLearnedCount: number) => boolean
         lastUpdatedAt: (entries: ScratchpadEntryApi[] | null) => string | null
         visibleEntries: (
             entries: ScratchpadEntryApi[] | null,
@@ -314,6 +316,13 @@ export const scratchpadLogic = kea<scratchpadLogicType>([
                 return entries.filter((entry) => entry.updated_at && dayjs(entry.updated_at).isAfter(windowStart))
                     .length
             },
+        ],
+        // Every fetched entry fell inside the window and the fetch hit its cap, so the real count is
+        // higher than the one shown.
+        recentlyLearnedCountCapped: [
+            (s) => [s.entries, s.recentlyLearnedCount],
+            (entries: ScratchpadEntryApi[] | null, recentlyLearnedCount: number): boolean =>
+                entries !== null && entries.length >= SCRATCHPAD_FETCH_LIMIT && recentlyLearnedCount === entries.length,
         ],
         // Entries are newest-first, so the head's timestamp drives the callout's "updated when" hint.
         lastUpdatedAt: [


### PR DESCRIPTION
## Problem

The scouts toolbar shows one red "N need you" stat that mixes two different situations. A scout the scheduler only warned still runs and can be kept, while a scout that paused itself has stopped. The one number does not say which action is due.

The other five stats have no tooltip ("on patrol" has none) or a tooltip that does not explain a capped value. "1000 learned" is the scratchpad fetch limit, not a real count.

## Changes

- "N need you" becomes two stats: "N pausing soon" in amber for warned scouts and "N recently paused" in red for scouts the system paused. Each shows only when its count is above zero.
- Every stat now has a tooltip that says what it counts and, for the two pause stats, what to do next.
- "learned" reads "1000+" when all fetched scratchpad entries fall inside the window, and its tooltip says the fetch caps at 1,000 entries.
- Mechanical: the roster group, status dot, and row subtitle keep the existing `needs_you` grouping. The split lives in a new `pauseAttentionCounts` selector so the group sort and heading do not change.
- Mechanical: the large-fleet story mock gains one system-paused scout and one warned scout so the new stats render in Storybook.

Before, the toolbar read "3 need you" in red ahead of "165 on patrol".

After, from the `ScoutsRoster / LargeFleet` story:

![scout-stats-after](https://raw.githubusercontent.com/PostHog/pr-assets/d0890d38bf348b030d49a2798e5b0d8c6ce83750/2026/08/cb08b3c9-9139-4625-a3ba-06a482dced8f.png)

![scout-stats-tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/43d466ba18670fb4ca1b5117fb0964e1e041556d/2026/08/d9573e87-09f1-48c2-8c8b-81be257ddc37.png)

## How did you test this code?

- `scoutFleetLogic.test.ts`: the roster test gains a `pending_pause` scout and asserts `pauseAttentionCounts` counts it apart from the system-paused one, and counts a human pause as neither.
- `scratchpadLogic.test.ts`: a new case catches the capped flag firing on a partial fetch, or failing to fire on a full fetch that all falls inside the window.
- Rendered the `LargeFleet` story in Storybook with headless Chrome and hovered each of the seven stats to confirm every tooltip renders with the intended text.
- Not run: the full Jest suite and the Storybook visual snapshots. CI covers both.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc under `docs/` mentions the roster stats.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) wrote the change; the assignee directed it. Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`. Session: https://claude.ai/code/session_01EQCBAPuPqTwhppHwhFMHMY

The tooltip sweep and the "1000+" cap marker came from a follow-up in the same session asking that every stat have a tooltip that makes sense.
