### PR TITLE
feat(dashboards): replace the intro card with the product empty state

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -64,6 +64,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Actions                | `products/actions/frontend/pages/Actions.tsx`                                       | on master             |
 | Annotations            | `frontend/src/scenes/annotations/Annotations.tsx`                                   | on master             |
 | Cohorts                | `frontend/src/scenes/cohorts/Cohorts.tsx`                                           | on master             |
+| Dashboards             | `frontend/src/scenes/dashboard/dashboards/Dashboards.tsx`                           | on master             |
 
 Only four products resolve their status at app boot, via a `setupProbe` in their manifest:
 LLM analytics, error tracking, MCP analytics, web analytics.
@@ -80,7 +81,6 @@ These are the scenes a new user is most likely to land on before they have data.
 | Product                | Scene                                                       | Shows instead                                                                          |
 | ---------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | Product analytics      | `frontend/src/scenes/saved-insights/SavedInsights.tsx`      | `SavedInsightsEmptyState`, plus a bespoke `SampleDataState` and `sampleDataStateLogic` |
-| Dashboards             | `frontend/src/scenes/dashboard/dashboards/Dashboards.tsx`   | `ProductIntroduction`                                                                  |
 | Single empty dashboard | `frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx` | `ProductIntroduction`                                                                  |
 
 ### Tier 2: cheap, or actively misleading today

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1768,6 +1768,10 @@ snapshots:
         hash: v1.k794b7964.83b26d21c2c1d191e3c7f6aa34bd3d8d24e9d6002d3e1369bf5b6a049f757758.PhaOyvOdwWsqT3HArkFs-5X-Bcgx3hwAnlhBFYnJUQo
     components-product-empty-state--cohorts-needs-setup--light:
         hash: v1.k794b7964.b827ea6e4b03f02c32a32b12c618f75a69ad0b2b58f913fe7d5c334c0ae5cac9.fKm3ytRKGmpO82oUS7SSw9GbRTxgdtlygk9c3Cmcd60
+    components-product-empty-state--dashboards-needs-setup--dark:
+        hash: v1.k794b7964.b3a148d96ca0b54ca8929084054b91f4e52ae02160039f3a47ee04db7aeb62cc.SH8xd4Ro7F3Zuetn_B_qgVFVbWtT__aDzaW2YOr-Eac
+    components-product-empty-state--dashboards-needs-setup--light:
+        hash: v1.k794b7964.2782384906e9b2efb6153b3bf4b8135fc541639245f74f0abd3456a35023e641.vaJwGqX3KJ-_XLxP_slQ1vIyHx0QZ4fCXnrMtPJHnjg
     components-product-empty-state--early-access-features-needs-setup--dark:
         hash: v1.k794b7964.ce612c03290780c1098886d9e2e0f9d920bfa899c591fadfecabf969b1897fe6.RlwNrGim39bhZH0hO39-bt6bWPUPJU-5XgIq2smDxSk
     components-product-empty-state--early-access-features-needs-setup--light:
@@ -8305,29 +8309,29 @@ snapshots:
     scenes-app-sidepanels--side-panel-activity--light:
         hash: v1.k794b7964.92e0230464c1b65c62f8a84b3ddc02a97f8127281cb7fccc775fbe599d9edfa1.LK30Oro2SxWnQTaosMAkKK7EAbxhuwImwe3Eq2RrWeQ
     scenes-app-sidepanels--side-panel-discussion--dark:
-        hash: v1.k794b7964.017149f36f963e3e949a0dcc6c45c43752ee0dd1cc7c37b94ba9f8b0c0f8fb05.oYMGNSAld48hLQnEKRhUquLoisqMTCKHihPF6d-O2P0
+        hash: v1.k794b7964.9da4b90fe84042fcb9c128467eee9e76eb0e1ed75e3ad7c1591ac70055fdc3a5.ngbV2D7_yO8135Moaeal9y25CLX9dkfet57v0WbqMk8
     scenes-app-sidepanels--side-panel-discussion--light:
-        hash: v1.k794b7964.18daa4f26c6c73c8c50175f985caafaea6ee7b1a54ee868e9bef28b412375a40.QEhJdGbJ6RgGlWtsivN0prxyWkpIOMfKb9TLGS-bfTA
+        hash: v1.k794b7964.1aa303afeb275c6fb0792ce8b38293ef267e4cdf5cf04e4ae414b768aafddd62.wmJ0O_35Fs02QjI0QPRN_t7c8qWEclcDQcfGbM6CRG8
     scenes-app-sidepanels--side-panel-exports--dark:
