### PR TITLE
chore(persons): correct docs describing the uuid index

### DIFF
--- a/.agents/skills/adding-personhog-rpc/references/database-indexes.md
+++ b/.agents/skills/adding-personhog-rpc/references/database-indexes.md
@@ -10,20 +10,27 @@ All indexes below are sourced from `rust/persons_migrations/` SQL files — the 
 Partitioned by `team_id` (64 hash partitions).
 Primary key is composite `(team_id, id)`.
 
-| Index name                    | Type   | Columns           | Notes                                                     |
-| ----------------------------- | ------ | ----------------- | --------------------------------------------------------- |
-| `posthog_person_new_pkey`     | PK     | `(team_id, id)`   | Partition-pruned lookup                                   |
-| `posthog_person_new_uuid_idx` | UNIQUE | `(team_id, uuid)` | Partition-pruned uuid lookup                              |
-| `posthog_person_p{i}_id_idx`  | INDEX  | `(id)`            | Per-partition index on id (64 indexes, one per partition) |
+| Index name                         | Type   | Columns           | Notes                                                                                                               |
+| ---------------------------------- | ------ | ----------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `posthog_person_new_pkey`          | PK     | `(team_id, id)`   | Partition-pruned lookup                                                                                             |
+| `posthog_person_team_id_uuid_uniq` | UNIQUE | `(team_id, uuid)` | Partition-pruned uuid lookup. **Named `posthog_person_new_uuid_idx` in migration-built databases** — see note below |
+| `posthog_person_p{i}_id_idx`       | INDEX  | `(id)`            | Per-partition index on id (64 indexes, one per partition)                                                           |
+
+> **The uuid index has two names.** `rust/persons_migrations/20251113000001` creates it as
+> `posthog_person_new_uuid_idx` (the table was `posthog_person_new` then, and `ALTER TABLE ... RENAME`
+> does not rename indexes). prod-US and prod-EU carry the same index as
+> `posthog_person_team_id_uuid_uniq`, built out-of-band in 2026-08 and enforcing from then on.
+> Both are UNIQUE on `(team_id, uuid)`, so query plans are identical — but **do not reference either
+> name in a migration or a query hint**, because neither exists in every environment.
 
 Constraints: `check_properties_size` — `pg_column_size(properties) <= 655360` (on old unpartitioned table; `personhog_person_tmp` has equivalent).
 
 **Typical query patterns:**
 
 - `WHERE team_id = $1 AND id = $2` → PK scan
-- `WHERE team_id = $1 AND uuid = $2` → `posthog_person_new_uuid_idx` (partition-pruned)
+- `WHERE team_id = $1 AND uuid = $2` → unique `(team_id, uuid)` index (partition-pruned)
 - `WHERE team_id = $1 AND id = ANY($2)` → PK scan
-- `WHERE team_id = $1 AND uuid = ANY($2)` → `posthog_person_new_uuid_idx` scan
+- `WHERE team_id = $1 AND uuid = ANY($2)` → unique `(team_id, uuid)` index scan
 
 ## posthog_persondistinctid
 

--- a/nodejs/src/common/persons/repositories/postgres-person-repository-stranded-claim.serial.test.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository-stranded-claim.serial.test.ts
@@ -15,11 +15,12 @@ import { TEST_TIMESTAMP, fetchDistinctIdValues, getFirstTeam } from './test-help
 
 jest.mock('~/common/utils/logger')
 
