### PR TITLE
feat(replay): remove the A/B test results template

### DIFF
--- a/frontend/src/scenes/session-recordings/templates/SessionRecordingTemplates.tsx
+++ b/frontend/src/scenes/session-recordings/templates/SessionRecordingTemplates.tsx
@@ -8,13 +8,7 @@ import { universalFiltersLogic } from 'lib/components/UniversalFilters/universal
 import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 
 import { actionsModel } from '~/models/actionsModel'
-import {
-    FeaturePropertyFilter,
-    FilterLogicalOperator,
-    ReplayTemplateCategory,
-    ReplayTemplateType,
-    ReplayTemplateVariableType,
-} from '~/types'
+import { FilterLogicalOperator, ReplayTemplateCategory, ReplayTemplateType, ReplayTemplateVariableType } from '~/types'
 
 import { replayTemplates } from './availableTemplates'
 import { sessionReplayTemplatesLogic } from './sessionRecordingTemplatesLogic'
@@ -28,7 +22,7 @@ const allCategories: ReplayTemplateCategory[] = replayTemplates
     .flatMap((template) => template.categories)
     .filter((category, index, self) => self.indexOf(category) === index)
 
-const NestedFilterGroup = ({ buttonTitle, selectOne }: { buttonTitle?: string; selectOne?: boolean }): JSX.Element => {
+const NestedFilterGroup = ({ buttonTitle }: { buttonTitle?: string }): JSX.Element => {
     const { filterGroup } = useValues(universalFiltersLogic)
     const { replaceGroupValue, removeGroupValue } = useActions(universalFiltersLogic)
 
@@ -50,11 +44,9 @@ const NestedFilterGroup = ({ buttonTitle, selectOne }: { buttonTitle?: string; s
                         />
                     )
                 })}
-                {!selectOne || (selectOne && filterGroup.values.length === 0) ? (
-                    <div>
-                        <UniversalFilters.AddFilterButton title={buttonTitle} type="secondary" size="xsmall" />
-                    </div>
-                ) : null}
+                <div>
+                    <UniversalFilters.AddFilterButton title={buttonTitle} type="secondary" size="xsmall" />
+                </div>
             </div>
         </div>
     )