-        hash: v1.k794b7964.d501d7acff7f818e533c85234b0e3beb4afd0e3ee82e9cb565c49051d351938e.P54U43_K_0jYHL8dIzuVWShN-AiwknWPKTC9RyNmjkw
+        hash: v1.k794b7964.7ce60432a7ef470b427747d0fc9d741dee89ab1366b5f59a19afd45b8a387d61.2HQNtrPeK0th4V1bg-IdK9btyiSvnW4ljCujRGRPDIA
     scenes-app-sidepanels--side-panel-exports--light:
-        hash: v1.k794b7964.7dbbeed7053f92435a24237d8362ff1e42f1f11049a5cef91d46866cd59df76c.mo6_4plmDco1FXntVQxu5dZ47iUIjrguOs3-RRCBU8s
+        hash: v1.k794b7964.a4f34bdb2b542478c1f239edccf2506b6213ea3350fe81a1163288a534766855.iEVnW8Z1b2IqnNkXYlHgfpJX-j2o5yvy0H4toshFnmU
     scenes-app-sidepanels--side-panel-info--dark:
         hash: v1.k794b7964.eded745dc22b062535738c5dce5ba3e32ead3597bc4ca8be6edbfb60627680f9.vmhOijXx4hnqSvuh7aRGW0_OKNUk9-4dFH6Ebs4mRNI
     scenes-app-sidepanels--side-panel-info--light:
         hash: v1.k794b7964.7d5d05f9443f5809b23bdf08bfe9c3a48c3085826a4323d9aa3d190ee1e49505.90Nt7uDjc5Iw-q2ebtPh4pEycNoBakH9d1iJOn9iE44
     scenes-app-sidepanels--side-panel-max--dark:
-        hash: v1.k794b7964.b0531663ce50cd93839e2faf3f35be1b15191de63e050481191fb1fdf81c89ad.MwGi7ojt0f3czE18LVMixrf_66BJbhDWUYvsVAB5kVo
+        hash: v1.k794b7964.514f41a883b32834fcb65abeea684e57f284adbfde04f052e4f45bc7310f68bf.u9o_fNFEPlO0JBoWc1QPcDmzGZNh4_UPj3gUeJCWynI
     scenes-app-sidepanels--side-panel-max--light:
-        hash: v1.k794b7964.3d89c93e6f7776c1d91786139e1ec90f8e19472d8d551f751e31d8f854c894f9.bx2_PVEQBfotbPeNvv4AHxwvqX4ieoK7tZ-p7a8Gmmk
+        hash: v1.k794b7964.040d9aa68be779d9f1834eb3067ee4b22e5fbacd645520514f82ee31131c9e5d.CGYetD-fqQbng9n-xq_EvSnpqJr0wykoX8-kchKqsTQ
     scenes-app-sidepanels--side-panel-notebooks--dark:
-        hash: v1.k794b7964.e9cfbae71fa42d8aab6b447ad75d8da2a3f13f1da48407a46aaa037ae2cb6d0e.wSG4PYaxWxErz1MhFYozkTiHinljUT_zyQJbElEv0Mo
+        hash: v1.k794b7964.864a03220ceabad6158538319fa9da26e8359340de8089e6e9e38915af723171.fjDYfu2_45Va7pEmAVZOjos6LiBRBq2NrLycJlfWGf8
     scenes-app-sidepanels--side-panel-notebooks--light:
-        hash: v1.k794b7964.5bc62aaf3e5350c82dc67e0fdc6950d1b1bc5c76e55820b175db016c5d4ea1f0.YGteVcsOwXMtGMc6CqEy0Ql-2bCOooO1WP959oibJO4
+        hash: v1.k794b7964.772ed6e382d1de91106e2b9d0a97bc6eef6f15395f9a5ee48ae1b735d0cf85ad.0Mn8TfTdtAGSyiuEOVVolAvCFxJXoLU4uk338xWCNBo
     scenes-app-sidepanels--side-panel-support--dark:
-        hash: v1.k794b7964.46ae70cb89cfb8f5c4775934cffa36b3954e1d7dc0f7f51c126b73fca20abc35.bdWdosfvbOnXbT4PkUV1j1rEfzY7OTyoANhqVTT7Lc8
+        hash: v1.k794b7964.3362f7e3189434319ec363172447f3fbbe529b2d745ef0ddf7f8e8c494fcd4a2.2bUlzu2lgIJbm8s_5ic3TtAcZ9hHX4_JFAE8hd9fQVk
     scenes-app-sidepanels--side-panel-support--light:
