### PR TITLE
fix(csp): only send CSP violation reports to PostHog on Cloud

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -53,6 +53,7 @@ from posthog.models.activity_logging.utils import (
     activity_storage,
 )
 from posthog.models.utils import generate_random_token
+from posthog.ph_client import PH_US_API_KEY, PH_US_HOST
 from posthog.settings import PROJECT_SWITCHING_TOKEN_ALLOWLIST, SITE_URL
 from posthog.user_permissions import UserPermissions
 from posthog.utils import get_ip_address, get_trusted_client_ip
@@ -1136,6 +1137,30 @@ class ActivityLoggingMiddleware:
         return response
 
 
+def get_csp_report_endpoint(**extra_params: str) -> Optional[str]:
+    """Where this instance's own CSP violations should be reported, or None to not report them.
+
+    PostHog Cloud collects violations on its own pages into the PostHog project, which is what
+    the `report-uri`/`Reporting-Endpoints` directives below are for. Self-hosted installs must
+    not inherit that: the report is sent by the *browser*, so it would carry their internal
+    hostnames, page paths, and their users' IP addresses and user agents to a PostHog-owned
+    endpoint they never opted into.
+
+    Gated like the rest of our phone-home telemetry in `posthog.ph_client` (`is_cloud()` plus
+    `OPT_OUT_CAPTURE`). It needs its own gate because a browser-delivered report never passes
+    through that client, so it silently bypassed those checks.
+
+    Reads `settings.OPT_OUT_CAPTURE` rather than the raw env var: `docker-compose.hobby.yml`
+    defaults it to the string `"false"`, which is truthy via `os.environ.get`. The setting is
+    parsed with `str_to_bool`.
+    """
+    if not is_cloud() or settings.OPT_OUT_CAPTURE:
+        return None
+
+    params = {"token": PH_US_API_KEY, **extra_params, "v": "2"}
+    return f"{PH_US_HOST}/report/?{urlencode(params)}"
+
+
 class CSPMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
@@ -1169,16 +1194,16 @@ class CSPMiddleware:
                 # used by the error page
                 "frame-src https://posthog.com",
                 "base-uri 'self'",
-                "report-uri https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=2",
-                "report-to posthog",
             ]
 
-            # Browsers only deliver crash reports to the endpoint named `default`; the CSP
-            # `report-to posthog` directive keeps routing violations to `posthog`.
-            admin_report_endpoint = "https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&v=2"
-            response.headers["Reporting-Endpoints"] = (
-                f'posthog="{admin_report_endpoint}", default="{admin_report_endpoint}"'
-            )
+            admin_report_endpoint = get_csp_report_endpoint()
+            if admin_report_endpoint:
+                csp_parts.extend([f"report-uri {admin_report_endpoint}", "report-to posthog"])
+                # Browsers only deliver crash reports to the endpoint named `default`; the CSP
+                # `report-to posthog` directive keeps routing violations to `posthog`.
+                response.headers["Reporting-Endpoints"] = (
+                    f'posthog="{admin_report_endpoint}", default="{admin_report_endpoint}"'
+                )
             response.headers["Content-Security-Policy"] = "; ".join(csp_parts)
         else:
             resource_url = "https://*.posthog.com"
@@ -1204,20 +1229,21 @@ class CSPMiddleware:
                 "frame-src https:",
                 "manifest-src 'self'",
                 "base-uri 'self'",
-                "report-uri https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&sample_rate=0.1&v=2",
-                "report-to posthog",
             ]
 
-            report_endpoint = "https://us.i.posthog.com/report/?token=sTMFPsFhdP1Ssg&sample_rate=0.1&v=2"
-            user = getattr(request, "user", None)
-            if user is not None and user.is_authenticated and getattr(user, "distinct_id", None):
-                # Crash reports arrive after the tab already died, so the report body is the
-                # only chance to attribute them; carrying the distinct_id in the endpoint URL
-                # ties the event to the person instead of a random per-report id.
-                report_endpoint += "&" + urlencode({"distinct_id": user.distinct_id})
-            # Browsers only deliver crash reports to the endpoint named `default`; the CSP
-            # `report-to posthog` directive keeps routing violations to `posthog`.
-            response.headers["Reporting-Endpoints"] = f'posthog="{report_endpoint}", default="{report_endpoint}"'
+            report_endpoint = get_csp_report_endpoint(sample_rate="0.1")
+            if report_endpoint:
+                csp_parts.extend([f"report-uri {report_endpoint}", "report-to posthog"])
+
+                user = getattr(request, "user", None)
+                if user is not None and user.is_authenticated and getattr(user, "distinct_id", None):
+                    # Crash reports arrive after the tab already died, so the report body is the
+                    # only chance to attribute them; carrying the distinct_id in the endpoint URL
+                    # ties the event to the person instead of a random per-report id.
+                    report_endpoint += "&" + urlencode({"distinct_id": user.distinct_id})
+                # Browsers only deliver crash reports to the endpoint named `default`; the CSP
+                # `report-to posthog` directive keeps routing violations to `posthog`.
+                response.headers["Reporting-Endpoints"] = f'posthog="{report_endpoint}", default="{report_endpoint}"'
             response.headers["Content-Security-Policy-Report-Only"] = "; ".join(csp_parts)
 
         return response

--- a/posthog/test/test_middleware.py
+++ b/posthog/test/test_middleware.py
@@ -1885,6 +1885,7 @@ class TestActivityLoggingMiddleware(APIBaseTest):
         self.assertIsNone(self.captured["ip_address"])
 
 
