### PR TITLE
fix(eng-analytics): resolve default dora scope by production name

### DIFF
--- a/products/engineering_analytics/backend/logic/queries/dora.py
+++ b/products/engineering_analytics/backend/logic/queries/dora.py
@@ -60,9 +60,9 @@ _MERGE_SCAN_LOOKBACK = timedelta(days=30)
 # per-repo and small enough that the wider floor costs nothing measurable.
 _DEPLOY_SCAN_SLACK = timedelta(days=7)
 
-# `prod`, `production`, and their regional/suffixed forms (`prod-us`, `production_eu`). Anchored
-# so `preview-pr-123` and `reproduction` do not read as production.
-_PRODUCTION_NAME_PATTERN = re.compile(r"^prod(uction)?([-_.].*)?$")
+# `prod`, `production`, and their regional/suffixed forms (`prod-us`, `Production-EU`), any case.
+# Anchored so `preview-pr-123` and `reproduction` do not read as production.
+_PRODUCTION_NAME_PATTERN = re.compile(r"^prod(uction)?([-_.].*)?$", re.IGNORECASE)
 
 _ENVIRONMENTS_LIMIT = 100
 _TEAMS_LIMIT = 500

--- a/products/engineering_analytics/backend/logic/queries/dora.py
+++ b/products/engineering_analytics/backend/logic/queries/dora.py
@@ -24,6 +24,7 @@ surface, aggregates only (SPEC §6). Deploy counts are repo events and ignore th
 team filter by design.
 """
 
+import re
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -58,6 +59,10 @@ _MERGE_SCAN_LOOKBACK = timedelta(days=30)
 # outcome lands inside it. A week covers even a badly stalled rollout; the deploy tables are
 # per-repo and small enough that the wider floor costs nothing measurable.
 _DEPLOY_SCAN_SLACK = timedelta(days=7)
+
+# `prod`, `production`, and their regional/suffixed forms (`prod-us`, `production_eu`). Anchored
+# so `preview-pr-123` and `reproduction` do not read as production.
+_PRODUCTION_NAME_PATTERN = re.compile(r"^prod(uction)?([-_.].*)?$")
 
 _ENVIRONMENTS_LIMIT = 100
 _TEAMS_LIMIT = 500
@@ -329,18 +334,25 @@ class _DoraScan:
 
 def _resolve_environment_scope(environment: str | None, environments: list[tuple[str, bool]]) -> _EnvironmentScope:
     """Pick the deploy population: the caller's exact environment when given; otherwise the
-    deployments GitHub marks production; otherwise the single busiest persistent environment,
-    so a repo that never sets the production flag still gets numbers instead of a false zero.
-    Busiest-single, not every-persistent: a multi-region repo deploys each merge to several
-    persistent environments (and to dev, package registries, ...), which would multiply every
-    deploy count and hand lead time to whichever region deploys first. 'persistent' survives
-    only when the window has no persistent environment at all. Transient environments never
-    join a default scope: they are ephemeral per-PR previews, and on this repo they outnumber
-    real deploys by an order of magnitude."""
+    deployments GitHub marks production; otherwise the busiest environment whose NAME says
+    production; otherwise the single busiest persistent environment, so a repo that never sets
+    the production flag still gets numbers instead of a false zero.
+    The name tier exists because the ``production_environment`` flag is optional and widely
+    unset, and a dev or staging environment can deploy more often than production, which would
+    put every default DORA figure on that environment.
+    Busiest-single, not every-name-matched: a multi-region repo deploys each merge to several
+    production environments, which would multiply every deploy count and hand lead time to
+    whichever region deploys first. 'persistent' survives only when the window has no persistent
+    environment at all. Transient environments never join a default scope: they are ephemeral
+    per-PR previews, and on this repo they outnumber real deploys by an order of magnitude."""
     if environment:
         return _EnvironmentScope(scope=environment, predicate="d.environment = {environment}")
     if any(is_production for _, is_production in environments):
         return _EnvironmentScope(scope="production", predicate="d.is_production_environment")
+    # ``environments`` arrives busiest-first, so the first name match is the busiest match.
+    named = next((name for name, _ in environments if _PRODUCTION_NAME_PATTERN.match(name)), None)
+    if named is not None:
+        return _EnvironmentScope(scope=named, predicate="d.environment = {environment}")
     if environments:
         return _EnvironmentScope(scope=environments[0][0], predicate="d.environment = {environment}")
     return _EnvironmentScope(scope="persistent", predicate="NOT d.is_transient_environment")

--- a/products/engineering_analytics/backend/tests/test_dora.py
+++ b/products/engineering_analytics/backend/tests/test_dora.py
@@ -302,11 +302,11 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
         # Deploy-scoped figures are unaffected.
         assert result.deployment_count == 2
 
