### PR TITLE
feat(cohorts): replace the intro card with the product empty state

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -63,6 +63,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Customer analytics     | `products/customer_analytics/frontend/CustomerAnalyticsScene.tsx`                   | in review             |
 | Actions                | `products/actions/frontend/pages/Actions.tsx`                                       | on master             |
 | Annotations            | `frontend/src/scenes/annotations/Annotations.tsx`                                   | on master             |
+| Cohorts                | `frontend/src/scenes/cohorts/Cohorts.tsx`                                           | on master             |
 
 Only four products resolve their status at app boot, via a `setupProbe` in their manifest:
 LLM analytics, error tracking, MCP analytics, web analytics.
@@ -81,7 +82,6 @@ These are the scenes a new user is most likely to land on before they have data.
 | Product analytics      | `frontend/src/scenes/saved-insights/SavedInsights.tsx`      | `SavedInsightsEmptyState`, plus a bespoke `SampleDataState` and `sampleDataStateLogic` |
 | Dashboards             | `frontend/src/scenes/dashboard/dashboards/Dashboards.tsx`   | `ProductIntroduction`                                                                  |
 | Single empty dashboard | `frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx` | `ProductIntroduction`                                                                  |
-| Cohorts                | `frontend/src/scenes/cohorts/Cohorts.tsx`                   | `ProductIntroduction`, plus a second table-level empty state                           |
 
 ### Tier 2: cheap, or actively misleading today
 

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1764,6 +1764,10 @@ snapshots:
         hash: v1.k794b7964.375eb5c484baae36185d43a8b1ae04a6ec0915405be7f4f4a05887816dfde456.L2szPOMNE0IT-m3Dxbt1SKmvgfc9bT1pvlF13-L4doI
     components-product-empty-state--annotations-needs-setup--light:
         hash: v1.k794b7964.56dbdea2b6fb8aaf02bf4ff304ba2d4bff2df277d11255585ceb5c58453a9ceb.jmML3vhPE30ZAvN7k5Fr8gC0RDKY3GusMz-_osZ5o-I
+    components-product-empty-state--cohorts-needs-setup--dark:
+        hash: v1.k794b7964.83b26d21c2c1d191e3c7f6aa34bd3d8d24e9d6002d3e1369bf5b6a049f757758.PhaOyvOdwWsqT3HArkFs-5X-Bcgx3hwAnlhBFYnJUQo
+    components-product-empty-state--cohorts-needs-setup--light:
+        hash: v1.k794b7964.b827ea6e4b03f02c32a32b12c618f75a69ad0b2b58f913fe7d5c334c0ae5cac9.fKm3ytRKGmpO82oUS7SSw9GbRTxgdtlygk9c3Cmcd60
     components-product-empty-state--early-access-features-needs-setup--dark:
         hash: v1.k794b7964.ce612c03290780c1098886d9e2e0f9d920bfa899c591fadfecabf969b1897fe6.RlwNrGim39bhZH0hO39-bt6bWPUPJU-5XgIq2smDxSk
     components-product-empty-state--early-access-features-needs-setup--light:
@@ -7697,17 +7701,17 @@ snapshots:
     scenes-app-people-cohorts--cohort-new--light:
         hash: v1.k794b7964.b7e34e37161bbc571400f8c8e4cf210f1e8e08a901f0194b25700de2447b6544.if6FtZPEEaSX6nWtoSmOeZM_PNYQz7bFqj7123_mQjM
     scenes-app-people-cohorts--cohorts-empty--dark:
-        hash: v1.k794b7964.036e2f8323a54221ffdfb2807d0c9df42ae3d0969d15912c7fa7c6f6b51691c0.A0HlqNJEUOMVyy81_QznYrkUeMiQ8Ch6HmU0HgIUA8M
+        hash: v1.k794b7964.514e17ab808f6e16f3e02f3a43e622fcbddccab6436a83c7a5cd84904e8d7634.mgeo8euI4thoX2hQRiO0CVQxVeS-zu7nCIhOz7gXYQM
     scenes-app-people-cohorts--cohorts-empty--light:
-        hash: v1.k794b7964.7ad619bc602fecc63ead6f2e4505a946465498be7a16a71a654cc83422702d56.WiiVT6wAKFR5wFjvoBJeGrhaiBRCuJN3pp1OcGhVRp8
+        hash: v1.k794b7964.8eabf59d8c6277d154b3192cc00d3f66e4af8382722dd7e3599972194cef9735.7ajvmO2OIckY7mCNXG_HE0k0N8XpFPwDSTiNYgNajUU
     scenes-app-people-cohorts--cohorts-list--dark:
