### PR TITLE
feat(actions): replace the intro card with the product empty state

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -61,6 +61,7 @@ tiles, or `FeaturePreviewSceneGate` rather than scene empty states.
 | Workflows              | `products/workflows/frontend/WorkflowsScene.tsx`                                    | in review             |
 | Marketing analytics    | `frontend/src/scenes/marketing-analytics/MarketingAnalyticsScene.tsx`               | in review             |
 | Customer analytics     | `products/customer_analytics/frontend/CustomerAnalyticsScene.tsx`                   | in review             |
+| Actions                | `products/actions/frontend/pages/Actions.tsx`                                       | on master             |
 
 Only four products resolve their status at app boot, via a `setupProbe` in their manifest:
 LLM analytics, error tracking, MCP analytics, web analytics.
@@ -81,7 +82,6 @@ These are the scenes a new user is most likely to land on before they have data.
 | Single empty dashboard | `frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx` | `ProductIntroduction`                                                                  |
 | Cohorts                | `frontend/src/scenes/cohorts/Cohorts.tsx`                   | `ProductIntroduction`, plus a second table-level empty state                           |
 | Annotations            | `frontend/src/scenes/annotations/Annotations.tsx`           | `ProductIntroduction`                                                                  |
-| Actions                | `products/actions/frontend/components/ActionsTable.tsx`     | `ProductIntroduction`                                                                  |
 
 ### Tier 2: cheap, or actively misleading today
 

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1752,6 +1752,10 @@ snapshots:
         hash: v1.k794b7964.a3e65d5201b873423bb6d077e88fcad12715ee293bdedcf5a2dc78efbc2d0cda.VSPF0yHLd7eCx-17S2ASvg21MoomuY6VOjuxq3oPQmI
     components-playerinspector-itemsessionchange--session-previous--light:
         hash: v1.k794b7964.33ce327f146d06d1412d431080ac84ae39558411b2073fe18a2ed98d834a2681.FDbDlC4-qfrH2RR1F_KpijnZNM9Ss_4s-p19Ee8fGtY
+    components-product-empty-state--actions-needs-setup--dark:
+        hash: v1.k794b7964.10ab8bd219c3110809c99653076caeaf5088284a876c9ab1aadb8a06d881b210.EucMhcIMbn1Z41tBACbSV89kJkEYWgjTkwl7THDWL0c
+    components-product-empty-state--actions-needs-setup--light:
+        hash: v1.k794b7964.6c495049afd9798382f53acd004c500608181045e9c2bef81c66ab9feb535a6b.TbUx7yVN6P2hiijY7RK9j5a0vrRDkN1WQAKcOPhfUZk
     components-product-empty-state--ai-observability-needs-setup--dark:
         hash: v1.k794b7964.f10735d00b8b7484f071fdcaebec654ef0042bf7894e374cbe077acb88d1de1f.DVP2UF6lwJvd5PyN12NBZIhS9EOv5z-N0T-aYKrAONw
     components-product-empty-state--ai-observability-needs-setup--light:
@@ -6201,9 +6205,9 @@ snapshots:
     scenes-app-data-management-actions--action--light:
         hash: v1.k794b7964.beb09296b4cd231bcc6b8067b8976e50e541095f18ec43f4523349ca0efc89a4.dEJitejN7lJT0FU6gQAaF5ydaZd_RGES2jbQNI4WuDw
     scenes-app-data-management-actions--actions-list--dark:
-        hash: v1.k794b7964.9f9b23bfb4431c3c1a5f881b171b8a25023f2dc0ef9e691e082984463a3c90f9.zRTh4Nciph_51htqF6G-W7dWAKfhZJieNI7gz5RnopI
+        hash: v1.k794b7964.bd5168e579fa746d3f0fe22cd50e94e879f638b594e39b93ed3cbf329d797045.t0zAJGmPzUfxAEBp7io3QgPwzbXoekfensWiOF3PmVo
     scenes-app-data-management-actions--actions-list--light:
