### PR TITLE
chore(email): register posthog templatetags as template builtins

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -247,7 +247,11 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "loginas.context_processors.impersonated_session_status",
                 "posthog.helpers.impersonation.impersonation_context",
-            ]
+            ],
+            "builtins": [
+                "posthog.templatetags.posthog_assets",
+                "posthog.templatetags.posthog_filters",
+            ],
         },
     }
 ]

--- a/posthog/templates/email/2fa_backup_code_used.html
+++ b/posthog/templates/email/2fa_backup_code_used.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_backup_code_used.html
+++ b/posthog/templates/email/2fa_backup_code_used.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_backup_code_used.html
+++ b/posthog/templates/email/2fa_backup_code_used.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_backup_code_used.html
+++ b/posthog/templates/email/2fa_backup_code_used.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_backup_code_used.html
+++ b/posthog/templates/email/2fa_backup_code_used.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_disabled.html
+++ b/posthog/templates/email/2fa_disabled.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_disabled.html
+++ b/posthog/templates/email/2fa_disabled.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_disabled.html
+++ b/posthog/templates/email/2fa_disabled.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_disabled.html
+++ b/posthog/templates/email/2fa_disabled.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_disabled.html
+++ b/posthog/templates/email/2fa_disabled.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_enabled.html
+++ b/posthog/templates/email/2fa_enabled.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_enabled.html
+++ b/posthog/templates/email/2fa_enabled.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_enabled.html
+++ b/posthog/templates/email/2fa_enabled.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_enabled.html
+++ b/posthog/templates/email/2fa_enabled.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_enabled.html
+++ b/posthog/templates/email/2fa_enabled.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_reset.html
+++ b/posthog/templates/email/2fa_reset.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_reset.html
+++ b/posthog/templates/email/2fa_reset.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_reset.html
+++ b/posthog/templates/email/2fa_reset.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_reset.html
+++ b/posthog/templates/email/2fa_reset.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/2fa_reset.html
+++ b/posthog/templates/email/2fa_reset.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/ai_observability_evaluation_disabled.html
+++ b/posthog/templates/email/ai_observability_evaluation_disabled.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}Your evaluation "{{ evaluation_name }}" has been disabled{% endblock %}
 {% block heading %}Your evaluation has been disabled{% endblock %}
 {% block section %}

--- a/posthog/templates/email/ai_observability_evaluation_disabled.html
+++ b/posthog/templates/email/ai_observability_evaluation_disabled.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %} {% load posthog_assets %}
 {% block preheader %}Your evaluation "{{ evaluation_name }}" has been disabled{% endblock %}
 {% block heading %}Your evaluation has been disabled{% endblock %}
 {% block section %}

--- a/posthog/templates/email/ai_observability_evaluation_disabled.html
+++ b/posthog/templates/email/ai_observability_evaluation_disabled.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}Your evaluation "{{ evaluation_name }}" has been disabled{% endblock %}
 {% block heading %}Your evaluation has been disabled{% endblock %}
 {% block section %}

--- a/posthog/templates/email/ai_observability_evaluation_disabled.html
+++ b/posthog/templates/email/ai_observability_evaluation_disabled.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}Your evaluation "{{ evaluation_name }}" has been disabled{% endblock %}
 {% block heading %}Your evaluation has been disabled{% endblock %}
 {% block section %}

--- a/posthog/templates/email/ai_observability_evaluation_disabled.html
+++ b/posthog/templates/email/ai_observability_evaluation_disabled.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block preheader %}Your evaluation "{{ evaluation_name }}" has been disabled{% endblock %}
 {% block heading %}Your evaluation has been disabled{% endblock %}
 {% block section %}

--- a/posthog/templates/email/ai_subscription_credit_limited.html
+++ b/posthog/templates/email/ai_subscription_credit_limited.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
     <p>
         Your prompt subscription <strong>{{ title }}</strong> didn't run this cycle because your

--- a/posthog/templates/email/ai_subscription_credit_limited.html
+++ b/posthog/templates/email/ai_subscription_credit_limited.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
     <p>
         Your prompt subscription <strong>{{ title }}</strong> didn't run this cycle because your
         organization reached its <strong>AI credit limit</strong>.

--- a/posthog/templates/email/ai_subscription_credit_limited.html
+++ b/posthog/templates/email/ai_subscription_credit_limited.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
     <p>
         Your prompt subscription <strong>{{ title }}</strong> didn't run this cycle because your

--- a/posthog/templates/email/ai_subscription_credit_limited.html
+++ b/posthog/templates/email/ai_subscription_credit_limited.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
     <p>
         Your prompt subscription <strong>{{ title }}</strong> didn't run this cycle because your

--- a/posthog/templates/email/ai_subscription_credit_limited.html
+++ b/posthog/templates/email/ai_subscription_credit_limited.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
     <p>
         Your prompt subscription <strong>{{ title }}</strong> didn't run this cycle because your
         organization reached its <strong>AI credit limit</strong>.

--- a/posthog/templates/email/ai_subscription_report.html
+++ b/posthog/templates/email/ai_subscription_report.html
@@ -1,5 +1,6 @@
 {% extends "email/base.html" %}
-
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{{ title }}{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/ai_subscription_report.html
+++ b/posthog/templates/email/ai_subscription_report.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ title }}{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/ai_subscription_report.html
+++ b/posthog/templates/email/ai_subscription_report.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ title }}{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/ai_subscription_report.html
+++ b/posthog/templates/email/ai_subscription_report.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ title }}{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/alert_check_failed_to_evaluate.html
+++ b/posthog/templates/email/alert_check_failed_to_evaluate.html
@@ -23,4 +23,4 @@
     <div class="mb mt text-center">
         <a class="button" href="{% absolute_uri alert_url %}">Review alert</a>
     </div>
-{% endblock %}{% load posthog_filters %}
+{% endblock %}

--- a/posthog/templates/email/alert_check_failed_to_evaluate.html
+++ b/posthog/templates/email/alert_check_failed_to_evaluate.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ alert_name }}{% endblock %} {% block section %}
     <p>
         PostHog could not evaluate this alert. This can happen when the insight or alert settings need attention, or

--- a/posthog/templates/email/alert_check_failed_to_evaluate.html
+++ b/posthog/templates/email/alert_check_failed_to_evaluate.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block heading %}{{ alert_name }}{% endblock %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block heading %}{{ alert_name }}{% endblock %} {% block section %}
     <p>
         PostHog could not evaluate this alert. This can happen when the insight or alert settings need attention, or
         when PostHog has a temporary problem.

--- a/posthog/templates/email/alert_check_failed_to_evaluate.html
+++ b/posthog/templates/email/alert_check_failed_to_evaluate.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ alert_name }}{% endblock %} {% block section %}
     <p>
         PostHog could not evaluate this alert. This can happen when the insight or alert settings need attention, or

--- a/posthog/templates/email/alert_check_failed_to_evaluate.html
+++ b/posthog/templates/email/alert_check_failed_to_evaluate.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ alert_name }}{% endblock %} {% block section %}
     <p>
         PostHog could not evaluate this alert. This can happen when the insight or alert settings need attention, or

--- a/posthog/templates/email/alert_check_firing.html
+++ b/posthog/templates/email/alert_check_firing.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
     <p>
         {% if is_test %}

--- a/posthog/templates/email/alert_check_firing.html
+++ b/posthog/templates/email/alert_check_firing.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
     <p>
         {% if is_test %}
             This is a test delivery for the <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert on <a

--- a/posthog/templates/email/alert_check_firing.html
+++ b/posthog/templates/email/alert_check_firing.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
     <p>
         {% if is_test %}

--- a/posthog/templates/email/alert_check_firing.html
+++ b/posthog/templates/email/alert_check_firing.html
@@ -16,4 +16,4 @@
     <div class="mb mt text-center">
         <a class="button" href="{% absolute_uri alert_url %}">Manage alert</a>
     </div>
-{% endblock %}{% load posthog_filters %}
+{% endblock %}

--- a/posthog/templates/email/alert_check_firing.html
+++ b/posthog/templates/email/alert_check_firing.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
     <p>
         {% if is_test %}

