### PR TITLE
feat(hogql): add trino query compilation

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -66,14 +66,14 @@ EXCEPTION_STRING_ARRAY_PROPERTIES = frozenset(
     }
 )
 
-type HogQLDialect = Literal["hogql", "clickhouse", "postgres", "duckdb", "mysql", "snowflake", "redshift"]
+type HogQLDialect = Literal["hogql", "clickhouse", "postgres", "duckdb", "mysql", "snowflake", "redshift", "trino"]
 
 # All dialects that compile to an external SQL database queried directly (as opposed to
 # ClickHouse / HogQL). MySQL shares the standard-SQL keyword surface (CURRENT_DATE & co.)
 # but not Postgres-specific features like PIVOT/UNPIVOT, TRY_CAST, or positional references.
 # Redshift is a Postgres fork: it reuses the Postgres-family lazy-table resolution and
 # property lowering, then its printer blocks the constructs the Redshift engine can't run.
-SQL_TARGET_DIALECTS: frozenset[HogQLDialect] = frozenset({"postgres", "duckdb", "mysql", "redshift"})
+SQL_TARGET_DIALECTS: frozenset[HogQLDialect] = frozenset({"postgres", "duckdb", "mysql", "redshift", "trino"})
 
 type HogQLParserBackend = Literal["cpp-json", "rust-json", "rust-py"]
 

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -2014,14 +2014,12 @@ class Database(BaseModel):
                                 # For a chain of type a.b.c, we want to create a nested table node
                                 # where a is the parent, b is the child of a, and c is the child of b
                                 # where a.b.c will contain the table.
-                                # Snowflake stores identifiers uppercase but resolves them
-                                # case-insensitively, so mark its nodes so `from tpch_sf1.nation`
-                                # (any case) resolves to the canonical `TPCH_SF1.NATION`.
+                                case_insensitive = table.external_data_source.direct_engine in {"snowflake", "trino"}
                                 warehouse_tables.add_child(
                                     TableNode.create_nested_for_chain(
                                         table_chain,
                                         table_for_key,
-                                        case_insensitive=table.external_data_source.is_direct_snowflake,
+                                        case_insensitive=case_insensitive,
                                     ),
                                     table_conflict_mode=table_conflict_mode,
                                 )
@@ -2069,9 +2067,10 @@ class Database(BaseModel):
                             TableNode.create_nested_for_chain(
                                 table_key.split("."),
                                 virtual_table,
-                                # Snowflake resolves identifiers case-insensitively; the model's
-                                # is_direct_snowflake prop is False for synced sources, so key off type.
-                                case_insensitive=(virtual_source.source_type == ExternalDataSourceType.SNOWFLAKE),
+                                case_insensitive=(
+                                    virtual_source.source_type
+                                    in {ExternalDataSourceType.SNOWFLAKE, ExternalDataSourceType.TRINO}
+                                ),
                             ),
                             table_conflict_mode="override",
                         )
@@ -2398,7 +2397,6 @@ class Database(BaseModel):
 
 
 def get_data_warehouse_table_name(source: ExternalDataSource | None, table_name: str):
-
     if source is None:
         return table_name
 
@@ -2763,7 +2761,6 @@ def _strip_external_source_prefix(source: ExternalDataSource, table_name: str) -
 
 
 def _get_warehouse_table_keys(warehouse_table: DataWarehouseTable, *, direct_query: bool) -> list[str]:
-
     source = warehouse_table.external_data_source
     if source is not None and source.access_method == ExternalDataSourceAccessMethod.DIRECT and direct_query:
         return [warehouse_table.name]
@@ -2776,7 +2773,6 @@ def _should_include_connection_table(
     *,
     connection_id: str,
 ) -> bool:
-
     source = warehouse_table.external_data_source
     if source is None or source.access_method != ExternalDataSourceAccessMethod.DIRECT:
         return False

--- a/posthog/hogql/database/direct_trino_table.py
+++ b/posthog/hogql/database/direct_trino_table.py
@@ -1,5 +1,8 @@
+from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.direct_sql_table import DirectSQLTable
+from posthog.hogql.database.models import FieldOrTable
 from posthog.hogql.errors import QueryError
+from posthog.hogql.escape_sql import escape_trino_identifier
 
 
 class DirectTrinoTable(DirectSQLTable):
@@ -7,11 +10,37 @@ class DirectTrinoTable(DirectSQLTable):
     trino_schema: str
     trino_table_name: str
 
-    def to_printed_duckdb(self, context) -> str:
-        raise QueryError("Trino direct connections support raw SQL only")
+    def _canonical_field_key(self, name: str | int) -> str | None:
+        target = str(name).lower()
+        return next((key for key in self.fields if key.lower() == target), None)
 
-    def to_printed_postgres(self, context) -> str:
+    def has_field(self, name: str | int) -> bool:
+        return super().has_field(name) or self._canonical_field_key(name) is not None
+
+    def get_field(self, name: str | int) -> FieldOrTable:
+        if super().has_field(name):
+            return super().get_field(name)
+        key = self._canonical_field_key(name)
+        if key is not None:
+            return self.fields[key]
+        return super().get_field(name)
+
+    def to_printed_trino(self, context: HogQLContext | None) -> str:
+        if not self.trino_catalog.strip():
+            raise QueryError("Direct Trino tables require a catalog name.")
+        if not self.trino_schema.strip():
+            raise QueryError("Direct Trino tables require a schema name.")
+        if not self.trino_table_name.strip():
+            raise QueryError("Direct Trino tables require a table name.")
+        return ".".join(
+            escape_trino_identifier(part) for part in (self.trino_catalog, self.trino_schema, self.trino_table_name)
+        )
+
+    def to_printed_duckdb(self, context: HogQLContext | None) -> str:
+        raise QueryError("Direct Trino tables cannot be printed into DuckDB SQL")
+
+    def to_printed_postgres(self, context: HogQLContext | None) -> str:
         raise QueryError("Direct Trino tables cannot be printed into Postgres SQL")
 
-    def to_printed_clickhouse(self, context) -> str:
+    def to_printed_clickhouse(self, context: HogQLContext | None) -> str:
         raise QueryError("Direct Trino tables cannot be printed into ClickHouse SQL")

--- a/posthog/hogql/direct_sql/adapter.py
+++ b/posthog/hogql/direct_sql/adapter.py
@@ -44,8 +44,7 @@ class DirectSQLAdapter(Protocol):
     """Contract every direct-query engine implements. The registry keys adapters by ``engine``.
 
     ``dialect`` is the HogQL printer dialect the engine compiles to, or ``None`` for raw-only
-    engines (no printer — only ``sendRawQuery`` works). Phase 1 engines (Postgres, MySQL) both
-    have a dialect; raw-only engines arrive in Phase 2.
+    engines where only ``sendRawQuery`` works.
     """
 
     engine: str

--- a/posthog/hogql/direct_sql/test/test_registry_and_capability.py
+++ b/posthog/hogql/direct_sql/test/test_registry_and_capability.py
@@ -39,6 +39,11 @@ class TestDirectSQLRegistry(SimpleTestCase):
         # dialect is non-None, so direct_supports_hogql is True (not raw-only).
         self.assertEqual(adapter.dialect, "clickhouse")
 
+    def test_trino_adapter_compiles_hogql(self):
+        adapter = get_adapter("trino")
+        assert adapter is not None
+        self.assertEqual(adapter.dialect, "trino")
+
     def test_register_adapter_round_trips(self):
         class FakeAdapter:
             engine = "fake"

--- a/posthog/hogql/direct_sql/test/test_trino_adapter.py
+++ b/posthog/hogql/direct_sql/test/test_trino_adapter.py
@@ -28,6 +28,7 @@ def test_execute_returns_rows_and_types() -> None:
     adapter = TrinoAdapter()
     request = MagicMock()
     request.sql = "SELECT id, active FROM users"
+    request.values = None
     request.team.pk = 1
     request.source.id = "source-id"
     request.settings.max_execution_time = 30
@@ -55,3 +56,33 @@ def test_execute_returns_rows_and_types() -> None:
     assert result.results == [(1, True)]
     assert result.print_columns == ["id", "active"]
     assert result.types == [("id", "Nullable(Int64)"), ("active", "Nullable(Bool)")]
+
+
+def test_execute_binds_printer_values_in_placeholder_order() -> None:
+    adapter = TrinoAdapter()
+    request = MagicMock()
+    request.sql = "SELECT id FROM users WHERE name = ? AND age = ?"
+    request.values = {"hogql_val_0": "Ada", "hogql_val_1": 37}
+    request.team.pk = 1
+    request.source.id = "source-id"
+    request.settings.max_execution_time = 30
+    request.timings.measure.return_value.__enter__.return_value = None
+    request.timings.measure.return_value.__exit__.return_value = None
+    cursor = MagicMock()
+    cursor.fetchmany.return_value = []
+    cursor.description = []
+    connection = MagicMock()
+    connection.cursor.return_value = cursor
+    connection_context = MagicMock()
+    connection_context.__enter__.return_value = connection
+
+    with (
+        patch.object(adapter, "validate_source_config", return_value=(MagicMock(), MagicMock())),
+        patch(
+            "products.warehouse_sources.backend.facade.source_management.connect_trino",
+            return_value=connection_context,
+        ),
+    ):
+        adapter.execute(request)
+
+    cursor.execute.assert_called_once_with(request.sql, ("Ada", 37))

--- a/posthog/hogql/direct_sql/trino_adapter.py
+++ b/posthog/hogql/direct_sql/trino_adapter.py
@@ -72,7 +72,7 @@ class _CancelWatchdog:
 
 class TrinoAdapter:
     engine = "trino"
