### PR TITLE
fix(desktop): use desktop workspace directory

### DIFF
--- a/products/desktop/apps/code/README.md
+++ b/products/desktop/apps/code/README.md
@@ -216,7 +216,7 @@ PostHog automatically sets environment variables in all workspace terminals and 
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `POSTHOG_CODE_WORKSPACE_NAME` | Worktree name, or folder name in root mode | `my-feature-branch` |
-| `POSTHOG_CODE_WORKSPACE_PATH` | Absolute path to the workspace | `/Users/dev/.posthog-code/worktrees/repo/my-feature` |
+| `POSTHOG_CODE_WORKSPACE_PATH` | Absolute path to the workspace | `/Users/dev/.posthog-desktop/worktrees/repo/my-feature` |
 | `POSTHOG_CODE_ROOT_PATH` | Absolute path to the repository root | `/Users/dev/repos/my-project` |
 | `POSTHOG_CODE_DEFAULT_BRANCH` | Default branch detected from git | `main` |
 | `POSTHOG_CODE_WORKSPACE_BRANCH` | Initial branch when workspace was created | `posthog/my-feature` |

--- a/products/desktop/apps/code/src/main/services/settingsStore.test.ts
+++ b/products/desktop/apps/code/src/main/services/settingsStore.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const existingPaths = vi.hoisted(() => new Set<string>());
+const storedSettings = vi.hoisted(() => new Map<string, unknown>());
+const renameSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  const existsSync = (filePath: string) => existingPaths.has(filePath);
+  return {
+    ...original,
+    default: { ...original, existsSync, renameSync },
+    existsSync,
+    renameSync,
+  };
+});
+
+vi.mock("node:os", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:os")>();
+  return {
+    ...original,
+    default: { ...original, homedir: () => "/home/test" },
+    homedir: () => "/home/test",
+  };
+});
+
+vi.mock("../utils/env", () => ({
+  getUserDataDir: () => "/tmp/posthog-code-test",
+  isDevBuild: () => false,
+}));
+
+vi.mock("electron-store", () => ({
+  default: class {
+    private readonly defaults: Record<string, unknown>;
+
+    constructor(options: { defaults: Record<string, unknown> }) {
+      this.defaults = options.defaults;
+    }
+
+    get(key: string, fallback?: unknown): unknown {
+      return storedSettings.has(key)
+        ? storedSettings.get(key)
+        : (this.defaults[key] ?? fallback);
+    }
+
+    set(key: string, value: unknown): void {
+      storedSettings.set(key, value);
+    }
+  },
+}));
+
+async function loadSettingsStore() {
+  return import("./settingsStore");
+}
+
+describe("workspace location compatibility", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    existingPaths.clear();
+    storedSettings.clear();
+    renameSync.mockClear();
+  });
+
+  it("uses the desktop directory for a new profile", async () => {
+    const { getWorktreeLocation } = await loadSettingsStore();
+
+    expect(getWorktreeLocation()).toBe("/home/test/.posthog-desktop/worktrees");
+  });
+
+  it("keeps the previous default when it is the only existing location", async () => {
+    existingPaths.add("/home/test/.posthog-code/worktrees");
+
+    const { getAllWorktreeLocations, getWorktreeLocation } =
+      await loadSettingsStore();
+
+    expect(getWorktreeLocation()).toBe("/home/test/.posthog-code/worktrees");
+    expect(getAllWorktreeLocations()).toEqual([
+      "/home/test/.posthog-code/worktrees",
+    ]);
+    expect(renameSync).not.toHaveBeenCalled();
+  });
+
+  it("discovers the previous default after the desktop directory exists", async () => {
+    existingPaths.add("/home/test/.posthog-code/worktrees");
+    existingPaths.add("/home/test/.posthog-desktop/worktrees");
+
+    const { getAllWorktreeLocations, getWorktreeLocation } =
+      await loadSettingsStore();
+
+    expect(getWorktreeLocation()).toBe("/home/test/.posthog-desktop/worktrees");
+    expect(getAllWorktreeLocations()).toEqual([
+      "/home/test/.posthog-desktop/worktrees",
+      "/home/test/.posthog-code/worktrees",
+    ]);
+  });
+});