--- a/posthog/templates/email/alert_disabled.html
+++ b/posthog/templates/email/alert_disabled.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
     <p>
         The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert for insight <a

--- a/posthog/templates/email/alert_disabled.html
+++ b/posthog/templates/email/alert_disabled.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
     <p>
         The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert for insight <a

--- a/posthog/templates/email/alert_disabled.html
+++ b/posthog/templates/email/alert_disabled.html
@@ -10,4 +10,4 @@
     <div class="mb mt text-center">
         <a class="button" href="{% absolute_uri alert_url %}">Manage alert</a>
     </div>
-{% endblock %}{% load posthog_filters %}
+{% endblock %}

--- a/posthog/templates/email/alert_disabled.html
+++ b/posthog/templates/email/alert_disabled.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
     <p>
         The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert for insight <a

--- a/posthog/templates/email/alert_disabled.html
+++ b/posthog/templates/email/alert_disabled.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
     <p>
         The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert for insight <a
             href="{% absolute_uri insight_url %}">{{ insight_name }}</a> in project <strong>{{ project_name }}</strong> has been <strong>automatically disabled</strong> because its configuration is no longer valid:

--- a/posthog/templates/email/approval_applied.html
+++ b/posthog/templates/email/approval_applied.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Your change is live! 🎉{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_applied.html
+++ b/posthog/templates/email/approval_applied.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Your change is live! 🎉{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_applied.html
+++ b/posthog/templates/email/approval_applied.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Your change is live! 🎉{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_applied.html
+++ b/posthog/templates/email/approval_applied.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}Your change is live! 🎉{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_applied.html
+++ b/posthog/templates/email/approval_applied.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Your change is live! 🎉{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_approved.html
+++ b/posthog/templates/email/approval_approved.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ approver_name }} approved your change{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_approved.html
+++ b/posthog/templates/email/approval_approved.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{{ approver_name }} approved your change{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_approved.html
+++ b/posthog/templates/email/approval_approved.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ approver_name }} approved your change{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_approved.html
+++ b/posthog/templates/email/approval_approved.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}{{ approver_name }} approved your change{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_approved.html
+++ b/posthog/templates/email/approval_approved.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ approver_name }} approved your change{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_expired.html
+++ b/posthog/templates/email/approval_expired.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Your change request timed out{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_expired.html
+++ b/posthog/templates/email/approval_expired.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}Your change request timed out{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_expired.html
+++ b/posthog/templates/email/approval_expired.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Your change request timed out{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_expired.html
+++ b/posthog/templates/email/approval_expired.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Your change request timed out{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_expired.html
+++ b/posthog/templates/email/approval_expired.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Your change request timed out{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_rejected.html
+++ b/posthog/templates/email/approval_rejected.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Your change request was declined{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_rejected.html
+++ b/posthog/templates/email/approval_rejected.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Your change request was declined{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_rejected.html
+++ b/posthog/templates/email/approval_rejected.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Your change request was declined{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_rejected.html
+++ b/posthog/templates/email/approval_rejected.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}Your change request was declined{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_rejected.html
+++ b/posthog/templates/email/approval_rejected.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Your change request was declined{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_requested.html
+++ b/posthog/templates/email/approval_requested.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{{ requester_name }} needs your sign-off{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_requested.html
+++ b/posthog/templates/email/approval_requested.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ requester_name }} needs your sign-off{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_requested.html
+++ b/posthog/templates/email/approval_requested.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ requester_name }} needs your sign-off{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_requested.html
+++ b/posthog/templates/email/approval_requested.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}{{ requester_name }} needs your sign-off{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/approval_requested.html
+++ b/posthog/templates/email/approval_requested.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ requester_name }} needs your sign-off{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/async_migration_error.html
+++ b/posthog/templates/email/async_migration_error.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <!-- prettier-ignore -->
 <p>
    Uh-oh. Async migration {{ migration_key }} experienced an error at {{ time }}. Here's what happened:

--- a/posthog/templates/email/async_migration_error.html
+++ b/posthog/templates/email/async_migration_error.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <!-- prettier-ignore -->
 <p>

--- a/posthog/templates/email/async_migration_error.html
+++ b/posthog/templates/email/async_migration_error.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <!-- prettier-ignore -->
 <p>

--- a/posthog/templates/email/async_migration_error.html
+++ b/posthog/templates/email/async_migration_error.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
 <!-- prettier-ignore -->
 <p>
    Uh-oh. Async migration {{ migration_key }} experienced an error at {{ time }}. Here's what happened:

--- a/posthog/templates/email/async_migration_error.html
+++ b/posthog/templates/email/async_migration_error.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <!-- prettier-ignore -->
 <p>

--- a/posthog/templates/email/async_migration_status.html
+++ b/posthog/templates/email/async_migration_status.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <!-- prettier-ignore -->
 <p>
     {{ migration_status_update }} 

--- a/posthog/templates/email/async_migration_status.html
+++ b/posthog/templates/email/async_migration_status.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
 <!-- prettier-ignore -->
 <p>
     {{ migration_status_update }} 

--- a/posthog/templates/email/async_migration_status.html
+++ b/posthog/templates/email/async_migration_status.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <!-- prettier-ignore -->
 <p>

--- a/posthog/templates/email/async_migration_status.html
+++ b/posthog/templates/email/async_migration_status.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <!-- prettier-ignore -->
 <p>

--- a/posthog/templates/email/async_migration_status.html
+++ b/posthog/templates/email/async_migration_status.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <!-- prettier-ignore -->
 <p>

--- a/posthog/templates/email/baa_signed_ai_disabled.html
+++ b/posthog/templates/email/baa_signed_ai_disabled.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <h1>AI features have been disabled for {{ organization_name }}</h1>
 <p>

--- a/posthog/templates/email/baa_signed_ai_disabled.html
+++ b/posthog/templates/email/baa_signed_ai_disabled.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <h1>AI features have been disabled for {{ organization_name }}</h1>
 <p>

--- a/posthog/templates/email/baa_signed_ai_disabled.html
+++ b/posthog/templates/email/baa_signed_ai_disabled.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block section %}
 <h1>AI features have been disabled for {{ organization_name }}</h1>
 <p>

--- a/posthog/templates/email/baa_signed_ai_disabled.html
+++ b/posthog/templates/email/baa_signed_ai_disabled.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <h1>AI features have been disabled for {{ organization_name }}</h1>
 <p>

--- a/posthog/templates/email/base.html
+++ b/posthog/templates/email/base.html
@@ -1,5 +1,5 @@
 {% load posthog_assets %}
-
+{% load posthog_filters %}
 <!DOCTYPE html>
 <html>
 

--- a/posthog/templates/email/base.html
+++ b/posthog/templates/email/base.html
@@ -1,6 +1,3 @@
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 <!DOCTYPE html>
 <html>
 

--- a/posthog/templates/email/base.html
+++ b/posthog/templates/email/base.html
@@ -1,5 +1,6 @@
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 <!DOCTYPE html>
 <html>
 

--- a/posthog/templates/email/batch_export_run_failure.html
+++ b/posthog/templates/email/batch_export_run_failure.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}Failing batch exports are automatically paused{% endblock %}
 {% block heading %}PostHog batch export {{ name }} has failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/batch_export_run_failure.html
+++ b/posthog/templates/email/batch_export_run_failure.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}Failing batch exports are automatically paused{% endblock %}
 {% block heading %}PostHog batch export {{ name }} has failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/batch_export_run_failure.html
+++ b/posthog/templates/email/batch_export_run_failure.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block preheader %}Failing batch exports are automatically paused{% endblock %}
 {% block heading %}PostHog batch export {{ name }} has failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/batch_export_run_failure.html
+++ b/posthog/templates/email/batch_export_run_failure.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %} {% load posthog_assets %}
 {% block preheader %}Failing batch exports are automatically paused{% endblock %}
 {% block heading %}PostHog batch export {{ name }} has failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/batch_export_run_failure.html
+++ b/posthog/templates/email/batch_export_run_failure.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}Failing batch exports are automatically paused{% endblock %}
 {% block heading %}PostHog batch export {{ name }} has failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/canary_email.html
+++ b/posthog/templates/email/canary_email.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>
     Good news!
     

--- a/posthog/templates/email/canary_email.html
+++ b/posthog/templates/email/canary_email.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
 <p>
     Good news!
     
@@ -8,4 +8,4 @@
     Nothing else to do here, emails will now be sent when
     applicable.
 </p>
-{% endblock %}{% load posthog_filters %} {% block heading %}Email successfully set up!{% endblock %}
+{% endblock %} {% block heading %}Email successfully set up!{% endblock %}

--- a/posthog/templates/email/canary_email.html
+++ b/posthog/templates/email/canary_email.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>
     Good news!

--- a/posthog/templates/email/canary_email.html
+++ b/posthog/templates/email/canary_email.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>
     Good news!

--- a/posthog/templates/email/canary_email.html
+++ b/posthog/templates/email/canary_email.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>
     Good news!

--- a/posthog/templates/email/code_based_verification.html
+++ b/posthog/templates/email/code_based_verification.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %}{% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 
 <p>We received a login attempt to your PostHog account. To continue, enter this verification code:</p>
 

--- a/posthog/templates/email/code_based_verification.html
+++ b/posthog/templates/email/code_based_verification.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 
 <p>We received a login attempt to your PostHog account. To continue, enter this verification code:</p>

--- a/posthog/templates/email/code_based_verification.html
+++ b/posthog/templates/email/code_based_verification.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 
 <p>We received a login attempt to your PostHog account. To continue, enter this verification code:</p>

--- a/posthog/templates/email/code_based_verification.html
+++ b/posthog/templates/email/code_based_verification.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
+{% extends "email/base.html" %}{% block section %}
 
 <p>We received a login attempt to your PostHog account. To continue, enter this verification code:</p>
 

--- a/posthog/templates/email/code_based_verification.html
+++ b/posthog/templates/email/code_based_verification.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 
 <p>We received a login attempt to your PostHog account. To continue, enter this verification code:</p>

--- a/posthog/templates/email/conversation_restore.html
+++ b/posthog/templates/email/conversation_restore.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Restore your conversations{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/conversation_restore.html
+++ b/posthog/templates/email/conversation_restore.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Restore your conversations{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/conversation_restore.html
+++ b/posthog/templates/email/conversation_restore.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Restore your conversations{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/conversation_restore.html
+++ b/posthog/templates/email/conversation_restore.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Restore your conversations{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/conversation_restore.html
+++ b/posthog/templates/email/conversation_restore.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}Restore your conversations{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/delegation_invite.html
+++ b/posthog/templates/email/delegation_invite.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> asked you to finish setting up PostHog for

--- a/posthog/templates/email/delegation_invite.html
+++ b/posthog/templates/email/delegation_invite.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> asked you to finish setting up PostHog for

--- a/posthog/templates/email/delegation_invite.html
+++ b/posthog/templates/email/delegation_invite.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> asked you to finish setting up PostHog for
     <strong>{{ org_name }}</strong>

--- a/posthog/templates/email/delegation_invite.html
+++ b/posthog/templates/email/delegation_invite.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> asked you to finish setting up PostHog for

--- a/posthog/templates/email/delegation_invite.html
+++ b/posthog/templates/email/delegation_invite.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> asked you to finish setting up PostHog for
     <strong>{{ org_name }}</strong>
@@ -25,4 +25,4 @@
 
 {% block footer %}
 {% endblock %}
-{% endblock %}{% load posthog_filters %}
+{% endblock %}

--- a/posthog/templates/email/discussions_mentioned.html
+++ b/posthog/templates/email/discussions_mentioned.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}You were mentioned in a discussion{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/discussions_mentioned.html
+++ b/posthog/templates/email/discussions_mentioned.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %} {% load posthog_assets %}
 {% block heading %}You were mentioned in a discussion{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/discussions_mentioned.html
+++ b/posthog/templates/email/discussions_mentioned.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}You were mentioned in a discussion{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/discussions_mentioned.html
+++ b/posthog/templates/email/discussions_mentioned.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}You were mentioned in a discussion{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/discussions_mentioned.html
+++ b/posthog/templates/email/discussions_mentioned.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}You were mentioned in a discussion{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_change_new_address.html
+++ b/posthog/templates/email/email_change_new_address.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}This is your new PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_new_address.html
+++ b/posthog/templates/email/email_change_new_address.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}This is your new PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_new_address.html
+++ b/posthog/templates/email/email_change_new_address.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}This is your new PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_new_address.html
+++ b/posthog/templates/email/email_change_new_address.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}This is your new PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_new_address.html
+++ b/posthog/templates/email/email_change_new_address.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}This is your new PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_old_address.html
+++ b/posthog/templates/email/email_change_old_address.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}This is no longer your PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_old_address.html
+++ b/posthog/templates/email/email_change_old_address.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}This is no longer your PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_old_address.html
+++ b/posthog/templates/email/email_change_old_address.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}This is no longer your PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_old_address.html
+++ b/posthog/templates/email/email_change_old_address.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}This is no longer your PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_change_old_address.html
+++ b/posthog/templates/email/email_change_old_address.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}This is no longer your PostHog account email{% endblock %}
 {% block section %}
 <p>Hey, {{ user_name }}! Just letting you know that your PostHog account email has been successfully changed from {{ old_address }} to {{ new_address }}.</p>