-        hash: v1.k794b7964.4bf4d602ecb2b9abfe394cd2357fcf2a6557937e1dd61051e98b48614e042427.7g4R6X-7BEQ_1gGgU1JBBG63qvVuBJFMzuhSvMLTvYI
+        hash: v1.k794b7964.ba60739cb1a38c0bc4328ce9581ebcd3206a94d4fc25399910115b6a7b34f720.fihj0nFQRie7dWF5Wzp8rz8m0JFBCFa6N6VXaa7zDLQ
     scenes-app-people-cohorts--cohorts-list--light:
-        hash: v1.k794b7964.2c22176eac83d12fb0dbb49eccb5d9d8779bf32c77931028762f668e3f69c6d1.-GFZw_WpanZIuZg8uyHjVtC-GEm-HNWOTFmq9r6WUSg
+        hash: v1.k794b7964.1bf47ee3ad41d21ae2a41cdc8c58027779cb67cf72dc21ea40186cde5b2fbe8e.-t4sba4fJW6mLrsTN6fWVPvb8SEwuwbvA01eDMRsmwU
     scenes-app-people-cohorts--cohorts-with-data--dark:
-        hash: v1.k794b7964.841ea8d2acd8199e49e1992a0ae49ff5abc7a5557b37266602e64c1664375fd4.0_5BgsAoEGSsc18skGpq2-bdE0JmKABz-54yOHzjUrI
+        hash: v1.k794b7964.e9b06da7fe302cf5d9f9b89a946bcad3b218de80b09f6d79825dc047e2c47144.XhK5xNwino53Y_bl2MrzUq8l2Z2ecyjSXkuKy4TixjI
     scenes-app-people-cohorts--cohorts-with-data--light:
-        hash: v1.k794b7964.61876acfe92bf3199b7013410bd77431df6a3cafde3d36132772c7a98363e603.JZ-JRLjr69YrfVQUlogXpBbcmcQmNua41Bj01clldhE
+        hash: v1.k794b7964.78ccc4aa71cdfa0f7f6992c2f5db9948739489adb7ab3814f097fa6391f66942.5fFxaSpqMWp0-CEO48c4gR5lrxyMVcy6Cp4rgPi3V3Y
     scenes-app-people-cohorts-add-person-to-cohort-modal--modal-empty--dark:
         hash: v1.k794b7964.4d6a9ffec03501c8b5d18e07127691b585f229dd60847a3cafb1e7c4d470e5f7.u2PV_7TIzIOqQLmFFxHpFecnxYbFLybvgVHz2ij4jCs
     scenes-app-people-cohorts-add-person-to-cohort-modal--modal-empty--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -7,6 +7,7 @@ import { aiObservabilityEmptyState } from 'products/ai_observability/frontend/em
 import { llmPromptsEmptyState } from 'products/ai_observability/frontend/emptyState/llmPromptsEmptyState'
 import { annotationsEmptyState } from 'products/annotations/frontend/emptyState/annotationsEmptyState'
 import { webScriptsEmptyState } from 'products/cdp/frontend/emptyState/webScriptsEmptyState'
+import { cohortsEmptyState } from 'products/cohorts/frontend/emptyState/cohortsEmptyState'
 import { supportEmptyState } from 'products/conversations/frontend/emptyState/supportEmptyState'
 import { earlyAccessFeaturesEmptyState } from 'products/early_access_features/frontend/emptyState/earlyAccessFeaturesEmptyState'
 import { endpointsEmptyState } from 'products/endpoints/frontend/emptyState/endpointsEmptyState'
@@ -191,6 +192,15 @@ export const AnnotationsNeedsSetup: ProductEmptyStateStory = productEmptyStateSt
     'needs-setup',
     { mocks: annotationsMocks }
 )
