### PR TITLE
fix(kafka): size the consumer-v2 rebalance test timeout to its wait budgets

### DIFF
--- a/nodejs/src/common/kafka/consumer/consumer-v2.rebalance.integration.serial.test.ts
+++ b/nodejs/src/common/kafka/consumer/consumer-v2.rebalance.integration.serial.test.ts
@@ -44,7 +44,13 @@ import { KafkaConsumerV2 } from './consumer-v2'
  * assigned offset is kept; all expectations are derived from those reports, never assumed.
  */
 
-jest.setTimeout(60_000)
+// These tests wait on real broker timers (the 6s session/rebalance timeout, deliberately
+// slow revoke hooks) and each step polls with its own generous upper bound. Those bounds
+// sum to 50-96s per test, so the per-test timeout must sit above the largest sum or a
+// slow runner hits Jest's timeout while a step is still legitimately waiting; that leaves
+// a consumer mid-rebalance, which --forceExit then blocks on. The step-level waitFor
+// budgets stay tight so a real regression still fails with a descriptive error.
+jest.setTimeout(150_000)
 
 const KAFKA_HOSTS = process.env.KAFKA_HOSTS ?? 'kafka:9092'
 const KAFKA_CONFIG = { 'metadata.broker.list': KAFKA_HOSTS }


### PR DESCRIPTION
## Problem

`consumer-v2.rebalance.integration.serial.test.ts` fails intermittently in `Node.js serial Tests` with `Exceeded timeout of 60000 ms for a test`, and when it does the job then hangs until GitHub cancels it (~40 min of runner time). Seen on PostHog/posthog#90492 ([run](https://github.com/PostHog/posthog/actions/runs/33211659965/job/98986609945)) in a test that touches nothing near this code.

The tests wait on real broker timers (6 s session/rebalance timeout, deliberately slow revoke hooks) and poll each step with a generous upper bound. Summing each test's `waitFor` budgets: six of the nine tests allow 66–96 s, while the file sets `jest.setTimeout(60_000)`. So on a slow shard a test can be killed by Jest while a step is still legitimately waiting. The killed test leaves a librdkafka consumer mid-rebalance, and `--forceExit` then blocks on it — that is the hang after "Force exiting Jest". The file normally completes in ~88 s on `master`; the failing run took 134 s.

## Changes

- `jest.setTimeout` for this file raised from 60 s to 150 s, above the largest per-test wait budget (96 s), with a comment carrying the arithmetic. The step-level `waitFor` budgets are unchanged, so a real regression still fails quickly with a descriptive error rather than a Jest timeout.

## How did you test this code?

- `eslint` and `oxfmt --check` on the file.
- Not run locally (needs the Kafka stack); the change only raises the file's timeout. Wait budgets per test were computed from the file's `waitFor`/`delay` calls (58, 66+8, 76, 78, 53, 78+2, 76, 96, 51+4 s).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

n/a

## 🤖 Agent context

Diagnosed and drafted with Claude Code while landing #90492. https://claude.ai/code/session_017iLTktHudqwbLq1NRWhTdu