-        hash: v1.k794b7964.4d0504ac873c3c206bbe5b25826e799db95d6d5135bdd0cadc2e90569978c7d3.E87ZnWHKbQXbovA8jqN1cp7GTqLVNZB74m6M2h-zxtU
+        hash: v1.k794b7964.cbca06140c5a7e89a6a42b316248dc0bfd96a9081da2ec658f5e2c7d508b8309.8CEchtwyS8jC91RTRJkZHXqoKwGQCTQNNpamYIuRZPU
     scenes-app-data-management-actions--new-action--dark:
         hash: v1.k794b7964.ba971e6b4e8a8e72c512b1edc53fc699eff7142f207aed6e1d22e4cc79d18c9c.WK1mMQL1L81fqQ7rDdXG0tr5I9kdtzLDkznyHOd7bN8
     scenes-app-data-management-actions--new-action--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -2,6 +2,7 @@ import { Meta } from '@storybook/react'
 
 import type { Mocks } from '~/mocks/utils'
 
+import { actionsEmptyState } from 'products/actions/frontend/emptyState/actionsEmptyState'
 import { aiObservabilityEmptyState } from 'products/ai_observability/frontend/emptyState/aiObservabilityEmptyState'
 import { llmPromptsEmptyState } from 'products/ai_observability/frontend/emptyState/llmPromptsEmptyState'
 import { webScriptsEmptyState } from 'products/cdp/frontend/emptyState/webScriptsEmptyState'
@@ -166,3 +167,12 @@ export const ReplayVisionNeedsSetup: ProductEmptyStateStory = productEmptyStateS
         },
     }
 )