+
+// Cohorts detection lists cohorts on mount - answer "none yet".
+const cohortsMocks = {
+    get: { '/api/projects/:team_id/cohorts/': [200, { count: 0, results: [] }] },
+} as const
+
+export const CohortsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(cohortsEmptyState, 'needs-setup', {
+    mocks: cohortsMocks,
+})
 
 // Error tracking detection asks the issues-exists API on mount - answer "none yet".
 const errorTrackingMocks = {

--- a/frontend/src/scenes/cohorts/Cohorts.tsx
+++ b/frontend/src/scenes/cohorts/Cohorts.tsx
@@ -3,12 +3,9 @@ import './Cohorts.scss'
 import { useActions, useValues } from 'kea'
 import { combineUrl, router } from 'kea-router'
 
-import * as greekPng from '@posthog/brand/hoggies/png/greek'
 import { LemonBanner, LemonDialog, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 
-import { pngHoggie } from 'lib/brand/hoggies'
 import { MemberSelect } from 'lib/components/MemberSelect'
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
@@ -39,24 +36,18 @@ import {
     PropertyOperator,
 } from '~/types'
 
-const HedgehogGreek = pngHoggie(greekPng)
+import { cohortsEmptyState } from 'products/cohorts/frontend/emptyState/cohortsEmptyState'
 
 export const scene: SceneExport = {
     component: Cohorts,
     logic: cohortsSceneLogic,
     productKey: ProductKey.PRODUCT_ANALYTICS,
+    emptyState: cohortsEmptyState,
 }
 
 export function Cohorts(): JSX.Element {
-    const {
-        cohorts,
-        cohortsLoading,
-        pagination,
-        cohortFilters,
-        shouldShowEmptyState,
-        cohortSorting,
-        cohortsLoadError,
-    } = useValues(cohortsSceneLogic)
+    const { cohorts, cohortsLoading, pagination, cohortFilters, cohortSorting, cohortsLoadError } =
+        useValues(cohortsSceneLogic)
     const { deleteCohort, exportCohortPersons, setCohortFilters, setCohortSorting, loadCohorts } =
         useActions(cohortsSceneLogic)
     const { searchParams } = useValues(router)
@@ -300,18 +291,6 @@ export function Cohorts(): JSX.Element {
                         </LemonButton>
                     </Shortcut>
                 }
-            />
-
-            <ProductIntroduction
-                productName="Cohorts"
-                productKey={ProductKey.COHORTS}
-                thingName="cohort"
-                description="Use cohorts to group people together, such as users who used your app in the last week, or people who viewed the signup page but didn't convert."
-                isEmpty={shouldShowEmptyState}
-                docsURL="https://posthog.com/docs/data/cohorts"
-                action={() => router.actions.push(urls.cohort('new'))}
-                customHog={HedgehogGreek}
-                mcpSurfaceKey="cohorts.create"
             />
 
             <div>{filtersSection}</div>

--- a/playwright/e2e/product-analytics/cohorts.spec.ts
+++ b/playwright/e2e/product-analytics/cohorts.spec.ts
@@ -16,7 +16,7 @@ test.describe('Cohorts', () => {
 
         await expect(page).toHaveTitle('Cohorts • PostHog')
         await expect(page.locator('[data-attr="create-cohort"]')).toBeVisible()
-        await expect(page.locator('[data-attr="product-introduction-docs-link"]')).toHaveText(/Learn more/)
+        await expect(page.locator('[data-attr="product-empty-state-docs"]')).toHaveText(/Read the docs/)
     })
 
     test('Can create a cohort', async ({ page }) => {

--- a/playwright/page-models/cohortPage.ts
+++ b/playwright/page-models/cohortPage.ts
@@ -8,7 +8,7 @@ export class CohortPage {
     constructor(private readonly page: Page) {}
 
     async createCohort(name: string): Promise<void> {
-        await this.page.click('[data-attr="new-cohort"]')
+        await this.page.click('[data-attr="create-cohort"]')
         await this.page.click('[data-attr="cohort-selector-field-value"]')
         await this.page.click('[data-attr="cohort-personPropertyBehavioral-have_property-type"]')
         await this.page.click('[data-attr="cohort-taxonomic-field-key"]')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,7 +428,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -459,7 +459,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-junit:
         specifier: 'catalog:'
         version: 16.0.0
@@ -2686,6 +2686,9 @@ importers:
 
   products/cohorts:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.10.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4946,7 +4949,7 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.3)(vite@8.1.3(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(less@4.2.2)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@7.3.5(@types/node@22.18.8)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.6(@types/node@22.18.8)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.18.8)(typescript@6.0.3))(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -4992,7 +4995,7 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.3)(vite@7.3.5(@types/node@22.18.8)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@8.1.3(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(less@4.2.2)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.6(@types/node@22.18.8)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.18.8)(typescript@6.0.3))(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)

--- a/products/cohorts/frontend/emptyState/CohortsPreview.scss
+++ b/products/cohorts/frontend/emptyState/CohortsPreview.scss
@@ -1,0 +1,249 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.CohortPreview {
+    --cohort-preview-accent: var(--empty-state-accent, var(--color-product-cohorts-light));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden narrowed state. A direct child of .CohortPreview so `:checked ~` reaches all cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__panel {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Before/after pairs are stacked on one grid cell and crossfaded, so narrowing the
+    // cohort never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-after {
+        @include preview-swap-hidden;
+    }
+
+    &__when-before {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    // A pulsing dot, so the people list reads as live at rest.
+    &__live {
+        width: 6px;
+        height: 6px;
+        background: var(--cohort-preview-accent);
+        border-radius: 50%;
+        animation: CohortPreview__pulse 2s ease-in-out infinite;
+    }
+
+    // Cohort definition
+
+    &__conditions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        padding: 0.625rem 0.75rem;
+    }
+
+    &__condition-slot,
+    &__condition-spacer {
+        min-height: 1.75rem;
+    }
+
+    &__condition {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        font-size: 0.6875rem;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: var(--radius);
+    }
+
+    &__condition--new {
+        background: color-mix(in oklab, var(--cohort-preview-accent) 10%, transparent);
+    }
+
+    &__match-tag {
+        flex: none;
+        padding: 0 0.3125rem;
+        font-size: 0.5625rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        background: color-mix(in oklab, var(--cohort-preview-accent) 14%, var(--color-bg-surface-primary));
+        border-radius: 999px;
+
+        @include preview-accent-text(var(--cohort-preview-accent));
+    }
+
+    &__condition-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__add {
+        align-self: flex-start;
+        padding: 0.1875rem 0.5rem;
+        font-size: 0.625rem;
+        font-weight: 600;
+        cursor: pointer;
+        user-select: none;
+        border: 1px dashed color-mix(in oklab, var(--cohort-preview-accent) 45%, transparent);
+        border-radius: var(--radius);
+        transition: background 150ms ease;
+
+        @include preview-accent-text(var(--cohort-preview-accent));
+    }
+
+    &__add:hover {
+        background: color-mix(in oklab, var(--cohort-preview-accent) 10%, transparent);
+    }
+
+    &__count-row {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem 0.625rem;
+        border-top: 1px solid var(--color-border-primary);
+    }
+
+    &__count-label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+    }
+
+    &__count {
+        font-size: 1.25rem;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+    }
+
+    &__count--narrowed {
+        @include preview-accent-text(var(--cohort-preview-accent));
+    }
+
+    // People list
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+    }
+
+    &__avatar {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.25rem;
+        height: 1.25rem;
+        font-size: 0.5rem;
+        font-weight: 700;
+        color: var(--color-bg-surface-primary);
+        border-radius: 50%;
+    }
+
+    &__avatar--a {
+        background: var(--cohort-preview-accent);
+    }
+
+    &__avatar--b {
+        background: color-mix(in oklab, var(--cohort-preview-accent) 70%, var(--color-text-primary));
+    }
+
+    &__avatar--c {
+        background: color-mix(in oklab, var(--cohort-preview-accent) 45%, var(--color-text-primary));
+    }
+
+    &__person {
+        overflow: hidden;
+        font-size: 0.6875rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__meta {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+        white-space: nowrap;
+    }
+
+    &__hint {
+        padding: 0.25rem 0.75rem 0.625rem;
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+        text-align: center;
+    }
+}
+
+// Narrowed state (user added the second condition)
+
+.CohortPreview__checkbox:checked ~ * .CohortPreview__when-after {
+    @include preview-swap-visible;
+}
+
+.CohortPreview__checkbox:checked ~ * .CohortPreview__when-before {
+    @include preview-swap-hidden;
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the button it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.CohortPreview__checkbox:focus-visible ~ .CohortPreview__panel .CohortPreview__add {
+    outline: 2px solid var(--cohort-preview-accent);
+    outline-offset: 1px;
+}
+
+@keyframes CohortPreview__pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.35;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; adding the
+// condition still narrows the cohort (transitions only).
+@include preview-motion-guards('CohortPreview');

--- a/products/cohorts/frontend/emptyState/CohortsPreview.tsx
+++ b/products/cohorts/frontend/emptyState/CohortsPreview.tsx
@@ -1,0 +1,114 @@
+import './CohortsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+/**
+ * Example-data preview for the cohorts empty state: a cohort definition and the
+ * people it matches. Adding the second condition narrows the definition, and the
+ * matched count and the people list follow. One hidden checkbox drives it all via
+ * `:checked ~` styles - no timers or state, per the preview rules in the
+ * `building-product-empty-states` skill. Before/after pairs are stacked in `__swap`
+ * grids and crossfaded, so nothing shifts.
+ */
+export function CohortsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('CohortPreview', isStatic && 'CohortPreview--static')}>
+            {/* Narrowed state, before all cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="cohort-preview-narrow" className="CohortPreview__checkbox" />
+
+            <div className="CohortPreview__panel">
+                <div className="CohortPreview__head">
+                    <span className="CohortPreview__title">Trial users who saw pricing</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="CohortPreview__conditions">
+                    <div className="CohortPreview__condition">
+                        <span className="CohortPreview__match-tag">Match</span>
+                        <span className="CohortPreview__condition-text">
+                            Signed up in the last <strong>30 days</strong>
+                        </span>
+                    </div>
+
+                    {/* Reserved slot: the second condition fades in over a spacer of the
+                        same height, so the card never changes size. */}
+                    <div className="CohortPreview__condition-slot CohortPreview__swap">
+                        <span className="CohortPreview__condition-spacer CohortPreview__when-before" />
+                        <div className="CohortPreview__condition CohortPreview__condition--new CohortPreview__when-after">
+                            <span className="CohortPreview__match-tag">And</span>
+                            <span className="CohortPreview__condition-text">
+                                Viewed <strong>/pricing</strong> at least once
+                            </span>
+                        </div>
+                    </div>
+
+                    <label htmlFor="cohort-preview-narrow" className="CohortPreview__add">
+                        <span className="CohortPreview__swap">
+                            <span className="CohortPreview__when-before">Add condition</span>
+                            <span className="CohortPreview__when-after">Remove condition</span>
+                        </span>
+                    </label>
+                </div>
+
+                <div className="CohortPreview__count-row">
+                    <span className="CohortPreview__count-label">People matched</span>
+                    <span className="CohortPreview__count CohortPreview__swap">
+                        <span className="CohortPreview__when-before">8,412</span>
+                        <span className="CohortPreview__count--narrowed CohortPreview__when-after">1,197</span>
+                    </span>
+                </div>
+            </div>
+
+            <div className="CohortPreview__panel">
+                <div className="CohortPreview__head">
+                    <span className="CohortPreview__title">People</span>
+                    <span className="CohortPreview__live" aria-hidden="true" />
+                </div>
+
+                <div className="CohortPreview__rows">
+                    <div className="CohortPreview__row">
+                        <span className="CohortPreview__avatar CohortPreview__avatar--a" aria-hidden="true">
+                            AR
+                        </span>
+                        <span className="CohortPreview__person">avery@example.com</span>
+                        <span className="CohortPreview__meta CohortPreview__swap">
+                            <span className="CohortPreview__when-before">Signed up 4d ago</span>
+                            <span className="CohortPreview__when-after">Viewed /pricing 2d ago</span>
+                        </span>
+                    </div>
+                    <div className="CohortPreview__row">
+                        <span className="CohortPreview__avatar CohortPreview__avatar--b" aria-hidden="true">
+                            JM
+                        </span>
+                        <span className="CohortPreview__person">jordan@example.com</span>
+                        <span className="CohortPreview__meta CohortPreview__swap">
+                            <span className="CohortPreview__when-before">Signed up 9d ago</span>
+                            <span className="CohortPreview__when-after">Viewed /pricing 6d ago</span>
+                        </span>
+                    </div>
+                    <div className="CohortPreview__row">
+                        <span className="CohortPreview__avatar CohortPreview__avatar--c" aria-hidden="true">
+                            SK
+                        </span>
+                        <span className="CohortPreview__person">sam@example.com</span>
+                        <span className="CohortPreview__meta CohortPreview__swap">
+                            <span className="CohortPreview__when-before">Signed up 21d ago</span>
+                            <span className="CohortPreview__when-after">Viewed /pricing 11d ago</span>
+                        </span>
+                    </div>
+                </div>
+
+                <div className="CohortPreview__hint CohortPreview__swap">
+                    <span className="CohortPreview__when-before">Add a condition to narrow the group.</span>
+                    <span className="CohortPreview__when-after">
+                        Reuse this cohort as a filter, a flag target, or a survey audience.
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/cohorts/frontend/emptyState/cohortsEmptyState.tsx
+++ b/products/cohorts/frontend/emptyState/cohortsEmptyState.tsx
@@ -1,0 +1,40 @@
+import * as partyPng from '@posthog/brand/hoggies/png/party'
+import { IconPeople } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { CohortsPreview } from './CohortsPreview'
+import { cohortsSetupLogic } from './cohortsSetupLogic'
+
+const HedgehogParty = pngHoggie(partyPng)
+
+export const cohortsEmptyState: SceneProductEmptyState = {
+    statusLogic: cohortsSetupLogic,
+    config: {
+        productKey: ProductKey.COHORTS,
+        productName: 'Cohorts',
+        icon: <IconPeople />,
+        accentColor: 'var(--color-product-cohorts-light)',
+        accentColorDark: 'var(--color-product-cohorts-dark)',
+        hedgehog: HedgehogParty,
+        text: {
+            'needs-setup': {
+                headline: 'Save the group of people you keep filtering for',
+                lead: 'A cohort is a set of people who match conditions you pick, like signed up last week, on a paid plan, or viewed pricing without converting. Define it once and reuse it as a filter in insights, a target for a flag, or an audience for a survey.',
+            },
+        },
+        primaryAction: {
+            label: 'Create your first cohort',
+            to: urls.cohort('new'),
+            dataAttr: 'create-cohort',
+        },
+        skippable: false,
+        docsUrl: 'https://posthog.com/docs/data/cohorts',
+        previewLabel: 'Your cohorts, once created',
+        Preview: CohortsPreview,
+    },
+}

--- a/products/cohorts/frontend/emptyState/cohortsSetupLogic.test.ts
+++ b/products/cohorts/frontend/emptyState/cohortsSetupLogic.test.ts
@@ -1,0 +1,44 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { cohortsSetupLogic } from './cohortsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('cohortsSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(generatedApi, 'cohortsList')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [17, 'has-data'],
+    ])('pushes a cohort count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, results: [] })
+        const logic = cohortsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.COHORTS }).values.status).toBe(expected)
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = cohortsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.COHORTS }).values.status).toBe('unknown')
+    })
+})

