### PR TITLE
fix(signals): stop scouts fetching built-in skills with skill-get

### DIFF
--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -1109,6 +1109,8 @@ Pin to v{skill.version} explicitly, since the run row, your tool resolution, and
 
 The body tells you what to investigate, in what order, with what hypotheses. Pull files on demand with `skill-file-get` only when the body references them. Don't start investigating before you've read it.
 
+`skill-get` and `skill-file-get` read this team's skills store: your bound scout and the companion skills seeded next to it. PostHog's built-in skills, such as `querying-posthog-data`, are not rows in that store. They are installed in this sandbox as local skills. When your skill body or a tool description tells you to read one of them, use the local copy: pick it from your available skills, or read its `SKILL.md` from the installed skills directory. A 404 from `skill-get` for a built-in skill is expected, not a gap: do not retry it and do not report it through `agent-feedback`.
+
 # Then: orient on this project
 
 Once you've read your skill, call:

--- a/services/mcp/src/templates/sections/examples.md
+++ b/services/mcp/src/templates/sections/examples.md
@@ -1,6 +1,6 @@
 ### Examples
 
-Before writing any queries, read the PostHog's skill `querying-posthog-data` to see if there are any relevant query examples and follow them.
+Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, `info execute-sql` carries the same core guidance.
 
 #### Creating an insight with segmentation
 

--- a/services/mcp/src/templates/sections/examples.md
+++ b/services/mcp/src/templates/sections/examples.md
@@ -1,6 +1,6 @@
 ### Examples
 
-Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, `info execute-sql` carries the same core guidance.
+Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, the `execute-sql` tool description carries the same core guidance.
 
 #### Creating an insight with segmentation
 

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -5,12 +5,11 @@ import { markExecPayload, buildToolResultPayload, estimateResponseTokens } from 
 import { isPostHogCodeConsumer } from '@/lib/client-detection'
 import { ExecCommandError, findRecoverableApiError, PostHogApiError, ToolInputValidationError } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
+import { GATEWAY_TOOL_SEPARATOR, isGatewayToolName } from '@/lib/gateway-tools'
 import { formatResponse } from '@/lib/response'
 
 import type { ExecHelpCatalog } from './exec-help'
 import { TOKEN_CHAR_LIMIT, listAvailablePaths, resolveSchemaPath, summarizeSchema } from './schema-utils'
