### PR TITLE
chore(taxonomic-filter): share the context filters and cover the menu

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
@@ -9,6 +9,7 @@ import { performQuery } from '~/queries/query'
 import { initKeaTests } from '~/test/init'
 
 import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
+import { taxonomicFilterPinnedPropertiesLogic } from '../taxonomicFilterPinnedPropertiesLogic'
 import { TaxonomicFilterGroupType } from '../types'
 import { useTaxonomicFilter } from './useTaxonomicFilter'
 import { __clearTaxonomicResourceCache } from './useTaxonomicResource'
@@ -478,5 +479,37 @@ describe('useTaxonomicFilter', () => {
         expect(input.searchQuery).toBe('')
         expect(input.showNumericalPropsOnly).toBe(true)
         expect(input.enableKeywordShortcuts).toBe(true)
+    })
+
+    // Pins are global, so a picker that offers only events would otherwise list a pinned cohort and
+    // hand back a value it cannot represent. The menu's shortcut rows already filter this way.
+    it('keeps the Pinned tab to groups this picker offers', () => {
+        const pinnedLogic = taxonomicFilterPinnedPropertiesLogic.build()
+        pinnedLogic.mount()
+        pinnedLogic.actions.setPinnedFilters([
+            {
+                groupType: TaxonomicFilterGroupType.Events,
+                groupName: 'Events',
+                value: 'signed up',
+                item: { name: 'signed up' },
+                timestamp: 0,
+            },
+            {
+                groupType: TaxonomicFilterGroupType.Cohorts,
+                groupName: 'Cohorts',
+                value: 1,
+                item: { name: 'Power users' },
+                timestamp: 0,
+            },
+        ] as any)
+
+        const { result } = renderHook(
+            () => useTaxonomicFilter({ taxonomicGroupTypes: [TaxonomicFilterGroupType.Events] }),
+            { wrapper }
+        )
+
+        const pinnedGroup = result.current.groups.find((g) => g.type === TaxonomicFilterGroupType.PinnedFilters)!
+        const pinned = result.current.getGroupListInput(pinnedGroup).localOverride ?? []
+        expect(pinned.map((item: any) => item.name)).toEqual(['signed up'])
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
@@ -501,7 +501,7 @@ describe('useTaxonomicFilter', () => {
                 item: { name: 'Power users' },
                 timestamp: 0,
             },
-        ] as any)
+        ])
 
         const { result } = renderHook(
             () => useTaxonomicFilter({ taxonomicGroupTypes: [TaxonomicFilterGroupType.Events] }),

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
@@ -481,9 +481,8 @@ describe('useTaxonomicFilter', () => {
         expect(input.enableKeywordShortcuts).toBe(true)
     })
 
-    // Only the headless primitives read this override, and none of them renders in production
-    // today, so this changes nothing a person sees. It keeps the hook in step with the rule the
-    // menu applies to the rows it does render.
+    // Pins are stored globally, so this override can carry items from groups the picker does not
+    // offer. Anything that reads it needs a list the picker can represent.
     it('filters the Pinned override to groups this picker offers', () => {
         const pinnedLogic = taxonomicFilterPinnedPropertiesLogic.build()
         pinnedLogic.mount()

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
@@ -481,9 +481,10 @@ describe('useTaxonomicFilter', () => {
         expect(input.enableKeywordShortcuts).toBe(true)
     })
 
-    // Pins are global, so a picker that offers only events would otherwise list a pinned cohort and
-    // hand back a value it cannot represent. The menu's shortcut rows already filter this way.
-    it('keeps the Pinned tab to groups this picker offers', () => {
+    // Only the headless primitives read this override, and none of them renders in production
+    // today, so this changes nothing a person sees. It keeps the hook in step with the rule the
+    // menu applies to the rows it does render.
+    it('filters the Pinned override to groups this picker offers', () => {
         const pinnedLogic = taxonomicFilterPinnedPropertiesLogic.build()
         pinnedLogic.mount()
         pinnedLogic.actions.setPinnedFilters([

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
@@ -21,7 +21,10 @@ import {
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
-import { filterRecentsForContext } from 'lib/components/TaxonomicFilter/utils/suggestedContextFilters'
+import {
+    filterPinnedForContext,
+    filterRecentsForContext,
+} from 'lib/components/TaxonomicFilter/utils/suggestedContextFilters'
 import { dataWarehouseSettingsSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsSceneLogic'
 
 import { actionsModel } from '~/models/actionsModel'
@@ -61,6 +64,10 @@ export function useTaxonomicLocalOverrides(context: {
             ),
         [recentFilterItems, taxonomicGroupTypes, excludedOperators, selectingKeyOnly, excludedProperties]
     )
+    const contextFilteredPinnedItems = useMemo(
+        () => filterPinnedForContext(pinnedFilterItems, taxonomicGroupTypes),
+        [pinnedFilterItems, taxonomicGroupTypes]
+    )
 
     return useCallback(
         (groupType: TaxonomicFilterGroupType): TaxonomicDefinitionTypes[] | undefined => {
@@ -70,7 +77,7 @@ export function useTaxonomicLocalOverrides(context: {
                 case TaxonomicFilterGroupType.RecentFilters:
                     return contextFilteredRecentItems
                 case TaxonomicFilterGroupType.PinnedFilters:
-                    return pinnedFilterItems
+                    return contextFilteredPinnedItems
                 case TaxonomicFilterGroupType.Dashboards:
                     return nameSortedDashboards as unknown as TaxonomicDefinitionTypes[]
                 case TaxonomicFilterGroupType.Experiments:
@@ -86,7 +93,7 @@ export function useTaxonomicLocalOverrides(context: {
         [
             actionsSorted,
             contextFilteredRecentItems,
-            pinnedFilterItems,
+            contextFilteredPinnedItems,
             nameSortedDashboards,
             experiments,
             dataWarehouseTablesAndViews,

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -59,6 +59,7 @@ import {
 } from 'lib/components/TaxonomicFilter/utils/floatRecentPinned'
 import { floatToFront } from 'lib/components/TaxonomicFilter/utils/floatToFront'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
+import { filterPinnedForContext } from 'lib/components/TaxonomicFilter/utils/suggestedContextFilters'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { mapGroupQueryResponse } from 'lib/utils/groups'
@@ -1155,15 +1156,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
             (
                 pinnedFilterItems: TaxonomicDefinitionTypes[],
                 taxonomicGroupTypes: TaxonomicFilterGroupType[]
-            ): TaxonomicDefinitionTypes[] => {
-                if (!pinnedFilterItems?.length) {
-                    return []
-                }
-                const availableTypes = new Set(taxonomicGroupTypes)
-                return pinnedFilterItems.filter(
-                    (item) => hasPinnedContext(item) && availableTypes.has(item._pinnedContext.sourceGroupType)
-                )
-            },
+            ): TaxonomicDefinitionTypes[] => filterPinnedForContext(pinnedFilterItems, taxonomicGroupTypes),
         ],
         // This list is the filter's only substantive (non-meta) group. There are no separate
         // Recent/Pinned tabs leading the filter, so this list floats recent/pinned items to

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -514,7 +514,7 @@ export interface infiniteListLogicMeta {
             recentFilterItems: TaxonomicDefinitionTypes[],
             taxonomicGroupTypes: TaxonomicFilterGroupType[],
             arg: ExcludedOperators | undefined,
-            arg2: import('lib/components/TaxonomicFilter/types').SelectingKeyOnly | undefined,
+            arg2: SelectingKeyOnly | undefined,
             arg3: import('lib/components/TaxonomicFilter/types').TaxonomicFilterGroupValueMap | undefined
         ) => TaxonomicDefinitionTypes[]
         contextFilteredPinnedItems: (

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -19,7 +19,6 @@ import posthog from 'posthog-js'
 import api, { ApiMethodOptions } from 'lib/api'
 import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
 import {
-    expandRecentsForDisplay,
     hasRecentContext,
     recentTaxonomicFiltersLogic,
 } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
@@ -35,6 +34,7 @@ import {
     InfiniteListLogicProps,
     META_GROUP_TYPES,
     QuickFilterItem,
+    SelectingKeyOnly,
     SkeletonItem,
     isQuickFilterItem,
     isSkeletonItem,
@@ -59,7 +59,10 @@ import {
 } from 'lib/components/TaxonomicFilter/utils/floatRecentPinned'
 import { floatToFront } from 'lib/components/TaxonomicFilter/utils/floatToFront'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
-import { filterPinnedForContext } from 'lib/components/TaxonomicFilter/utils/suggestedContextFilters'
+import {
+    filterPinnedForContext,
+    filterRecentsForContext,
+} from 'lib/components/TaxonomicFilter/utils/suggestedContextFilters'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { mapGroupQueryResponse } from 'lib/utils/groups'
@@ -1119,37 +1122,16 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 recentFilterItems: TaxonomicDefinitionTypes[],
                 taxonomicGroupTypes: TaxonomicFilterGroupType[],
                 excludedOperators: ExcludedOperators | undefined,
-                selectingKeyOnly: boolean | undefined,
+                selectingKeyOnly: SelectingKeyOnly | undefined,
                 excludedProperties: ExcludedProperties | undefined
-            ): TaxonomicDefinitionTypes[] => {
-                if (!recentFilterItems?.length) {
-                    return []
-                }
-                const availableTypes = new Set(taxonomicGroupTypes)
-                const inScope = recentFilterItems.filter((item) => {
-                    if (!hasRecentContext(item) || !availableTypes.has(item._recentContext.sourceGroupType)) {
-                        return false
-                    }
-                    // A group's excluded values (e.g. `message` for the logs group-by picker) must be
-                    // dropped from the Recent tab too, not just the group's own option list — otherwise
-                    // an excluded key recorded elsewhere leaks back in as a selectable recent.
-                    const excludedValues = excludedProperties?.[item._recentContext.sourceGroupType]
-                    if (excludedValues?.length && excludedValues.includes(item._recentContext.sourceValue)) {
-                        return false
-                    }
-                    const excludedForGroup = excludedOperators?.[item._recentContext.sourceGroupType]
-                    if (excludedForGroup?.length) {
-                        const propertyFilter = item._recentContext.propertyFilter
-                        const operator =
-                            propertyFilter && 'operator' in propertyFilter ? propertyFilter.operator : undefined
-                        if (operator && excludedForGroup.includes(operator)) {
-                            return false
-                        }
-                    }
-                    return true
-                })
-                return expandRecentsForDisplay(inScope, selectingKeyOnly)
-            },
+            ): TaxonomicDefinitionTypes[] =>
+                filterRecentsForContext(
+                    recentFilterItems,
+                    taxonomicGroupTypes,
+                    excludedOperators,
+                    selectingKeyOnly,
+                    excludedProperties
+                ),
         ],
         contextFilteredPinnedItems: [
             (s) => [s.pinnedFilterItems, s.taxonomicGroupTypes],

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.pinned.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.pinned.test.tsx
@@ -1,0 +1,107 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Provider } from 'kea'
+
+import { useMocks } from '~/mocks/jest'
+import { actionsModel } from '~/models/actionsModel'
+import { groupsModel } from '~/models/groupsModel'
+import { performQuery } from '~/queries/query'
+import { initKeaTests } from '~/test/init'
+import { emptyPaginated } from '~/test/mocks/taxonomicFilterApiMock'
+
+import { TaxonomicFilterHeadless } from '../headless'
+import { __clearTaxonomicResourceCache } from '../hooks/useTaxonomicResource'
+import { taxonomicFilterPinnedPropertiesLogic } from '../taxonomicFilterPinnedPropertiesLogic'
+import { TaxonomicFilterGroupType } from '../types'
+import { TaxonomicFilterMenu } from './TaxonomicFilterMenu'
+
+jest.mock('~/queries/query', () => ({
+    performQuery: jest.fn(),
+}))
+
+jest.mock('posthog-js', () => ({
+    __esModule: true,
+    default: { capture: jest.fn() },
+}))
+
+jest.mock('lib/api', () => require('~/test/mocks/taxonomicFilterApiMock').buildTaxonomicFilterApiMock())
+
+const apiGet = jest.requireMock('lib/api').default.get as jest.MockedFunction<any>
+
+// Two content groups, so the picker does not take the sole-group path that
+// promotes pinned items into the single list.
+const GROUP_TYPES = [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.EventProperties]
+
+function renderMenu(): ReturnType<typeof render> {
+    return render(
+        <Provider>
+            <TaxonomicFilterHeadless.Root taxonomicGroupTypes={GROUP_TYPES} onChange={jest.fn()}>
+                <TaxonomicFilterMenu />
+            </TaxonomicFilterHeadless.Root>
+        </Provider>
+    )
+}
+
+function pinnedRowTexts(): string[] {
+    return Array.from(document.querySelectorAll('[data-slot="taxonomic-filter-menu-row"]')).map(
+        (el) => el.textContent ?? ''
+    )
+}
+
+describe('TaxonomicFilterMenu pinned rows', () => {
+    beforeEach(() => {
+        __clearTaxonomicResourceCache()
+        apiGet.mockReset()
+        apiGet.mockImplementation(emptyPaginated)
+        ;(performQuery as jest.Mock).mockResolvedValue({ tables: {}, joins: [] })
+        useMocks({})
+        localStorage.clear()
+        initKeaTests()
+        actionsModel.mount()
+        groupsModel.mount()
+    })
+
+    afterEach(() => cleanup())
+
+    // Pins are stored globally, so a pin can outlive the picker it was made in.
+    // Without the context filter the cohort still renders: resolveShortcutGroup
+    // falls back to the first non-meta group, so it appears as an Events row and
+    // commits a cohort id under the Events group.
+    it('leaves out a pin whose source group this picker does not offer', async () => {
+        const pinnedLogic = taxonomicFilterPinnedPropertiesLogic.build()
+        pinnedLogic.mount()
+        pinnedLogic.actions.setPinnedFilters([
+            {
+                groupType: TaxonomicFilterGroupType.Events,
+                groupName: 'Events',
+                value: 'signed up',
+                item: { name: 'signed up' },
+                timestamp: 0,
+            },
+            {
+                groupType: TaxonomicFilterGroupType.Cohorts,
+                groupName: 'Cohorts',
+                value: 1,
+                item: { name: 'Power users' },
+                timestamp: 0,
+            },
+        ])
+
+        renderMenu()
+
+        await userEvent.click(screen.getByTestId('taxonomic-filter-menu-trigger'))
+        await waitFor(() => {
+            expect(screen.getByText('Pinned')).toBeInTheDocument()
+        })
+        await userEvent.click(screen.getByText('Pinned'))
+
+        await waitFor(() => {
+            expect(pinnedRowTexts().length).toBeGreaterThan(0)
+        })
+        const rows = pinnedRowTexts()
+        expect(rows.some((text) => text.includes('signed up'))).toBe(true)
+        expect(rows.some((text) => text.includes('Power users'))).toBe(false)
+    })
+})

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
@@ -9,12 +9,11 @@ import {
 } from 'lib/components/TaxonomicFilter/types'
 
 /*
- * These mirror the legacy `infiniteListLogic` context-filter selectors
- * (`contextFilteredRecentItems` / `contextFilteredPinnedItems`). It's a
- * deliberate fork, not a shared util: the rebuild and the legacy kea picker
- * are independent code paths, and the legacy one is being retired with the
- * rest of `infiniteListLogic`. Until then, behaviour changes here that should
- * also apply to the legacy picker must be made in both places.
+ * The legacy `infiniteListLogic` picker and the rebuild both call
+ * `filterPinnedForContext`, so a change to pinned behaviour reaches both.
+ * `filterRecentsForContext` is not shared: `infiniteListLogic` holds its own
+ * copy of the same rule in `contextFilteredRecentItems`, so a change to recents
+ * behaviour must be made in both places until the legacy picker is retired.
  */
 
 /** Recents whose source group is one of the picker's groups, with operators the

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
@@ -9,11 +9,8 @@ import {
 } from 'lib/components/TaxonomicFilter/types'
 
 /*
- * The legacy `infiniteListLogic` picker and the rebuild both call
- * `filterPinnedForContext`, so a change to pinned behaviour reaches both.
- * `filterRecentsForContext` is not shared: `infiniteListLogic` holds its own
- * copy of the same rule in `contextFilteredRecentItems`, so a change to recents
- * behaviour must be made in both places until the legacy picker is retired.
+ * The legacy `infiniteListLogic` picker and the rebuild both call these helpers,
+ * so a change to recent or pinned behavior reaches both.
  */
 
 /** Recents whose source group is one of the picker's groups, with operators the
@@ -36,7 +33,8 @@ export function filterRecentsForContext(
             return false
         }
         // A group's excluded values (e.g. `message` for the logs group-by picker) must be dropped
-        // from the Recent tab too, not just the group's own option list.
+        // from the Recent tab too, not just the group's own option list. Otherwise an excluded key
+        // recorded elsewhere leaks back in as a selectable recent.
         const excludedValues = excludedProperties?.[item._recentContext.sourceGroupType]
         if (excludedValues?.length && excludedValues.includes(item._recentContext.sourceValue)) {
             return false


### PR DESCRIPTION
> [!IMPORTANT]
> This is a refactoring and test PR. It does not change the user experience in any way.

## Problem

Pins and recent items are saved globally, but each picker should only offer the ones whose source group it can actually represent. An events-only picker should not list a pinned cohort. That rule was written out in several places, and one of those places had no test.

- The rebuilt menu applies the rule by calling `filterPinnedForContext` at `TaxonomicFilterMenu.tsx:378`. No test ran that call. Removing it left all 602 tests in the `TaxonomicFilter` suite passing.
- Removing that call does more than add a row nobody wants. `resolveShortcutGroup` falls back to the first non-meta group, so the pinned cohort appears as an Events row and commits a cohort id under the Events group.
- `infiniteListLogic` spelled both rules out again in its own selectors. The two recents versions had already drifted apart: the hand-written one typed `selectingKeyOnly` as `boolean`, while the generated types and the prop both allow a per-group dict.
- `useTaxonomicLocalOverrides` returned pins without applying the rule, so it handed back a different list than the menu did. Only the headless primitives read that list, and none of them renders today.

## Changes

- `menu/TaxonomicFilterMenu.pinned.test.tsx` covers the menu's pinned filter. It renders the menu with an events-only picker and a pinned cohort, then asserts the cohort does not appear.
- `infiniteListLogic` calls `filterPinnedForContext` and `filterRecentsForContext` instead of holding its own copies. The pinned body it replaced was character-level equivalent; the recents body differed only in the selector wrapper.
- The recents selector types `selectingKeyOnly` as `SelectingKeyOnly`, matching the generated types and the prop.
- `useTaxonomicLocalOverrides` runs pins through the same shared helper.
- The comment in `suggestedContextFilters.ts` describes one shared rule instead of telling readers to maintain two copies.

Each rule is now written once, and every caller uses that copy.

## How did you test this code?

The new test catches deletion of `filterPinnedForContext` at `TaxonomicFilterMenu.tsx:378`. Nothing else does. `Combobox.test.tsx` takes `pinnedEntries` as a prop, so its seven pinned tests run after the filter has already been applied. The helper's own unit tests never assert that the menu calls it.

Measured rather than assumed. Delete the filter and the full `TaxonomicFilter` suite fails exactly one test out of 602, the new one. Restore it and all 602 pass.

The two delegations are covered by the helpers' existing unit tests in `utils/suggestedContextFilters.test.ts` and by the legacy suites, which stay green.

Not checked: the running app. No manual pass through the picker, and no screenshot.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing doc describes which pins a picker lists.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop wrote the first commit. Claude Code then ran the /go pipeline over the branch: opened the PR, ran a six-agent review, and carried out the work above.
- Skills invoked: /go, /create-pr, /writing-pr-descriptions, /modifying-taxonomic-filter, /writing-tests, /review-code, /plain-writing.
- The PR opened claiming a user-visible fix, that an events-only picker listed a pinned cohort. That bug does not exist, because the menu already filtered the rows people see. ReviewHog flagged the claim and five review agents confirmed the trace. The author chose to keep the change, retarget it at the real gap, and add the missing coverage rather than drop it.
- The test data is invented. Nothing here draws on non-public material.
