### PR TITLE
chore(dags): move skip_on_kill_switch to the shared dags module

### DIFF
--- a/posthog/dags/common/__init__.py
+++ b/posthog/dags/common/__init__.py
@@ -6,6 +6,7 @@ from .common import (
     dagster_tags,
     settings_with_log_comment,
     skip_if_already_running,
+    skip_on_kill_switch,
 )
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "dagster_tags",
     "settings_with_log_comment",
     "skip_if_already_running",
+    "skip_on_kill_switch",
 ]

--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -7,7 +7,9 @@ from typing import Optional
 import dagster
 
 from posthog.clickhouse import query_tagging
+from posthog.clickhouse.client.execute import KillSwitchLevel, get_kill_switch_level
 from posthog.clickhouse.query_tagging import DagsterTags
+from posthog.settings import TEST
 
 
 def dagster_tags(
@@ -80,6 +82,21 @@ def check_for_concurrent_runs(
         return dagster.SkipReason(f"Skipping {job_name} run because another run of the same job is already active")
 
     return None
+
+
+def skip_on_kill_switch(fn: Callable) -> Callable:
+    """Decorator that skips schedule execution while the ClickHouse kill switch is on."""
+
+    @wraps(fn)
+    def wrapper(context: dagster.ScheduleEvaluationContext):
+        if not TEST:
+            kill_switch_level = get_kill_switch_level()
+            if kill_switch_level != KillSwitchLevel.OFF:
+                context.log.info(f"Skipping due to ClickHouse kill switch: {kill_switch_level}")
+                return dagster.SkipReason(f"ClickHouse kill switch is enabled ({kill_switch_level})")
+        return fn(context)
+
+    return wrapper
 
 
 def skip_if_already_running(fn: Callable) -> Callable:

--- a/posthog/dags/common/common.py
+++ b/posthog/dags/common/common.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime, timedelta
 from functools import wraps
-from typing import Optional
+from typing import Optional, Union
 
 import dagster
 
@@ -10,6 +10,9 @@ from posthog.clickhouse import query_tagging
 from posthog.clickhouse.client.execute import KillSwitchLevel, get_kill_switch_level
 from posthog.clickhouse.query_tagging import DagsterTags
 from posthog.settings import TEST
+
+# What a Dagster schedule function may return.
+ScheduleResult = Union[dagster.SkipReason, dagster.RunRequest, None]
 
 
 def dagster_tags(
@@ -84,11 +87,13 @@ def check_for_concurrent_runs(
     return None
 
 
-def skip_on_kill_switch(fn: Callable) -> Callable:
+def skip_on_kill_switch(
+    fn: Callable[[dagster.ScheduleEvaluationContext], ScheduleResult],
+) -> Callable[[dagster.ScheduleEvaluationContext], ScheduleResult]:
     """Decorator that skips schedule execution while the ClickHouse kill switch is on."""
 
     @wraps(fn)
-    def wrapper(context: dagster.ScheduleEvaluationContext):
+    def wrapper(context: dagster.ScheduleEvaluationContext) -> ScheduleResult:
         if not TEST:
             kill_switch_level = get_kill_switch_level()
             if kill_switch_level != KillSwitchLevel.OFF:

--- a/products/web_analytics/dags/web_dimensional_precompute.py
+++ b/products/web_analytics/dags/web_dimensional_precompute.py
@@ -28,14 +28,13 @@ import structlog
 from prometheus_client import Counter
 
 from posthog.cloud_utils import is_cloud
-from posthog.dags.common import JobOwners, chunk_ranges
+from posthog.dags.common import JobOwners, chunk_ranges, skip_on_kill_switch
 from posthog.models import Team
 
 from products.web_analytics.backend.hogql_queries.web_dimensional_precompute import (
     ensure_web_bounces_dimensional_precomputed,
     ensure_web_stats_dimensional_precomputed,
 )
-from products.web_analytics.dags.web_preaggregated import skip_on_kill_switch
 from products.web_analytics.dags.web_preaggregated_utils import check_for_concurrent_runs
 
 logger = structlog.get_logger(__name__)

--- a/products/web_analytics/dags/web_preaggregated.py
+++ b/products/web_analytics/dags/web_preaggregated.py
@@ -1,7 +1,6 @@
 import os
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from functools import wraps
 from typing import Union
 
 import dagster
@@ -11,10 +10,9 @@ from posthog.schema import ProductKey
 
 from posthog.clickhouse import query_tagging
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.client.execute import KillSwitchLevel, get_kill_switch_level
 from posthog.clickhouse.cluster import ClickhouseCluster
 from posthog.clickhouse.query_tagging import Feature, tags_context
-from posthog.dags.common import JobOwners, dagster_tags
+from posthog.dags.common import JobOwners, dagster_tags, skip_on_kill_switch
 from posthog.models.web_preaggregated.sql import (
     REPLACE_WEB_BOUNCES_V2_STAGING_SQL,
     REPLACE_WEB_STATS_V2_STAGING_SQL,
@@ -39,21 +37,6 @@ from products.web_analytics.dags.web_preaggregated_utils import (
 )
 
 ScheduleResult = Union[dagster.SkipReason, dagster.RunRequest, None]
-
-
-def skip_on_kill_switch(
-    fn: Callable[[dagster.ScheduleEvaluationContext], ScheduleResult],
-) -> Callable[[dagster.ScheduleEvaluationContext], ScheduleResult]:
-    @wraps(fn)
-    def wrapper(context: dagster.ScheduleEvaluationContext) -> ScheduleResult:
-        if not TEST:
-            kill_switch_level = get_kill_switch_level()
-            if kill_switch_level != KillSwitchLevel.OFF:
-                context.log.info(f"Skipping due to ClickHouse kill switch: {kill_switch_level}")
-                return dagster.SkipReason(f"ClickHouse kill switch is enabled ({kill_switch_level})")
-        return fn(context)
-
-    return wrapper
 
 
 MAX_PARTITIONS_PER_RUN_ENV_VAR = "DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN"

--- a/products/web_analytics/dags/web_preaggregated.py
+++ b/products/web_analytics/dags/web_preaggregated.py
@@ -1,7 +1,6 @@
 import os
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from typing import Union
 
 import dagster
 from dagster import BackfillPolicy, DailyPartitionsDefinition
@@ -35,9 +34,6 @@ from products.web_analytics.dags.web_preaggregated_utils import (
     sync_partitions_on_replicas,
     web_analytics_retry_policy_def,
 )
-
-ScheduleResult = Union[dagster.SkipReason, dagster.RunRequest, None]
-
 
 MAX_PARTITIONS_PER_RUN_ENV_VAR = "DAGSTER_WEB_PREAGGREGATED_MAX_PARTITIONS_PER_RUN"
 max_partitions_per_run = int(os.getenv(MAX_PARTITIONS_PER_RUN_ENV_VAR, 1))


### PR DESCRIPTION
## Problem

Any product outside web analytics that wants a Dagster schedule to stand down while the ClickHouse kill switch is on has to import the decorator from `products/web_analytics/dags/web_preaggregated.py`. That crosses a product boundary, which `tach` rejects, so the alternative is a second copy of the same eight lines.

The decorator has nothing to do with web analytics. It reads a global kill switch and skips the run.

## Changes

- `skip_on_kill_switch` moves to `posthog/dags/common/`, next to `skip_if_already_running`, which guards schedules the same way.
- The three DAGs that use it import it from there. One of them was reaching it indirectly through `web_preaggregated`, which now imports it from the shared module too.
- No behavior changes. The decorator body is unchanged, and nothing user-visible moves.

## How did you test this code?

No new tests. The move is behavior-preserving, and `products/web_analytics/dags/tests/` already covers the schedules that use the decorator.

Checked locally:

- The web analytics DAG tests pass.
- `tach check --dependencies --interfaces` reports the same 44 pre-existing failures with and without this change, none of them in `dags` or either product touched here. The cross-product import this removes is not among them, because the importing DAG that motivated the move is not on master yet.
- Only one definition of `skip_on_kill_switch` remains in the tree.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`.

Split out of work on a marketing analytics precompute DAG, which is what first needed the decorator from outside web analytics. It lands on its own so the boundary fix is reviewable without the feature that motivated it.

An earlier attempt also moved `check_for_concurrent_runs` into a new module. That was dropped: an equivalent already exists in `posthog/dags/common/`, with a `tags` parameter the web analytics copy lacks, and consolidating the two is a separate question from this move.

Public artifact: nothing here comes from a non-public source.