-        hash: v1.k794b7964.5d2aeef3d8aa94c6aa1626787a6e727f329cc0ea53ced7943401b1b0ec5d8d51.IoBwRDBrpOANTh-0CYkB3km0MvpohonHkpHzOfkkIio
+        hash: v1.k794b7964.deb388fad6d54211a52bf0228e80a62f18903b5a91ed77f47408f1fbb9137480.c8bN-QxTmTOSLWxd37aThlQhlWmlZ9r6N1YUBjhRsU8
     scenes-app-stamphog-digests--digests-list--dark:
         hash: v1.k794b7964.28fbaad98ddd90b171e6774057e8e9656af77e67fd0b5d462235a1d063c1777c.6E_uVxcZxkBaFZgqKmXAg4njrs4xCTiNBGWAUNg9GT0
     scenes-app-stamphog-digests--digests-list--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -9,6 +9,7 @@ import { annotationsEmptyState } from 'products/annotations/frontend/emptyState/
 import { webScriptsEmptyState } from 'products/cdp/frontend/emptyState/webScriptsEmptyState'
 import { cohortsEmptyState } from 'products/cohorts/frontend/emptyState/cohortsEmptyState'
 import { supportEmptyState } from 'products/conversations/frontend/emptyState/supportEmptyState'
+import { dashboardsEmptyState } from 'products/dashboards/frontend/emptyState/dashboardsEmptyState'
 import { earlyAccessFeaturesEmptyState } from 'products/early_access_features/frontend/emptyState/earlyAccessFeaturesEmptyState'
 import { endpointsEmptyState } from 'products/endpoints/frontend/emptyState/endpointsEmptyState'
 import { errorTrackingEmptyState } from 'products/error_tracking/frontend/emptyState/errorTrackingEmptyState'
@@ -203,6 +204,17 @@ const cohortsMocks = {
 export const CohortsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(cohortsEmptyState, 'needs-setup', {
     mocks: cohortsMocks,
 })
+
+// Dashboards detection lists dashboards on mount - answer "none yet".
+const dashboardsMocks = {
+    get: { '/api/projects/:team_id/dashboards/': [200, { count: 0, results: [] }] },
+} as const
+
+export const DashboardsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    dashboardsEmptyState,
+    'needs-setup',
+    { mocks: dashboardsMocks }
+)
 
 // Error tracking detection asks the issues-exists API on mount - answer "none yet".
 const errorTrackingMocks = {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -39961,6 +39961,7 @@
                 "comments",
                 "conversations",
                 "customer_analytics",
+                "dashboards",
                 "data_catalog",
                 "data_warehouse",
                 "data_warehouse_saved_queries",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -9976,6 +9976,7 @@ export enum ProductKey {
     COMMENTS = 'comments',
     CONVERSATIONS = 'conversations',
     CUSTOMER_ANALYTICS = 'customer_analytics',
+    DASHBOARDS = 'dashboards',
     DATA_CATALOG = 'data_catalog',
     DATA_WAREHOUSE = 'data_warehouse',
     DATA_WAREHOUSE_SAVED_QUERY = 'data_warehouse_saved_queries',

--- a/frontend/src/scenes/dashboard/dashboards/Dashboards.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/Dashboards.tsx
@@ -1,11 +1,8 @@
 import { useActions, useValues } from 'kea'
 
-import * as chartPng from '@posthog/brand/hoggies/png/chart'
 import { LemonButton } from '@posthog/lemon-ui'
 
-import { pngHoggie } from 'lib/brand/hoggies'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
@@ -26,17 +23,15 @@ import { dashboardsModel } from '~/models/dashboardsModel'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+import { dashboardsEmptyState } from 'products/dashboards/frontend/emptyState/dashboardsEmptyState'
+
 import { DashboardsTableContainer } from './DashboardsTable'
-import { FeaturedTemplatesChooser } from './templates/FeaturedTemplatesChooser'
-
-const HedgehogChart = pngHoggie(chartPng)
-
-const DASHBOARD_DOCS_URL = 'https://posthog.com/docs/product-analytics/dashboards'
 
 export const scene: SceneExport = {
     component: Dashboards,
     logic: dashboardsLogic,
     productKey: ProductKey.PRODUCT_ANALYTICS,
+    emptyState: dashboardsEmptyState,
 }
 
 export function Dashboards(): JSX.Element {
@@ -110,22 +105,7 @@ export function Dashboards(): JSX.Element {
                     <DashboardTemplatesTable />
                 ) : dashboardsLoading || dashboards.length > 0 || isFiltering ? (
                     <DashboardsTableContainer />
-                ) : (
-                    <ProductIntroduction
-                        productName="Dashboards"
-                        thingName="dashboard"
-                        titleOverride="Your home for what you actually care about"
-                        description="Keep analytics, session replay, logs, and the rest of your PostHog stack in one place. Below are customer-favorite dashboards to get you started quickly. Or skip them and start blank, up to you."
-                        isEmpty={true}
-                        docsURL={DASHBOARD_DOCS_URL}
-                        customHog={HedgehogChart}
-                        hogLayout="responsive"
-                        useMainContentContainerQueries={true}
-                        contentClassName="max-w-[1000px]"
-                        actionElementOverride={<FeaturedTemplatesChooser />}
-                        mcpSurfaceKey="dashboards.create"
-                    />
-                )}
+                ) : null}
             </div>
         </SceneContent>
     )

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -355,6 +355,7 @@
     --color-product-user-interviews-light: rgb(0 140 255);
     --color-product-user-interviews-dark: rgb(77 171 255);
     --color-product-dashboards-light: rgb(255 139 7);
