### PR TITLE
fix(desktop): restore Command Center task actions

### DIFF
--- a/products/desktop/packages/core/src/command-center/grid.test.ts
+++ b/products/desktop/packages/core/src/command-center/grid.test.ts
@@ -5,7 +5,6 @@ import {
   countActiveTaskCells,
   getCanvasCellId,
   getCellCount,
-  getCellSessionId,
   getExpandedLayout,
   getExpansionCellIndex,
   getGridDimensions,
@@ -231,12 +230,6 @@ describe("terminal cells", () => {
   ])("isTerminalCell($value) -> $expected", ({ value, expected }) => {
     expect(isTerminalCell(value)).toBe(expected);
     expect(getTerminalCellId(value)).toBeNull();
-  });
-});
-
-describe("getCellSessionId", () => {
-  it("formats the cell session id", () => {
-    expect(getCellSessionId(2)).toBe("cc-cell-2");
   });
 });
 

--- a/products/desktop/packages/core/src/command-center/grid.ts
+++ b/products/desktop/packages/core/src/command-center/grid.ts
@@ -223,7 +223,3 @@ export function reflowCells(
 export function clampZoom(value: number): number {
   return Math.round(Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, value)) * 10) / 10;
 }
-
-export function getCellSessionId(cellIndex: number): string {
-  return `cc-cell-${cellIndex}`;
-}

--- a/products/desktop/packages/ui/src/features/command-center/commandCenterStore.test.ts
+++ b/products/desktop/packages/ui/src/features/command-center/commandCenterStore.test.ts
@@ -115,13 +115,11 @@ describe("commandCenterStore", () => {
       ]);
     });
 
-    it("focuses the cell, clears its creating state, and marks the grid curated", () => {
-      useCommandCenterStore.setState({ creatingCells: [3] });
+    it("focuses the cell and marks the grid curated", () => {
       useCommandCenterStore.getState().setBrainrotCell(3);
       const state = useCommandCenterStore.getState();
       expect(state.activeCellIndex).toBe(3);
       expect(state.activeTaskId).toBeNull();
-      expect(state.creatingCells).toEqual([]);
       expect(state.hasAutofilled).toBe(true);
     });
 
@@ -148,13 +146,11 @@ describe("commandCenterStore", () => {
       ]);
     });
 
