### PR TITLE
fix(desktop): connect GitHub from repository dialog

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRepositoryDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRepositoryDialog.test.tsx
@@ -1,12 +1,42 @@
+import { useIntegrationStore } from "@posthog/ui/features/integrations/store";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskRepositoryDialog } from "./TaskRepositoryDialog";
 
+vi.mock(
+  "@posthog/ui/features/settings/sections/ProjectGithubConnectionSection",
+  () => ({
+    ProjectGithubConnectionSection: () => (
+      <button type="button">Connect GitHub</button>
+    ),
+  }),
+);
+
+vi.mock(
+  "@posthog/ui/features/integrations/useIntegrations",
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    useGithubRepositories: () => ({
+      repositories: [],
+      getIntegrationIdForRepo: vi.fn(),
+      isPending: false,
+      isFetchingMore: false,
+      hasMore: false,
+      loadMore: vi.fn(),
+    }),
+  }),
+);
+
 describe("TaskRepositoryDialog", () => {
+  beforeEach(() => {
+    useIntegrationStore.getState().setIntegrations([]);
+  });
+
   it("applies an empty repository selection", async () => {
     const user = userEvent.setup();
     const onApply = vi.fn();
+    useIntegrationStore.getState().setIntegrations([{ id: 7, kind: "github" }]);
 
     render(
       <TaskRepositoryDialog
@@ -34,5 +64,29 @@ describe("TaskRepositoryDialog", () => {
       folder: "",
       saveToSpace: false,
     });
+  });
+
+  it("shows GitHub connection setup instead of repository controls when disconnected", () => {
+    render(
+      <TaskRepositoryDialog
+        open
+        onOpenChange={vi.fn()}
+        cloud
+        repositories={[]}
+        integrationId={null}
+        folder=""
+        onApply={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Connect GitHub" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Apply" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Use these repositories for the whole space"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskRepositoryDialog.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskRepositoryDialog.tsx
@@ -12,6 +12,8 @@ import {
 } from "@posthog/quill";
 import { FolderPicker } from "@posthog/ui/features/folder-picker/FolderPicker";
 import { RepositoriesField } from "@posthog/ui/features/integrations/components/RepositoriesField";
+import { useIntegrationSelectors } from "@posthog/ui/features/integrations/store";
+import { ProjectGithubConnectionSection } from "@posthog/ui/features/settings/sections/ProjectGithubConnectionSection";
 import { useState } from "react";
 
 interface TaskRepositoryDialogProps {
@@ -81,6 +83,7 @@ export function TaskRepositoryDialog({
   folder,
   onApply,
 }: TaskRepositoryDialogProps) {
+  const { hasGithubIntegration } = useIntegrationSelectors();
   const [draftRepositories, setDraftRepositories] = useState(repositories);
   const [draftIntegrationId, setDraftIntegrationId] = useState(integrationId);
   const [draftFolder, setDraftFolder] = useState(folder);
@@ -112,29 +115,33 @@ export function TaskRepositoryDialog({
         </DialogHeader>
         <DialogBody>
           {cloud ? (
-            <div className="flex flex-col gap-4">
-              <RepositoriesField
-                selected={draftRepositories}
-                integrationId={draftIntegrationId}
-                onChange={(next, nextIntegrationId) => {
-                  setDraftRepositories(next);
-                  setDraftIntegrationId(nextIntegrationId);
-                }}
-              />
-              <label
-                htmlFor="save-task-repositories-to-space"
-                className="flex cursor-pointer items-center gap-2 text-sm"
-              >
-                <Checkbox
-                  id="save-task-repositories-to-space"
-                  checked={saveToSpace}
-                  onCheckedChange={(checked) =>
-                    setSaveToSpace(checked === true)
-                  }
+            hasGithubIntegration ? (
+              <div className="flex flex-col gap-4">
+                <RepositoriesField
+                  selected={draftRepositories}
+                  integrationId={draftIntegrationId}
+                  onChange={(next, nextIntegrationId) => {
+                    setDraftRepositories(next);
+                    setDraftIntegrationId(nextIntegrationId);
+                  }}
                 />
-                Use these repositories for the whole space
-              </label>
-            </div>
+                <label
+                  htmlFor="save-task-repositories-to-space"
+                  className="flex cursor-pointer items-center gap-2 text-sm"
+                >
+                  <Checkbox
+                    id="save-task-repositories-to-space"
+                    checked={saveToSpace}
+                    onCheckedChange={(checked) =>
+                      setSaveToSpace(checked === true)
+                    }
+                  />
+                  Use these repositories for the whole space
+                </label>
+              </div>
+            ) : (
+              <ProjectGithubConnectionSection />
+            )
           ) : (
             <FolderPicker
               value={draftFolder}
@@ -148,26 +155,28 @@ export function TaskRepositoryDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button
-            variant="primary"
-            disabled={!cloud && !draftFolder}
-            onClick={() => {
-              onApply({
-                repositories: draftRepositories,
-                integrationId: draftIntegrationId,
-                folder: draftFolder,
-                saveToSpace,
-              });
-              onOpenChange(false);
-            }}
-          >
-            {cloud ? (
-              <GithubLogoIcon size={16} />
-            ) : (
-              <FolderOpenIcon size={16} />
-            )}
-            Apply
-          </Button>
+          {!cloud || hasGithubIntegration ? (
+            <Button
+              variant="primary"
+              disabled={!cloud && !draftFolder}
+              onClick={() => {
+                onApply({
+                  repositories: draftRepositories,
+                  integrationId: draftIntegrationId,
+                  folder: draftFolder,
+                  saveToSpace,
+                });
+                onOpenChange(false);
+              }}
+            >
+              {cloud ? (
+                <GithubLogoIcon size={16} />
+              ) : (
+                <FolderOpenIcon size={16} />
+              )}
+              Apply
+            </Button>
+          ) : null}
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Problem

People without a GitHub project connection hit a disabled repository picker and must leave the task dialog to fix it.

## Changes

- The repository dialog now shows the existing project GitHub connection setup when GitHub is unavailable.
- The dialog switches to repository selection after the connection completes.
- The Apply action stays hidden until a GitHub connection exists.
- Screenshot not included because the cloud sandbox's fresh desktop profile could not reach this authenticated dialog.

## How did you test this code?

- Added a component test that guards the disconnected setup flow and hides unusable repository controls.
- Ran the focused component test, the UI package typecheck, desktop lint, and CI preflight.
- The full desktop suite reached unrelated Git tests that create temporary unsigned commits. The sandbox blocks those commits.
- Live UI verification stopped at the sign-in screen in the fresh development profile.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The dialog reuses the existing GitHub connection flow and copy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop authored this change with pi, GitHub CLI, and the desktop browser harness.

Skills invoked: `/posthog-desktop`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The change reuses the settings connection section instead of adding a second GitHub authorization flow.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
