### PR TITLE
feat(product-empty-states): preview any empty state with ?empty_state=1

### DIFF
--- a/.agents/skills/building-product-empty-states/SKILL.md
+++ b/.agents/skills/building-product-empty-states/SKILL.md
@@ -121,6 +121,8 @@ Add one story per mode to `lib/components/ProductEmptyState/ProductEmptyState.st
 
 ## QA checklist
 
+Add `?empty_state=1` to the scene URL to pull up the setup screen on a project that already has data - it overrides detection and a local skip, and `?empty_state=waiting-for-data` gives you the other mode. Check the list below through that param rather than emptying a project.
+
 - Dark mode, reduced motion (`prefers-reduced-motion`), self-hosted (no wizard terminal).
 - Loading never flashes the real scene or the empty dashboard.
 - Skip → scene renders immediately, persists across reload, "Set up" banner shows, onboarding redirect suppressed.

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyStateGate.test.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyStateGate.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { kea, path } from 'kea'
+import { router } from 'kea-router'
+
+import { useMocks } from '~/mocks/jest'
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import { ProductEmptyStateGate } from './ProductEmptyStateGate'
+import { productSetupStatusLogic } from './productSetupStatusLogic'
+import type { ProductEmptyStateConfig, SceneProductEmptyState } from './types'
+
+const config: ProductEmptyStateConfig = {
+    productKey: ProductKey.EXPERIMENTS,
+    productName: 'Experiments',
+    icon: <span />,
+    accentColor: 'red',
+    text: { 'needs-setup': { headline: 'Set up experiments', lead: 'Lead' } },
+    previewLabel: 'Preview',
+    Preview: () => <div />,
+}
+
+const noopStatusLogic = kea([path(['lib', 'components', 'ProductEmptyState', 'testNoopStatusLogic'])])
+
+const emptyState: SceneProductEmptyState = { config, statusLogic: noopStatusLogic }
+
+describe('ProductEmptyStateGate', () => {
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/_preflight/': { cloud: false },
+                '/api/environments/@current/': {},
+                '/api/users/@me/': {},
+            },
+        })
+        initKeaTests()
+        productSetupStatusLogic({ productKey: ProductKey.EXPERIMENTS }).mount()
+        productSetupStatusLogic({ productKey: ProductKey.EXPERIMENTS }).actions.setDetectedStatus('has-data')
+    })
+
+    afterEach(() => cleanup())
+
+    // `?empty_state` exists so anyone can review the setup screen on a project that already
+    // has data. Matching it too loosely would hide a real scene from a normal URL, so the
+    // off cases matter as much as the on ones.
+    it.each([
+        ['?empty_state=1', true],
+        ['?empty_state', true],
+        ['?empty_state=waiting-for-data', true],
+        ['?empty_state=0', false],
+        ['', false],
+    ])('renders the setup screen for %s: %s', (search, expectedForced) => {
+        router.actions.push(`/experiments${search}`)
+
+        render(
+            <ProductEmptyStateGate emptyState={emptyState}>
+                <div>the real scene</div>
+            </ProductEmptyStateGate>
+        )
+
+        expect(!!screen.queryByText('Set up experiments')).toBe(expectedForced)
+        expect(!!screen.queryByText('the real scene')).toBe(!expectedForced)
+    })
+})

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyStateGate.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyStateGate.tsx
@@ -1,4 +1,5 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
+import { router } from 'kea-router'
 import type { ReactNode } from 'react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -13,7 +14,28 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductEmptyState } from './ProductEmptyState'
 import { productSetupStatusLogic } from './productSetupStatusLogic'
 import { SetupReminderContext } from './setupReminderContext'
-import type { ProductEmptyStateConfig, SceneProductEmptyState } from './types'
+import type { ProductEmptyStateConfig, ProductEmptyStateMode, SceneProductEmptyState } from './types'
+
+/**
+ * Search param that puts the setup screen on a scene that already has data, so anyone can
+ * review an empty state without emptying a project. `?empty_state=1` shows the `needs-setup`
+ * screen, `?empty_state=waiting-for-data` shows the other mode, and dropping the param
+ * returns the real scene.
+ */
+export const EMPTY_STATE_PARAM = 'empty_state'
+
+function forcedModeFromParam(value: unknown): ProductEmptyStateMode | null {
+    if (value === 'waiting-for-data') {
+        return 'waiting-for-data'
+    }
+    // kea-router parses search params before we see them, so `?empty_state=1` arrives as the
+    // number 1 and a bare `?empty_state` as null. Match those forms exactly rather than any
+    // truthy value, so a param we don't recognize leaves the real scene alone.
+    if (value === null || value === 1 || value === true || value === '1' || value === 'true') {
+        return 'needs-setup'
+    }
+    return null
+}
 
 export interface ProductEmptyStateGateProps {
     emptyState: SceneProductEmptyState
@@ -29,6 +51,9 @@ export interface ProductEmptyStateGateProps {
  * Mounts the product's detection logic, which pushes its normalized status into
  * `productSetupStatusLogic`. Wired automatically by the app shell for scenes that
  * declare `emptyState` on their `SceneExport`.
+ *
+ * `?empty_state=1` on any gated scene forces the setup screen regardless of status,
+ * so the screen can be reviewed on a project that already has data.
  */
 export function ProductEmptyStateGate({ emptyState, children }: ProductEmptyStateGateProps): JSX.Element {
     const { featureFlags } = useValues(featureFlagLogic)
@@ -48,6 +73,8 @@ function ProductEmptyStateGateInner({ emptyState, children }: ProductEmptyStateG
     const { status, skipped, mode } = useValues(setupLogic)
     const { unskipEmptyState } = useActions(setupLogic)
     const { featureFlags } = useValues(featureFlagLogic)
+    const { searchParams } = useValues(router)
+    const forcedMode = forcedModeFromParam(searchParams[EMPTY_STATE_PARAM])
 
     // A lingering local skip is ignored for non-skippable products (the button may have been
     // shown before the product opted out of skipping). Derived once, because the empty-state
@@ -55,6 +82,16 @@ function ProductEmptyStateGateInner({ emptyState, children }: ProductEmptyStateG
     // render the bare scene with neither the setup screen nor the reminder banner, and a
     // non-skippable product has no button left to clear the stored flag with.
     const skipHonored = skipped && config.skippable !== false
+
+    // Forcing wins over skip, over the detected status, and over detection still loading.
+    // The whole point is to see the screen on a project that would never show it on its own.
+    if (forcedMode) {
+        return (
+            <ProductSceneFrame config={config}>
+                <ProductEmptyState config={config} mode={forcedMode} />
+            </ProductSceneFrame>
+        )
+    }
 
     if (skipHonored) {
         // Skip bypasses the screen, not detection: render the scene, plus a "Set up" reminder

--- a/frontend/src/lib/components/ProductEmptyState/README.md
+++ b/frontend/src/lib/components/ProductEmptyState/README.md
@@ -10,6 +10,8 @@ Most detection logics are one call to `createSetupDetectionLogic` (`setupDetecti
 
 Products detectable from event definitions also declare a `setupProbe` in their manifest, which `productSetupPreloadLogic` answers at app boot with one batched request — so the status is usually known before the scene is ever opened. Probes support a `staleAfterDays` window for products where old, abandoned data shouldn't count as set up.
 
