### PR TITLE
feat(product-analytics): add the product empty state to saved insights

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -65,6 +65,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Annotations            | `frontend/src/scenes/annotations/Annotations.tsx`                                   | on master             |
 | Cohorts                | `frontend/src/scenes/cohorts/Cohorts.tsx`                                           | on master             |
 | Dashboards             | `frontend/src/scenes/dashboard/dashboards/Dashboards.tsx`                           | on master             |
+| Product analytics      | `frontend/src/scenes/saved-insights/SavedInsights.tsx`                              | on master             |
 
 Only four products resolve their status at app boot, via a `setupProbe` in their manifest:
 LLM analytics, error tracking, MCP analytics, web analytics.
@@ -78,10 +79,9 @@ do not have one yet.
 
 These are the scenes a new user is most likely to land on before they have data.
 
-| Product                | Scene                                                       | Shows instead                                                                          |
-| ---------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Product analytics      | `frontend/src/scenes/saved-insights/SavedInsights.tsx`      | `SavedInsightsEmptyState`, plus a bespoke `SampleDataState` and `sampleDataStateLogic` |
-| Single empty dashboard | `frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx` | `ProductIntroduction`                                                                  |
+| Product                | Scene                                                       | Shows instead         |
+| ---------------------- | ----------------------------------------------------------- | --------------------- |
+| Single empty dashboard | `frontend/src/scenes/dashboard/EmptyDashboardComponent.tsx` | `ProductIntroduction` |
 
 ### Tier 2: cheap, or actively misleading today
 

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1852,6 +1852,10 @@ snapshots:
         hash: v1.k794b7964.e344a03ab4fb6bbef2cf88d2b89c12bccfe1b5307e5e80051e47ad6adec22d93.w4TEddGy6INFXoaPeIr201fD_4xWA6jG0Uugfke9ytM
     components-product-empty-state--not-empty-with-action--light:
         hash: v1.k794b7964.1500e8a17e5bfb2cdc59cea8794c8499622f0218ea6a7dc2bdde259d044d3235.IqteBA6dHdaJztqTmvDTi_IdMolu_vwld3w7xHahpvo
+    components-product-empty-state--product-analytics-needs-setup--dark:
+        hash: v1.k794b7964.1ba74ff0bea7eef70d4faedf8160e9edd14b89ac74b23b98a1322f74f29c7188.eXqkpdeyPlzK4NAYg9xIMc73g54455Ng0wnqLkFqOCg
+    components-product-empty-state--product-analytics-needs-setup--light:
+        hash: v1.k794b7964.e090c6d53b8aa01575575b5ffb99c69d884033dfbda577571c740ae424ba0edb.wX4jI_gpHjxLPca_EFTH1-f2YzmvnU1Rozi3zQVGtsk
     components-product-empty-state--product-introduction--dark:
         hash: v1.k794b7964.6fb2d5feff1fa62c3ed888268602b4eb017f75d33178538542ee4a6d28072fc3.tHRCmCQubhMPmffxXOGXE0jpd1kSvcnGMay-GOjl-J0
     components-product-empty-state--product-introduction--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -19,6 +19,7 @@ import { linksEmptyState } from 'products/links/frontend/emptyState/linksEmptySt
 import { logsEmptyState } from 'products/logs/frontend/emptyState/logsEmptyState'
 import { mcpAnalyticsEmptyState } from 'products/mcp_analytics/frontend/emptyState/mcpAnalyticsEmptyState'
 import { metricsEmptyState } from 'products/metrics/frontend/emptyState/metricsEmptyState'
+import { productAnalyticsEmptyState } from 'products/product_analytics/frontend/emptyState/productAnalyticsEmptyState'
 import { productToursEmptyState } from 'products/product_tours/frontend/emptyState/productToursEmptyState'
 import { sessionReplayEmptyState } from 'products/replay/frontend/emptyState/sessionReplayEmptyState'
 import { replayVisionEmptyState } from 'products/replay_vision/frontend/emptyState/replayVisionEmptyState'
@@ -215,6 +216,17 @@ export const DashboardsNeedsSetup: ProductEmptyStateStory = productEmptyStateSto
     dashboardsEmptyState,
     'needs-setup',
     { mocks: dashboardsMocks }