-    it("focuses the cell, clears its creating state, and marks the grid curated", () => {
-      useCommandCenterStore.setState({ creatingCells: [3] });
+    it("focuses the cell and marks the grid curated", () => {
       useCommandCenterStore.getState().setTerminalCell(3, "term-1");
       const state = useCommandCenterStore.getState();
       expect(state.activeCellIndex).toBe(3);
       expect(state.activeTaskId).toBeNull();
-      expect(state.creatingCells).toEqual([]);
       expect(state.hasAutofilled).toBe(true);
     });
 
@@ -247,20 +243,6 @@ describe("commandCenterStore", () => {
       const state = useCommandCenterStore.getState();
       expect(state.activeTaskId).toBeNull();
       expect(state.activeCellIndex).toBe(0);
-    });
-
-    // Otherwise a "creating" spinner sits on a tile that now holds a session.
-    it("stops marking a filled cell as creating", () => {
-      useCommandCenterStore.setState({
-        cells: [null, null, null, null],
-        creatingCells: [1, 2],
-      });
-
-      useCommandCenterStore
-        .getState()
-        .applyPlacement({ layout: "2x2", cells: [null, "a", null, null] });
-
-      expect(useCommandCenterStore.getState().creatingCells).toEqual([2]);
     });
 
     it("marks the grid curated so autofill can't stuff it later", () => {

--- a/products/desktop/packages/ui/src/features/command-center/commandCenterStore.ts
+++ b/products/desktop/packages/ui/src/features/command-center/commandCenterStore.ts
@@ -15,10 +15,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 export type { LayoutPreset } from "@posthog/core/command-center/grid";
-export {
-  getCellSessionId,
-  getGridDimensions,
-} from "@posthog/core/command-center/grid";
+export { getGridDimensions } from "@posthog/core/command-center/grid";
 
 export type CommandCenterPlacement = {
   kind: "task" | "canvas";
@@ -32,7 +29,6 @@ interface CommandCenterStoreState {
   activeTaskId: string | null;
   activeCellIndex: number | null;
   zoom: number;
-  creatingCells: number[];
   // Persisted so autofill bootstraps the grid only once, not on every remount.
   hasAutofilled: boolean;
   pendingPlacement: CommandCenterPlacement | null;
@@ -63,8 +59,6 @@ interface CommandCenterStoreActions {
   setZoom: (zoom: number) => void;
   zoomIn: () => void;
   zoomOut: () => void;
-  startCreating: (cellIndex: number) => void;
-  stopCreating: (cellIndex: number) => void;
   requestPlacement: (placement: CommandCenterPlacement) => void;
   cancelPlacement: () => void;
 }
@@ -75,7 +69,6 @@ export const COMMAND_CENTER_INITIAL_STATE: CommandCenterStoreState = {
   activeTaskId: null,
   activeCellIndex: null,
   zoom: 1,
-  creatingCells: [],
   hasAutofilled: false,
   pendingPlacement: null,
 };
@@ -106,7 +99,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
                 : null,
             layout: preset,
             cells,
-            creatingCells: state.creatingCells.filter((i) => i < newCount),
           };
         }),
 
@@ -129,7 +121,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
             // Highlight where it landed — otherwise a task dropped into an
             // empty tile of a busy grid is easy to miss.
             activeCellIndex: cellIndex,
-            creatingCells: state.creatingCells.filter((i) => i !== cellIndex),
             // Manually placing a task counts as curating the grid.
             hasAutofilled: true,
             pendingPlacement: null,
@@ -150,7 +141,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
             cells,
             activeTaskId: null,
             activeCellIndex: cellIndex,
-            creatingCells: state.creatingCells.filter((i) => i !== cellIndex),
             hasAutofilled: true,
             pendingPlacement: null,
           };
@@ -165,7 +155,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
             cells,
             activeTaskId: null,
             activeCellIndex: cellIndex,
-            creatingCells: state.creatingCells.filter((i) => i !== cellIndex),
             hasAutofilled: true,
           };
         }),
@@ -179,7 +168,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
             cells,
             activeTaskId: null,
             activeCellIndex: cellIndex,
-            creatingCells: state.creatingCells.filter((i) => i !== cellIndex),
             hasAutofilled: true,
           };
         }),
@@ -203,9 +191,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
                   state.activeCellIndex < cells.length
                 ? state.activeCellIndex
                 : null,
-            creatingCells: state.creatingCells.filter(
-              (i) => i < cells.length && cells[i] == null,
-            ),
             // A bulk placement is the user curating the grid, so the one-shot
             // autofill must not later stuff tiles behind their back.
             hasAutofilled: true,
@@ -248,7 +233,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
             cells,
             activeTaskId,
             activeCellIndex: activeTaskId ? cells.indexOf(activeTaskId) : null,
-            creatingCells: [],
           };
         }),
 
@@ -284,7 +268,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
           activeTaskId: null,
           activeCellIndex: null,
           cells: state.cells.map(() => null),
-          creatingCells: [],
         })),
 
       setZoom: (zoom) => set({ zoom: clampZoom(zoom) }),
@@ -292,18 +275,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
         set((state) => ({ zoom: clampZoom(state.zoom + ZOOM_STEP) })),
       zoomOut: () =>
         set((state) => ({ zoom: clampZoom(state.zoom - ZOOM_STEP) })),
-
-      startCreating: (cellIndex) =>
-        set((state) => ({
-          creatingCells: state.creatingCells.includes(cellIndex)
-            ? state.creatingCells
-            : [...state.creatingCells, cellIndex],
-        })),
-
-      stopCreating: (cellIndex) =>
-        set((state) => ({
-          creatingCells: state.creatingCells.filter((i) => i !== cellIndex),
-        })),
 
       requestPlacement: (placement) => set({ pendingPlacement: placement }),
       cancelPlacement: () => set({ pendingPlacement: null }),