-import { GATEWAY_TOOL_SEPARATOR, isGatewayToolName } from '@/lib/gateway-tools'
-
 import { isRegexPattern, searchToolsRanked, searchToolsRegex } from './tool-search'
 import type { ScopeGatedTool } from './toolDefinitions'
 import {
@@ -314,10 +313,10 @@ export function createExecInnerToolCallResolver(
 const DEPRECATED_TOOL_REDIRECTS: Record<string, (allTools: Tool<ZodObjectAny>[]) => string> = {
     // Removed in favor of SQL-based schema discovery via `system.information_schema.*`.
     'read-data-warehouse-schema': () =>
-        'Tool "read-data-warehouse-schema" was removed in favor of SQL-based schema discovery. Use "execute-sql" against `system.information_schema.*` (`tables`, `columns`, `relationships`, `data_types`) — it scales to large catalogs and supports filtering/search (e.g. `WHERE description ILIKE \'%...%\'`). Consult the `querying-posthog-data` skill for patterns.',
+        'Tool "read-data-warehouse-schema" was removed in favor of SQL-based schema discovery. Use "execute-sql" against `system.information_schema.*` (`tables`, `columns`, `relationships`, `data_types`) — it scales to large catalogs and supports filtering/search (e.g. `WHERE description ILIKE \'%...%\'`). Consult the `querying-posthog-data` skill (a built-in local skill, when installed) for patterns.',
     'entity-search': (allTools) => {
         const base =
-            'Tool "entity-search" was removed. Use "execute-sql" to search PostHog data via HogQL. Consult the `querying-posthog-data` skill for system-table patterns (system.insights, system.dashboards, system.cohorts, ...).'
+            'Tool "entity-search" was removed. Use "execute-sql" to search PostHog data via HogQL. Consult the `querying-posthog-data` skill (a built-in local skill, when installed) for system-table patterns (system.insights, system.dashboards, system.cohorts, ...).'
         const hasCatalog = allTools.some((t) => t.name === 'data-catalog-metric-run')
         return hasCatalog
             ? `${base} For governed business metrics, search \`system.information_schema.metrics\` instead of \`system.insights\`.`
@@ -330,7 +329,7 @@ const DEPRECATED_TOOL_REDIRECTS: Record<string, (allTools: Tool<ZodObjectAny>[])
     'property-definitions': () =>
         'Tool "property-definitions" was removed. Use "read-data-schema" with the appropriate kind: "event_properties", "entity_properties", or "action_properties" — see its info schema for required fields.',
     'query-generate-hogql-from-question': () =>
-        'Tool "query-generate-hogql-from-question" was removed. Write the HogQL yourself and run it via "execute-sql". Consult the `querying-posthog-data` skill for HogQL patterns.',
+        'Tool "query-generate-hogql-from-question" was removed. Write the HogQL yourself and run it via "execute-sql". Consult the `querying-posthog-data` skill (a built-in local skill, when installed) for HogQL patterns.',
     'query-run': (allTools) => {
         const queryTools = allTools
             .filter((t) => t.name.startsWith('query-'))

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
@@ -298,7 +298,7 @@ Submitting feedback is **not** a way to end your turn or skip work. It's a side 
 
 ### Examples
 
-Before writing any queries, read the PostHog's skill `querying-posthog-data` to see if there are any relevant query examples and follow them.
+Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, `info execute-sql` carries the same core guidance.
 
 #### Creating an insight with segmentation
 

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-command-reference-full.txt
@@ -298,7 +298,7 @@ Submitting feedback is **not** a way to end your turn or skip work. It's a side 
 
 ### Examples
 
-Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, `info execute-sql` carries the same core guidance.
+Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, the `execute-sql` tool description carries the same core guidance.
 
 #### Creating an insight with segmentation
 

--- a/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
@@ -185,7 +185,7 @@ Submitting feedback is **not** a way to end your turn or skip work. It's a side 
 
 ### Examples
 
-Before writing any queries, read the PostHog's skill `querying-posthog-data` to see if there are any relevant query examples and follow them.
+Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, `info execute-sql` carries the same core guidance.
 
 #### Creating an insight with segmentation
 

--- a/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/tools-instructions.txt
@@ -185,7 +185,7 @@ Submitting feedback is **not** a way to end your turn or skip work. It's a side 
 
 ### Examples
 
-Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, `info execute-sql` carries the same core guidance.
+Before writing any queries, read the `querying-posthog-data` skill when it is installed in your environment, and follow any relevant query examples. It is a built-in PostHog skill, not a team skill in the skills store, so do not fetch it with `skill-get`. When it is not installed, the `execute-sql` tool description carries the same core guidance.
 
 #### Creating an insight with segmentation
 


### PR DESCRIPTION
## Problem

- Scouts fail to read the `querying-posthog-data` skill on about half of all runs, and report each failure through `agent-feedback`. Over the last week that was about 2,000 feedback events per day across more than a thousand projects.
- The skill is on disk in the scout sandbox. The sandbox base image installs the rendered built-in skills as local skills.
- The run prompt and the MCP instructions tell the scout to read skills with `skill-get`.
- `skill-get` serves only the team's skills store, so it answers 404 for a built-in skill.
- The scout then falls back to the local file, and files feedback about the 404.

## Changes

- Scouts no longer treat a `skill-get` 404 for a built-in skill as a gap. The run prompt now says that `skill-get` reads the team store, that built-in skills are local files, and that the 404 is expected and not to report.
- MCP agents are told to read `querying-posthog-data` as a local skill when it is installed, and to use `info execute-sql` when it is not. The `examples.md` instructions section and three removed-tool redirect messages in `exec.ts` change.
- Mechanical: two MCP instruction snapshots updated to the new sentence, and one import line re-sorted by the formatter.

Seeding the skill into each team's store was rejected. 21 of its files are Jinja2 templates that need a database-backed renderer, so the seed would copy raw templates.

## How did you test this code?

- Ran `products/signals/backend/test/test_scout_harness.py` with `-k "prompt or skill"`. The existing assertions on the "First: read your skill" section still hold.
- Not run: the `services/mcp` vitest suite. The two snapshot files were updated by a verbatim text replace of the changed sentence.
- No new tests. The change is prompt text only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5), session https://claude.ai/code/session_016UGf5U196Bas5VJqrcXt5h
- Skills invoked: /writing-pr-descriptions
- The session started from feedback volume in the `mcp feedback submitted` events. The first plan was to seed the skill as an external companion in `lazy_seed.py`. The Jinja2 templates and the feedback text ("fell back to the local bundled file") changed the fix to guidance only.
- Open follow-up: a `skill-get` fallback to the built-in skills would fix every MCP client, not only scouts.

https://claude.ai/code/session_016UGf5U196Bas5VJqrcXt5h