-    def test_busiest_environment_fallback_excludes_transient_and_sibling_environments(self):
-        # Nothing is production-marked (this repo's real shape), so the default scope falls back
-        # to the single busiest persistent environment: the ephemeral per-PR preview deploys and
-        # the quieter sibling environment (a second region, dev, a package registry) must stay
-        # out of the counts — every-persistent counted them all and multiplied every metric.
+    def test_production_named_environment_beats_busier_dev_environment(self):
+        # Nothing is production-marked (this repo's real shape) and dev deploys more often than
+        # production, so the default scope must resolve through the environment NAME: without the
+        # name tier the busiest-persistent fallback reported dev deploys as every DORA figure.
+        # Transient per-PR previews stay out of every default scope.
         curated = self._curated(
             self.team,
             deployment_rows=[
@@ -314,12 +314,16 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
                 _deployment_row(2, "sha-b", "preview-pr-123", "2026-01-12 09:30:00", production=False, transient=True),
                 _deployment_row(3, "sha-c", "prod-us", "2026-01-13 09:30:00", production=False),
                 _deployment_row(4, "sha-d", "dev", "2026-01-12 09:30:00", production=False),
+                _deployment_row(5, "sha-e", "dev", "2026-01-13 09:30:00", production=False),
+                _deployment_row(6, "sha-f", "dev", "2026-01-14 09:30:00", production=False),
             ],
             status_rows=[
                 _status_row(11, 1, "success", "prod-us", "2026-01-12 10:00:00"),
                 _status_row(21, 2, "success", "preview-pr-123", "2026-01-12 10:00:00"),
                 _status_row(31, 3, "success", "prod-us", "2026-01-13 10:00:00"),
                 _status_row(41, 4, "success", "dev", "2026-01-12 10:00:00"),
+                _status_row(51, 5, "success", "dev", "2026-01-13 10:00:00"),
+                _status_row(61, 6, "success", "dev", "2026-01-14 10:00:00"),
             ],
             # One never-merged PR keeps the seeded CSV non-empty without joining any deploy.
             pr_rows=[_pr_row(1, "alice", "open", 0, "2026-01-11 08:00:00")],
@@ -331,7 +335,33 @@ class TestDoraQuery(ClickhouseTestMixin, BaseTest):
         )
 
         assert result.environment_scope == "prod-us"
-        assert result.environments == ["prod-us", "dev"]
+        assert result.environments == ["dev", "prod-us"]
+        assert result.deployment_count == 2
+
+    def test_busiest_environment_fallback_without_production_named_environment(self):
+        # No production flag and no production-looking name: the single busiest persistent
+        # environment still carries the default scope, so such a repo gets numbers, not zeros.
+        curated = self._curated(
+            self.team,
+            deployment_rows=[
+                _deployment_row(1, "sha-a", "staging", "2026-01-12 09:30:00", production=False),
+                _deployment_row(2, "sha-b", "staging", "2026-01-13 09:30:00", production=False),
+                _deployment_row(3, "sha-c", "dev", "2026-01-12 09:30:00", production=False),
+            ],
+            status_rows=[
+                _status_row(11, 1, "success", "staging", "2026-01-12 10:00:00"),
+                _status_row(21, 2, "success", "staging", "2026-01-13 10:00:00"),
+                _status_row(31, 3, "success", "dev", "2026-01-12 10:00:00"),
+            ],
+            pr_rows=[_pr_row(1, "alice", "open", 0, "2026-01-11 08:00:00")],
+        )
+        result = query_dora_overview(
+            curated=curated,
+            date_from=datetime(2026, 1, 10, tzinfo=UTC),
+            date_to=datetime(2026, 1, 20, tzinfo=UTC),
+        )
+
+        assert result.environment_scope == "staging"
         assert result.deployment_count == 2
 
     def test_deploy_scan_slack_bounds_prewindow_deployments(self):


### PR DESCRIPTION
## Problem

- On a repo that never sets GitHub's `production_environment` flag and has a dev environment busier than production, every default DORA figure on the Health tab reports the dev environment's deploys. PostHog/posthog is that repo: verified by executing the resolver against the connected source, where the default scope resolved to `dev`.

## Changes

- The default scope now prefers the busiest environment whose name says production (`^prod(uction)?([-_.].*)?$`), after the flag tier and before the busiest-persistent fallback. On this repo the Health tab default moves from `dev` to `prod-eu`.
- The scope stays single-environment: every production SHA here ships to both regions, so a multi-environment scope would double every deploy count.
- Repos with neither the flag nor a production-looking name keep the busiest-persistent fallback.

## How did you test this code?

- Reworked `test_production_named_environment_beats_busier_dev_environment`: dev is now the busiest fixture environment, which the old fallback reported as the scope.
- Added `test_busiest_environment_fallback_without_production_named_environment`: guards the fallback for repos with no production-looking name.
- The regex was checked against every environment name ever recorded on the connected source; it matches exactly the two production regions.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Agent-authored fix from a data-validation pass

- The defect was confirmed by running `_resolve_environment_scope` with real query output, not by reading the code.
- Skills: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
