### PR TITLE
feat(data-quality): delete the history of subjects that no longer exist

### DIFF
--- a/products/data_quality/backend/temporal/activities/cleanup.py
+++ b/products/data_quality/backend/temporal/activities/cleanup.py
@@ -1,34 +1,59 @@
 from collections import defaultdict
+from collections.abc import Iterable
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from uuid import UUID
 
-from django.db.models import Exists, OuterRef, Q, QuerySet
+from django.db import transaction
+from django.db.models import Exists, F, OuterRef, Q, QuerySet, Value
+from django.db.models.functions import Greatest
 
 from asgiref.sync import sync_to_async
 from temporalio import activity
 
+from posthog.dataclasses import frozen
 from posthog.temporal.common.logger import get_logger
 
-from ...facade.enums import SuiteRunStatus
-from ...models import DataQualityCheckRun, DataQualitySuiteRun
+from products.data_modeling.backend.facade import api as data_modeling_facade
+from products.warehouse_sources.backend.facade import api as warehouse_facade
+
+from ...facade.enums import SubjectType, SuiteRunStatus
+from ...models import DataQualityCheck, DataQualityCheckRun, DataQualitySuiteRun
 from ..contracts import CleanupOutcome
 
 LOGGER = get_logger(__name__)
 
 COMPILED_QUERY_RETENTION_DAYS = 30
-CHECK_RUN_RETENTION_DAYS = 365
+CHECK_RUN_RETENTION_DAYS = 90
 SUITE_RUN_RETENTION_DAYS = 90
 STALE_SUITE_HOURS = 24
 STALE_SUITE_ERROR = "The workflow stopped without recording a result."
 RETENTION_DELETE_BATCH_SIZE = 1_000
+# A row created while the sweep is running postdates the snapshot of live subjects its team's pass
+# took, so it would read as pointing at a subject that does not exist. Spared this round instead.
+SUBJECT_GRACE_HOURS = 1
+
+_COUNTER_COLUMNS = {
+    "passed": "checks_passed",
+    "failed": "checks_failed",
+    "errored": "checks_errored",
+    "skipped": "checks_skipped",
+}
+
+
+def _heartbeat() -> None:
+    # Called from the sweep itself so a long pass keeps reporting progress; a direct call outside a
+    # worker (a test, a shell) has no activity to report to.
+    if activity.in_activity():
+        activity.heartbeat()
 
 
 def _delete_in_batches(queryset: "QuerySet[Any]") -> dict[str, int]:
     """Delete a queryset in id-batches, returning how many rows went per model label.
 
     One unbounded ``.delete()`` loads every matched row and everything that cascades with it into
-    Django's collector. Each run drags its subject rows in, and each suite its check runs, so capping
-    the parent rows per pass bounds that memory whatever the reverse relations pull along.
+    Django's collector. Each suite drags its check runs in, so capping the parent rows per pass
+    bounds that memory whatever the reverse relations pull along.
     """
     model = queryset.model
     totals: dict[str, int] = defaultdict(int)
@@ -36,6 +61,7 @@ def _delete_in_batches(queryset: "QuerySet[Any]") -> dict[str, int]:
         _, by_model = model.objects.unscoped().filter(id__in=ids).delete()
         for label, count in by_model.items():
             totals[label] += count
+        _heartbeat()
     return totals
 
 
@@ -55,11 +81,12 @@ def _cleanup() -> CleanupOutcome:
         .update(compiled_query="")
     )
 
+    dead = _sweep_dead_subjects(now)
+
     has_newer_run = runs.filter(quality_check_id=OuterRef("quality_check_id"), created_at__gt=OuterRef("created_at"))
     expired_runs = runs.filter(created_at__lt=now - timedelta(days=CHECK_RUN_RETENTION_DAYS)).filter(
         Q(quality_check_id__isnull=True) | Exists(has_newer_run)
     )
-    # Count only the runs -- the subject rows that cascade with each one would otherwise inflate it.
     runs_deleted = _delete_in_batches(expired_runs).get(DataQualityCheckRun._meta.label, 0)
 
     backs_a_run = DataQualityCheckRun.objects.unscoped().filter(suite_run_id=OuterRef("id"))
@@ -76,16 +103,119 @@ def _cleanup() -> CleanupOutcome:
         .update(status=SuiteRunStatus.FAILED, error=STALE_SUITE_ERROR, finished_at=now, updated_at=now)
     )
 