@@ -317,7 +288,6 @@ export const useCommandCenterStore = create<CommandCenterStore>()(
         activeTaskId: state.activeTaskId,
         activeCellIndex: state.activeCellIndex,
         zoom: state.zoom,
-        creatingCells: state.creatingCells,
         hasAutofilled: state.hasAutofilled,
       }),
     },

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.test.tsx
@@ -1,0 +1,112 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommandCenterCellData } from "../hooks/useCommandCenterData";
+
+const mocks = vi.hoisted(() => ({
+  openTask: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/router/useOpenTask", () => ({
+  openTask: (...args: unknown[]) => mocks.openTask(...args),
+}));
+vi.mock("@posthog/ui/features/canvas/freeform/FreeformCanvasView", () => ({
+  FreeformCanvasView: () => null,
+}));
+vi.mock("@posthog/ui/features/canvas/grid/GridCanvasView", () => ({
+  GridCanvasView: () => null,
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/useDashboards", () => ({
+  useDashboard: () => ({ dashboard: null, isLoading: false }),
+}));
+vi.mock("@posthog/ui/features/terminal/destroyShellTerminal", () => ({
+  destroyShellTerminal: vi.fn(),
+}));
+vi.mock("@posthog/ui/features/terminal/ShellTerminal", () => ({
+  ShellTerminal: () => null,
+}));
+vi.mock("@posthog/ui/shell/analytics", () => ({ track: vi.fn() }));
+vi.mock("@posthog/ui/shell/useHostCapabilities", () => ({
+  useHostCapabilities: () => ({ localWorkspaces: true }),
+}));
+vi.mock("@posthog/ui/utils/random", () => ({
+  secureRandomString: () => "random",
+}));
+vi.mock("@radix-ui/themes", () => ({
+  Flex: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+vi.mock("../../folders/useFolders", () => ({
+  useFolders: () => ({
+    getRecentFolders: () => [],
+    getFolderDisplayName: () => "",
+  }),
+}));
+vi.mock("../../git-interaction/useCloudPrUrl", () => ({
+  useCloudPrUrl: () => null,
+}));
+vi.mock("../../sessions/components/EmbeddedSessionView", () => ({
+  EmbeddedSessionView: () => <div>session</div>,
+}));
+vi.mock("../../sidebar/components/items/TaskIcon", () => ({
+  TaskIcon: () => null,
+}));
+vi.mock("../../sidebar/useTaskPrStatus", () => ({
+  useTaskPrStatus: () => ({ prState: null, hasDiff: false }),
+}));
+vi.mock("../commandCenterStore", () => ({
+  useCommandCenterStore: (
+    selector: (state: { clearCell: () => void }) => unknown,
+  ) => selector({ clearCell: vi.fn() }),
+}));
+vi.mock("./CommandCenterPRButton", () => ({
+  CommandCenterPRButton: () => null,
+}));
+vi.mock("./TaskSelector", () => ({
+  TaskSelector: ({ children }: { children: ReactNode }) => children,
+}));
+
+import { CommandCenterPanel } from "./CommandCenterPanel";
+
+const task = {
+  id: "task-1",
+  task_number: 1,
+  slug: "task-1",
+  title: "Fix Command Center",
+  description: "",
+  created_at: "2026-08-28T00:00:00.000Z",
+  updated_at: "2026-08-28T00:00:00.000Z",
+  origin_product: "code",
+  channel: "channel-1",
+} satisfies Task;
+
+const cell = {
+  cellIndex: 0,
+  taskId: task.id,
+  task,
+  session: undefined,
+  status: "idle",
+  repoName: null,
+  workspaceMode: null,
+  isBrainrot: false,
+  canvasId: null,
+  terminalId: null,
+  terminalCwd: null,
+} satisfies CommandCenterCellData;
+
+describe("CommandCenterPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves the task's space when opening it", () => {
+    render(<CommandCenterPanel cell={cell} isActiveSession={false} />);
+
+    fireEvent.click(screen.getByTitle("Open task"));
+
+    expect(mocks.openTask).toHaveBeenCalledWith(task, {
+      channelId: "channel-1",
+    });
+  });
+});

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
@@ -37,12 +37,10 @@ import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useFolders } from "../../folders/useFolders";
 import { useCloudPrUrl } from "../../git-interaction/useCloudPrUrl";