--- a/posthog/templates/email/email_sending_reputation_finding.html
+++ b/posthog/templates/email/email_sending_reputation_finding.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{% if high_impact %}Email sending is at risk of being paused{% else %}Reputation warning for your email sending{% endif %}{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_reputation_finding.html
+++ b/posthog/templates/email/email_sending_reputation_finding.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{% if high_impact %}Email sending is at risk of being paused{% else %}Reputation warning for your email sending{% endif %}{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_reputation_finding.html
+++ b/posthog/templates/email/email_sending_reputation_finding.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{% if high_impact %}Email sending is at risk of being paused{% else %}Reputation warning for your email sending{% endif %}{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_reputation_finding.html
+++ b/posthog/templates/email/email_sending_reputation_finding.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{% if high_impact %}Email sending is at risk of being paused{% else %}Reputation warning for your email sending{% endif %}{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_suspended.html
+++ b/posthog/templates/email/email_sending_suspended.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Email sending has been suspended{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_suspended.html
+++ b/posthog/templates/email/email_sending_suspended.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Email sending has been suspended{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_suspended.html
+++ b/posthog/templates/email/email_sending_suspended.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Email sending has been suspended{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_suspended.html
+++ b/posthog/templates/email/email_sending_suspended.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Email sending has been suspended{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_unsuspended.html
+++ b/posthog/templates/email/email_sending_unsuspended.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Email sending has been re-enabled{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_unsuspended.html
+++ b/posthog/templates/email/email_sending_unsuspended.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Email sending has been re-enabled{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_unsuspended.html
+++ b/posthog/templates/email/email_sending_unsuspended.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Email sending has been re-enabled{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_sending_unsuspended.html
+++ b/posthog/templates/email/email_sending_unsuspended.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Email sending has been re-enabled{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/email_verification.html
+++ b/posthog/templates/email/email_verification.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %}{% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>Welcome to PostHog! Click on the following link to verify your email address.</p>
 <div class="mb mt text-center">
     <a class="button" href="{% absolute_uri link %}">Verify email address</a>

--- a/posthog/templates/email/email_verification.html
+++ b/posthog/templates/email/email_verification.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
+{% extends "email/base.html" %} {% load posthog_assets %}{% block section %}
 <p>Welcome to PostHog! Click on the following link to verify your email address.</p>
 <div class="mb mt text-center">
     <a class="button" href="{% absolute_uri link %}">Verify email address</a>

--- a/posthog/templates/email/email_verification.html
+++ b/posthog/templates/email/email_verification.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>Welcome to PostHog! Click on the following link to verify your email address.</p>
 <div class="mb mt text-center">

--- a/posthog/templates/email/email_verification.html
+++ b/posthog/templates/email/email_verification.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>Welcome to PostHog! Click on the following link to verify your email address.</p>
 <div class="mb mt text-center">

--- a/posthog/templates/email/email_verification.html
+++ b/posthog/templates/email/email_verification.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>Welcome to PostHog! Click on the following link to verify your email address.</p>
 <div class="mb mt text-center">

--- a/posthog/templates/email/email_verification_code.html
+++ b/posthog/templates/email/email_verification_code.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>Enter this code to verify your email address:</p>
 

--- a/posthog/templates/email/email_verification_code.html
+++ b/posthog/templates/email/email_verification_code.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>Enter this code to verify your email address:</p>
 

--- a/posthog/templates/email/email_verification_code.html
+++ b/posthog/templates/email/email_verification_code.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
+{% extends "email/base.html" %}{% block section %}
 <p>Enter this code to verify your email address:</p>
 
 <div class="mb mt text-center">

--- a/posthog/templates/email/email_verification_code.html
+++ b/posthog/templates/email/email_verification_code.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %}{% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>Enter this code to verify your email address:</p>
 
 <div class="mb mt text-center">

--- a/posthog/templates/email/email_verification_code.html
+++ b/posthog/templates/email/email_verification_code.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>Enter this code to verify your email address:</p>
 

--- a/posthog/templates/email/error_tracking_issue_assigned.html
+++ b/posthog/templates/email/error_tracking_issue_assigned.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}An issue has been assigned to you{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/error_tracking_issue_assigned.html
+++ b/posthog/templates/email/error_tracking_issue_assigned.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}An issue has been assigned to you{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/error_tracking_issue_assigned.html
+++ b/posthog/templates/email/error_tracking_issue_assigned.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %} {% load posthog_assets %}
 {% block heading %}An issue has been assigned to you{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/error_tracking_issue_assigned.html
+++ b/posthog/templates/email/error_tracking_issue_assigned.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}An issue has been assigned to you{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/error_tracking_issue_assigned.html
+++ b/posthog/templates/email/error_tracking_issue_assigned.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}An issue has been assigned to you{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/evaluation_report.html
+++ b/posthog/templates/email/evaluation_report.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/evaluation_report.html
+++ b/posthog/templates/email/evaluation_report.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/evaluation_report.html
+++ b/posthog/templates/email/evaluation_report.html
@@ -1,5 +1,6 @@
 {% extends "email/base.html" %}
-
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/evaluation_report.html
+++ b/posthog/templates/email/evaluation_report.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/external_data_failure_digest.html
+++ b/posthog/templates/email/external_data_failure_digest.html
@@ -1,6 +1,6 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
-
+{% load posthog_filters %}
 {% block preheader %}Data warehouse sync failures in {{ team.name }}{% endblock %}
 
 {% block heading %}Data warehouse sync failures{% endblock %}

--- a/posthog/templates/email/external_data_failure_digest.html
+++ b/posthog/templates/email/external_data_failure_digest.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}Data warehouse sync failures in {{ team.name }}{% endblock %}
 
 {% block heading %}Data warehouse sync failures{% endblock %}

--- a/posthog/templates/email/external_data_failure_digest.html
+++ b/posthog/templates/email/external_data_failure_digest.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}Data warehouse sync failures in {{ team.name }}{% endblock %}
 
 {% block heading %}Data warehouse sync failures{% endblock %}

--- a/posthog/templates/email/external_data_failure_digest.html
+++ b/posthog/templates/email/external_data_failure_digest.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}Data warehouse sync failures in {{ team.name }}{% endblock %}
 
 {% block heading %}Data warehouse sync failures{% endblock %}

--- a/posthog/templates/email/fatal_plugin_error.html
+++ b/posthog/templates/email/fatal_plugin_error.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/fatal_plugin_error.html
+++ b/posthog/templates/email/fatal_plugin_error.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/fatal_plugin_error.html
+++ b/posthog/templates/email/fatal_plugin_error.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/fatal_plugin_error.html
+++ b/posthog/templates/email/fatal_plugin_error.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/fatal_plugin_error.html
+++ b/posthog/templates/email/fatal_plugin_error.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %} {% load posthog_assets %}
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/feature_flags_secure_api_key_exposed.html
+++ b/posthog/templates/email/feature_flags_secure_api_key_exposed.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Feature Flags Secure API key has been exposed{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/feature_flags_secure_api_key_exposed.html
+++ b/posthog/templates/email/feature_flags_secure_api_key_exposed.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Feature Flags Secure API key has been exposed{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/feature_flags_secure_api_key_exposed.html
+++ b/posthog/templates/email/feature_flags_secure_api_key_exposed.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}Feature Flags Secure API key has been exposed{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/feature_flags_secure_api_key_exposed.html
+++ b/posthog/templates/email/feature_flags_secure_api_key_exposed.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Feature Flags Secure API key has been exposed{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/feature_flags_secure_api_key_exposed.html
+++ b/posthog/templates/email/feature_flags_secure_api_key_exposed.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Feature Flags Secure API key has been exposed{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/hog_function_disabled.html
+++ b/posthog/templates/email/hog_function_disabled.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/hog_function_disabled.html
+++ b/posthog/templates/email/hog_function_disabled.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/hog_function_disabled.html
+++ b/posthog/templates/email/hog_function_disabled.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/hog_function_disabled.html
+++ b/posthog/templates/email/hog_function_disabled.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/hog_function_disabled.html
+++ b/posthog/templates/email/hog_function_disabled.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %} {% load posthog_assets %}
 {% block heading %}A PostHog app has experienced a fatal error{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/hog_functions_daily_digest.html
+++ b/posthog/templates/email/hog_functions_daily_digest.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}Data Pipeline Failures Alert{% endblock %}
 
 {% block heading %}Data Pipeline Failures Alert{% endblock %}

--- a/posthog/templates/email/hog_functions_daily_digest.html
+++ b/posthog/templates/email/hog_functions_daily_digest.html
@@ -1,7 +1,6 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
-
 {% block preheader %}Data Pipeline Failures Alert{% endblock %}
 
 {% block heading %}Data Pipeline Failures Alert{% endblock %}

--- a/posthog/templates/email/hog_functions_daily_digest.html
+++ b/posthog/templates/email/hog_functions_daily_digest.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}Data Pipeline Failures Alert{% endblock %}
 
 {% block heading %}Data Pipeline Failures Alert{% endblock %}

--- a/posthog/templates/email/hog_functions_daily_digest.html
+++ b/posthog/templates/email/hog_functions_daily_digest.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}Data Pipeline Failures Alert{% endblock %}
 
 {% block heading %}Data Pipeline Failures Alert{% endblock %}

--- a/posthog/templates/email/integration_access_requested.html
+++ b/posthog/templates/email/integration_access_requested.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ requester_name }} requested the {{ integration_name }} integration{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/integration_access_requested.html
+++ b/posthog/templates/email/integration_access_requested.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ requester_name }} requested the {{ integration_name }} integration{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/integration_access_requested.html
+++ b/posthog/templates/email/integration_access_requested.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ requester_name }} requested the {{ integration_name }} integration{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/integration_access_requested.html
+++ b/posthog/templates/email/integration_access_requested.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{{ requester_name }} requested the {{ integration_name }} integration{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/integration_access_requested.html
+++ b/posthog/templates/email/integration_access_requested.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}{{ requester_name }} requested the {{ integration_name }} integration{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/interview_invite.html
+++ b/posthog/templates/email/interview_invite.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Got 5 minutes to chat?{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/interview_invite.html
+++ b/posthog/templates/email/interview_invite.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Got 5 minutes to chat?{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/interview_invite.html
+++ b/posthog/templates/email/interview_invite.html
@@ -1,5 +1,6 @@
 {% extends "email/base.html" %}
-
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Got 5 minutes to chat?{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/interview_invite.html
+++ b/posthog/templates/email/interview_invite.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Got 5 minutes to chat?{% endblock %}
 
 {% block section %}

--- a/posthog/templates/email/invite.html
+++ b/posthog/templates/email/invite.html
@@ -31,4 +31,4 @@
 
 {% block footer %}
 {% endblock %}
-{% endblock %}{% load posthog_filters %}
+{% endblock %}

--- a/posthog/templates/email/invite.html
+++ b/posthog/templates/email/invite.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> has invited you to join

--- a/posthog/templates/email/invite.html
+++ b/posthog/templates/email/invite.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> has invited you to join

--- a/posthog/templates/email/invite.html
+++ b/posthog/templates/email/invite.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> has invited you to join

--- a/posthog/templates/email/invite.html
+++ b/posthog/templates/email/invite.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <h1 class="invite-header">
     <strong>{{ inviter_first_name }}</strong> has invited you to join
     <strong>{{ org_name }}</strong> on PostHog

--- a/posthog/templates/email/login_notification.html
+++ b/posthog/templates/email/login_notification.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block preheader %}{{preheader}}{% endblock %}
 {% block heading %}We spotted a login from a new device{% endblock %}
 {% block section %}

--- a/posthog/templates/email/login_notification.html
+++ b/posthog/templates/email/login_notification.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}{{preheader}}{% endblock %}
 {% block heading %}We spotted a login from a new device{% endblock %}
 {% block section %}

--- a/posthog/templates/email/login_notification.html
+++ b/posthog/templates/email/login_notification.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}{{preheader}}{% endblock %}
 {% block heading %}We spotted a login from a new device{% endblock %}
 {% block section %}

--- a/posthog/templates/email/login_notification.html
+++ b/posthog/templates/email/login_notification.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}{{preheader}}{% endblock %}
 {% block heading %}We spotted a login from a new device{% endblock %}
 {% block section %}

--- a/posthog/templates/email/login_notification.html
+++ b/posthog/templates/email/login_notification.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block preheader %}{{preheader}}{% endblock %}
 {% block heading %}We spotted a login from a new device{% endblock %}
 {% block section %}

--- a/posthog/templates/email/loop_run_summary.html
+++ b/posthog/templates/email/loop_run_summary.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ event_title }}{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/loop_run_summary.html
+++ b/posthog/templates/email/loop_run_summary.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ event_title }}{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/loop_run_summary.html
+++ b/posthog/templates/email/loop_run_summary.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{{ event_title }}{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/loop_run_summary.html
+++ b/posthog/templates/email/loop_run_summary.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ event_title }}{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/loop_run_summary.html
+++ b/posthog/templates/email/loop_run_summary.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}{{ event_title }}{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/matview_failure_digest.html
+++ b/posthog/templates/email/matview_failure_digest.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}Materialized view failures in {{ team.name }}{% endblock %}
 
 {% block heading %}Materialized view failures{% endblock %}

--- a/posthog/templates/email/matview_failure_digest.html
+++ b/posthog/templates/email/matview_failure_digest.html
@@ -1,6 +1,6 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
-
+{% load posthog_filters %}
 {% block preheader %}Materialized view failures in {{ team.name }}{% endblock %}
 
 {% block heading %}Materialized view failures{% endblock %}

--- a/posthog/templates/email/matview_failure_digest.html
+++ b/posthog/templates/email/matview_failure_digest.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}Materialized view failures in {{ team.name }}{% endblock %}
 
 {% block heading %}Materialized view failures{% endblock %}

--- a/posthog/templates/email/matview_failure_digest.html
+++ b/posthog/templates/email/matview_failure_digest.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}Materialized view failures in {{ team.name }}{% endblock %}
 
 {% block heading %}Materialized view failures{% endblock %}

