### PR TITLE
fix(tasks): avoid SIGPIPE aborting the golden setup script

### DIFF
--- a/products/tasks/backend/sandbox/images/hogland/setup-golden.sh
+++ b/products/tasks/backend/sandbox/images/hogland/setup-golden.sh
@@ -93,7 +93,11 @@ make -C /tmp/git prefix=/usr NO_GETTEXT=YesPlease NO_TCLTK=YesPlease -j"$(nproc)
 make -C /tmp/git prefix=/usr NO_GETTEXT=YesPlease NO_TCLTK=YesPlease install
 rm -rf /tmp/git /tmp/git.tar.xz
 git --version
-git help -a | grep -q '[[:space:]]backfill'
+# Materialise `git help -a` before matching. Piping it straight into `grep -q`
+# lets grep close the pipe on the first match, so git dies with SIGPIPE (141)
+# and pipefail aborts the whole setup. Capture first, then grep the string.
+git_help_all="$(git help -a)"
+grep -q '[[:space:]]backfill' <<<"$git_help_all"
 
 log "node 24"
 # The rootfs bakes node 22 into /usr/local/bin, which precedes /usr/bin (where
@@ -195,10 +199,13 @@ rm -rf "$skills_extract_dir"
 # Fail closed: an empty tarball or a broken install must not ship a golden that
 # silently lost its skills.
 for skills_target in /scripts/plugins/posthog/skills /root/.agents/skills /root/.claude/skills; do
-    find "$skills_target" -name 'SKILL.md' -type f 2>/dev/null | grep -q . || {
+    # Capture then test. `find ... | grep -q .` lets grep close the pipe on the
+    # first hit, so find dies with SIGPIPE (141) and pipefail flips this guard.
+    found_skill="$(find "$skills_target" -name 'SKILL.md' -type f 2>/dev/null)"
+    if [ -z "$found_skill" ]; then
         echo "no SKILL.md found under ${skills_target} after installing ${SKILLS_TARBALL}" >&2
         exit 1
-    }
+    fi
 done
 
 log "guards + cpu sampler (delivered over ssh by bake-golden.sh)"


### PR DESCRIPTION
## Problem

The dev golden bake now authenticates and creates the seed box (the earlier 401 is fixed by the new `v1.6.0-cli` release). It then fails inside the box:

```
[tasks-bake] FAIL: setup-golden.sh exited 141 in the box; not snapshotting
```

Exit **141 = SIGPIPE**. `setup-golden.sh` runs under `set -euo pipefail`. Two guards pipe a producer into `grep -q`, which closes the pipe on its first match; the producer then gets SIGPIPE, and `pipefail` turns that into a script abort. The bake died right after the git build, on the `git help -a | grep -q backfill` check.

## Changes

- `git help -a | grep -q '[[:space:]]backfill'` → capture `git help -a` into a variable, then grep the string.
- `find ... | grep -q .` (the installed-skills guard) → capture the `find` output, then test it is non-empty.

Both keep the exact fail-closed behavior (missing backfill or missing skills still aborts the bake) without the early-closing pipe. shellcheck clean.

The sibling `smoke-golden.sh` has `printf "$var" | grep -q` lines, but those are safe: a small variable is written atomically into the pipe buffer before `grep -q` exits, so the producer never gets SIGPIPE.

## How did you test this code?

I am an agent (Claude Code), work by Tom Owers. shellcheck clean. The failure is a confirmed repro from run 33241343666 (log: `setup-golden.sh exited 141` immediately after `git version 2.49.1`, i.e. the `git help -a | grep -q` line). The real check is the next dev bake, which should clear this step and reach the snapshot.

## 🤖 Agent context

Agent-authored (Claude Code), authored by Tom Owers. This is the next blocker after the auth fix (the `v1.6.0-cli` release). Must merge to master before re-dispatching, because the bake checks out `setup-golden.sh` from the validated ref (master), not from a branch.