+
+// Actions detection lists actions on mount - answer "none yet".
+const actionsMocks = {
+    get: { '/api/projects/:team_id/actions/': [200, { count: 0, results: [] }] },
+} as const
+
+export const ActionsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(actionsEmptyState, 'needs-setup', {
+    mocks: actionsMocks,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2266,6 +2266,9 @@ importers:
 
   products/actions:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.10.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22439,8 +22442,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.474.0:
-    resolution: {integrity: sha512-YSoKMESTCa5zLNqXKI6sKUV1B/RZKU31k9Fmj6yFLndRMixYXyqXVF15Qkobtc1apqJaVZ1XvCl4PIlk5SpJYw==}
+  unlayer-types@1.471.0:
+    resolution: {integrity: sha512-f3FNjzFPhBAe2nxy7Jc2bKp8gIpD7QbhOpR/A/Ce8cc2NBV3ehfjVLINjng2j2AMQZPGE6VtcbGU03Dg7kcwTw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -42902,7 +42905,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.474.0
+      unlayer-types: 1.471.0
 
   react-grid-layout@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -45217,7 +45220,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.474.0: {}
+  unlayer-types@1.471.0: {}
 
   unpipe@1.0.0: {}
 

--- a/products/actions/frontend/components/ActionsTable.tsx
+++ b/products/actions/frontend/components/ActionsTable.tsx
@@ -6,7 +6,6 @@ import { LemonInput } from '@posthog/lemon-ui'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { MemberSelectMultiplePopover } from 'lib/components/MemberSelectMultiplePopover'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { TagSelect } from 'lib/components/TagSelect'
 import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -23,7 +22,6 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
 import { InsightVizNode, NodeKind, ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 import {
@@ -37,14 +35,11 @@ import {
 import { ACTIONS_PER_PAGE, actionsLogic } from '../logics/actionsLogic'
 import { ActionStepConditions, ActionStepSummary } from '../utils/actionStepDescription'
 import { deleteActionWithWarning } from '../utils/deleteAction'
-import { NewActionButton } from './NewActionButton'
 
 export function ActionsTable(): JSX.Element {
-    const { actionsList, actionCount, actionsResponseLoading, page, filters, searchTerm, shouldShowEmptyState } =
-        useValues(actionsLogic)
+    const { actionsList, actionCount, actionsResponseLoading, page, filters, searchTerm } = useValues(actionsLogic)
     const { setSearchTerm, setFilters, setPage, pinAction, unpinAction, loadActions } = useActions(actionsLogic)
     const { addProductIntentForCrossSell } = useActions(teamLogic)
-    const { updateHasSeenProductIntroFor } = useActions(userLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const referenceCountEnabled = !!featureFlags[FEATURE_FLAGS.ACTION_REFERENCE_COUNT]
 
@@ -235,66 +230,46 @@ export function ActionsTable(): JSX.Element {
 
     return (
         <div data-attr="manage-events-table">
-            <ProductIntroduction
-                productName="Actions"
-                productKey={ProductKey.ACTIONS}
-                thingName="action"
-                isEmpty={shouldShowEmptyState}
-                description="Use actions to combine events that you want to have tracked together or to make detailed Autocapture events easier to reuse."
-                docsURL="https://posthog.com/docs/data/actions"
-                actionElementOverride={
-                    <NewActionButton onSelectOption={() => updateHasSeenProductIntroFor(ProductKey.ACTIONS)} />
-                }
-                mcpSurfaceKey="actions.create"
-            />
-            {!shouldShowEmptyState && (
-                <>
-                    <div className="flex items-center justify-between gap-2 flex-wrap mb-4">
-                        <LemonInput
-                            type="search"
-                            placeholder="Search for actions"
-                            onChange={setSearchTerm}
-                            value={searchTerm}
-                        />
-                        <div className="flex items-center gap-2 flex-wrap">
-                            <span>Filter to:</span>
-                            <TagSelect
-                                defaultLabel="Any tags"
-                                value={filters.tags}
-                                onChange={(tags) => setFilters({ tags })}
-                            />
-                            <MemberSelectMultiplePopover
-                                value={filters.createdBy}
-                                onChange={(ids) => setFilters({ createdBy: ids })}
-                            />
-                        </div>
-                    </div>
-                    <LemonTable
-                        columns={columns}
-                        loading={actionsResponseLoading}
-                        rowKey="id"
-                        data-attr="actions-table"
-                        dataSource={actionsList}
-                        sorting={sorting}
-                        onSort={(newSorting) =>
-                            setFilters({
-                                ordering: newSorting
-                                    ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
-                                    : '-created_by',
-                            })
-                        }
-                        pagination={{
-                            controlled: true,
-                            currentPage: page,
-                            entryCount: actionCount,
-                            pageSize: ACTIONS_PER_PAGE,
-                            onForward: page * ACTIONS_PER_PAGE < actionCount ? () => setPage(page + 1) : undefined,
-                            onBackward: page > 1 ? () => setPage(page - 1) : undefined,
-                        }}
-                        emptyState="No results. Create a new action?"
+            <div className="flex items-center justify-between gap-2 flex-wrap mb-4">
+                <LemonInput
+                    type="search"
+                    placeholder="Search for actions"
+                    onChange={setSearchTerm}
+                    value={searchTerm}
+                />
+                <div className="flex items-center gap-2 flex-wrap">
+                    <span>Filter to:</span>
+                    <TagSelect defaultLabel="Any tags" value={filters.tags} onChange={(tags) => setFilters({ tags })} />
+                    <MemberSelectMultiplePopover
+                        value={filters.createdBy}
+                        onChange={(ids) => setFilters({ createdBy: ids })}
                     />
-                </>
-            )}
+                </div>
+            </div>
+            <LemonTable
+                columns={columns}
+                loading={actionsResponseLoading}
+                rowKey="id"
+                data-attr="actions-table"
+                dataSource={actionsList}
+                sorting={sorting}
+                onSort={(newSorting) =>
+                    setFilters({
+                        ordering: newSorting
+                            ? `${newSorting.order === -1 ? '-' : ''}${newSorting.columnKey}`
+                            : '-created_by',
+                    })
+                }
+                pagination={{
+                    controlled: true,
+                    currentPage: page,
+                    entryCount: actionCount,
+                    pageSize: ACTIONS_PER_PAGE,
+                    onForward: page * ACTIONS_PER_PAGE < actionCount ? () => setPage(page + 1) : undefined,
+                    onBackward: page > 1 ? () => setPage(page - 1) : undefined,
+                }}
+                emptyState="No results. Create a new action?"
+            />
         </div>
     )
 }

--- a/products/actions/frontend/emptyState/ActionsPreview.scss
+++ b/products/actions/frontend/emptyState/ActionsPreview.scss
@@ -1,0 +1,302 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.ActionPreview {
+    --action-preview-accent: var(--empty-state-accent, var(--color-product-actions-light));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden click state. A direct child of .ActionPreview so `:checked ~` reaches all cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__app,
+    &__panel {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Before/after pairs are stacked on one grid cell and crossfaded, so sending the
+    // event never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-after {
+        @include preview-swap-hidden;
+    }
+
+    &__when-before {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    // Mini pricing page
+
+    &__chrome {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+        padding: 0.4375rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__url {
+        margin-left: 0.375rem;
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        color: var(--color-text-secondary);
+    }
+
+    &__screen {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 0.75rem;
+    }
+
+    &__plan {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.625rem;
+        font-size: 0.75rem;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: var(--radius);
+    }
+
+    &__plan-name {
+        font-weight: 500;
+    }
+
+    &__plan-price {
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-secondary);
+    }
+
+    &__cta {
+        display: block;
+        padding: 0.4375rem 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--color-bg-surface-primary);
+        text-align: center;
+        cursor: pointer;
+        user-select: none;
+        background: var(--action-preview-accent);
+        border-radius: var(--radius);
+        transition: filter 150ms ease;
+    }
+
+    &__cta:hover {
+        filter: brightness(1.05);
+    }
+
+    &__toast-slot {
+        min-height: 1.5rem;
+    }
+
+    &__toast-spacer {
+        min-height: 1.5rem;
+    }
+
+    &__toast {
+        align-self: center;
+        padding: 0.25rem 0.5rem;
+        font-family: var(--font-mono);
+        font-size: 0.625rem;
+        background: color-mix(in oklab, var(--action-preview-accent) 12%, var(--color-bg-surface-primary));
+        border: 1px solid color-mix(in oklab, var(--action-preview-accent) 35%, transparent);
+        border-radius: var(--radius);
+
+        @include preview-accent-text(var(--action-preview-accent));
+    }
+
+    &__hint {
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+        text-align: center;
+    }
+
+    // Actions panel
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+    }
+
+    &__dot {
+        width: 7px;
+        height: 7px;
+        background: var(--action-preview-accent);
+        border-radius: 50%;
+    }
+
+    &__action {
+        display: flex;
+        flex-direction: column;
+        gap: 0.0625rem;
+        overflow: hidden;
+    }
+
+    &__name {
+        overflow: hidden;
+        font-size: 0.6875rem;
+        font-weight: 600;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__match {
+        overflow: hidden;
+        font-family: var(--font-mono);
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__badge {
+        padding: 0 0.3125rem;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        white-space: nowrap;
+        background: color-mix(in oklab, var(--action-preview-accent) 12%, var(--color-bg-surface-primary));
+        border-radius: 999px;
+
+        @include preview-accent-text(var(--action-preview-accent));
+    }
+
+    &__count {
+        font-size: 0.6875rem;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-secondary);
+        text-align: right;
+    }
+
+    &__count--bumped {
+        @include preview-accent-text(var(--action-preview-accent));
+    }
+
+    // Sign-ups stat + sparkline, inside the actions panel
+
+    &__spark {
+        padding: 0.5rem 0.75rem 0.625rem;
+        border-top: 1px solid var(--color-border-primary);
+    }
+
+    &__spark-value {
+        font-size: 1.25rem;
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--action-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--action-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--action-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: ActionPreview__trace 3.2s linear infinite;
+    }
+
+    @include preview-chrome-dot;
+    @include preview-sparkline;
+}
+
+// Clicked state (user sent the event)
+
+.ActionPreview__checkbox:checked ~ * .ActionPreview__when-after {
+    @include preview-swap-visible;
+}
+
+.ActionPreview__checkbox:checked ~ * .ActionPreview__when-before {
+    @include preview-swap-hidden;
+}
+
+.ActionPreview__checkbox:checked ~ .ActionPreview__panel .ActionPreview__row--hero {
+    background: color-mix(in oklab, var(--action-preview-accent) 8%, transparent);
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the button it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.ActionPreview__checkbox:focus-visible ~ .ActionPreview__app .ActionPreview__cta {
+    outline: 2px solid var(--action-preview-accent);
+    outline-offset: 1px;
+}
+
+// Nudge attention at the trial button until it's clicked.
+.ActionPreview:not(.ActionPreview--static)
+    .ActionPreview__checkbox:not(:checked)
+    ~ .ActionPreview__app
+    .ActionPreview__cta {
+    animation: ActionPreview__nudge 2.4s ease-in-out infinite;
+}
+
+@keyframes ActionPreview__nudge {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--action-preview-accent) 45%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--action-preview-accent) 20%, transparent);
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes ActionPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; clicking the
+// trial button still flips the state (transitions only).
+@include preview-motion-guards('ActionPreview');

--- a/products/actions/frontend/emptyState/ActionsPreview.tsx
+++ b/products/actions/frontend/emptyState/ActionsPreview.tsx
@@ -1,0 +1,148 @@
+import './ActionsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored sign-up series for the stat card. The "after" series adds the click
+// the user just made at the far right.
+const LINE_BEFORE = 'M 0 30 L 14 27 L 28 29 L 42 24 L 56 26 L 70 21 L 84 22 L 100 18'
+const LINE_AFTER = 'M 0 30 L 14 27 L 28 29 L 42 24 L 56 26 L 70 21 L 84 22 L 92 18 L 100 8'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the actions empty state: a mini pricing page, the action
+ * that watches it, and the sign-up count it feeds. Clicking "Start free trial" in the
+ * app fires an autocapture event - the action matches it, its row lights up, and the
+ * count steps up. One hidden checkbox drives it all via `:checked ~` styles - no timers
+ * or state, per the preview rules in the `building-product-empty-states` skill.
+ * Before/after pairs are stacked in `__swap` grids and crossfaded, so nothing shifts.
+ */
+export function ActionsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('ActionPreview', isStatic && 'ActionPreview--static')}>
+            {/* Click state, before all cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="action-preview-click" className="ActionPreview__checkbox" />
+
+            <div className="ActionPreview__app">
+                <div className="ActionPreview__chrome">
+                    <span className="ActionPreview__chrome-dot" />
+                    <span className="ActionPreview__chrome-dot" />
+                    <span className="ActionPreview__chrome-dot" />
+                    <span className="ActionPreview__url">yourapp.com/pricing</span>
+                </div>
+                <div className="ActionPreview__screen">
+                    <div className="ActionPreview__plan">
+                        <span className="ActionPreview__plan-name">Pro</span>
+                        <span className="ActionPreview__plan-price">$29/mo</span>
+                    </div>
+                    <label htmlFor="action-preview-click" className="ActionPreview__cta">
+                        Start free trial
+                    </label>
+                    <div className="ActionPreview__toast-slot ActionPreview__swap" aria-hidden="true">
+                        <span className="ActionPreview__toast-spacer ActionPreview__when-before" />
+                        <span className="ActionPreview__toast ActionPreview__when-after">
+                            $autocapture · button.cta-primary
+                        </span>
+                    </div>
+                    <div className="ActionPreview__hint ActionPreview__swap">
+                        <span className="ActionPreview__when-before">Click the button to send an event.</span>
+                        <span className="ActionPreview__when-after">
+                            Matched by "Signed up" and counted below. Click again to undo.
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <div className="ActionPreview__panel">
+                <div className="ActionPreview__head">
+                    <span className="ActionPreview__title">Actions</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="ActionPreview__rows">
+                    <div className="ActionPreview__row ActionPreview__row--hero">
+                        <span className="ActionPreview__dot" aria-hidden="true" />
+                        <span className="ActionPreview__action">
+                            <span className="ActionPreview__name">Signed up</span>
+                            <span className="ActionPreview__match">button.cta-primary on /pricing</span>
+                        </span>
+                        <span className="ActionPreview__badge ActionPreview__when-after">matched</span>
+                        <span className="ActionPreview__count ActionPreview__swap">
+                            <span className="ActionPreview__when-before">1,284</span>
+                            <span className="ActionPreview__count--bumped ActionPreview__when-after">1,285</span>
+                        </span>
+                    </div>
+                    <div className="ActionPreview__row">
+                        <span className="ActionPreview__dot" aria-hidden="true" />
+                        <span className="ActionPreview__action">
+                            <span className="ActionPreview__name">Started checkout</span>
+                            <span className="ActionPreview__match">3 events</span>
+                        </span>
+                        <span className="ActionPreview__count">642</span>
+                    </div>
+                    <div className="ActionPreview__row">
+                        <span className="ActionPreview__dot" aria-hidden="true" />
+                        <span className="ActionPreview__action">
+                            <span className="ActionPreview__name">Invited a teammate</span>
+                            <span className="ActionPreview__match">2 events</span>
+                        </span>
+                        <span className="ActionPreview__count">318</span>
+                    </div>
+                </div>
+
+                <div className="ActionPreview__spark">
+                    <div className="ActionPreview__spark-head">
+                        <span className="ActionPreview__spark-title">Signed up · 7 days</span>
+                    </div>
+                    <div className="ActionPreview__spark-value">
+                        <span className="ActionPreview__swap">
+                            <span className="ActionPreview__when-before">1,284</span>
+                            <span className="ActionPreview__when-after">1,285</span>
+                        </span>
+                    </div>
+                    <svg
+                        className="ActionPreview__spark-svg"
+                        viewBox="0 0 100 40"
+                        preserveAspectRatio="none"
+                        aria-hidden="true"
+                    >
+                        <g className="ActionPreview__spark-g ActionPreview__when-before">
+                            <path className="ActionPreview__spark-area" d={areaPath(LINE_BEFORE)} />
+                            <path
+                                className="ActionPreview__spark-line"
+                                d={LINE_BEFORE}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="ActionPreview__spark-trace"
+                                d={LINE_BEFORE}
+                                pathLength={100}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </g>
+                        <g className="ActionPreview__spark-g ActionPreview__when-after">
+                            <path className="ActionPreview__spark-area" d={areaPath(LINE_AFTER)} />
+                            <path
+                                className="ActionPreview__spark-line"
+                                d={LINE_AFTER}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="ActionPreview__spark-trace"
+                                d={LINE_AFTER}
+                                pathLength={100}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </g>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/actions/frontend/emptyState/actionsEmptyState.tsx
+++ b/products/actions/frontend/emptyState/actionsEmptyState.tsx
@@ -1,0 +1,45 @@
+import * as cursorPng from '@posthog/brand/hoggies/png/cursor'
+import { IconCursorClick } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { ActionsPreview } from './ActionsPreview'
+import { actionsSetupLogic } from './actionsSetupLogic'
+
+const HedgehogCursor = pngHoggie(cursorPng)
+
+export const actionsEmptyState: SceneProductEmptyState = {
+    statusLogic: actionsSetupLogic,
+    config: {
+        productKey: ProductKey.ACTIONS,
+        productName: 'Actions',
+        icon: <IconCursorClick />,
+        accentColor: 'var(--color-product-actions-light)',
+        accentColorDark: 'var(--color-product-actions-dark)',
+        hedgehog: HedgehogCursor,
+        text: {
+            'needs-setup': {
+                headline: 'Give the clicks that matter a name',
+                lead: 'An action groups several events under one name, so "Signed up" can cover the button on your pricing page and the one in your nav. Point it at an element, a page, or an event you already send, then use that one name in insights, funnels, and cohorts.',
+            },
+        },
+        primaryAction: {
+            label: 'Create your first action',
+            to: urls.createAction(),
+            dataAttr: 'create-action',
+            accessControl: {
+                resourceType: AccessControlResourceType.Action,
+                minAccessLevel: AccessControlLevel.Editor,
+            },
+        },
+        skippable: false,
+        docsUrl: 'https://posthog.com/docs/data/actions',
+        previewLabel: 'Your actions, once created',
+        Preview: ActionsPreview,
+    },
+}

--- a/products/actions/frontend/emptyState/actionsSetupLogic.test.ts
+++ b/products/actions/frontend/emptyState/actionsSetupLogic.test.ts
@@ -1,0 +1,44 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { actionsSetupLogic } from './actionsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('actionsSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(generatedApi, 'actionsList')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [17, 'has-data'],
+    ])('pushes an action count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, results: [] })
+        const logic = actionsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.ACTIONS }).values.status).toBe(expected)
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = actionsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.ACTIONS }).values.status).toBe('unknown')
+    })
+})

--- a/products/actions/frontend/emptyState/actionsSetupLogic.ts
+++ b/products/actions/frontend/emptyState/actionsSetupLogic.ts
@@ -1,0 +1,21 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { actionsList } from '../generated/api'
+
+/**
+ * Setup detection for the actions empty state. Actions are a creation-first
+ * product, so "set up" simply means the project has at least one action - no event
+ * or traffic signal involved.
+ */
+export const actionsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.ACTIONS,
+    path: ['products', 'actions', 'frontend', 'emptyState', 'actionsSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await actionsList(projectId, { limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/actions/frontend/pages/Actions.tsx
+++ b/products/actions/frontend/pages/Actions.tsx
@@ -3,14 +3,18 @@ import { Scene, SceneExport } from 'scenes/sceneTypes'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+import { ProductKey } from '~/queries/schema/schema-general'
 
 import { ActionsTable } from '../components/ActionsTable'
 import { NewActionButton } from '../components/NewActionButton'
+import { actionsEmptyState } from '../emptyState/actionsEmptyState'
 import { actionsLogic } from '../logics/actionsLogic'
 
 export const scene: SceneExport = {
     component: Actions,
     logic: actionsLogic,
+    productKey: ProductKey.ACTIONS,
+    emptyState: actionsEmptyState,
 }
 
 export function Actions(): JSX.Element {

--- a/products/actions/package.json
+++ b/products/actions/package.json
@@ -14,6 +14,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",


### PR DESCRIPTION
## Problem

Someone opening Actions for the first time gets a card built on `ProductIntroduction`, which is deprecated. Actions is one of the highest-traffic first-run surfaces in the app and is still on the old path.

Part of moving every product scene onto the shared `ProductEmptyState` gate. Remaining work is tracked in #91027.

## Changes

- Actions shows the shared setup empty state until the project has an action.
- The create button carries the same permission check and `data-attr` as the scene's own, so a viewer sees it disabled rather than failing on save.
- The preview is interactive: clicking "Start free trial" on a mini pricing page fires an autocapture event, the example action matches it, and its count steps up.
- Detection is an action count through the generated API, with four cases covered by a new test.
- Declares `@posthog/brand` as a peer dependency of the actions package. Without it the hedgehog asset does not resolve from a product folder. Mechanical.

The scene's own table keeps its "No results" empty state for the filtered case, which the gate does not cover.

## How did you test this code?

`products/actions/frontend/emptyState/actionsSetupLogic.test.ts` covers the count-to-status mapping and the fail-open path. Without it a broken count query strands the gate on its spinner, and no existing test covers this product.

Frontend typecheck passes. Not verified: the empty state rendered in a browser, in dark mode, or at a narrow width. The storybook story added here gives visual-regression coverage on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/stacking-prs`, `/writing-pr-descriptions`.

The hedgehog started as `noir-1` and moved to `cursor`, which matches the scene's own icon. An apparent module-resolution failure on the first choice turned out to be a stale `tsconfig.tsbuildinfo` rather than a missing asset.
