### PR TITLE
fix(mcp-analytics): improve paginated tool quality table

### DIFF
--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/AccountTrackRules.stories.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/AccountTrackRules.stories.tsx
@@ -67,6 +67,7 @@ const meta: Meta = {
             FEATURE_FLAGS.CUSTOMER_ANALYTICS_TRACK_RULES,
         ],
         pageUrl: `${urls.customerAnalyticsConfiguration()}?tab=customer-analytics-track-rules`,
+        mockDate: '2026-08-29T12:00:00Z',
         testOptions: {
             waitForSelector: '[data-attr="account-track-rules"]',
         },

--- a/products/mcp_analytics/backend/hogql_queries/tool_quality_tables.py
+++ b/products/mcp_analytics/backend/hogql_queries/tool_quality_tables.py
@@ -85,8 +85,9 @@ def _named_tool_where(
     categories: list[str] | None,
     *,
     tool_name: str | None = None,
+    search: str | None = None,
 ) -> ast.Expr:
-    """WHERE for tool-name-bearing $mcp_tool_call events in the window, filtered by category/tool."""
+    """Apply tool-name filters before aggregation so non-matching events skip the percentile and distinct aggregates."""
     exprs: list[ast.Expr] = [
         parse_expr("event = {event}", placeholders={"event": ast.Constant(value=MCP_TOOL_CALL_EVENT)}),
         parse_expr("timestamp >= {date_from}", placeholders={"date_from": date_range.date_from_as_hogql()}),
@@ -102,6 +103,16 @@ def _named_tool_where(
                 placeholders={
                     "effective_tool": parse_expr(EFFECTIVE_TOOL_SQL),
                     "tool": ast.Constant(value=tool_name),
+                },
+            )
+        )
+    if search:
+        exprs.append(
+            parse_expr(
+                "positionCaseInsensitive({effective_tool}, {search}) > 0",
+                placeholders={
+                    "effective_tool": parse_expr(EFFECTIVE_TOOL_SQL),
+                    "search": ast.Constant(value=search),
                 },
             )
         )
