### PR TITLE
feat(code): prepare glm-5.3 for rollout

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/session/models.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/models.test.ts
@@ -196,7 +196,7 @@ describe("getEffortOptions", () => {
     ["claude-sonnet-4-6", ["low", "medium", "high"]],
     ["claude-opus-4-7", ["low", "medium", "high", "xhigh", "max", "ultracode"]],
     ["@cf/zai-org/glm-5.2", ["high", "max"]],
-    ["zai-org/glm-5.3", ["high", "max"]],
+    ["zai-org/glm-5.3", ["low", "high", "max"]],
     ["zai-org/glm-5.3-flash", ["high", "max"]],
   ])("returns the exact effort levels for %s", (modelId, expected) => {
     expect(getEffortOptions(modelId)?.map((o) => o.value)).toEqual(expected);

--- a/products/desktop/packages/agent/src/adapters/claude/session/models.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/models.ts
@@ -88,7 +88,7 @@ const MODEL_EFFORT_LEVELS: Readonly<Record<string, readonly EffortLevel[]>> = {
   "claude-sonnet-5": EXTENDED_EFFORT_LEVELS,
   "claude-fable-5": EXTENDED_EFFORT_LEVELS,
   "@cf/zai-org/glm-5.2": ["high", "max"],
-  "zai-org/glm-5.3": ["high", "max"],
+  "zai-org/glm-5.3": ["low", "high", "max"],
   "zai-org/glm-5.3-flash": ["high", "max"],
 };
 

--- a/products/desktop/packages/shared/src/reasoning-effort.test.ts
+++ b/products/desktop/packages/shared/src/reasoning-effort.test.ts
@@ -13,6 +13,7 @@ describe("isSupportedReasoningEffort", () => {
     ["claude", "@cf/zai-org/glm-5.2", "medium", false],
     ["claude", "zai-org/glm-5.3", "high", true],
     ["claude", "zai-org/glm-5.3", "max", true],
+    ["claude", "zai-org/glm-5.3", "low", true],
     ["claude", "zai-org/glm-5.3", "medium", false],
     ["claude", "zai-org/glm-5.3-flash", "high", true],
     ["claude", "zai-org/glm-5.3-flash", "medium", false],

--- a/products/desktop/packages/shared/src/reasoning-effort.ts
+++ b/products/desktop/packages/shared/src/reasoning-effort.ts
@@ -37,7 +37,7 @@ const CLAUDE_MODEL_EFFORTS: Readonly<
   "claude-sonnet-5": EXTENDED_EFFORTS,
   "claude-fable-5": EXTENDED_EFFORTS,
   "@cf/zai-org/glm-5.2": ["high", "max"],
-  "zai-org/glm-5.3": ["high", "max"],
+  "zai-org/glm-5.3": ["low", "high", "max"],
   "zai-org/glm-5.3-flash": ["high", "max"],
   "claude-opus-5": EXTENDED_EFFORTS,
 };

--- a/services/llm-gateway/PARITY.md
+++ b/services/llm-gateway/PARITY.md
@@ -49,8 +49,8 @@ Existing Django callers should use `build_openai_client`, `build_async_openai_cl
 For PostHog Desktop, the Python gateway maps Django credential rejections to generic access denials. Transport, server, and malformed-response failures remain retryable service errors.
 
 Flag-gated open-weight models added to the Python gateway under the freeze stay there for the same reason.
-`zai-org/glm-5.3-flash` is Baseten-exclusive, gated by the `posthog-code-glm-53-flash-model` flag, and reachable only by the `posthog_code` and `review_hog` products.
-Its callers are PostHog Desktop and PostHog Code, so the model depends on the OAuth application allowlists, the request-selected project validated against OAuth scope and live organization membership, the billing policy, and the per-model access flags named in the first row above.
+`zai-org/glm-5.3` and `zai-org/glm-5.3-flash` are Baseten-exclusive, gated independently, and reachable only by the `posthog_code` and `review_hog` products.
+Their callers are PostHog Desktop and PostHog Code, so the models depend on the OAuth application allowlists, the request-selected project validated against OAuth scope and live organization membership, the billing policy, and the per-model access flags named in the first row above.
 The Go catalog serves GLM 5.2 only, and Baseten on Go still depends on the provider deployment check below.
 
 ### 🔎 Verify before switching
@@ -97,10 +97,10 @@ Run `/migrating-llm-gateway-callers` to inventory and convert a caller.
 
 Run `/auditing-llm-gateway-parity` after either gateway changes auth, attribution, billing, endpoints, providers, models, routing, or event metadata. The skill audits implementation sources in both repositories and updates this file without migrating callers.
 
-Last verified on 2026-08-27 against:
+Last verified on 2026-08-28 against:
 
-- `PostHog/posthog` working tree compared with master at `88997b515b337b2482814df60c132f60d5de5be4`
-- `PostHog/ai-gateway` main at `37ee8bca725a13bca71e40b36f916765f625f939`
+- `PostHog/posthog` working tree compared with master at `098981e3715839d18ca101da92da57aaf66a495b`
+- `PostHog/ai-gateway` main at `c529392ff89ea6c5767362ac35dd3ee601f16e20`
 
 ## References
 

--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -217,8 +217,7 @@ The gateway exposes models consistently across Anthropic Messages, chat/completi
 - **GLM 5.2** (`@cf/zai-org/glm-5.2`) can run on Cloudflare Workers AI, Modal, or Baseten.
 - **GLM 5.3** (`zai-org/glm-5.3`) runs only on Baseten and is available to ReviewHog and PostHog Desktop behind its own `posthog-code-glm-53-model` flag.
   Deliberately not `tasks-glm-baseten-inference`: that one only moves GLM 5.2 traffic onto Baseten, so sharing it would grant 5.3 by proxy the moment 5.2 routing changed.
-  GLM 5.3 has no open weights released yet, so the flag is not created: the access gate fails closed, keeping the model blocked server-side and hidden in every picker.
-  Do not create the flag until Baseten lists the model and the deployment slug, context window, and contract rate in `model_cost_overrides.py` / `model_registry.py` are confirmed against `inference.baseten.co/v1/models`: the rate is pinned, so a wrong placeholder bills at the wrong price with no automatic correction.
+  The contract rate, 1M context window, and low/high/max reasoning efforts come from the Baseten listing and are pinned in the gateway and desktop model registries.
 - **GLM 5.3 Flash** (`zai-org/glm-5.3-flash`) runs only on Baseten and is available to ReviewHog and PostHog Desktop behind its own `posthog-code-glm-53-flash-model` flag.
   Contract rate and 1M context window come from the Baseten listing and are pinned in `model_cost_overrides.py` / `model_registry.py`.
 - **DeepSeek V4 Flash** (`deepseek-ai/deepseek-v4-flash-0731`) runs only on Baseten and is available to ReviewHog and PostHog Desktop (client-gated by the `posthog-code-deepseek-model` flag).

--- a/services/llm-gateway/src/llm_gateway/inference_routing.py
+++ b/services/llm-gateway/src/llm_gateway/inference_routing.py
@@ -61,13 +61,15 @@ from llm_gateway.modal_routing import send_modal_request
 
 LlmCall = Callable[..., Awaitable[Any]]
 
-GLM_REASONING_EFFORTS: frozenset[str] = frozenset({"high", "max"})
+GLM_REASONING_EFFORTS: dict[str, frozenset[str]] = {
+    BASETEN_PUBLIC_MODEL: frozenset({"high", "max"}),
+    BASETEN_GLM53_PUBLIC_MODEL: frozenset({"low", "high", "max"}),
+    BASETEN_GLM53_FLASH_PUBLIC_MODEL: frozenset({"high", "max"}),
+}
 
 # GLM models across all backends: these need the Claude-runtime reasoning rewrite on the
 # Anthropic surface regardless of which provider serves them.
-GLM_MODELS: frozenset[str] = frozenset(
-    {BASETEN_PUBLIC_MODEL, BASETEN_GLM53_PUBLIC_MODEL, BASETEN_GLM53_FLASH_PUBLIC_MODEL}
-)
+GLM_MODELS: frozenset[str] = frozenset(GLM_REASONING_EFFORTS)
 
 
 def is_inference_routed_model(model: str) -> bool:
@@ -88,8 +90,10 @@ def normalize_glm_anthropic_request(request_data: dict[str, Any], *, product: st
     normalized = dict(request_data)
     output_config = normalized.get("output_config")
     effort = output_config.get("effort") if isinstance(output_config, dict) else None
+    model = str(normalized.get("model", "")).strip().lower()
+    supported_efforts = GLM_REASONING_EFFORTS.get(model)
 
-    if effort in GLM_REASONING_EFFORTS:
+    if supported_efforts is not None and effort in supported_efforts:
         normalized["thinking"] = {"type": "adaptive"}
 
     return drop_orphaned_clear_thinking(normalized, product=product)

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
@@ -38,9 +38,7 @@ BASETEN_GLM_COST: Final[ModelCost] = {
     "supports_prompt_caching": True,
 }
 
-# Placeholder: the GLM 5.2 contract rate, pending Baseten listing GLM 5.3. The pin below
-# blocks any automatic correction, so confirm the real contract rate here BEFORE creating
-# the posthog-code-glm-53-model flag (see the README's GLM 5.3 go-live note).
+# Pricing verified against Baseten's GLM 5.3 listing.
 BASETEN_GLM53_COST: Final[ModelCost] = {
     "litellm_provider": "baseten",
     "mode": "chat",

--- a/services/llm-gateway/src/llm_gateway/services/model_registry.py
+++ b/services/llm-gateway/src/llm_gateway/services/model_registry.py
@@ -33,8 +33,7 @@ _CLOUDFLARE_PROVIDER: Final[str] = "cloudflare"
 _CLOUDFLARE_DEFAULT_CONTEXT_WINDOW: Final[int] = 128_000
 _BASETEN_CONTEXT_WINDOWS: Final[dict[str, int]] = {
     BASETEN_DEEPSEEK_PUBLIC_MODEL: 1_048_000,
-    # Placeholder pending confirmation against the Baseten deployment.
-    BASETEN_GLM53_PUBLIC_MODEL: 200_000,
+    BASETEN_GLM53_PUBLIC_MODEL: 1_000_000,
     BASETEN_GLM53_FLASH_PUBLIC_MODEL: 1_000_000,
 }
 

--- a/services/llm-gateway/tests/test_inference_routing.py
+++ b/services/llm-gateway/tests/test_inference_routing.py
@@ -225,14 +225,23 @@ async def test_deepseek_does_not_apply_glm_anthropic_normalization() -> None:
     assert handle.call_args.kwargs["request_data"] == request
 
 
-@pytest.mark.parametrize("model", [GLM53_MODEL, GLM53_FLASH_MODEL])
-async def test_baseten_exclusive_glm_still_applies_anthropic_normalization(model: str) -> None:
+@pytest.mark.parametrize(
+    ("model", "effort"),
+    [
+        (GLM53_MODEL, "low"),
+        (GLM53_MODEL, "high"),
+        (GLM53_MODEL, "max"),
+        (GLM53_FLASH_MODEL, "high"),
+        (GLM53_FLASH_MODEL, "max"),
+    ],
+)
+async def test_baseten_exclusive_glm_still_applies_anthropic_normalization(model: str, effort: str) -> None:
     # A Baseten-exclusive GLM is still a GLM: the Claude-runtime reasoning rewrite must apply.
     handle = AsyncMock(return_value={"ok": True})
     request = {
         "model": model,
         "messages": [{"role": "user", "content": "hi"}],
-        "output_config": {"effort": "high"},
+        "output_config": {"effort": effort},
     }
 
     await _send(_settings(baseten_api_key="baseten-key"), handle, request_data=request)

--- a/services/llm-gateway/tests/test_model_registry.py
+++ b/services/llm-gateway/tests/test_model_registry.py
@@ -385,7 +385,7 @@ class TestBasetenModelAdvertising:
         ("model_id", "context_window", "allowed_products"),
         [
             ("deepseek-ai/deepseek-v4-flash-0731", 1_048_000, ("review_hog", "posthog_code")),
-            ("zai-org/glm-5.3", 200_000, ("review_hog", "posthog_code")),
+            ("zai-org/glm-5.3", 1_000_000, ("review_hog", "posthog_code")),
             ("zai-org/glm-5.3-flash", 1_000_000, ("review_hog", "posthog_code")),
         ],
     )


### PR DESCRIPTION
## Problem

PostHog Desktop cannot offer standard GLM-5.3 safely because its model contract still uses prerelease placeholders.

**Why:** Baseten now publishes the final context, reasoning, and pricing contract, so the existing rollout gate can move forward.

## Changes

- PostHog Desktop can offer GLM-5.3 with low, high, and max reasoning after the existing rollout flag enables it.
- The gateway advertises the 1M context window and normalizes each supported reasoning level.
- GLM-5.2 and GLM-5.3 Flash keep their current reasoning options.
- The Python gateway change stays limited to Desktop because the Go gateway lacks its OAuth and per-model policy.
- No screenshot: the inactive rollout flag keeps this model hidden until the change deploys.

## How did you test this code?

- Extended existing capability matrices to cover the 1M context and low reasoning through gateway and desktop paths.
- Relevant gateway and desktop tests, full desktop typechecking, gateway typechecking, and repository preflight passed.
- Not tested: a live Baseten generation because this environment has no provider credential.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the gateway routing guidance and gateway parity record.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used repository inspection and terminal tools with `/posthog-desktop`, `/auditing-llm-gateway-parity`, `/writing-tests`, `/hogli`, and `/writing-pr-descriptions`.

The final design keeps the provider rollout gated and limits the new reasoning level to standard GLM-5.3. No customer data or private session material appears here.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*