### PR TITLE
fix(ingestion): stop the Rust consumer e2e from racing on worker ports

### DIFF
--- a/nodejs/tests/service-e2e/rust-ingestion-consumer.serial.test.ts
+++ b/nodejs/tests/service-e2e/rust-ingestion-consumer.serial.test.ts
@@ -101,6 +101,10 @@ describe('Rust ingestion consumer with Node ingestion API workers', () => {
 
     afterEach(async () => {
         await Promise.allSettled(services.map((service) => service.stop()))
+        // stop() returns when the direct child (pnpm) exits; the node process it spawned
+        // can still be draining its gRPC listener. Do not let the next test allocate
+        // ports while they are held.
+        await waitForPortsFree(workerPortsInUse.splice(0))
         services = []
         outputTopicStartWatermarks = new Map()
     })
@@ -402,8 +406,29 @@ async function startRustNodeStack(
     return { workers, ...rust }
 }
 
+// Every port a worker has listened on this test, so afterEach can wait for them to be
+// released before the next test allocates.
+const workerPortsInUse: number[] = []
+
 async function startNodeIngestionApiWorker(name: string, port?: number): Promise<NodeWorker> {
-    const workerPort = port ?? (await getFreeWorkerPort())
+    // A free-port check is a snapshot: another socket can take the port before the
+    // worker binds it. Unpinned starts retry with a fresh pair; pinned restarts wait
+    // for the previous holder to let go (see restartNodeIngestionApiWorker).
+    for (let attempt = 1; ; attempt++) {
+        const workerPort = port ?? (await getFreeWorkerPort())
+        try {
+            return await spawnNodeIngestionApiWorker(name, workerPort)
+        } catch (error) {
+            const addressInUse = error instanceof Error && error.message.includes('EADDRINUSE')
+            if (port !== undefined || !addressInUse || attempt >= 3) {
+                throw error
+            }
+        }
+    }
+}
+
+async function spawnNodeIngestionApiWorker(name: string, workerPort: number): Promise<NodeWorker> {
+    workerPortsInUse.push(workerPort, workerPort + GRPC_PORT_OFFSET)
     const service = new ServiceProcess(name, 'pnpm', ['exec', 'tsx', 'src/index.ts'], {
         cwd: NODEJS_ROOT,
         env: {
@@ -447,12 +472,28 @@ function isPortFree(port: number): Promise<boolean> {
     })
 }
 
+// Poll until every port can be bound. A stopped worker's node process releases its
+// listeners only after its graceful shutdown (gRPC drain), which outlives the pnpm
+// wrapper that ServiceProcess.stop() waits on.
+async function waitForPortsFree(ports: number[], timeoutMs = 15_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs
+    for (const port of ports) {
+        while (!(await isPortFree(port))) {
+            if (Date.now() > deadline) {
+                throw new Error(`port ${port} was not released within ${timeoutMs}ms`)
+            }
+            await new Promise((resolve) => setTimeout(resolve, 100))
+        }
+    }
+}
+
 async function restartNodeIngestionApiWorker(
     services: ServiceProcess[],
     worker: NodeWorker,
     name: string
 ): Promise<NodeWorker> {
     const port = Number(new URL(worker.url).port)
+    await waitForPortsFree([port, port + GRPC_PORT_OFFSET])
     const restartedWorker = await startNodeIngestionApiWorker(name, port)
     services.push(restartedWorker.service)
     return restartedWorker

--- a/nodejs/tests/service-e2e/rust-ingestion-consumer.serial.test.ts
+++ b/nodejs/tests/service-e2e/rust-ingestion-consumer.serial.test.ts
@@ -428,7 +428,6 @@ async function startNodeIngestionApiWorker(name: string, port?: number): Promise
 }
 
 async function spawnNodeIngestionApiWorker(name: string, workerPort: number): Promise<NodeWorker> {
-    workerPortsInUse.push(workerPort, workerPort + GRPC_PORT_OFFSET)
     const service = new ServiceProcess(name, 'pnpm', ['exec', 'tsx', 'src/index.ts'], {
         cwd: NODEJS_ROOT,
         env: {
@@ -450,6 +449,9 @@ async function spawnNodeIngestionApiWorker(name: string, workerPort: number): Pr
 
     const url = `http://127.0.0.1:${workerPort}`
     await service.waitForHttpOk(`${url}/_ready`)
+    // Only a worker that actually bound its ports owns them; a failed attempt's pair
+    // belongs to whatever foreign socket caused the collision.
+    workerPortsInUse.push(workerPort, workerPort + GRPC_PORT_OFFSET)
     return { service, url }
 }
 


### PR DESCRIPTION
## Problem

Since #90790 the `Rust ingestion consumer Node API e2e` job fails intermittently with `listen EADDRINUSE` when a Node ingestion API worker starts. Any PR that touches `rust/` or the ingestion Node code can hit it (two of three runs on #90491 did) and the only remedy is re-running the job.

A worker now listens on two adjacent ports: HTTP on `port` and gRPC on `port + 1`. `ServiceProcess.stop()` resolves when the direct child (the `pnpm exec tsx` wrapper) exits, but the `node` process it spawned keeps its gRPC listener open until its own drain completes. So a worker restarted on the same port ("healthy, failed, recovered" test), or the next test's fresh port pair, can collide with a listener that is still going away. The existing `isPortFree` check is a snapshot taken before the bind, which does not cover that window.

## Changes

- **Restarting a worker waits for its two ports to be released** before spawning the replacement (poll `isPortFree`, 15 s deadline).
- **`afterEach` waits for every worker port used in the test** to be released after stopping services, so the next test's allocation cannot land on a port a dying worker still holds.
- **An unpinned worker start that still loses the check-then-bind race retries** with a fresh port pair (up to 3 attempts); pinned restarts do not retry, they wait.
- Mechanical: ports are recorded in a module-level list when a worker is spawned.

## How did you test this code?

- `eslint` on the file; `tsc --noEmit` reports no errors in it (the only errors locally are unbuilt native workspace packages unrelated to this change).
- Not run end to end locally (needs the full Kafka/ClickHouse stack). The change only adds waits/retries around existing helpers; the CI job on this PR is the real test. Evidence for the diagnosis: failures in #90491 runs [33195694146](https://github.com/PostHog/posthog/actions/runs/33195694146) and [33198837773](https://github.com/PostHog/posthog/actions/runs/33198837773) both show `EADDRINUSE :::<http port + 1>` from the worker's gRPC server at startup, in the two tests that stop and restart workers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

n/a

## 🤖 Agent context

Diagnosed and drafted with Claude Code while working on #90491. https://claude.ai/code/session_017iLTktHudqwbLq1NRWhTdu
