### PR TITLE
fix(cdp): prevent false log message truncation near maxLength

### DIFF
--- a/nodejs/src/cdp/utils.test.ts
+++ b/nodejs/src/cdp/utils.test.ts
@@ -179,5 +179,14 @@ describe('Utils', () => {
             expect(sanitizeLogMessage(['🚀🚀🚀🚀🚀'], [], 3)).toMatchInlineSnapshot(`"🚀... (truncated)"`)
             expect(sanitizeLogMessage(['🚀🚀🚀🚀🚀'], [], 4)).toMatchInlineSnapshot(`"🚀🚀... (truncated)"`)
         })
+        it('should not truncate messages shorter than maxLength even if close to limit', () => {
+            const msgNearLimit = 'a'.repeat(9990)
+            const message = sanitizeLogMessage([msgNearLimit])
+            expect(message).toBe(msgNearLimit)
+            expect(message).not.toContain('... (truncated)')
+
+            const shortMsg = 'a'.repeat(18)
+            expect(sanitizeLogMessage([shortMsg], [], 20)).toBe(shortMsg)
+        })
     })
 })

--- a/nodejs/src/cdp/utils.ts
+++ b/nodejs/src/cdp/utils.ts
@@ -398,7 +398,7 @@ export const sanitizeLogMessage = (args: any[], sensitiveValues?: string[], maxL
     let truncateAt = maxLength
 
     // Check if we're in the middle of a surrogate pair
-    if (truncateAt > 0 && truncateAt < message.length + TRUNCATION_SUFFIX.length) {
+    if (truncateAt > 0 && truncateAt < message.length) {
         const charAtTruncate = message.charCodeAt(truncateAt)
         const charBeforeTruncate = message.charCodeAt(truncateAt - 1)
 


### PR DESCRIPTION
## Problem

CDP log entries that are close to `maxLength` but still within bounds (e.g. 9,986–9,999 characters against the default 10,000 limit) were falsely marked as truncated. The guard checked `truncateAt < message.length + TRUNCATION_SUFFIX.length`, which triggered when `message.length` was within 15 characters of `maxLength`.

Closes #91233

## Changes

- Only truncate log messages when `message.length` actually exceeds `maxLength`.
- Add test coverage in `utils.test.ts` verifying that messages near `maxLength` are not truncated.

## How did you test this code?

- Ran `npx jest src/cdp/utils.test.ts` in `nodejs/` (15/15 tests passing, including surrogate pair and near-limit tests).
- Confirmed that messages of length 9,990 are preserved without `... (truncated)` appended.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Identified edge-case defect where `truncateAt < message.length + TRUNCATION_SUFFIX.length` triggered on messages shorter than `maxLength`.
- Skills used: `writing-pr-descriptions`, `merging-prs`.