+    --color-product-dashboards-dark: rgb(255 168 71);
     --color-product-early-access-features-light: rgb(39 171 151);
     --color-product-early-access-features-dark: rgb(53 213 189);
     --color-product-support-light: rgb(243 84 84);

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3641,6 +3641,7 @@ class ProductKey(StrEnum):
     COMMENTS = "comments"
     CONVERSATIONS = "conversations"
     CUSTOMER_ANALYTICS = "customer_analytics"
+    DASHBOARDS = "dashboards"
     DATA_CATALOG = "data_catalog"
     DATA_WAREHOUSE = "data_warehouse"
     DATA_WAREHOUSE_SAVED_QUERIES = "data_warehouse_saved_queries"

--- a/products/dashboards/frontend/emptyState/DashboardsPreview.scss
+++ b/products/dashboards/frontend/emptyState/DashboardsPreview.scss
@@ -1,0 +1,258 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.DashboardPreview {
+    --dashboard-preview-accent: var(--empty-state-accent, var(--color-product-dashboards-light));
+
+    display: flex;
+    flex-direction: column;
+
+    // Hidden range selection. A direct child of .DashboardPreview so `:checked ~` reaches the board.
+    &__radio {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__board {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Range variants are stacked on one grid cell and crossfaded, so switching the
+    // range never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__on-30d {
+        @include preview-swap-hidden;
+    }
+
+    &__on-7d {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    &__ranges {
+        display: flex;
+        gap: 0.25rem;
+        padding: 0.125rem;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: var(--radius);
+    }
+
+    &__range {
+        padding: 0.125rem 0.4375rem;
+        font-size: 0.625rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        user-select: none;
+        border-radius: calc(var(--radius) - 1px);
+        transition:
+            background 150ms ease,
+            color 150ms ease;
+    }
+
+    // Tiles
+
+    &__grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.5rem;
+        padding: 0.625rem 0.75rem;
+    }
+
+    &__tile {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        min-height: 4.5rem;
+        padding: 0.5rem 0.625rem;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: var(--radius);
+    }
+
+    &__tile-title {
+        font-size: 0.5625rem;
+        font-weight: 600;
+        color: var(--color-text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+    }
+
+    &__tile-value {
+        font-size: 1.125rem;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+        line-height: 1.1;
+    }
+
+    &__tile-delta {
+        font-size: 0.5625rem;
+
+        @include preview-accent-text(var(--dashboard-preview-accent));
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--dashboard-preview-accent) 15%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--dashboard-preview-accent) 35%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--dashboard-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: DashboardPreview__trace 3.2s linear infinite;
+    }
+
+    &__funnel {
+        display: flex;
+        gap: 0.25rem;
+        align-items: flex-end;
+        height: 1.75rem;
+    }
+
+    &__bar {
+        flex: 1;
+        background: var(--dashboard-preview-accent);
+        border-radius: 2px 2px 0 0;
+        transition: height 250ms ease;
+    }
+
+    &__bar--1 {
+        height: 100%;
+    }
+
+    &__bar--2 {
+        height: 62%;
+        opacity: 0.7;
+    }
+
+    &__bar--3 {
+        height: 31%;
+        opacity: 0.45;
+    }
+
+    &__list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1875rem;
+    }
+
+    &__list-row {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        font-size: 0.5625rem;
+    }
+
+    &__list-key {
+        overflow: hidden;
+        font-family: var(--font-mono);
+        color: var(--color-text-secondary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__list-value {
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        text-align: right;
+    }
+
+    &__foot {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 0.75rem 0.625rem;
+    }
+
+    &__hint {
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    @include preview-sparkline;
+}
+
+// 7-day range (the default)
+
+.DashboardPreview__radio#dashboard-preview-7d:checked ~ .DashboardPreview__board .DashboardPreview__range--7d {
+    color: var(--color-text-primary);
+    background: var(--color-bg-surface-primary);
+}
+
+// 30-day range
+
+.DashboardPreview__radio#dashboard-preview-30d:checked ~ .DashboardPreview__board .DashboardPreview__on-30d {
+    @include preview-swap-visible;
+}
+
+.DashboardPreview__radio#dashboard-preview-30d:checked ~ .DashboardPreview__board .DashboardPreview__on-7d {
+    @include preview-swap-hidden;
+}
+
+.DashboardPreview__radio#dashboard-preview-30d:checked ~ .DashboardPreview__board .DashboardPreview__range--30d {
+    color: var(--color-text-primary);
+    background: var(--color-bg-surface-primary);
+}
+
+// The funnel shape answers to the range too, so the tile is not static decoration.
+.DashboardPreview__radio#dashboard-preview-30d:checked ~ .DashboardPreview__board .DashboardPreview__bar--2 {
+    height: 54%;
+}
+
+.DashboardPreview__radio#dashboard-preview-30d:checked ~ .DashboardPreview__board .DashboardPreview__bar--3 {
+    height: 27%;
+}
+
+// The radios stay keyboard-focusable while visually hidden, so the labels they drive
+// need a visible focus indicator (WCAG 2.4.7).
+.DashboardPreview__radio#dashboard-preview-7d:focus-visible ~ .DashboardPreview__board .DashboardPreview__range--7d,
+.DashboardPreview__radio#dashboard-preview-30d:focus-visible ~ .DashboardPreview__board .DashboardPreview__range--30d {
+    outline: 2px solid var(--dashboard-preview-accent);
+    outline-offset: 1px;
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes DashboardPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; switching the
+// range still redraws the tiles (transitions only).
+@include preview-motion-guards('DashboardPreview');

