### PR TITLE
fix(apple-search-ads): classify transient API 5xx and 429 as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/source.py
@@ -82,6 +82,25 @@ class AppleSearchAdsSource(ResumableSource[AppleSearchAdsSourceConfig, AppleSear
             "Could not sign the Apple Ads client secret": "The private key isn't a valid unencrypted EC (P-256) PEM. Paste the key you generated for your Apple Ads API client and reconnect.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # Apple's transport already retries these statuses in-process (see the
+        # `status_forcelist` on `APPLE_SEARCH_ADS_RETRY`) with backoff, so one only reaches
+        # here once that budget is exhausted — Apple is rate-limiting us (429) or its API is
+        # briefly unavailable (5xx). Both are transient and self-recovering, so let Temporal
+        # retry the whole activity. Unlike the shared REST engine, this source has its own
+        # client, so `raise_for_status()` surfaces a plain `requests.HTTPError` that no
+        # `RESTClientRetryableError` type-check catches; without this classification the
+        # benign, self-recovering failure is logged at `exception` and reported as an
+        # unclassified error every run. Match the code-anchored fragment, not the volatile
+        # reason phrase or per-request URL.
+        return {
+            "429 Client Error",
+            "500 Server Error",
+            "502 Server Error",
+            "503 Server Error",
+            "504 Server Error",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/tests/test_apple_search_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/apple_search_ads/tests/test_apple_search_ads_source.py
@@ -20,7 +20,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.apple_sear
 from products.warehouse_sources.backend.temporal.data_imports.sources.apple_search_ads.source import (
     AppleSearchAdsSource,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import VersionDeprecation
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
+    VersionDeprecation,
+    error_message_matches,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.applesearchads import (
     AppleSearchAdsSourceConfig,
@@ -113,6 +116,27 @@ class TestAppleSearchAdsSource:
 
         assert any(str(status) in key and host in key for key in errors)
         assert all(message for message in errors.values())
+
+    @parameterized.expand(
+        [
+            (
+                "rate_limited",
+                "429 Client Error: Too Many Requests for url: https://api.searchads.apple.com/api/v5/reports",
+            ),
+            (
+                "service_unavailable",
+                "503 Server Error: Service Temporarily Unavailable for url: https://api.searchads.apple.com/api/v5/targetingkeywords/find",
+            ),
+            ("bad_gateway", "502 Server Error: Bad Gateway for url: https://api.ads.apple.com/v1/campaigns"),
+            ("gateway_timeout", "504 Server Error: Gateway Timeout for url: https://api.ads.apple.com/v1/reports"),
+        ]
+    )
+    def test_transient_api_statuses_are_retryable(self, _name: str, error_msg: str) -> None:
+        # These are the statuses the transport already retries; once exhausted they must stay
+        # retryable (and out of the non-retryable set) so a self-recovering blip isn't reported
+        # as an unclassified error and the sync isn't disabled.
+        assert error_message_matches(error_msg, self.source.get_retryable_errors())
+        assert not error_message_matches(error_msg, self.source.get_non_retryable_errors().keys())
 
     def test_get_resumable_source_manager_is_namespaced_per_schema(self) -> None:
         inputs = mock.MagicMock()


### PR DESCRIPTION
## Problem

Apple Ads sources that hit an Apple rate limit (429) or a brief Apple API outage (5xx) log the failure as an exception and record it as an unclassified error on every run, even though the failure is transient and self-recovering. That noise is exactly what hides real, actionable failures during triage.

- Apple's transport already retries 429 and 5xx with backoff (`APPLE_SEARCH_ADS_RETRY.status_forcelist`), so one only reaches the activity handler once that budget is exhausted.
- This source has its own HTTP client, not the shared REST engine, so `raise_for_status()` surfaces a plain `requests.HTTPError` that the shared `RESTClientRetryableError` type-check never catches.
- With no retryable classification, the handler falls through to `logger.aexception` and the run is reported as an unclassified error.

## Changes

- Transient Apple 429 and 5xx failures are now logged as warnings and re-raised for a normal Temporal retry, instead of being reported as unclassified errors.
- Added `get_retryable_errors` to the source, matching the code-anchored status fragments the transport already retries (429, 500, 502, 503, 504). Retryability is unchanged; only the classification and log level change.
- These statuses are disjoint from the source's non-retryable auth/4xx entries, so a permanent 400/401/403/404 still stops the sync.

## How did you test this code?

Added `test_transient_api_statuses_are_retryable` (4 cases) to `test_apple_search_ads_source.py`. It catches a regression where the retryable classification is dropped or a status leaks into the non-retryable set. No existing test covered `get_retryable_errors` for this source.

Ran locally: `test_apple_search_ads_source.py -k retryable` — 8 passed. Not run: the broader backend suites (no database in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of a batch of data-warehouse sync failure classes surfaced this one: transient Apple 5xx/429 responses recorded as unclassified errors. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. The fix mirrors the existing `get_retryable_errors` pattern in the Postgres, MySQL, and Salesforce sources rather than routing Apple's client through `RESTClientRetryableError`, which would be a larger change to the source's own transport. All example error strings in the code and tests use invented URLs and reason phrases, not customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