--- a/posthog/templates/email/matview_failure_digest.html
+++ b/posthog/templates/email/matview_failure_digest.html
@@ -1,6 +1,5 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
-{% load posthog_filters %}
 
 {% block preheader %}Materialized view failures in {{ team.name }}{% endblock %}
 

--- a/posthog/templates/email/member_join.html
+++ b/posthog/templates/email/member_join.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ invitee_first_name }}{% if invitee_last_name %} {{ invitee_last_name }}{% endif %} accepted their PostHog invitation{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/member_join.html
+++ b/posthog/templates/email/member_join.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{{ invitee_first_name }}{% if invitee_last_name %} {{ invitee_last_name }}{% endif %} accepted their PostHog invitation{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/member_join.html
+++ b/posthog/templates/email/member_join.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %} {% load posthog_assets %}
 {% block heading %}{{ invitee_first_name }}{% if invitee_last_name %} {{ invitee_last_name }}{% endif %} accepted their PostHog invitation{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/member_join.html
+++ b/posthog/templates/email/member_join.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ invitee_first_name }}{% if invitee_last_name %} {{ invitee_last_name }}{% endif %} accepted their PostHog invitation{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/member_join.html
+++ b/posthog/templates/email/member_join.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ invitee_first_name }}{% if invitee_last_name %} {{ invitee_last_name }}{% endif %} accepted their PostHog invitation{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/new_conversation_ticket.html
+++ b/posthog/templates/email/new_conversation_ticket.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}New support ticket received{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/new_conversation_ticket.html
+++ b/posthog/templates/email/new_conversation_ticket.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}New support ticket received{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/new_conversation_ticket.html
+++ b/posthog/templates/email/new_conversation_ticket.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}New support ticket received{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/new_conversation_ticket.html
+++ b/posthog/templates/email/new_conversation_ticket.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}New support ticket received{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/new_conversation_ticket.html
+++ b/posthog/templates/email/new_conversation_ticket.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}New support ticket received{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/oauth_token_exposed.html
+++ b/posthog/templates/email/oauth_token_exposed.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ token_type }} has been revoked{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/oauth_token_exposed.html
+++ b/posthog/templates/email/oauth_token_exposed.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{{ token_type }} has been revoked{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/oauth_token_exposed.html
+++ b/posthog/templates/email/oauth_token_exposed.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}{{ token_type }} has been revoked{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/oauth_token_exposed.html
+++ b/posthog/templates/email/oauth_token_exposed.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ token_type }} has been revoked{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/oauth_token_exposed.html
+++ b/posthog/templates/email/oauth_token_exposed.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ token_type }} has been revoked{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/organization_deleted.html
+++ b/posthog/templates/email/organization_deleted.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>
     As requested, we've deleted your organization <strong>{{ organization_name }}</strong>{% if project_names %} and its project{{ project_names|length|pluralize }}: <strong>{{ project_names|join:", " }}</strong>{% endif %}.
 </p>

--- a/posthog/templates/email/organization_deleted.html
+++ b/posthog/templates/email/organization_deleted.html
@@ -1,8 +1,8 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
 <p>
     As requested, we've deleted your organization <strong>{{ organization_name }}</strong>{% if project_names %} and its project{{ project_names|length|pluralize }}: <strong>{{ project_names|join:", " }}</strong>{% endif %}.
 </p>
 <p>
     This can't be undone, but hey, if you ever want to start fresh, we'll be here.
 </p>
-{% endblock %}{% load posthog_filters %} {% block heading %}Organization deleted{% endblock %}
+{% endblock %} {% block heading %}Organization deleted{% endblock %}

--- a/posthog/templates/email/organization_deleted.html
+++ b/posthog/templates/email/organization_deleted.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>
     As requested, we've deleted your organization <strong>{{ organization_name }}</strong>{% if project_names %} and its project{{ project_names|length|pluralize }}: <strong>{{ project_names|join:", " }}</strong>{% endif %}.

--- a/posthog/templates/email/organization_deleted.html
+++ b/posthog/templates/email/organization_deleted.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>
     As requested, we've deleted your organization <strong>{{ organization_name }}</strong>{% if project_names %} and its project{{ project_names|length|pluralize }}: <strong>{{ project_names|join:", " }}</strong>{% endif %}.

--- a/posthog/templates/email/organization_deleted.html
+++ b/posthog/templates/email/organization_deleted.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>
     As requested, we've deleted your organization <strong>{{ organization_name }}</strong>{% if project_names %} and its project{{ project_names|length|pluralize }}: <strong>{{ project_names|join:", " }}</strong>{% endif %}.

--- a/posthog/templates/email/passkey_added.html
+++ b/posthog/templates/email/passkey_added.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_added.html
+++ b/posthog/templates/email/passkey_added.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_added.html
+++ b/posthog/templates/email/passkey_added.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_added.html
+++ b/posthog/templates/email/passkey_added.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_added.html
+++ b/posthog/templates/email/passkey_added.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_removed.html
+++ b/posthog/templates/email/passkey_removed.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_removed.html
+++ b/posthog/templates/email/passkey_removed.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_removed.html
+++ b/posthog/templates/email/passkey_removed.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_removed.html
+++ b/posthog/templates/email/passkey_removed.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/passkey_removed.html
+++ b/posthog/templates/email/passkey_removed.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>Hey, {{ user_name }},</p>
 

--- a/posthog/templates/email/password_changed.html
+++ b/posthog/templates/email/password_changed.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>
     Someone (hopefully you) changed the password on your PostHog account{% if cloud %} on PostHog Cloud.{%else%}

--- a/posthog/templates/email/password_changed.html
+++ b/posthog/templates/email/password_changed.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>
     Someone (hopefully you) changed the password on your PostHog account{% if cloud %} on PostHog Cloud.{%else%}

--- a/posthog/templates/email/password_changed.html
+++ b/posthog/templates/email/password_changed.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>
     Someone (hopefully you) changed the password on your PostHog account{% if cloud %} on PostHog Cloud.{%else%}

--- a/posthog/templates/email/password_changed.html
+++ b/posthog/templates/email/password_changed.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %}{% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>
     Someone (hopefully you) changed the password on your PostHog account{% if cloud %} on PostHog Cloud.{%else%}
     hosted on {% strip_protocol site_url %}{% endif %}.

--- a/posthog/templates/email/password_changed.html
+++ b/posthog/templates/email/password_changed.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
+{% extends "email/base.html" %} {% load posthog_assets %}{% block section %}
 <p>
     Someone (hopefully you) changed the password on your PostHog account{% if cloud %} on PostHog Cloud.{%else%}
     hosted on {% strip_protocol site_url %}{% endif %}.

--- a/posthog/templates/email/password_reset.html
+++ b/posthog/templates/email/password_reset.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>
     Someone (hopefully you) requested a password reset for your PostHog account{% if cloud %} on PostHog Cloud.{%else%}

--- a/posthog/templates/email/password_reset.html
+++ b/posthog/templates/email/password_reset.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>
     Someone (hopefully you) requested a password reset for your PostHog account{% if cloud %} on PostHog Cloud.{%else%}

--- a/posthog/templates/email/password_reset.html
+++ b/posthog/templates/email/password_reset.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %}{% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>
     Someone (hopefully you) requested a password reset for your PostHog account{% if cloud %} on PostHog Cloud.{%else%}
     hosted on {% strip_protocol site_url %}{% endif %}.

--- a/posthog/templates/email/password_reset.html
+++ b/posthog/templates/email/password_reset.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
+{% extends "email/base.html" %} {% load posthog_assets %}{% block section %}
 <p>
     Someone (hopefully you) requested a password reset for your PostHog account{% if cloud %} on PostHog Cloud.{%else%}
     hosted on {% strip_protocol site_url %}{% endif %}.

--- a/posthog/templates/email/password_reset.html
+++ b/posthog/templates/email/password_reset.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>
     Someone (hopefully you) requested a password reset for your PostHog account{% if cloud %} on PostHog Cloud.{%else%}

--- a/posthog/templates/email/personal_api_key_exposed.html
+++ b/posthog/templates/email/personal_api_key_exposed.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}Personal API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/personal_api_key_exposed.html
+++ b/posthog/templates/email/personal_api_key_exposed.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Personal API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/personal_api_key_exposed.html
+++ b/posthog/templates/email/personal_api_key_exposed.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Personal API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/personal_api_key_exposed.html
+++ b/posthog/templates/email/personal_api_key_exposed.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Personal API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/personal_api_key_exposed.html
+++ b/posthog/templates/email/personal_api_key_exposed.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Personal API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/posthog_ai_access_requested.html
+++ b/posthog/templates/email/posthog_ai_access_requested.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}{{ requester_name }} requested access to PostHog AI{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/posthog_ai_access_requested.html
+++ b/posthog/templates/email/posthog_ai_access_requested.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}{{ requester_name }} requested access to PostHog AI{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/posthog_ai_access_requested.html
+++ b/posthog/templates/email/posthog_ai_access_requested.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}{{ requester_name }} requested access to PostHog AI{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/posthog_ai_access_requested.html
+++ b/posthog/templates/email/posthog_ai_access_requested.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}{{ requester_name }} requested access to PostHog AI{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/posthog_ai_access_requested.html
+++ b/posthog/templates/email/posthog_ai_access_requested.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}{{ requester_name }} requested access to PostHog AI{% endblock %}
 {% block section %}
 <!-- prettier-ignore -->

