### PR TITLE
feat(desktop): add Open in new tab to task and canvas row context menu

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.test.tsx
@@ -84,6 +84,9 @@ vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
   useFileTaskToChannel: () => vi.fn(),
 }));
+vi.mock("@posthog/ui/features/browser-tabs/useOpenBrowserTab", () => ({
+  useOpenBrowserTab: () => vi.fn(),
+}));
 vi.mock("@posthog/ui/features/browser-tabs/TaskTabIcon", () => ({
   TaskTabIcon: () => <span />,
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemHoverCard.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemHoverCard.test.tsx
@@ -19,6 +19,9 @@ vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
   useFileTaskToChannel: () => vi.fn(),
 }));
+vi.mock("@posthog/ui/features/browser-tabs/useOpenBrowserTab", () => ({
+  useOpenBrowserTab: () => vi.fn(),
+}));
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => true,
 }));

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
     isPending: false,
     run: vi.fn(),
   },
+  openBrowserTab: vi.fn(),
 }));
 vi.mock("@posthog/ui/features/auth/useCurrentUser", () => ({
   useCurrentUser: () => ({
@@ -54,6 +55,9 @@ vi.mock("@posthog/ui/features/canvas/hooks/useChannels", () => ({
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
   useFileTaskToChannel: () => vi.fn(),
+}));
+vi.mock("@posthog/ui/features/browser-tabs/useOpenBrowserTab", () => ({
+  useOpenBrowserTab: () => mocks.openBrowserTab,
 }));
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => true,
@@ -132,6 +136,7 @@ function renderRow(model: ChannelItemModel) {
 beforeEach(() => {
   mocks.status = null;
   mocks.analysis = { canAnalyze: false, isPending: false, run: vi.fn() };
+  mocks.openBrowserTab.mockClear();
   useSidebarStore.setState({ listItemMetadataFields: [] });
   usePendingCanvasDeleteStore.setState({ pending: {} });
   useTaskSelectionStore.setState({
@@ -421,6 +426,41 @@ describe("ChannelItemRow", () => {
     for (const label of MENU_ITEMS) {
       expect(screen.getByRole("menuitem", { name: label })).not.toBeNull();
     }
+  });
+
+  it("opens a task in a new tab from the context menu", () => {
+    renderWithMenu({});
+
+    fireEvent.contextMenu(screen.getByText("Investigate signup drop-off"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open in new tab" }));
+
+    expect(mocks.openBrowserTab).toHaveBeenCalledWith("/tasks/task-1");
+  });
+
+  it("opens a canvas in a new tab at its space's URL", () => {
+    const canvas = item({
+      key: "canvas:c1",
+      kind: "canvas",
+      id: "c1",
+      title: "Web analytics overview",
+      authorUuid: "u-1",
+    });
+    renderInList(
+      <ChannelItemRow
+        actions={actions}
+        isActive={false}
+        item={canvas}
+        channelId="channel-1"
+        onAddToCommandCenter={() => {}}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText("Web analytics overview"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Open in new tab" }));
+
+    expect(mocks.openBrowserTab).toHaveBeenCalledWith(
+      "/spaces/channel-1/dashboards/c1",
+    );
   });
 
   it("keeps the hover sidebar open while the context menu is open", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -76,6 +76,9 @@ vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
 vi.mock("@posthog/ui/features/canvas/hooks/useFileTaskToChannel", () => ({
   useFileTaskToChannel: () => ({ fileTask: vi.fn() }),
 }));
+vi.mock("@posthog/ui/features/browser-tabs/useOpenBrowserTab", () => ({
+  useOpenBrowserTab: () => vi.fn(),
+}));
 vi.mock(
   "@posthog/ui/features/task-detail/components/HandoffTaskDialog",
   () => ({

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRowMenu.tsx
@@ -1,5 +1,6 @@
 import {
   ArchiveIcon,
+  ArrowSquareOutIcon,
   CaretRightIcon,
   DotsThreeIcon,
   FolderSimpleIcon,
@@ -30,6 +31,7 @@ import {
 } from "@posthog/quill";
 import { PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
+import { useOpenBrowserTab } from "@posthog/ui/features/browser-tabs/useOpenBrowserTab";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useFileTaskToChannel } from "@posthog/ui/features/canvas/hooks/useFileTaskToChannel";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
@@ -150,6 +152,7 @@ function TaskRowMenuItems({
   const analysisTask = isTask && menu.task?.latest_run ? menu.task : null;
   const { channels } = useChannels({ enabled: bluebirdEnabled });
   const fileToChannel = useFileTaskToChannel();
+  const openBrowserTab = useOpenBrowserTab();
 
   const channelItems: MenuFlyoutItem[] = channels.map((channel) => ({
     id: channel.id,
@@ -158,8 +161,27 @@ function TaskRowMenuItems({
     starred: channel.starred,
   }));
 
+  // A canvas lives in one space, so its new-tab URL needs that space's id; a
+  // task has a channel-independent route, so it opens even when the row is
+  // listed outside its own space (activity, saved search).
+  const newTabHref = isTask
+    ? `/tasks/${menu.id}`
+    : menu.channelId
+      ? `/spaces/${menu.channelId}/dashboards/${menu.id}`
+      : null;
+  const canOpenInNewTab = newTabHref !== null;
+
   return (
     <>
+      <Item
+        disabled={!canOpenInNewTab}
+        onClick={() => {
+          if (newTabHref) openBrowserTab(newTabHref);
+        }}
+      >
+        <ArrowSquareOutIcon size={14} />
+        Open in new tab
+      </Item>
       <Item onClick={menu.onTogglePin}>
         {menu.isPinned ? (
           <PushPinSlashIcon size={14} />


### PR DESCRIPTION
## Problem

In the desktop app, a task or canvas row in the side menu (a space, all spaces, activity, or a saved search) had no way to open in a separate top-level browser tab. You could only open it in the current tab, so comparing two tasks or keeping a canvas open while working in another space meant navigating back and forth.

## Changes

- Adds an "Open in new tab" item at the top of the task/canvas row context menu (right-click, the three-dot menu, and the hover card all share the same `TaskRowMenuItems`, so it appears on every surface the menu does).
- Tasks open at their channel-independent route `/tasks/<id>`, so the item works from activity and saved searches too, not only from the owning space.
- Canvases open at `/spaces/<channelId>/dashboards/<id>`; the item is disabled when the row has no space id (canvases only render inside a space, so this is defensive).
- Reuses the existing `useOpenBrowserTab` hook (same one the nav rail uses) rather than a new tab primitive.

### Screenshot

The new item at the top of the task row context menu (rendered with the real Quill `ContextMenu` primitives and the actual icons):

![Task row context menu with Open in new tab](https://us.posthog.com/api/projects/2/tasks/4b978791-5557-4b01-b872-0716bd5112a1/runs/c5f8ca73-f0da-4424-97a2-628ef11a21fe/artifacts/1017f51a7b0542e3811d7318fedf5ba3/download/)

> [!NOTE]
> The image link above points to a PostHog-internal task artifact and may not render for external reviewers. The screenshot is also attached as a downloadable artifact to this task. It shows the context menu with "Open in new tab" as the first item, followed by Pin, Rename, Run analysis, Add to Command Center…, File to…, Hand off…, and Archive.

## How did you test this code?

- Extended `ChannelItemRow.test.tsx` with two cases: one opens a task's menu and asserts `openBrowserTab` is called with `/tasks/task-1`; the other opens a canvas's menu and asserts `/spaces/channel-1/dashboards/c1`. These catch a wrong href or a missing item; no existing test covered the new-tab path.
- Added a `useOpenBrowserTab` module mock to the four test files that render the row menu (`ChannelItemRow`, `ChannelItemHoverCard`, `ChannelFeedView`, `ChannelsList`), matching the existing mock pattern in `NavRail.test.tsx`. The hook reads the DI service container, which the unit tests do not provide.
- Rendered the menu with the real Quill `ContextMenu` primitives in a Vite playground and captured a screenshot with Playwright Chromium; the rendered item list matches the implementation order exactly.
- Ran `pnpm --filter @posthog/ui typecheck` (clean), the full `@posthog/ui` vitest suite (487 files, 3974 tests, green), Biome lint/format on the touched files (clean), and `scripts/check-host-boundaries.mjs` (no new violations).
- Did not manually run the desktop Electron app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- [ ] skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tools: PostHog Desktop coding agent (this session).
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, and the `posthog-desktop` skill (scoped work to the `products/desktop` nested workspace and its Biome/turbo toolchain).
- The row context menu (`TaskRowMenu.tsx` → `TaskRowMenuItems`) is the one surface shared by tasks and canvases across all requested lists, so the item was added there rather than per-surface. A canvas's href needs its space id; a task's does not, so the task path stays usable in activity and saved-search lists where the owning space is not in context.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
