### PR TITLE
fix(desktop): suppress toasts for open task panels

### DIFF
--- a/products/desktop/apps/code/src/renderer/desktop-services.ts
+++ b/products/desktop/apps/code/src/renderer/desktop-services.ts
@@ -70,6 +70,7 @@ import {
   type IAuthSideEffects,
 } from "@posthog/ui/features/auth/identifiers";
 import { authKeys } from "@posthog/ui/features/auth/useCurrentUser";
+import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import {
   FEATURE_FLAGS,
   type FeatureFlags,
@@ -93,6 +94,7 @@ import {
   NOTIFICATION_SETTINGS_PROVIDER,
   SPEECH_NOTIFY_SETTINGS,
 } from "@posthog/ui/features/notifications/identifiers";
+import { resolveActiveNotificationTarget } from "@posthog/ui/features/notifications/routeNotification";
 import { OnboardingGithubConnectClient } from "@posthog/ui/features/onboarding/githubConnectClientImpl";
 import {
   AGENT_PROMPT_SENDER,
@@ -322,32 +324,22 @@ container
 
 container.bind<IActiveView>(ACTIVE_VIEW_PROVIDER).toConstantValue({
   hasFocus: () => document.hasFocus(),
-  // Read the active leaf route directly: AppView collapses the channel routes
-  // and drops channelId/dashboardId, which we need to identify a canvas target.
   getActiveTarget: (): NotificationTarget | undefined => {
     const matches = getCurrentMatches();
     const last = matches[matches.length - 1];
-    if (!last) return undefined;
-    const params = last.params as Record<string, string | undefined>;
-    // `fullPath`, not `routeId`: the space routes sit under the pathless
-    // `_shell` layout, which routeId spells out and the URL pattern doesn't.
-    switch (last.fullPath) {
-      case "/tasks/$taskId":
-      case "/spaces/$channelId/tasks/$taskId":
-        return params.taskId
-          ? { kind: "task", taskId: params.taskId }
-          : undefined;
-      case "/spaces/$channelId/dashboards/$dashboardId":
-        return params.channelId && params.dashboardId
-          ? {
-              kind: "canvas",
-              channelId: params.channelId,
-              dashboardId: params.dashboardId,
-            }
-          : undefined;
-      default:
-        return undefined;
-    }
+    const params = last?.params as
+      | Record<string, string | undefined>
+      | undefined;
+    const threadPanel = useThreadPanelStore.getState();
+    const openThreadTaskId = params?.channelId
+      ? threadPanel.openByChannel[params.channelId]
+      : undefined;
+
+    return resolveActiveNotificationTarget(
+      last ? { fullPath: last.fullPath, params: params ?? {} } : undefined,
+      openThreadTaskId,
+      threadPanel.collapsed,
+    );
   },
 });
 

--- a/products/desktop/apps/web/src/web-notifications.ts
+++ b/products/desktop/apps/web/src/web-notifications.ts
@@ -3,11 +3,13 @@ import type {
   NotificationOptions,
   NotificationTarget,
 } from "@posthog/platform/notifications";
+import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import type {
   IActiveView,
   INotificationSettings,
   NotificationSettings,
 } from "@posthog/ui/features/notifications/identifiers";
+import { resolveActiveNotificationTarget } from "@posthog/ui/features/notifications/routeNotification";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import {
   getCurrentMatches,
@@ -84,26 +86,18 @@ export const webActiveView: IActiveView = {
   getActiveTarget: (): NotificationTarget | undefined => {
     const matches = getCurrentMatches();
     const last = matches[matches.length - 1];
-    if (!last) return undefined;
-    const params = last.params as Record<string, string | undefined>;
-    // `fullPath`, not `routeId`: the space routes sit under the pathless
-    // `_shell` layout, which routeId spells out and the URL pattern doesn't.
-    switch (last.fullPath) {
-      case "/tasks/$taskId":
-      case "/spaces/$channelId/tasks/$taskId":
-        return params.taskId
-          ? { kind: "task", taskId: params.taskId }
-          : undefined;
-      case "/spaces/$channelId/dashboards/$dashboardId":
-        return params.channelId && params.dashboardId
-          ? {
-              kind: "canvas",
-              channelId: params.channelId,
-              dashboardId: params.dashboardId,
-            }
-          : undefined;
-      default:
-        return undefined;
-    }
+    const params = last?.params as
+      | Record<string, string | undefined>
+      | undefined;
+    const threadPanel = useThreadPanelStore.getState();
+    const openThreadTaskId = params?.channelId
+      ? threadPanel.openByChannel[params.channelId]
+      : undefined;
+
+    return resolveActiveNotificationTarget(
+      last ? { fullPath: last.fullPath, params: params ?? {} } : undefined,
+      openThreadTaskId,
+      threadPanel.collapsed,
+    );
   },
 };

--- a/products/desktop/packages/ui/src/features/notifications/routeNotification.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/routeNotification.test.ts
@@ -2,6 +2,7 @@ import type { NotificationTarget } from "@posthog/platform/notifications";
 import { describe, expect, it } from "vitest";
 import {
   type NotificationChannel,
+  resolveActiveNotificationTarget,
   routeNotification,
   targetsEqual,
 } from "./routeNotification";
@@ -11,6 +12,88 @@ const canvas = (id: string): NotificationTarget => ({
   kind: "canvas",
   channelId: "chan",
   dashboardId: id,
+});
+
+describe("resolveActiveNotificationTarget", () => {
+  it.each<
+    [
+      string,
+      Parameters<typeof resolveActiveNotificationTarget>,
+      NotificationTarget | undefined,
+    ]
+  >([
+    [
+      "task route",
+      [
+        { fullPath: "/tasks/$taskId", params: { taskId: "t1" } },
+        undefined,
+        false,
+      ],
+      task("t1"),
+    ],
+    [
+      "channel task route",
+      [
+        {
+          fullPath: "/spaces/$channelId/tasks/$taskId",
+          params: { channelId: "chan", taskId: "t1" },
+        },
+        undefined,
+        false,
+      ],
+      task("t1"),
+    ],
+    [
+      "canvas route",
+      [
+        {
+          fullPath: "/spaces/$channelId/dashboards/$dashboardId",
+          params: { channelId: "chan", dashboardId: "d1" },
+        },
+        undefined,
+        false,
+      ],
+      canvas("d1"),
+    ],
+    [
+      "expanded thread panel",
+      [
+        {
+          fullPath: "/spaces/$channelId/",
+          params: { channelId: "chan" },
+        },
+        "t1",
+        false,
+      ],
+      task("t1"),
+    ],
+    [
+      "collapsed thread panel",
+      [
+        {
+          fullPath: "/spaces/$channelId/",
+          params: { channelId: "chan" },
+        },
+        "t1",
+        true,
+      ],
+      undefined,
+    ],
+    [
+      "thread state on another channel page",
+      [
+        {
+          fullPath: "/spaces/$channelId/history",
+          params: { channelId: "chan" },
+        },
+        "t1",
+        false,
+      ],
+      undefined,
+    ],
+  ])("%s", (_label, args, expected) => {
+    expect(resolveActiveNotificationTarget(...args)).toEqual(expected);
+  });
 });
 
 describe("targetsEqual", () => {

--- a/products/desktop/packages/ui/src/features/notifications/routeNotification.ts
+++ b/products/desktop/packages/ui/src/features/notifications/routeNotification.ts
@@ -1,5 +1,41 @@
 import type { NotificationTarget } from "@posthog/platform/notifications";
 
+interface ActiveRoute {
+  // routeId includes pathless layouts such as `_shell`, but fullPath matches the URL patterns below.
+  fullPath: string;
+  params: Record<string, string | undefined>;
+}
+
+export function resolveActiveNotificationTarget(
+  route: ActiveRoute | undefined,
+  openThreadTaskId: string | null | undefined,
+  threadPanelCollapsed: boolean,
+): NotificationTarget | undefined {
+  if (!route) return undefined;
+
+  switch (route.fullPath) {
+    case "/tasks/$taskId":
+    case "/spaces/$channelId/tasks/$taskId":
+      return route.params.taskId
+        ? { kind: "task", taskId: route.params.taskId }
+        : undefined;
+    case "/spaces/$channelId/dashboards/$dashboardId":
+      return route.params.channelId && route.params.dashboardId
+        ? {
+            kind: "canvas",
+            channelId: route.params.channelId,
+            dashboardId: route.params.dashboardId,
+          }
+        : undefined;
+    case "/spaces/$channelId/":
+      return openThreadTaskId && !threadPanelCollapsed
+        ? { kind: "task", taskId: openThreadTaskId }
+        : undefined;
+    default:
+      return undefined;
+  }
+}
+
 // Stable identity string for a target. A new kind is a compile error here (the
 // switch is exhaustive), so equality and key-based lookups stay in one place.
 export function targetKey(target: NotificationTarget): string {


### PR DESCRIPTION
## Problem

People viewing an expanded channel task panel still receive a redundant permission toast for that task.

The notification system only recognizes tasks represented in the active URL.

## Changes

- Expanded channel task panels now suppress notifications for their visible task.
- Collapsed panels and inactive channel pages keep the existing notification behavior.
- Desktop and web share the same active-target resolver.
- Screenshots are not included because the fix removes a transient toast and does not alter panel rendering.

## How did you test this code?

- Automated tests cover expanded, collapsed, and stale task panel state.
- Local verification included the targeted Vitest test and TypeScript checks for shared UI, desktop, and web.
- Manual UI verification was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This corrects internal notification routing without changing configuration or documented workflows.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Slack app used repository search, Vitest, TypeScript, Biome, and hogli preflight. Skills: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The public artifact contains no customer data or private operational details.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1787925889518269?thread_ts=1787925889.518269&cid=C09G8Q32R6F)*