--- a/products/dashboards/frontend/emptyState/DashboardsPreview.tsx
+++ b/products/dashboards/frontend/emptyState/DashboardsPreview.tsx
@@ -1,0 +1,163 @@
+import './DashboardsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored active-user series, one per date range. The 30-day line carries more
+// shape, so switching ranges visibly redraws the tile.
+const LINE_7D = 'M 0 26 L 16 24 L 33 25 L 50 20 L 66 21 L 83 16 L 100 14'
+const LINE_30D = 'M 0 34 L 14 30 L 28 32 L 42 25 L 56 27 L 70 18 L 84 20 L 100 10'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the dashboards empty state: a four-tile dashboard whose
+ * every tile answers to one date range. Switching between 7 and 30 days redraws the
+ * chart, the funnel, and both numbers at once, which is the thing a dashboard does
+ * that a single insight cannot. Two hidden radios drive it via `:checked ~` styles -
+ * no timers or state, per the preview rules in the `building-product-empty-states`
+ * skill. Range variants are stacked in `__swap` grids and crossfaded, so nothing shifts.
+ */
+export function DashboardsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('DashboardPreview', isStatic && 'DashboardPreview--static')}>
+            {/* Range selection, before the board so `:checked ~` can style every tile. */}
+            <input
+                type="radio"
+                name="dashboard-preview-range"
+                id="dashboard-preview-7d"
+                defaultChecked
+                className="DashboardPreview__radio"
+            />
+            <input
+                type="radio"
+                name="dashboard-preview-range"
+                id="dashboard-preview-30d"
+                className="DashboardPreview__radio"
+            />
+
+            <div className="DashboardPreview__board">
+                <div className="DashboardPreview__head">
+                    <span className="DashboardPreview__title">Product health</span>
+                    <div className="DashboardPreview__ranges">
+                        <label
+                            htmlFor="dashboard-preview-7d"
+                            className="DashboardPreview__range DashboardPreview__range--7d"
+                        >
+                            7 days
+                        </label>
+                        <label
+                            htmlFor="dashboard-preview-30d"
+                            className="DashboardPreview__range DashboardPreview__range--30d"
+                        >
+                            30 days
+                        </label>
+                    </div>
+                </div>
+
+                <div className="DashboardPreview__grid">
+                    <div className="DashboardPreview__tile">
+                        <span className="DashboardPreview__tile-title">Active users</span>
+                        <span className="DashboardPreview__tile-value DashboardPreview__swap">
+                            <span className="DashboardPreview__on-7d">4,182</span>
+                            <span className="DashboardPreview__on-30d">12,940</span>
+                        </span>
+                        <span className="DashboardPreview__tile-delta DashboardPreview__swap">
+                            <span className="DashboardPreview__on-7d">+8.2% vs previous</span>
+                            <span className="DashboardPreview__on-30d">+14.6% vs previous</span>
+                        </span>
+                    </div>
+
+                    <div className="DashboardPreview__tile">
+                        <span className="DashboardPreview__tile-title">Weekly actives</span>
+                        <svg
+                            className="DashboardPreview__spark-svg"
+                            viewBox="0 0 100 40"
+                            preserveAspectRatio="none"
+                            aria-hidden="true"
+                        >
+                            <g className="DashboardPreview__spark-g DashboardPreview__on-7d">
+                                <path className="DashboardPreview__spark-area" d={areaPath(LINE_7D)} />
+                                <path
+                                    className="DashboardPreview__spark-line"
+                                    d={LINE_7D}
+                                    vectorEffect="non-scaling-stroke"
+                                />
+                                <path
+                                    className="DashboardPreview__spark-trace"
+                                    d={LINE_7D}
+                                    pathLength={100}
+                                    vectorEffect="non-scaling-stroke"
+                                />
+                            </g>
+                            <g className="DashboardPreview__spark-g DashboardPreview__on-30d">
+                                <path className="DashboardPreview__spark-area" d={areaPath(LINE_30D)} />
+                                <path
+                                    className="DashboardPreview__spark-line"
+                                    d={LINE_30D}
+                                    vectorEffect="non-scaling-stroke"
+                                />
+                                <path
+                                    className="DashboardPreview__spark-trace"
+                                    d={LINE_30D}
+                                    pathLength={100}
+                                    vectorEffect="non-scaling-stroke"
+                                />
+                            </g>
+                        </svg>
+                    </div>
+
+                    <div className="DashboardPreview__tile">
+                        <span className="DashboardPreview__tile-title">Sign-up funnel</span>
+                        <div className="DashboardPreview__funnel">
+                            <span className="DashboardPreview__bar DashboardPreview__bar--1" />
+                            <span className="DashboardPreview__bar DashboardPreview__bar--2" />
+                            <span className="DashboardPreview__bar DashboardPreview__bar--3" />
+                        </div>
+                        <span className="DashboardPreview__tile-delta DashboardPreview__swap">
+                            <span className="DashboardPreview__on-7d">31% complete</span>
+                            <span className="DashboardPreview__on-30d">27% complete</span>
+                        </span>
+                    </div>
+
+                    <div className="DashboardPreview__tile">
+                        <span className="DashboardPreview__tile-title">Top pages</span>
+                        <div className="DashboardPreview__list">
+                            <span className="DashboardPreview__list-row">
+                                <span className="DashboardPreview__list-key">/pricing</span>
+                                <span className="DashboardPreview__swap DashboardPreview__list-value">
+                                    <span className="DashboardPreview__on-7d">1,204</span>
+                                    <span className="DashboardPreview__on-30d">4,860</span>
+                                </span>
+                            </span>
+                            <span className="DashboardPreview__list-row">
+                                <span className="DashboardPreview__list-key">/docs</span>
+                                <span className="DashboardPreview__swap DashboardPreview__list-value">
+                                    <span className="DashboardPreview__on-7d">932</span>
+                                    <span className="DashboardPreview__on-30d">3,417</span>
+                                </span>
+                            </span>
+                            <span className="DashboardPreview__list-row">
+                                <span className="DashboardPreview__list-key">/blog</span>
+                                <span className="DashboardPreview__swap DashboardPreview__list-value">
+                                    <span className="DashboardPreview__on-7d">618</span>
+                                    <span className="DashboardPreview__on-30d">2,205</span>
+                                </span>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="DashboardPreview__foot">
+                    <LemonTag size="small">example data</LemonTag>
+                    <span className="DashboardPreview__hint">Switch the range to move every tile at once.</span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/dashboards/frontend/emptyState/DashboardsPrimaryAction.tsx
+++ b/products/dashboards/frontend/emptyState/DashboardsPrimaryAction.tsx
@@ -1,0 +1,23 @@
+import { useActions } from 'kea'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
+import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
+
+/**
+ * Create button for the dashboards empty state. New dashboards are picked in a modal
+ * that the scene normally renders, and the gate replaces the scene - so the empty
+ * state has to render the modal itself or the button would open nothing.
+ */
+export function DashboardsPrimaryAction(): JSX.Element {
+    const { showNewDashboardModal } = useActions(newDashboardLogic)
+
+    return (
+        <>
+            <LemonButton type="primary" onClick={showNewDashboardModal} data-attr="new-dashboard">
+                Create your first dashboard
+            </LemonButton>
+            <NewDashboardModal />
+        </>
+    )
+}