--- a/posthog/templates/email/project_deleted.html
+++ b/posthog/templates/email/project_deleted.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>
     As requested, we've deleted <strong>{{ project_name }}</strong> and all its data.

--- a/posthog/templates/email/project_deleted.html
+++ b/posthog/templates/email/project_deleted.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>
     As requested, we've deleted <strong>{{ project_name }}</strong> and all its data.
 </p>

--- a/posthog/templates/email/project_deleted.html
+++ b/posthog/templates/email/project_deleted.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>
     As requested, we've deleted <strong>{{ project_name }}</strong> and all its data.

--- a/posthog/templates/email/project_deleted.html
+++ b/posthog/templates/email/project_deleted.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>
     As requested, we've deleted <strong>{{ project_name }}</strong> and all its data.

--- a/posthog/templates/email/project_deleted.html
+++ b/posthog/templates/email/project_deleted.html
@@ -1,8 +1,8 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
 <p>
     As requested, we've deleted <strong>{{ project_name }}</strong> and all its data.
 </p>
 <p>
     This can't be undone, but hey, if you ever want to start fresh, we'll be here.
 </p>
-{% endblock %}{% load posthog_filters %} {% block heading %}Project deleted{% endblock %}
+{% endblock %} {% block heading %}Project deleted{% endblock %}