--- a/products/desktop/apps/code/src/main/services/settingsStore.ts
+++ b/products/desktop/apps/code/src/main/services/settingsStore.ts
@@ -1,7 +1,11 @@
 import { existsSync, renameSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { LEGACY_DATA_DIRS, WORKTREES_DIR } from "@shared/constants";
+import {
+  LEGACY_DATA_DIRS,
+  PREVIOUS_WORKTREES_DIR,
+  WORKTREES_DIR,
+} from "@shared/constants";
 import Store from "electron-store";
 import { getUserDataDir, isDevBuild } from "../utils/env";
 
@@ -17,10 +21,28 @@ interface SettingsSchema {
   missionControlOverlayEnabled: boolean;
 }
 
-function getDefaultWorktreeLocation(): string {
+function getWorktreePath(dir: string): string {
   const isDev = isDevBuild();
-  const dir = isDev ? `${WORKTREES_DIR}-dev` : WORKTREES_DIR;
-  return path.join(os.homedir(), dir);
+  return path.join(os.homedir(), isDev ? `${dir}-dev` : dir);
+}
+
+function getCurrentDefaultWorktreeLocation(): string {
+  return getWorktreePath(WORKTREES_DIR);
+}
+
+function getPreviousDefaultWorktreeLocation(): string {
+  return getWorktreePath(PREVIOUS_WORKTREES_DIR);
+}
+
+function getDefaultWorktreeLocation(): string {
+  const currentDefault = getCurrentDefaultWorktreeLocation();
+  const previousDefault = getPreviousDefaultWorktreeLocation();
+
+  if (!existsSync(currentDefault) && existsSync(previousDefault)) {
+    return previousDefault;
+  }
+
+  return currentDefault;
 }
 
 function getLegacyWorktreeLocations(): string[] {
@@ -152,6 +174,11 @@ export function getWorktreeLocation(): string {
 export function getAllWorktreeLocations(): string[] {
   const primary = getWorktreeLocation();
   const locations = [primary];
+
+  const previousDefault = getPreviousDefaultWorktreeLocation();
+  if (previousDefault !== primary && existsSync(previousDefault)) {
+    locations.push(previousDefault);
+  }
 
   // Add legacy locations if they exist and aren't the primary
   for (const legacyPath of getLegacyWorktreeLocations()) {

--- a/products/desktop/apps/code/src/shared/constants.ts
+++ b/products/desktop/apps/code/src/shared/constants.ts
@@ -63,6 +63,7 @@ export const ARTIFACT_PREVIEW_DATA_URL_PREFIX =
   "data:text/html;charset=utf-8;base64,";
 export const ARTIFACT_PREVIEW_PARTITION_PREFIX = "artifact-preview-";
 export const WORKTREES_DIR = ".posthog-desktop/worktrees";
+export const PREVIOUS_WORKTREES_DIR = ".posthog-code/worktrees";
 export const LEGACY_DATA_DIRS = [
   ".twig",
   ".twig/worktrees",

--- a/products/desktop/apps/code/src/shared/constants.ts
+++ b/products/desktop/apps/code/src/shared/constants.ts
@@ -62,7 +62,7 @@ export const ARTIFACT_PREVIEW_TO_HOST_CHANNEL = "posthog-artifact-message";
 export const ARTIFACT_PREVIEW_DATA_URL_PREFIX =
   "data:text/html;charset=utf-8;base64,";
 export const ARTIFACT_PREVIEW_PARTITION_PREFIX = "artifact-preview-";
-export const WORKTREES_DIR = ".posthog-code/worktrees";
+export const WORKTREES_DIR = ".posthog-desktop/worktrees";
 export const LEGACY_DATA_DIRS = [
   ".twig",
   ".twig/worktrees",

--- a/products/desktop/packages/host-router/src/routers/os.router.ts
+++ b/products/desktop/packages/host-router/src/routers/os.router.ts
@@ -19,6 +19,7 @@ import {
   selectAttachmentsInput,
   selectAttachmentsOutput,
   selectFilesOutput,
+  setWorktreeLocationInput,
   showMessageBoxInput,
   userAgentInstructionsOutput,
 } from "@posthog/workspace-server/services/os/schemas";
@@ -92,6 +93,14 @@ export const osRouter = router({
   getWorktreeLocation: publicProcedure.query(({ ctx }) =>
     ctx.container.get<OsService>(OS_SERVICE).getWorktreeLocation(),
   ),
+
+  setWorktreeLocation: publicProcedure
+    .input(setWorktreeLocationInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<OsService>(OS_SERVICE)
+        .setWorktreeLocation(input.location),
+    ),
 
   readFileAsDataUrl: publicProcedure
     .input(readFileAsDataUrlInput)

--- a/products/desktop/packages/ui/src/features/settings/sections/WorkspacesSettings.test.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/WorkspacesSettings.test.tsx
@@ -1,0 +1,78 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getWorktreeLocation = vi.hoisted(() => vi.fn());
+const setWorktreeLocation = vi.hoisted(() => vi.fn());
+
+vi.mock("@posthog/host-router/react", () => ({
+  useHostTRPCClient: () => ({
+    os: {
+      getWorktreeLocation: { query: getWorktreeLocation },
+      setWorktreeLocation: { mutate: setWorktreeLocation },
+      selectDirectory: { query: vi.fn() },
+    },
+    additionalDirectories: {
+      listDefaults: { query: vi.fn().mockResolvedValue([]) },
+      addDefault: { mutate: vi.fn() },
+      removeDefault: { mutate: vi.fn() },
+    },
+  }),
+}));
+
+vi.mock("../../folder-picker/FolderPicker", () => ({
+  FolderPicker: ({
+    onChange,
+    placeholder,
+    value,
+  }: {
+    onChange: (path: string) => void;
+    placeholder: string;
+    value: string;
+  }) => (
+    <button
+      type="button"
+      onClick={() => onChange("/tmp/posthog-desktop/worktrees")}
+    >
+      {value || placeholder}
+    </button>
+  ),
+}));
+
+import { WorkspacesSettings } from "./WorkspacesSettings";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("WorkspacesSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getWorktreeLocation.mockResolvedValue("/tmp/existing-worktrees");
+    setWorktreeLocation.mockResolvedValue(undefined);
+  });
+
+  it("loads and saves the runtime worktree location", async () => {
+    const user = userEvent.setup();
+    render(<WorkspacesSettings />, { wrapper });
+
+    const picker = await screen.findByText("/tmp/existing-worktrees");
+    await user.click(picker);
+
+    await waitFor(() =>
+      expect(setWorktreeLocation).toHaveBeenCalledWith({
+        location: "/tmp/posthog-desktop/worktrees",
+      }),
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/settings/sections/WorkspacesSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/WorkspacesSettings.tsx
@@ -28,10 +28,7 @@ export function WorkspacesSettings() {
 
   const { data: worktreeLocation } = useQuery({
     queryKey: ["settings", "worktreeLocation"],
-    queryFn: async () =>
-      (await hostClient.secureStore.getItem.query({
-        key: "worktreeLocation",
-      })) ?? null,
+    queryFn: () => hostClient.os.getWorktreeLocation.query(),
   });
 
   useEffect(() => {
@@ -43,9 +40,8 @@ export function WorkspacesSettings() {
   const handleWorktreeLocationChange = async (newLocation: string) => {
     setLocalWorktreeLocation(newLocation);
     try {
-      await hostClient.secureStore.setItem.query({
-        key: "worktreeLocation",
-        value: newLocation,
+      await hostClient.os.setWorktreeLocation.mutate({
+        location: newLocation,
       });
     } catch (error) {
       log.error("Failed to set worktree location:", error);
@@ -97,7 +93,7 @@ export function WorkspacesSettings() {
             <FolderPicker
               value={localWorktreeLocation}
               onChange={handleWorktreeLocationChange}
-              placeholder="~/.posthog-code"
+              placeholder="~/.posthog-desktop/worktrees"
             />
           </div>
         </SettingsCardRow>

--- a/products/desktop/packages/workspace-server/src/services/os/os.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.test.ts
@@ -34,6 +34,7 @@ function createService() {
   const imageProcessor = { downscale: vi.fn() };
   const workspaceSettings = {
     getWorktreeLocation: vi.fn(() => "/tmp/worktrees"),
+    setWorktreeLocation: vi.fn(),
   };
 
   const storagePaths = {
@@ -154,9 +155,15 @@ describe("OsService simple delegations", () => {
     expect(service.getAppVersion()).toBe("9.9.9");
   });
 
-  it("returns the worktree location from workspace settings", () => {
-    const { service } = createService();
+  it("reads and updates the worktree location through workspace settings", () => {
+    const { service, workspaceSettings } = createService();
     expect(service.getWorktreeLocation()).toBe("/tmp/worktrees");
+
+    service.setWorktreeLocation("/tmp/posthog-desktop/worktrees");
+
+    expect(workspaceSettings.setWorktreeLocation).toHaveBeenCalledWith(
+      "/tmp/posthog-desktop/worktrees",
+    );
   });
 
   it("opens external URLs through the url launcher", async () => {

--- a/products/desktop/packages/workspace-server/src/services/os/os.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/os.ts
@@ -479,6 +479,10 @@ export class OsService {
     return this.workspaceSettings.getWorktreeLocation();
   }
 
+  setWorktreeLocation(location: string): void {
+    this.workspaceSettings.setWorktreeLocation(location);
+  }
+
   async readFileAsDataUrl(
     filePath: string,
     maxSizeBytes: number,

--- a/products/desktop/packages/workspace-server/src/services/os/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/os/schemas.ts
@@ -44,6 +44,10 @@ export const selectFilesOutput = z.array(z.string());
 
 export const checkWriteAccessInput = z.object({ directoryPath: z.string() });
 
+export const setWorktreeLocationInput = z.object({
+  location: z.string().min(1),
+});
+
 export const messageBoxOptionsSchema = z.object({
   type: z.enum(["none", "info", "error", "question", "warning"]).optional(),
   title: z.string().optional(),


### PR DESCRIPTION
## Problem

People who changed Workspace location saw the new folder in Settings, but new task workspaces still used the previous runtime location.

The control wrote to renderer storage while workspace creation read a separate settings store.

## Changes

- Workspace location now reads and writes the same runtime setting that workspace creation uses.
- New profiles use `~/.posthog-desktop/worktrees`.
- Existing saved and custom locations stay in place. The change does not move active worktrees or rename compatibility identifiers.

```diff
- ~/.posthog-code/worktrees
+ ~/.posthog-desktop/worktrees
```

The setting stays in Workspaces. The picker abbreviates both paths to `worktrees`, so the layout does not change.

![Workspaces settings with the workspace location control](https://raw.githubusercontent.com/PostHog/pr-assets/d313b3de58eb5c923f286fbabf3fd491724b1e5b/2026/08/2a8d3769-ae13-4df4-a310-c8b01b06b436.png)

## How did you test this code?

Added coverage for the settings control loading and saving through the runtime service. The affected UI and workspace service tests passed.

Rendered the Workspaces setting in Storybook and confirmed it fits the existing settings layout. Fresh-profile testing in the full Electron app remains unchecked.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the workspace environment variable example to use the new default.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex used the `posthog-desktop`, `writing-tests`, `writing-user-facing-copy`, `writing-pr-descriptions`, `test-electron-app`, and `storybook-stories` skills.

The screenshot uses a static Storybook fixture with no user data. The implementation preserves existing workspace paths and compatibility identifiers.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