--- a/products/dashboards/frontend/emptyState/DashboardsPrimaryAction.tsx
+++ b/products/dashboards/frontend/emptyState/DashboardsPrimaryAction.tsx
@@ -1,8 +1,11 @@
 import { useActions } from 'kea'
 
+import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
+
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 /**
  * Create button for the dashboards empty state. New dashboards are picked in a modal
@@ -14,9 +17,14 @@ export function DashboardsPrimaryAction(): JSX.Element {
 
     return (
         <>
-            <LemonButton type="primary" onClick={showNewDashboardModal} data-attr="new-dashboard">
-                Create your first dashboard
-            </LemonButton>
+            <AccessControlAction
+                resourceType={AccessControlResourceType.Dashboard}
+                minAccessLevel={AccessControlLevel.Editor}
+            >
+                <LemonButton type="primary" onClick={showNewDashboardModal} data-attr="new-dashboard">
+                    Create your first dashboard
+                </LemonButton>
+            </AccessControlAction>
             <NewDashboardModal />
         </>
     )

--- a/products/dashboards/frontend/emptyState/dashboardsEmptyState.tsx
+++ b/products/dashboards/frontend/emptyState/dashboardsEmptyState.tsx
@@ -1,0 +1,36 @@
+import * as chartPng from '@posthog/brand/hoggies/png/chart'
+import { IconDashboard } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { DashboardsPreview } from './DashboardsPreview'
+import { DashboardsPrimaryAction } from './DashboardsPrimaryAction'
+import { dashboardsSetupLogic } from './dashboardsSetupLogic'
+
+const HedgehogChart = pngHoggie(chartPng)
+
+export const dashboardsEmptyState: SceneProductEmptyState = {
+    statusLogic: dashboardsSetupLogic,
+    config: {
+        productKey: ProductKey.DASHBOARDS,
+        productName: 'Dashboards',
+        icon: <IconDashboard />,
+        accentColor: 'var(--color-product-dashboards-light)',
+        accentColorDark: 'var(--color-product-dashboards-dark)',
+        hedgehog: HedgehogChart,
+        text: {
+            'needs-setup': {
+                headline: 'Put the numbers you check every day on one page',
+                lead: 'A dashboard collects insights, replays, and anything else you track into a single view your whole team can open. Start from a template built for a common job, like product health or web traffic, or start blank and add tiles as you go.',
+            },
+        },
+        PrimaryAction: DashboardsPrimaryAction,
+        skippable: false,
+        docsUrl: 'https://posthog.com/docs/product-analytics/dashboards',
+        previewLabel: 'Your dashboard, once created',
+        Preview: DashboardsPreview,
+    },
+}

--- a/products/dashboards/frontend/emptyState/dashboardsSetupLogic.test.ts
+++ b/products/dashboards/frontend/emptyState/dashboardsSetupLogic.test.ts
@@ -1,0 +1,44 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { dashboardsSetupLogic } from './dashboardsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('dashboardsSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(generatedApi, 'dashboardsList')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [17, 'has-data'],
+    ])('pushes a dashboard count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, results: [] })
+        const logic = dashboardsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.DASHBOARDS }).values.status).toBe(expected)
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = dashboardsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.DASHBOARDS }).values.status).toBe('unknown')
+    })
+})

--- a/products/dashboards/frontend/emptyState/dashboardsSetupLogic.test.ts
+++ b/products/dashboards/frontend/emptyState/dashboardsSetupLogic.test.ts
@@ -2,6 +2,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
 
+import { dashboardsModel } from '~/models/dashboardsModel'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
@@ -32,6 +33,20 @@ describe('dashboardsSetupLogic', () => {
         logic.mount()
         await expectLogic(logic).toFinishAllListeners()
         expect(productSetupStatusLogic({ productKey: ProductKey.DASHBOARDS }).values.status).toBe(expected)
+    })
+
+    it('re-detects when a dashboard is created without leaving the scene', async () => {
+        listSpy.mockResolvedValueOnce({ count: 0, results: [] }).mockResolvedValue({ count: 1, results: [] })
+        const logic = dashboardsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.DASHBOARDS }).values.status).toBe('needs-setup')
+
+        // Creating from the empty state's modal does not navigate unless the user opts in,
+        // so without the recheck wiring the gate would keep hiding the new dashboard.
+        dashboardsModel.actions.addDashboardSuccess({ id: 1, name: 'First' } as any)
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.DASHBOARDS }).values.status).toBe('has-data')
     })
 
     it('fails open to unknown when the count query fails before any answer', async () => {

--- a/products/dashboards/frontend/emptyState/dashboardsSetupLogic.ts
+++ b/products/dashboards/frontend/emptyState/dashboardsSetupLogic.ts
@@ -1,0 +1,21 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { dashboardsList } from '../generated/api'
+
+/**
+ * Setup detection for the dashboards empty state. Dashboards are a creation-first
+ * product, so "set up" simply means the project has at least one dashboard - no
+ * event or traffic signal involved.
+ */
+export const dashboardsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.DASHBOARDS,
+    path: ['products', 'dashboards', 'frontend', 'emptyState', 'dashboardsSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await dashboardsList(projectId, { limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/dashboards/frontend/emptyState/dashboardsSetupLogic.ts
+++ b/products/dashboards/frontend/emptyState/dashboardsSetupLogic.ts
@@ -1,6 +1,7 @@
 import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
 import { projectLogic } from 'scenes/projectLogic'
 
+import { dashboardsModel } from '~/models/dashboardsModel'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { dashboardsList } from '../generated/api'
@@ -18,4 +19,8 @@ export const dashboardsSetupLogic = createSetupDetectionLogic({
         const response = await dashboardsList(projectId, { limit: 1 })
         return response.count > 0 ? 'has-data' : 'needs-setup'
     },
+    // The empty state creates the first dashboard in a modal, and its "open after
+    // creation" field defaults to off, so the usual path leaves the user on this scene
+    // with no remount to re-run detection.
+    recheckActionTypes: () => [dashboardsModel.actionTypes.addDashboardSuccess],
 })


