### PR TITLE
feat(replay-vision): collapse the prompt on the observation page

### DIFF
--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react'
 import {
     IconArrowLeft,
     IconArrowRight,
+    IconChevronRight,
     IconClock,
     IconCollapse,
     IconExpand,
@@ -22,6 +23,7 @@ import { dayjs } from 'lib/dayjs'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
+import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyDuration, humanFriendlyMilliseconds } from 'lib/utils/durations'
 import { SceneExport } from 'scenes/sceneTypes'
 import { SessionRecordingPlayer } from 'scenes/session-recordings/player/SessionRecordingPlayer'
@@ -107,6 +109,34 @@ function AutoSeekToTime({
         seekedForTrigger.current = trigger
     }, [startMs, endMs, ms, trigger, playerKey, sessionRecordingId])
     return null
+}
+
+// A reader opens an observation for the result, not the prompt they configured. Collapse the prompt to one
+// peek line so the verdict and reasoning stay above the fold.
+function PromptRow({ prompt }: { prompt: string }): JSX.Element {
+    const [expanded, setExpanded] = useState(false)
+    return (
+        <div>
+            <button
+                type="button"
+                className="flex items-center gap-0.5 text-xs text-muted mb-0.5 hover:text-default"
+                onClick={() => setExpanded(!expanded)}
+                aria-expanded={expanded}
+                data-attr="vision-observation-prompt-toggle"
+            >
+                <IconChevronRight className={cn('transition-transform', expanded && 'rotate-90')} />
+                Prompt
+            </button>
+            <p
+                className={cn(
+                    'text-sm m-0 leading-snug',
+                    expanded ? 'text-default whitespace-pre-wrap' : 'text-muted line-clamp-1'
+                )}
+            >
+                {prompt}
+            </p>
+        </div>
+    )
 }
 
 export function ReplayObservationSceneComponent(): JSX.Element {
@@ -391,11 +421,6 @@ export function ReplayObservationSceneComponent(): JSX.Element {
                                     <ScannerTypeBadge scannerType={scannerType} />
                                 </LabeledRow>
                             )}
-                            {prompt && scannerType !== 'summarizer' && (
-                                <LabeledRow label="Prompt">
-                                    <p className="text-sm text-default m-0 leading-snug">{prompt}</p>
-                                </LabeledRow>
-                            )}
                             <LabeledRow label={scannerType ? SUCCEEDED_OUTPUT_LABEL[scannerType] : ''}>
                                 <ObservationPrimaryOutput
                                     observation={observation}
@@ -404,6 +429,7 @@ export function ReplayObservationSceneComponent(): JSX.Element {
                                     copyable
                                 />
                             </LabeledRow>
+                            {prompt && scannerType !== 'summarizer' && <PromptRow prompt={prompt} />}
                             {observation.completed_at && (
                                 <LabeledRow label="Event">
                                     <Link to={urls.event(observation.id, observation.completed_at)}>


### PR DESCRIPTION
## Problem

Someone opening a Replay Vision observation wants the verdict and the model's reasoning. Today the Result card leads with the full scanner prompt, which is config they already wrote, so a long prompt pushes the actual result below the fold.

## Changes

- The prompt now sits below the result as a single clamped line. Clicking it expands the full text; clicking again collapses it.
- The result and the Categories/Verdict/Score row are the first thing in the card.
- Summarizers are unchanged, since they never showed the prompt here.

| Collapsed (default) | Expanded |
| --- | --- |
| ![Result card with the prompt collapsed to one line](https://raw.githubusercontent.com/PostHog/pr-assets/b0aa727fe4380dbc4ce3b6c373af8bf0ad29977e/2026/08/8b160bb5-3b18-4c27-83e7-ef53b804cefe.png) | ![Result card with the prompt expanded](https://raw.githubusercontent.com/PostHog/pr-assets/b0aa727fe4380dbc4ce3b6c373af8bf0ad29977e/2026/08/978d6ef5-01e1-43a6-a027-9587a15efa13.png) |

## How did you test this code?

Rendered in Storybook and captured above. The screenshots come from a monitor-observation story added in the PR stacked on top of this one, since the existing `ObservationDetail` story uses a summarizer, which never showed the prompt.

Typecheck, oxlint, and oxfmt are clean on the changed file. No automated test was added: this is presentation-only, and the collapse state is local component state with no logic to assert against.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog Desktop task. The direction asked for the prompt to be minimized but still expandable, on the reasoning that the result is the interesting part.

Two decisions worth a reviewer's attention: the prompt was moved below the primary output rather than left in place, because collapsing alone still leaves config ahead of the answer; and the toggle is a plain clickable label with a rotating chevron rather than `LemonCollapse`, to match the existing expand pattern in this same file and keep the row visually identical to its `LabeledRow` neighbors.

An earlier revision of this description claimed the scene could not be rendered because the local quill workspace build was broken. That was wrong — the workspace simply had not been built yet, and it compiles fine. The screenshots above replace that claim.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