+)
+
+// Product analytics detection lists insights on mount - answer "none yet".
+const productAnalyticsMocks = {
+    get: { '/api/projects/:team_id/insights/': [200, { count: 0, results: [] }] },
+} as const
+
+export const ProductAnalyticsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    productAnalyticsEmptyState,
+    'needs-setup',
+    { mocks: productAnalyticsMocks }
 )
 
 // Error tracking detection asks the issues-exists API on mount - answer "none yet".

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
@@ -300,25 +300,37 @@ function QuestionSectionBlock({ section }: { section: QuestionSection }): JSX.El
     )
 }
 
-export function NewInsightMenuOverlay(): JSX.Element {
+/**
+ * The insight-type card grid, without any sizing of its own - the dropdown and the
+ * empty state's modal each give it the width they can spare. The two columns stack
+ * once the surface is too narrow to hold them side by side.
+ */
+export function NewInsightMenuContent(): JSX.Element {
     const sections = useQuestionSections()
     const columns = [sections.slice(0, 2), sections.slice(2)]
     return (
-        <div
-            className="flex w-[58rem] max-w-[calc(100vw-1rem)] gap-4 overflow-y-auto p-4 max-h-[calc(100vh-10rem)]"
-            data-attr="new-insight-menu"
-        >
-            <div className="flex flex-1 flex-col gap-6">
-                {columns[0].map((section) => (
-                    <QuestionSectionBlock key={section.title} section={section} />
-                ))}
+        <div className="@container/new-insight-menu" data-attr="new-insight-menu">
+            <div className="flex flex-col gap-6 @min-[44rem]/new-insight-menu:flex-row @min-[44rem]/new-insight-menu:gap-4">
+                <div className="flex flex-1 flex-col gap-6">
+                    {columns[0].map((section) => (
+                        <QuestionSectionBlock key={section.title} section={section} />
+                    ))}
+                </div>
+                <LemonDivider vertical className="hidden self-stretch @min-[44rem]/new-insight-menu:block" />
+                <div className="flex flex-1 flex-col gap-6">
+                    {columns[1].map((section) => (
+                        <QuestionSectionBlock key={section.title} section={section} />
+                    ))}
+                </div>
             </div>
-            <LemonDivider vertical className="self-stretch" />
-            <div className="flex flex-1 flex-col gap-6">
-                {columns[1].map((section) => (
-                    <QuestionSectionBlock key={section.title} section={section} />
-                ))}
-            </div>
+        </div>
+    )
+}
+
+export function NewInsightMenuOverlay(): JSX.Element {
+    return (
+        <div className="w-[58rem] max-w-[calc(100vw-1rem)] overflow-y-auto p-4 max-h-[calc(100vh-10rem)]">
+            <NewInsightMenuContent />
         </div>
     )
 }

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -47,6 +47,8 @@ import {
     SavedInsightsTabs,
 } from '~/types'
 
+import { productAnalyticsEmptyState } from 'products/product_analytics/frontend/emptyState/productAnalyticsEmptyState'
+
 export * from './insightTypesMetadata'
 
 import { ProductAnalyticsNotifications } from 'products/product_analytics/frontend/notifications/ProductAnalyticsNotifications'
@@ -62,6 +64,7 @@ export const scene: SceneExport = {
     component: SavedInsights,
     logic: savedInsightsLogic,
     productKey: ProductKey.PRODUCT_ANALYTICS,
+    emptyState: productAnalyticsEmptyState,
 }
 
 export function InsightIcon({

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -313,6 +313,7 @@
     --color-product-data-pipeline-light: rgb(46 162 211);
     --color-product-data-pipeline-dark: rgb(84 189 235);
     --color-product-product-analytics-light: rgb(47 128 250);
+    --color-product-product-analytics-dark: rgb(96 165 250);
     --color-product-workflows-light: rgb(47 128 250);
     --color-product-web-analytics-light: rgb(52 175 102);
     --color-product-web-analytics-dark: rgb(54 196 111); // original color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4048,6 +4048,9 @@ importers:
 
   products/product_analytics:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.10.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/products/product_analytics/frontend/emptyState/ProductAnalyticsPreview.scss
+++ b/products/product_analytics/frontend/emptyState/ProductAnalyticsPreview.scss
@@ -1,0 +1,245 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.InsightPreview {
+    --insight-preview-accent: var(--empty-state-accent, var(--color-product-product-analytics-light));
+
+    display: flex;
+    flex-direction: column;
+
+    // Hidden breakdown state. A direct child of .InsightPreview so `:checked ~` reaches the card.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__card {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Before/after pairs are stacked on one grid cell and crossfaded, so turning the
+    // breakdown on never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-after {
+        @include preview-swap-hidden;
+    }
+
+    &__when-before {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    // Query row
+
+    &__query {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+    }
+
+    &__series-dot {
+        width: 7px;
+        height: 7px;
+        background: var(--insight-preview-accent);
+        border-radius: 50%;
+    }
+
+    &__series {
+        font-size: 0.6875rem;
+        font-weight: 600;
+    }
+
+    &__breakdown {
+        padding: 0.1875rem 0.5rem;
+        margin-left: auto;
+        font-size: 0.625rem;
+        font-weight: 600;
+        cursor: pointer;
+        user-select: none;
+        border: 1px dashed color-mix(in oklab, var(--insight-preview-accent) 45%, transparent);
+        border-radius: var(--radius);
+        transition: background 150ms ease;
+
+        @include preview-accent-text(var(--insight-preview-accent));
+    }
+
+    &__breakdown:hover {
+        background: color-mix(in oklab, var(--insight-preview-accent) 10%, transparent);
+    }
+
+    // Chart
+
+    &__plot {
+        padding: 0 0.75rem;
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--insight-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--insight-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The three breakdown series step down in weight, so they read as parts of the total.
+    &__spark-line--chrome {
+        stroke: var(--insight-preview-accent);
+    }
+
+    &__spark-line--safari {
+        stroke: color-mix(in oklab, var(--insight-preview-accent) 62%, var(--color-text-primary));
+    }
+
+    &__spark-line--firefox {
+        stroke: color-mix(in oklab, var(--insight-preview-accent) 38%, var(--color-text-primary));
+    }
+
+    // The moving bit: a short bright segment cycling along the top line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--insight-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: InsightPreview__trace 3.2s linear infinite;
+    }
+
+    // Legend
+
+    &__legend {
+        padding: 0.375rem 0.75rem 0;
+    }
+
+    &__legend-slot,
+    &__legend-spacer {
+        min-height: 3rem;
+    }
+
+    &__legend-rows {
+        display: flex;
+        flex-direction: column;
+        gap: 0.1875rem;
+    }
+
+    &__legend-row {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+        font-size: 0.625rem;
+    }
+
+    &__key {
+        width: 8px;
+        height: 3px;
+        border-radius: 999px;
+    }
+
+    &__key--chrome {
+        background: var(--insight-preview-accent);
+    }
+
+    &__key--safari {
+        background: color-mix(in oklab, var(--insight-preview-accent) 62%, var(--color-text-primary));
+    }
+
+    &__key--firefox {
+        background: color-mix(in oklab, var(--insight-preview-accent) 38%, var(--color-text-primary));
+    }
+
+    &__legend-value {
+        margin-left: auto;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-secondary);
+    }
+
+    &__hint {
+        padding: 0.375rem 0.75rem 0.625rem;
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+        text-align: center;
+    }
+
+    @include preview-sparkline;
+}
+
+// Broken-down state (user turned the breakdown on)
+
+.InsightPreview__checkbox:checked ~ * .InsightPreview__when-after {
+    @include preview-swap-visible;
+}
+
+.InsightPreview__checkbox:checked ~ * .InsightPreview__when-before {
+    @include preview-swap-hidden;
+}
+
+.InsightPreview__checkbox:checked ~ .InsightPreview__card .InsightPreview__breakdown {
+    background: color-mix(in oklab, var(--insight-preview-accent) 12%, transparent);
+    border-style: solid;
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the control it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.InsightPreview__checkbox:focus-visible ~ .InsightPreview__card .InsightPreview__breakdown {
+    outline: 2px solid var(--insight-preview-accent);
+    outline-offset: 1px;
+}
+
+// Nudge attention at the breakdown control until it's used.
+.InsightPreview:not(.InsightPreview--static)
+    .InsightPreview__checkbox:not(:checked)
+    ~ .InsightPreview__card
+    .InsightPreview__breakdown {
+    animation: InsightPreview__nudge 2.4s ease-in-out infinite;
+}
+
+@keyframes InsightPreview__nudge {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--insight-preview-accent) 45%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--insight-preview-accent) 18%, transparent);
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes InsightPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; turning the
+// breakdown on still splits the series (transitions only).
+@include preview-motion-guards('InsightPreview');

--- a/products/product_analytics/frontend/emptyState/ProductAnalyticsPreview.tsx
+++ b/products/product_analytics/frontend/emptyState/ProductAnalyticsPreview.tsx
@@ -1,0 +1,130 @@
+import './ProductAnalyticsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// One combined series, then the same total split three ways. The parts stay under the
+// whole at every point, so the breakdown reads as a decomposition rather than new data.
+const LINE_TOTAL = 'M 0 30 L 16 27 L 33 28 L 50 22 L 66 24 L 83 17 L 100 13'
+const LINE_CHROME = 'M 0 33 L 16 31 L 33 31 L 50 26 L 66 28 L 83 22 L 100 19'
+const LINE_SAFARI = 'M 0 36 L 16 35 L 33 35 L 50 32 L 66 33 L 83 30 L 100 28'
+const LINE_FIREFOX = 'M 0 38 L 16 38 L 33 37 L 50 36 L 66 36 L 83 35 L 100 34'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the product analytics empty state: one insight, and what
+ * a breakdown does to it. Turning the breakdown on splits a single pageview line into
+ * one line per browser and fills in the legend. One hidden checkbox drives it via
+ * `:checked ~` styles - no timers or state, per the preview rules in the
+ * `building-product-empty-states` skill. Before/after pairs are stacked in `__swap`
+ * grids and crossfaded, so nothing shifts.
+ */
+export function ProductAnalyticsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('InsightPreview', isStatic && 'InsightPreview--static')}>
+            {/* Breakdown state, before the card so `:checked ~` can style it. */}
+            <input type="checkbox" id="insight-preview-breakdown" className="InsightPreview__checkbox" />
+
+            <div className="InsightPreview__card">
+                <div className="InsightPreview__head">
+                    <span className="InsightPreview__title">Pageviews, last 7 days</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="InsightPreview__query">
+                    <span className="InsightPreview__series-dot" aria-hidden="true" />
+                    <span className="InsightPreview__series">Pageview</span>
+                    <label htmlFor="insight-preview-breakdown" className="InsightPreview__breakdown">
+                        <span className="InsightPreview__swap">
+                            <span className="InsightPreview__when-before">Break down by browser</span>
+                            <span className="InsightPreview__when-after">Breakdown: Browser</span>
+                        </span>
+                    </label>
+                </div>
+
+                <div className="InsightPreview__plot">
+                    <svg
+                        className="InsightPreview__spark-svg"
+                        viewBox="0 0 100 40"
+                        preserveAspectRatio="none"
+                        aria-hidden="true"
+                    >
+                        <g className="InsightPreview__spark-g InsightPreview__when-before">
+                            <path className="InsightPreview__spark-area" d={areaPath(LINE_TOTAL)} />
+                            <path
+                                className="InsightPreview__spark-line"
+                                d={LINE_TOTAL}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="InsightPreview__spark-trace"
+                                d={LINE_TOTAL}
+                                pathLength={100}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </g>
+                        <g className="InsightPreview__spark-g InsightPreview__when-after">
+                            <path
+                                className="InsightPreview__spark-line InsightPreview__spark-line--chrome"
+                                d={LINE_CHROME}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="InsightPreview__spark-line InsightPreview__spark-line--safari"
+                                d={LINE_SAFARI}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="InsightPreview__spark-line InsightPreview__spark-line--firefox"
+                                d={LINE_FIREFOX}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                            <path
+                                className="InsightPreview__spark-trace"
+                                d={LINE_CHROME}
+                                pathLength={100}
+                                vectorEffect="non-scaling-stroke"
+                            />
+                        </g>
+                    </svg>
+                </div>
+
+                <div className="InsightPreview__legend">
+                    <div className="InsightPreview__legend-slot InsightPreview__swap">
+                        <span className="InsightPreview__legend-spacer InsightPreview__when-before" />
+                        <div className="InsightPreview__legend-rows InsightPreview__when-after">
+                            <span className="InsightPreview__legend-row">
+                                <span className="InsightPreview__key InsightPreview__key--chrome" aria-hidden="true" />
+                                Chrome
+                                <span className="InsightPreview__legend-value">18,204</span>
+                            </span>
+                            <span className="InsightPreview__legend-row">
+                                <span className="InsightPreview__key InsightPreview__key--safari" aria-hidden="true" />
+                                Safari
+                                <span className="InsightPreview__legend-value">6,918</span>
+                            </span>
+                            <span className="InsightPreview__legend-row">
+                                <span className="InsightPreview__key InsightPreview__key--firefox" aria-hidden="true" />
+                                Firefox
+                                <span className="InsightPreview__legend-value">2,140</span>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="InsightPreview__hint InsightPreview__swap">
+                    <span className="InsightPreview__when-before">Break the total down to see who is behind it.</span>
+                    <span className="InsightPreview__when-after">
+                        Save this insight, or drop it on a dashboard. Click again to undo.
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/product_analytics/frontend/emptyState/ProductAnalyticsPrimaryAction.tsx
+++ b/products/product_analytics/frontend/emptyState/ProductAnalyticsPrimaryAction.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+
+import { AccessControlAction } from 'lib/components/AccessControlAction'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { NewInsightMenuContent } from 'scenes/saved-insights/NewInsightMenu'
+
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+/**
+ * Create button for the product analytics empty state. It offers the same insight
+ * types as the scene's own "New" button, in a modal rather than that button's
+ * dropdown - the empty state's action sits mid-scene, where a menu this wide has
+ * no room to open against.
+ */
+export function ProductAnalyticsPrimaryAction(): JSX.Element {
+    const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+    return (
+        <>
+            <AccessControlAction
+                resourceType={AccessControlResourceType.Insight}
+                minAccessLevel={AccessControlLevel.Editor}
+            >
+                <LemonButton
+                    type="primary"
+                    className="self-start"
+                    onClick={() => setIsMenuOpen(true)}
+                    data-attr="add-insight-button-empty-state"
+                >
+                    Create your first insight
+                </LemonButton>
+            </AccessControlAction>
+            <LemonModal
+                isOpen={isMenuOpen}
+                onClose={() => setIsMenuOpen(false)}
+                title="Create an insight"
+                description="Pick the question you want to answer. You can change the type later."
+                width="58rem"
+                maxWidth="calc(100vw - 2rem)"
+            >
+                <NewInsightMenuContent />
+            </LemonModal>
+        </>
+    )
+}