-// Production does NOT have the unique (team_id, uuid) index the tracked schema declares
-// (posthog_person_new_uuid_idx is non-unique in both prod regions), which is what lets
-// duplicate persons exist there at all. The tests below recreate that reality; with the
-// tracked schema's unique index in place, the duplicate scenarios cannot even be seeded
-// and every claim test would pass vacuously.
+// The tracked schema's UNIQUE (team_id, uuid) index blocks the duplicate rows these tests
+// seed, so the index is recreated non-unique for the fixture. Production enforces uniqueness,
+// which is why the claim path matters: a stranded person (one no distinct ID resolves to) still
+// holds its uuid, and a returning user derives that same uuid, so the insert hits a constraint
+// violation the claim path has to resolve. Without the fixture every claim test would pass
+// vacuously.
 async function makeUuidIndexNonUnique(postgres: PostgresRouter): Promise<void> {
     const { rows } = await postgres.query(
         PostgresUse.PERSONS_WRITE,

--- a/posthog/management/commands/test/test_persons_dedup.py
+++ b/posthog/management/commands/test/test_persons_dedup.py
@@ -22,11 +22,11 @@ pytestmark = pytest.mark.django_db
 
 TEAM = 987654
 
-# The test database is built from rust/persons_migrations, which declares
-# posthog_person_new_uuid_idx as UNIQUE. Production does not have it -- that divergence
-# is the entire reason this command exists, and it means the test database physically
-# rejects the duplicate rows we need to seed. Recreate the index non-unique so the
-# fixture holds what production holds, and restore it afterwards.
+# The test database declares a UNIQUE (team_id, uuid) index, so it physically rejects the
+# duplicate rows these tests need to seed. Drop to a non-unique index for the fixture and
+# restore it afterwards. The duplicates this command repairs accumulated while production
+# carried a non-unique index. Production enforces uniqueness, so the command operates on
+# historical rows rather than newly created ones.
 DROP_UNIQUE_UUID_INDEX = "DROP INDEX IF EXISTS posthog_person_new_uuid_idx"
 CREATE_NON_UNIQUE_UUID_INDEX = "CREATE INDEX posthog_person_new_uuid_idx ON posthog_person (team_id, uuid)"
 RESTORE_UNIQUE_UUID_INDEX = "CREATE UNIQUE INDEX posthog_person_new_uuid_idx ON posthog_person (team_id, uuid)"


### PR DESCRIPTION
## Problem

An engineer designing a personhog RPC reads `database-indexes.md` to check their `WHERE` clause hits an index. For uuid lookups the page names `posthog_person_new_uuid_idx`. That index does not exist in production, so anyone who trusts the page and references it by name — in a migration, a query hint, or a comment — writes something that fails there.

Two test files assert the reverse: that production has no unique `(team_id, uuid)` index. It has one, in both regions.

## Changes

- The index reference now names `posthog_person_team_id_uuid_uniq`, which is what production carries.
- The typical-query-pattern lines say "unique `(team_id, uuid)` index" instead of naming one index, because the name differs by environment.
- A note explains that the index has two names, and that neither should be referenced by name in a migration or query hint.
- Two stale test comments corrected. Mechanical: comment text only, no test logic touched.

The index has two names because `rust/persons_migrations/20251113000001` created it as `posthog_person_new_uuid_idx` when the table was still `posthog_person_new`, and `ALTER TABLE ... RENAME` does not rename indexes.

**No index DDL and no migration.** The tracked schema already declares this index `UNIQUE`, so dev and CI behaviour is unchanged. A migration that dropped the old name would leave migration-built databases with no `(team_id, uuid)` index at all.

## How did you test this code?

No automated tests were added — this changes documentation and two comments, and there is no behaviour to regress.

What I ran:

- `ruff check` and `ruff format --check` on the changed Python file: pass.
- `prettier --check` on the changed TypeScript file: pass.
- lint-staged on commit ran `hogli format:markdown`, `format:nodejs`, `lint:python:fix`, `format:python` and `ty check`: all pass.
- Verified the diff touches only comments and documentation, no executable lines.

I did not run the two affected test suites. Both force their own index state at runtime and neither reads the comments, so the change cannot affect them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This is the docs update.

## 🤖 Agent context

Written while completing the `(team_id, uuid)` unique index rollout on the persons database. Production now enforces uniqueness in both regions under the `posthog_person_team_id_uuid_uniq` name, which is what made the reference page wrong.

The reviewer question worth answering: should the tracked schema converge on the production name? I argue no in this PR. The schema already declares the index `UNIQUE`, so the invariant holds; adding DDL to rename it would change dev and CI for no correctness gain, and every shape I considered breaks the two test files that drop this index by name to seed duplicate fixtures.
