### PR TITLE
chore(signals): wait for legacy inbox story to load

### DIFF
--- a/products/signals/frontend/inbox/InboxScene.stories.tsx
+++ b/products/signals/frontend/inbox/InboxScene.stories.tsx
@@ -121,7 +121,10 @@ const LEGACY_FLAGS = {
 }
 
 export const Legacy: Story = {
-    parameters: { featureFlags: LEGACY_FLAGS },
+    parameters: {
+        featureFlags: LEGACY_FLAGS,
+        testOptions: { waitForLoadersToDisappear: true },
+    },
     decorators: [routeTo(urls.inbox('pulls'))],
 }
 


### PR DESCRIPTION
## Problem

🤖 Robot: The legacy inbox visual test sometimes captures the loading state and produces an unstable dark snapshot.

## Changes

- The legacy inbox story now waits for loading indicators to disappear before it takes snapshots.
- This test-only change has no visible product effect.

## How did you test this code?

- Ran the focused Inbox scene visual test three times with Chromium.
- Ran the frontend formatter and linter.
- Ran the frontend TypeScript check.
- Not run: `hogli ci:preflight --fix` because this environment has neither `hogli` nor `flox`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change only controls when a visual test takes its snapshots.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

🤖 Robot: The Pi coding agent used read, edit, bash, and signed commit tools. It followed `/fixing-flaky-tests`, `/writing-tests`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.