--- a/products/product_analytics/frontend/emptyState/productAnalyticsEmptyState.tsx
+++ b/products/product_analytics/frontend/emptyState/productAnalyticsEmptyState.tsx
@@ -1,0 +1,45 @@
+import * as magnifyingGlassPng from '@posthog/brand/hoggies/png/magnifying-glass-2'
+import { IconGraph } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { ProductAnalyticsPreview } from './ProductAnalyticsPreview'
+import { productAnalyticsSetupLogic } from './productAnalyticsSetupLogic'
+
+const HedgehogMagnifyingGlass = pngHoggie(magnifyingGlassPng)
+
+export const productAnalyticsEmptyState: SceneProductEmptyState = {
+    statusLogic: productAnalyticsSetupLogic,
+    config: {
+        productKey: ProductKey.PRODUCT_ANALYTICS,
+        productName: 'Product analytics',
+        icon: <IconGraph />,
+        accentColor: 'var(--color-product-product-analytics-light)',
+        accentColorDark: 'var(--color-product-product-analytics-dark)',
+        hedgehog: HedgehogMagnifyingGlass,
+        text: {
+            'needs-setup': {
+                headline: 'Ask a question about your product and save the answer',
+                lead: 'An insight is one question about the events you already send: how many people did this, where do they drop off, who comes back. Break the answer down by any property, then save it so you can reopen it later or drop it on a dashboard.',
+            },
+        },
+        primaryAction: {
+            label: 'Create your first insight',
+            to: urls.insightNew(),
+            dataAttr: 'add-insight-button-empty-state',
+            accessControl: {
+                resourceType: AccessControlResourceType.Insight,
+                minAccessLevel: AccessControlLevel.Editor,
+            },
+        },
+        skippable: false,
+        docsUrl: 'https://posthog.com/docs/product-analytics/insights',
+        previewLabel: 'Your insights, once created',
+        Preview: ProductAnalyticsPreview,
+    },
+}