+    outcome = CleanupOutcome(
+        compiled_queries_cleared=queries_cleared,
+        checks_deleted=dead.checks_deleted,
+        check_runs_deleted=runs_deleted + dead.check_runs_deleted,
+        suite_runs_deleted=suites_deleted + dead.suite_runs_deleted,
+        stale_suites_failed=stale_failed,
+    )
     LOGGER.info(
         "Cleaned up data quality history",
-        queries_cleared=queries_cleared,
-        runs_deleted=runs_deleted,
-        suites_deleted=suites_deleted,
-        stale_suites_failed=stale_failed,
+        queries_cleared=outcome.compiled_queries_cleared,
+        checks_deleted=outcome.checks_deleted,
+        runs_deleted=outcome.check_runs_deleted,
+        suites_deleted=outcome.suite_runs_deleted,
+        stale_suites_failed=outcome.stale_suites_failed,
     )
-    return CleanupOutcome(
-        compiled_queries_cleared=queries_cleared,
-        check_runs_deleted=runs_deleted,
-        suite_runs_deleted=suites_deleted,
-        stale_suites_failed=stale_failed,
+    return outcome
+
+
+@frozen
+class _LiveSubjects:
+    """The warehouse objects a team still has, by id."""
+
+    table_ids: frozenset[UUID]
+    view_ids: frozenset[UUID]
+
+    def alive_q(self, table_field: str = "subject_uuid", view_field: str = "subject_uuid") -> Q:
+        # An explicit predicate per known kind, so a row of a kind this sweep does not know reads as
+        # dead rather than as alive by default. Runs and suites denormalize the subject into one
+        # column; a check carries it as whichever of its two foreign keys is set.
+        return Q(**{"subject_type": SubjectType.TABLE, f"{table_field}__in": self.table_ids}) | Q(
+            **{"subject_type": SubjectType.VIEW, f"{view_field}__in": self.view_ids}
+        )
+
+
+def _sweep_dead_subjects(now: datetime) -> CleanupOutcome:
+    """Delete the rows whose warehouse subject no longer exists, team by team.
+
+    Deleting a table or view takes its object-level denial with it, so nothing left can show a
+    restricted member was allowed the rows a check ran over. The gates withhold such rows meanwhile;
+    this is what closes that window instead of leaving it open for the life of the history.
+
+    Only the subject a row declares is judged. A live check that references a subject which died
+    stays, because an admin can still see it and repoint it.
+    """
+    checks = runs = suites = 0
+    for team_id in _teams_with_history():
+        live = _live_subjects(team_id)
+        grace = now - timedelta(hours=SUBJECT_GRACE_HOURS)
+        checks += _delete_dead_checks(team_id, live, grace)
+        runs += _delete_dead_runs(team_id, live, grace)
+        suites += _delete_dead_suites(team_id, live, grace)
+        _heartbeat()
+    return CleanupOutcome(checks_deleted=checks, check_runs_deleted=runs, suite_runs_deleted=suites)
+
+
+def _teams_with_history() -> set[int]:
+    return {
+        team_id
+        for manager in (DataQualityCheck.objects, DataQualityCheckRun.objects, DataQualitySuiteRun.objects)
+        for team_id in manager.unscoped().values_list("team_id", flat=True).distinct()
+    }
+
+
+def _live_subjects(team_id: int) -> _LiveSubjects:
+    return _LiveSubjects(
+        table_ids=frozenset(warehouse_facade.all_queryable_table_names(team_id)),
+        view_ids=frozenset(UUID(view_id) for view_id in data_modeling_facade.all_saved_query_names(team_id)),
     )
+
+
+def _delete_dead_checks(team_id: int, live: _LiveSubjects, grace: datetime) -> int:
+    alive = live.alive_q(table_field="table_id", view_field="saved_query_id")
+    dead = DataQualityCheck.objects.for_team(team_id).filter(created_at__lt=grace).exclude(alive)
+    return _delete_in_batches(dead).get(DataQualityCheck._meta.label, 0)
+
+
+def _delete_dead_runs(team_id: int, live: _LiveSubjects, grace: datetime) -> int:
+    dead = DataQualityCheckRun.objects.for_team(team_id).filter(created_at__lt=grace).exclude(live.alive_q())
+    deleted = 0
+    while batch := list(dead.values_list("id", "suite_run_id", "status")[:RETENTION_DELETE_BATCH_SIZE]):
+        with transaction.atomic():
+            _decrement_suite_counters((suite_run_id, status) for _, suite_run_id, status in batch)
+            _, by_model = (
+                DataQualityCheckRun.objects.unscoped().filter(id__in=[run_id for run_id, _, _ in batch]).delete()
+            )
+        deleted += by_model.get(DataQualityCheckRun._meta.label, 0)
+        _heartbeat()
+    return deleted
+
+
+def _decrement_suite_counters(deleted: Iterable[tuple[UUID, str]]) -> None:
+    """Take each deleted run back out of its suite's outcome counters.
+
+    A sweep covers several subjects, so its suite survives one of them dying. Counters left at their
+    original totals would still report the deleted run, which is the count oracle over unreadable
+    rows this whole layer exists to close -- rebuilt by subtraction.
+    """
+    tally: dict[UUID, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for suite_run_id, status in deleted:
+        if column := _COUNTER_COLUMNS.get(status):
+            tally[suite_run_id][column] += 1
+    for suite_run_id, columns in tally.items():
+        DataQualitySuiteRun.objects.unscoped().filter(id=suite_run_id).update(
+            **{column: Greatest(F(column) - count, Value(0)) for column, count in columns.items()}
+        )
+
+
+def _delete_dead_suites(team_id: int, live: _LiveSubjects, grace: datetime) -> int:
+    backs_a_run = DataQualityCheckRun.objects.unscoped().filter(suite_run_id=OuterRef("id"))
+    dead = (
+        DataQualitySuiteRun.objects.for_team(team_id)
+        .filter(created_at__lt=grace, subject_uuid__isnull=False)
+        .exclude(live.alive_q())
+        .filter(~Exists(backs_a_run))
+    )
+    return _delete_in_batches(dead).get(DataQualitySuiteRun._meta.label, 0)

--- a/products/data_quality/backend/temporal/activities/cleanup.py
+++ b/products/data_quality/backend/temporal/activities/cleanup.py
@@ -181,7 +181,12 @@ def _delete_dead_checks(team_id: int, live: _LiveSubjects, grace: datetime) -> i
 
 
 def _delete_dead_runs(team_id: int, live: _LiveSubjects, grace: datetime) -> int:
-    dead = DataQualityCheckRun.objects.for_team(team_id).filter(created_at__lt=grace).exclude(live.alive_q())
+    dead = (
+        DataQualityCheckRun.objects.for_team(team_id)
+        .filter(created_at__lt=grace)
+        .exclude(suite_run__status=SuiteRunStatus.RUNNING)
+        .exclude(live.alive_q())
+    )
     deleted = 0
     while True:
         with transaction.atomic():

--- a/products/data_quality/backend/temporal/activities/cleanup.py
+++ b/products/data_quality/backend/temporal/activities/cleanup.py
@@ -52,8 +52,8 @@ def _delete_in_batches(queryset: "QuerySet[Any]") -> dict[str, int]:
     """Delete a queryset in id-batches, returning how many rows went per model label.
 
     One unbounded ``.delete()`` loads every matched row and everything that cascades with it into
-    Django's collector. Each suite drags its check runs in, so capping the parent rows per pass
-    bounds that memory whatever the reverse relations pull along.
+    Django's collector. Each run drags its subject rows in, and each suite its check runs, so capping
+    the parent rows per pass bounds that memory whatever the reverse relations pull along.
     """
     model = queryset.model
     totals: dict[str, int] = defaultdict(int)
@@ -87,6 +87,7 @@ def _cleanup() -> CleanupOutcome:
     expired_runs = runs.filter(created_at__lt=now - timedelta(days=CHECK_RUN_RETENTION_DAYS)).filter(
         Q(quality_check_id__isnull=True) | Exists(has_newer_run)
     )
+    # Count only the runs -- the subject rows that cascade with each one would otherwise inflate it.
     runs_deleted = _delete_in_batches(expired_runs).get(DataQualityCheckRun._meta.label, 0)
 
     backs_a_run = DataQualityCheckRun.objects.unscoped().filter(suite_run_id=OuterRef("id"))
@@ -182,15 +183,21 @@ def _delete_dead_checks(team_id: int, live: _LiveSubjects, grace: datetime) -> i
 def _delete_dead_runs(team_id: int, live: _LiveSubjects, grace: datetime) -> int:
     dead = DataQualityCheckRun.objects.for_team(team_id).filter(created_at__lt=grace).exclude(live.alive_q())
     deleted = 0
-    while batch := list(dead.values_list("id", "suite_run_id", "status")[:RETENTION_DELETE_BATCH_SIZE]):
+    while True:
         with transaction.atomic():
+            batch = list(
+                dead.select_for_update(skip_locked=True).values_list("id", "suite_run_id", "status")[
+                    :RETENTION_DELETE_BATCH_SIZE
+                ]
+            )
+            if not batch:
+                return deleted
             _decrement_suite_counters((suite_run_id, status) for _, suite_run_id, status in batch)
             _, by_model = (
                 DataQualityCheckRun.objects.unscoped().filter(id__in=[run_id for run_id, _, _ in batch]).delete()
             )
         deleted += by_model.get(DataQualityCheckRun._meta.label, 0)
         _heartbeat()
-    return deleted
 
 
 def _decrement_suite_counters(deleted: Iterable[tuple[UUID, str]]) -> None:

--- a/products/data_quality/backend/temporal/activities/finalize_check_suite.py
+++ b/products/data_quality/backend/temporal/activities/finalize_check_suite.py
@@ -19,6 +19,8 @@ async def finalize_check_suite_activity(inputs: FinalizeCheckSuiteInputs) -> Che
 
 def _finalize(inputs: FinalizeCheckSuiteInputs) -> CheckSuiteResult:
     suite_run = DataQualitySuiteRun.objects.for_team(inputs.team_id).get(id=inputs.suite_run_id)
+    if suite_run.status != SuiteRunStatus.RUNNING:
+        return _result(suite_run, inputs)
 
     suite_run.checks_passed = sum(outcome.passed for outcome in inputs.outcomes)
     suite_run.checks_failed = sum(outcome.failed for outcome in inputs.outcomes)
@@ -45,9 +47,13 @@ def _finalize(inputs: FinalizeCheckSuiteInputs) -> CheckSuiteResult:
         failed=suite_run.checks_failed,
         errored=suite_run.checks_errored,
     )
+    return _result(suite_run, inputs)
+
+
+def _result(suite_run: DataQualitySuiteRun, inputs: FinalizeCheckSuiteInputs) -> CheckSuiteResult:
     return CheckSuiteResult(
         suite_run_id=str(suite_run.id),
-        status=SuiteRunStatus.COMPLETED,
+        status=SuiteRunStatus(suite_run.status),
         checks_passed=suite_run.checks_passed,
         checks_failed=suite_run.checks_failed,
         checks_errored=suite_run.checks_errored,

--- a/products/data_quality/backend/temporal/contracts.py
+++ b/products/data_quality/backend/temporal/contracts.py
@@ -81,6 +81,7 @@ class MarkSuiteFailedInputs:
 @frozen
 class CleanupOutcome:
     compiled_queries_cleared: int = 0
+    checks_deleted: int = 0
     check_runs_deleted: int = 0
     suite_runs_deleted: int = 0
     stale_suites_failed: int = 0

--- a/products/data_quality/backend/temporal/workflows/cleanup.py
+++ b/products/data_quality/backend/temporal/workflows/cleanup.py
@@ -22,5 +22,8 @@ class CleanupCheckRunsWorkflow(PostHogWorkflow):
         return await workflow.execute_activity(
             cleanup_check_runs_activity,
             start_to_close_timeout=dt.timedelta(minutes=30),
+            # The sweep heartbeats per team and per delete batch; without a timeout to compare them
+            # against, those heartbeats are inert and a stuck pass holds the slot for the full 30.
+            heartbeat_timeout=dt.timedelta(minutes=5),
             retry_policy=RetryPolicy(maximum_attempts=3),
         )

--- a/products/data_quality/backend/tests/test_cleanup.py
+++ b/products/data_quality/backend/tests/test_cleanup.py
@@ -9,6 +9,7 @@ from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
 
+from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
 from products.data_quality.backend.facade.enums import (
     CheckRunStatus,
     CheckType,
@@ -21,6 +22,7 @@ from products.data_quality.backend.temporal.activities.cleanup import (
     CHECK_RUN_RETENTION_DAYS,
     COMPILED_QUERY_RETENTION_DAYS,
     STALE_SUITE_HOURS,
+    SUBJECT_GRACE_HOURS,
     SUITE_RUN_RETENTION_DAYS,
     _cleanup,
 )
@@ -31,19 +33,31 @@ BATCH_SIZE = "products.data_quality.backend.temporal.activities.cleanup.RETENTIO
 class TestRetentionSweep(BaseTest):
     def setUp(self) -> None:
         super().setUp()
-        self.check = DataQualityCheck.objects.for_team(self.team.id).create(
+        self.view = self._view("orders")
+        self.check = self._check(self.view)
+
+    def _view(self, name: str) -> DataWarehouseSavedQuery:
+        return DataWarehouseSavedQuery.objects.create(
+            team=self.team, name=name, query={"kind": "HogQLQuery", "query": "SELECT 1 AS id"}
+        )
+
+    def _check(self, view: DataWarehouseSavedQuery, *, age_days: float = 1) -> DataQualityCheck:
+        check = DataQualityCheck.objects.for_team(self.team.id).create(
             team=self.team,
             subject_type=SubjectType.VIEW,
-            saved_query_id=uuid4(),
-            subject_name="orders",
+            saved_query_id=view.id,
+            subject_name=view.name,
             check_type=CheckType.NOT_NULL,
             column_name="customer_id",
             fingerprint=uuid4().hex,
         )
+        return self._age(DataQualityCheck, check, age_days)
 
-    def _suite(self, *, age_days: float = 0, status: SuiteRunStatus = SuiteRunStatus.COMPLETED) -> DataQualitySuiteRun:
+    def _suite(
+        self, *, age_days: float = 0, status: SuiteRunStatus = SuiteRunStatus.COMPLETED, **kwargs
+    ) -> DataQualitySuiteRun:
         suite = DataQualitySuiteRun.objects.for_team(self.team.id).create(
-            team=self.team, trigger=SuiteRunTrigger.MANUAL, status=status
+            team=self.team, trigger=SuiteRunTrigger.MANUAL, status=status, **kwargs
         )
         return self._age(DataQualitySuiteRun, suite, age_days)
 
@@ -53,8 +67,8 @@ class TestRetentionSweep(BaseTest):
             "quality_check": self.check,
             "suite_run": kwargs.pop("suite_run", None) or self._suite(),
             "subject_type": SubjectType.VIEW,
-            "subject_uuid": uuid4(),
-            "subject_name": "orders",
+            "subject_uuid": self.view.id,
+            "subject_name": self.view.name,
             "check_type": CheckType.NOT_NULL,
             "check_fingerprint": uuid4().hex,
             "status": CheckRunStatus.PASSED,
@@ -163,3 +177,88 @@ class TestRetentionSweep(BaseTest):
         suite.refresh_from_db()
         assert suite.status == expected_status
         assert (suite.finished_at is not None) == (expected_status == SuiteRunStatus.FAILED)
+
+    def test_a_deleted_subject_takes_its_check_runs_and_single_subject_suites(self) -> None:
+        # Deleting a table or view takes its object-level denial with it, so nothing left can show a
+        # restricted member was allowed the rows this history reports on. The gates withhold it
+        # meanwhile; this is what ends that window.
+        doomed = self._view("temp_orders")
+        doomed_check = self._check(doomed)
+        doomed_suite = self._suite(age_days=1, subject_type=SubjectType.VIEW, subject_uuid=doomed.id)
+        doomed_run = self._run(age_days=1, quality_check=doomed_check, suite_run=doomed_suite, subject_uuid=doomed.id)
+        kept_suite = self._suite(age_days=1, subject_type=SubjectType.VIEW, subject_uuid=self.view.id)
+        kept_run = self._run(age_days=1, suite_run=kept_suite)
+        doomed.delete()
+
+        outcome = _cleanup()
+
+        assert outcome.checks_deleted == 1
+        assert not DataQualityCheck.objects.unscoped().filter(id=doomed_check.id).exists()
+        assert not DataQualityCheckRun.objects.unscoped().filter(id=doomed_run.id).exists()
+        assert not DataQualitySuiteRun.objects.unscoped().filter(id=doomed_suite.id).exists()
+        assert DataQualityCheck.objects.unscoped().filter(id=self.check.id).exists()
+        assert DataQualityCheckRun.objects.unscoped().filter(id=kept_run.id).exists()
+        assert DataQualitySuiteRun.objects.unscoped().filter(id=kept_suite.id).exists()
+
+    def test_rows_created_inside_the_grace_window_are_spared(self) -> None:
+        # A row written while the sweep runs postdates the snapshot of live subjects it is judged
+        # against, so it would read as pointing at a subject that does not exist.
+        fresh = self._view("temp_orders")
+        check = self._check(fresh, age_days=(SUBJECT_GRACE_HOURS - 0.5) / 24)
+        run = self._run(age_days=(SUBJECT_GRACE_HOURS - 0.5) / 24, quality_check=check, subject_uuid=fresh.id)
+        fresh.delete()
+
+        _cleanup()
+
+        assert DataQualityCheck.objects.unscoped().filter(id=check.id).exists()
+        assert DataQualityCheckRun.objects.unscoped().filter(id=run.id).exists()
+
+    def test_a_check_that_only_references_a_dead_subject_survives(self) -> None:
+        # Its own subject is alive, so an admin can still see it and repoint it. Deleting it because
+        # an unrelated view vanished would destroy a fixable check.
+        doomed = self._view("customers")
+        check = self._check(self.view)
+        DataQualityCheck.objects.unscoped().filter(id=check.id).update(
+            check_type=CheckType.CUSTOM_SQL, column_name="", config={"query": "SELECT 1 FROM customers"}
+        )
+        self._run(
+            age_days=1,
+            quality_check=check,
+            referenced_subjects=[{"subject_type": "view", "subject_uuid": str(doomed.id)}],
+        )
+        doomed.delete()
+
+        outcome = _cleanup()
+
+        assert outcome.checks_deleted == 0
+        assert DataQualityCheck.objects.unscoped().filter(id=check.id).exists()
+
+    def test_a_sweep_suite_gives_up_the_counters_of_the_runs_it_loses(self) -> None:
+        # The suite survives, because it covered a live subject too. Counters left at their original
+        # totals would still report the deleted run, which is the count oracle by subtraction.
+        doomed = self._view("temp_orders")
+        sweep = self._suite(age_days=1)
+        self._run(age_days=1, suite_run=sweep, status=CheckRunStatus.FAILED)
+        self._run(age_days=1, suite_run=sweep, subject_uuid=doomed.id, status=CheckRunStatus.FAILED)
+        self._run(age_days=1, suite_run=sweep, subject_uuid=doomed.id, status=CheckRunStatus.PASSED)
+        DataQualitySuiteRun.objects.unscoped().filter(id=sweep.id).update(checks_failed=2, checks_passed=1)
+        doomed.delete()
+
+        _cleanup()
+
+        sweep.refresh_from_db()
+        assert (sweep.checks_failed, sweep.checks_passed) == (1, 0)
+
+    def test_dead_subject_runs_are_deleted_one_batch_at_a_time(self) -> None:
+        doomed = self._view("temp_orders")
+        for _ in range(3):
+            self._run(age_days=1, subject_uuid=doomed.id)
+        doomed.delete()
+
+        with patch(BATCH_SIZE, 1), CaptureQueriesContext(connection) as queries:
+            outcome = _cleanup()
+
+        assert outcome.check_runs_deleted == 3
+        assert not DataQualityCheckRun.objects.unscoped().filter(subject_uuid=doomed.id).exists()
+        run_delete = f'DELETE FROM "{DataQualityCheckRun._meta.db_table}"'
+        assert sum(run_delete in query["sql"] for query in queries.captured_queries) == 3

--- a/products/data_quality/backend/tests/test_cleanup.py
+++ b/products/data_quality/backend/tests/test_cleanup.py
@@ -26,6 +26,7 @@ from products.data_quality.backend.temporal.activities.cleanup import (
     SUITE_RUN_RETENTION_DAYS,
     _cleanup,
 )
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 BATCH_SIZE = "products.data_quality.backend.temporal.activities.cleanup.RETENTION_DELETE_BATCH_SIZE"
 
@@ -227,6 +228,32 @@ class TestRetentionSweep(BaseTest):
             referenced_subjects=[{"subject_type": "view", "subject_uuid": str(doomed.id)}],
         )
         doomed.delete()
+
+        outcome = _cleanup()
+
+        assert outcome.checks_deleted == 0
+        assert DataQualityCheck.objects.unscoped().filter(id=check.id).exists()
+
+    def test_a_check_declared_on_a_materialized_view_backing_table_survives(self) -> None:
+        backing_table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name="orders_backing",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            url_pattern=f"s3://bucket/{self.view.folder_path}/{self.view.normalized_name}",
+        )
+        self.view.table = backing_table
+        self.view.is_materialized = True
+        self.view.save(update_fields=["table", "is_materialized"])
+        check = DataQualityCheck.objects.for_team(self.team.id).create(
+            team=self.team,
+            subject_type=SubjectType.TABLE,
+            table=backing_table,
+            subject_name=backing_table.name,
+            check_type=CheckType.NOT_NULL,
+            column_name="customer_id",
+            fingerprint=uuid4().hex,
+        )
+        self._age(DataQualityCheck, check, 1)
 
         outcome = _cleanup()
 

--- a/products/data_quality/backend/tests/test_cleanup.py
+++ b/products/data_quality/backend/tests/test_cleanup.py
@@ -1,10 +1,13 @@
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from threading import Event, Lock
+from uuid import UUID, uuid4
 
-from posthog.test.base import BaseTest
+from posthog.test.base import BaseTest, NonAtomicBaseTest
 from unittest.mock import patch
 
-from django.db import connection
+from django.db import close_old_connections, connection
 from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
@@ -18,6 +21,7 @@ from products.data_quality.backend.facade.enums import (
     SuiteRunTrigger,
 )
 from products.data_quality.backend.models import DataQualityCheck, DataQualityCheckRun, DataQualitySuiteRun
+from products.data_quality.backend.temporal.activities import cleanup as cleanup_module
 from products.data_quality.backend.temporal.activities.cleanup import (
     CHECK_RUN_RETENTION_DAYS,
     COMPILED_QUERY_RETENTION_DAYS,
@@ -25,6 +29,8 @@ from products.data_quality.backend.temporal.activities.cleanup import (
     SUBJECT_GRACE_HOURS,
     SUITE_RUN_RETENTION_DAYS,
     _cleanup,
+    _delete_dead_runs,
+    _LiveSubjects,
 )
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
@@ -214,6 +220,22 @@ class TestRetentionSweep(BaseTest):
         assert DataQualityCheck.objects.unscoped().filter(id=check.id).exists()
         assert DataQualityCheckRun.objects.unscoped().filter(id=run.id).exists()
 
+    def test_rows_with_an_unknown_subject_type_are_treated_as_dead(self) -> None:
+        suite = self._suite(age_days=1, subject_type=SubjectType.VIEW, subject_uuid=self.view.id)
+        run = self._run(age_days=1, suite_run=suite)
+        DataQualityCheck.objects.unscoped().filter(id=self.check.id).update(subject_type="future_subject")
+        DataQualityCheckRun.objects.unscoped().filter(id=run.id).update(subject_type="future_subject")
+        DataQualitySuiteRun.objects.unscoped().filter(id=suite.id).update(subject_type="future_subject")
+
+        outcome = _cleanup()
+
+        assert outcome.checks_deleted == 1
+        assert outcome.check_runs_deleted == 1
+        assert outcome.suite_runs_deleted == 1
+        assert not DataQualityCheck.objects.unscoped().filter(id=self.check.id).exists()
+        assert not DataQualityCheckRun.objects.unscoped().filter(id=run.id).exists()
+        assert not DataQualitySuiteRun.objects.unscoped().filter(id=suite.id).exists()
+
     def test_a_check_that_only_references_a_dead_subject_survives(self) -> None:
         # Its own subject is alive, so an admin can still see it and repoint it. Deleting it because
         # an unrelated view vanished would destroy a fixable check.
@@ -289,3 +311,68 @@ class TestRetentionSweep(BaseTest):
         assert not DataQualityCheckRun.objects.unscoped().filter(subject_uuid=doomed.id).exists()
         run_delete = f'DELETE FROM "{DataQualityCheckRun._meta.db_table}"'
         assert sum(run_delete in query["sql"] for query in queries.captured_queries) == 3
+
+
+class TestDeadRunCleanupConcurrency(NonAtomicBaseTest):
+    def test_overlapping_sweeps_decrement_a_suite_once_for_each_deleted_run(self) -> None:
+        suite = DataQualitySuiteRun.objects.for_team(self.team.id).create(
+            team=self.team,
+            trigger=SuiteRunTrigger.MANUAL,
+            status=SuiteRunStatus.COMPLETED,
+            checks_failed=2,
+        )
+        run = DataQualityCheckRun.objects.for_team(self.team.id).create(
+            team=self.team,
+            suite_run=suite,
+            subject_type=SubjectType.VIEW,
+            subject_uuid=uuid4(),
+            subject_name="deleted_orders",
+            check_type=CheckType.NOT_NULL,
+            check_fingerprint=uuid4().hex,
+            status=CheckRunStatus.FAILED,
+        )
+        DataQualityCheckRun.objects.unscoped().filter(id=run.id).update(
+            created_at=datetime.now(UTC) - timedelta(days=1)
+        )
+        live = _LiveSubjects(table_ids=frozenset(), view_ids=frozenset())
+        grace = datetime.now(UTC) - timedelta(hours=SUBJECT_GRACE_HOURS)
+        first_at_decrement = Event()
+        second_progressed = Event()
+        call_lock = Lock()
+        decrement_calls = 0
+        decrement_suite_counters = cleanup_module._decrement_suite_counters
+
+        def coordinate_decrement(deleted: Iterable[tuple[UUID, str]]) -> None:
+            nonlocal decrement_calls
+            with call_lock:
+                decrement_calls += 1
+                call_number = decrement_calls
+            if call_number == 1:
+                first_at_decrement.set()
+                assert second_progressed.wait(timeout=5)
+            else:
+                second_progressed.set()
+            decrement_suite_counters(deleted)
+
+        def run_cleanup(*, signal_completion: bool = False) -> int:
+            close_old_connections()
+            try:
+                return _delete_dead_runs(self.team.id, live, grace)
+            finally:
+                if signal_completion:
+                    second_progressed.set()
+                close_old_connections()
+
+        with (
+            patch.object(cleanup_module, "_decrement_suite_counters", side_effect=coordinate_decrement),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            first_sweep = executor.submit(run_cleanup)
+            assert first_at_decrement.wait(timeout=5)
+            second_sweep = executor.submit(run_cleanup, signal_completion=True)
+            deleted = first_sweep.result(timeout=10) + second_sweep.result(timeout=10)
+
+        suite.refresh_from_db()
+        assert deleted == 1
+        assert suite.checks_failed == 1
+        assert not DataQualityCheckRun.objects.unscoped().filter(id=run.id).exists()

--- a/products/data_quality/backend/tests/test_cleanup.py
+++ b/products/data_quality/backend/tests/test_cleanup.py
@@ -298,6 +298,24 @@ class TestRetentionSweep(BaseTest):
         sweep.refresh_from_db()
         assert (sweep.checks_failed, sweep.checks_passed) == (1, 0)
 
+    def test_dead_subject_runs_wait_for_a_running_suite_to_finish(self) -> None:
+        doomed = self._view("temp_orders")
+        suite = self._suite(status=SuiteRunStatus.RUNNING, checks_failed=1)
+        run = self._run(
+            age_days=1,
+            suite_run=suite,
+            subject_uuid=doomed.id,
+            status=CheckRunStatus.FAILED,
+        )
+        doomed.delete()
+
+        outcome = _cleanup()
+
+        suite.refresh_from_db()
+        assert outcome.check_runs_deleted == 0
+        assert DataQualityCheckRun.objects.unscoped().filter(id=run.id).exists()
+        assert suite.checks_failed == 1
+
     def test_dead_subject_runs_are_deleted_one_batch_at_a_time(self) -> None:
         doomed = self._view("temp_orders")
         for _ in range(3):

--- a/products/data_quality/backend/tests/test_run_check_suite.py
+++ b/products/data_quality/backend/tests/test_run_check_suite.py
@@ -208,6 +208,25 @@ class TestCheckSuiteActivities(BaseTest):
         assert result.checks_failed_blocking == 1
         assert result.status == SuiteRunStatus.COMPLETED
 
+    def test_finalize_retry_preserves_counters_adjusted_after_completion(self) -> None:
+        prepared = self._prepare()
+        suite_run = DataQualitySuiteRun.objects.for_team(self.team.id).get(id=prepared.suite_run_id)
+        suite_run.status = SuiteRunStatus.COMPLETED
+        suite_run.checks_failed = 1
+        suite_run.save(update_fields=["status", "checks_failed", "updated_at"])
+
+        result = _finalize(
+            FinalizeCheckSuiteInputs(
+                team_id=self.team.id,
+                suite_run_id=prepared.suite_run_id,
+                outcomes=[BatchOutcome(failed=2, failed_blocking=2)],
+            )
+        )
+
+        suite_run.refresh_from_db()
+        assert result.checks_failed == 1
+        assert suite_run.checks_failed == 1
+
 
 class TestRunCheckSuiteWorkflow(BaseTest):
     def _run(self, prepared: PreparedSuite, activity_results: list) -> tuple[CheckSuiteResult, AsyncMock]:


### PR DESCRIPTION
## Problem

Restricted members cannot see data quality history after its warehouse subject is deleted, but that hidden history remains stored for the full retention window.

The parent PR #89690 hides these rows because deleting a table or view also removes its object-level access control. Nothing currently removes the rows.

Admins see the same rows as dead weight: checks that cannot run and history whose subject name cannot resolve.

## Changes

- The nightly sweep deletes checks, runs, and single-subject suites whose declared subject no longer exists.
- Restricted members lose the hidden rows within about a day. Admins lose the same history on the same schedule.
- Check-run retention drops from 365 days to 90 days, matching suite retention.
- Multi-subject suites survive one subject deletion, and their counters drop only for deleted runs.
- Cleanup waits for running suites to finish before deleting their runs.
- Finalization retries preserve stored terminal counters instead of replaying stale batch outcomes.
- Overlapping cleanup attempts claim dead runs under row locks, so surviving suite counters decrement once per deleted run.
- Materialized-view backing tables remain live to cleanup, although the parent PR excludes them from non-admin authorization snapshots.
- The activity heartbeats after each team and delete batch. The workflow gives missing heartbeats a timeout.
- Unknown future subject kinds fail closed and cleanup deletes their aged rows.

A check whose declared subject remains live survives when only a referenced subject disappears. An admin can still repoint that fixable check.

Rows younger than one hour survive because they can postdate the sweep's live-subject snapshot.

Each batch commits before the next starts. Counter updates and run deletion share one transaction.

> [!WARNING]
> This PR permanently deletes rows across every team on a schedule. It remains separate from #89690 so the deletion receives an independent review.

### Cursor measurement

Complete-loop PostgreSQL benchmarks compared each repeated-slice loop with its UUID keyset alternative on identical reset fixtures.

| Complete loop | Repeated slice | UUID keyset |
|---|---:|---:|
| Generic retention time | 73.5 ms | 139.7 ms |
| Generic retention buffers | 74,148 | 153,973 |
| Dead-subject time | 200.7 ms | 179.4 ms |
| Dead-subject buffers | 205,718 | 286,057 |

Both cursor alternatives remain omitted. The generic cursor regressed both dimensions, while the dead-subject cursor used 39% more buffers.

## How did you test this code?

Automated only. No manual testing.

- Deleted subjects remove aged checks, runs, and single-subject suites while live-subject rows remain.
- Rows inside the grace window survive.
- Checks that only reference a dead subject survive.
- Materialized-view backing-table checks survive cleanup.
- Unknown subject kinds delete across checks, runs, and subject-scoped suites.
- Multi-subject suite counters lose only deleted runs.
- Running suites keep dead-subject runs until finalization.
- Finalization retries preserve counters that cleanup adjusted after completion.
- Two overlapping sweeps delete and decrement the same run exactly once.
- Batched retention and dead-subject cleanup issue one target-model `DELETE` per non-empty batch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The product is behind a feature flag and does not document this retention window.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote the original second stack layer. Codex added the backing-table guard, lifecycle protections, complete-loop cursor measurements, and overlap-safe row claiming.

Skills invoked: `/writing-tests`, `/stacking-prs`, `/writing-pr-descriptions`, and the systematic debugging and verification skills from Superpowers.

The assignee chose deleted-subject cleanup, 90-day retention, and preservation of checks that only reference dead subjects. All benchmark data was seeded locally and removed.