@@ -81,7 +73,7 @@ const SingleTemplateVariable = ({
                 size="small"
             />
         </div>
-    ) : ['event', 'flag', 'person-property'].includes(variable.type) ? (
+    ) : ['event', 'person-property'].includes(variable.type) ? (
         <div>
             <LemonLabel info={variable.description}>{variable.name}</LemonLabel>
             <UniversalFilters
@@ -93,28 +85,17 @@ const SingleTemplateVariable = ({
                 taxonomicGroupTypes={
                     variable.type === 'event'
                         ? [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.Actions]
-                        : variable.type === 'flag'
-                          ? [TaxonomicFilterGroupType.FeatureFlags]
-                          : variable.type === 'person-property'
-                            ? [TaxonomicFilterGroupType.PersonProperties]
-                            : []
+                        : [TaxonomicFilterGroupType.PersonProperties]
                 }
                 onChange={(thisFilterGroup) => {
                     if (thisFilterGroup.values.length === 0) {
                         resetVariable({ ...variable, filterGroup: undefined })
-                    } else if (variable.type === 'flag') {
-                        setVariable({ ...variable, value: (thisFilterGroup.values[0] as FeaturePropertyFilter).key })
                     } else {
                         setVariable({ ...variable, filterGroup: thisFilterGroup.values[0] })
                     }
                 }}
             >
-                <NestedFilterGroup
-                    buttonTitle={`Select ${
-                        variable.type === 'event' ? 'event' : variable.type === 'flag' ? 'flag' : 'person property'
-                    }`}
-                    selectOne={variable.type == 'flag'}
-                />
+                <NestedFilterGroup buttonTitle={`Select ${variable.type === 'event' ? 'event' : 'person property'}`} />
             </UniversalFilters>
         </div>
     ) : null

--- a/frontend/src/scenes/session-recordings/templates/availableTemplates.tsx
+++ b/frontend/src/scenes/session-recordings/templates/availableTemplates.tsx
@@ -1,7 +1,6 @@
 import {
     IconApp,
     IconCursorClick,
-    IconFlag,
     IconHandMoney,
     IconPhone,
     IconSearch,
@@ -135,21 +134,6 @@ export const replayTemplates: ReplayTemplateType[] = [
         ],
         categories: ['B2C'],
         icon: <IconSearch />,
-    },
-    {
-        key: 'experiment',
-        name: 'A/B test results',
-        description: 'Watch how users interact with your A/B test. Look for any areas or steps that cause friction.',
-        variables: [
-            {
-                type: 'flag',
-                name: 'Feature flag',
-                key: 'feature-flag',
-                description: 'The feature flag that you want to observe.',
-            },
-        ],
-        categories: ['More'],
-        icon: <IconFlag />,
     },
     {
         key: 'rageclicks',

--- a/frontend/src/scenes/session-recordings/templates/sessionRecordingTemplatesLogic.tsx
+++ b/frontend/src/scenes/session-recordings/templates/sessionRecordingTemplatesLogic.tsx
@@ -29,34 +29,6 @@ const getPageviewFilterValue = (pageview: string): UniversalFiltersGroupValue =>
     }
 }
 
-const getFlagFilterValue = (flag: string): UniversalFiltersGroupValue => {
-    return {
-        id: '$feature_flag_called',
-        name: '$feature_flag_called',
-        type: 'events',
-        properties: [
-            {
-                key: `$feature/${flag}`,
-                type: PropertyFilterType.Event,
-                value: ['false'],
-                operator: PropertyOperator.IsNot,
-            },
-            {
-                key: `$feature/${flag}`,
-                type: PropertyFilterType.Event,
-                value: 'is_set',
-                operator: PropertyOperator.IsSet,
-            },
-            {
-                key: '$feature_flag',
-                type: PropertyFilterType.Event,
-                value: flag,
-                operator: PropertyOperator.Exact,
-            },
-        ],
-    }
-}
-
 export interface ReplayTemplateLogicPropsType {
     template: ReplayTemplateType
     // one card can be in multiple categories,
@@ -166,9 +138,6 @@ export const sessionReplayTemplatesLogic = kea<sessionReplayTemplatesLogicType>(
                     .map((variable) => {
                         if (variable.type === 'pageview' && variable.value) {
                             return getPageviewFilterValue(variable.value)
-                        }
-                        if (variable.type === 'flag' && variable.value) {
-                            return getFlagFilterValue(variable.value)
                         }
                         if (
                             ['snapshot_source', 'event', 'person-property'].includes(variable.type) &&

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7614,7 +7614,7 @@ export type ReplayTemplateType = {
 export type ReplayTemplateCategory = 'B2B' | 'B2C' | 'More'
 
 export type ReplayTemplateVariableType = {
-    type: 'event' | 'flag' | 'pageview' | 'person-property' | 'snapshot_source'
+    type: 'event' | 'pageview' | 'person-property' | 'snapshot_source'
     name: string
     key: string
     touched?: boolean


### PR DESCRIPTION
## Problem

The "A/B test results" replay template is about to stop finding recordings for anyone who uses it.

The template builds its playlist from `$feature_flag_called` events. Those rows are moving out of the events table, so the filter the template generates will match nothing once the move lands. The card still returns recordings today, so this removal lands ahead of the move rather than after it.

Keeping the template would mean filtering on `$feature/<flag>` instead, the way `getExposureFallbackFilter` does. That property carries the flag's value on each event rather than the enrollment moment, so it approximates exposure instead of measuring it.

## Changes

- The replay templates grid no longer offers the "A/B test results" card.
- The `flag` template variable type is gone, with its feature flag picker and the `$feature_flag_called` filter it built.
- That template held the only `flag` variable, so no other template loses a control.
- The rest is mechanical. `NestedFilterGroup` drops the `selectOne` prop that only the flag picker set, and `ReplayTemplateVariableType` drops `'flag'` from its union.

No screenshot: the only visual change is one card disappearing from the templates grid, and this scene has no Storybook story to capture it from.

## How did you test this code?

No tests added. The change deletes a template definition and the code paths only that template used, so there is no new behavior to cover. The scene has no existing test or story files.

Not checked: the templates grid was never rendered in a browser.

## Automatic notifications

- [x] Publish to changelog?

## Docs update

None. No file under `docs/` references the template.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop wrote the implementation commit. This Claude Code session picked the branch up and ran the review pipeline over it.
- Skills invoked: `/go`, `/simplify`, `/create-pr`, `/writing-pr-descriptions`.
- Four cleanup reviewers ran over the diff. Three found nothing. I declined the fourth's suggestion to rewrite the surviving `['event', 'person-property'].includes(...)` guard as two equality checks, because the type narrowing it would buy is unused and `.includes()` matches the sibling guard in `sessionRecordingTemplatesLogic.tsx`.
- Anyone who configured this template keeps a dead `session-recordings.templates.variables.*.experiment` key in browser localStorage. Nothing reads it after this change.