--- a/products/product_analytics/frontend/emptyState/productAnalyticsEmptyState.tsx
+++ b/products/product_analytics/frontend/emptyState/productAnalyticsEmptyState.tsx
@@ -3,12 +3,11 @@ import { IconGraph } from '@posthog/icons'
 
 import { pngHoggie } from 'lib/brand/hoggies'
 import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
-import { urls } from 'scenes/urls'
 
 import { ProductKey } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 import { ProductAnalyticsPreview } from './ProductAnalyticsPreview'
+import { ProductAnalyticsPrimaryAction } from './ProductAnalyticsPrimaryAction'
 import { productAnalyticsSetupLogic } from './productAnalyticsSetupLogic'
 
 const HedgehogMagnifyingGlass = pngHoggie(magnifyingGlassPng)
@@ -28,15 +27,7 @@ export const productAnalyticsEmptyState: SceneProductEmptyState = {
                 lead: 'An insight is one question about the events you already send: how many people did this, where do they drop off, who comes back. Break the answer down by any property, then save it so you can reopen it later or drop it on a dashboard.',
             },
         },
-        primaryAction: {
-            label: 'Create your first insight',
-            to: urls.insightNew(),
-            dataAttr: 'add-insight-button-empty-state',
-            accessControl: {
-                resourceType: AccessControlResourceType.Insight,
-                minAccessLevel: AccessControlLevel.Editor,
-            },
-        },
+        PrimaryAction: ProductAnalyticsPrimaryAction,
         skippable: false,
         docsUrl: 'https://posthog.com/docs/product-analytics/insights',
         previewLabel: 'Your insights, once created',