-import { useDraftStore } from "../../message-editor/draftStore";
 import { EmbeddedSessionView } from "../../sessions/components/EmbeddedSessionView";
 import { TaskIcon } from "../../sidebar/components/items/TaskIcon";
 import { useTaskPrStatus } from "../../sidebar/useTaskPrStatus";
-import { TaskInput } from "../../task-detail/components/TaskInput";
-import { getCellSessionId, useCommandCenterStore } from "../commandCenterStore";
+import { useCommandCenterStore } from "../commandCenterStore";
 import type {
   CellStatus,
   CommandCenterCellData,
@@ -126,20 +124,11 @@ function EmptyCell({ cellIndex }: { cellIndex: number }) {
   const [selectorOpen, setSelectorOpen] = useState(false);
   // The command-center terminal is unavailable on cloud-only hosts.
   const { localWorkspaces } = useHostCapabilities();
-  const isCreating = useCommandCenterStore((s) =>
-    s.creatingCells.includes(cellIndex),
-  );
-  const assignTask = useCommandCenterStore((s) => s.assignTask);
   const setBrainrotCell = useCommandCenterStore((s) => s.setBrainrotCell);
   const setTerminalCell = useCommandCenterStore((s) => s.setTerminalCell);
-  const startCreating = useCommandCenterStore((s) => s.startCreating);
-  const stopCreating = useCommandCenterStore((s) => s.stopCreating);
   const layout = useCommandCenterStore((s) => s.layout);
   const cells = useCommandCenterStore((s) => s.cells);
   const brainrotMode = useSettingsStore((s) => s.brainrotMode);
-  const clearDraft = useDraftStore((s) => s.actions.setDraft);
-
-  const sessionId = getCellSessionId(cellIndex);
 
   const handleBrainrot = useCallback(() => {
     track(ANALYTICS_EVENTS.BRAINROT_ACTIVATED, {
@@ -156,56 +145,6 @@ function EmptyCell({ cellIndex }: { cellIndex: number }) {
     [setTerminalCell, cellIndex],
   );
 
-  const handleTaskCreated = useCallback(
-    (task: Task) => {
-      assignTask(cellIndex, task.id);
-      clearDraft(sessionId, null);
-    },
-    [assignTask, cellIndex, clearDraft, sessionId],
-  );
-
-  const handleCancel = useCallback(() => {
-    stopCreating(cellIndex);
-    clearDraft(sessionId, null);
-  }, [stopCreating, cellIndex, clearDraft, sessionId]);
-
-  const wasCreatingRef = useRef(false);
-  useEffect(() => {
-    if (wasCreatingRef.current && !isCreating) {
-      clearDraft(sessionId, null);
-    }
-    wasCreatingRef.current = isCreating;
-  }, [isCreating, clearDraft, sessionId]);
-
-  if (isCreating) {
-    return (
-      <Flex direction="column" height="100%">
-        <Flex
-          align="center"
-          justify="between"
-          px="2"
-          py="1"
-          className="shrink-0 border-gray-6 border-b"
-        >
-          <Text className="font-medium font-mono text-[11px] text-gray-11">
-            New task
-          </Text>
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="flex h-5 w-5 items-center justify-center rounded text-gray-10 transition-colors hover:bg-gray-4 hover:text-gray-12"
-            title="Cancel"
-          >
-            <X size={12} />
-          </button>
-        </Flex>
-        <Flex direction="column" className="min-h-0 flex-1">
-          <TaskInput sessionId={sessionId} onTaskCreated={handleTaskCreated} />
-        </Flex>
-      </Flex>
-    );
-  }
-
   return (
     <Flex align="center" justify="center" height="100%">
       <Flex direction="column" align="center" gap="2" className="select-none">
@@ -213,7 +152,6 @@ function EmptyCell({ cellIndex }: { cellIndex: number }) {
           cellIndex={cellIndex}
           open={selectorOpen}
           onOpenChange={setSelectorOpen}
-          onNewTask={() => startCreating(cellIndex)}
           onNewTerminal={localWorkspaces ? handleNewTerminal : undefined}
           onBrainrot={brainrotMode ? handleBrainrot : undefined}
         >
@@ -544,7 +482,9 @@ function PopulatedCell({
   const clearCell = useCommandCenterStore((s) => s.clearCell);
 
   const handleExpand = useCallback(() => {
-    void openTask(cell.task);
+    void openTask(cell.task, {
+      channelId: cell.task.channel ?? undefined,
+    });
   }, [cell.task]);
 
   const handleRemove = useCallback(() => {

--- a/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.test.tsx
@@ -1,7 +1,11 @@
 import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const openTaskInput = vi.hoisted(() => vi.fn());
+
+vi.mock("@posthog/ui/router/useOpenTask", () => ({ openTaskInput }));
 
 vi.mock("@posthog/ui/features/command-center/hooks/useAvailableTasks", () => ({
   useAvailableTasks: () => [],
@@ -40,6 +44,10 @@ function expectPopupWidth(input: HTMLElement) {
 }
 
 describe("TaskSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("keeps the task popup wider than its compact trigger", () => {
     renderSelector();
 
@@ -52,5 +60,13 @@ describe("TaskSelector", () => {
     await userEvent.click(screen.getByRole("button", { name: "Terminal" }));
 
     expectPopupWidth(screen.getByPlaceholderText("Search folders..."));
+  });
+
+  it("opens the full task composer for a new task", async () => {
+    renderSelector();
+
+    await userEvent.click(screen.getByRole("button", { name: "New task" }));
+
+    expect(openTaskInput).toHaveBeenCalledOnce();
   });
 });

--- a/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.tsx
@@ -17,7 +17,6 @@ interface TaskSelectorProps {
   cellIndex: number;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onNewTask?: () => void;
   onNewTerminal?: (cwd?: string) => void;
   onBrainrot?: () => void;
   children: ReactNode;
@@ -30,7 +29,6 @@ export function TaskSelector({
   cellIndex,
   open,
   onOpenChange,
-  onNewTask,
   onNewTerminal,
   onBrainrot,
   children,
@@ -63,12 +61,8 @@ export function TaskSelector({
 
   const handleNewTask = useCallback(() => {
     handleOpenChange(false);
-    if (onNewTask) {
-      onNewTask();
-    } else {
-      openTaskInput();
-    }
-  }, [handleOpenChange, onNewTask]);
+    openTaskInput();
+  }, [handleOpenChange]);
 
   const handleNewTerminal = useCallback(() => {
     if (folders.length > 1) {


### PR DESCRIPTION
## Problem

Tasks expanded from Command Center lose their Space context, so the task view does not show its copy-link action. Empty tiles also use an outdated embedded composer.

## Changes

- Expanded tasks now open inside their Space, which restores the copy-link action.
- New tasks now open the standard full-page composer.
- The obsolete per-tile creation state and helper are removed mechanically.
- Screenshots are omitted because this changes navigation between existing screens, not their styling.

## How did you test this code?

- Added a component test that guards Space-aware task expansion.
- Extended the selector test to guard full-page composer navigation.
- Ran focused Vitest suites for Command Center UI and grid behavior.
- Ran UI, core, and web typechecks, plus host-boundary and mobile-baseline checks.
- Not manually tested in the desktop app.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The desktop docs do not describe this transitional navigation behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The PostHog Slack app used repository and shell tools. Invoked `/writing-tests`, `/writing-ui-components`, `/announcing-behavior-changes`, and `/writing-pr-descriptions`.

The regression tests use invented task data. No private conversation content appears in the public artifacts.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787933572716089?thread_ts=1787933572.716089&cid=C09G8Q32R6F)*
