### PR TITLE
fix(desktop): address review findings for Claude own-subscription sessions

### DIFF
--- a/products/desktop/packages/agent/src/adapters/base-acp-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/base-acp-agent.ts
@@ -16,7 +16,7 @@ import type {
   WriteTextFileRequest,
   WriteTextFileResponse,
 } from "@agentclientprotocol/sdk";
-import { restrictedModelMeta } from "@posthog/shared";
+import { isAnthropicModelId, restrictedModelMeta } from "@posthog/shared";
 import {
   compareModelsForPicker,
   DEFAULT_GATEWAY_MODEL,
@@ -190,6 +190,27 @@ export abstract class BaseAcpAgent implements Agent {
       isDeepseekModelId(modelId);
 
     let currentModelId = currentModelOverride ?? DEFAULT_GATEWAY_MODEL;
+
+    // Subscription mode: no gateway URL means fetchGatewayModels returned an
+    // empty list, so `options` is empty and the picker cannot validate the
+    // saved id. A gateway-only id (Cloudflare, Modal, Deepseek, GLM) saved
+    // from a gateway session survives here and fails on the first turn
+    // (F-3500, F-3499). Fall back to the Anthropic default in that case.
+    if (
+      adapterModels.length === 0 &&
+      currentModelId !== DEFAULT_GATEWAY_MODEL
+    ) {
+      if (!isAnthropicModelId(currentModelId)) {
+        this.logger.warn(
+          "Saved model is not available without the gateway; falling back to default",
+          {
+            requestedModel: currentModelId,
+            fallbackModel: DEFAULT_GATEWAY_MODEL,
+          },
+        );
+        currentModelId = DEFAULT_GATEWAY_MODEL;
+      }
+    }
 
     if (!options.some((opt) => opt.value === currentModelId)) {
       if (!isClaudeAdapterModelId(currentModelId)) {

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1858,7 +1858,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         abortController: newAbortController,
         // `rest.model` is the creation-time value; the user may have switched
         // models since, so re-root the new Query on the live session model.
-        ...rerootedModelOptions(session.modelId, rest.fallbackModel),
+        ...rerootedModelOptions(
+          session.modelId,
+          rest.fallbackModel,
+          !!this.options?.machineAuth,
+        ),
       };
 
       const newInput = new Pushable<SDKUserMessage>();
@@ -2082,7 +2086,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         abortController,
         // `rest.model` is the creation-time value; the user may have
         // switched models since, so answer on the live session model.
-        ...rerootedModelOptions(this.session.modelId, rest.fallbackModel),
+        ...rerootedModelOptions(
+          this.session.modelId,
+          rest.fallbackModel,
+          !!this.options?.machineAuth,
+        ),
       };
 
       const oneShot = query({
@@ -2192,7 +2200,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         abortController: newAbortController,
         // `rest.model` is the creation-time value; the user may have switched
         // models since, so re-root the new Query on the live session model.
-        ...rerootedModelOptions(prev.modelId, rest.fallbackModel),
+        ...rerootedModelOptions(
+          prev.modelId,
+          rest.fallbackModel,
+          !!this.options?.machineAuth,
+        ),
       };
 
       const newInput = new Pushable<SDKUserMessage>();
@@ -2583,7 +2595,10 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
 
     const input = new Pushable<SDKUserMessage>();
 
-    const settingsManager = new SettingsManager(cwd);
+    const settingsManager = new SettingsManager(
+      cwd,
+      !!this.options?.machineAuth,
+    );
     await settingsManager.initialize();
 
     // The session's explicit pick outranks the shared claude settings file:

--- a/products/desktop/packages/agent/src/adapters/claude/machine-auth.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/machine-auth.ts
@@ -1,3 +1,6 @@
+import * as os from "node:os";
+import * as path from "node:path";
+
 export interface MachineClaudeAuth {
   configDir?: string;
 }
@@ -9,6 +12,14 @@ export const MACHINE_AUTH_STRIPPED_KEYS = [
   "ANTHROPIC_CUSTOM_HEADERS",
   "OPENAI_BASE_URL",
   "OPENAI_API_KEY",
+  // Provider selectors route the CLI to a third-party inference surface
+  // (Bedrock, Vertex, Foundry, AWS, Mantle) instead of the first-party
+  // Claude.ai subscription. An ambient value can bypass the user login.
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  "CLAUDE_CODE_USE_FOUNDRY",
+  "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+  "CLAUDE_CODE_USE_MANTLE",
   "CLAUDE_CODE_ENABLE_TELEMETRY",
   "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA",
   "CLAUDE_CODE_PROPAGATE_TRACEPARENT",
@@ -39,7 +50,12 @@ export function applyMachineClaudeAuth(
   if (auth.configDir) {
     env.CLAUDE_CONFIG_DIR = auth.configDir;
   } else {
-    delete env.CLAUDE_CONFIG_DIR;
+    // Pin the child to the user's Claude config so the CLI reads the
+    // subscription login from a single, known location. Deleting the
+    // variable also resolves to ~/.claude, but an explicit value keeps the
+    // parent and child on the same directory so imported transcripts and
+    // gateway-resume hydration find the same files (F-3545).
+    env.CLAUDE_CONFIG_DIR = path.join(os.homedir(), ".claude");
   }
 }
 
@@ -51,5 +67,8 @@ export function machineClaudeAuthShellEnv(auth: MachineClaudeAuth): {
   if (auth.configDir) {
     return { set: { CLAUDE_CONFIG_DIR: auth.configDir }, unset };
   }
-  return { set: {}, unset: [...unset, "CLAUDE_CONFIG_DIR"] };
+  return {
+    set: { CLAUDE_CONFIG_DIR: path.join(os.homedir(), ".claude") },
+    unset,
+  };
 }

--- a/products/desktop/packages/agent/src/adapters/claude/session/models.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/models.ts
@@ -26,10 +26,17 @@ export function resolveFallbackModel(modelId: string): string | undefined {
 export function rerootedModelOptions(
   modelId: string | undefined,
   existingFallbackModel?: string,
+  machineAuth?: boolean,
 ):
   | { model: string; fallbackModel: string | undefined }
   | Record<string, never> {
   if (!modelId) return {};
+  // Machine-auth sessions bill against the user's Claude plan, which may
+  // not include the gateway fallback model. Leave the fallback unset so a
+  // query rebuild (/clear, MCP refresh, /btw) does not restore it (F-3499).
+  if (machineAuth) {
+    return { model: modelId, fallbackModel: undefined };
+  }
   const fallbackModel =
     existingFallbackModel && existingFallbackModel !== modelId
       ? existingFallbackModel

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -453,6 +453,11 @@ describe("buildSessionOptions", () => {
       "ANTHROPIC_AUTH_TOKEN",
       "ANTHROPIC_API_KEY",
       "ANTHROPIC_CUSTOM_HEADERS",
+      "CLAUDE_CODE_USE_BEDROCK",
+      "CLAUDE_CODE_USE_VERTEX",
+      "CLAUDE_CODE_USE_FOUNDRY",
+      "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+      "CLAUDE_CODE_USE_MANTLE",
       "CLAUDE_CODE_ENABLE_TELEMETRY",
       "OTEL_EXPORTER_OTLP_ENDPOINT",
       "TRACEPARENT",
@@ -507,7 +512,7 @@ describe("buildSessionOptions", () => {
     });
 
     it.each([
-      { configDir: undefined, expected: undefined },
+      { configDir: undefined, expected: path.join(os.homedir(), ".claude") },
       { configDir: "/home/me/.claude", expected: "/home/me/.claude" },
     ])(
       "runs against the machine config dir $configDir, not the app one",

--- a/products/desktop/packages/agent/src/adapters/claude/session/settings.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/settings.ts
@@ -4,9 +4,29 @@ import * as path from "node:path";
 import type { PermissionRuleValue } from "@anthropic-ai/claude-agent-sdk";
 import { minimatch } from "minimatch";
 import { AsyncMutex } from "../../../utils/async-mutex";
+import { MACHINE_AUTH_STRIPPED_KEYS } from "../machine-auth";
 import { resolveMainRepoPath } from "./repo-path";
 
 const ACP_TOOL_NAME_PREFIX = "mcp__acp__";
+
+// Variables a repository settings file can set to redirect the CLI off the
+// user subscription. Mirrors MACHINE_AUTH_STRIPPED_KEYS so the filter stays
+// in sync with the strip list (F-3467).
+const MACHINE_AUTH_REJECTED_ENV_KEYS = new Set<string>(
+  MACHINE_AUTH_STRIPPED_KEYS,
+);
+
+function filterMachineAuthEnv(
+  env: Record<string, string>,
+): Record<string, string> {
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (!MACHINE_AUTH_REJECTED_ENV_KEYS.has(key)) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
+}
 
 const acpToolNames = {
   read: `${ACP_TOOL_NAME_PREFIX}Read`,
@@ -250,10 +270,12 @@ export class SettingsManager {
   private initialized = false;
   private initPromise: Promise<void> | null = null;
   private writeMutex = new AsyncMutex();
+  private readonly machineAuth: boolean;
 
-  constructor(cwd: string) {
+  constructor(cwd: string, machineAuth = false) {
     this.cwd = cwd;
     this.repoRoot = cwd;
+    this.machineAuth = machineAuth;
   }
 
   async initialize(): Promise<void> {
@@ -342,7 +364,16 @@ export class SettingsManager {
         }
       }
       if (settings.env) {
-        merged.env = { ...merged.env, ...settings.env };
+        // Repository-controlled settings can restore gateway variables
+        // that machine auth stripped, redirecting requests carrying the
+        // user OAuth token. Drop auth, endpoint, proxy, and telemetry keys
+        // from project and local layers during machine-auth sessions
+        // (F-3467). User and enterprise layers stay trusted.
+        let env = settings.env;
+        if (this.machineAuth && (layer === "project" || layer === "local")) {
+          env = filterMachineAuthEnv(env);
+        }
+        merged.env = { ...merged.env, ...env };
       }
       if (settings.model) {
         merged.model = settings.model;

--- a/products/desktop/packages/agent/src/adapters/claude/subscription-login.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/subscription-login.test.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from "node:events";
 import { existsSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -29,7 +31,16 @@ const STRIPPED_KEYS = [
   "ANTHROPIC_AUTH_TOKEN",
   "ANTHROPIC_API_KEY",
   "ANTHROPIC_CUSTOM_HEADERS",
+  "CLAUDE_CODE_USE_BEDROCK",
+  "CLAUDE_CODE_USE_VERTEX",
+  "CLAUDE_CODE_USE_FOUNDRY",
+  "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+  "CLAUDE_CODE_USE_MANTLE",
 ] as const;
+
+function statusJson(loggedIn: boolean, authMethod: string): string {
+  return JSON.stringify({ loggedIn, authMethod });
+}
 
 describe("hasClaudeLogin", () => {
   const original: Partial<Record<string, string | undefined>> = {};
@@ -59,42 +70,85 @@ describe("hasClaudeLogin", () => {
     delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
   });
 
+  function emitStdout(data: string): void {
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from(data, "utf8"));
+      child.emit("exit", 0);
+    });
+  }
+
   function exit(code: number): void {
     queueMicrotask(() => child.emit("exit", code));
   }
 
-  it("reports logged in when `claude auth status` exits 0", async () => {
+  it("reports logged in for a claude.ai subscription", async () => {
     const result = hasClaudeLogin({
       claudeCliPath: "/bundled/claude",
       machineAuth: {},
     });
-    exit(0);
-    await expect(result).resolves.toBe(true);
+    emitStdout(statusJson(true, "claude.ai"));
+    await expect(result).resolves.toBe("logged-in");
   });
 
-  it("reports logged out when the CLI exits non-zero", async () => {
+  it("reports logged in for an oauth_token subscription", async () => {
+    const result = hasClaudeLogin({
+      claudeCliPath: "/bundled/claude",
+      machineAuth: {},
+    });
+    emitStdout(statusJson(true, "oauth_token"));
+    await expect(result).resolves.toBe("logged-in");
+  });
+
+  it("reports logged out for a third-party Bedrock provider", async () => {
+    const result = hasClaudeLogin({
+      claudeCliPath: "/bundled/claude",
+      machineAuth: {},
+    });
+    emitStdout(statusJson(true, "third_party"));
+    await expect(result).resolves.toBe("logged-out");
+  });
+
+  it("reports logged out for an api_key auth method", async () => {
+    const result = hasClaudeLogin({
+      claudeCliPath: "/bundled/claude",
+      machineAuth: {},
+    });
+    emitStdout(statusJson(true, "api_key"));
+    await expect(result).resolves.toBe("logged-out");
+  });
+
+  it("reports logged out when the CLI confirms no login", async () => {
+    const result = hasClaudeLogin({
+      claudeCliPath: "/bundled/claude",
+      machineAuth: {},
+    });
+    emitStdout(statusJson(false, "none"));
+    await expect(result).resolves.toBe("logged-out");
+  });
+
+  it("reports unknown when the CLI exits non-zero with no JSON", async () => {
     const result = hasClaudeLogin({
       claudeCliPath: "/bundled/claude",
       machineAuth: {},
     });
     exit(1);
-    await expect(result).resolves.toBe(false);
+    await expect(result).resolves.toBe("unknown");
   });
 
-  it("reports logged out when the CLI cannot start", async () => {
+  it("reports unknown when the CLI cannot start", async () => {
     const result = hasClaudeLogin({
       claudeCliPath: "/bundled/claude",
       machineAuth: {},
     });
     queueMicrotask(() => child.emit("error", new Error("spawn failed")));
-    await expect(result).resolves.toBe(false);
+    await expect(result).resolves.toBe("unknown");
   });
 
-  it("reports logged out when the bundled binary is missing", async () => {
+  it("reports unknown when the bundled binary is missing", async () => {
     vi.mocked(existsSync).mockReturnValue(false);
     await expect(
       hasClaudeLogin({ claudeCliPath: "/bundled/claude", machineAuth: {} }),
-    ).resolves.toBe(false);
+    ).resolves.toBe("unknown");
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -103,7 +157,7 @@ describe("hasClaudeLogin", () => {
       claudeCliPath: "/bundled/claude",
       machineAuth: {},
     });
-    exit(0);
+    emitStdout(statusJson(true, "claude.ai"));
     await result;
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
@@ -113,7 +167,7 @@ describe("hasClaudeLogin", () => {
       { env: NodeJS.ProcessEnv },
     ];
     expect(command).toBe("/bundled/claude");
-    expect(args).toEqual(["auth", "status"]);
+    expect(args).toEqual(["auth", "status", "--json"]);
     for (const key of STRIPPED_KEYS) {
       expect(spawnOptions.env[key]).toBeUndefined();
     }
@@ -121,7 +175,7 @@ describe("hasClaudeLogin", () => {
   });
 
   it.each([
-    { configDir: undefined, expected: undefined },
+    { configDir: undefined, expected: path.join(os.homedir(), ".claude") },
     { configDir: "/home/me/.claude", expected: "/home/me/.claude" },
   ])(
     "checks the machine config dir $configDir, not the app one",
@@ -132,7 +186,7 @@ describe("hasClaudeLogin", () => {
           claudeCliPath: "/bundled/claude",
           machineAuth: { configDir },
         });
-        exit(0);
+        emitStdout(statusJson(true, "claude.ai"));
         await result;
 
         const [, , spawnOptions] = spawnMock.mock.calls[0] as [
@@ -140,6 +194,8 @@ describe("hasClaudeLogin", () => {
           string[],
           { env: NodeJS.ProcessEnv },
         ];
+        // When no explicit configDir is set, machine auth pins the child to
+        // the user's ~/.claude so the probe and the session agree (F-3545).
         expect(spawnOptions.env.CLAUDE_CONFIG_DIR).toBe(expected);
       } finally {
         delete process.env.CLAUDE_CONFIG_DIR;
@@ -152,15 +208,20 @@ describe("hasClaudeLogin", () => {
       claudeCliPath: "/bundled/claude/cli.js",
       machineAuth: {},
     });
-    exit(0);
+    emitStdout(statusJson(true, "claude.ai"));
     await result;
 
     const [command, args] = spawnMock.mock.calls[0] as [string, string[]];
     expect(command).toBe(process.execPath);
-    expect(args).toEqual(["/bundled/claude/cli.js", "auth", "status"]);
+    expect(args).toEqual([
+      "/bundled/claude/cli.js",
+      "auth",
+      "status",
+      "--json",
+    ]);
   });
 
-  it("reports logged out when the status check times out", async () => {
+  it("reports unknown when the status check times out", async () => {
     vi.useFakeTimers();
     try {
       const result = hasClaudeLogin({
@@ -169,7 +230,7 @@ describe("hasClaudeLogin", () => {
         timeoutMs: 100,
       });
       vi.advanceTimersByTime(200);
-      await expect(result).resolves.toBe(false);
+      await expect(result).resolves.toBe("unknown");
       expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     } finally {
       vi.useRealTimers();

--- a/products/desktop/packages/agent/src/adapters/claude/subscription-login.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/subscription-login.ts
@@ -14,6 +14,11 @@ export interface ClaudeAuthTerminalCommand {
 }
 
 function shellQuote(value: string): string {
+  // POSIX single quotes do not quote paths on Windows. Use double quotes
+  // there, escaping embedded double quotes (F-3494).
+  if (process.platform === "win32") {
+    return `"${value.replaceAll('"', '\\"')}"`;
+  }
   return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
@@ -47,21 +52,58 @@ export interface ClaudeLoginCheckOptions {
   timeoutMs?: number;
 }
 
+// Three-state result so callers can tell a confirmed logout from an
+// operational failure (missing binary, spawn error, timeout, unparseable
+// output). Treating a failed probe as "logged out" can route later sessions
+// through the gateway and spend PostHog credits by accident.
+export type ClaudeLoginResult = "logged-in" | "logged-out" | "unknown";
+
+interface ClaudeAuthStatusJson {
+  loggedIn?: unknown;
+  authMethod?: unknown;
+  apiProvider?: unknown;
+  subscriptionType?: unknown;
+}
+
+// A first-party Claude subscription login. `claude.ai` OAuth (Pro/Max/Team/
+// Enterprise) and a long-lived `oauth_token` both bill against the user plan.
+// `api_key` and `third_party` (Bedrock, Vertex, Foundry, Mantle) do not, so
+// they must not be reported as a subscription login.
+function isSubscriptionLogin(status: ClaudeAuthStatusJson): boolean {
+  if (status.loggedIn !== true) return false;
+  const method = status.authMethod;
+  return method === "claude.ai" || method === "oauth_token";
+}
+
+function parseAuthStatusJson(stdout: string): ClaudeAuthStatusJson | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object") {
+      return parsed as ClaudeAuthStatusJson;
+    }
+  } catch {
+    // Fall through; non-JSON output means the CLI is older or errored.
+  }
+  return null;
+}
+
 export async function hasClaudeLogin(
   options: ClaudeLoginCheckOptions,
-): Promise<boolean> {
+): Promise<ClaudeLoginResult> {
   if (!existsSync(options.claudeCliPath)) {
-    options.logger?.debug("Claude CLI not found, reporting no login", {
+    options.logger?.debug("Claude CLI not found, reporting unknown", {
       claudeCliPath: options.claudeCliPath,
     });
-    return false;
+    return "unknown";
   }
 
   const isLegacyJs = options.claudeCliPath.endsWith(".js");
   const command = isLegacyJs ? process.execPath : options.claudeCliPath;
   const args = isLegacyJs
-    ? [options.claudeCliPath, "auth", "status"]
-    : ["auth", "status"];
+    ? [options.claudeCliPath, "auth", "status", "--json"]
+    : ["auth", "status", "--json"];
 
   const env: NodeJS.ProcessEnv = { ...process.env };
   applyMachineClaudeAuth(env, options.machineAuth);
@@ -69,13 +111,13 @@ export async function hasClaudeLogin(
     env.ELECTRON_RUN_AS_NODE = "1";
   }
 
-  return new Promise<boolean>((resolve) => {
+  return new Promise<ClaudeLoginResult>((resolve) => {
     let settled = false;
-    const finish = (loggedIn: boolean): void => {
+    const finish = (result: ClaudeLoginResult): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolve(loggedIn);
+      resolve(result);
     };
 
     const child = spawn(command, args, {
@@ -85,11 +127,14 @@ export async function hasClaudeLogin(
 
     const timer = setTimeout(() => {
       child.kill("SIGTERM");
-      finish(false);
+      finish("unknown");
     }, options.timeoutMs ?? STATUS_TIMEOUT_MS);
 
+    let stdout = "";
     let stderr = "";
-    child.stdout?.on("data", () => {});
+    child.stdout?.on("data", (chunk: Buffer) => {
+      if (stdout.length < 10_000) stdout += chunk.toString("utf8");
+    });
     child.stderr?.on("data", (chunk: Buffer) => {
       if (stderr.length < 500) stderr += chunk.toString("utf8");
     });
@@ -97,15 +142,29 @@ export async function hasClaudeLogin(
       options.logger?.debug("Failed to run claude auth status", {
         error: error.message,
       });
-      finish(false);
+      finish("unknown");
     });
     child.on("exit", (code) => {
+      const status = parseAuthStatusJson(stdout);
       options.logger?.debug("claude auth status finished", {
         claudeCliPath: options.claudeCliPath,
         exitCode: code,
+        authMethod: status?.authMethod ?? null,
         stderr: stderr.slice(0, 500),
       });
-      finish(code === 0);
+      if (status && isSubscriptionLogin(status)) {
+        finish("logged-in");
+        return;
+      }
+      // Exit 0 with a parsed status that is not a subscription login means a
+      // third-party provider or API key is active. Exit non-zero with no JSON
+      // means the CLI confirmed no login. Either way the user is not on their
+      // Claude subscription.
+      if (status || code === 0) {
+        finish("logged-out");
+        return;
+      }
+      finish("unknown");
     });
   });
 }

--- a/products/desktop/packages/agent/src/agent.ts
+++ b/products/desktop/packages/agent/src/agent.ts
@@ -1,4 +1,9 @@
-import { buildPrOutput, mergePrUrls, readPrUrls } from "@posthog/shared";
+import {
+  buildPrOutput,
+  isAnthropicModelId,
+  mergePrUrls,
+  readPrUrls,
+} from "@posthog/shared";
 import {
   buildPosthogPropertyHeaderLines,
   buildPosthogPropertyHeaderRecord,
@@ -91,10 +96,13 @@ export class Agent {
       : await this._resolveGatewayConfig(options.gatewayUrl);
     this.taskRunId = taskRunId;
 
-    // getTask and getUserNode are independent, so start both before building
-    // attribution rather than serializing two startup round trips.
+    // Task attribution and the user node only feed the gateway auth headers.
+    // Subscription sessions have no gateway env, so the requests are unused.
+    // Skip them to avoid a slow PostHog fetch delaying a direct Claude session
+    // (F-3518).
+    const needsAttribution = !claudeSubscription && gatewayConfig !== null;
     const taskPromise =
-      this.posthogAPI && taskId !== "__preview__"
+      needsAttribution && this.posthogAPI && taskId !== "__preview__"
         ? this.posthogAPI.getTask(taskId).catch((error) => {
             this.logger.debug("Failed to fetch task attribution", error);
             return null;
@@ -103,8 +111,9 @@ export class Agent {
     // The node the gateway holds a person's spend limit against. Null (a
     // task-scoped credential) simply carries no user node, so the limit does
     // not apply rather than applying to the wrong person.
-    const userNodePromise =
-      this.posthogAPI?.getUserNode() ?? Promise.resolve(null);
+    const userNodePromise = needsAttribution
+      ? (this.posthogAPI?.getUserNode() ?? Promise.resolve(null))
+      : Promise.resolve(null);
     const [task, userNode] = await Promise.all([taskPromise, userNodePromise]);
 
     const attribution =
@@ -188,6 +197,21 @@ export class Agent {
       }
     }
     if (!sanitizedModel && options.adapter !== "codex" && !claudeSubscription) {
+      sanitizedModel = DEFAULT_GATEWAY_MODEL;
+    }
+    // A first-party Claude subscription can only run Anthropic models. A
+    // saved gateway-only id (Cloudflare, Modal, Deepseek, GLM) survives the
+    // skip of the gateway model fetch and then fails on the first turn
+    // (F-3412). Fall back to the Anthropic default so the session starts.
+    if (
+      claudeSubscription &&
+      sanitizedModel &&
+      !isAnthropicModelId(sanitizedModel)
+    ) {
+      this.logger.warn(
+        "Saved model is not available on the Claude subscription; using default",
+        { savedModel: sanitizedModel, fallback: DEFAULT_GATEWAY_MODEL },
+      );
       sanitizedModel = DEFAULT_GATEWAY_MODEL;
     }
 

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -167,6 +167,26 @@ export function isAnthropicModel(model: GatewayModel): boolean {
   return model.id.startsWith("claude-") || model.id.startsWith("anthropic/");
 }
 
+// Model-id check for paths that have no GatewayModel object, such as a saved
+// preference replayed on reconnect. A first-party Claude subscription can
+// only run Anthropic models; gateway-routed third-party ids (Cloudflare,
+// Modal, Baseten/Deepseek, GLM) are not valid against the user plan.
+export function isAnthropicModelId(modelId: string): boolean {
+  if (modelId.startsWith("claude-") || modelId.startsWith("anthropic/")) {
+    return true;
+  }
+  if (
+    isCloudflareModelId(modelId) ||
+    isModalModelId(modelId) ||
+    isDeepseekModelId(modelId) ||
+    isGlmModelId(modelId) ||
+    isBasetenModel({ id: modelId } as GatewayModel)
+  ) {
+    return false;
+  }
+  return false;
+}
+
 export function isOpenAIModel(model: GatewayModel): boolean {
   if (model.owned_by) {
     return model.owned_by === "openai";

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -108,6 +108,7 @@ export {
   getCloudTaskGatewayUrl,
   getProviderName,
   isAnthropicModel,
+  isAnthropicModelId,
   isBasetenModel,
   isBlockedModelId,
   isCloudflareModel,

--- a/products/desktop/packages/shared/src/models.test.ts
+++ b/products/desktop/packages/shared/src/models.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { isAnthropicModelId } from "./cloud-task-models";
 import { defaultEligibleModel } from "./models";
 
 describe("defaultEligibleModel", () => {
@@ -18,5 +19,21 @@ describe("defaultEligibleModel", () => {
     [undefined, undefined],
   ] as const)("%s -> %s", (modelId, expected) => {
     expect(defaultEligibleModel(modelId)).toBe(expected);
+  });
+});
+
+describe("isAnthropicModelId", () => {
+  it.each([
+    ["claude-sonnet-5", true],
+    ["anthropic/claude-opus-4", true],
+    ["@cf/zai-org/glm-5.2", false],
+    ["modal/claude-3", false],
+    ["deepseek/deepseek-chat", false],
+    ["glm-4", false],
+    ["baseten/claude-3", false],
+    ["gpt-5", false],
+    ["", false],
+  ] as const)("%s -> %s", (modelId, expected) => {
+    expect(isAnthropicModelId(modelId)).toBe(expected);
   });
 });

--- a/products/desktop/packages/ui/src/features/settings/adapterSubscription.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/adapterSubscription.test.ts
@@ -12,10 +12,13 @@ import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import {
   effectiveModelAccess,
   registerSubscriptionAtBoot,
+  type SubscriptionStatus,
   subscriptionNeedsConnection,
 } from "./adapterSubscription";
 
-const status = (loggedIn: boolean) => ({ loggedIn });
+const status = (loginState: "logged-in" | "logged-out" | "unknown") => ({
+  loginState,
+});
 
 describe("adapter subscription gating", () => {
   it.each([
@@ -24,7 +27,7 @@ describe("adapter subscription gating", () => {
       {
         flagEnabled: true,
         subscriptionOn: true,
-        loggedIn: true,
+        loginState: "logged-in" as const,
         workspaceMode: "cloud" as const,
       },
       "posthog-gateway",
@@ -34,7 +37,17 @@ describe("adapter subscription gating", () => {
       {
         flagEnabled: true,
         subscriptionOn: true,
-        loggedIn: false,
+        loginState: "logged-out" as const,
+        workspaceMode: "local" as const,
+      },
+      "posthog-gateway",
+    ],
+    [
+      "unknown status while loading falls back to the gateway",
+      {
+        flagEnabled: true,
+        subscriptionOn: true,
+        loginState: "unknown" as const,
         workspaceMode: "local" as const,
       },
       "posthog-gateway",
@@ -44,7 +57,7 @@ describe("adapter subscription gating", () => {
       {
         flagEnabled: false,
         subscriptionOn: true,
-        loggedIn: true,
+        loginState: "logged-in" as const,
         workspaceMode: "local" as const,
       },
       "posthog-gateway",
@@ -54,7 +67,7 @@ describe("adapter subscription gating", () => {
       {
         flagEnabled: true,
         subscriptionOn: true,
-        loggedIn: true,
+        loginState: "logged-in" as const,
         workspaceMode: "local" as const,
       },
       "own-subscription",
@@ -64,7 +77,7 @@ describe("adapter subscription gating", () => {
       {
         flagEnabled: true,
         subscriptionOn: true,
-        loggedIn: true,
+        loginState: "logged-in" as const,
         workspaceMode: "worktree" as const,
       },
       "own-subscription",
@@ -81,22 +94,35 @@ describe("adapter subscription gating", () => {
     ],
     [
       "confirmed signed out needs connection",
-      { flagEnabled: true, subscriptionOn: true, status: status(false) },
+      { flagEnabled: true, subscriptionOn: true, status: status("logged-out") },
       true,
     ],
     [
       "signed in does not need connection",
-      { flagEnabled: true, subscriptionOn: true, status: status(true) },
+      { flagEnabled: true, subscriptionOn: true, status: status("logged-in") },
+      false,
+    ],
+    [
+      "unknown status does not need connection",
+      { flagEnabled: true, subscriptionOn: true, status: status("unknown") },
       false,
     ],
     [
       "subscription off never needs connection",
-      { flagEnabled: true, subscriptionOn: false, status: status(false) },
+      {
+        flagEnabled: true,
+        subscriptionOn: false,
+        status: status("logged-out"),
+      },
       false,
     ],
     [
       "flag off never needs connection",
-      { flagEnabled: false, subscriptionOn: true, status: status(false) },
+      {
+        flagEnabled: false,
+        subscriptionOn: true,
+        status: status("logged-out"),
+      },
       false,
     ],
   ])("%s", (_name, input, expected) => {
@@ -130,12 +156,30 @@ describe("adapter subscription gating", () => {
     it("reports the login state once the check answers", async () => {
       await registerSubscriptionAtBoot(
         "claude",
-        () => Promise.resolve({ loggedIn: true }),
+        () => Promise.resolve({ loginState: "logged-in" }),
         true,
       );
 
       expect(registerAdapterSubscription).toHaveBeenLastCalledWith("claude", {
         access: "own-subscription",
+        connected: true,
+      });
+    });
+
+    it("re-reads the setting after the probe so a toggle change is not stale", async () => {
+      useSettingsStore.setState({
+        _hasHydrated: true,
+        claudeModelAccess: "own-subscription",
+      });
+      const fetchStatus = vi.fn((): Promise<SubscriptionStatus> => {
+        // Simulate the user flipping the toggle while the probe runs.
+        useSettingsStore.setState({ claudeModelAccess: "posthog-gateway" });
+        return Promise.resolve({ loginState: "logged-in" });
+      });
+      await registerSubscriptionAtBoot("claude", fetchStatus, true);
+
+      expect(registerAdapterSubscription).toHaveBeenLastCalledWith("claude", {
+        access: "posthog-gateway",
         connected: true,
       });
     });

--- a/products/desktop/packages/ui/src/features/settings/adapterSubscription.ts
+++ b/products/desktop/packages/ui/src/features/settings/adapterSubscription.ts
@@ -17,7 +17,7 @@ import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { useQuery } from "@tanstack/react-query";
 
 export interface SubscriptionStatus {
-  loggedIn: boolean;
+  loginState: "logged-in" | "logged-out" | "unknown";
 }
 
 export type WorkspaceModeForAccess = "local" | "worktree" | "cloud";
@@ -55,20 +55,20 @@ export function subscriptionNeedsConnection(input: {
   return (
     input.flagEnabled &&
     input.subscriptionOn &&
-    input.status?.loggedIn === false
+    input.status?.loginState === "logged-out"
   );
 }
 
 export function effectiveModelAccess(input: {
   flagEnabled: boolean;
   subscriptionOn: boolean;
-  loggedIn: boolean;
+  loginState: "logged-in" | "logged-out" | "unknown";
   workspaceMode: WorkspaceModeForAccess;
 }): ModelAccess {
   const usesOwnSubscription =
     input.flagEnabled &&
     input.subscriptionOn &&
-    input.loggedIn &&
+    input.loginState === "logged-in" &&
     input.workspaceMode !== "cloud";
   return usesOwnSubscription ? "own-subscription" : "posthog-gateway";
 }
@@ -81,13 +81,18 @@ export function applyModelAccess(
   const spec = SPECS[adapter];
   const state = useSettingsStore.getState();
   const prev = spec.readAccess(state);
-  if (prev === next) return;
-  spec.writeAccess(state, next);
-  track(ANALYTICS_EVENTS.SETTING_CHANGED, {
-    setting_name: spec.settingName,
-    new_value: next,
-    old_value: prev,
-  });
+  // Always sync the connected super property. Only the setting write and
+  // the SETTING_CHANGED event are gated on an access change, because a
+  // login/logout transition can flip `connected` while `ModelAccess` stays
+  // the same (F-3429, F-3541).
+  if (prev !== next) {
+    spec.writeAccess(state, next);
+    track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+      setting_name: spec.settingName,
+      new_value: next,
+      old_value: prev,
+    });
+  }
   registerAdapterSubscription(adapter, { access: next, connected });
 }
 
@@ -102,7 +107,15 @@ export async function registerSubscriptionAtBoot(
     : "posthog-gateway";
   registerAdapterSubscription(adapter, { access, connected: false });
   const status = await fetchStatus();
-  registerAdapterSubscription(adapter, { access, connected: status.loggedIn });
+  // Re-read the setting after the probe. A user can change the toggle while
+  // the status check is in flight; the earlier `access` value is stale.
+  const freshAccess = flagEnabled
+    ? SPECS[adapter].readAccess(useSettingsStore.getState())
+    : "posthog-gateway";
+  registerAdapterSubscription(adapter, {
+    access: freshAccess,
+    connected: status.loginState === "logged-in",
+  });
 }
 
 function settingsHydrated(): Promise<void> {
@@ -122,8 +135,11 @@ export interface AdapterSubscription {
   subscriptionOn: boolean;
   status: SubscriptionStatus | undefined;
   loggedIn: boolean;
+  loginState: "logged-in" | "logged-out" | "unknown";
+  statusPending: boolean;
   needsConnection: boolean;
   setSubscriptionOn: (on: boolean) => void;
+  refetchStatus: () => Promise<void>;
 }
 
 export function useAdapterSubscription(adapter: Adapter): AdapterSubscription {
@@ -132,19 +148,29 @@ export function useAdapterSubscription(adapter: Adapter): AdapterSubscription {
   const modelAccess = useSettingsStore(spec.readAccess);
   const { localWorkspaces } = useHostCapabilities();
   const hostTRPC = useHostTRPC();
-  const { data: status } = useQuery({
-    ...hostTRPC.agent[spec.statusProcedure].queryOptions(),
+  const statusQueryOptions =
+    hostTRPC.agent[spec.statusProcedure].queryOptions();
+  // Short stale time so a login or logout between actions does not stick. The
+  // desktop client default is five minutes, which can route a task through the
+  // wrong billing source after the user changes state (F-3553).
+  const { data: status, refetch } = useQuery({
+    ...statusQueryOptions,
     enabled: flagEnabled && localWorkspaces,
+    staleTime: 30_000,
   });
 
   const subscriptionOn = modelAccess === "own-subscription";
-  const loggedIn = status?.loggedIn === true;
+  const loggedIn = status?.loginState === "logged-in";
+  const loginState = status?.loginState ?? "unknown";
+  const statusPending = status === undefined;
 
   return {
     flagEnabled,
     subscriptionOn,
     status,
     loggedIn,
+    loginState,
+    statusPending,
     needsConnection: subscriptionNeedsConnection({
       flagEnabled,
       subscriptionOn,
@@ -156,5 +182,8 @@ export function useAdapterSubscription(adapter: Adapter): AdapterSubscription {
         on ? "own-subscription" : "posthog-gateway",
         loggedIn,
       ),
+    refetchStatus: async () => {
+      await refetch();
+    },
   };
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/ClaudeAuthTerminalDialog.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/ClaudeAuthTerminalDialog.tsx
@@ -13,7 +13,7 @@ import { Terminal } from "@posthog/ui/features/terminal/Terminal";
 import { useThemeStore } from "@posthog/ui/shell/themeStore";
 import { secureRandomString } from "@posthog/ui/utils/random";
 import { useQuery } from "@tanstack/react-query";
-import { type ReactElement, useCallback, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useState } from "react";
 
 export type ClaudeAuthAction = "login" | "logout";
 
@@ -80,9 +80,10 @@ export function ClaudeAuthTerminalDialog({
     ...hostTRPC.agent.claudeSubscriptionStatus.queryOptions(),
     enabled: stopped,
   });
-  const loggedIn = statusQuery.data?.loggedIn;
+  const loggedIn = statusQuery.data?.loginState === "logged-in";
+  const statusKnown = statusQuery.data?.loginState !== undefined;
   const verified = ((): boolean | undefined => {
-    if (!stopped || statusQuery.isFetching || loggedIn === undefined) {
+    if (!stopped || statusQuery.isFetching || !statusKnown) {
       return undefined;
     }
     return action === "login" ? loggedIn : !loggedIn;
@@ -113,6 +114,15 @@ export function ClaudeAuthTerminalDialog({
     destroyTerminalSession(sessionId);
     onClose();
   }, [sessionId, onClose]);
+
+  // A route or flag change can unmount the dialog without a close callback.
+  // Destroy the auth terminal and its server pty on unmount so the sensitive
+  // process does not survive the component (F-3449, F-3475).
+  useEffect(() => {
+    return () => {
+      destroyTerminalSession(sessionId);
+    };
+  }, [sessionId]);
 
   return (
     <Dialog open onOpenChange={(open) => !open && handleClose()}>

--- a/products/desktop/packages/ui/src/features/settings/sections/ClaudeSubscriptionSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/ClaudeSubscriptionSettings.tsx
@@ -1,12 +1,10 @@
 import { useHostTRPC } from "@posthog/host-router/react";
 import { Button, Switch } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared";
-import {
-  applyModelAccess,
-  useAdapterSubscription,
-} from "@posthog/ui/features/settings/adapterSubscription";
+import { useAdapterSubscription } from "@posthog/ui/features/settings/adapterSubscription";
 import { SettingsCardRow } from "@posthog/ui/features/settings/components/SettingsCard";
 import { track } from "@posthog/ui/shell/analytics";
+import { registerAdapterSubscription } from "@posthog/ui/shell/posthogAnalyticsImpl";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { type ReactElement, useEffect, useRef, useState } from "react";
 import {
@@ -30,23 +28,33 @@ export function ClaudeSubscriptionSettings(): ReactElement | null {
     ...statusQuery,
     enabled: subscription.flagEnabled,
   });
-  const loggedIn = status?.loggedIn === true;
-  const settled = !isPending && !isError;
+  const loggedIn = status?.loginState === "logged-in";
+  const statusUnknown = status?.loginState === "unknown";
+  const settled = !isPending && !isError && !statusUnknown;
 
+  // Track connection state for analytics only. The toggle stays the source
+  // of truth for the billing preference; a status observation must not write
+  // the setting (F-3471).
   const lastKnownLoggedIn = useRef<boolean | null>(null);
   useEffect(() => {
     if (!settled) return;
     const previous = lastKnownLoggedIn.current;
     lastKnownLoggedIn.current = loggedIn;
-    if (previous === null || previous === loggedIn) return;
+    if (previous === loggedIn) return;
     if (loggedIn) {
       track(ANALYTICS_EVENTS.CLAUDE_SUBSCRIPTION_CONNECTED);
-      applyModelAccess("claude", "own-subscription", true);
-      return;
+    } else {
+      track(ANALYTICS_EVENTS.CLAUDE_SUBSCRIPTION_SIGNED_OUT);
     }
-    track(ANALYTICS_EVENTS.CLAUDE_SUBSCRIPTION_SIGNED_OUT);
-    applyModelAccess("claude", "posthog-gateway", false);
-  }, [settled, loggedIn]);
+    // Keep the connected super property in sync with the login state without
+    // touching the access preference.
+    registerAdapterSubscription("claude", {
+      access: subscription.subscriptionOn
+        ? "own-subscription"
+        : "posthog-gateway",
+      connected: loggedIn,
+    });
+  }, [settled, loggedIn, subscription.subscriptionOn]);
 
   if (!subscription.flagEnabled) {
     return null;
@@ -56,15 +64,21 @@ export function ClaudeSubscriptionSettings(): ReactElement | null {
     void queryClient.invalidateQueries({ queryKey: statusQuery.queryKey });
   };
 
-  const summary = loggedIn
+  // The summary reflects the effective billing source, which needs both
+  // the login and the toggle (F-3420). A logged-in account with the switch
+  // off still bills PostHog credits.
+  const usingSubscription = loggedIn && subscription.subscriptionOn;
+  const summary = usingSubscription
     ? "Local and worktree Claude sessions run on your Claude plan instead of PostHog credits. Cloud tasks always use PostHog credits"
-    : "Run local and worktree Claude sessions on your Claude plan instead of PostHog credits. Log in once with the Claude Code CLI, then re-check";
+    : loggedIn
+      ? "Your Claude account is connected, but the switch is off. Local and worktree Claude sessions still use PostHog credits. Turn the switch on to use your Claude plan"
+      : "Run local and worktree Claude sessions on your Claude plan instead of PostHog credits. Log in once with the Claude Code CLI, then re-check";
 
   const statusLine = ((): { color: string; label: string } => {
     if (isPending) {
       return { color: "bg-(--gray-9)", label: "Checking" };
     }
-    if (isError) {
+    if (isError || statusUnknown) {
       return { color: "bg-(--amber-9)", label: "Could not check the login" };
     }
     if (loggedIn) {
@@ -116,6 +130,7 @@ export function ClaudeSubscriptionSettings(): ReactElement | null {
         </Button>
         <Switch
           size="sm"
+          aria-label="Use your Claude subscription"
           checked={subscription.subscriptionOn}
           onCheckedChange={(checked) => {
             subscription.setSubscriptionOn(checked === true);

--- a/products/desktop/packages/ui/src/features/settings/sections/CodexSubscriptionSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/CodexSubscriptionSettings.tsx
@@ -28,9 +28,11 @@ export function CodexSubscriptionSettings(): ReactElement | null {
     ...statusQuery,
     enabled: subscription.flagEnabled,
     refetchInterval: (query) =>
-      awaitingLogin && query.state.data?.loggedIn !== true ? 2000 : false,
+      awaitingLogin && query.state.data?.loginState !== "logged-in"
+        ? 2000
+        : false,
   });
-  const loggedIn = status?.loggedIn === true;
+  const loggedIn = status?.loginState === "logged-in";
 
   useEffect(() => {
     if (!awaitingLogin || !loggedIn) return;

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -412,12 +412,29 @@ export function useTaskCreation({
             localMcpServers,
             adapter,
           );
+          // Refetch the subscription status before routing a task, so a stale or
+          // pending login result does not silently select the wrong billing
+          // source (F-3451, F-3535, F-3553).
+          if (
+            runtime !== "pi" &&
+            adapter === "claude" &&
+            claudeSubscription.flagEnabled
+          ) {
+            await claudeSubscription.refetchStatus();
+          }
+          if (
+            runtime !== "pi" &&
+            adapter === "codex" &&
+            codexSubscription.flagEnabled
+          ) {
+            await codexSubscription.refetchStatus();
+          }
           const codexModelAccess =
             runtime !== "pi" && adapter === "codex"
               ? effectiveModelAccess({
                   flagEnabled: codexSubscription.flagEnabled,
                   subscriptionOn: codexSubscription.subscriptionOn,
-                  loggedIn: codexSubscription.loggedIn,
+                  loginState: codexSubscription.loginState,
                   workspaceMode,
                 })
               : undefined;
@@ -426,7 +443,7 @@ export function useTaskCreation({
               ? effectiveModelAccess({
                   flagEnabled: claudeSubscription.flagEnabled,
                   subscriptionOn: claudeSubscription.subscriptionOn,
-                  loggedIn: claudeSubscription.loggedIn,
+                  loginState: claudeSubscription.loginState,
                   workspaceMode,
                 })
               : undefined;
@@ -720,11 +737,13 @@ export function useTaskCreation({
       taskService,
       tasks,
       codexSubscription.flagEnabled,
-      codexSubscription.loggedIn,
+      codexSubscription.loginState,
       codexSubscription.subscriptionOn,
       claudeSubscription.flagEnabled,
-      claudeSubscription.loggedIn,
+      claudeSubscription.loginState,
       claudeSubscription.subscriptionOn,
+      claudeSubscription.refetchStatus,
+      codexSubscription.refetchStatus,
     ],
   );
 

--- a/products/desktop/packages/ui/src/features/terminal/terminalStore.test.ts
+++ b/products/desktop/packages/ui/src/features/terminal/terminalStore.test.ts
@@ -61,7 +61,7 @@ describe("terminalStore persistence", () => {
     });
   });
 
-  it("drops transcripts written before sensitive terminals were marked", () => {
+  it("drops only auth terminal transcripts, not task terminal scrollback", () => {
     expect(
       clearPersistedTranscripts({
         terminalStates: {
@@ -75,7 +75,7 @@ describe("terminalStore persistence", () => {
     ).toEqual({
       terminalStates: {
         "claude-auth-login-abc": { serializedState: null, sessionId: null },
-        "task-1-shell": { serializedState: null, sessionId: null },
+        "task-1-shell": { serializedState: "scrollback", sessionId: null },
       },
     });
   });

--- a/products/desktop/packages/ui/src/features/terminal/terminalStore.ts
+++ b/products/desktop/packages/ui/src/features/terminal/terminalStore.ts
@@ -74,12 +74,17 @@ export function clearPersistedTranscripts(persistedState: unknown) {
     return persistedState;
   }
 
+  // Only auth terminals hold sensitive login/logout scrollback. Normal task
+  // terminals use serializedState to restore shell history, so the upgrade
+  // must not clear them (F-3505).
   return {
     ...state,
     terminalStates: Object.fromEntries(
       Object.entries(state.terminalStates).map(([key, value]) => [
         key,
-        { ...value, serializedState: null },
+        key.startsWith("claude-auth-")
+          ? { ...value, serializedState: null }
+          : value,
       ]),
     ),
   };

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
@@ -128,6 +128,42 @@ describe("registerAppVersion", () => {
   });
 });
 
+describe("registerAdapterSubscription", () => {
+  it("reports the saved access when connected", async () => {
+    const { initializePostHog, registerAdapterSubscription } =
+      await loadAnalytics();
+    initializePostHog();
+
+    registerAdapterSubscription("claude", {
+      access: "own-subscription",
+      connected: true,
+    });
+
+    expect(mockPosthog.register).toHaveBeenCalledWith({
+      claude_model_access: "own-subscription",
+      claude_subscription_connected: true,
+    });
+  });
+
+  it("reports the gateway as effective access when disconnected (F-3460)", async () => {
+    const { initializePostHog, registerAdapterSubscription } =
+      await loadAnalytics();
+    initializePostHog();
+
+    // The toggle is on but the login is not active. The session uses the
+    // gateway, so the super property must say so for correct billing.
+    registerAdapterSubscription("claude", {
+      access: "own-subscription",
+      connected: false,
+    });
+
+    expect(mockPosthog.register).toHaveBeenCalledWith({
+      claude_model_access: "posthog-gateway",
+      claude_subscription_connected: false,
+    });
+  });
+});
+
 describe("track", () => {
   it("stamps inbox_client on inbox events", async () => {
     const { initializePostHog, track } = await loadAnalytics();

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -69,8 +69,13 @@ function subscriptionProperties(
   adapter: Adapter,
   { access, connected }: AdapterSubscriptionState,
 ): Record<string, string | boolean> {
+  // Report the effective billing source, not the saved preference. A
+  // logged-out session with the toggle on still uses the gateway, so the
+  // super property must say so to keep billing attribution correct
+  // (F-3460).
+  const effectiveAccess = connected ? access : "posthog-gateway";
   return {
-    [`${adapter}_model_access`]: access,
+    [`${adapter}_model_access`]: effectiveAccess,
     [`${adapter}_subscription_connected`]: connected,
   };
 }

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -325,8 +325,41 @@ describe("AgentService", () => {
         "/mock/appPath/.vite/build/claude-cli/claude",
       );
       expect(terminal.command).toContain(expected);
-      expect(terminal.unsetEnv).toContain("CLAUDE_CONFIG_DIR");
+      // Machine auth pins the child to the user's ~/.claude instead of
+      // unsetting the app config dir (F-3545).
+      expect(terminal.additionalEnv.CLAUDE_CONFIG_DIR).toMatch(
+        /[\\/]\.claude$/,
+      );
       expect(terminal.unsetEnv).toContain("ANTHROPIC_API_KEY");
+    });
+
+    it("stops active subscription sessions when logout starts", async () => {
+      const sessions = (
+        service as unknown as { sessions: Map<string, unknown> }
+      ).sessions;
+      const cleanedUp: string[] = [];
+      vi.spyOn(
+        service as unknown as { cleanupSession: (id: string) => Promise<void> },
+        "cleanupSession",
+      ).mockImplementation((taskRunId: string) => {
+        cleanedUp.push(taskRunId);
+        return Promise.resolve();
+      });
+      sessions.set("run-sub-1", {
+        config: { claudeModelAccess: "own-subscription" },
+      });
+      sessions.set("run-gw-1", {
+        config: { claudeModelAccess: "posthog-gateway" },
+      });
+
+      service.getClaudeAuthTerminal("logout");
+      // prepareClaudeAccountChange runs async; let it flush.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Only the subscription session is cleaned up; the gateway session is
+      // left alone (F-3530).
+      expect(cleanedUp).toEqual(["run-sub-1"]);
     });
   });
 

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -531,19 +531,19 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
 
   private codexLogin?: CodexLoginSession;
   private codexAuthGeneration = 0;
+  private claudeAuthGeneration = 0;
 
   async getCodexSubscriptionStatus(): Promise<CodexSubscriptionStatus> {
-    if (this.codexLogin) return { loggedIn: false };
-    return {
-      loggedIn: await hasCodexChatgptLogin({
-        binaryPath: this.getCodexBinaryPath(),
-      }),
-    };
+    if (this.codexLogin) return { loginState: "logged-out" };
+    const loggedIn = await hasCodexChatgptLogin({
+      binaryPath: this.getCodexBinaryPath(),
+    });
+    return { loginState: loggedIn ? "logged-in" : "logged-out" };
   }
 
   async getClaudeSubscriptionStatus(): Promise<ClaudeSubscriptionStatus> {
     return {
-      loggedIn: await hasClaudeLogin({
+      loginState: await hasClaudeLogin({
         claudeCliPath: this.getClaudeCliPath(),
         machineAuth: machineClaudeAuth(),
         logger: this.log,
@@ -552,6 +552,12 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
   }
 
   getClaudeAuthTerminal(action: ClaudeAuthAction): ClaudeAuthTerminal {
+    // A logout invalidates the credentials every active subscription session
+    // holds. Stop them first so a later prompt does not fail mid-turn
+    // (F-3530). Login does not need the guard.
+    if (action === "logout") {
+      void this.prepareClaudeAccountChange();
+    }
     const { command, env } = claudeAuthTerminalCommand(
       action,
       this.getClaudeCliPath(),
@@ -563,6 +569,23 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
       additionalEnv: env.set,
       unsetEnv: env.unset,
     };
+  }
+
+  private async prepareClaudeAccountChange(): Promise<void> {
+    this.claudeAuthGeneration += 1;
+    await this.stopClaudeSubscriptionSessions();
+  }
+
+  private async stopClaudeSubscriptionSessions(): Promise<void> {
+    const sessionIds = [...this.sessions.entries()]
+      .filter(
+        ([, session]) =>
+          session.config.claudeModelAccess === "own-subscription",
+      )
+      .map(([taskRunId]) => taskRunId);
+    await Promise.all(
+      sessionIds.map((taskRunId) => this.cleanupSession(taskRunId)),
+    );
   }
 
   async startCodexSubscriptionLogin(): Promise<{ authUrl: string }> {
@@ -979,9 +1002,29 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
       );
       const codexSubscription =
         adapter === "codex" && config.codexModelAccess === "own-subscription";
-      const claudeSubscription =
+      let claudeSubscription =
         adapter === "claude" && config.claudeModelAccess === "own-subscription";
+      // Re-verify the Claude login before honoring the own-subscription
+      // preference. The client can send a stale access value after the user
+      // signed out in another terminal, and reconnect replays the stored
+      // value without a fresh check (F-3439, F-3483). Downgrade to the gateway
+      // so the session starts with PostHog credentials instead of no auth.
+      if (claudeSubscription) {
+        const loginState = await hasClaudeLogin({
+          claudeCliPath: this.getClaudeCliPath(),
+          machineAuth: machineClaudeAuth(),
+          logger: this.log,
+        });
+        if (loginState !== "logged-in") {
+          this.log.warn(
+            "Claude own-subscription requested but login is not active; using gateway",
+            { loginState, isReconnect },
+          );
+          claudeSubscription = false;
+        }
+      }
       const codexAuthGeneration = this.codexAuthGeneration;
+      const claudeAuthGeneration = this.claudeAuthGeneration;
 
       let codexHome: string | undefined;
       if (adapter === "codex") {
@@ -1324,6 +1367,13 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
       ) {
         await this.cleanupSession(taskRunId);
         throw new Error("The Codex account changed during task setup.");
+      }
+      if (
+        claudeSubscription &&
+        claudeAuthGeneration !== this.claudeAuthGeneration
+      ) {
+        await this.cleanupSession(taskRunId);
+        throw new Error("The Claude account changed during task setup.");
       }
       this.recordActivity(taskRunId);
 

--- a/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
@@ -291,7 +291,7 @@ export const rtkStatusOutput = z.object({
 export type RtkStatus = z.infer<typeof rtkStatusOutput>;
 
 export const codexSubscriptionStatusOutput = z.object({
-  loggedIn: z.boolean(),
+  loginState: z.enum(["logged-in", "logged-out", "unknown"]),
 });
 
 export type CodexSubscriptionStatus = z.infer<
@@ -299,7 +299,11 @@ export type CodexSubscriptionStatus = z.infer<
 >;
 
 export const claudeSubscriptionStatusOutput = z.object({
-  loggedIn: z.boolean(),
+  // "logged-in": the CLI reports a first-party Claude subscription.
+  // "logged-out": the CLI confirmed no subscription login.
+  // "unknown": the probe failed (missing binary, spawn error, timeout), so
+  // the saved preference must not change.
+  loginState: z.enum(["logged-in", "logged-out", "unknown"]),
 });
 
 export type ClaudeSubscriptionStatus = z.infer<

--- a/products/desktop/packages/workspace-server/src/services/claude-cli-sessions/claude-cli-sessions.ts
+++ b/products/desktop/packages/workspace-server/src/services/claude-cli-sessions/claude-cli-sessions.ts
@@ -52,6 +52,9 @@ interface ScannedSession {
 }
 
 function claudeCliDir(): string {
+  // The host always reads transcripts from the user's ~/.claude. Machine
+  // auth pins CLAUDE_CONFIG_DIR for the child process env, but the host
+  // reads from the same default location the CLI writes to in both modes.
   return path.join(os.homedir(), ".claude");
 }
 

--- a/products/desktop/packages/workspace-server/src/services/shell/shell.ts
+++ b/products/desktop/packages/workspace-server/src/services/shell/shell.ts
@@ -63,6 +63,20 @@ function getShellArgs(shell: string): string[] {
   return ["-l"];
 }
 
+// The flag a shell uses to run a command string. POSIX shells use `-c`,
+// cmd.exe uses `/c`, and PowerShell uses `-Command`. A single `-c` breaks
+// auth terminals on Windows (F-3494).
+function getCommandShellArgs(shell: string, command: string): string[] {
+  if (platform() === "win32") {
+    const lower = shell.toLowerCase();
+    if (lower.includes("powershell") || lower.includes("pwsh")) {
+      return ["-NoLogo", "-Command", command];
+    }
+    return ["/c", command];
+  }
+  return ["-c", command];
+}
+
 function buildShellEnv(
   additionalEnv?: Record<string, string>,
   unsetEnv?: string[],
@@ -253,7 +267,7 @@ export class ShellService extends TypedEventEmitter<ShellEvents> {
     const workingDir = this.resolveWorkingDir(sessionId, cwd);
     const shell = getDefaultShell();
 
-    const ptyProcess = pty.spawn(shell, ["-c", command], {
+    const ptyProcess = pty.spawn(shell, getCommandShellArgs(shell, command), {
       name: "xterm-256color",
       cols: 80,
       rows: 24,


### PR DESCRIPTION
## Problem

PR #90933 added the ability for local Claude Code sessions to run on a user's own Claude Pro/Max subscription. Review found 26 issues across login detection, auth-variable leakage, session lifecycle, billing attribution, and Windows shell support. This PR fixes all 26 findings so the feature is safe to ship.

## Changes

**Login detection is now accurate.** `hasClaudeLogin` runs `claude auth status --json` and checks the `authMethod` field. Only `claude.ai` and `oauth_token` count as a subscription login. Bedrock, Vertex, and API-key providers report logged-out. The return type changed from boolean to a three-state result (`logged-in`, `logged-out`, `unknown`) so a confirmed logout is distinct from a probe failure. Five provider selectors (`CLAUDE_CODE_USE_BEDROCK`, etc.) are now stripped from the probe environment.

**Auth variables cannot leak back in.** Machine auth pins `CLAUDE_CONFIG_DIR` to `~/.claude` explicitly instead of deleting it. `SettingsManager` filters auth, endpoint, proxy, and telemetry variables from project and local settings layers during machine-auth sessions, so a repo `.claude/settings.json` cannot restore stripped gateway variables.

**Server re-checks login before honoring the toggle.** `getOrCreateSession` calls `hasClaudeLogin` on both start and reconnect. A stale login downgrades to the gateway instead of starting a session with no auth.

**Non-Anthropic models fall back safely.** A new `isAnthropicModelId` check validates the saved model for subscription sessions. A non-Anthropic saved model falls back to the default gateway model. `rerootedModelOptions` skips fallback restoration in machine-auth mode.

**Logout stops active sessions.** Claude logout now stops active subscription sessions before the auth terminal opens, mirroring the Codex path. A generation guard cancels sessions whose account changed during setup.

**Subscription sessions skip unused API fetches.** `getTask` and `getUserNode` only feed gateway auth headers, so subscription sessions skip both.

**Status race fixed.** `useAdapterSubscription` exposes `loginState`, `statusPending`, and `refetchStatus`. `staleTime` is 30 seconds. `useTaskCreation` refetches status before routing a task. The settings summary reflects both login and toggle state. The login effect no longer writes settings on transitions. `applyModelAccess` always syncs the connected super property. `registerSubscriptionAtBoot` re-reads the setting after the probe.

**Billing attribution reports effective access.** `subscriptionProperties` reports `posthog-gateway` when the session is disconnected, not the saved `own-subscription` preference.

**Terminal cleanup and Windows shell.** Auth terminal dialog destroys the session on unmount. `clearPersistedTranscripts` scopes to `claude-auth-` prefixed keys only. `shell.ts` uses `/c` for cmd.exe and `-Command` for PowerShell. `shellQuote` uses double quotes on Windows.

## How did you test this code

Automated tests run and pass:

- `subscription-login.test.ts` — 13 tests covering JSON parsing, provider classification, three-state result, config dir pinning, timeout. New cases: `claude.ai` login, `oauth_token` login, `third_party` logout, `api_key` logout, `none` logout, non-zero exit returns `unknown`, missing binary returns `unknown`, timeout returns `unknown`.
- `adapterSubscription.test.ts` — 15 tests covering `loginState`-based gating, `unknown` status, stale-setting re-read after probe.
- `posthogAnalyticsImpl.test.ts` — 2 new tests: connected reports saved access, disconnected reports gateway (F-3460).
- `terminalStore.test.ts` — updated test confirms auth terminals cleared, task terminals keep scrollback.
- `agent.test.ts` (workspace-server) — 61 tests including new test: logout stops subscription sessions only, not gateway sessions.
- `options.test.ts` — updated for `CLAUDE_CONFIG_DIR` pinning and provider selector stripping.
- `models.test.ts` (shared) — 9 new cases for `isAnthropicModelId`.
- `shell.test.ts`, `claude-cli-sessions.test.ts` — pass unchanged.

The agent did not run the app or perform manual browser testing. The `settings.test.ts` suite has 13 pre-existing failures on the base branch (it uses `git commit` for worktree setup, which is disabled in this environment) — not caused by these changes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs touch this feature yet.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Implemented all 26 review findings from PR #90933 in a single pass. Grouped findings by root cause and file to avoid conflicting edits. Key decisions: three-state `ClaudeLoginResult` over boolean to distinguish probe failure from confirmed logout; `isAnthropicModelId` as a shared helper for subscription-safe model validation; `CLAUDE_CONFIG_DIR` explicit pin over deletion to keep parent and child consistent; server-side login re-check on both start and reconnect; 30-second `staleTime` on the status query so login/logout between actions does not stick.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*