--- a/posthog/templates/email/project_secret_api_key_exposed.html
+++ b/posthog/templates/email/project_secret_api_key_exposed.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block heading %}Project secret API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/project_secret_api_key_exposed.html
+++ b/posthog/templates/email/project_secret_api_key_exposed.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block heading %}Project secret API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/project_secret_api_key_exposed.html
+++ b/posthog/templates/email/project_secret_api_key_exposed.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block heading %}Project secret API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/project_secret_api_key_exposed.html
+++ b/posthog/templates/email/project_secret_api_key_exposed.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block heading %}Project secret API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/project_secret_api_key_exposed.html
+++ b/posthog/templates/email/project_secret_api_key_exposed.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block heading %}Project secret API key has been deactivated{% endblock %}
 {% block section %}
 <p>

--- a/posthog/templates/email/provisioning_welcome.html
+++ b/posthog/templates/email/provisioning_welcome.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %}{% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>
     Welcome to PostHog! Your account was created{% if partner_name %} via {{ partner_name }}{% endif %}.
 </p>

--- a/posthog/templates/email/provisioning_welcome.html
+++ b/posthog/templates/email/provisioning_welcome.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>
     Welcome to PostHog! Your account was created{% if partner_name %} via {{ partner_name }}{% endif %}.

--- a/posthog/templates/email/provisioning_welcome.html
+++ b/posthog/templates/email/provisioning_welcome.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>
     Welcome to PostHog! Your account was created{% if partner_name %} via {{ partner_name }}{% endif %}.

--- a/posthog/templates/email/provisioning_welcome.html
+++ b/posthog/templates/email/provisioning_welcome.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
+{% extends "email/base.html" %} {% load posthog_assets %}{% block section %}
 <p>
     Welcome to PostHog! Your account was created{% if partner_name %} via {{ partner_name }}{% endif %}.
 </p>

--- a/posthog/templates/email/provisioning_welcome.html
+++ b/posthog/templates/email/provisioning_welcome.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>
     Welcome to PostHog! Your account was created{% if partner_name %} via {{ partner_name }}{% endif %}.

--- a/posthog/templates/email/proxy_provisioned.html
+++ b/posthog/templates/email/proxy_provisioned.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block preheader %}Your reverse proxy for {{ domain }} is ready to use{% endblock %}
 {% block heading %}Your reverse proxy is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/proxy_provisioned.html