@@ -149,7 +160,6 @@ class MCPToolQualityRowsQueryRunner(AnalyticsQueryRunner[MCPToolQualityRowsQuery
             FROM events
             WHERE {where}
             GROUP BY tool
-            HAVING positionCaseInsensitive(tool, {search}) > 0
             ORDER BY total_calls DESC, tool ASC
             LIMIT {limit}
             OFFSET {offset}
@@ -160,8 +170,7 @@ class MCPToolQualityRowsQueryRunner(AnalyticsQueryRunner[MCPToolQualityRowsQuery
                 "_P50": parse_expr(_P50),
                 "_P95": parse_expr(_P95),
                 "_P99": parse_expr(_P99),
-                "where": _named_tool_where(self.query_date_range, self.query.categories),
-                "search": ast.Constant(value=search),
+                "where": _named_tool_where(self.query_date_range, self.query.categories, search=search),
                 "limit": ast.Constant(value=limit),
                 "offset": ast.Constant(value=offset),
             },

--- a/products/mcp_analytics/backend/tests/test_tool_quality_tables.py
+++ b/products/mcp_analytics/backend/tests/test_tool_quality_tables.py
@@ -17,6 +17,8 @@ from posthog.schema import (
     MCPToolQualityRowsQueryResponse,
 )
 
+from posthog.hogql import ast
+
 from products.access_control.backend.facade.user_access_control import UserAccessControlError
 from products.mcp_analytics.backend.hogql_queries.tool_quality_tables import (
     MCPToolCategoriesQueryRunner,
@@ -113,10 +115,12 @@ class TestMCPToolQualityRowsQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Clickh
             query=MCPToolQualityRowsQuery(dateRange=DateRange(date_from="-7d"), limit=2, offset=100),
             team=self.team,
         ).calculate()
-        searched = MCPToolQualityRowsQueryRunner(
+        searched_runner = MCPToolQualityRowsQueryRunner(
             query=MCPToolQualityRowsQuery(dateRange=DateRange(date_from="-7d"), search="TARGET", limit=1),
             team=self.team,
-        ).calculate()
+        )
+        searched_query = searched_runner.to_query()
+        searched = searched_runner.calculate()
         highest_error_rate = MCPToolQualityRowsQueryRunner(
             query=MCPToolQualityRowsQuery(
                 dateRange=DateRange(date_from="-7d"),
@@ -133,6 +137,8 @@ class TestMCPToolQualityRowsQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Clickh
         assert last_page.totalCount == 3
         assert out_of_range_page.results == []
         assert out_of_range_page.totalCount == 3
+        assert isinstance(searched_query, ast.SelectQuery)
+        assert searched_query.having is None
         assert [row.tool for row in searched.results] == ["rare_target"]
         assert searched.totalCount == 1
         assert [row.tool for row in highest_error_rate.results] == ["rare_target"]

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
@@ -222,9 +222,11 @@ describe('mcpAnalyticsToolQualityLogic', () => {
             logic.actions.setToolQualityPageIndex(1)
 
             expect(logic.values.toolRowsPageLoading).toBe(true)
+            expect(logic.values.loadedToolQualityPageIndex).toBe(0)
             expect(logic.values.toolRows.map((row) => row.tool)).toEqual(['page-one-tool'])
 
             await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.loadedToolQualityPageIndex).toBe(1)
             expect(logic.values.toolRows.map((row) => row.tool)).toEqual(['page-two-tool'])
         })
 

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.test.ts
@@ -205,6 +205,29 @@ describe('mcpAnalyticsToolQualityLogic', () => {
             expect(logic.values.selectedTool).toBe('tool_a')
         })
 
+        it('keeps the current rows visible while another page loads', async () => {
+            mockApi.query.mockImplementation(async (query: any) => {
+                if (query.kind !== NodeKind.MCPToolQualityRowsQuery) {
+                    return { results: [] }
+                }
+                const tool = query.offset === 0 ? 'page-one-tool' : 'page-two-tool'
+                return { ...emptyToolRowsResponse, results: [toolRowResult(tool)], totalCount: 100 }
+            })
+            const logic = mcpAnalyticsToolQualityLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.toolRows.map((row) => row.tool)).toEqual(['page-one-tool'])
+
+            logic.actions.setToolQualityPageIndex(1)
+
+            expect(logic.values.toolRowsPageLoading).toBe(true)
+            expect(logic.values.toolRows.map((row) => row.tool)).toEqual(['page-one-tool'])
+
+            await expectLogic(logic).toFinishAllListeners()
+            expect(logic.values.toolRows.map((row) => row.tool)).toEqual(['page-two-tool'])
+        })
+
         it('sends search, global sort, and page offsets to the rows query', async () => {
             mockApi.query.mockImplementation(async (query: any) =>
                 query.kind === NodeKind.MCPToolQualityRowsQuery

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolQualityLogic.ts
@@ -50,6 +50,10 @@ export interface DateFilter {
     dateTo: string | null
 }
 
+interface ToolRowsPage extends MCPToolQualityRowsQueryResponse {
+    pageIndex: number
+}
+
 // Carry the selected window across navigation as date_from / date_to, plus the grouping interval
 // when one is pinned, mirroring the tab's actionToUrl. Only set them when present so a cleared range
 // and an auto interval stay out of the URL.
@@ -138,6 +142,7 @@ export interface mcpAnalyticsToolQualityLogicValues {
     incompleteTail: boolean
     interval: IntervalType
     intervalOptions: IntervalOption[]
+    loadedToolQualityPageIndex: number
     pinnedInterval: IntervalType | null
     scopeShare: ScopeShare
     searchTerm: string
@@ -146,7 +151,7 @@ export interface mcpAnalyticsToolQualityLogicValues {
     toolQualityPageIndex: number
     toolQualitySort: SortState
     toolRows: MCPToolQualityRowItem[]
-    toolRowsPage: MCPToolQualityRowsQueryResponse | null
+    toolRowsPage: ToolRowsPage | null
     toolRowsPageLoading: boolean
     toolRowsTotalCount: number
 }
@@ -207,10 +212,10 @@ export interface mcpAnalyticsToolQualityLogicActions {
         errorObject?: any
     }
     loadToolRowsPageSuccess: (
-        toolRowsPage: MCPToolQualityRowsQueryResponse,
+        toolRowsPage: ToolRowsPage,
         payload?: void
     ) => {
-        toolRowsPage: MCPToolQualityRowsQueryResponse
+        toolRowsPage: ToolRowsPage
         payload?: void
     }
     reloadAll: () => {
@@ -254,8 +259,9 @@ export interface mcpAnalyticsToolQualityLogicMeta {
         intervalOptions: (dateFilter: DateFilter, timezone: string) => IntervalOption[]
         interval: (dateFilter: DateFilter, pinnedInterval: IntervalType | null, timezone: string) => IntervalType
         scopeShare: (categoryCounts: CategoryCount[], selectedCategories: string[]) => ScopeShare
-        toolRows: (toolRowsPage: MCPToolQualityRowsQueryResponse | null) => MCPToolQualityRowItem[]
-        toolRowsTotalCount: (toolRowsPage: MCPToolQualityRowsQueryResponse | null) => number
+        loadedToolQualityPageIndex: (toolRowsPage: ToolRowsPage | null) => number
+        toolRows: (toolRowsPage: ToolRowsPage | null) => MCPToolQualityRowItem[]
+        toolRowsTotalCount: (toolRowsPage: ToolRowsPage | null) => number
         dailyChartData: (
             dailyStats: DailyToolStat[],
             dateFilter: DateFilter,
@@ -362,10 +368,11 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
             },
         ],
         toolRowsPage: [
-            null as MCPToolQualityRowsQueryResponse | null,
+            null as ToolRowsPage | null,
             {
-                loadToolRowsPage: async (_: void, breakpoint): Promise<MCPToolQualityRowsQueryResponse> => {
+                loadToolRowsPage: async (_: void, breakpoint): Promise<ToolRowsPage> => {
                     await breakpoint(300)
+                    const pageIndex = values.toolQualityPageIndex
                     const response = (await api.query({
                         kind: NodeKind.MCPToolQualityRowsQuery,
                         dateRange: { date_from: values.dateFilter.dateFrom, date_to: values.dateFilter.dateTo },
@@ -374,10 +381,10 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                         sortColumn: values.toolQualitySort.column,
                         sortDirection: values.toolQualitySort.direction,
                         limit: TOOL_QUALITY_PAGE_SIZE,
-                        offset: values.toolQualityPageIndex * TOOL_QUALITY_PAGE_SIZE,
+                        offset: pageIndex * TOOL_QUALITY_PAGE_SIZE,
                     })) as MCPToolQualityRowsQueryResponse
                     breakpoint()
-                    return response
+                    return { ...response, pageIndex }
                 },
             },
         ],
@@ -439,14 +446,17 @@ export const mcpAnalyticsToolQualityLogic = kea<mcpAnalyticsToolQualityLogicType
                 return { inScope, total, pct: total > 0 ? (inScope / total) * 100 : null }
             },
         ],
+        loadedToolQualityPageIndex: [
+            (s) => [s.toolRowsPage],
+            (toolRowsPage: ToolRowsPage | null): number => toolRowsPage?.pageIndex ?? 0,
+        ],
         toolRows: [
             (s) => [s.toolRowsPage],
-            (toolRowsPage: MCPToolQualityRowsQueryResponse | null): MCPToolQualityRowItem[] =>
-                toolRowsPage?.results ?? [],
+            (toolRowsPage: ToolRowsPage | null): MCPToolQualityRowItem[] => toolRowsPage?.results ?? [],
         ],
         toolRowsTotalCount: [
             (s) => [s.toolRowsPage],
-            (toolRowsPage: MCPToolQualityRowsQueryResponse | null): number => toolRowsPage?.totalCount ?? 0,
+            (toolRowsPage: ToolRowsPage | null): number => toolRowsPage?.totalCount ?? 0,
         ],
         dailyChartData: [
             (s) => [s.dailyStats, s.dateFilter, s.interval, teamLogic.selectors.timezone],

--- a/products/mcp_analytics/frontend/tool-quality/ToolQualityTable.tsx
+++ b/products/mcp_analytics/frontend/tool-quality/ToolQualityTable.tsx
@@ -71,7 +71,6 @@ const SORTABLE_COLUMNS: ColumnSpec[] = [
     { key: 'last_seen', label: 'Last seen' },
 ]
 
-// Tool column + every sortable column + the trailing "Full report" action.
 const COLUMN_COUNT = SORTABLE_COLUMNS.length + 2
 
 function ErrorRateBadge({ pct }: { pct: number }): JSX.Element {
@@ -179,12 +178,19 @@ function ToolRows(): JSX.Element {
 }
 
 export function ToolQualityTable(): JSX.Element {
-    const { toolQualitySort, toolQualityPageIndex, toolRows, toolRowsPageLoading, toolRowsTotalCount, searchTerm } =
-        useValues(mcpAnalyticsToolQualityLogic)
+    const {
+        toolQualitySort,
+        toolQualityPageIndex,
+        loadedToolQualityPageIndex,
+        toolRows,
+        toolRowsPageLoading,
+        toolRowsTotalCount,
+        searchTerm,
+    } = useValues(mcpAnalyticsToolQualityLogic)
     const { setToolQualitySort, setToolQualityPageIndex, setSearchTerm } = useActions(mcpAnalyticsToolQualityLogic)
     const pageCount = Math.max(Math.ceil(toolRowsTotalCount / TOOL_QUALITY_PAGE_SIZE), 1)
     const pageRange = getPaginationRange(pageCount, toolQualityPageIndex)
-    const firstRow = toolRowsTotalCount === 0 ? 0 : toolQualityPageIndex * TOOL_QUALITY_PAGE_SIZE + 1
+    const firstRow = toolRowsTotalCount === 0 ? 0 : loadedToolQualityPageIndex * TOOL_QUALITY_PAGE_SIZE + 1
     const lastRow = Math.min(firstRow + toolRows.length - 1, toolRowsTotalCount)
 
     return (

--- a/products/mcp_analytics/frontend/tool-quality/ToolQualityTable.tsx
+++ b/products/mcp_analytics/frontend/tool-quality/ToolQualityTable.tsx
@@ -1,6 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconSearch } from '@posthog/icons'
+import { LemonSkeleton } from '@posthog/lemon-ui'
 import {
     Badge,
     Button,
@@ -127,7 +128,13 @@ function ToolRows(): JSX.Element {
         return (
             <TableBody>
                 <TableRow>
-                    <TableCell colSpan={COLUMN_COUNT} className="h-32" />
+                    <TableCell colSpan={COLUMN_COUNT}>
+                        <div className="space-y-2 py-1">
+                            {Array.from({ length: 6 }).map((_, i) => (
+                                <LemonSkeleton key={i} className="h-3.5 w-full" />
+                            ))}
+                        </div>
+                    </TableCell>
                 </TableRow>
             </TableBody>
         )

--- a/products/mcp_analytics/frontend/tool-quality/ToolQualityTable.tsx
+++ b/products/mcp_analytics/frontend/tool-quality/ToolQualityTable.tsx
@@ -1,7 +1,6 @@
 import { useActions, useValues } from 'kea'
 
 import { IconSearch } from '@posthog/icons'
-import { LemonSkeleton } from '@posthog/lemon-ui'
 import {
     Badge,
     Button,
@@ -20,6 +19,7 @@ import {
     PaginationItem,
     PaginationNext,
     PaginationPrevious,
+    Spinner,
     Table,
     TableBody,
     TableCell,
@@ -71,7 +71,7 @@ const SORTABLE_COLUMNS: ColumnSpec[] = [
     { key: 'last_seen', label: 'Last seen' },
 ]
 
-// Tool column + every sortable column + the trailing "Full report" action, for the skeleton-row colSpan
+// Tool column + every sortable column + the trailing "Full report" action.
 const COLUMN_COUNT = SORTABLE_COLUMNS.length + 2
 
 function ErrorRateBadge({ pct }: { pct: number }): JSX.Element {
@@ -124,17 +124,11 @@ function ToolRows(): JSX.Element {
         useValues(mcpAnalyticsToolQualityLogic)
     const { setSelectedTool } = useActions(mcpAnalyticsToolQualityLogic)
 
-    if (toolRowsPageLoading) {
+    if (toolRowsPageLoading && toolRows.length === 0) {
         return (
             <TableBody>
                 <TableRow>
-                    <TableCell colSpan={COLUMN_COUNT}>
-                        <div className="space-y-2 py-1">
-                            {Array.from({ length: 6 }).map((_, i) => (
-                                <LemonSkeleton key={i} className="h-3.5 w-full" />
-                            ))}
-                        </div>
-                    </TableCell>
+                    <TableCell colSpan={COLUMN_COUNT} className="h-32" />
                 </TableRow>
             </TableBody>
         )
@@ -212,25 +206,32 @@ export function ToolQualityTable(): JSX.Element {
                     />
                 </InputGroup>
             </CardHeader>
-            <Table fullWidth stickyHeader className="max-h-[44rem]">
-                <TableHeader>
-                    <TableRow>
-                        <TableHead expand>Tool</TableHead>
-                        {SORTABLE_COLUMNS.map((column) => (
-                            <SortableHead
-                                key={column.key}
-                                column={column}
-                                sort={toolQualitySort}
-                                loading={toolRowsPageLoading}
-                                onSort={setToolQualitySort}
-                            />
-                        ))}
-                        <TableHead />
-                    </TableRow>
-                </TableHeader>
-                <ToolRows />
-            </Table>
-            {!toolRowsPageLoading && toolRowsTotalCount > 0 && (
+            <div className="relative">
+                <Table fullWidth stickyHeader className="max-h-[44rem]" aria-busy={toolRowsPageLoading}>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead expand>Tool</TableHead>
+                            {SORTABLE_COLUMNS.map((column) => (
+                                <SortableHead
+                                    key={column.key}
+                                    column={column}
+                                    sort={toolQualitySort}
+                                    loading={toolRowsPageLoading}
+                                    onSort={setToolQualitySort}
+                                />
+                            ))}
+                            <TableHead />
+                        </TableRow>
+                    </TableHeader>
+                    <ToolRows />
+                </Table>
+                {toolRowsPageLoading ? (
+                    <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60">
+                        <Spinner className="size-5" />
+                    </div>
+                ) : null}
+            </div>
+            {toolRowsTotalCount > 0 && (
                 <CardFooter className="flex flex-row flex-wrap items-center justify-between gap-2 border-t border-border">
                     <Text size="xs" variant="muted" render={<span />} className="tabular-nums">
                         {firstRow}-{lastRow} of {pluralize(toolRowsTotalCount, 'tool')}
@@ -240,7 +241,7 @@ export function ToolQualityTable(): JSX.Element {
                             <PaginationContent>
                                 <PaginationItem>
                                     <PaginationPrevious
-                                        disabled={toolQualityPageIndex === 0}
+                                        disabled={toolRowsPageLoading || toolQualityPageIndex === 0}
                                         onClick={() => setToolQualityPageIndex(toolQualityPageIndex - 1)}
                                         data-attr="mcp-tool-quality-page-previous"
                                     />
@@ -254,6 +255,7 @@ export function ToolQualityTable(): JSX.Element {
                                         <PaginationItem key={item}>
                                             <PaginationButton
                                                 isActive={item === toolQualityPageIndex}
+                                                disabled={toolRowsPageLoading}
                                                 aria-label={`Go to page ${item + 1}`}
                                                 onClick={() => setToolQualityPageIndex(item)}
                                                 data-attr="mcp-tool-quality-page"
@@ -265,7 +267,7 @@ export function ToolQualityTable(): JSX.Element {
                                 )}
                                 <PaginationItem>
                                     <PaginationNext
-                                        disabled={toolQualityPageIndex === pageCount - 1}
+                                        disabled={toolRowsPageLoading || toolQualityPageIndex === pageCount - 1}
                                         onClick={() => setToolQualityPageIndex(toolQualityPageIndex + 1)}
                                         data-attr="mcp-tool-quality-page-next"
                                     />


### PR DESCRIPTION
## Problem

Tool Quality users lose context during table requests, and searches aggregate non-matching tool calls before filtering them.

[#90981](https://github.com/PostHog/posthog/pull/90981) added server pagination but reused the initial-load skeleton for every request.

## Changes

- Tool Quality keeps resolved rows and pagination visible while the next result set loads.
- A subtle overlay and spinner communicate pending table requests.
- Tool-name search now filters matching calls before percentile, user, and session aggregation.
- Exact filtered totals continue to determine the page count.
- Screenshot not included because browser validation requires interactive Coder authentication unavailable in the agent session.

Before:

```mermaid
flowchart LR
    A[Tool call events] --> B[Aggregate every tool]
    B --> C[Filter the search]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
    class C phRed;
```

After:

```mermaid
flowchart LR
    A[Tool call events] --> B[Filter the search]
    B --> C[Aggregate matching tools]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phRed;
    class C phBlue;
```

## How did you test this code?

- The frontend logic test guards stale rows and page ranges during pending requests.
- The ClickHouse-backed test guards case-insensitive search, exact totals, and pre-aggregation filtering.
- Ran the focused frontend test, frontend typecheck, frontend formatter, backend test file, Ruff lint, and Ruff format checks.
- The emitted SQL places search in `WHERE` before `GROUP BY` and omits `HAVING`.
- Production query performance was not benchmarked.
- Manual browser testing was not completed because the Devbox route requires interactive Coder authentication.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes existing table loading and query execution without changing the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested loading behavior, corrected the loaded-page footer, and moved search filtering before aggregation.

Skills invoked: `debugging-mcp-analytics`, `optimizing-clickhouse-and-hogql-queries`, `writing-clickhouse-queries`, `writing-tests`, `writing-code-comments`, `writing-ui-components`, `writing-kea-logics`, `qa-frontend`, `writing-pr-descriptions`, and `setting-up-devbox`.