### PR DESCRIPTION
## Problem

Someone opening Dashboards for the first time gets a card built on `ProductIntroduction`, which is deprecated. Dashboards is one of the highest-traffic first-run surfaces in the app.

Part of moving every product scene onto the shared `ProductEmptyState` gate. Remaining work is tracked in #91027.

## Changes

- Dashboards shows the shared setup empty state until the project has a dashboard.
- The preview is a four-tile board where switching between 7 and 30 days redraws the chart, reshapes the funnel, and moves both numbers at once. That is the thing a dashboard does that a single insight cannot.
- The empty state renders the new dashboard modal itself. The gate replaces the scene that normally renders it, so the button would otherwise open nothing.
- Adds a `DASHBOARDS` product key.
- Adds `--color-product-dashboards-dark`. The palette had only the light variant.

> [!WARNING]
> The new product key is the one thing here worth close review. Dashboards previously shared `PRODUCT_ANALYTICS`, and `productSetupStatusLogic` is keyed by product key. Without its own key, a dashboard existing would read as product analytics being set up, and the saved insights empty state in the layer above would never show. Regenerating the schema also touches `schema.json` and `posthog/schema_enums.py`.

The tabbed scene loses its Templates tab while the empty state shows. Templates remain reachable from the new dashboard modal the primary action opens.

## How did you test this code?

`products/dashboards/frontend/emptyState/dashboardsSetupLogic.test.ts` covers the count-to-status mapping and the fail-open path. Without it a broken count query strands the gate on its spinner, and no existing test covers this product.

Frontend typecheck passes after regenerating both schemas. Not verified: the empty state rendered in a browser, and the backend consequences of the new enum value beyond the generated files. The storybook story added here gives visual-regression coverage on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/stacking-prs`, `/writing-pr-descriptions`.

`EmptyDashboardComponent` (a single dashboard with no tiles) still uses `ProductIntroduction`. It is a per-entity empty state rather than a product landing surface, so it is out of the gate's scope and stays on the tracking list.
