### PR TITLE
fix(desktop): keep active session status dots loading

### DIFF
--- a/products/desktop/packages/api-client/src/generated.ts
+++ b/products/desktop/packages/api-client/src/generated.ts
@@ -16201,6 +16201,13 @@ export namespace Schemas {
         id: string;
         status: TaskRunStatusEnum | NullEnum;
         environment: TaskRunEnvironmentEnum | NullEnum;
+        /**
+         * Execution mode of the latest run.
+         *
+         * * `interactive` - interactive
+         * * `background` - background
+         */
+        mode: TaskExecutionModeEnum;
     };
     /**
      * Summary response for a task — reads from a frozen ``TaskSummaryDTO``.

--- a/products/desktop/packages/core/src/canvas/channelFeed.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelFeed.test.ts
@@ -2,15 +2,30 @@ import { describe, expect, it } from "vitest";
 import { taskFeedRunStatus } from "./channelFeed";
 
 describe("taskFeedRunStatus", () => {
-  it.each(["queued", "in_progress"] as const)(
-    "preserves a cloud %s status even when local session activity has settled",
-    (status) => {
+  it("preserves a queued cloud status", () => {
+    expect(
+      taskFeedRunStatus({
+        status: "queued",
+        environment: "cloud",
+      }),
+    ).toBe("queued");
+  });
+
+  it.each([
+    ["an active interactive run", "interactive", true, "in_progress"],
+    ["an idle interactive run", "interactive", false, null],
+    ["a restored background run", "background", false, "in_progress"],
+  ] as const)(
+    "shows the status for %s",
+    (_case, runMode, isGenerating, expected) => {
       expect(
         taskFeedRunStatus({
-          status,
+          status: "in_progress",
           environment: "cloud",
+          runMode,
+          isGenerating,
         }),
-      ).toBe(status);
+      ).toBe(expected);
     },
   );
 

--- a/products/desktop/packages/core/src/canvas/channelFeed.ts
+++ b/products/desktop/packages/core/src/canvas/channelFeed.ts
@@ -1,5 +1,9 @@
-import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import type {
+  TaskRunEnvironment,
+  TaskRunStatus,
+} from "@posthog/shared/domain-types";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { runStatusForDisplay } from "../tasks/taskStatusPresentation";
 
 const PERMANENT_CHANNEL_FEED_FAILURES = new Set([401, 403, 404]);
 
@@ -14,10 +18,22 @@ export function shouldPollChannelFeed(error: unknown): boolean {
 export function taskFeedRunStatus({
   status,
   environment,
+  runMode,
+  isGenerating,
 }: {
   status: TaskRunStatus | null | undefined;
-  environment: string | null | undefined;
+  environment: TaskRunEnvironment | null | undefined;
+  runMode?: "interactive" | "background" | null;
+  isGenerating?: boolean;
 }): TaskRunStatus | null {
-  if (!status) return null;
-  return environment === "cloud" || isTerminalStatus(status) ? status : null;
+  const displayStatus = runStatusForDisplay({
+    status,
+    environment,
+    runMode,
+    isGenerating,
+  });
+  if (!displayStatus) return null;
+  return environment === "cloud" || isTerminalStatus(displayStatus)
+    ? displayStatus
+    : null;
 }

--- a/products/desktop/packages/core/src/command-center/cells.ts
+++ b/products/desktop/packages/core/src/command-center/cells.ts
@@ -1,5 +1,6 @@
 import type { AgentSession, WorkspaceMode } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
+import { narrowFullTask } from "../sidebar/buildSidebarData";
 import {
   getCanvasCellId,
   getTerminalCellCwd,
@@ -8,7 +9,12 @@ import {
   isCanvasCell,
   isTerminalCell,
 } from "./grid";
-import { type CellStatus, deriveStatus, getRepoName } from "./status";
+import {
+  type CellStatus,
+  deriveStatus,
+  deriveTaskCellStatus,
+  getRepoName,
+} from "./status";
 
 export interface CommandCenterCellData {
   cellIndex: number;
@@ -76,7 +82,11 @@ export function buildCommandCenterCells(
     const taskId = cellValue;
     const task = taskId ? taskById.get(taskId) : undefined;
     const session = taskId ? sessionByTaskId.get(taskId) : undefined;
-    const status = taskId ? deriveStatus(session) : "idle";
+    const status = task
+      ? deriveTaskCellStatus(narrowFullTask(task), session)
+      : taskId
+        ? deriveStatus(session)
+        : "idle";
     const repoName = task ? getRepoName(task) : null;
     const workspaceMode = (taskId ? workspaces?.[taskId]?.mode : null) ?? null;
 

--- a/products/desktop/packages/core/src/command-center/status.test.ts
+++ b/products/desktop/packages/core/src/command-center/status.test.ts
@@ -3,6 +3,7 @@ import {
   buildStatusSummary,
   type CellStatus,
   deriveStatus,
+  deriveTaskCellStatus,
   type SessionStatusInput,
 } from "./status";
 
@@ -26,7 +27,7 @@ describe("deriveStatus", () => {
     expect(deriveStatus(makeSession({ status: "error" }))).toBe("error");
   });
 
-  it.each(["failed", "cancelled"])(
+  it.each(["failed", "cancelled"] as const)(
     "returns error for cloudStatus %s",
     (cloudStatus) => {
       expect(deriveStatus(makeSession({ cloudStatus }))).toBe("error");
@@ -54,6 +55,45 @@ describe("deriveStatus", () => {
   it("returns idle otherwise", () => {
     expect(deriveStatus(makeSession())).toBe("idle");
   });
+
+  it.each([
+    ["background", undefined, "running"],
+    ["interactive", undefined, "idle"],
+    [
+      "interactive",
+      {
+        ...makeSession({ pendingPermissions: { size: 1 } }),
+        taskRunId: "run-1",
+      },
+      "waiting",
+    ],
+    [
+      "interactive",
+      {
+        ...makeSession({ status: "error", pendingPermissions: { size: 1 } }),
+        taskRunId: "run-0",
+      },
+      "idle",
+    ],
+  ] as const)(
+    "derives the task-aware status for a %s run",
+    (mode, session, expected) => {
+      expect(
+        deriveTaskCellStatus(
+          {
+            id: "task-1",
+            latest_run: {
+              id: "run-1",
+              status: "in_progress",
+              environment: "cloud",
+              mode,
+            },
+          },
+          session,
+        ),
+      ).toBe(expected);
+    },
+  );
 });
 
 describe("buildStatusSummary", () => {

--- a/products/desktop/packages/core/src/command-center/status.ts
+++ b/products/desktop/packages/core/src/command-center/status.ts
@@ -1,11 +1,16 @@
 import { getTaskRepository, parseRepository } from "@posthog/shared";
-import type { Task } from "@posthog/shared/domain-types";
+import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
+import {
+  deriveTaskRunState,
+  type SidebarTask,
+  type TaskSession,
+} from "../sidebar/buildSidebarData";
 
 export type CellStatus = "running" | "waiting" | "idle" | "error" | "completed";
 
 export interface SessionStatusInput {
   status: string;
-  cloudStatus?: string;
+  cloudStatus?: TaskRunStatus;
   pendingPermissions: { size: number };
   isPromptPending: boolean;
 }
@@ -26,6 +31,34 @@ export function deriveStatus(
     return "running";
 
   return "idle";
+}
+
+export function deriveTaskCellStatus(
+  task: Pick<SidebarTask, "id" | "latest_run">,
+  session: (TaskSession & SessionStatusInput) | undefined,
+): CellStatus {
+  const runState = deriveTaskRunState(task, session);
+  switch (runState.taskRunStatus) {
+    case "completed":
+      return "completed";
+    case "failed":
+    case "cancelled":
+      return "error";
+  }
+
+  const sessionRunsLatestRun = session?.taskRunId === runState.taskRunId;
+  if (
+    sessionRunsLatestRun &&
+    session &&
+    (session.status === "error" ||
+      session.cloudStatus === "failed" ||
+      session.cloudStatus === "cancelled")
+  ) {
+    return "error";
+  }
+  if (runState.needsPermission) return "waiting";
+  if (runState.isGenerating) return "running";
+  return sessionRunsLatestRun ? deriveStatus(session) : "idle";
 }
 
 export function getRepoName(task: Task): string | null {

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
@@ -5,6 +5,7 @@ import {
   deriveTaskRunState,
   limitTasksPerGroup,
   narrowFullTask,
+  type RunMode,
   readRunMode,
   sliceVisibleTasks,
   type TaskSession,
@@ -40,35 +41,92 @@ function makeGroup(id: string, taskCount: number): TaskGroup {
 
 describe("deriveTaskRunState", () => {
   it.each<
-    [string, TaskRunStatus, "local" | "cloud", TaskSession | undefined, boolean]
-  >([
-    ["a cloud run reconnects", "in_progress", "cloud", undefined, true],
-    ["a cloud run waits for setup", "not_started", "cloud", undefined, true],
     [
-      "the current cloud run is active",
+      string,
+      TaskRunStatus,
+      "local" | "cloud",
+      RunMode | undefined,
+      TaskSession | undefined,
+      boolean,
+    ]
+  >([
+    [
+      "a background cloud run reconnects",
       "in_progress",
       "cloud",
+      "background",
+      undefined,
+      true,
+    ],
+    [
+      "an interactive cloud run waits after restart",
+      "in_progress",
+      "cloud",
+      "interactive",
+      undefined,
+      false,
+    ],
+    [
+      "an older server omits the cloud run mode",
+      "in_progress",
+      "cloud",
+      undefined,
+      undefined,
+      false,
+    ],
+    [
+      "a cloud run waits for setup",
+      "not_started",
+      "cloud",
+      undefined,
+      undefined,
+      true,
+    ],
+    [
+      "a matching cloud session has no activity evidence",
+      "in_progress",
+      "cloud",
+      "interactive",
       { taskRunId: "run-1" },
+      false,
+    ],
+    [
+      "the current interactive cloud run has a prompt in flight",
+      "in_progress",
+      "cloud",
+      "interactive",
+      { taskRunId: "run-1", isPromptPending: true },
       true,
     ],
     [
       "the current cloud run reports idle",
       "in_progress",
       "cloud",
+      "background",
       { taskRunId: "run-1", agentIdleForRunId: "run-1" },
       false,
     ],
     [
-      "a session for another run reports idle",
+      "a session for another background run reports idle",
       "in_progress",
       "cloud",
+      "background",
       { taskRunId: "run-2", agentIdleForRunId: "run-2" },
       true,
+    ],
+    [
+      "a session for another run cannot activate an interactive run",
+      "in_progress",
+      "cloud",
+      "interactive",
+      { taskRunId: "run-2", agentIdleForRunId: "run-2" },
+      false,
     ],
     [
       "the previous run left an idle marker",
       "in_progress",
       "cloud",
+      "background",
       { taskRunId: "run-1", agentIdleForRunId: "run-0" },
       true,
     ],
@@ -76,6 +134,7 @@ describe("deriveTaskRunState", () => {
       "an old cloud session still reports work",
       "completed",
       "cloud",
+      "background",
       { taskRunId: "run-0", cloudStatus: "in_progress" },
       false,
     ],
@@ -83,29 +142,80 @@ describe("deriveTaskRunState", () => {
       "the current cloud run settles while the session lags",
       "completed",
       "cloud",
-      { taskRunId: "run-1", cloudStatus: "in_progress" },
+      "background",
+      {
+        taskRunId: "run-1",
+        cloudStatus: "in_progress",
+        isPromptPending: true,
+      },
       false,
     ],
-    ["a cloud run completes", "completed", "cloud", undefined, false],
-    ["a local run stays in progress", "in_progress", "local", undefined, false],
+    [
+      "a cloud run completes",
+      "completed",
+      "cloud",
+      "background",
+      undefined,
+      false,
+    ],
+    [
+      "a local run stays in progress",
+      "in_progress",
+      "local",
+      undefined,
+      undefined,
+      false,
+    ],
     [
       "a local agent streams output",
       "in_progress",
       "local",
+      undefined,
       { taskRunId: "run-1", isPromptPending: true },
       true,
     ],
+    [
+      "an old local session streams output",
+      "in_progress",
+      "local",
+      undefined,
+      { taskRunId: "run-0", isPromptPending: true },
+      false,
+    ],
   ])(
     "derives loading for %s",
-    (_case, status, environment, session, expected) => {
+    (_case, status, environment, mode, session, expected) => {
       const result = deriveTaskRunState(
-        { id: "task-1", latest_run: { id: "run-1", status, environment } },
+        {
+          id: "task-1",
+          latest_run: { id: "run-1", status, environment, mode },
+        },
         session,
       );
 
       expect(result.isGenerating).toBe(expected);
     },
   );
+
+  it.each([
+    ["the latest run", "run-1", true],
+    ["an older run", "run-0", false],
+  ])("reads pending permissions from %s", (_case, taskRunId, expected) => {
+    const result = deriveTaskRunState(
+      {
+        id: "task-1",
+        latest_run: {
+          id: "run-1",
+          status: "in_progress",
+          environment: "cloud",
+          mode: "interactive",
+        },
+      },
+      { taskRunId, pendingPermissions: { size: 1 } },
+    );
+
+    expect(result.needsPermission).toBe(expected);
+  });
 });
 
 describe("sliceVisibleTasks", () => {

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
@@ -59,11 +59,32 @@ describe("deriveTaskRunState", () => {
       false,
     ],
     [
-      "an old cloud run reports idle",
+      "a session for another run reports idle",
       "in_progress",
       "cloud",
-      { taskRunId: "run-2", agentIdleForRunId: "run-1" },
+      { taskRunId: "run-2", agentIdleForRunId: "run-2" },
       true,
+    ],
+    [
+      "the previous run left an idle marker",
+      "in_progress",
+      "cloud",
+      { taskRunId: "run-1", agentIdleForRunId: "run-0" },
+      true,
+    ],
+    [
+      "an old cloud session still reports work",
+      "completed",
+      "cloud",
+      { taskRunId: "run-0", cloudStatus: "in_progress" },
+      false,
+    ],
+    [
+      "the current cloud run settles while the session lags",
+      "completed",
+      "cloud",
+      { taskRunId: "run-1", cloudStatus: "in_progress" },
+      false,
     ],
     ["a cloud run completes", "completed", "cloud", undefined, false],
     ["a local run stays in progress", "in_progress", "local", undefined, false],
@@ -78,7 +99,7 @@ describe("deriveTaskRunState", () => {
     "derives loading for %s",
     (_case, status, environment, session, expected) => {
       const result = deriveTaskRunState(
-        { id: "task-1", latest_run: { status, environment } },
+        { id: "task-1", latest_run: { id: "run-1", status, environment } },
         session,
       );
 

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.test.ts
@@ -1,10 +1,13 @@
+import type { TaskRunStatus } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
 import {
   deriveTaskData,
+  deriveTaskRunState,
   limitTasksPerGroup,
   narrowFullTask,
   readRunMode,
   sliceVisibleTasks,
+  type TaskSession,
 } from "./buildSidebarData";
 import type { TaskData, TaskGroup } from "./sidebarData.types";
 
@@ -34,6 +37,55 @@ function makeGroup(id: string, taskCount: number): TaskGroup {
     tasks: Array.from({ length: taskCount }, (_, i) => makeTask(`${id}-${i}`)),
   };
 }
+
+describe("deriveTaskRunState", () => {
+  it.each<
+    [string, TaskRunStatus, "local" | "cloud", TaskSession | undefined, boolean]
+  >([
+    ["a cloud run reconnects", "in_progress", "cloud", undefined, true],
+    ["a cloud run waits for setup", "not_started", "cloud", undefined, true],
+    [
+      "the current cloud run is active",
+      "in_progress",
+      "cloud",
+      { taskRunId: "run-1" },
+      true,
+    ],
+    [
+      "the current cloud run reports idle",
+      "in_progress",
+      "cloud",
+      { taskRunId: "run-1", agentIdleForRunId: "run-1" },
+      false,
+    ],
+    [
+      "an old cloud run reports idle",
+      "in_progress",
+      "cloud",
+      { taskRunId: "run-2", agentIdleForRunId: "run-1" },
+      true,
+    ],
+    ["a cloud run completes", "completed", "cloud", undefined, false],
+    ["a local run stays in progress", "in_progress", "local", undefined, false],
+    [
+      "a local agent streams output",
+      "in_progress",
+      "local",
+      { taskRunId: "run-1", isPromptPending: true },
+      true,
+    ],
+  ])(
+    "derives loading for %s",
+    (_case, status, environment, session, expected) => {
+      const result = deriveTaskRunState(
+        { id: "task-1", latest_run: { status, environment } },
+        session,
+      );
+
+      expect(result.isGenerating).toBe(expected);
+    },
+  );
+});
 
 describe("sliceVisibleTasks", () => {
   it("caps the flat list to the visible count and reports hasMore", () => {

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
@@ -145,9 +145,11 @@ export function computeSidebarSessionSignature(
         ? session.cloudOutput.pr_url
         : "";
     const isAgentIdle = session.agentIdleForRunId === session.taskRunId;
-    signature += `${session.taskId}:${session.isPromptPending ? 1 : 0}:${
-      session.pendingPermissions?.size ?? 0
-    }:${session.cloudStatus ?? ""}:${prUrl}:${isAgentIdle ? 1 : 0};`;
+    signature += `${session.taskId}:${session.taskRunId ?? ""}:${
+      session.isPromptPending ? 1 : 0
+    }:${session.pendingPermissions?.size ?? 0}:${
+      session.cloudStatus ?? ""
+    }:${prUrl}:${isAgentIdle ? 1 : 0};`;
   }
   return signature;
 }
@@ -217,27 +219,40 @@ export function deriveTaskRunState(
   session: TaskSession | undefined,
 ): Pick<
   TaskData,
-  "id" | "isGenerating" | "taskRunId" | "taskRunStatus" | "taskRunEnvironment"
+  | "id"
+  | "isGenerating"
+  | "needsPermission"
+  | "taskRunId"
+  | "taskRunStatus"
+  | "taskRunEnvironment"
 > {
-  // The task detail header reads the same rule, so a row and its header cannot
-  // disagree about one task. A session that belongs to an earlier run does not
-  // speak for the current one: it must not report work the run has finished,
-  // nor hide work on a run it never watched.
+  // The task detail header reads the same status rule. A session from an older
+  // run must not report activity for the latest run.
   const latestRunId = task.latest_run?.id;
   const sessionRunsLatestRun =
     latestRunId !== undefined && session?.taskRunId === latestRunId;
   const taskRunStatus = resolveEffectiveCloudStatus(task, session) ?? undefined;
   const isAgentIdle =
     sessionRunsLatestRun && session?.agentIdleForRunId === latestRunId;
+  const isPromptPending =
+    sessionRunsLatestRun &&
+    session?.isPromptPending === true &&
+    !isTerminalStatus(taskRunStatus);
+  const isCloudRunStarting =
+    taskRunStatus === "not_started" || taskRunStatus === "queued";
+  const isCloudRunWorking =
+    taskRunStatus === "in_progress" &&
+    (isPromptPending ||
+      (task.latest_run?.mode === "background" && !isAgentIdle));
   const isActiveCloudRun =
     task.latest_run?.environment === "cloud" &&
-    taskRunStatus !== undefined &&
-    !isTerminalStatus(taskRunStatus) &&
-    !isAgentIdle;
+    (isCloudRunStarting || isCloudRunWorking);
 
   return {
     id: task.id,
-    isGenerating: session?.isPromptPending === true || isActiveCloudRun,
+    isGenerating: isPromptPending || isActiveCloudRun,
+    needsPermission:
+      sessionRunsLatestRun && (session?.pendingPermissions?.size ?? 0) > 0,
     taskRunId: task.latest_run?.id ?? undefined,
     taskRunStatus,
     taskRunEnvironment: task.latest_run?.environment ?? undefined,
@@ -274,7 +289,6 @@ export function deriveTaskData(
     isUnread,
     isPinned: ctx.pinnedIds.has(task.id),
     isSuspended: ctx.suspendedIds.has(task.id),
-    needsPermission: (session?.pendingPermissions?.size ?? 0) > 0,
     repository: getRepositoryInfo(task, workspace?.folderPath ?? undefined),
     folderId: workspace?.folderId || undefined,
     runMode: task.latest_run?.mode ?? undefined,

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
@@ -4,6 +4,7 @@ import {
   type Task,
   type TaskRunStatus,
 } from "@posthog/shared/domain-types";
+import { resolveEffectiveCloudStatus } from "../task-detail/cloudRunState";
 import { taskActivityAt } from "../tasks/taskActivity";
 import { getRepositoryInfo } from "./groupTasks";
 import type { TaskData, TaskGroup } from "./sidebarData.types";
@@ -218,10 +219,16 @@ export function deriveTaskRunState(
   TaskData,
   "id" | "isGenerating" | "taskRunId" | "taskRunStatus" | "taskRunEnvironment"
 > {
-  const taskRunStatus =
-    session?.cloudStatus ?? task.latest_run?.status ?? undefined;
+  // The task detail header reads the same rule, so a row and its header cannot
+  // disagree about one task. A session that belongs to an earlier run does not
+  // speak for the current one: it must not report work the run has finished,
+  // nor hide work on a run it never watched.
+  const latestRunId = task.latest_run?.id;
+  const sessionRunsLatestRun =
+    latestRunId !== undefined && session?.taskRunId === latestRunId;
+  const taskRunStatus = resolveEffectiveCloudStatus(task, session) ?? undefined;
   const isAgentIdle =
-    session !== undefined && session.agentIdleForRunId === session.taskRunId;
+    sessionRunsLatestRun && session?.agentIdleForRunId === latestRunId;
   const isActiveCloudRun =
     task.latest_run?.environment === "cloud" &&
     taskRunStatus !== undefined &&

--- a/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
+++ b/products/desktop/packages/core/src/sidebar/buildSidebarData.ts
@@ -1,5 +1,9 @@
 import { readPrUrls, type WorkspaceMode } from "@posthog/shared";
-import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
+import {
+  isTerminalStatus,
+  type Task,
+  type TaskRunStatus,
+} from "@posthog/shared/domain-types";
 import { taskActivityAt } from "../tasks/taskActivity";
 import { getRepositoryInfo } from "./groupTasks";
 import type { TaskData, TaskGroup } from "./sidebarData.types";
@@ -115,10 +119,12 @@ export function filterVisibleTasks(
 }
 
 export interface TaskSession {
+  taskRunId: string;
   isPromptPending?: boolean;
   pendingPermissions?: { size: number };
   cloudStatus?: TaskRunStatus;
   cloudOutput?: { pr_url?: unknown } | null;
+  agentIdleForRunId?: string;
 }
 
 /**
@@ -137,9 +143,10 @@ export function computeSidebarSessionSignature(
       typeof session.cloudOutput?.pr_url === "string"
         ? session.cloudOutput.pr_url
         : "";
+    const isAgentIdle = session.agentIdleForRunId === session.taskRunId;
     signature += `${session.taskId}:${session.isPromptPending ? 1 : 0}:${
       session.pendingPermissions?.size ?? 0
-    }:${session.cloudStatus ?? ""}:${prUrl};`;
+    }:${session.cloudStatus ?? ""}:${prUrl}:${isAgentIdle ? 1 : 0};`;
   }
   return signature;
 }
@@ -211,11 +218,21 @@ export function deriveTaskRunState(
   TaskData,
   "id" | "isGenerating" | "taskRunId" | "taskRunStatus" | "taskRunEnvironment"
 > {
+  const taskRunStatus =
+    session?.cloudStatus ?? task.latest_run?.status ?? undefined;
+  const isAgentIdle =
+    session !== undefined && session.agentIdleForRunId === session.taskRunId;
+  const isActiveCloudRun =
+    task.latest_run?.environment === "cloud" &&
+    taskRunStatus !== undefined &&
+    !isTerminalStatus(taskRunStatus) &&
+    !isAgentIdle;
+
   return {
     id: task.id,
-    isGenerating: session?.isPromptPending ?? false,
+    isGenerating: session?.isPromptPending === true || isActiveCloudRun,
     taskRunId: task.latest_run?.id ?? undefined,
-    taskRunStatus: session?.cloudStatus ?? task.latest_run?.status ?? undefined,
+    taskRunStatus,
     taskRunEnvironment: task.latest_run?.environment ?? undefined,
   };
 }

--- a/products/desktop/packages/core/src/sidebar/computeSidebarSessionSignature.test.ts
+++ b/products/desktop/packages/core/src/sidebar/computeSidebarSessionSignature.test.ts
@@ -33,7 +33,7 @@ describe("computeSidebarSessionSignature", () => {
     expect(a).not.toBe(b);
   });
 
-  it("changes when cloud status or PR url changes", () => {
+  it("changes when cloud status, PR url, or agent activity changes", () => {
     const a = sig({ r1: { taskId: "t1", cloudStatus: "running" } });
     const b = sig({ r1: { taskId: "t1", cloudStatus: "completed" } });
     expect(a).not.toBe(b);
@@ -41,6 +41,12 @@ describe("computeSidebarSessionSignature", () => {
     const c = sig({ r1: { taskId: "t1", cloudOutput: { pr_url: "x" } } });
     const d = sig({ r1: { taskId: "t1", cloudOutput: { pr_url: "y" } } });
     expect(c).not.toBe(d);
+
+    const e = sig({ r1: { taskId: "t1", taskRunId: "r1" } });
+    const f = sig({
+      r1: { taskId: "t1", taskRunId: "r1", agentIdleForRunId: "r1" },
+    });
+    expect(e).not.toBe(f);
   });
 
   it("skips sessions without a taskId", () => {

--- a/products/desktop/packages/core/src/sidebar/computeSidebarSessionSignature.test.ts
+++ b/products/desktop/packages/core/src/sidebar/computeSidebarSessionSignature.test.ts
@@ -33,7 +33,7 @@ describe("computeSidebarSessionSignature", () => {
     expect(a).not.toBe(b);
   });
 
-  it("changes when cloud status, PR url, or agent activity changes", () => {
+  it("changes when the rendered session identity or state changes", () => {
     const a = sig({ r1: { taskId: "t1", cloudStatus: "running" } });
     const b = sig({ r1: { taskId: "t1", cloudStatus: "completed" } });
     expect(a).not.toBe(b);
@@ -47,6 +47,10 @@ describe("computeSidebarSessionSignature", () => {
       r1: { taskId: "t1", taskRunId: "r1", agentIdleForRunId: "r1" },
     });
     expect(e).not.toBe(f);
+
+    const g = sig({ r1: { taskId: "t1", taskRunId: "r1" } });
+    const h = sig({ r2: { taskId: "t1", taskRunId: "r2" } });
+    expect(g).not.toBe(h);
   });
 
   it("skips sessions without a taskId", () => {

--- a/products/desktop/packages/core/src/sidebar/taskRunning.test.ts
+++ b/products/desktop/packages/core/src/sidebar/taskRunning.test.ts
@@ -27,6 +27,7 @@ describe("isTaskActivelyRunning", () => {
     environment: "local" | "cloud" | undefined;
     status: TaskRunStatus | undefined;
     isGenerating: boolean;
+    runMode?: TaskData["runMode"];
     expected: boolean;
   }>([
     // The regression: local runs stay "in_progress" forever, so this must NOT
@@ -60,11 +61,27 @@ describe("isTaskActivelyRunning", () => {
       expected: false,
     },
     {
-      name: "cloud run in progress",
+      name: "background cloud run in progress",
       environment: "cloud",
       status: "in_progress",
       isGenerating: false,
+      runMode: "background",
       expected: true,
+    },
+    {
+      name: "idle interactive cloud run",
+      environment: "cloud",
+      status: "in_progress",
+      isGenerating: false,
+      runMode: "interactive",
+      expected: false,
+    },
+    {
+      name: "idle cloud run from an older server",
+      environment: "cloud",
+      status: "in_progress",
+      isGenerating: false,
+      expected: false,
     },
     {
       name: "queued cloud run",
@@ -102,10 +119,11 @@ describe("isTaskActivelyRunning", () => {
       expected: false,
     },
     {
-      name: "cloud run generating",
+      name: "interactive cloud run generating",
       environment: "cloud",
       status: "in_progress",
       isGenerating: true,
+      runMode: "interactive",
       expected: true,
     },
     {
@@ -124,13 +142,14 @@ describe("isTaskActivelyRunning", () => {
     },
   ])(
     "$name -> $expected",
-    ({ environment, status, isGenerating, expected }) => {
+    ({ environment, status, isGenerating, runMode, expected }) => {
       expect(
         isTaskActivelyRunning(
           task({
             taskRunEnvironment: environment,
             taskRunStatus: status,
             isGenerating,
+            runMode,
           }),
         ),
       ).toBe(expected);

--- a/products/desktop/packages/core/src/sidebar/taskRunning.ts
+++ b/products/desktop/packages/core/src/sidebar/taskRunning.ts
@@ -1,17 +1,17 @@
-import { isTerminalStatus } from "@posthog/shared/domain-types";
 import type { TaskData } from "./sidebarData.types";
 
-// Drives the "Archive running task?" confirmation. Persisted run status is only
-// trustworthy for cloud runs; local runs stay "in_progress" forever (nothing
-// writes a terminal status when the agent goes idle), so a local run counts as
-// running only while a prompt is in flight (isGenerating).
+// Drives the "Archive running task?" confirmation. An interactive cloud run can
+// stay in_progress while it waits for input, so its status does not prove work.
 export function isTaskActivelyRunning(
-  task: Pick<TaskData, "isGenerating" | "taskRunEnvironment" | "taskRunStatus">,
+  task: Pick<
+    TaskData,
+    "isGenerating" | "runMode" | "taskRunEnvironment" | "taskRunStatus"
+  >,
 ): boolean {
   if (task.isGenerating) return true;
-  return (
-    task.taskRunEnvironment === "cloud" &&
-    task.taskRunStatus !== undefined &&
-    !isTerminalStatus(task.taskRunStatus)
-  );
+  if (task.taskRunEnvironment !== "cloud") return false;
+  if (task.taskRunStatus === "not_started" || task.taskRunStatus === "queued") {
+    return true;
+  }
+  return task.taskRunStatus === "in_progress" && task.runMode === "background";
 }

--- a/products/desktop/packages/core/src/task-detail/cloudRunState.ts
+++ b/products/desktop/packages/core/src/task-detail/cloudRunState.ts
@@ -10,13 +10,18 @@ export interface CloudRunSessionLike {
   cloudStatus?: TaskRunStatus | null;
 }
 
+/** The run fields the status rule reads, so sidebar rows can pass their own task shape. */
+export interface CloudRunTaskLike {
+  latest_run?: { id?: string; status?: TaskRunStatus | null } | null;
+}
+
 /**
  * Effective run status for the UI: a terminal task status always wins;
  * otherwise the session's live status wins while the session belongs to the
  * task's latest run.
  */
 export function resolveEffectiveCloudStatus(
-  task: Task,
+  task: CloudRunTaskLike,
   session:
     | { taskRunId?: string | null; cloudStatus?: TaskRunStatus | null }
     | null

--- a/products/desktop/packages/core/src/tasks/taskStatusPresentation.test.ts
+++ b/products/desktop/packages/core/src/tasks/taskStatusPresentation.test.ts
@@ -1,6 +1,9 @@
 import type { Task, TaskRun } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
-import { getTaskStatusPresentationKind } from "./taskStatusPresentation";
+import {
+  getTaskStatusPresentationKind,
+  runStatusForDisplay,
+} from "./taskStatusPresentation";
 
 function makeTask(latestRun?: Partial<TaskRun>): Pick<Task, "latest_run"> {
   return {
@@ -66,4 +69,23 @@ describe("getTaskStatusPresentationKind", () => {
   it("falls back to chat when a task has no run", () => {
     expect(getTaskStatusPresentationKind(makeTask())).toBe("chat");
   });
+
+  it.each([
+    ["an active interactive run", "interactive", true, "in_progress"],
+    ["an idle interactive run", "interactive", false, null],
+    ["an idle run from an older server", undefined, false, null],
+    ["a restored background run", "background", false, "in_progress"],
+  ] as const)(
+    "shows the status for %s",
+    (_case, runMode, isGenerating, expected) => {
+      expect(
+        runStatusForDisplay({
+          status: "in_progress",
+          environment: "cloud",
+          runMode,
+          isGenerating,
+        }),
+      ).toBe(expected);
+    },
+  );
 });

--- a/products/desktop/packages/core/src/tasks/taskStatusPresentation.ts
+++ b/products/desktop/packages/core/src/tasks/taskStatusPresentation.ts
@@ -1,5 +1,9 @@
 import { readPrUrls } from "@posthog/shared";
-import type { Task } from "@posthog/shared/domain-types";
+import type {
+  Task,
+  TaskRunEnvironment,
+  TaskRunStatus,
+} from "@posthog/shared/domain-types";
 
 export type TaskStatusPresentationKind =
   | "pr"
@@ -8,6 +12,28 @@ export type TaskStatusPresentationKind =
   | "running"
   | "started"
   | "chat";
+
+export function runStatusForDisplay({
+  status,
+  environment,
+  runMode,
+  isGenerating,
+}: {
+  status: TaskRunStatus | null | undefined;
+  environment: TaskRunEnvironment | null | undefined;
+  runMode?: "interactive" | "background" | null;
+  isGenerating?: boolean;
+}): TaskRunStatus | null {
+  if (
+    status === "in_progress" &&
+    environment === "cloud" &&
+    isGenerating === false &&
+    runMode !== "background"
+  ) {
+    return null;
+  }
+  return status ?? null;
+}
 
 export function getTaskStatusPresentationKind(
   task: Pick<Task, "latest_run">,

--- a/products/desktop/packages/ui/src/features/archive/useTaskArchive.tsx
+++ b/products/desktop/packages/ui/src/features/archive/useTaskArchive.tsx
@@ -1,5 +1,9 @@
 import { PI_SESSION_CONTROLLER } from "@posthog/core/pi-runtime/identifiers";
 import type { PiSessionController } from "@posthog/core/pi-runtime/piSessionController";
+import {
+  deriveTaskRunState,
+  narrowFullTask,
+} from "@posthog/core/sidebar/buildSidebarData";
 import { isTaskActivelyRunning } from "@posthog/core/sidebar/taskRunning";
 import { useService } from "@posthog/di/react";
 import type { Task } from "@posthog/shared/domain-types";
@@ -42,22 +46,41 @@ export function useTaskArchive(
   },
 ): TaskArchive {
   const taskId = task?.id;
-  const { isPromptPending, cloudStatus } = useSessionSelector(
-    taskId,
-    (session) => ({
-      isPromptPending: session?.isPromptPending ?? false,
-      cloudStatus: session?.cloudStatus ?? null,
-    }),
-    shallow,
-  );
+  const { taskRunId, isPromptPending, cloudStatus, agentIdleForRunId } =
+    useSessionSelector(
+      taskId,
+      (session) => ({
+        taskRunId: session?.taskRunId,
+        isPromptPending: session?.isPromptPending ?? false,
+        cloudStatus: session?.cloudStatus ?? null,
+        agentIdleForRunId: session?.agentIdleForRunId,
+      }),
+      shallow,
+    );
   const piSessionController = useService<PiSessionController>(
     PI_SESSION_CONTROLLER,
   );
   const isPiGenerating = useStore(piSessionController.store, (state) =>
     taskId ? (state.sessions[taskId]?.status?.isStreaming ?? false) : false,
   );
+  const sidebarTask = task ? narrowFullTask(task) : undefined;
+  const taskRunState = sidebarTask
+    ? deriveTaskRunState(
+        sidebarTask,
+        taskRunId
+          ? {
+              taskRunId,
+              isPromptPending,
+              cloudStatus: cloudStatus ?? undefined,
+              agentIdleForRunId,
+            }
+          : undefined,
+      )
+    : undefined;
   const isGenerating =
-    task?.runtime === "pi" ? isPiGenerating : isPromptPending;
+    task?.runtime === "pi"
+      ? isPiGenerating
+      : (taskRunState?.isGenerating ?? false);
 
   const { archiveTask } = useArchiveTask({
     navigateUnscoped: options?.navigateUnscoped,
@@ -90,15 +113,23 @@ export function useTaskArchive(
     if (
       isTaskActivelyRunning({
         isGenerating,
-        taskRunEnvironment: task?.latest_run?.environment,
-        taskRunStatus: cloudStatus ?? task?.latest_run?.status ?? undefined,
+        runMode: sidebarTask?.latest_run?.mode ?? undefined,
+        taskRunEnvironment: taskRunState?.taskRunEnvironment,
+        taskRunStatus: taskRunState?.taskRunStatus,
       })
     ) {
       setConfirmOpen(true);
       return;
     }
     void runArchive().catch(() => undefined);
-  }, [cloudStatus, isGenerating, runArchive, task?.latest_run, taskId]);
+  }, [
+    isGenerating,
+    runArchive,
+    sidebarTask?.latest_run?.mode,
+    taskId,
+    taskRunState?.taskRunEnvironment,
+    taskRunState?.taskRunStatus,
+  ]);
 
   return {
     requestArchive,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.test.tsx
@@ -162,6 +162,58 @@ describe("ChannelFeedView", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Loading tasks");
   });
 
+  it("shows a queued cloud run as starting", () => {
+    channelTaskData.current = {
+      cloudPrUrl: null,
+      isGenerating: true,
+      isPinned: false,
+      needsPermission: false,
+      taskRunEnvironment: "cloud",
+      taskRunStatus: "queued",
+    };
+
+    render(
+      <Theme>
+        <ChannelFeedView
+          channelId="channel-1"
+          tasks={[task]}
+          isLoading={false}
+          onOpenTask={vi.fn()}
+          onOpenThread={vi.fn()}
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByText("Starting")).toBeInTheDocument();
+    expect(screen.queryByText("In progress")).not.toBeInTheDocument();
+  });
+
+  it("does not show an idle interactive cloud run as in progress", () => {
+    channelTaskData.current = {
+      cloudPrUrl: null,
+      isGenerating: false,
+      isPinned: false,
+      needsPermission: false,
+      runMode: "interactive",
+      taskRunEnvironment: "cloud",
+      taskRunStatus: "in_progress",
+    };
+
+    render(
+      <Theme>
+        <ChannelFeedView
+          channelId="channel-1"
+          tasks={[task]}
+          isLoading={false}
+          onOpenTask={vi.fn()}
+          onOpenThread={vi.fn()}
+        />
+      </Theme>,
+    );
+
+    expect(screen.queryByText("In progress")).not.toBeInTheDocument();
+  });
+
   it("hides archived tasks from the feed", () => {
     const archived = {
       ...task,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelFeedView.tsx
@@ -161,7 +161,12 @@ function useTaskStatusDisplay(task: Task): TaskStatusDisplay {
   });
   const status = data?.taskRunStatus ?? task.latest_run?.status;
   const environment = data?.taskRunEnvironment ?? task.latest_run?.environment;
-  const displayStatus = taskFeedRunStatus({ status, environment });
+  const displayStatus = taskFeedRunStatus({
+    status,
+    environment,
+    runMode: data?.runMode,
+    isGenerating: data?.isGenerating,
+  });
   // `prState` is resolved async from git/`gh` and is routinely null for cloud
   // tasks (the details fetch hasn't landed, or there's no cached row). But the
   // PR URL itself is a hard signal a PR exists — the card's "PR" link keys off
@@ -181,10 +186,14 @@ function useTaskStatusDisplay(task: Task): TaskStatusDisplay {
     // waiting on the user right now, which matters more than a PR existing.
     base = <Badge variant="warning">Needs input</Badge>;
   } else if (data?.isGenerating) {
+    const label =
+      status === "not_started" || status === "queued"
+        ? "Starting"
+        : "In progress";
     base = (
       <Badge variant="info">
         <Spinner className="size-2.5" />
-        In progress
+        {label}
       </Badge>
     );
   } else if (showPrState) {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -177,6 +177,15 @@ describe("ChannelItemRow", () => {
       "All caught up",
     ],
     [
+      "a running cloud session restored after an app restart",
+      {
+        taskRunStatus: "in_progress" as const,
+        workspaceMode: "cloud" as const,
+        isGenerating: true,
+      },
+      "Working",
+    ],
+    [
       // The backend leaves an interactive run in_progress after it succeeds, so
       // the session stays open for a follow-up. Reading that as a claim marked
       // every finished session pending, forever, on a row opening it could not
@@ -187,6 +196,14 @@ describe("ChannelItemRow", () => {
         runMode: "interactive" as const,
       },
       "All caught up",
+    ],
+    [
+      "a cloud run waiting to be queued",
+      {
+        taskRunStatus: "not_started" as const,
+        workspaceMode: "cloud" as const,
+      },
+      "Loading",
     ],
     [
       // Launching: a sandbox is being claimed and the backend leaves this state

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useUnreadSessionCount.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useUnreadSessionCount.ts
@@ -1,7 +1,8 @@
 import { countSessionsByChannel } from "@posthog/core/canvas/channelUnread";
 import {
+  deriveTaskRunState,
   isTaskUnread,
-  readRunMode,
+  narrowFullTask,
 } from "@posthog/core/sidebar/buildSidebarData";
 import { taskActivityAt } from "@posthog/core/tasks/taskActivity";
 import { readPrUrls } from "@posthog/shared";
@@ -22,25 +23,22 @@ import { useMemo } from "react";
  * the space's dots have to mean what the session rows' dots mean, and there is
  * one function that decides that.
  *
- * The renderer-only inputs (a live session's streaming and permission prompts)
- * are absent here, and can only turn a row yellow or blue that this already
- * counts for another reason, or that is genuinely quiet in the poll. So this
- * can undercount a session that started moving since the last poll, never
- * overcount one.
+ * Live prompt and permission state are absent here, so this count can lag until
+ * the next task poll. The persisted run mode still restores background activity.
  */
 export function wantsAttention(
   task: Task,
   lastViewedAt: TaskTimestamps,
 ): boolean {
+  const sidebarTask = narrowFullTask(task);
+  const runState = deriveTaskRunState(sidebarTask, undefined);
   const { tone } = taskDot({
+    isGenerating: runState.isGenerating,
     isUnread: isTaskUnread(taskActivityAt(task), lastViewedAt[task.id]),
-    taskRunStatus: task.latest_run?.status ?? undefined,
-    // A run's mode decides whether its status is a claim about work at all, so
-    // without it the "Pending" rows never count. It rides on the run's state,
-    // which the poll already carries.
-    runMode: readRunMode(task.latest_run?.state),
+    taskRunStatus: runState.taskRunStatus,
+    runMode: sidebarTask.latest_run?.mode ?? undefined,
     workspaceMode:
-      task.latest_run?.environment === "cloud" ? "cloud" : undefined,
+      runState.taskRunEnvironment === "cloud" ? "cloud" : undefined,
     prUrl: readPrUrls(task.latest_run?.output)[0] ?? null,
   });
   return tone !== "gray";

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
@@ -12,6 +12,8 @@ import {
 } from "@phosphor-icons/react";
 import { getAuthIdentity } from "@posthog/core/auth/authIdentity";
 import { isBrainrotCell } from "@posthog/core/command-center/grid";
+import { readRunMode } from "@posthog/core/sidebar/buildSidebarData";
+import { resolveEffectiveCloudStatus } from "@posthog/core/task-detail/cloudRunState";
 import {
   Button,
   Empty,
@@ -104,16 +106,17 @@ function CellStatusBadge({
   if (label === null) return null;
 
   const taskRunStatus = isCloud
-    ? (session?.cloudStatus ?? task.latest_run?.status ?? undefined)
+    ? (resolveEffectiveCloudStatus(task, session) ?? undefined)
     : undefined;
 
   return (
     <span className="inline-flex items-center gap-0.5 rounded bg-gray-3 px-1 py-0.5 text-[10px] text-gray-11">
       <TaskIcon
         workspaceMode={workspaceMode ?? undefined}
-        isGenerating={session?.isPromptPending}
-        needsPermission={(session?.pendingPermissions?.size ?? 0) > 0}
+        isGenerating={status === "running"}
+        needsPermission={status === "waiting"}
         taskRunStatus={taskRunStatus}
+        runMode={readRunMode(task.latest_run?.state)}
         prState={prState}
         hasDiff={hasDiff}
         size={10}

--- a/products/desktop/packages/ui/src/features/command/TaskCommandIcon.test.tsx
+++ b/products/desktop/packages/ui/src/features/command/TaskCommandIcon.test.tsx
@@ -2,6 +2,10 @@ import type { Task } from "@posthog/shared/domain-types";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("@posthog/ui/features/canvas/hooks/useChannelsLayout", () => ({
+  useChannelsLayout: () => false,
+}));
+
 vi.mock("@posthog/ui/features/sidebar/useTaskPrStatus", () => ({
   useTaskPrStatus: () => ({ prState: "open", hasDiff: false }),
 }));

--- a/products/desktop/packages/ui/src/features/command/TaskCommandIcon.test.tsx
+++ b/products/desktop/packages/ui/src/features/command/TaskCommandIcon.test.tsx
@@ -1,0 +1,43 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/ui/features/sidebar/useTaskPrStatus", () => ({
+  useTaskPrStatus: () => ({ prState: "open", hasDiff: false }),
+}));
+
+import { TaskCommandIcon } from "./TaskCommandIcon";
+
+const task: Task = {
+  id: "task-1",
+  task_number: 1,
+  slug: "keep-ci-green",
+  title: "Keep CI green",
+  description: "Monitor the pull request checks.",
+  created_at: "2026-09-07T12:00:00Z",
+  updated_at: "2026-09-07T12:00:00Z",
+  origin_product: "user_created",
+  latest_run: {
+    id: "run-1",
+    task: "task-1",
+    team: 2,
+    branch: null,
+    status: "in_progress",
+    environment: "cloud",
+    log_url: "",
+    error_message: null,
+    output: null,
+    state: { mode: "background" },
+    created_at: "2026-09-07T12:00:00Z",
+    updated_at: "2026-09-07T12:00:00Z",
+    completed_at: null,
+  },
+};
+
+describe("TaskCommandIcon", () => {
+  it("shows active background work before an existing pull request", () => {
+    render(<TaskCommandIcon task={task} />);
+
+    expect(screen.getByRole("img", { name: "Working" })).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/command/TaskCommandIcon.tsx
+++ b/products/desktop/packages/ui/src/features/command/TaskCommandIcon.tsx
@@ -1,3 +1,7 @@
+import {
+  deriveTaskRunState,
+  narrowFullTask,
+} from "@posthog/core/sidebar/buildSidebarData";
 import type { Task } from "@posthog/shared/domain-types";
 import { TaskIcon } from "@posthog/ui/features/sidebar/components/items/TaskIcon";
 import { useTaskPrStatus } from "@posthog/ui/features/sidebar/useTaskPrStatus";
@@ -13,6 +17,8 @@ export function TaskCommandIcon({ task }: { task: Task }) {
     cloudPrUrl: null,
     taskRunEnvironment: task.latest_run?.environment,
   });
+  const sidebarTask = narrowFullTask(task);
+  const runState = deriveTaskRunState(sidebarTask, undefined);
   const stateSlackThreadUrl = (
     task.latest_run?.state as { slack_thread_url?: unknown } | undefined
   )?.slack_thread_url;
@@ -20,8 +26,10 @@ export function TaskCommandIcon({ task }: { task: Task }) {
     typeof stateSlackThreadUrl === "string" ? stateSlackThreadUrl : undefined;
   return (
     <TaskIcon
-      workspaceMode={task.latest_run?.environment}
-      taskRunStatus={task.latest_run?.status}
+      workspaceMode={runState.taskRunEnvironment}
+      isGenerating={runState.isGenerating}
+      taskRunStatus={runState.taskRunStatus}
+      runMode={sidebarTask.latest_run?.mode ?? undefined}
       originProduct={task.origin_product}
       slackThreadUrl={slackThreadUrl}
       prState={prState}

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskIcon.tsx
@@ -18,6 +18,7 @@ import {
   WarningCircle,
 } from "@phosphor-icons/react";
 import type { RunMode } from "@posthog/core/sidebar/buildSidebarData";
+import { runStatusForDisplay } from "@posthog/core/tasks/taskStatusPresentation";
 import type { WorkspaceMode } from "@posthog/shared";
 import {
   isTerminalStatus,
@@ -300,6 +301,7 @@ export function TaskIcon({
   isSuspended,
   needsPermission,
   taskRunStatus,
+  runMode,
   originProduct,
   slackThreadUrl,
   prState,
@@ -307,7 +309,14 @@ export function TaskIcon({
   size = ICON_SIZE,
 }: TaskIconProps) {
   const isCloudTask = workspaceMode === "cloud";
-  const isTerminalCloud = isCloudTask && isTerminalStatus(taskRunStatus);
+  const displayedTaskRunStatus = runStatusForDisplay({
+    status: taskRunStatus,
+    environment: isCloudTask ? "cloud" : "local",
+    runMode,
+    isGenerating,
+  });
+  const isTerminalCloud =
+    isCloudTask && isTerminalStatus(displayedTaskRunStatus);
   const originProductMeta = getOriginProductMeta(originProduct);
 
   if (needsPermission) {
@@ -320,7 +329,15 @@ export function TaskIcon({
     );
   }
   if (isGenerating) {
-    return <DotsCircleSpinner size={size} className="text-accent-11" />;
+    const label =
+      taskRunStatus === "not_started" || taskRunStatus === "queued"
+        ? "Starting"
+        : "Working";
+    return (
+      <span role="img" aria-label={label}>
+        <DotsCircleSpinner size={size} className="text-accent-11" />
+      </span>
+    );
   }
   // Unread outranks the cloud/PR/diff status icons: when an agent finishes a
   // task there is fresh activity the user has not seen, and that "needs
@@ -339,7 +356,7 @@ export function TaskIcon({
   if (isTerminalCloud) {
     return (
       <CloudStatusIcon
-        taskRunStatus={taskRunStatus}
+        taskRunStatus={displayedTaskRunStatus ?? undefined}
         originProduct={originProduct}
         threadUrl={slackThreadUrl}
         size={size}
@@ -364,7 +381,7 @@ export function TaskIcon({
   if (isCloudTask) {
     return (
       <CloudStatusIcon
-        taskRunStatus={taskRunStatus}
+        taskRunStatus={displayedTaskRunStatus ?? undefined}
         originProduct={originProduct}
         threadUrl={slackThreadUrl}
         size={size}

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.tsx
@@ -93,9 +93,6 @@ function dotMark(dot: TaskDot, decorative = false): ReactElement {
       {...naming}
       className={cn(
         "block shrink-0 rounded-full",
-        // ph-pulse is the app's existing flash, but it has no reduced-motion
-        // rule of its own — hold a static dot rather than blinking at someone
-        // who asked us not to.
         dot.pulse && "ph-pulse motion-reduce:animate-none",
       )}
       style={{

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -100,8 +100,8 @@ export interface TaskDot {
  * Recoverable run mechanics stay behind one loading state. A failed run uses a
  * red mark because the loading spinner must end with a clear result.
  *
- * A cloud run's queued state shows the same loading spinner as other startup
- * states. A local run at `queued`, or any run at `in_progress` with nothing
+ * A cloud run's `not_started` and `queued` states show the same loading spinner
+ * as other startup states. A local run at `queued`, or any run at `in_progress` with nothing
  * streaming, is not a live signal by itself because those states can outlive
  * the work.
  *
@@ -109,10 +109,11 @@ export interface TaskDot {
  * that story; only a visibly loading or streaming run lights the dot.
  */
 export function taskDot(props: TaskStatusInput): TaskDot {
-  // Cloud `queued` is a sandbox being claimed, and the backend leaves that
-  // state by itself. A local run can remain `queued` after the agent finishes.
+  // Cloud `not_started` and `queued` are setup states that the backend leaves
+  // by itself. A local run can remain `queued` after the agent finishes.
   const isLoadingCloudRun =
-    props.taskRunStatus === "queued" &&
+    (props.taskRunStatus === "not_started" ||
+      props.taskRunStatus === "queued") &&
     props.workspaceMode === "cloud" &&
     !props.isGenerating;
   const isLoading = props.isAgentSessionStarting || isLoadingCloudRun;

--- a/products/desktop/packages/ui/src/primitives/DotsCircleSpinner.tsx
+++ b/products/desktop/packages/ui/src/primitives/DotsCircleSpinner.tsx
@@ -15,6 +15,7 @@ export function DotsCircleSpinner({
 }: DotsCircleSpinnerProps) {
   return (
     <span
+      aria-hidden="true"
       className={`inline-grid place-items-center ${className}`}
       style={{
         width: size,

--- a/products/desktop/packages/ui/src/styles/globals.css
+++ b/products/desktop/packages/ui/src/styles/globals.css
@@ -483,6 +483,16 @@ body:has(.rt-DialogOverlay[data-state="open"]) {
   animation: ph-dots-frame 800ms step-end infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .ph-dots-frame {
+    animation: none;
+  }
+
+  .ph-dots-frame:first-child {
+    opacity: 1;
+  }
+}
+
 /* Dot-ring spinner: eight dots on a 3x3 grid, one keyframe per dot with a
    staggered delay so a highlight travels the ring. Only `opacity` animates, so
    this composites without repainting — and unlike the braille spinner it isn't
@@ -529,6 +539,12 @@ body:has(.rt-DialogOverlay[data-state="open"]) {
 
 .ph-pulse {
   animation: ph-pulse 1s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ph-pulse {
+    animation: none;
+  }
 }
 
 /* Shimmer for an item whose run is still in flight. A highlight band sweeps

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5556,7 +5556,14 @@ def get_task_summaries(team_id: int, user_id: int | None, *, ids: list) -> list[
     latest_run = (
         TaskRun.objects.filter(task=OuterRef("pk"), team_id=team_id)
         .order_by("-created_at", "-id")
-        .annotate(_data=JSONObject(id="id", status="status", environment="environment"))
+        .annotate(
+            _mode=Case(
+                When(state__mode="interactive", then=Value("interactive")),
+                default=Value("background"),
+                output_field=CharField(),
+            ),
+            _data=JSONObject(id="id", status="status", environment="environment", mode="_mode"),
+        )
     )
     tasks = (
         Task.objects.filter(team_id=team_id, deleted=False, id__in=ids)
@@ -5569,7 +5576,10 @@ def get_task_summaries(team_id: int, user_id: int | None, *, ids: list) -> list[
         raw = getattr(task, "_latest_run", None)
         latest = (
             contracts.TaskLatestRunSummaryDTO(
-                id=raw["id"], status=raw.get("status"), environment=raw.get("environment")
+                id=raw["id"],
+                status=raw.get("status"),
+                environment=raw.get("environment"),
+                mode=raw.get("mode", "background"),
             )
             if isinstance(raw, dict)
             else None

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -372,11 +372,12 @@ class TaskCommentDetailDTO:
 
 @dataclass(frozen=True)
 class TaskLatestRunSummaryDTO:
-    """The latest-run status/environment pair nested in a task summary response."""
+    """The latest-run state nested in a task summary response."""
 
     id: UUID
     status: str | None
     environment: str | None
+    mode: Literal["interactive", "background"]
 
 
 @dataclass(frozen=True)
@@ -384,7 +385,7 @@ class TaskSummaryDTO:
     """The HTTP summary representation of a task.
 
     Mirrors exactly the fields ``TaskSummarySerializer`` emits. ``latest_run`` carries the
-    most-recent run's ``status`` and ``environment`` (or ``None`` when the task has no runs).
+    most-recent run's status, environment, and mode (or ``None`` when the task has no runs).
     """
 
     id: UUID

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1914,6 +1914,11 @@ class TaskRunPeerMessageResponseSerializer(serializers.Serializer):
 TASK_SUMMARIES_MAX_IDS = 5000
 
 
+class TaskExecutionMode(models.TextChoices):
+    INTERACTIVE = "interactive", "interactive"
+    BACKGROUND = "background", "background"
+
+
 class TaskSummariesRequestSerializer(serializers.Serializer):
     ids = serializers.ListField(
         child=serializers.UUIDField(),
@@ -1930,6 +1935,10 @@ class TaskRunSummarySerializer(serializers.Serializer):
     id = serializers.UUIDField(help_text="ID of the latest run.")
     status = serializers.ChoiceField(choices=tasks_facade.TaskRunStatus.choices, allow_null=True)
     environment = serializers.ChoiceField(choices=tasks_facade.TaskRunEnvironment.choices, allow_null=True)
+    mode = serializers.ChoiceField(
+        choices=TaskExecutionMode.choices,
+        help_text="Execution mode of the latest run.",
+    )
 
 
 class TaskSummarySerializer(DataclassSerializer):
@@ -2980,11 +2989,6 @@ def get_relayed_imported_mcp_name_collision_error(attrs: dict) -> str | None:
         if server["name"].lower() in imported_names:
             return f"Relayed MCP server name '{server['name']}' collides with an imported MCP server name."
     return None
-
-
-class TaskExecutionMode(models.TextChoices):
-    INTERACTIVE = "interactive", "interactive"
-    BACKGROUND = "background", "background"
 
 
 class TaskRunCreateRequestSerializer(ImportedMcpServersFieldMixin, RelayedMcpServersFieldMixin, serializers.Serializer):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -5086,16 +5086,22 @@ class TestTaskSummariesAPI(BaseTaskAPITest):
         [payload] = response.json()["results"]
         self.assertEqual(
             payload["latest_run"],
-            {"id": str(valid_run.id), "status": valid_run.status, "environment": valid_run.environment},
+            {
+                "id": str(valid_run.id),
+                "status": valid_run.status,
+                "environment": valid_run.environment,
+                "mode": "background",
+            },
         )
 
     @parameterized.expand(
         [
-            ("with_run", True),
-            ("no_runs", False),
+            ("background_run", {}, "background"),
+            ("interactive_run", {"mode": "interactive"}, "interactive"),
+            ("no_runs", None, None),
         ]
     )
-    def test_summaries_response_shape(self, _name, with_run):
+    def test_summaries_response_shape(self, _name, run_state, expected_mode):
         task = self.create_task("Task")
         run = (
             TaskRun.objects.create(
@@ -5103,8 +5109,9 @@ class TestTaskSummariesAPI(BaseTaskAPITest):
                 task=task,
                 status=TaskRun.Status.IN_PROGRESS,
                 environment=TaskRun.Environment.LOCAL,
+                state=run_state,
             )
-            if with_run
+            if run_state is not None
             else None
         )
 
@@ -5114,7 +5121,16 @@ class TestTaskSummariesAPI(BaseTaskAPITest):
         [payload] = response.json()["results"]
         self.assertEqual(set(payload.keys()), self.SUMMARY_FIELDS)
         self.assertEqual(payload["created_by_id"], self.user.id)
-        expected_run = {"id": str(run.id), "status": run.status, "environment": run.environment} if run else None
+        expected_run = (
+            {
+                "id": str(run.id),
+                "status": run.status,
+                "environment": run.environment,
+                "mode": expected_mode,
+            }
+            if run
+            else None
+        )
         self.assertEqual(payload["latest_run"], expected_run)
 
     def test_summaries_paginates_large_id_sets(self):

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -4778,6 +4778,11 @@ export interface TaskRunSummaryApi {
     id: string
     status: TaskRunStatusEnumApi | null
     environment: TaskRunEnvironmentEnumApi | null
+    /** Execution mode of the latest run.
+     *
+     * * `interactive` - interactive
+     * * `background` - background */
+    mode: TaskExecutionModeEnumApi
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -59639,6 +59639,11 @@ export namespace Schemas {
       id: string;
       status: TaskRunStatusEnum | null;
       environment: TaskRunEnvironmentEnum | null;
+      /** Execution mode of the latest run.
+       *
+       * * `interactive` - interactive
+       * * `background` - background */
+      mode: TaskExecutionModeEnum;
     }
 
     /**


### PR DESCRIPTION
## Problem

Active cloud sessions can show a stationary yellow dot after the desktop app restarts, even while the agent is still working.

Persisted `in_progress` state also makes idle interactive runs look active when no live turn exists.

## Changes

- Active background runs now keep the loading icon after restart, while idle interactive runs stay quiet.
- Task summaries now include the latest run mode, with generated clients updated from the API schema.
- Older backends omit the mode, so Desktop uses the prior quiet fallback until the field is available.
- Status decisions now reject stale sessions across task lists, channel feeds, command surfaces, attention counts, and archive confirmation.
- Loading icons now expose clear status labels and stop animation when reduced motion is enabled.

![Before and after status dot comparison](https://raw.githubusercontent.com/PostHog/pr-assets/3295ffd0f06125b21e89e9d5f00c470740073c16/2026/08/baa2df0d-c76e-46ca-9fc8-458f04436a94.png)

## How did you test this code?

- Added status cases for restart, run modes, stale sessions, terminal states, permissions, archive checks, command surfaces, and reduced activity.
- Ran the full `@posthog/core` and `@posthog/ui` Vitest suites.
- Ran the full Desktop typecheck and Biome checks.
- Ran `TestTaskSummariesAPI`, repository-wide mypy, OpenAPI generation, and `hogli ci:preflight --strict`.
- Ran the React Doctor scan. It found no new issue in this change.
- The live app flow was not run.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. The API change adds an internal summary field, and the UI restores existing status behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop used repository, shell, workflow, subagent, and signed-commit tools.
- Skills used: `/posthog-desktop`, `/improving-drf-endpoints`, `/writing-dataclasses`, `/writing-tests`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-code-comments`, `/react-doctor`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/writing-simplified-technical-english`.
- A multi-agent Thermo-Nuclear review checked state, API, reliability, UI, tests, and accessibility before the final release gate.
- The committed test data and public screenshot use invented labels and contain no private session material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
