### PR TITLE
fix(replay): remove ClickHouse metadata for deleted recordings

### DIFF
--- a/docs/internal/clickhouse-deletion-coverage.md
+++ b/docs/internal/clickhouse-deletion-coverage.md
@@ -96,8 +96,12 @@ Each is a decision that erasure may lag by the retention window.
 
 - `sharded_events_recent` — a transient mirror of the last few days of events, 7-day TTL keyed on `inserted_at`. It partitions by day with `ttl_only_drop_parts = 1`, so a part drops only once its newest row expires: the real worst case is about 8 days plus TTL-merge lag, not a flat 7. Short enough to accept as the erasure bound, and a sweep would race the TTL for little benefit.
 
-Session recordings, the dead letter queue, and logs are likewise TTL-reclaimed.
+The dead letter queue and logs are likewise TTL-reclaimed.
 That decision predates this document; the older `posthog/models/async_deletion/delete_events.py` records it in a comment, but that module is legacy and is not the source of truth here.
+
+Session recordings are NOT on a TTL: the type-fix migration `0145_session_replay_events_fix_retention_type` removed the table TTL that `0140_session_replay_events_add_ttl` had added, and nothing re-added it.
+Retention is enforced at read time only (`HAVING expiry_time >= now()`).
+Replay metadata is removed by the recording-deletion workflows instead: `delete-recordings-with-team` ends with a `delete-team-metadata` sweep of the team's rows, and the nightly `purge-deleted-recording-metadata` workflow removes the rows of individually shredded sessions once their deletion marker passes the grace period.
 
 ## Known gaps
 

--- a/posthog/session_recordings/queries/test/test_purge_deleted_recording_metadata.py
+++ b/posthog/session_recordings/queries/test/test_purge_deleted_recording_metadata.py
@@ -1,0 +1,94 @@
+from datetime import UTC, datetime, timedelta
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from posthog.clickhouse.client import sync_execute
+from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
+from posthog.temporal.session_replay.delete_recordings.activities import (
+    delete_team_metadata_query,
+    purge_delete_sessions_query,
+    purge_select_markers_query,
+)
+
+# Waits for the lightweight DELETE, so the assertions read post-delete state.
+DELETE_SETTINGS = {"lightweight_deletes_sync": 2, "mutations_sync": 2}
+
+
+def _stored_row_count(team_id: int, session_id: str) -> int:
+    [[count]] = sync_execute(
+        "SELECT count() FROM session_replay_events WHERE team_id = %(team_id)s AND session_id = %(session_id)s",
+        {"team_id": team_id, "session_id": session_id},
+    )
+    return count
+
+
+class TestPurgeDeletedRecordingMetadata(ClickhouseTestMixin, BaseTest):
+    def test_purge_removes_all_rows_of_an_old_shredded_recording(self):
+        # The recording's rows sit in a two-month-old partition. The shred marker carries
+        # the deletion time, so it sits in the current partition and never merges with
+        # them. The purge must delete the recording's rows anyway, not only the marker.
+        now = datetime.now(UTC)
+        old_start = now - timedelta(days=60)
+
+        produce_replay_summary(
+            team_id=self.team.pk,
+            session_id="shredded-session",
+            first_timestamp=old_start,
+            last_timestamp=old_start + timedelta(minutes=5),
+            ensure_analytics_event_in_session=False,
+        )
+        # The deletion marker, as recording-api writes it: empty distinct_id,
+        # timestamps at deletion time, past the purge grace period.
+        produce_replay_summary(
+            team_id=self.team.pk,
+            session_id="shredded-session",
+            distinct_id="",
+            first_timestamp=now - timedelta(minutes=1),
+            last_timestamp=now - timedelta(minutes=1),
+            is_deleted=True,
+            kafka_timestamp=now - timedelta(days=11),
+            ensure_analytics_event_in_session=False,
+        )
+        produce_replay_summary(
+            team_id=self.team.pk,
+            session_id="kept-session",
+            first_timestamp=old_start,
+            last_timestamp=old_start + timedelta(minutes=5),
+            ensure_analytics_event_in_session=False,
+        )
+
+        pairs = sync_execute(purge_select_markers_query(), {"grace_period_days": 10, "limit": 100})
+        assert (self.team.pk, "shredded-session") in pairs
+        assert (self.team.pk, "kept-session") not in pairs
+
+        for team_id, session_id in pairs:
+            sync_execute(
+                purge_delete_sessions_query(),
+                {"team_id": team_id, "session_ids": [session_id]},
+                settings=DELETE_SETTINGS,
+            )
+
+        assert _stored_row_count(self.team.pk, "shredded-session") == 0
+        assert _stored_row_count(self.team.pk, "kept-session") > 0
+
+    def test_team_metadata_sweep_removes_only_that_teams_rows(self):
+        now = datetime.now(UTC)
+        other_team_id = self.team.pk + 1_000_000
+
+        produce_replay_summary(
+            team_id=self.team.pk,
+            session_id="doomed-session",
+            first_timestamp=now - timedelta(days=60),
+            ensure_analytics_event_in_session=False,
+        )
+        produce_replay_summary(
+            team_id=other_team_id,
+            session_id="other-team-session",
+            first_timestamp=now - timedelta(days=60),
+            ensure_analytics_event_in_session=False,
+        )
+
+        sync_execute(delete_team_metadata_query(), {"team_id": self.team.pk}, settings=DELETE_SETTINGS)
+
+        assert _stored_row_count(self.team.pk, "doomed-session") == 0
+        assert _stored_row_count(other_team_id, "other-team-session") > 0