--- a/products/product_analytics/frontend/emptyState/productAnalyticsSetupLogic.test.ts
+++ b/products/product_analytics/frontend/emptyState/productAnalyticsSetupLogic.test.ts
@@ -1,0 +1,44 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { productAnalyticsSetupLogic } from './productAnalyticsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('productAnalyticsSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(generatedApi, 'insightsList')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [17, 'has-data'],
+    ])('pushes an insight count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, results: [] })
+        const logic = productAnalyticsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PRODUCT_ANALYTICS }).values.status).toBe(expected)
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = productAnalyticsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.PRODUCT_ANALYTICS }).values.status).toBe('unknown')
+    })
+})

--- a/products/product_analytics/frontend/emptyState/productAnalyticsSetupLogic.ts
+++ b/products/product_analytics/frontend/emptyState/productAnalyticsSetupLogic.ts
@@ -1,0 +1,21 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { insightsList } from '../generated/api'
+
+/**
+ * Setup detection for the product analytics empty state. The gated scene is the
+ * saved insights list, so "set up" means the project has at least one saved
+ * insight - not that events are arriving, which the scene does not depend on.
+ */
+export const productAnalyticsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.PRODUCT_ANALYTICS,
+    path: ['products', 'product_analytics', 'frontend', 'emptyState', 'productAnalyticsSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await insightsList(projectId, { limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/product_analytics/package.json
+++ b/products/product_analytics/package.json
@@ -17,6 +17,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",


### PR DESCRIPTION
## Problem

Someone opening Product analytics for the first time gets `SavedInsightsEmptyState`, a bespoke screen predating the shared gate. It is the highest-traffic first-run surface in the app.

Top of the stack that moves five product scenes onto the shared `ProductEmptyState` gate. Remaining work is tracked in #91027.

## Changes

- Saved insights shows the shared setup empty state until the project has an insight.
- The create button carries the same permission check and `data-attr` as the scene's own, so a viewer sees it disabled rather than failing on save.
- The preview is interactive: turning on a breakdown splits one pageview line into one line per browser and fills in the legend, which is the move that makes an insight useful.
- Adds `--color-product-product-analytics-dark`. The palette had only the light variant.
- Detection is an insight count through the generated API, with four cases covered by a new test.

`SavedInsightsEmptyState` stays on the table rather than being deleted. It also covers the filtered-to-nothing case, which the gate does not handle. The gate takes the unfiltered zero case that the component used to serve.

## How did you test this code?

`products/product_analytics/frontend/emptyState/productAnalyticsSetupLogic.test.ts` covers the count-to-status mapping and the fail-open path. Without it a broken count query strands the gate on its spinner, and no existing test covers this product.

Frontend typecheck passes and all five suites in this stack pass together (20 tests). Not verified: the empty state rendered in a browser, in dark mode, or at a narrow width, and the split of responsibility with `SavedInsightsEmptyState` described above is reasoned from the code rather than clicked through. The storybook story added here gives visual-regression coverage on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/stacking-prs`, `/writing-pr-descriptions`.

Detection here counts saved insights rather than incoming events, because the gated scene is the saved insights list and it does not depend on ingestion. A project sending events but holding no saved insight still sees the empty state.
