### PR TITLE
fix(data-warehouse): treat S3 permission denials as transient in repartition

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -144,6 +144,14 @@ def _is_transient_infra_error(error: Exception) -> bool:
     # classification in delta.errors.is_transient_maintenance_error.
     if isinstance(error, InternalError) and isinstance(error.__cause__, psycopg.errors.ReadOnlySqlTransaction):
         return True
+    # s3fs collapses every S3 auth-failure response code (AccessDenied, ExpiredToken, InvalidAccessKeyId)
+    # into a bare PermissionError, and a 403 carries no code in its body to tell them apart. The rewrite
+    # only ever touches our own instance-role-authenticated data-warehouse bucket, so a denial here is
+    # the same transient IMDS/STS credential-resolution race already recognized as retryable in
+    # delta.table._is_retryable_purge_error — not a customer credential problem. Retrying on the next
+    # sync self-heals it; burning an attempt and reporting it instead abandons the table after the cap.
+    if isinstance(error, PermissionError):
+        return True
     message = str(error).lower()
     return any(snippet in message for snippet in _TRANSIENT_ERROR_SNIPPETS)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -596,6 +596,46 @@ class TestTransientObjectStoreFailure:
         skip_calls = [c for c in mock_capture_event.call_args_list if c.args[0] == "warehouse_repartition_skipped"]
         assert any(c.args[1].get("reason") == "transient_infra_error" for c in skip_calls)
 
+    @patch(f"{MODULE}.capture_exception")
+    @patch(f"{MODULE}.capture_repartition_event")
+    @patch(f"{MODULE}.HeartbeaterSync")
+    @patch(f"{MODULE}.repartition_table_in_place", new_callable=AsyncMock)
+    @patch(f"{MODULE}.DeltaTableRef")
+    @patch(f"{MODULE}.is_auto_repartition_enabled", return_value=True)
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.ExternalDataSchema")
+    def test_s3_permission_error_stands_down_without_burning_an_attempt(
+        self,
+        mock_schema_model: MagicMock,
+        _mock_job_model: MagicMock,
+        _mock_enabled: MagicMock,
+        _mock_helper_cls: MagicMock,
+        mock_repartition: AsyncMock,
+        _mock_heartbeater: MagicMock,
+        mock_capture_event: MagicMock,
+        mock_capture_exception: MagicMock,
+    ) -> None:
+        # s3fs raises a bare PermissionError for a transient credential-resolution race against our own
+        # data-warehouse bucket. It must stand down like the other infra blips, not burn an attempt or
+        # report a failure — otherwise a flagged table loses its whole retry budget to a self-healing
+        # blip and is abandoned at the cap.
+        schema = _schema(name="public.usages", s3_folder_name="usages", pending={**PENDING_TARGET, "attempts": 0})
+        mock_schema_model.objects.select_related.return_value.get.return_value = schema
+        mock_repartition.side_effect = PermissionError("Access Denied")
+
+        _maybe_repartition_table(
+            RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
+            MagicMock(),
+        )
+
+        mock_capture_exception.assert_not_called()
+        emitted = [c.args[0] for c in mock_capture_event.call_args_list]
+        assert "warehouse_repartition_failed" not in emitted
+        # Charged before the rewrite and refunded on stand-down, so the retry budget is untouched.
+        assert schema.repartition_pending["attempts"] == 0
+        skip_calls = [c for c in mock_capture_event.call_args_list if c.args[0] == "warehouse_repartition_skipped"]
+        assert any(c.args[1].get("reason") == "transient_infra_error" for c in skip_calls)
+
 
 class TestFeatureFlagGate:
     @parameterized.expand(


### PR DESCRIPTION
## Problem

- A data-warehouse table that repartitions is abandoned un-synced when the rewrite hits a transient S3 credential blip, so the table keeps failing to sync until someone intervenes.
- The rewrite reads and writes our own instance-role-authenticated data-warehouse bucket. s3fs collapses every S3 auth-failure code (AccessDenied, ExpiredToken, InvalidAccessKeyId) into a bare `PermissionError`, and a 403 carries no code to tell a transient IMDS/STS race from a real denial.
- `_is_transient_infra_error` in the repartition activity did not recognize `PermissionError`, so the rewrite counted it as a real failure, burned a retry attempt, and reported it to error tracking.
- After the attempt cap the controller gives up, clears the pending marker, and backs the table off to the daily cooldown, leaving it on the old layout.

## Changes

- A repartition rewrite that hits an S3 `PermissionError` now stands down and retries on the next sync, instead of burning an attempt and abandoning the table.
- `_is_transient_infra_error` classifies `PermissionError` as transient, matching the existing treatment in `delta.table._is_retryable_purge_error`. The attempt is refunded, no `warehouse_repartition_failed` event fires, and nothing is reported to error tracking.
- This mirrors a convention the codebase already applies to the same bucket elsewhere; the classifier is the one place the repartition path had missed it.

## How did you test this code?

- Added `test_s3_permission_error_stands_down_without_burning_an_attempt` to `test_repartition_table.py`. It catches the regression where a `PermissionError` from the rewrite emits `warehouse_repartition_failed`, captures to error tracking, and consumes the retry budget — none of which existing cases covered.
- Ran the file locally: the new test and the sibling transient-error cases pass.
- Not run: the ClickHouse- or Postgres-backed suites; this change is a pure classification branch with no datastore path.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged warehouse repartition failure telemetry and traced the `PermissionError` failure mode to a gap in the repartition activity's transient-error classifier, which diverged from the same-bucket convention in `delta.table` and `delta.errors`. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`. The fix is scoped to the single classifier branch and its regression test; no sync semantics or partition heuristics were touched.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
