### PR TITLE
fix(tasks): query hogpanion via sudo in the golden smoke test

### DIFF
--- a/products/tasks/backend/sandbox/images/hogland/bake-golden.sh
+++ b/products/tasks/backend/sandbox/images/hogland/bake-golden.sh
@@ -222,14 +222,6 @@ if [[ "$setup_rc" -ne 0 ]]; then
 fi
 log "setup-golden.sh completed in the box"
 
-# Diagnostic (temporary): record hogpanion's state at snapshot time. The dev
-# smoke finds hogpanion.service with no MainPID in the restored golden; this
-# shows whether the daemon is already down HERE (setup left it dead) or only
-# after resume. Best-effort over SSH; never fail the bake.
-log "hogpanion state at snapshot time (diagnostic)"
-"${ssh_base[@]}" "echo '--- hogpanion @ snapshot time ---'; sudo systemctl show hogpanion.service -p MainPID -p ActiveState -p SubState; sudo systemctl status hogpanion.service --no-pager 2>&1 | head -8; echo '--- hogpanion journal (tail) ---'; sudo journalctl -u hogpanion.service --no-pager 2>&1 | tail -40" \
-    || log "hogpanion snapshot-time diagnostic failed (non-fatal)"
-
 # Snapshot the seed box, then point the candidate alias at the new snapshot id.
 # `box snapshot` pauses the box and persists it to S3, emitting the record JSON.
 log "snapshotting seed box $SEED_BOX_ID"

--- a/products/tasks/backend/sandbox/images/hogland/smoke-golden.sh
+++ b/products/tasks/backend/sandbox/images/hogland/smoke-golden.sh
@@ -179,13 +179,17 @@ fi
 log "asserting exec-daemon (hogpanion) env carries the container-style env"
 # shellcheck disable=SC2016 # $pid/$environ must expand on the box, not locally
 daemon_env_probe='set -eu
-pid=$(systemctl show hogpanion.service -p MainPID --value 2>/dev/null || echo 0)
+# Query via sudo. The box runs no system D-Bus daemon, only the systemd
+# root-only private socket, so a non-root systemctl fails with "Failed to
+# connect to bus" and reports a false MainPID=0. The ssh user hog has
+# passwordless sudo, same as the environ read below.
+pid=$(sudo systemctl show hogpanion.service -p MainPID --value 2>/dev/null || echo 0)
 if [ -z "$pid" ] || [ "$pid" = "0" ]; then
     echo "hogpanion has no running MainPID" >&2
     echo "--- hogpanion.service status ---" >&2
-    systemctl status hogpanion.service --no-pager >&2 2>&1 || true
+    sudo systemctl status hogpanion.service --no-pager >&2 2>&1 || true
     echo "--- hogpanion journal (tail) ---" >&2
-    journalctl -u hogpanion.service --no-pager 2>&1 | tail -40 >&2 || true
+    sudo journalctl -u hogpanion.service --no-pager 2>&1 | tail -40 >&2 || true
     exit 1
 fi
 environ=$(sudo cat "/proc/$pid/environ" | tr "\0" "\n")
@@ -200,7 +204,7 @@ printf "%s\n" "$environ" | grep -qx "HOME=/root" || { echo "daemon env missing H
 # the guard is actually there so the guarded path the daemon exposes is real.
 test -x /opt/posthog/bin/git || { echo "/opt/posthog/bin/git missing" >&2; exit 1; }
 grep -q POSTHOG_ALLOW_UNSIGNED_GIT /opt/posthog/bin/git || { echo "/opt/posthog/bin/git is not the git guard" >&2; exit 1; }
-systemctl show hogpanion.service -p Environment -p EnvironmentFiles --no-pager >&2'
+sudo systemctl show hogpanion.service -p Environment -p EnvironmentFiles --no-pager >&2'
 if ! ssh_assert "$daemon_env_probe"; then
     log "FAIL: hogpanion daemon env is not the container-style env (restart likely did not take before snapshot)"
     exit 1


### PR DESCRIPTION
## Problem

The dev golden bake reaches the smoke test, which fails with `hogpanion has no running MainPID` — but the golden is **healthy**. I restored the actual candidate snapshot and inspected it as root:

```
PGREP=7323 /usr/sbin/hogpanion   PID1=systemd   SYSRUN=running
MAINPID=7323   ACTIVE=active
```

The smoke check runs `systemctl show hogpanion.service -p MainPID` as the non-root ssh user `hog`. The box runs **no system D-Bus daemon** — only systemd's root-only private socket — so a non-root `systemctl` fails with `Failed to connect to bus: No such file or directory`, and the probe reads that as `MainPID=0`. A false negative. Proven on a live box:

```
hog, no sudo:   [Failed to connect to bus: No such file or directory]
hog, with sudo: [7323]
/run/dbus/system_bus_socket: MISSING
```

The probe already reads the daemon environ via `sudo cat`, but queried `MainPID` and the `Environment` dump without sudo.

## Changes

- **`smoke-golden.sh`**: run the `MainPID` query, the `Environment`/`EnvironmentFiles` dump, and the failure-path `status`/`journal` via `sudo`. The `hog` user has passwordless sudo, which the environ read already relied on.
- **`bake-golden.sh`**: revert the temporary snapshot-time diagnostic added to find this; it is no longer needed (and it could not ssh the seed box after the hogpanion restart anyway).

No golden or setup change — the golden was correct all along.

## How did you test this code?

I am an agent (Claude Code), work by Tom Owers. `shellcheck -S warning` clean on both scripts. Root cause proven on a live restored candidate box: hogpanion.service active (`MainPID=7323`), and the exact `hog`-no-sudo vs `hog`-with-sudo behavior above. The real check is the next dev bake, which should now pass smoke and promote the golden.

## 🤖 Agent context

Agent-authored (Claude Code), authored by Tom Owers. This is the last blocker: after auth, render, setup, and bake+snapshot were fixed, smoke was a false negative from a non-root systemctl on a box with no system D-Bus. Once merged, re-dispatch the dev bake to promote `posthog-tasks-default`.