--- a/posthog/temporal/session_replay/delete_recordings/__init__.py
+++ b/posthog/temporal/session_replay/delete_recordings/__init__.py
@@ -1,6 +1,7 @@
 from posthog.temporal.session_replay.delete_recordings.activities import (
     cleanup_session_id_chunks,
     delete_recordings,
+    delete_team_metadata,
     load_recordings_with_person,
     load_recordings_with_query,
     load_recordings_with_team_id,
@@ -30,5 +31,6 @@ DELETE_RECORDINGS_ACTIVITIES = [
     load_session_id_chunk,
     cleanup_session_id_chunks,
     delete_recordings,
+    delete_team_metadata,
     purge_deleted_metadata,
 ]

--- a/posthog/temporal/session_replay/delete_recordings/activities.py
+++ b/posthog/temporal/session_replay/delete_recordings/activities.py
@@ -302,8 +302,13 @@ async def delete_recordings(input: DeleteRecordingsInput) -> DeleteRecordingsRes
         response.raise_for_status()
         data = response.json()
 
-    deleted = [r["sessionId"] for r in data if r.get("ok")]
-    failed_count = len(data) - len(deleted)
+    # Count failures against the request, not the response. The team metadata sweep is
+    # gated on zero failures, so a session the response omits must count as failed —
+    # its key was not confirmed shredded.
+    requested = list(dict.fromkeys(input.session_ids))
+    confirmed = {r["sessionId"] for r in data if r.get("ok")}
+    deleted = [session_id for session_id in requested if session_id in confirmed]
+    failed_count = len(requested) - len(deleted)
 
     logger.info(
         "Delete batch completed",

--- a/posthog/temporal/session_replay/delete_recordings/activities.py
+++ b/posthog/temporal/session_replay/delete_recordings/activities.py
@@ -15,6 +15,7 @@ from posthog.session_recordings.queries.session_recording_list_from_query import
 from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.session_recordings.recordings.recording_api_jwt import recording_api_auth_headers
 from posthog.session_recordings.utils import filter_from_params_to_query
+from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import get_client
 from posthog.temporal.common.logger import get_write_only_logger
@@ -23,6 +24,7 @@ from posthog.temporal.session_replay.delete_recordings.types import (
     CleanupChunksInput,
     DeleteRecordingsInput,
     DeleteRecordingsResult,
+    DeleteTeamMetadataInput,
     LoadChunkInput,
     LoadRecordingError,
     LoadRecordingsPage,
@@ -34,6 +36,51 @@ from posthog.temporal.session_replay.delete_recordings.types import (
 )
 
 LOGGER = get_write_only_logger()
+
+# Bounds one purge run. Markers past the cap wait for the next nightly run.
+PURGE_MARKER_LIMIT = 100_000
+# Bounds one DELETE statement, to keep the query under the ClickHouse query-size limit.
+PURGE_DELETE_BATCH_SIZE = 1_000
+
+
+def purge_select_markers_query() -> str:
+    """Find the (team_id, session_id) pairs whose deletion marker is past the grace period.
+
+    Reads the distributed table: the marker is written with an empty distinct_id, and the
+    Distributed engine shards on sipHash64(distinct_id), so the marker usually lands on a
+    different shard than the recording's other rows. A shard-local subquery would miss it.
+    """
+    return """
+        SELECT DISTINCT team_id, session_id
+        FROM session_replay_events
+        WHERE is_deleted = 1
+          AND _timestamp < now() - INTERVAL %(grace_period_days)s DAY
+        LIMIT %(limit)s
+    """
+
+
+def purge_delete_sessions_query() -> str:
+    """Delete every stored row of the marked sessions, in one team's batch.
+
+    The marker carries min_first_timestamp = deletion time, so it sits in a different
+    partition and sort-key range than the recording's real rows and never merges with
+    them. Deleting by (team_id, session_id) removes the recording's rows and the marker;
+    a `WHERE is_deleted = 1` predicate would only ever match the marker.
+    """
+    return f"""
+        DELETE FROM sharded_session_replay_events
+        ON CLUSTER '{CLICKHOUSE_CLUSTER}'
+        WHERE team_id = %(team_id)s AND session_id IN %(session_ids)s
+    """
+
+
+def delete_team_metadata_query() -> str:
+    """Delete all replay metadata for a team. The table has no TTL, so nothing else removes it."""
+    return f"""
+        DELETE FROM sharded_session_replay_events
+        ON CLUSTER '{CLICKHOUSE_CLUSTER}'
+        WHERE team_id = %(team_id)s
+    """
 
 
 def _parse_session_recording_list_response(raw_response: bytes) -> list[str]:
@@ -141,16 +188,27 @@ async def load_recordings_with_query(input: RecordingsWithQueryInput) -> LoadRec
     return LoadRecordingsPage(session_ids=session_ids, next_cursor=next_cursor)
 
 
+def _parse_marker_pairs(raw_response: bytes) -> list[tuple[int, str]]:
+    if len(raw_response) == 0:
+        raise LoadRecordingError("Got empty response from ClickHouse.")
+
+    try:
+        rows = json.loads(raw_response)["data"]
+        return [(int(row["team_id"]), row["session_id"]) for row in rows]
+    except json.JSONDecodeError as e:
+        raise LoadRecordingError("Unable to parse JSON response from ClickHouse.") from e
+    except KeyError as e:
+        raise LoadRecordingError("Got malformed JSON response from ClickHouse.") from e
+
+
 @activity.defn(name="purge-deleted-metadata")
 async def purge_deleted_metadata(input: PurgeDeletedMetadataInput) -> PurgeDeletedMetadataResult:
     """Purge metadata from ClickHouse for recordings that have been deleted.
 
-    This runs nightly to clean up metadata.
-    Uses lightweight DELETE to remove rows where is_deleted=1 and older than the grace period.
+    This runs nightly. It finds sessions whose deletion marker is older than the grace
+    period, then deletes every stored row of those sessions by (team_id, session_id).
     The grace period provides a safety buffer for recovery if needed.
     """
-    from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
-
     started_at = datetime.now(UTC)
     logger = LOGGER.bind()
     logger.info(
@@ -158,29 +216,41 @@ async def purge_deleted_metadata(input: PurgeDeletedMetadataInput) -> PurgeDelet
         grace_period_days=input.grace_period_days,
     )
 
-    query_id = str(uuid4())
-
     if not (1 <= input.grace_period_days <= 365):
         raise ValueError(f"grace_period_days must be between 1 and 365, got {input.grace_period_days}")
 
-    delete_query = f"""
-        DELETE FROM sharded_session_replay_events
-        ON CLUSTER '{CLICKHOUSE_CLUSTER}'
-        WHERE is_deleted = 1
-          AND _timestamp < now() - INTERVAL {{grace_period_days:Int32}} DAY
-    """
+    select_query = purge_select_markers_query() + " FORMAT JSON"
+    select_parameters = {"grace_period_days": input.grace_period_days, "limit": PURGE_MARKER_LIMIT}
 
-    logger.info("Executing delete query", query_id=query_id)
     async with get_client() as client:
-        await client.execute_query(
-            delete_query,
-            query_id=query_id,
-            query_parameters={"grace_period_days": input.grace_period_days},
-        )
+        raw_response: bytes = b""
+        async with client.aget_query(
+            query=select_query, query_parameters=select_parameters, query_id=str(uuid4())
+        ) as ch_response:
+            raw_response = await ch_response.content.read()
+
+        pairs = _parse_marker_pairs(raw_response)
+        if len(pairs) >= PURGE_MARKER_LIMIT:
+            logger.warning("Marker limit reached; remaining markers wait for the next run", limit=PURGE_MARKER_LIMIT)
+
+        sessions_by_team: dict[int, list[str]] = {}
+        for team_id, session_id in pairs:
+            sessions_by_team.setdefault(team_id, []).append(session_id)
+
+        for team_id, session_ids in sessions_by_team.items():
+            for start in range(0, len(session_ids), PURGE_DELETE_BATCH_SIZE):
+                batch = session_ids[start : start + PURGE_DELETE_BATCH_SIZE]
+                await client.execute_query(
+                    purge_delete_sessions_query(),
+                    query_id=str(uuid4()),
+                    query_parameters={"team_id": team_id, "session_ids": batch},
+                )
 
     completed_at = datetime.now(UTC)
     logger.info(
         "Metadata purge completed",
+        session_count=len(pairs),
+        team_count=len(sessions_by_team),
         duration_seconds=(completed_at - started_at).total_seconds(),
     )
 
@@ -188,6 +258,23 @@ async def purge_deleted_metadata(input: PurgeDeletedMetadataInput) -> PurgeDelet
         started_at=started_at,
         completed_at=completed_at,
     )
+
+
+@activity.defn(name="delete-team-metadata")
+async def delete_team_metadata(input: DeleteTeamMetadataInput) -> None:
+    """Delete all ClickHouse replay metadata for a team, after its recordings are shredded."""
+    bind_contextvars(team_id=input.team_id)
+    logger = LOGGER.bind()
+    logger.info("Deleting all replay metadata for team")
+
+    async with get_client() as client:
+        await client.execute_query(
+            delete_team_metadata_query(),
+            query_id=str(uuid4()),
+            query_parameters={"team_id": input.team_id},
+        )
+
+    logger.info("Replay metadata deleted for team")
 
 
 @activity.defn(name="delete-recordings")

--- a/posthog/temporal/session_replay/delete_recordings/metrics.py
+++ b/posthog/temporal/session_replay/delete_recordings/metrics.py
@@ -48,6 +48,7 @@ DELETE_RECORDINGS_ACTIVITY_TYPES = {
     "load-session-id-chunk",
     "cleanup-session-id-chunks",
     "delete-recordings",
+    "delete-team-metadata",
     "purge-deleted-metadata",
 }
 

--- a/posthog/temporal/session_replay/delete_recordings/types.py
+++ b/posthog/temporal/session_replay/delete_recordings/types.py
@@ -114,6 +114,12 @@ class LoadRecordingError(Exception):
     pass
 
 
+class DeleteTeamMetadataInput(BaseModel):
+    """Input for the terminal metadata sweep of a team-wide deletion."""
+
+    team_id: int
+
+
 class PurgeDeletedMetadataInput(BaseModel):
     """Input for the nightly metadata purge workflow."""
 

--- a/posthog/temporal/session_replay/delete_recordings/workflow.py
+++ b/posthog/temporal/session_replay/delete_recordings/workflow.py
@@ -192,8 +192,11 @@ class DeleteRecordingsWithTeamWorkflow(PostHogWorkflow):
                 # The session loader hides expired and already-marked sessions, so the shred
                 # alone leaves their metadata rows in ClickHouse, and the table has no TTL.
                 # Sweep the whole team once every key is shredded. Ordering matters: the
-                # loader reads these rows, so the sweep must stay after the last page.
-                if workflow.patched("delete-team-metadata") and not input.config.dry_run:
+                # loader reads these rows, so the sweep must stay after the last page, and
+                # a failed shred must skip it — the failed sessions' keys are still alive,
+                # and a retry needs these rows to find them.
+                shred_is_clean = not input.config.dry_run and progress.total_failed == 0
+                if workflow.patched("delete-team-metadata") and shred_is_clean:
                     await workflow.execute_activity(
                         delete_team_metadata,
                         DeleteTeamMetadataInput(team_id=input.team_id),
@@ -202,6 +205,10 @@ class DeleteRecordingsWithTeamWorkflow(PostHogWorkflow):
                             maximum_attempts=3,
                             initial_interval=timedelta(minutes=1),
                         ),
+                    )
+                elif progress.total_failed > 0:
+                    workflow.logger.warning(
+                        "Skipping team metadata sweep: %d recordings failed to shred", progress.total_failed
                     )
                 return _build_certificate(
                     "team",

--- a/posthog/temporal/session_replay/delete_recordings/workflow.py
+++ b/posthog/temporal/session_replay/delete_recordings/workflow.py
@@ -9,6 +9,7 @@ from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.session_replay.delete_recordings.activities import (
     cleanup_session_id_chunks,
     delete_recordings,
+    delete_team_metadata,
     load_recordings_with_person,
     load_recordings_with_query,
     load_recordings_with_team_id,
@@ -23,6 +24,7 @@ from posthog.temporal.session_replay.delete_recordings.types import (
     CleanupChunksInput,
     DeleteRecordingsInput,
     DeleteRecordingsResult,
+    DeleteTeamMetadataInput,
     DeletionCertificate,
     DeletionConfig,
     DeletionProgress,
@@ -187,6 +189,20 @@ class DeleteRecordingsWithTeamWorkflow(PostHogWorkflow):
             await _delete_page(page, input.team_id, input.config, progress)
 
             if page.next_cursor is None:
+                # The session loader hides expired and already-marked sessions, so the shred
+                # alone leaves their metadata rows in ClickHouse, and the table has no TTL.
+                # Sweep the whole team once every key is shredded. Ordering matters: the
+                # loader reads these rows, so the sweep must stay after the last page.
+                if workflow.patched("delete-team-metadata") and not input.config.dry_run:
+                    await workflow.execute_activity(
+                        delete_team_metadata,
+                        DeleteTeamMetadataInput(team_id=input.team_id),
+                        start_to_close_timeout=timedelta(hours=1),
+                        retry_policy=common.RetryPolicy(
+                            maximum_attempts=3,
+                            initial_interval=timedelta(minutes=1),
+                        ),
+                    )
                 return _build_certificate(
                     "team",
                     workflow.info().workflow_id,

--- a/posthog/temporal/tests/session_replay/delete_recordings/test_activities.py
+++ b/posthog/temporal/tests/session_replay/delete_recordings/test_activities.py
@@ -48,8 +48,24 @@ from posthog.temporal.session_replay.delete_recordings.types import (
         pytest.param(
             [],
             [],
+            2,
+            id="empty_response_counts_all_requested_as_failed",
+        ),
+        pytest.param(
+            [{"sessionId": "s1", "ok": True, "status": "deleted", "deletedAt": 1700000000}],
+            ["s1"],
+            1,
+            id="short_response_counts_missing_session_as_failed",
+        ),
+        pytest.param(
+            [
+                {"sessionId": "s1", "ok": True, "status": "deleted", "deletedAt": 1700000000},
+                {"sessionId": "s2", "ok": True, "status": "deleted", "deletedAt": 1700000000},
+                {"sessionId": "unrequested", "ok": True, "status": "deleted", "deletedAt": 1700000000},
+            ],
+            ["s1", "s2"],
             0,
-            id="empty_results",
+            id="unrequested_session_in_response_is_ignored",
         ),
     ],
 )

--- a/posthog/temporal/tests/session_replay/delete_recordings/test_activities.py
+++ b/posthog/temporal/tests/session_replay/delete_recordings/test_activities.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import override_settings
 
@@ -9,12 +9,15 @@ import httpx
 
 from posthog.jwt import PosthogJwtAudience, decode_jwt
 from posthog.temporal.session_replay.delete_recordings.activities import (
+    PURGE_DELETE_BATCH_SIZE,
     _parse_session_recording_list_response,
     delete_recordings,
+    delete_team_metadata,
     purge_deleted_metadata,
 )
 from posthog.temporal.session_replay.delete_recordings.types import (
     DeleteRecordingsInput,
+    DeleteTeamMetadataInput,
     LoadRecordingError,
     PurgeDeletedMetadataInput,
 )
@@ -206,34 +209,91 @@ async def test_delete_recordings_raises_on_http_error():
             await delete_recordings(DeleteRecordingsInput(team_id=1, session_ids=["s1"], deleted_by="test@posthog.com"))
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "grace_period_days",
-    [
-        pytest.param(1, id="minimum"),
-        pytest.param(10, id="default"),
-        pytest.param(30, id="monthly"),
-        pytest.param(365, id="maximum"),
-    ],
-)
-async def test_purge_deleted_metadata_parameterizes_grace_period(grace_period_days):
+def _mock_clickhouse_client(marker_rows: list[dict]) -> AsyncMock:
     mock_client = AsyncMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with (
-        patch("posthog.temporal.session_replay.delete_recordings.activities.get_client", return_value=mock_client),
-        patch("posthog.settings.data_stores.CLICKHOUSE_CLUSTER", "posthog"),
-    ):
-        result = await purge_deleted_metadata(PurgeDeletedMetadataInput(grace_period_days=grace_period_days))
+    response = MagicMock()
+    response.content.read = AsyncMock(return_value=json.dumps({"data": marker_rows}).encode())
+    aget_query_ctx = MagicMock()
+    aget_query_ctx.__aenter__ = AsyncMock(return_value=response)
+    aget_query_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_client.aget_query = MagicMock(return_value=aget_query_ctx)
+
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_purge_deleted_metadata_deletes_marked_sessions_by_pair():
+    """The purge must delete the marked sessions' rows by (team_id, session_id).
+
+    A `WHERE is_deleted = 1` predicate only ever matches the marker row: the marker is
+    stamped with the deletion time, so it never merges with the recording's real rows.
+    """
+    marker_rows = [
+        {"team_id": "1", "session_id": "s1"},
+        {"team_id": "1", "session_id": "s2"},
+        {"team_id": "2", "session_id": "s3"},
+    ]
+    mock_client = _mock_clickhouse_client(marker_rows)
+
+    with patch("posthog.temporal.session_replay.delete_recordings.activities.get_client", return_value=mock_client):
+        result = await purge_deleted_metadata(PurgeDeletedMetadataInput(grace_period_days=10))
+
+    select_kwargs = mock_client.aget_query.call_args.kwargs
+    assert select_kwargs["query_parameters"]["grace_period_days"] == 10
+
+    assert mock_client.execute_query.call_count == 2
+    delete_parameters = []
+    for call in mock_client.execute_query.call_args_list:
+        query = call.args[0]
+        assert "team_id = %(team_id)s AND session_id IN %(session_ids)s" in query
+        assert "is_deleted" not in query
+        delete_parameters.append(call.kwargs["query_parameters"])
+    assert {"team_id": 1, "session_ids": ["s1", "s2"]} in delete_parameters
+    assert {"team_id": 2, "session_ids": ["s3"]} in delete_parameters
+
+    assert result.completed_at >= result.started_at
+
+
+@pytest.mark.asyncio
+async def test_purge_deleted_metadata_issues_no_delete_without_markers():
+    mock_client = _mock_clickhouse_client([])
+
+    with patch("posthog.temporal.session_replay.delete_recordings.activities.get_client", return_value=mock_client):
+        await purge_deleted_metadata(PurgeDeletedMetadataInput(grace_period_days=10))
+
+    mock_client.execute_query.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_purge_deleted_metadata_batches_deletes_per_team():
+    marker_rows = [{"team_id": "1", "session_id": f"s{i}"} for i in range(PURGE_DELETE_BATCH_SIZE + 1)]
+    mock_client = _mock_clickhouse_client(marker_rows)
+
+    with patch("posthog.temporal.session_replay.delete_recordings.activities.get_client", return_value=mock_client):
+        await purge_deleted_metadata(PurgeDeletedMetadataInput(grace_period_days=10))
+
+    assert mock_client.execute_query.call_count == 2
+    batch_sizes = [
+        len(call.kwargs["query_parameters"]["session_ids"]) for call in mock_client.execute_query.call_args_list
+    ]
+    assert batch_sizes == [PURGE_DELETE_BATCH_SIZE, 1]
+
+
+@pytest.mark.asyncio
+async def test_delete_team_metadata_deletes_by_team_id():
+    mock_client = _mock_clickhouse_client([])
+
+    with patch("posthog.temporal.session_replay.delete_recordings.activities.get_client", return_value=mock_client):
+        await delete_team_metadata(DeleteTeamMetadataInput(team_id=123))
 
     mock_client.execute_query.assert_called_once()
-    call_kwargs = mock_client.execute_query.call_args
-    assert call_kwargs.kwargs["query_parameters"] == {"grace_period_days": grace_period_days}
-    assert "{grace_period_days:Int32}" in call_kwargs.args[0]
-    assert result.started_at is not None
-    assert result.completed_at is not None
-    assert result.completed_at >= result.started_at
+    query = mock_client.execute_query.call_args.args[0]
+    assert "DELETE FROM sharded_session_replay_events" in query
+    assert "team_id = %(team_id)s" in query
+    assert mock_client.execute_query.call_args.kwargs["query_parameters"] == {"team_id": 123}
 
 
 @pytest.mark.asyncio

--- a/posthog/temporal/tests/session_replay/delete_recordings/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/delete_recordings/test_workflow.py
@@ -497,6 +497,9 @@ async def test_delete_recordings_certificate_with_mixed_results():
                 task_queue=task_queue_name,
             )
 
+    # Failed shreds leave live keys, and retrying them needs the metadata rows: no sweep.
+    assert swept_teams == []
+
     certificate = DeletionCertificate.model_validate(result)
     assert certificate.workflow_type == "team"
     assert certificate.team_id == TEST_TEAM_ID

--- a/posthog/temporal/tests/session_replay/delete_recordings/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/delete_recordings/test_workflow.py
@@ -12,6 +12,7 @@ from posthog.temporal.session_replay.delete_recordings.types import (
     CleanupChunksInput,
     DeleteRecordingsInput,
     DeleteRecordingsResult,
+    DeleteTeamMetadataInput,
     DeletionCertificate,
     DeletionConfig,
     LoadChunkInput,
@@ -32,6 +33,14 @@ from posthog.temporal.session_replay.delete_recordings.workflow import (
 )
 
 TEST_CONFIG = DeletionConfig(deleted_by="test@posthog.com")
+
+
+def make_delete_team_metadata_mock(swept_teams: list[int]):
+    @activity.defn(name="delete-team-metadata")
+    async def delete_team_metadata_mocked(input: DeleteTeamMetadataInput) -> None:
+        swept_teams.append(input.team_id)
+
+    return delete_team_metadata_mocked
 
 
 @pytest.mark.asyncio
@@ -142,6 +151,7 @@ async def test_delete_recordings_with_person_workflow_dry_run():
 @pytest.mark.asyncio
 async def test_delete_recordings_with_no_sessions_found():
     TEST_TEAM_ID: int = 77777
+    swept_teams: list[int] = []
 
     delete_called = False
 
@@ -165,6 +175,7 @@ async def test_delete_recordings_with_no_sessions_found():
             activities=[
                 load_recordings_with_team_id_mocked,
                 delete_recordings_mocked,
+                make_delete_team_metadata_mock(swept_teams),
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
@@ -193,6 +204,7 @@ async def test_delete_recordings_with_team_workflow():
     ]
 
     deleted_sessions: list[str] = []
+    swept_teams: list[int] = []
 
     @activity.defn(name="load-recordings-with-team-id")
     async def load_recordings_with_team_id_mocked(input: RecordingsWithTeamInput) -> LoadRecordingsPage:
@@ -215,6 +227,7 @@ async def test_delete_recordings_with_team_workflow():
             activities=[
                 load_recordings_with_team_id_mocked,
                 delete_recordings_mocked,
+                make_delete_team_metadata_mock(swept_teams),
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
@@ -226,6 +239,7 @@ async def test_delete_recordings_with_team_workflow():
             )
 
     assert sorted(deleted_sessions) == sorted(TEST_SESSION_IDS)
+    assert swept_teams == [TEST_TEAM_ID]
 
     certificate = DeletionCertificate.model_validate(result)
     assert certificate.workflow_type == "team"
@@ -239,6 +253,7 @@ async def test_delete_recordings_with_team_workflow():
 async def test_delete_recordings_with_team_workflow_dry_run():
     TEST_TEAM_ID: int = 44444
     TEST_SESSION_IDS = ["dry-run-session-1", "dry-run-session-2"]
+    swept_teams: list[int] = []
 
     @activity.defn(name="load-recordings-with-team-id")
     async def load_recordings_with_team_id_mocked(input: RecordingsWithTeamInput) -> LoadRecordingsPage:
@@ -260,6 +275,7 @@ async def test_delete_recordings_with_team_workflow_dry_run():
             activities=[
                 load_recordings_with_team_id_mocked,
                 delete_recordings_mocked,
+                make_delete_team_metadata_mock(swept_teams),
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
@@ -271,6 +287,8 @@ async def test_delete_recordings_with_team_workflow_dry_run():
                 id=workflow_id,
                 task_queue=task_queue_name,
             )
+
+    assert swept_teams == []
 
     certificate = DeletionCertificate.model_validate(result)
     assert certificate.workflow_type == "team"
@@ -390,6 +408,7 @@ async def test_delete_recordings_with_batching():
     TEST_SESSION_IDS = [f"session-{i}" for i in range(250)]
 
     batch_calls: list[list[str]] = []
+    swept_teams: list[int] = []
 
     @activity.defn(name="load-recordings-with-team-id")
     async def load_recordings_with_team_id_mocked(input: RecordingsWithTeamInput) -> LoadRecordingsPage:
@@ -410,6 +429,7 @@ async def test_delete_recordings_with_batching():
             activities=[
                 load_recordings_with_team_id_mocked,
                 delete_recordings_mocked,
+                make_delete_team_metadata_mock(swept_teams),
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
@@ -443,6 +463,7 @@ async def test_delete_recordings_certificate_with_mixed_results():
     """Test that the certificate correctly captures mixed results (deleted and failed)."""
     TEST_TEAM_ID: int = 55555
     TEST_SESSION_IDS = ["session-1", "session-2", "session-3", "session-4"]
+    swept_teams: list[int] = []
 
     @activity.defn(name="load-recordings-with-team-id")
     async def load_recordings_with_team_id_mocked(input: RecordingsWithTeamInput) -> LoadRecordingsPage:
@@ -465,6 +486,7 @@ async def test_delete_recordings_certificate_with_mixed_results():
             activities=[
                 load_recordings_with_team_id_mocked,
                 delete_recordings_mocked,
+                make_delete_team_metadata_mock(swept_teams),
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
@@ -492,6 +514,7 @@ async def test_delete_recordings_with_pagination():
 
     deleted_sessions: list[str] = []
     load_call_count = 0
+    swept_teams: list[int] = []
 
     @activity.defn(name="load-recordings-with-team-id")
     async def load_recordings_with_team_id_mocked(input: RecordingsWithTeamInput) -> LoadRecordingsPage:
@@ -518,6 +541,7 @@ async def test_delete_recordings_with_pagination():
             activities=[
                 load_recordings_with_team_id_mocked,
                 delete_recordings_mocked,
+                make_delete_team_metadata_mock(swept_teams),
             ],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
@@ -550,6 +574,7 @@ async def test_rate_limiting_sleeps_when_execution_is_fast(num_sessions, max_per
     """When batch execution is instant (frozen time), sleep = num_sessions / max_per_second."""
     TEST_TEAM_ID = 11111
     session_ids = [f"s-{i}" for i in range(num_sessions)]
+    swept_teams: list[int] = []
 
     @activity.defn(name="load-recordings-with-team-id")
     async def load_mocked(input: RecordingsWithTeamInput) -> LoadRecordingsPage:
@@ -567,7 +592,7 @@ async def test_rate_limiting_sleeps_when_execution_is_fast(num_sessions, max_per
             env.client,
             task_queue=task_queue_name,
             workflows=[DeleteRecordingsWithTeamWorkflow],
-            activities=[load_mocked, delete_mocked],
+            activities=[load_mocked, delete_mocked, make_delete_team_metadata_mock(swept_teams)],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
             with patch("posthog.temporal.session_replay.delete_recordings.workflow.asyncio.sleep", mock_sleep):
@@ -591,6 +616,7 @@ async def test_rate_limiting_disabled_when_zero():
     """No sleep when max_deletions_per_second=0."""
     TEST_TEAM_ID = 22222
     session_ids = [f"s-{i}" for i in range(50)]
+    swept_teams: list[int] = []
 
     @activity.defn(name="load-recordings-with-team-id")
     async def load_mocked(input: RecordingsWithTeamInput) -> LoadRecordingsPage:
@@ -608,7 +634,7 @@ async def test_rate_limiting_disabled_when_zero():
             env.client,
             task_queue=task_queue_name,
             workflows=[DeleteRecordingsWithTeamWorkflow],
-            activities=[load_mocked, delete_mocked],
+            activities=[load_mocked, delete_mocked, make_delete_team_metadata_mock(swept_teams)],
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
             with patch("posthog.temporal.session_replay.delete_recordings.workflow.asyncio.sleep", mock_sleep):


### PR DESCRIPTION
## Problem

Deleting a recording (crypto shred) or a whole team leaves every session's metadata rows — session_id, distinct_id, visited URLs, timestamps — in ClickHouse indefinitely.

- `sharded_session_replay_events` has no TTL: `0145_session_replay_events_fix_retention_type` removed the TTL that `0140` had added (a column type change required it) and nothing re-added it. Retention is read-time only (`HAVING expiry_time >= now()`).
- The nightly purge (`WHERE is_deleted = 1`) only ever matches its own marker row. The marker is stamped with the deletion time, so it lands in a different partition and sort-key range than the recording's rows and never merges with them. After the grace period the purge deletes the marker and leaves the recording's rows behind — which also makes the shredded recording reappear in listings, unplayable.
- The purge also never ran at all: its `{grace_period_days:Int32}` placeholder makes the temporal ClickHouse client's `prepare_query` raise `Invalid format specifier`.

## Changes

- Deleting a project now removes the team's replay metadata from ClickHouse: `delete-recordings-with-team` ends with a new `delete-team-metadata` activity (`DELETE ... WHERE team_id = X`), gated with `workflow.patched` for in-flight executions and skipped on dry runs. It runs after the last page, because the session loader reads those rows.
- Shredded recordings now stay hidden and their metadata is actually removed: the nightly purge selects marked `(team_id, session_id)` pairs past the grace period through the distributed table (the marker's empty `distinct_id` usually shards it away from the recording's rows), then deletes those sessions' rows in batched statements. This also replaces the broken placeholder style.
- Mechanical: activity/metrics registration, and a correction to `docs/internal/clickhouse-deletion-coverage.md`, which still claimed recordings are TTL-reclaimed.

## How did you test this code?

- New ClickHouse-backed test (`test_purge_deleted_recording_metadata.py`): a 60-day-old recording with a current-partition marker — the exact case the old purge missed — is fully removed, and an unmarked session survives; the team sweep removes only that team's rows. Ran locally against real ClickHouse.
- Updated activity tests: purge deletes by pair (never by `is_deleted`), issues no DELETE without markers, batches per team; team sweep passes `team_id`.
- Updated workflow tests: the team workflow runs the sweep once after the deletes, and skips it on dry run.
- All three suites ran locally and passed. Not checked: mypy repo-wide and `hogli ci:preflight` (no node_modules in this environment) — leaving to CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `docs/internal/clickhouse-deletion-coverage.md` in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Desktop task) while investigating replay deletion behavior ahead of a large team offboarding; raised in #team-clickhouse. Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions. Design decision made during the session: the purge selects markers through the distributed table and deletes by explicit pair batches instead of an `IN` subquery, because the marker's empty `distinct_id` shards it away from the recording's rows, so a shard-local subquery would miss them. The team sweep deliberately keeps the `now()` marker timestamp unchanged — backdating it would move shredded sessions out of closed billing periods.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*