-    dialect: HogQLDialect | None = None
+    dialect: HogQLDialect | None = "trino"
 
     def validate_source_config(self, source: ExternalDataSource, team: Team) -> tuple[TrinoSource, TrinoSourceConfig]:
         from products.warehouse_sources.backend.facade.source_management import (
@@ -120,9 +120,14 @@ class TrinoAdapter:
                     cursor = connection.cursor()
                     with _CancelWatchdog(cursor, timeout_seconds) as watchdog:
                         try:
-                            cursor.execute(  # nosemgrep: python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute -- direct SQL is intentionally user-authored and SELECT-gated
-                                request.sql
-                            )
+                            if request.values:
+                                cursor.execute(  # nosemgrep: python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute -- printer-generated SQL uses qmark placeholders
+                                    request.sql, tuple(request.values.values())
+                                )
+                            else:
+                                cursor.execute(  # nosemgrep: python.django.security.injection.sql.sql-injection-using-db-cursor-execute.sql-injection-db-cursor-execute -- direct SQL is intentionally user-authored and SELECT-gated
+                                    request.sql
+                                )
                             results = cursor.fetchmany(DIRECT_TRINO_MAX_ROWS + 1)
                         except Exception as error:
                             if watchdog.fired:

--- a/posthog/hogql/escape_sql.py
+++ b/posthog/hogql/escape_sql.py
@@ -276,6 +276,14 @@ def escape_snowflake_identifier(v: str) -> str:
     return '"' + v.replace('"', '""') + '"'
 
 
+def escape_trino_identifier(v: str) -> str:
+    if "?" in v:
+        raise QueryError(f'The Trino identifier "{v}" is not permitted as it contains the "?" character')
+    if "\0" in v:
+        raise QueryError(f'The Trino identifier "{v}" is not permitted as it contains a NUL character')
+    return '"' + v.replace('"', '""') + '"'
+
+
 def _quote_postgres_wire_identifier(v: str, extra_reserved_keywords: set[str] | None) -> str:
     # Reject ``%`` for parity with the HogQL and ClickHouse escape paths. psycopg
     # interprets ``%`` as the start of a parameter placeholder when scanning SQL

--- a/posthog/hogql/printer/__init__.py
+++ b/posthog/hogql/printer/__init__.py
@@ -5,6 +5,7 @@ from posthog.hogql.printer.hogql import HogQLPrinter
 from posthog.hogql.printer.mysql import MySQLPrinter
 from posthog.hogql.printer.postgres import PostgresPrinter
 from posthog.hogql.printer.snowflake import SnowflakePrinter
+from posthog.hogql.printer.trino import TrinoPrinter
 from posthog.hogql.printer.utils import (
     prepare_and_print_ast,
     prepare_ast_for_printing,
@@ -24,4 +25,5 @@ __all__ = [
     "MySQLPrinter",
     "PostgresPrinter",
     "SnowflakePrinter",
+    "TrinoPrinter",
 ]

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -204,6 +204,38 @@ class BasePrinter(Visitor[str]):
             raise QueryError(f"LIMIT percent is not allowed in {self.DIALECT_NAME} dialect")
         return f"LIMIT {self.visit(limit)}"
 
+    def _append_select_limit_and_offset(
+        self, clauses: list[str | None], node: ast.SelectQuery, limit: ast.Expr | None
+    ) -> None:
+        if limit is not None:
+            if node.limit_with_ties:
+                self._assert_with_ties_supported()
+            clauses.append(self._render_select_query_limit_clause(limit, bool(node.limit_percent)))
+            if node.limit_with_ties:
+                clauses.append("WITH TIES")
+
+        if node.offset is not None:
+            clauses.append(f"OFFSET {self.visit(node.offset)}")
+
+    def _append_set_limit_and_offset(self, sql: str, node: ast.SelectSetQuery) -> str:
+        if node.limit is not None:
+            limit_str = self.visit(node.limit)
+            if node.limit_percent:
+                limit_str = self._render_set_query_limit_percent(node.limit, limit_str)
+            if node.limit_with_ties:
+                limit_str += " WITH TIES"
+            if self.pretty:
+                sql = sql.rstrip() + f"\n{self.indent(1)}LIMIT {limit_str}"
+            else:
+                sql += f" LIMIT {limit_str}"
+        if node.offset is not None:
+            offset_str = self.visit(node.offset)
+            if self.pretty:
+                sql = sql.rstrip() + f"\n{self.indent(1)}OFFSET {offset_str}"
+            else:
+                sql += f" OFFSET {offset_str}"
+        return sql
+
     def _validate_within_group_for_aggregation(self, node: "ast.Call", func_meta) -> None:
         """Validate that this dialect accepts the WITHIN GROUP clause for `node`.
 
@@ -280,23 +312,7 @@ class BasePrinter(Visitor[str]):
                     ret += f" {expr.set_operator} "
             ret += query
         self._indent += 1
-        if node.limit is not None:
-            limit_str = self.visit(node.limit)
-            if node.limit_percent:
-                limit_str = self._render_set_query_limit_percent(node.limit, limit_str)
-
-            if node.limit_with_ties:
-                limit_str += " WITH TIES"
-            if self.pretty:
-                ret = ret.rstrip() + f"\n{self.indent(1)}LIMIT {limit_str}"
-            else:
-                ret += f" LIMIT {limit_str}"
-        if node.offset is not None:
-            offset_str = self.visit(node.offset)
-            if self.pretty:
-                ret = ret.rstrip() + f"\n{self.indent(1)}OFFSET {offset_str}"
-            else:
-                ret += f" OFFSET {offset_str}"
+        ret = self._append_set_limit_and_offset(ret, node)
         if len(self.stack) > 1:
             return f"({ret.strip()})"
         return ret
@@ -310,6 +326,9 @@ class BasePrinter(Visitor[str]):
 
     def _print_select_columns(self, columns: Iterable[ast.Expr]) -> list[str]:
         return [self.visit(column) for column in columns]
+
+    def _render_group_by_all_clause(self) -> str:
+        return "GROUP BY ALL"
 
     def visit_select_query(self, node: ast.SelectQuery):
         # if we are the first parsed node in the tree, or a child of a SelectSetQuery, mark us as a top level query
@@ -405,7 +424,7 @@ class BasePrinter(Visitor[str]):
             f"PREWHERE{space}" + prewhere if prewhere else None,
             f"WHERE{space}" + where if where else None,
             (
-                f"GROUP BY ALL"
+                self._render_group_by_all_clause()
                 if node.group_by_mode == "all"
                 else f"GROUP BY{space}GROUPING SETS ({comma.join(group_by or [])})"
                 if node.group_by_mode == "grouping_sets"
@@ -450,16 +469,7 @@ class BasePrinter(Visitor[str]):
                 f"LIMIT {self.visit(node.limit_by.n)} {f'OFFSET {self.visit(node.limit_by.offset_value)}' if node.limit_by.offset_value else ''} BY {', '.join([self.visit(expr) for expr in node.limit_by.exprs])}"
             )
 
-        if limit is not None:
-            if node.limit_with_ties:
-                self._assert_with_ties_supported()
-            limit_str = self._render_select_query_limit_clause(limit, bool(node.limit_percent))
-            clauses.append(limit_str)
-            if node.limit_with_ties:
-                clauses.append("WITH TIES")
-
-        if node.offset is not None:
-            clauses.append(f"OFFSET {self.visit(node.offset)}")
+        self._append_select_limit_and_offset(clauses, node, limit)
 
         clauses.extend(
             self._get_extra_select_clauses(

--- a/posthog/hogql/printer/test/test_trino_printer.py
+++ b/posthog/hogql/printer/test/test_trino_printer.py
@@ -1,0 +1,338 @@
+import pytest
+
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
+from posthog.hogql.database.direct_trino_table import DirectTrinoTable
+from posthog.hogql.database.models import IntegerDatabaseField, StringDatabaseField, StringJSONDatabaseField, TableNode
+from posthog.hogql.errors import QueryError
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
+
+
+def _context() -> HogQLContext:
+    database = Database(include_posthog_tables=False)
+    for table_name, trino_table_name in (("orders", "order facts"), ("customers", "customers")):
+        database.tables.add_child(
+            TableNode(
+                name=table_name,
+                case_insensitive=True,
+                table=DirectTrinoTable(
+                    name=table_name,
+                    fields={
+                        "id": IntegerDatabaseField(name="id"),
+                        "name": StringDatabaseField(name="name"),
+                        "properties": StringJSONDatabaseField(name="properties"),
+                    },
+                    trino_catalog="iceberg",
+                    trino_schema="analytics",
+                    trino_table_name=trino_table_name,
+                    external_data_source_id="source-id",
+                ),
+            )
+        )
+    return HogQLContext(
+        team_id=1,
+        enable_select_queries=True,
+        database=database,
+        restricted_properties=set(),
+    )
+
+
+def _print(query: str, context: HogQLContext | None = None) -> tuple[str, HogQLContext]:
+    context = context or _context()
+    sql, _ = prepare_and_print_ast(parse_select(query, backend="cpp-json"), context, "trino")
+    return sql, context
+
+
+def test_prints_direct_table_and_qmark_parameters() -> None:
+    sql, context = _print("SELECT id FROM orders WHERE name = 'Ada'")
+
+    assert sql == (
+        'SELECT "orders"."id" FROM "iceberg"."analytics"."order facts" AS "orders" '
+        'WHERE ("orders"."name" = ?) LIMIT 50000'
+    )
+    assert list(context.values.values()) == ["Ada"]
+
+
+def test_resolves_trino_identifiers_case_insensitively() -> None:
+    sql, _ = _print("SELECT ID FROM ORDERS")
+
+    assert 'SELECT "ORDERS"."id" FROM "iceberg"."analytics"."order facts" AS "ORDERS"' in sql
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_suffix"),
+    [
+        ("SELECT id FROM orders LIMIT 10 OFFSET 4", "OFFSET 4 ROWS LIMIT 10"),
+        ("SELECT id FROM orders ORDER BY id LIMIT 10 WITH TIES", "FETCH FIRST 10 ROWS WITH TIES"),
+    ],
+)
+def test_prints_trino_limit_syntax(query: str, expected_suffix: str) -> None:
+    sql, _ = _print(query)
+
+    assert sql.endswith(expected_suffix)
+
+
+def test_prints_trino_limit_syntax_after_set_operation() -> None:
+    query = parse_select("SELECT id FROM orders UNION ALL SELECT id FROM orders", backend="cpp-json")
+    assert isinstance(query, ast.SelectSetQuery)
+    query.limit = ast.Constant(value=10)
+    query.offset = ast.Constant(value=4)
+    sql, _ = prepare_and_print_ast(query, _context(), "trino")
+
+    assert sql.endswith("OFFSET 4 ROWS LIMIT 10")
+
+
+@pytest.mark.parametrize("operator", ["INTERSECT", "INTERSECT ALL", "EXCEPT", "EXCEPT ALL"])
+def test_prints_trino_set_operators(operator: str) -> None:
+    sql, _ = _print(f"SELECT id FROM orders {operator} SELECT id FROM orders")
+
+    assert f" {operator} " in sql
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_fragment"),
+    [
+        ("SELECT [1, 2, 3][1:2] FROM orders", "slice(ARRAY[1, 2, 3], 1, greatest(0, (2) - (1) + 1))"),
+        ("SELECT toString(id) FROM orders", 'CAST("orders"."id" AS VARCHAR)'),
+        ("SELECT countIf(id > 0) FROM orders", 'count(*) FILTER (WHERE ("orders"."id" > 0))'),
+        ("SELECT name ILIKE 'ada%' FROM orders", 'lower("orders"."name") LIKE lower(?)'),
+        ("SELECT position(name, 'd') FROM orders", 'strpos("orders"."name", ?)'),
+        ("SELECT CAST([1] AS Array(String)) FROM orders", "CAST(ARRAY[1] AS ARRAY(VARCHAR))"),
+        ("SELECT CAST(id AS timestamp(0)) FROM orders", 'CAST("orders"."id" AS TIMESTAMP(0))'),
+        ("SELECT id, count() FROM orders GROUP BY ALL", "GROUP BY AUTO"),
+        ("SELECT id FROM orders ORDER BY #1", "ORDER BY 1 ASC"),
+        ("SELECT uniq(id, name) FROM orders", 'count(DISTINCT ROW("orders"."id", "orders"."name"))'),
+        ("SELECT toDecimal(id, 2) FROM orders", 'CAST("orders"."id" AS DECIMAL(18,2))'),
+        ("SELECT toDateTime64(name, 6) FROM orders", 'CAST("orders"."name" AS TIMESTAMP(6))'),
+        (
+            "SELECT toIntOrDefault(name, 7) FROM orders",
+            'COALESCE(TRY_CAST("orders"."name" AS BIGINT), CAST(7 AS BIGINT))',
+        ),
+        ("SELECT arrayMap(x -> x + 1, [1, 2]) FROM orders", 'transform(ARRAY[1, 2], "x" -> ("x" + 1))'),
+        ("SELECT arrayFilter(x -> x > 1, [1, 2]) FROM orders", 'filter(ARRAY[1, 2], "x" -> ("x" > 1))'),
+        ("SELECT tuple(id, name) FROM orders", 'ROW("orders"."id", "orders"."name")'),
+        ("SELECT tupleElement(tuple(id, name), 2) FROM orders", '(ROW("orders"."id", "orders"."name"))[2]'),
+        (
+            "SELECT dateTrunc('month', toDateTime(name, 'UTC')) FROM orders",
+            'date_trunc(?, with_timezone(CAST("orders"."name" AS TIMESTAMP), ?))',
+        ),
+        ("SELECT extract(name, '([a-z]+)') FROM orders", 'regexp_extract("orders"."name", ?)'),
+        ("SELECT groupUniqArray(name) FROM orders", 'array_distinct(array_agg("orders"."name"))'),
+        (
+            "SELECT groupUniqArrayIf(name, id > 0) FROM orders",
+            'array_distinct(array_agg("orders"."name") FILTER (WHERE ("orders"."id" > 0)))',
+        ),
+        (
+            "SELECT argMaxIf(name, id, id > 0) FROM orders",
+            'max_by("orders"."name", "orders"."id") FILTER (WHERE ("orders"."id" > 0))',
+        ),
+        ("SELECT arrayElement([1, 2], -1) FROM orders", "element_at(ARRAY[1, 2], -1)"),
+        (
+            "SELECT arrayFirst(x -> x > 1, [1, 2]) FROM orders",
+            'element_at(filter(ARRAY[1, 2], "x" -> ("x" > 1)), 1)',
+        ),
+        ("SELECT extractAll(name, '([a-z]+)') FROM orders", 'regexp_extract_all("orders"."name", ?)'),
+        ("SELECT multiplyDecimal(id, 100) FROM orders", '("orders"."id" * 100)'),
+        (
+            "SELECT intDiv(id, 1000) FROM orders",
+            'CAST(floor(CAST("orders"."id" AS DOUBLE) / 1000) AS BIGINT)',
+        ),
+        ("SELECT md5(name) FROM orders", 'to_hex(md5(to_utf8(CAST("orders"."name" AS VARCHAR))))'),
+        ("SELECT md5(name AS TEXT) FROM orders", 'to_hex(md5(to_utf8(CAST("orders"."name" AS VARCHAR))))'),
+        ("SELECT arrayMin([1, 2]) FROM orders", "array_min(ARRAY[1, 2])"),
+        ("SELECT greaterOrEquals(id, 1) FROM orders", '("orders"."id" >= 1)'),
+        ("SELECT in(id, (1, 2)) FROM orders", '("orders"."id" IN (1, 2))'),
+        (
+            "SELECT dateAdd(toDate('2026-01-01'), toIntervalMonth(1)) FROM orders",
+            "(CAST(? AS DATE) + (1 * INTERVAL '1' MONTH))",
+        ),
+        ("SELECT current_timestamp() FROM orders", "CURRENT_TIMESTAMP"),
+        (
+            "SELECT toTimeZone(toDateTime(name), 'America/New_York') FROM orders",
+            'at_timezone(with_timezone(CAST(CAST("orders"."name" AS TIMESTAMP) AS TIMESTAMP), \'UTC\'), ?)',
+        ),
+        ("SELECT JSONHas(properties, 'segment') FROM orders", '(json_extract("orders"."properties", ?) IS NOT NULL)'),
+        (
+            "SELECT JSONExtract(properties, 'Map(String, Float64)') FROM orders",
+            'CAST(json_extract("orders"."properties", \'$\') AS MAP(VARCHAR, DOUBLE))',
+        ),
+        (
+            "SELECT JSONExtractKeys(properties) FROM orders",
+            'map_keys(CAST(json_extract("orders"."properties", ?) AS MAP(VARCHAR, JSON)))',
+        ),
+        (
+            "SELECT JSONExtractKeysAndValues(properties, 'Float64') FROM orders",
+            'map_entries(CAST(json_extract("orders"."properties", ?) AS MAP(VARCHAR, DOUBLE)))',
+        ),
+        (
+            "SELECT JSONExtractKeysAndValuesRaw(properties) FROM orders",
+            'map_entries(CAST(json_extract("orders"."properties", ?) AS MAP(VARCHAR, JSON)))',
+        ),
+        ("SELECT quantile(0.9)(id) FROM orders", 'approx_percentile("orders"."id", 0.9)'),
+        (
+            "SELECT quantileIf(0.9)(id, id > 0) FROM orders",
+            'approx_percentile("orders"."id", 0.9) FILTER (WHERE ("orders"."id" > 0))',
+        ),
+        (
+            "SELECT groupArrayIf(10)(name, id > 0) FROM orders",
+            'slice(array_agg("orders"."name") FILTER (WHERE ("orders"."id" > 0)), 1, 10)',
+        ),
+        (
+            "SELECT date_part('year', toDateTime(name)) FROM orders",
+            'EXTRACT(YEAR FROM CAST("orders"."name" AS TIMESTAMP))',
+        ),
+        (
+            "SELECT orders.id FROM orders LEFT JOIN customers ON orders.id = customers.id",
+            'LEFT JOIN "iceberg"."analytics"."customers" AS "customers" ON ("orders"."id" = "customers"."id")',
+        ),
+        (
+            "SELECT t.a FROM (SELECT id FROM orders) AS t(a)",
+            'AS "t" ("a")',
+        ),
+    ],
+)
+def test_prints_trino_expressions(query: str, expected_fragment: str) -> None:
+    sql, _ = _print(query)
+
+    assert expected_fragment in sql
+
+
+def test_prints_json_property_access_as_bound_json_path() -> None:
+    sql, context = _print("SELECT properties.customer.name FROM orders")
+
+    assert 'json_extract_scalar("orders"."properties", ?)' in sql
+    assert list(context.values.values()) == ['$."customer"."name"']
+
+
+def test_array_slice_does_not_duplicate_bound_parameters() -> None:
+    sql, context = _print("SELECT ['a', 'b'][2:] FROM orders")
+
+    assert "slice(ARRAY[?, ?], 2, 2147483647)" in sql
+    assert sql.count("?") == len(context.values) == 2
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_fragment"),
+    [
+        (
+            "SELECT row_number() OVER (ORDER BY id) FROM orders",
+            'row_number() OVER (ORDER BY "orders"."id" ASC)',
+        ),
+        (
+            "SELECT groupArray(name) OVER (ORDER BY id) FROM orders",
+            'array_agg("orders"."name") OVER (ORDER BY "orders"."id" ASC)',
+        ),
+        (
+            "SELECT countIf(id > 0) OVER (ORDER BY id) FROM orders",
+            'count(*) FILTER (WHERE ("orders"."id" > 0)) OVER (ORDER BY "orders"."id" ASC)',
+        ),
+        (
+            "SELECT lag(name) OVER ordered FROM orders WINDOW ordered AS (ORDER BY id)",
+            'lag("orders"."name") OVER "ordered"',
+        ),
+        (
+            "SELECT lagInFrame(name, 1, 'missing') OVER (ORDER BY id) FROM orders",
+            'lag("orders"."name", 1, ?) OVER (ORDER BY "orders"."id" ASC)',
+        ),
+        (
+            "SELECT countDistinct(name) OVER () FROM orders",
+            'count(DISTINCT "orders"."name") OVER ()',
+        ),
+    ],
+)
+def test_prints_trino_window_functions(query: str, expected_fragment: str) -> None:
+    sql, _ = _print(query)
+
+    assert expected_fragment in sql
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT empty('a') FROM orders",
+        "SELECT toStartOfFiveMinutes(toDateTime('2026-01-02 03:04:05')) FROM orders",
+    ],
+)
+def test_parameterized_rewrites_keep_qmarks_and_values_aligned(query: str) -> None:
+    sql, context = _print(query)
+
+    assert sql.count("?") == len(context.values) == 1
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT id FROM orders PREWHERE id > 0",
+        "SELECT id FROM orders QUALIFY id > 0",
+        "SELECT id FROM orders LIMIT 10 BY name",
+        "SELECT id FROM orders ORDER BY id WITH FILL",
+        "SELECT id FROM orders LIMIT 10 WITH TIES",
+        "SELECT orders.id FROM orders LEFT ANY JOIN customers ON orders.id = customers.id",
+        "SELECT quantiles(0.5)(id) OVER () FROM orders",
+        "SELECT lag(name) OVER () FROM orders",
+        "SELECT row_number() OVER (ORDER BY id ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM orders",
+        "WITH 1 AS scalar_value SELECT scalar_value FROM orders",
+        "SELECT * FROM orders PIVOT(count(id) FOR name IN ('a'))",
+        "SELECT * FROM orders UNPIVOT(value FOR key IN (id))",
+        "SELECT arrayMap((x, y) -> x + y, [1], [2]) FROM orders",
+    ],
+)
+def test_rejects_hogql_clauses_without_trino_equivalents(query: str) -> None:
+    with pytest.raises(QueryError):
+        _print(query)
+
+
+def test_rejects_set_with_ties_without_outer_ordering() -> None:
+    query = parse_select("SELECT id FROM orders UNION ALL SELECT id FROM orders", backend="cpp-json")
+    assert isinstance(query, ast.SelectSetQuery)
+    query.limit = ast.Constant(value=10)
+    query.limit_with_ties = True
+
+    with pytest.raises(QueryError):
+        prepare_and_print_ast(query, _context(), "trino")
+
+
+def test_rejects_non_literal_limit_that_trino_cannot_parse() -> None:
+    query = parse_select("SELECT id FROM orders", backend="cpp-json")
+    assert isinstance(query, ast.SelectQuery)
+    query.limit = ast.Call(name="least", args=[ast.Constant(value=10), ast.Constant(value=20)])
+
+    with pytest.raises(QueryError):
+        prepare_and_print_ast(query, _context(), "trino")
+
+
+@pytest.mark.parametrize("modifier", ["distinct", "filter"])
+def test_rejects_aggregate_only_modifiers_on_scalar_calls(modifier: str) -> None:
+    query = parse_select("SELECT toDecimal(id, 2) FROM orders", backend="cpp-json")
+    assert isinstance(query, ast.SelectQuery)
+    call = query.select[0]
+    assert isinstance(call, ast.Call)
+    if modifier == "distinct":
+        call.distinct = True
+    else:
+        call.filter_expr = ast.Constant(value=True)
+
+    with pytest.raises(QueryError):
+        prepare_and_print_ast(query, _context(), "trino")
+
+
+@pytest.mark.parametrize(
+    "type_name",
+    [
+        "varchar); DROP TABLE users; --",
+        "decimal(39,0)",
+        "decimal(2,3)",
+        "timestamp(13)",
+        "char(1,2)",
+    ],
+)
+def test_rejects_invalid_cast_type_name(type_name: str) -> None:
+    context = _context()
+    query = parse_select("SELECT id FROM orders", backend="cpp-json")
+    assert isinstance(query, ast.SelectQuery)
+    query.select[0] = ast.TypeCast(expr=query.select[0], type_name=type_name)
+
+    with pytest.raises(QueryError):
+        prepare_and_print_ast(query, context, "trino")

--- a/posthog/hogql/printer/trino.py
+++ b/posthog/hogql/printer/trino.py
@@ -1,0 +1,677 @@
+import re
+import json
+from collections.abc import Callable, Iterable
+from typing import Any, ClassVar
+from uuid import UUID
+
+from posthog.hogql import ast
+from posthog.hogql.constants import HogQLDialect
+from posthog.hogql.database.direct_trino_table import DirectTrinoTable
+from posthog.hogql.database.models import Table
+from posthog.hogql.errors import QueryError
+from posthog.hogql.escape_sql import escape_trino_identifier
+from posthog.hogql.functions import find_hogql_aggregation
+from posthog.hogql.functions.mapping import HOGQL_COMPARISON_MAPPING
+from posthog.hogql.printer.base import BasePrinter
+from posthog.hogql.printer.postgres import PostgresPrinter
+from posthog.hogql.printer.trino_functions import (
+    TRINO_FUNCTION_HANDLERS_LOWER,
+    TRINO_FUNCTION_RENAMES_LOWER,
+    TRINO_PASSTHROUGH_FUNCTIONS,
+)
+from posthog.hogql.printer.types import JoinExprResponse
+
+from posthog.uuidt import UUIDT
+
+_TRINO_SIMPLE_TYPES = {
+    "bigint": "BIGINT",
+    "bool": "BOOLEAN",
+    "boolean": "BOOLEAN",
+    "date": "DATE",
+    "datetime": "TIMESTAMP",
+    "double": "DOUBLE",
+    "double precision": "DOUBLE",
+    "float": "DOUBLE",
+    "int": "BIGINT",
+    "int8": "BIGINT",
+    "int16": "BIGINT",
+    "int32": "BIGINT",
+    "int64": "BIGINT",
+    "integer": "INTEGER",
+    "json": "JSON",
+    "real": "REAL",
+    "smallint": "SMALLINT",
+    "string": "VARCHAR",
+    "text": "VARCHAR",
+    "timestamp": "TIMESTAMP",
+    "timestamp with local time zone": "TIMESTAMP WITH TIME ZONE",
+    "timestamp with time zone": "TIMESTAMP WITH TIME ZONE",
+    "timestamptz": "TIMESTAMP WITH TIME ZONE",
+    "tinyint": "TINYINT",
+    "uint8": "SMALLINT",
+    "uint16": "INTEGER",
+    "uint32": "BIGINT",
+    "uint64": "DECIMAL(20, 0)",
+    "uuid": "UUID",
+    "varbinary": "VARBINARY",
+    "varchar": "VARCHAR",
+}
+_TRINO_PARAMETERIZED_TYPE_RE = re.compile(
+    r"^(decimal|numeric|varchar|char|fixedstring|datetime64|timestamp)\s*\((\d+(?:\s*,\s*\d+)?)\)$", re.I
+)
+
+_TRINO_JOIN_TYPES = frozenset(
+    {
+        "JOIN",
+        "INNER JOIN",
+        "LEFT JOIN",
+        "LEFT OUTER JOIN",
+        "RIGHT JOIN",
+        "RIGHT OUTER JOIN",
+        "FULL JOIN",
+        "FULL OUTER JOIN",
+        "CROSS JOIN",
+    }
+)
+_TRINO_WINDOW_FUNCTION_RENAMES = {
+    "any": "arbitrary",
+    "argmax": "max_by",
+    "argmin": "min_by",
+    "grouparray": "array_agg",
+    "laginframe": "lag",
+}
+_TRINO_WINDOW_FUNCTIONS = frozenset(
+    {
+        "arbitrary",
+        "array_agg",
+        "avg",
+        "count",
+        "cume_dist",
+        "dense_rank",
+        "first_value",
+        "lag",
+        "last_value",
+        "lead",
+        "max",
+        "max_by",
+        "min",
+        "min_by",
+        "nth_value",
+        "ntile",
+        "percent_rank",
+        "rank",
+        "row_number",
+        "sum",
+    }
+)
+_TRINO_NO_FRAME_WINDOW_FUNCTIONS = frozenset(
+    {"cume_dist", "dense_rank", "lag", "lead", "ntile", "percent_rank", "rank", "row_number"}
+)
+_TRINO_CONDITIONAL_WINDOW_FUNCTIONS = {
+    "anyif": "arbitrary",
+    "avgif": "avg",
+    "countif": "count",
+    "grouparrayif": "array_agg",
+    "maxif": "max",
+    "minif": "min",
+    "sumif": "sum",
+}
+_TRINO_UNIQ_WINDOW_FUNCTIONS = frozenset({"countdistinct", "uniq", "uniqexact", "uniqif", "uniqexactif"})
+_TRINO_COMPARISON_MAPPING = {name.lower(): operation for name, operation in HOGQL_COMPARISON_MAPPING.items()}
+_TRINO_EXTRACT_FIELDS = frozenset(
+    {
+        "day",
+        "day_of_week",
+        "day_of_year",
+        "dow",
+        "doy",
+        "hour",
+        "minute",
+        "month",
+        "quarter",
+        "second",
+        "timezone_hour",
+        "timezone_minute",
+        "week",
+        "year",
+        "year_of_week",
+        "yow",
+    }
+)
+
+
+class TrinoPrinter(PostgresPrinter):
+    DIALECT_NAME: ClassVar[HogQLDialect] = "trino"
+    DIALECT_LABEL: ClassVar[str] = "Trino"
+
+    def _get_connection_supported_functions(self) -> set[str]:
+        return set()
+
+    def _get_function_renames(self) -> dict[str, str]:
+        return TRINO_FUNCTION_RENAMES_LOWER
+
+    def _get_function_handlers(self) -> dict[str, Callable[[list[str]], str]]:
+        return TRINO_FUNCTION_HANDLERS_LOWER
+
+    def _get_passthrough_functions(self) -> frozenset[str]:
+        return TRINO_PASSTHROUGH_FUNCTIONS
+
+    def _render_group_by_all_clause(self) -> str:
+        return "GROUP BY AUTO"
+
+    def _assert_set_operator_supported(self, set_operator: str) -> None:
+        if set_operator not in {
+            "UNION DISTINCT",
+            "UNION ALL",
+            "INTERSECT DISTINCT",
+            "INTERSECT ALL",
+            "INTERSECT",
+            "EXCEPT DISTINCT",
+            "EXCEPT ALL",
+            "EXCEPT",
+        }:
+            raise QueryError(f"{set_operator} is not supported in the 'trino' dialect")
+
+    def _assert_qualify_supported(self) -> None:
+        raise QueryError("QUALIFY is not supported in the Trino dialect")
+
+    def _assert_with_ties_supported(self) -> None:
+        return
+
+    def _append_select_limit_and_offset(
+        self, clauses: list[str | None], node: ast.SelectQuery, limit: ast.Expr | None
+    ) -> None:
+        if node.offset is not None:
+            self._validate_row_count(node.offset, "OFFSET")
+            clauses.append(f"OFFSET {self.visit(node.offset)} ROWS")
+        if limit is None:
+            return
+        self._validate_row_count(limit, "LIMIT")
+        if node.limit_percent:
+            raise QueryError("LIMIT percent is not allowed in trino dialect")
+        if node.limit_with_ties:
+            if not node.order_by:
+                raise QueryError("LIMIT WITH TIES requires ORDER BY in the Trino dialect")
+            clauses.append(f"FETCH FIRST {self.visit(limit)} ROWS WITH TIES")
+        else:
+            clauses.append(f"LIMIT {self.visit(limit)}")
+
+    def _append_set_limit_and_offset(self, sql: str, node: ast.SelectSetQuery) -> str:
+        suffixes: list[str] = []
+        if node.offset is not None:
+            self._validate_row_count(node.offset, "OFFSET")
+            suffixes.append(f"OFFSET {self.visit(node.offset)} ROWS")
+        if node.limit is not None:
+            self._validate_row_count(node.limit, "LIMIT")
+            if node.limit_percent:
+                raise QueryError("LIMIT percent is not allowed in trino dialect")
+            if node.limit_with_ties:
+                raise QueryError("WITH TIES is not supported on HogQL set queries in the Trino dialect")
+            else:
+                suffixes.append(f"LIMIT {self.visit(node.limit)}")
+        separator = f"\n{self.indent(1)}" if self.pretty else " "
+        return sql.rstrip() + separator + separator.join(suffixes) if suffixes else sql
+
+    @staticmethod
+    def _validate_row_count(value: ast.Expr, clause: str) -> None:
+        if (
+            not isinstance(value, ast.Constant)
+            or isinstance(value.value, bool)
+            or not isinstance(value.value, int)
+            or value.value < 0
+        ):
+            raise QueryError(f"{clause} must be a non-negative integer in the Trino dialect")
+
+    def visit_select_query(self, node: ast.SelectQuery) -> str:
+        if node.array_join_op is not None:
+            raise QueryError("ARRAY JOIN is not supported in the Trino dialect")
+        if node.prewhere is not None:
+            raise QueryError("PREWHERE is not supported in the Trino dialect")
+        if node.limit_by is not None:
+            raise QueryError("LIMIT BY is not supported in the Trino dialect")
+        if node.interpolate is not None:
+            raise QueryError("INTERPOLATE is not supported in the Trino dialect")
+        return super().visit_select_query(node)
+
+    def visit_join_expr(self, node: ast.JoinExpr) -> JoinExprResponse:
+        if node.join_type is not None and node.join_type not in _TRINO_JOIN_TYPES:
+            raise QueryError(f"Join type '{node.join_type}' is not supported in the Trino dialect")
+        if node.constraint is not None and node.join_type in {None, "CROSS JOIN"}:
+            raise QueryError(f"{node.join_type or 'FROM'} does not accept a join constraint in the Trino dialect")
+        return super().visit_join_expr(node)
+
+    def visit_order_expr(self, node: ast.OrderExpr) -> str:
+        if node.with_fill is not None:
+            raise QueryError("WITH FILL is not supported in the Trino dialect")
+        return super().visit_order_expr(node)
+
+    def visit_named_argument(self, node: ast.NamedArgument) -> str:
+        raise QueryError("Named arguments are not supported in the Trino dialect")
+
+    def visit_positional_ref(self, node: ast.PositionalRef) -> str:
+        if not isinstance(node.index, int) or isinstance(node.index, bool) or node.index < 1:
+            raise QueryError(f"Positional reference must be a positive integer, got {node.index}")
+        return str(node.index)
+
+    def visit_sample_expr(self, node: ast.SampleExpr) -> None:
+        if node.sample_value.left.value == 1 and node.sample_value.right is None and node.offset_value is None:
+            return None
+        raise QueryError("SAMPLE is not supported in the Trino dialect")
+
+    def visit_constant(self, node: ast.Constant) -> str:
+        if node.value is None or isinstance(node.value, bool | int | float):
+            return self._print_escaped_string(node.value)
+        value = str(node.value) if isinstance(node.value, UUID | UUIDT) else node.value
+        self.context.add_value(value)
+        return "?"
+
+    def _print_identifier(self, name: str) -> str:
+        return escape_trino_identifier(name)
+
+    def _print_table_sql(self, table: Table) -> str:
+        return self._print_table(table)
+
+    def _print_table(self, table: Table) -> str:
+        if isinstance(table, DirectTrinoTable):
+            return table.to_printed_trino(self.context)
+        raise QueryError("Only direct Trino tables can be printed into Trino SQL")
+
+    def visit_type_cast(self, node: ast.TypeCast) -> str:
+        return f"CAST({self.visit(node.expr)} AS {self._render_type_name(node.type_name)})"
+
+    def visit_try_cast(self, node: ast.TryCast) -> str:
+        return f"TRY_CAST({self.visit(node.expr)} AS {self._render_type_name(node.type_name)})"
+
+    def _render_type_name(self, type_name: str) -> str:
+        normalized = " ".join(type_name.strip().lower().split())
+        if normalized in _TRINO_SIMPLE_TYPES:
+            return _TRINO_SIMPLE_TYPES[normalized]
+        if normalized.startswith("array(") and normalized.endswith(")"):
+            return f"ARRAY({self._render_type_name(normalized[6:-1])})"
+        if normalized.startswith("nullable(") and normalized.endswith(")"):
+            return self._render_type_name(normalized[9:-1])
+        match = _TRINO_PARAMETERIZED_TYPE_RE.fullmatch(normalized)
+        if match is not None:
+            base, parameters = match.groups()
+            values = [int(parameter.strip()) for parameter in parameters.split(",")]
+            normalized_base = base.lower()
+            if normalized_base in {"decimal", "numeric"}:
+                precision = values[0]
+                scale = values[1] if len(values) == 2 else 0
+                if len(values) > 2 or not 1 <= precision <= 38 or not 0 <= scale <= precision:
+                    raise QueryError(f"Type '{type_name}' is not supported in the Trino dialect")
+                rendered_parameters = str(precision) if len(values) == 1 else f"{precision},{scale}"
+                return f"DECIMAL({rendered_parameters})"
+            if normalized_base in {"datetime64", "timestamp"}:
+                if len(values) != 1 or not 0 <= values[0] <= 12:
+                    raise QueryError(f"Type '{type_name}' is not supported in the Trino dialect")
+                return f"TIMESTAMP({values[0]})"
+            if len(values) != 1 or values[0] < 1:
+                raise QueryError(f"Type '{type_name}' is not supported in the Trino dialect")
+            rendered_base = "CHAR" if normalized_base == "fixedstring" else normalized_base.upper()
+            return f"{rendered_base}({values[0]})"
+        raise QueryError(f"Type '{type_name}' is not supported in the Trino dialect")
+
+    def visit_arithmetic_operation(self, node: ast.ArithmeticOperation) -> str:
+        if node.op == ast.ArithmeticOperationOp.Div:
+            return f"(CAST({self.visit(node.left)} AS DOUBLE) / {self.visit(node.right)})"
+        return super().visit_arithmetic_operation(node)
+
+    def visit_array(self, node: ast.Array) -> str:
+        return f"ARRAY[{', '.join(self.visit(expr) for expr in node.exprs)}]"
+
+    def visit_array_slice(self, node: ast.ArraySlice) -> str:
+        array = self.visit(node.array)
+        start = self.visit(node.start_expr) if node.start_expr is not None else "1"
+        if node.end_expr is None:
+            length = "2147483647"
+        else:
+            end = self.visit(node.end_expr)
+            length = f"greatest(0, ({end}) - ({start}) + 1)"
+        return f"slice({array}, {start}, {length})"
+
+    def visit_tuple(self, node: ast.Tuple) -> str:
+        if not node.exprs:
+            raise QueryError("Empty tuple expressions are not supported in the Trino dialect")
+        return f"ROW({', '.join(self.visit(expr) for expr in node.exprs)})"
+
+    def visit_tuple_access(self, node: ast.TupleAccess) -> str:
+        if node.index < 1:
+            raise QueryError("Tuple positions must be positive in the Trino dialect")
+        return f"({self.visit(node.tuple)})[{node.index}]"
+
+    def visit_lambda(self, node: ast.Lambda) -> str:
+        return BasePrinter.visit_lambda(self, node)
+
+    def visit_call(self, node: ast.Call) -> str:
+        function_name = node.name.lower()
+        if function_name == "date_part":
+            if (
+                node.params is not None
+                or node.within_group is not None
+                or node.distinct
+                or node.order_by
+                or node.filter_expr is not None
+            ):
+                raise QueryError("date_part does not accept aggregate modifiers in the Trino dialect")
+            if (
+                len(node.args) != 2
+                or not isinstance(node.args[0], ast.Constant)
+                or not isinstance(node.args[0].value, str)
+                or node.args[0].value.lower() not in _TRINO_EXTRACT_FIELDS
+            ):
+                raise QueryError("date_part requires a supported literal field in the Trino dialect")
+            return f"EXTRACT({node.args[0].value.upper()} FROM {self.visit(node.args[1])})"
+        if node.params is not None:
+            if (
+                function_name in {"quantile", "quantileif"}
+                and len(node.params) == 1
+                and len(node.args) == (2 if function_name.endswith("if") else 1)
+                and node.within_group is None
+                and not node.distinct
+                and not node.order_by
+                and (node.filter_expr is None or not function_name.endswith("if"))
+            ):
+                rendered = f"approx_percentile({self.visit(node.args[0])}, {self.visit(node.params[0])})"
+                condition = node.args[1] if function_name.endswith("if") else node.filter_expr
+                if condition is not None:
+                    rendered += f" FILTER (WHERE {self.visit(condition)})"
+                return rendered
+            if (
+                function_name == "grouparrayif"
+                and len(node.params) == 1
+                and len(node.args) == 2
+                and node.within_group is None
+                and not node.distinct
+                and not node.order_by
+                and node.filter_expr is None
+            ):
+                rendered = (
+                    f"slice(array_agg({self.visit(node.args[0])}) "
+                    f"FILTER (WHERE {self.visit(node.args[1])}), 1, {self.visit(node.params[0])})"
+                )
+                return rendered
+            raise QueryError(f"Parametric function '{node.name}' is not supported in the Trino dialect")
+        if node.within_group is not None:
+            raise QueryError(f"WITHIN GROUP is not supported for '{node.name}' in the Trino dialect")
+        aggregation = find_hogql_aggregation(node.name)
+        if aggregation is None:
+            if node.distinct:
+                raise QueryError(f"DISTINCT is only supported for aggregate functions in the Trino dialect")
+            if node.order_by:
+                raise QueryError(f"ORDER BY is only supported for aggregate functions in the Trino dialect")
+            if node.filter_expr is not None:
+                raise QueryError(f"FILTER is only supported for aggregate functions in the Trino dialect")
+        elif node.filter_expr is not None and function_name.endswith("if"):
+            raise QueryError(f"Function '{node.name}' cannot combine its If condition with FILTER in the Trino dialect")
+        if function_name in _TRINO_COMPARISON_MAPPING:
+            if len(node.args) != 2:
+                raise QueryError(f"Comparison '{node.name}' requires exactly two arguments")
+            return self.visit_compare_operation(
+                ast.CompareOperation(
+                    left=node.args[0],
+                    right=node.args[1],
+                    op=_TRINO_COMPARISON_MAPPING[function_name],
+                )
+            )
+        if function_name == "todecimal":
+            if (
+                len(node.args) != 2
+                or not isinstance(node.args[1], ast.Constant)
+                or isinstance(node.args[1].value, bool)
+                or not isinstance(node.args[1].value, int)
+                or not 0 <= node.args[1].value <= 18
+            ):
+                raise QueryError("toDecimal requires a literal scale between 0 and 18 in the Trino dialect")
+            return f"CAST({self.visit(node.args[0])} AS DECIMAL(18,{node.args[1].value}))"
+        if function_name == "todatetime64":
+            if len(node.args) not in {1, 2}:
+                raise QueryError("toDateTime64 timezone overrides are not supported in the Trino dialect")
+            precision = 3
+            if len(node.args) == 2:
+                precision_arg = node.args[1]
+                if (
+                    not isinstance(precision_arg, ast.Constant)
+                    or isinstance(precision_arg.value, bool)
+                    or not isinstance(precision_arg.value, int)
+                    or not 0 <= precision_arg.value <= 12
+                ):
+                    raise QueryError("toDateTime64 requires a literal precision from 0 to 12 in the Trino dialect")
+                precision = precision_arg.value
+            return f"CAST({self.visit(node.args[0])} AS TIMESTAMP({precision}))"
+        if function_name == "todatetime" and len(node.args) not in {1, 2}:
+            raise QueryError("toDateTime expects a value and an optional timezone in the Trino dialect")
+        if function_name == "tostring" and len(node.args) != 1:
+            raise QueryError("toString expects exactly one argument in the Trino dialect")
+        if function_name == "tupleelement":
+            if (
+                len(node.args) != 2
+                or not isinstance(node.args[1], ast.Constant)
+                or isinstance(node.args[1].value, bool)
+                or not isinstance(node.args[1].value, int)
+                or node.args[1].value < 1
+            ):
+                raise QueryError("tupleElement requires a positive literal position in the Trino dialect")
+            return f"({self.visit(node.args[0])})[{node.args[1].value}]"
+        if function_name == "md5" and len(node.args) == 1 and isinstance(node.args[0], ast.Alias):
+            value = self.visit(node.args[0].expr)
+            return f"to_hex(md5(to_utf8(CAST({value} AS VARCHAR))))"
+        if node.args and isinstance(node.args[0].type, ast.ArrayType | ast.StringArrayType | ast.MapType):
+            value = self.visit(node.args[0])
+            if function_name == "length":
+                return f"cardinality({value})"
+            if function_name == "empty":
+                return f"(COALESCE(cardinality({value}), 0) = 0)"
+            if function_name == "notempty":
+                return f"(COALESCE(cardinality({value}), 0) > 0)"
+        json_call = self._visit_json_call(node)
+        if json_call is not None:
+            return json_call
+        rendered = super().visit_call(node)
+        if node.filter_expr is not None:
+            rendered += f" FILTER (WHERE {self.visit(node.filter_expr)})"
+        return rendered
+
+    def visit_window_function(self, node: ast.WindowFunction) -> str:
+        if node.args:
+            raise QueryError(f"Parametric window function '{node.name}' is not supported in the Trino dialect")
+
+        function_name = node.name.lower()
+        exprs = [self.visit(expr) for expr in node.exprs or []]
+        if function_name in _TRINO_CONDITIONAL_WINDOW_FUNCTIONS:
+            if len(exprs) < 1:
+                raise QueryError(f"Window function '{node.name}' requires a condition")
+            target = _TRINO_CONDITIONAL_WINDOW_FUNCTIONS[function_name]
+            arguments = exprs[:-1]
+            if target == "count" and not arguments:
+                call = f"count(*) FILTER (WHERE {exprs[-1]})"
+            else:
+                call = f"{target}({', '.join(arguments)}) FILTER (WHERE {exprs[-1]})"
+        elif function_name in _TRINO_UNIQ_WINDOW_FUNCTIONS:
+            conditional = function_name.endswith("if")
+            arguments = exprs[:-1] if conditional else exprs
+            if not arguments:
+                raise QueryError(f"Window function '{node.name}' requires at least one value")
+            distinct_value = arguments[0] if len(arguments) == 1 else f"ROW({', '.join(arguments)})"
+            call = f"count(DISTINCT {distinct_value})"
+            if conditional:
+                call += f" FILTER (WHERE {exprs[-1]})"
+        else:
+            target = _TRINO_WINDOW_FUNCTION_RENAMES.get(function_name, function_name)
+            if target not in _TRINO_WINDOW_FUNCTIONS:
+                raise QueryError(f"Window function '{node.name}' is not supported in the Trino dialect")
+            rendered_arguments = "*" if target == "count" and not exprs else ", ".join(exprs)
+            call = f"{target}({rendered_arguments})"
+
+        window_expr = self._window_expression(node)
+        target_name = _TRINO_WINDOW_FUNCTION_RENAMES.get(function_name, function_name)
+        if target_name in _TRINO_NO_FRAME_WINDOW_FUNCTIONS and window_expr is not None and window_expr.frame_method:
+            raise QueryError(f"Window function '{node.name}' does not allow a window frame in the Trino dialect")
+        if target_name in {"lag", "lead"} and (window_expr is None or not window_expr.order_by):
+            raise QueryError(f"Window function '{node.name}' requires ORDER BY in the Trino dialect")
+
+        if node.over_expr is not None:
+            over = f"({self.visit(node.over_expr)})"
+        elif node.over_identifier is not None:
+            over = self._print_identifier(node.over_identifier)
+        else:
+            over = "()"
+        return f"{call} OVER {over}"
+
+    def _window_expression(self, node: ast.WindowFunction) -> ast.WindowExpr | None:
+        if node.over_expr is not None:
+            return node.over_expr
+        if node.over_identifier is None:
+            return None
+        select = self._last_select()
+        if select is None or select.window_exprs is None:
+            return None
+        return select.window_exprs.get(node.over_identifier)
+
+    def _visit_json_call(self, node: ast.Call) -> str | None:
+        function_name = node.name.lower()
+        result_types = {
+            "jsonextractstring": "VARCHAR",
+            "jsonextractint": "BIGINT",
+            "jsonextractuint": "DECIMAL(20, 0)",
+            "jsonextractfloat": "DOUBLE",
+            "jsonextractbool": "BOOLEAN",
+        }
+        if function_name not in {
+            *result_types,
+            "jsonextractraw",
+            "jsonextractarrayraw",
+            "jsonextract",
+            "jsonhas",
+            "jsonextractkeys",
+            "jsonextractkeysandvalues",
+            "jsonextractkeysandvaluesraw",
+        }:
+            return None
+        if not node.args:
+            raise QueryError(f"{node.name} expects at least one argument in the Trino dialect")
+
+        source = self.visit(node.args[0])
+        path_args = node.args[1:]
+        if function_name == "jsonhas":
+            if len(path_args) != 1:
+                raise QueryError("JSONHas expects a single path component in the Trino dialect")
+            path = self._json_path(path_args)
+            self.context.add_value(path)
+            return f"(json_extract({source}, ?) IS NOT NULL)"
+        if function_name == "jsonextractkeys":
+            path = self._json_path(path_args)
+            self.context.add_value(path)
+            return f"map_keys(CAST(json_extract({source}, ?) AS MAP(VARCHAR, JSON)))"
+        if function_name in {"jsonextractkeysandvalues", "jsonextractkeysandvaluesraw"}:
+            target_types = {
+                "bool": "BOOLEAN",
+                "float64": "DOUBLE",
+                "int64": "BIGINT",
+                "string": "VARCHAR",
+                "uint64": "DECIMAL(20, 0)",
+            }
+            if function_name == "jsonextractkeysandvalues":
+                if not path_args or not isinstance(path_args[-1], ast.Constant):
+                    raise QueryError("JSONExtractKeysAndValues requires a literal target type in the Trino dialect")
+                target_type = target_types.get(str(path_args[-1].value).lower())
+                if target_type is None:
+                    raise QueryError(
+                        f"JSONExtractKeysAndValues target type '{path_args[-1].value}' is not supported in the Trino dialect"
+                    )
+                path_args = path_args[:-1]
+            else:
+                target_type = "JSON"
+            path = self._json_path(path_args)
+            self.context.add_value(path)
+            return f"map_entries(CAST(json_extract({source}, ?) AS MAP(VARCHAR, {target_type})))"
+        if function_name == "jsonextract":
+            if len(path_args) != 1 or not isinstance(path_args[0], ast.Constant):
+                raise QueryError("JSONExtract requires a literal target type in the Trino dialect")
+            target_type = str(path_args[0].value).lower()
+            if target_type == "array(string)":
+                return f"CAST(json_extract({source}, '$') AS ARRAY(VARCHAR))"
+            if target_type == "map(string, float64)":
+                return f"CAST(json_extract({source}, '$') AS MAP(VARCHAR, DOUBLE))"
+            raise QueryError(f"JSONExtract target type '{path_args[0].value}' is not supported in the Trino dialect")
+
+        path = self._json_path(path_args)
+        self.context.add_value(path)
+        extracted = f"json_extract({source}, ?)"
+        if function_name in {"jsonextractraw", "jsonextractarrayraw"}:
+            return extracted
+        scalar = f"json_extract_scalar({source}, ?)"
+        if function_name == "jsonextractstring":
+            return scalar
+        return f"CAST({scalar} AS {result_types[function_name]})"
+
+    def _json_path(self, path_args: Iterable[ast.Expr]) -> str:
+        path = "$"
+        for arg in path_args:
+            if not isinstance(arg, ast.Constant) or not isinstance(arg.value, str | int):
+                raise QueryError("Trino JSON paths require literal string or integer components")
+            if isinstance(arg.value, int):
+                path += f"[{arg.value}]"
+            else:
+                path += f".{json.dumps(arg.value, ensure_ascii=False)}"
+        return path
+
+    def _json_property_args(self, chain: Iterable[Any]) -> list[str]:
+        path = "$" + "".join(f".{json.dumps(str(key), ensure_ascii=False)}" for key in chain)
+        self.context.add_value(path)
+        return ["?"]
+
+    def _unsafe_json_extract_trim_quotes(self, unsafe_field: str, unsafe_args: list[str]) -> str:
+        if not unsafe_args:
+            return unsafe_field
+        return f"json_extract_scalar({unsafe_field}, {unsafe_args[0]})"
+
+    def _get_compare_op(self, op: ast.CompareOperationOp, left: str, right: str) -> str:
+        if op == ast.CompareOperationOp.ILike:
+            return f"(lower({left}) LIKE lower({right}))"
+        if op == ast.CompareOperationOp.NotILike:
+            return f"(lower({left}) NOT LIKE lower({right}))"
+        if op == ast.CompareOperationOp.Regex:
+            return f"regexp_like({left}, {right})"
+        if op == ast.CompareOperationOp.NotRegex:
+            return f"NOT regexp_like({left}, {right})"
+        if op == ast.CompareOperationOp.IRegex:
+            return f"regexp_like({left}, concat('(?i)', {right}))"
+        if op == ast.CompareOperationOp.NotIRegex:
+            return f"NOT regexp_like({left}, concat('(?i)', {right}))"
+        return super()._get_compare_op(op, left, right)
+
+    def _render_start_of(self, unit: str, arg: str, week_mode: int = 3) -> str:
+        if unit == "week":
+            if week_mode in {1, 3}:
+                return f"date_trunc('week', {arg})"
+            if week_mode == 0:
+                return f"date_add('day', -1, date_trunc('week', date_add('day', 1, {arg})))"
+            raise QueryError(f"Unsupported toStartOfWeek mode `{week_mode}` in Trino mode.")
+        if unit == "isoyear":
+            return f"date_trunc('week', date_parse(concat(CAST(year_of_week({arg}) AS VARCHAR), '-01-04'), '%Y-%m-%d'))"
+        return f"date_trunc('{unit}', {arg})"
+
+    def _render_minute_bucket(self, arg: str, bucket_size: int) -> str:
+        bucket_seconds = bucket_size * 60
+        return f"from_unixtime(floor(to_unixtime({arg}) / {bucket_seconds}) * {bucket_seconds})"
+
+    def visit_cte(self, node: ast.CTE) -> str:
+        if node.materialized is not None:
+            raise QueryError("CTE materialization hints are not supported in the Trino dialect")
+        if node.using_key is not None:
+            raise QueryError("CTE USING KEY is not supported in the Trino dialect")
+        if node.cte_type == "subquery":
+            columns = (
+                ""
+                if node.columns is None
+                else f"({', '.join(self._print_identifier(column) for column in node.columns)})"
+            )
+            return f"{self._print_identifier(node.name)}{columns} AS {self.visit(node.expr)}"
+        raise QueryError("Scalar CTEs are not supported in the Trino dialect")
+
+    def visit_unpivot_expr(self, node: ast.UnpivotExpr) -> str:
+        raise QueryError("UNPIVOT is not supported in the Trino dialect")
+
+    def visit_pivot_expr(self, node: ast.PivotExpr) -> str:
+        raise QueryError("PIVOT is not supported in the Trino dialect")

--- a/posthog/hogql/printer/trino_functions.py
+++ b/posthog/hogql/printer/trino_functions.py
@@ -1,0 +1,383 @@
+from collections.abc import Callable
+
+from posthog.hogql.errors import QueryError
+
+
+def _cast(type_name: str) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        return f"CAST({args[0]} AS {type_name})"
+
+    return handler
+
+
+def _try_cast_or_default(type_name: str) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        if len(args) not in {1, 2}:
+            raise QueryError(f"Conversion to {type_name} expects one value and an optional default")
+        default = args[1] if len(args) == 2 else "0"
+        return f"COALESCE(TRY_CAST({args[0]} AS {type_name}), CAST({default} AS {type_name}))"
+
+    return handler
+
+
+def _extract(unit: str) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        return f"EXTRACT({unit} FROM {args[0]})"
+
+    return handler
+
+
+def _aggregate_if(function_name: str) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        return f"{function_name}({', '.join(args[:-1])}) FILTER (WHERE {args[-1]})"
+
+    return handler
+
+
+def _if(args: list[str]) -> str:
+    return f"CASE WHEN {args[0]} THEN {args[1]} ELSE {args[2]} END"
+
+
+def _multi_if(args: list[str]) -> str:
+    parts = ["CASE"]
+    for index in range(0, len(args) - 1, 2):
+        parts.append(f"WHEN {args[index]} THEN {args[index + 1]}")
+    parts.append(f"ELSE {args[-1]} END")
+    return " ".join(parts)
+
+
+def _count_if(args: list[str]) -> str:
+    if len(args) == 1:
+        return f"count(*) FILTER (WHERE {args[0]})"
+    return f"count({args[0]}) FILTER (WHERE {args[1]})"
+
+
+def _uniq(args: list[str]) -> str:
+    distinct_value = args[0] if len(args) == 1 else f"ROW({', '.join(args)})"
+    return f"count(DISTINCT {distinct_value})"
+
+
+def _uniq_if(args: list[str]) -> str:
+    values = args[:-1]
+    distinct_value = values[0] if len(values) == 1 else f"ROW({', '.join(values)})"
+    return f"count(DISTINCT {distinct_value}) FILTER (WHERE {args[-1]})"
+
+
+def _date_diff(args: list[str]) -> str:
+    return f"date_diff({args[0]}, {args[1]}, {args[2]})"
+
+
+def _date_add(args: list[str]) -> str:
+    if len(args) == 2:
+        return f"({args[0]} + {args[1]})"
+    return f"date_add({args[0]}, {args[1]}, {args[2]})"
+
+
+def _date_sub(args: list[str]) -> str:
+    return f"date_add({args[0]}, -({args[1]}), {args[2]})"
+
+
+def _date_trunc(args: list[str]) -> str:
+    value = args[1]
+    if len(args) == 3:
+        value = f"at_timezone(with_timezone(CAST({value} AS TIMESTAMP), 'UTC'), {args[2]})"
+    return f"date_trunc({args[0]}, {value})"
+
+
+def _array_map(args: list[str]) -> str:
+    if len(args) != 2:
+        raise QueryError("arrayMap with multiple arrays is not supported in the Trino dialect")
+    return f"transform({args[1]}, {args[0]})"
+
+
+def _array_filter(args: list[str]) -> str:
+    if len(args) != 2:
+        raise QueryError("arrayFilter with multiple arrays is not supported in the Trino dialect")
+    return f"filter({args[1]}, {args[0]})"
+
+
+def _split_by_string(args: list[str]) -> str:
+    return f"split({args[1]}, {args[0]})"
+
+
+def _binary_operator(operator: str, *, cast_left_to_double: bool = False) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        left = f"CAST({args[0]} AS DOUBLE)" if cast_left_to_double else args[0]
+        return f"({left} {operator} {args[1]})"
+
+    return handler
+
+
+def _logical_operator(operator: str) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        return f"({f' {operator} '.join(args)})"
+
+    return handler
+
+
+def _group_uniq_array(args: list[str]) -> str:
+    return f"array_distinct(array_agg({args[0]}))"
+
+
+def _group_uniq_array_if(args: list[str]) -> str:
+    return f"array_distinct(array_agg({args[0]}) FILTER (WHERE {args[1]}))"
+
+
+def _arg_extreme_if(function_name: str) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        return f"{function_name}({args[0]}, {args[1]}) FILTER (WHERE {args[2]})"
+
+    return handler
+
+
+def _md5(args: list[str]) -> str:
+    return f"to_hex(md5(to_utf8(CAST({args[0]} AS VARCHAR))))"
+
+
+def _int_div(args: list[str]) -> str:
+    return f"CAST(floor(CAST({args[0]} AS DOUBLE) / {args[1]}) AS BIGINT)"
+
+
+def _to_datetime(args: list[str]) -> str:
+    timestamp = f"CAST({args[0]} AS TIMESTAMP)"
+    return timestamp if len(args) == 1 else f"with_timezone({timestamp}, {args[1]})"
+
+
+def _to_timezone(args: list[str]) -> str:
+    return f"at_timezone(with_timezone(CAST({args[0]} AS TIMESTAMP), 'UTC'), {args[1]})"
+
+
+def _interval(unit: str, multiplier: int = 1) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        amount = args[0] if multiplier == 1 else f"({args[0]} * {multiplier})"
+        return f"({amount} * INTERVAL '1' {unit})"
+
+    return handler
+
+
+def _add_date(unit: str, multiplier: int = 1, subtract: bool = False) -> Callable[[list[str]], str]:
+    def handler(args: list[str]) -> str:
+        amount = f"({args[1]} * {multiplier})" if multiplier != 1 else args[1]
+        if subtract:
+            amount = f"-({amount})"
+        return f"date_add('{unit}', {amount}, {args[0]})"
+
+    return handler
+
+
+TRINO_FUNCTION_RENAMES: dict[str, str] = {
+    "ifNull": "coalesce",
+    "groupArray": "array_agg",
+    "fromUnixTimestamp": "from_unixtime",
+    "replaceAll": "replace",
+    "replaceRegexpAll": "regexp_replace",
+    "arrayStringConcat": "array_join",
+    "JSONLength": "json_array_length",
+    "toTypeName": "typeof",
+    "formatDateTime": "date_format",
+    "formatReadableTimeDelta": "human_readable_seconds",
+    "now": "now",
+    "any": "arbitrary",
+    "anyLast": "arbitrary",
+    "startsWith": "starts_with",
+    "endsWith": "ends_with",
+    "rand": "random",
+    "argMax": "max_by",
+    "argMin": "min_by",
+    "arrayConcat": "concat",
+    "arrayDistinct": "array_distinct",
+    "arrayFlatten": "flatten",
+    "arrayMin": "array_min",
+    "arraySort": "array_sort",
+    "dateTrunc": "date_trunc",
+    "hasAny": "arrays_overlap",
+    "mapFromArrays": "map",
+    "mapUpdate": "map_concat",
+    "substringUTF8": "substring",
+    "parseDateTime": "date_parse",
+}
+
+
+TRINO_FUNCTION_HANDLERS: dict[str, Callable[[list[str]], str]] = {
+    "toDate": _cast("DATE"),
+    "_toDate": _cast("DATE"),
+    "toDateTime": _to_datetime,
+    "toString": _cast("VARCHAR"),
+    "toInt": _cast("BIGINT"),
+    "toInt8": _cast("BIGINT"),
+    "toInt16": _cast("BIGINT"),
+    "_toInt16": _cast("BIGINT"),
+    "toInt32": _cast("BIGINT"),
+    "toInt64": _cast("BIGINT"),
+    "toUInt": _cast("BIGINT"),
+    "toUInt8": _cast("BIGINT"),
+    "toUInt16": _cast("BIGINT"),
+    "toUInt32": _cast("BIGINT"),
+    "toUInt64": _cast("DECIMAL(20, 0)"),
+    "toFloat": _cast("DOUBLE"),
+    "toFloat32": _cast("REAL"),
+    "toFloat64": _cast("DOUBLE"),
+    "toFloatOrZero": _try_cast_or_default("DOUBLE"),
+    "toFloatOrDefault": _try_cast_or_default("DOUBLE"),
+    "toIntOrZero": _try_cast_or_default("BIGINT"),
+    "toIntOrDefault": _try_cast_or_default("BIGINT"),
+    "toBool": _cast("BOOLEAN"),
+    "toUUID": _cast("UUID"),
+    "toDecimal": _cast("DECIMAL"),
+    "toDateTime64": _cast("TIMESTAMP"),
+    "toUnixTimestamp": lambda args: f"CAST(to_unixtime({args[0]}) AS BIGINT)",
+    "toYear": _extract("YEAR"),
+    "toQuarter": _extract("QUARTER"),
+    "toMonth": _extract("MONTH"),
+    "toDayOfMonth": _extract("DAY"),
+    "toDayOfWeek": _extract("DAY_OF_WEEK"),
+    "toDayOfYear": _extract("DAY_OF_YEAR"),
+    "toHour": _extract("HOUR"),
+    "toMinute": _extract("MINUTE"),
+    "toSecond": _extract("SECOND"),
+    "toISOWeek": lambda args: f"week({args[0]})",
+    "toISOYear": lambda args: f"year_of_week({args[0]})",
+    "toYYYYMM": lambda args: f"CAST(date_format({args[0]}, '%Y%m') AS INTEGER)",
+    "toYYYYMMDD": lambda args: f"CAST(date_format({args[0]}, '%Y%m%d') AS INTEGER)",
+    "toYYYYMMDDhhmmss": lambda args: f"CAST(date_format({args[0]}, '%Y%m%d%H%i%s') AS BIGINT)",
+    "toMonday": lambda args: f"CAST(date_trunc('week', {args[0]}) AS DATE)",
+    "toLastDayOfMonth": lambda args: f"last_day_of_month({args[0]})",
+    "toLastDayOfWeek": lambda args: f"CAST(date_add('day', 6, date_trunc('week', {args[0]})) AS DATE)",
+    "today": lambda args: "CURRENT_DATE",
+    "yesterday": lambda args: "date_add('day', -1, CURRENT_DATE)",
+    "toIntervalSecond": _interval("SECOND"),
+    "toIntervalMinute": _interval("MINUTE"),
+    "toIntervalHour": _interval("HOUR"),
+    "toIntervalDay": _interval("DAY"),
+    "toIntervalWeek": _interval("DAY", 7),
+    "toIntervalMonth": _interval("MONTH"),
+    "toIntervalQuarter": _interval("MONTH", 3),
+    "toIntervalYear": _interval("YEAR"),
+    "addSeconds": _add_date("second"),
+    "addMinutes": _add_date("minute"),
+    "addHours": _add_date("hour"),
+    "addDays": _add_date("day"),
+    "addWeeks": _add_date("week"),
+    "addMonths": _add_date("month"),
+    "addQuarters": _add_date("month", 3),
+    "addYears": _add_date("year"),
+    "subtractSeconds": _add_date("second", subtract=True),
+    "subtractMinutes": _add_date("minute", subtract=True),
+    "subtractHours": _add_date("hour", subtract=True),
+    "subtractDays": _add_date("day", subtract=True),
+    "subtractWeeks": _add_date("week", subtract=True),
+    "subtractMonths": _add_date("month", subtract=True),
+    "subtractQuarters": _add_date("month", 3, subtract=True),
+    "subtractYears": _add_date("year", subtract=True),
+    "if": _if,
+    "multiIf": _multi_if,
+    "countIf": _count_if,
+    "sumIf": _aggregate_if("sum"),
+    "avgIf": _aggregate_if("avg"),
+    "minIf": _aggregate_if("min"),
+    "maxIf": _aggregate_if("max"),
+    "anyIf": _aggregate_if("arbitrary"),
+    "groupArrayIf": _aggregate_if("array_agg"),
+    "groupUniqArray": _group_uniq_array,
+    "groupUniqArrayIf": _group_uniq_array_if,
+    "argMaxIf": _arg_extreme_if("max_by"),
+    "argMinIf": _arg_extreme_if("min_by"),
+    "uniq": _uniq,
+    "uniqExact": _uniq,
+    "uniqIf": _uniq_if,
+    "uniqExactIf": _uniq_if,
+    "dateDiff": _date_diff,
+    "date_diff": _date_diff,
+    "dateAdd": _date_add,
+    "dateSub": _date_sub,
+    "dateTrunc": _date_trunc,
+    "date_trunc": _date_trunc,
+    "empty": lambda args: f"(COALESCE(length({args[0]}), 0) = 0)",
+    "notEmpty": lambda args: f"(COALESCE(length({args[0]}), 0) > 0)",
+    "isNull": lambda args: f"({args[0]} IS NULL)",
+    "isNotNull": lambda args: f"({args[0]} IS NOT NULL)",
+    "assumeNotNull": lambda args: args[0],
+    "toNullable": lambda args: args[0],
+    "match": lambda args: f"regexp_like({args[0]}, {args[1]})",
+    "extract": lambda args: f"regexp_extract({args[0]}, {args[1]})",
+    "extractAll": lambda args: f"regexp_extract_all({args[0]}, {args[1]})",
+    "splitByString": _split_by_string,
+    "splitByChar": _split_by_string,
+    "arrayMap": _array_map,
+    "arrayFilter": _array_filter,
+    "arrayFirst": lambda args: f"element_at(filter({args[1]}, {args[0]}), 1)",
+    "has": lambda args: f"contains({args[0]}, {args[1]})",
+    "arrayElement": lambda args: f"element_at({args[0]}, {args[1]})",
+    "concat": lambda args: f"concat({', '.join(args)})",
+    "position": lambda args: f"strpos({args[0]}, {args[1]})",
+    "e": lambda args: "exp(1)",
+    "tuple": lambda args: f"ROW({', '.join(args)})",
+    "not": lambda args: f"(NOT {args[0]})",
+    "and": _logical_operator("AND"),
+    "or": _logical_operator("OR"),
+    "plus": _binary_operator("+"),
+    "minus": _binary_operator("-"),
+    "multiply": _binary_operator("*"),
+    "multiplyDecimal": _binary_operator("*"),
+    "divide": _binary_operator("/", cast_left_to_double=True),
+    "divideDecimal": _binary_operator("/"),
+    "intDiv": _int_div,
+    "md5": _md5,
+    "current_timestamp": lambda args: "CURRENT_TIMESTAMP",
+    "toTimeZone": _to_timezone,
+    "toJSONString": lambda args: f"json_format(CAST({args[0]} AS JSON))",
+    "medianIf": lambda args: f"approx_percentile({args[0]}, 0.5) FILTER (WHERE {args[1]})",
+}
+
+TRINO_FUNCTION_HANDLERS_LOWER = {name.lower(): handler for name, handler in TRINO_FUNCTION_HANDLERS.items()}
+TRINO_FUNCTION_RENAMES_LOWER = {name.lower(): target for name, target in TRINO_FUNCTION_RENAMES.items()}
+
+TRINO_PASSTHROUGH_FUNCTIONS: frozenset[str] = frozenset(
+    {
+        "count",
+        "sum",
+        "avg",
+        "min",
+        "max",
+        "abs",
+        "floor",
+        "ceil",
+        "round",
+        "sqrt",
+        "pow",
+        "power",
+        "exp",
+        "ln",
+        "sign",
+        "sin",
+        "cos",
+        "tan",
+        "asin",
+        "acos",
+        "atan",
+        "atan2",
+        "pi",
+        "degrees",
+        "radians",
+        "cbrt",
+        "greatest",
+        "least",
+        "lower",
+        "upper",
+        "trim",
+        "ltrim",
+        "rtrim",
+        "substring",
+        "length",
+        "reverse",
+        "replace",
+        "lpad",
+        "rpad",
+        "repeat",
+        "log2",
+        "log10",
+        "coalesce",
+        "nullif",
+        "date_trunc",
+    }
+)

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -28,6 +28,7 @@ from posthog.hogql.printer.mysql import MySQLPrinter
 from posthog.hogql.printer.postgres import PostgresPrinter
 from posthog.hogql.printer.redshift import RedshiftPrinter
 from posthog.hogql.printer.snowflake import SnowflakePrinter
+from posthog.hogql.printer.trino import TrinoPrinter
 from posthog.hogql.resolver import ResolverFactory, resolve_types
 from posthog.hogql.transforms.events_predicate_pushdown import apply_events_predicate_pushdown, events_pushdown_enabled
 from posthog.hogql.transforms.in_cohort import resolve_in_cohorts, resolve_in_cohorts_conjoined
@@ -56,6 +57,7 @@ PRINTER_CLASSES: dict[HogQLDialect, type[BasePrinter]] = {
     "snowflake": SnowflakePrinter,
     "redshift": RedshiftPrinter,
     "hogql": HogQLPrinter,
+    "trino": TrinoPrinter,
 }
 
 

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -163,6 +163,12 @@ assert POSTGRES_KEYWORD_TYPES.keys() == ast.VALID_KEYWORD_NAMES, (
 # DuckDB is Postgres-wire compatible and accepts nearly all PG-specific constructs, so it
 # takes the PG code path in the resolver.
 _POSTGRES_FAMILY: frozenset[HogQLDialect] = frozenset({"postgres", "duckdb"})
+_TRINO_DIALECTS: frozenset[HogQLDialect] = frozenset({"trino"})
+_CLICKHOUSE_AND_TRINO_DIALECTS: frozenset[HogQLDialect] = frozenset({"clickhouse", "trino"})
+_TRY_CAST_DIALECTS: frozenset[HogQLDialect] = _POSTGRES_FAMILY | _TRINO_DIALECTS
+_ARRAY_SLICE_DIALECTS: frozenset[HogQLDialect] = _POSTGRES_FAMILY | _CLICKHOUSE_AND_TRINO_DIALECTS
+_STANDARD_COLUMN_ALIAS_DIALECTS: frozenset[HogQLDialect] = _POSTGRES_FAMILY | _TRINO_DIALECTS
+_POSITIONAL_REFERENCE_DIALECTS: frozenset[HogQLDialect] = _POSTGRES_FAMILY | _TRINO_DIALECTS
 
 # Dialects with native PIVOT/UNPIVOT support. Snowflake speaks the same standard-SQL
 # `PIVOT (agg FOR col IN (...))` shape, so it joins the Postgres family here even though it
@@ -1529,7 +1535,7 @@ class Resolver(CloningVisitor):
                 # For non-postgres dialects, bake column aliases into the inner
                 # SELECT as AS aliases so ClickHouse/HogQL (which don't support
                 # the ``AS t(col1, col2)`` syntax) get correct column names.
-                if self.dialect not in _POSTGRES_FAMILY:
+                if self.dialect not in _STANDARD_COLUMN_ALIAS_DIALECTS:
                     inner_query = cast(ast.SelectQuery, inner_select)
                     new_select: list[ast.Expr] = []
                     for i, expr in enumerate(inner_query.select):
@@ -2139,7 +2145,7 @@ class Resolver(CloningVisitor):
         return node
 
     def visit_try_cast(self, node: ast.TryCast):
-        if self.dialect not in _POSTGRES_FAMILY:
+        if self.dialect not in _TRY_CAST_DIALECTS:
             raise QueryError(f"TRY_CAST is not allowed in {self.dialect} dialect")
         node = cast(ast.TryCast, clone_expr(node))
         node.expr = self.visit(node.expr)
@@ -2154,14 +2160,14 @@ class Resolver(CloningVisitor):
         return node
 
     def visit_positional_ref(self, node: ast.PositionalRef):
-        if self.dialect not in _POSTGRES_FAMILY:
+        if self.dialect not in _POSITIONAL_REFERENCE_DIALECTS:
             raise QueryError(f"Positional references are not allowed in {self.dialect} dialect")
         node = cast(ast.PositionalRef, clone_expr(node))
         node.type = ast.UnknownType()
         return node
 
     def visit_array_slice(self, node: ast.ArraySlice):
-        if self.dialect not in _POSTGRES_FAMILY and self.dialect != "clickhouse":
+        if self.dialect not in _ARRAY_SLICE_DIALECTS:
             raise QueryError(f"Array slices are not allowed in {self.dialect} dialect")
         node = cast(ast.ArraySlice, clone_expr(node))
         node.array = self.visit(node.array)

--- a/posthog/hogql/type_system.py
+++ b/posthog/hogql/type_system.py
@@ -36,7 +36,7 @@ type RuntimeTypeFamily = Literal[
     "enum",
     "aggregate_state",
 ]
-type RuntimeTypeDialect = Literal["common", "clickhouse", "postgres", "duckdb", "mysql"]
+type RuntimeTypeDialect = Literal["common", "clickhouse", "postgres", "duckdb", "mysql", "trino"]
 
 
 class ComparisonCompatibility(StrEnum):


### PR DESCRIPTION
## Problem

Data warehouse users can run HogQL against Trino connections instead of relying on raw SQL.

Direct Trino connections previously bypassed HogQL compilation because the query printer did not support the Trino dialect.

## Changes

- Direct queries now compile HogQL into native Trino SQL with bound parameters.
- Compilation covers identifiers, types, functions, joins, windows, JSON access, pagination, and case-insensitive catalog resolution.
- Unsupported constructs fail with explicit errors instead of emitting invalid SQL.
- Shared printer hooks preserve existing dialect behavior while enabling Trino-specific clauses.
- This backend-only change has no visible UI changes.

## How did you test this code?

- `hogli test posthog/hogql/printer/test posthog/hogql/direct_sql/test` validates printer and adapter behavior.
- `uv run mypy --cache-fine-grained .` validates repository-wide Python typing.
- The staged-file commit hook validates Ruff formatting, Ruff lint, and `ty` typing.
- `hogli ci:preflight --fix` validates branch freshness and applicable pre-push checks.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update. This introduces internal compiler support without changing a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex produced the implementation with `/writing-pr-descriptions`, `/running-ci-preflight`, and `/signed-git-publish`.

The design isolates Trino behavior behind printer hooks and covers it with synthetic unit tests.