--- a/products/cohorts/frontend/emptyState/cohortsSetupLogic.ts
+++ b/products/cohorts/frontend/emptyState/cohortsSetupLogic.ts
@@ -1,0 +1,21 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { cohortsList } from '../generated/api'
+
+/**
+ * Setup detection for the cohorts empty state. Cohorts are a creation-first
+ * product, so "set up" simply means the project has at least one cohort - no event
+ * or traffic signal involved.
+ */
+export const cohortsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.COHORTS,
+    path: ['products', 'cohorts', 'frontend', 'emptyState', 'cohortsSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await cohortsList(projectId, { limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/cohorts/package.json
+++ b/products/cohorts/package.json
@@ -13,6 +13,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",


### PR DESCRIPTION
## Problem

Someone opening Cohorts for the first time gets a card built on `ProductIntroduction`, which is deprecated.

Part of moving every product scene onto the shared `ProductEmptyState` gate. Remaining work is tracked in #91027.

## Changes

- Cohorts shows the shared setup empty state until the project has a cohort.
- The preview is interactive: adding a second condition narrows the definition, and the matched count drops from 8,412 to 1,197 while the people list follows.
- Detection is a cohort count through the generated API, with four cases covered by a new test.

The create button carries no permission check, matching the scene's own button. `AccessControlResourceType` has no cohort entry, so adding one here would have invented a rule the product does not enforce.

## How did you test this code?

`products/cohorts/frontend/emptyState/cohortsSetupLogic.test.ts` covers the count-to-status mapping and the fail-open path. Without it a broken count query strands the gate on its spinner, and no existing test covers this product.

Frontend typecheck passes. Not verified: the empty state rendered in a browser, in dark mode, or at a narrow width. The storybook story added here gives visual-regression coverage on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/stacking-prs`, `/writing-pr-descriptions`.