+To review an empty state on a project that already has data, add `?empty_state=1` to the scene URL. It forces the `needs-setup` screen past detection and past a local skip, `?empty_state=waiting-for-data` forces the other mode, and dropping the param gives the real scene back. Use it for design review and screenshots instead of clearing a project.
+
 **To adopt this for your product, follow the `building-product-empty-states` skill** (`.agents/skills/building-product-empty-states/SKILL.md`). Reference adoption: `products/mcp_analytics/frontend/emptyState/`.
 
 `ProductIntroduction` is deprecated in favor of this component.


### PR DESCRIPTION
## Problem

Anyone reviewing a product's setup empty state has to find or build a project with no data for that product. Most PostHog projects have data, so these screens get looked at once when they ship and then drift unnoticed.

The gate that decides between the setup screen and the real scene reads only detected status, so there is no way to ask for the screen directly.

## Changes

- `?empty_state=1` on any scene that has an empty state now shows that scene's setup screen, whatever the project holds.
- `?empty_state=waiting-for-data` shows the other mode, for products with an "installed but no traffic yet" state.
- Dropping the param returns the real scene. Nothing is written to the backend or to localStorage.
- The override sits in `ProductEmptyStateGate`, the single component every gated scene passes through, so it covers all of them with no per-product wiring.
- Forcing beats a local skip and beats the loading spinner, so the screen renders on the first paint rather than after detection answers.

Nothing looks different without the param. The screen the param shows is the existing empty state, unchanged, so there is no before-and-after to show.

The `README.md` and `SKILL.md` edits are documentation only.

> [!NOTE]
> A flag-gated empty state still needs its flag. The param sits inside the gate's flag check, and in every current case that flag also gates the scene itself.

## How did you test this code?

`ProductEmptyStateGate.test.tsx` is new. It renders the gate against a `has-data` status and asserts which of the two screens appears, across five URLs.

The regression it catches: kea-router parses search params before the gate reads them, so `?empty_state=1` arrives as the number `1` and a bare `?empty_state` as `null`. A matcher written against the string `'1'` silently does nothing, and a matcher written as a truthiness check hides the real scene from `?empty_state=0`. The off cases are in the table for that second reason.

Not checked: the param against a running dev stack. The dev server was not up in this session, and the assertions above run in jest instead.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The two docs that describe this platform are updated in this PR: `frontend/src/lib/components/ProductEmptyState/README.md` and the `building-product-empty-states` skill's QA checklist.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.

The param started as a throwaway local edit for reviewing the empty states in the stack at #91050, and became a shipped feature at the reviewer's request. Two decisions worth flagging: the matcher is an explicit allowlist rather than a truthiness check, so an unrecognized value leaves the real scene alone; and the force branch is placed after the gate's feature-flag check rather than before it, so a flag-gated empty state stays invisible while its flag is off.

Nothing in this PR comes from a non-public source.