+@override_settings(CLOUD_DEPLOYMENT="US")
 class TestCSPMiddleware(APIBaseTest):
     def test_non_html_response_gets_strict_csp(self):
         response = self.client.get("/api/users/@me/")
@@ -1913,6 +1914,40 @@ class TestCSPMiddleware(APIBaseTest):
         header = response["Reporting-Endpoints"]
         assert 'default="https://us.i.posthog.com/report/' in header
         assert "distinct_id" not in header
+
+
+class TestCSPReportingIsCloudOnly(APIBaseTest):
+    """The CSP report is sent by the browser, so a self-hosted install that inherited our
+    `report-uri` would ship its internal URLs and its users' IPs to a PostHog-owned endpoint
+    nobody there opted into. Reporting is Cloud-only; the policy itself still applies."""
+
+    def _assert_not_reporting(self, response):
+        assert "Reporting-Endpoints" not in response
+        policy = response.get("Content-Security-Policy-Report-Only") or response["Content-Security-Policy"]
+        assert "report-uri" not in policy
+        assert "report-to" not in policy
+        # The protection itself must survive — only the phone-home is dropped.
+        assert "default-src 'self'" in policy
+
+    @override_settings(CLOUD_DEPLOYMENT=None, DEBUG=False)
+    def test_self_hosted_app_page_does_not_report(self):
+        self._assert_not_reporting(self.client.get("/"))
+
+    @override_settings(CLOUD_DEPLOYMENT=None, DEBUG=False)
+    def test_self_hosted_admin_page_does_not_report(self):
+        self.user.is_staff = True
+        self.user.save()
+        self._assert_not_reporting(self.client.get("/admin/"))
+
+    @override_settings(CLOUD_DEPLOYMENT="US", OPT_OUT_CAPTURE=True)
+    def test_cloud_respects_opt_out_capture(self):
+        self._assert_not_reporting(self.client.get("/"))
+
+    @override_settings(CLOUD_DEPLOYMENT="US", OPT_OUT_CAPTURE=False)
+    def test_cloud_still_reports(self):
+        response = self.client.get("/")
+        assert "Reporting-Endpoints" in response
+        assert "report-uri https://us.i.posthog.com/report/" in response["Content-Security-Policy-Report-Only"]
 
 
 class TestSocialAuthExceptionMiddleware(APIBaseTest):


### PR DESCRIPTION
## Problem

Anyone running PostHog self-hosted has their browsers reporting CSP violations to a PostHog-owned endpoint they never opted into.

`CSPMiddleware` sets `report-uri` and `Reporting-Endpoints` to a PostHog ingestion URL with no environment gate, so every install emits it — Cloud and self-hosted alike. The report is delivered by the *browser*, not the server, so it carries the install's own hostnames and page paths plus their users' IP addresses and user agents. It also never passes through `posthog.ph_client`, which is where the rest of our phone-home telemetry gets its `is_cloud()` / `OPT_OUT_CAPTURE` checks — so it bypassed all of them silently.

This is visible in practice: reports arrive from self-hosted deployments across a range of unrelated domains, identifiable by the PostHog `report-uri` embedded in their own policy.

## Changes

- Self-hosted installs no longer send CSP violation reports anywhere. The policy itself is byte-for-byte unchanged, so they keep the same protection — only the phone-home is dropped.
- Cloud behavior is unchanged, and now also respects `OPT_OUT_CAPTURE`.
- New `get_csp_report_endpoint()` builds the endpoint or returns `None`, gated on `is_cloud()` and `OPT_OUT_CAPTURE` to match `posthog.ph_client`.
- Reads `settings.OPT_OUT_CAPTURE` rather than the raw env var: `docker-compose.hobby.yml` defaults it to the string `"false"`, which is truthy via `os.environ.get`.
- Mechanical: the endpoint URL was written out twice per branch (once in the policy, once for the header); it is now built once.

## How did you test this code?

Automated tests only. This environment has no Postgres/ClickHouse stack, so the Django suite could not be run here — CI is the first execution of these tests, and no manual browser verification was done.

Added `TestCSPReportingIsCloudOnly`, covering regressions no existing test caught, because every prior CSP test implicitly assumed reporting is always on:
- self-hosted app page and `/admin/` emit no `report-uri`, `report-to`, or `Reporting-Endpoints`, while still emitting `default-src 'self'` — this is the leak itself, and the `default-src` assertion is what stops a future "fix" from disabling the policy rather than just the reporting
- Cloud with `OPT_OUT_CAPTURE=1` stops reporting
- Cloud without it still reports

`TestCSPMiddleware` now sets `CLOUD_DEPLOYMENT="US"`, since it asserts on reporting headers that are Cloud-only under this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code). No repo skills were invoked.

Started from a Signals scout report about a third-party endpoint appearing in CSP violations on PostHog pages. That turned out to be a browser extension on end users' machines and needed no code change — the source-file attribution pointed at PostHog scripts only because our `fetch`/XHR wrappers sit outermost on the page. Checking whether reports were arriving from domains that aren't ours surfaced this separate, unrelated issue, which is what this PR fixes.

One deliberate non-change, worth a reviewer's opinion: EU Cloud also reports to the US ingestion endpoint, unlike `ph_client`, which routes EU to EU. That may be intentional to keep all CSP data in one project, but it has data-residency implications. Left alone here rather than bundled into a leak fix.

Public artifact: nothing in this PR draws on non-public material. No customer data, domains, or volumes appear in the code, tests, commit message, or this description.