+++ b/posthog/templates/email/proxy_provisioned.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}Your reverse proxy for {{ domain }} is ready to use{% endblock %}
 {% block heading %}Your reverse proxy is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/proxy_provisioned.html
+++ b/posthog/templates/email/proxy_provisioned.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}Your reverse proxy for {{ domain }} is ready to use{% endblock %}
 {% block heading %}Your reverse proxy is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/proxy_provisioned.html
+++ b/posthog/templates/email/proxy_provisioned.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block preheader %}Your reverse proxy for {{ domain }} is ready to use{% endblock %}
 {% block heading %}Your reverse proxy is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/proxy_provisioned.html
+++ b/posthog/templates/email/proxy_provisioned.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}Your reverse proxy for {{ domain }} is ready to use{% endblock %}
 {% block heading %}Your reverse proxy is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/saved_query_materialization_failure.html
+++ b/posthog/templates/email/saved_query_materialization_failure.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}Your materialized view failed to sync{% endblock %}
 {% block heading %}Materialized view '{{ saved_query_name }}' sync failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/saved_query_materialization_failure.html
+++ b/posthog/templates/email/saved_query_materialization_failure.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %} {% load posthog_assets %}
 {% block preheader %}Your materialized view failed to sync{% endblock %}
 {% block heading %}Materialized view '{{ saved_query_name }}' sync failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/saved_query_materialization_failure.html
+++ b/posthog/templates/email/saved_query_materialization_failure.html
@@ -1,4 +1,6 @@
-{% extends "email/base.html" %} {% load posthog_assets %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block preheader %}Your materialized view failed to sync{% endblock %}
 {% block heading %}Materialized view '{{ saved_query_name }}' sync failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/saved_query_materialization_failure.html
+++ b/posthog/templates/email/saved_query_materialization_failure.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}Your materialized view failed to sync{% endblock %}
 {% block heading %}Materialized view '{{ saved_query_name }}' sync failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/saved_query_materialization_failure.html
+++ b/posthog/templates/email/saved_query_materialization_failure.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}Your materialized view failed to sync{% endblock %}
 {% block heading %}Materialized view '{{ saved_query_name }}' sync failed{% endblock %}
 {% block section %}

--- a/posthog/templates/email/subscription_delivery_failed.html
+++ b/posthog/templates/email/subscription_delivery_failed.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
 <p>
     PostHog could not deliver your subscription <strong>{{ subscription_title }}</strong>.
 </p>

--- a/posthog/templates/email/subscription_delivery_failed.html
+++ b/posthog/templates/email/subscription_delivery_failed.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 <p>
     PostHog could not deliver your subscription <strong>{{ subscription_title }}</strong>.

--- a/posthog/templates/email/subscription_delivery_failed.html
+++ b/posthog/templates/email/subscription_delivery_failed.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 <p>
     PostHog could not deliver your subscription <strong>{{ subscription_title }}</strong>.

--- a/posthog/templates/email/subscription_delivery_failed.html
+++ b/posthog/templates/email/subscription_delivery_failed.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 <p>
     PostHog could not deliver your subscription <strong>{{ subscription_title }}</strong>.
 </p>

--- a/posthog/templates/email/subscription_delivery_failed.html
+++ b/posthog/templates/email/subscription_delivery_failed.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 <p>
     PostHog could not deliver your subscription <strong>{{ subscription_title }}</strong>.

--- a/posthog/templates/email/subscription_disabled.html
+++ b/posthog/templates/email/subscription_disabled.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
     <p>
         Your subscription <strong>{{ subscription_title }}</strong> has been

--- a/posthog/templates/email/subscription_disabled.html
+++ b/posthog/templates/email/subscription_disabled.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
     <p>
         Your subscription <strong>{{ subscription_title }}</strong> has been

--- a/posthog/templates/email/subscription_disabled.html
+++ b/posthog/templates/email/subscription_disabled.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %} {% block section %}
+{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
     <p>
         Your subscription <strong>{{ subscription_title }}</strong> has been
         <strong>automatically disabled</strong> because:

--- a/posthog/templates/email/subscription_disabled.html
+++ b/posthog/templates/email/subscription_disabled.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
     <p>
         Your subscription <strong>{{ subscription_title }}</strong> has been

--- a/posthog/templates/email/subscription_disabled.html
+++ b/posthog/templates/email/subscription_disabled.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
     <p>
         Your subscription <strong>{{ subscription_title }}</strong> has been
         <strong>automatically disabled</strong> because:

--- a/posthog/templates/email/subscription_report.html
+++ b/posthog/templates/email/subscription_report.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block section %}
 
 {% if inviter %}

--- a/posthog/templates/email/subscription_report.html
+++ b/posthog/templates/email/subscription_report.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
+{% extends "email/base.html" %} {% block section %}
 
 {% if inviter %}
 <h1 class="invite-header">
@@ -77,4 +77,4 @@
     or
     <a target="_blank" href="{{ unsubscribe_url }}"><b>unsubscribe now.</b></a>
 </p>
-{% endblock %}{% load posthog_filters %}
+{% endblock %}

--- a/posthog/templates/email/subscription_report.html
+++ b/posthog/templates/email/subscription_report.html
@@ -1,4 +1,7 @@
-{% extends "email/base.html" %} {% block section %}
+{% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
+{% block section %}
 
 {% if inviter %}
 <h1 class="invite-header">

--- a/posthog/templates/email/subscription_report.html
+++ b/posthog/templates/email/subscription_report.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block section %}
 
 {% if inviter %}

--- a/posthog/templates/email/subscription_report.html
+++ b/posthog/templates/email/subscription_report.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block section %}
 
 {% if inviter %}

