### PR TITLE
chore(tasks): instrument golden bake to diagnose hogpanion at snapshot

### DIFF
--- a/products/tasks/backend/sandbox/images/hogland/bake-golden.sh
+++ b/products/tasks/backend/sandbox/images/hogland/bake-golden.sh
@@ -222,6 +222,14 @@ if [[ "$setup_rc" -ne 0 ]]; then
 fi
 log "setup-golden.sh completed in the box"
 
+# Diagnostic (temporary): record hogpanion's state at snapshot time. The dev
+# smoke finds hogpanion.service with no MainPID in the restored golden; this
+# shows whether the daemon is already down HERE (setup left it dead) or only
+# after resume. Best-effort over SSH; never fail the bake.
+log "hogpanion state at snapshot time (diagnostic)"
+"${ssh_base[@]}" "echo '--- hogpanion @ snapshot time ---'; sudo systemctl show hogpanion.service -p MainPID -p ActiveState -p SubState; sudo systemctl status hogpanion.service --no-pager 2>&1 | head -8; echo '--- hogpanion journal (tail) ---'; sudo journalctl -u hogpanion.service --no-pager 2>&1 | tail -40" \
+    || log "hogpanion snapshot-time diagnostic failed (non-fatal)"
+
 # Snapshot the seed box, then point the candidate alias at the new snapshot id.
 # `box snapshot` pauses the box and persists it to S3, emitting the record JSON.
 log "snapshotting seed box $SEED_BOX_ID"

--- a/products/tasks/backend/sandbox/images/hogland/smoke-golden.sh
+++ b/products/tasks/backend/sandbox/images/hogland/smoke-golden.sh
@@ -181,7 +181,12 @@ log "asserting exec-daemon (hogpanion) env carries the container-style env"
 daemon_env_probe='set -eu
 pid=$(systemctl show hogpanion.service -p MainPID --value 2>/dev/null || echo 0)
 if [ -z "$pid" ] || [ "$pid" = "0" ]; then
-    echo "hogpanion has no running MainPID" >&2; exit 1
+    echo "hogpanion has no running MainPID" >&2
+    echo "--- hogpanion.service status ---" >&2
+    systemctl status hogpanion.service --no-pager >&2 2>&1 || true
+    echo "--- hogpanion journal (tail) ---" >&2
+    journalctl -u hogpanion.service --no-pager 2>&1 | tail -40 >&2 || true
+    exit 1
 fi
 environ=$(sudo cat "/proc/$pid/environ" | tr "\0" "\n")
 printf "%s\n" "$environ" | grep -qx "IS_SANDBOX=1" || { echo "daemon env missing IS_SANDBOX=1" >&2; exit 1; }


### PR DESCRIPTION
## Problem

The dev golden bake now works end to end except the final smoke check: `hogpanion.service` has **no `MainPID`** in the restored golden, so the exec-daemon env assertion fails and the golden is (correctly) not promoted.

I could not reproduce it with proxy experiments against a live dev box:
- On a healthy restored golden (`devbox-golden`), `hogpanion.service` is `active` with a `MainPID` — so the smoke check is valid.
- Restore is a Firecracker memory-resume, so `systemctl enable` is irrelevant.
- Applying the `setup-golden.sh` drop-in + detached restart, then snapshotting and restoring, keeps hogpanion running — **even when the snapshot is taken mid-restart**.

So the cause lives in the **full bake** (cold-boot of the hogland base + the entire `setup-golden.sh` over SSH), which proxies do not reproduce. The faithful environment has to report the truth.

## Changes

Temporary, best-effort diagnostics — no behavior change, cannot fail the bake:

- **`bake-golden.sh`**: right before `box snapshot`, dump hogpanion's `MainPID`, `ActiveState`, `SubState`, `systemctl status`, and journal tail over SSH. This shows whether hogpanion is **already dead at snapshot time** (setup left it dead) or only after resume.
- **`smoke-golden.sh`**: when the daemon check finds no `MainPID`, dump the service status and journal tail before exiting, so the restored-box side shows **why** hogpanion is down.

## How did you test this code?

I am an agent (Claude Code), work by Tom Owers. `shellcheck -S warning` clean on both scripts. This PR adds logging only; the payoff is the next dev bake, whose log will pinpoint whether hogpanion dies during setup or on resume. To be reverted once the cause is fixed.

## 🤖 Agent context

Agent-authored (Claude Code), authored by Tom Owers. Instrumentation to root-cause the last golden-bake blocker after proxy reproduction failed. The bake-side probe is the decisive signal: hogpanion up at snapshot but down after restore points to a resume issue; down at snapshot points to setup. Revert after the fix.
