### PR TITLE
chore(clickhouse): match events_recent ttl to production at 9 days

### DIFF
--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -6999,7 +6999,7 @@
   ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.sharded_events_recent', '{replica}', _timestamp)
   PARTITION BY toStartOfDay(inserted_at)
   ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid))
-  TTL toDateTime(inserted_at) + INTERVAL 7 DAY
+  TTL toDate(inserted_at) + INTERVAL 9 DAY
   
   SETTINGS ttl_only_drop_parts = 1
   
@@ -12028,7 +12028,7 @@
   ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/77f1df52-4b43-11e9-910f-b8ca3a9b9f3e_{shard}/posthog.sharded_events_recent', '{replica}', _timestamp)
   PARTITION BY toStartOfDay(inserted_at)
   ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid))
-  TTL toDateTime(inserted_at) + INTERVAL 7 DAY
+  TTL toDate(inserted_at) + INTERVAL 9 DAY
   SETTINGS storage_policy = 'hot_to_cold'
   SETTINGS ttl_only_drop_parts = 1
   

--- a/posthog/models/event/sql.py
+++ b/posthog/models/event/sql.py
@@ -670,7 +670,7 @@ def SHARDED_EVENTS_RECENT_TABLE_SQL():
         EVENTS_TABLE_BASE_SQL
         + """PARTITION BY toStartOfDay(inserted_at)
 ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid))
-TTL toDateTime(inserted_at) + INTERVAL 7 DAY
+TTL toDate(inserted_at) + INTERVAL 9 DAY
 {storage_policy}
 SETTINGS ttl_only_drop_parts = 1
 """


### PR DESCRIPTION
## Problem

New ClickHouse environments, CI, and local dev create `events_recent` with a 7-day TTL, while production US and EU now run 9 days. The retention was changed directly on the clusters, so the repo's source of truth drifted.

## Changes

- Fresh `events_recent` tables now get `TTL toDate(inserted_at) + INTERVAL 9 DAY`, matching both production regions.
- Constant only, no migration — existing tables in every environment are unchanged, and the edit reaches only newly created tables.
- The `toDate` truncation drops each daily partition at a fixed boundary instead of trailing the last row's insert time.
- Regenerated the `sharded_events_recent` schema snapshots that pin this CREATE TABLE.

## How did you test this code?

- Confirmed the new expression matches the TTL currently live on `events_recent` in both production regions.
- Ran the `sharded_events_recent` schema snapshot cases (`pytest posthog/clickhouse/test/test_schema.py -k sharded_events_recent`) — both pass, so the updated snapshots match the generated SQL.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal ClickHouse schema constant.

## 🤖 Agent context

**Autonomy:** Human-driven by @tpgilmore (agent-assisted)

- Shaped in a Claude Code session. @tpgilmore directed the change, applied the production TTL alters, and made the final file edit.
- Skills invoked: `/writing-pr-descriptions`.
- A ClickHouse migration was considered and dropped: both production regions were already altered directly, so a constant-only edit keeps fresh creations in sync without a redundant no-op migration.