--- a/posthog/templates/email/web_analytics_weekly_digest.html
+++ b/posthog/templates/email/web_analytics_weekly_digest.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block head %}
 <style type="text/css">
     body, .main { background-color: #f3f4f0 !important; }

--- a/posthog/templates/email/web_analytics_weekly_digest.html
+++ b/posthog/templates/email/web_analytics_weekly_digest.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block head %}
 <style type="text/css">
     body, .main { background-color: #f3f4f0 !important; }

--- a/posthog/templates/email/web_analytics_weekly_digest.html
+++ b/posthog/templates/email/web_analytics_weekly_digest.html
@@ -1,6 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
 {% load posthog_filters %}
-
 {% block head %}
 <style type="text/css">
     body, .main { background-color: #f3f4f0 !important; }

--- a/posthog/templates/email/web_analytics_weekly_digest.html
+++ b/posthog/templates/email/web_analytics_weekly_digest.html
@@ -1,5 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
 {% load posthog_filters %}
 
 {% block head %}

--- a/posthog/templates/email/web_analytics_weekly_digest.html
+++ b/posthog/templates/email/web_analytics_weekly_digest.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block head %}
 <style type="text/css">
     body, .main { background-color: #f3f4f0 !important; }

--- a/posthog/templates/email/wizard_pr_ready.html
+++ b/posthog/templates/email/wizard_pr_ready.html
@@ -1,4 +1,6 @@
 {% extends "email/base.html" %}
+{% load posthog_assets %}
+{% load posthog_filters %}
 {% block preheader %}Your pull request is ready{% endblock %}
 {% block heading %}Your pull request is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/wizard_pr_ready.html
+++ b/posthog/templates/email/wizard_pr_ready.html
@@ -1,6 +1,7 @@
 {% extends "email/base.html" %}
 {% load posthog_assets %}
 {% load posthog_filters %}
+
 {% block preheader %}Your pull request is ready{% endblock %}
 {% block heading %}Your pull request is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/wizard_pr_ready.html
+++ b/posthog/templates/email/wizard_pr_ready.html
@@ -1,4 +1,5 @@
 {% extends "email/base.html" %}
+
 {% block preheader %}Your pull request is ready{% endblock %}
 {% block heading %}Your pull request is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/wizard_pr_ready.html
+++ b/posthog/templates/email/wizard_pr_ready.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}
+{% extends "email/base.html" %}
 {% block preheader %}Your pull request is ready{% endblock %}
 {% block heading %}Your pull request is ready{% endblock %}
 {% block section %}

--- a/posthog/templates/email/wizard_pr_ready.html
+++ b/posthog/templates/email/wizard_pr_ready.html
@@ -1,7 +1,4 @@
 {% extends "email/base.html" %}
-{% load posthog_assets %}
-{% load posthog_filters %}
-
 {% block preheader %}Your pull request is ready{% endblock %}
 {% block heading %}Your pull request is ready{% endblock %}
 {% block section %}

--- a/posthog/templatetags/posthog_assets.py
+++ b/posthog/templatetags/posthog_assets.py
@@ -1,3 +1,7 @@
+# Tags for building URLs in the email templates under posthog/templates/email.
+# Every one of those templates loads this library, even when it extends email/base.html,
+# because Django resolves {% load %} per file rather than through template inheritance.
+
 import re
 
 from django.conf import settings

--- a/posthog/templatetags/posthog_assets.py
+++ b/posthog/templatetags/posthog_assets.py
@@ -1,6 +1,7 @@
 # Tags for building URLs in the email templates under posthog/templates/email.
-# Every one of those templates loads this library, even when it extends email/base.html,
-# because Django resolves {% load %} per file rather than through template inheritance.
+# Registered as a template builtin in posthog/settings/web.py, so templates use these tags
+# without a {% load %}. Django resolves {% load %} per file, so without the builtin every
+# template would have to repeat it, including those that extend email/base.html.
 
 import re
 

--- a/posthog/templatetags/posthog_filters.py
+++ b/posthog/templatetags/posthog_filters.py
@@ -1,6 +1,7 @@
 # Number formatting filters for the email templates under posthog/templates/email.
-# Every one of those templates loads this library, even when it extends email/base.html,
-# because Django resolves {% load %} per file rather than through template inheritance.
+# Registered as a template builtin in posthog/settings/web.py, so templates use these
+# filters without a {% load %}. Django resolves {% load %} per file, so without the builtin
+# every template would have to repeat it, including those that extend email/base.html.
 
 from typing import Optional, Union
 

--- a/posthog/templatetags/posthog_filters.py
+++ b/posthog/templatetags/posthog_filters.py
@@ -12,21 +12,6 @@ register.filter(compact_number)
 
 
 @register.filter
-def percentage(value: Optional[Number], decimals: int = 1) -> str:
-    """
-    Returns a rounded formatted with a specific number of decimal digits and a % sign. Expects a decimal-based ratio.
-    Example:
-      {% percentage 0.2283113 %}
-      =>  "22.8%"
-    """
-
-    if value is None:
-        return "-"
-
-    return "{0:.{decimals}f}%".format(value * 100, decimals=decimals)
-
-
-@register.filter
 def intcomma(value: Optional[Number]) -> str:
     """
     Converts an integer to a string containing commas every three digits.

--- a/posthog/templatetags/posthog_filters.py
+++ b/posthog/templatetags/posthog_filters.py
@@ -1,3 +1,7 @@
+# Number formatting filters for the email templates under posthog/templates/email.
+# Every one of those templates loads this library, even when it extends email/base.html,
+# because Django resolves {% load %} per file rather than through template inheritance.
+
 from typing import Optional, Union
 
 from django import template

--- a/posthog/test/test_templatetags.py
+++ b/posthog/test/test_templatetags.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from posthog.templatetags.posthog_filters import compact_number, percentage
+from posthog.templatetags.posthog_filters import compact_number
 
 
 class TestTemplateTags(TestCase):
@@ -10,7 +10,3 @@ class TestTemplateTags(TestCase):
         self.assertEqual(compact_number(5392), "5.39K")
         self.assertEqual(compact_number(2833102), "2.83M")
         self.assertEqual(compact_number(8283310234), "8.28B")
-
-    def test_percentage(self):
-        self.assertEqual(percentage(0.1829348, 2), "18.29%")
-        self.assertEqual(percentage(0.7829, 1), "78.3%")


### PR DESCRIPTION
## Problem

Every email template opened with `{% load posthog_assets %}` and `{% load posthog_filters %}`, and the lines had drifted: some sat on the `{% extends %}` line, some were split, and a few were stranded after a closing `{% endblock %}`. Anyone adding an email template had no single shape to copy.

The repetition also looks like copy-paste debt, so the obvious cleanup is to delete the loads a template does not appear to need. That breaks the email. Django resolves `{% load %}` per file and does not carry it through `{% extends %}`, so `email/base.html` cannot declare it once on behalf of the templates that extend it.

## Changes

- `posthog_assets` and `posthog_filters` are registered in `TEMPLATES["OPTIONS"]["builtins"]`. Their tags and filters are now available to every template with no `{% load %}` at all.
- All 65 email templates drop their load block. A new email template is now just `{% extends "email/base.html" %}` and its blocks, with no preamble to remember.
- Both templatetag modules gain a header comment pointing at the settings entry, so a reader who finds `{% absolute_uri %}` with no local `{% load %}` can tell where it comes from.
- Removes the `percentage` filter and its test. No template calls it.
- No rendered output changes. `{% load %}` and `builtins` only control which tags a template can resolve.

## Changed shape

Before:

```
{% extends "email/base.html" %} {% load posthog_assets %} {% load posthog_filters %}{% block section %}
```

After:

```
{% extends "email/base.html" %}
{% block section %}
```

## How did you test this code?

Compiled all 146 templates under `posthog/templates/` and `frontend/dist/` through Django's template loader, not just the email ones, because `builtins` is project-wide. All compiled.

That check has teeth: Django resolves tags and filters at compile time, so a template left unable to resolve one raises `TemplateSyntaxError`. Confirmed against a control, where `{{ v|compact_number }}` with the library neither loaded nor registered fails with `Invalid filter: 'compact_number'`.

Compiling only proves the tags resolve, so the templates that call into these libraries were also rendered and asserted on:

- `web_analytics_weekly_digest.html` renders `5.31K` and `2.83M` through `compact_number`.
- `hog_functions_daily_digest.html` renders `1,234,567` through `intcomma`.
- `password_reset.html` renders `GitHub, Google` through `human_social_providers`.
- `base.html` still emits `<!DOCTYPE html>` as the first thing in its output.

`posthog/test/test_templatetags.py` could not run in this sandbox. The test database fails to set up for reasons unrelated to this diff, with a migration reporting `column "slack_channel_id" of relation "posthog_conversations_ticket" already exists`. CI covers it.

### Worth a reviewer's attention

`builtins` is project-wide, so these tags are now implicitly available to the admin, surveys, two-factor, and exporter templates too, not only to emails. Nothing outside emails uses them today.

One latent hazard: our `intcomma` shares a name with `django.contrib.humanize`'s. Humanize is not in `INSTALLED_APPS`, so there is no conflict today. If it is ever added, an explicit `{% load humanize %}` in a template wins over the builtin, so the failure mode is a template silently getting the other implementation rather than an error.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog Desktop cloud task.

The PR went through three shapes, and the reasoning is worth recording because the first two were wrong in instructive ways. It started by reading the duplicated loads as dead code and stripping every load whose library a template never called, across 55 files. That was wrong about intent: the loads are a convention, and consistency was worth more than deleted lines. The second shape kept a load block in every template and normalized its formatting.

The third shape came from a reviewer question, whether the loads could just live in `email/base.html`. They cannot, and that was verified rather than assumed: stripping a child's loads while leaving `base.html`'s intact fails with `Invalid block tag ... 'absolute_uri'`. Testing that question surfaced `builtins`, which achieves what putting them in `base.html` was meant to achieve, and is what shipped here.

Both the audit and the rewrite were scripted over the template directories, so the result is uniform rather than hand-edited.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
