### PR TITLE
feat(signals): offer scout model pins as a dropdown

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6993,17 +6993,17 @@ snapshots:
     scenes-app-inbox-scene--triage--light:
         hash: v1.k794b7964.1fcdda8455a45b636d29f42c681696c649b26a1339ba5b5890d166ec5bd98aaf.CejUDitmTV84DoeFjFwwFhrEP62iSRHVYAgYCu77zAM
     scenes-app-inbox-scoutconfigform--disabled--dark:
-        hash: v1.k794b7964.c7ec994ac1d65f711be7805c9cae7e3db5c8846f859c77f565faa24618b3b5a2.oDVuzPoCmul8km-CQhaZ7ZwFSLfob_HQTpzZSXkGtgs
+        hash: v1.k794b7964.38bcff8c4bccb9efada389815c510c2e54f58e908bdb63da8367ecd5415748b9.XVEvN3IjfQYend5vFDGFj_YhycAakVu41l45lDcWX7U
     scenes-app-inbox-scoutconfigform--disabled--light:
-        hash: v1.k794b7964.86ae13cc6c174ff7be406e2a458b0e130e0da95a13908a13b1e4d2f354bdfeda.Wd-vAysy8wGyYzR4n0JuLx1mDjR_iMlOBOg6naT4m8E
+        hash: v1.k794b7964.61ea68895845a1d3ea77a943c43d51f5ffe3035123974874fb72607a57b47d57.e8k5SuTevy4_9AzlQLaMp3ALv8sWDpQdRyymxYNF864
     scenes-app-inbox-scoutconfigform--dry-run--dark:
-        hash: v1.k794b7964.c0899205490439c88e086e5a9dacea08bb3434456ed926ab4479f5221b408fa9.eZWbRAQHY0eyNbx503YAvE7QAcBQntKlka4Nzo7MG_k
+        hash: v1.k794b7964.f4348a4f5e229257b208630f91328bf348cd1d61a1942f7082c59cd784d8b829.C24_4fUkNvt_VEDTAfRcgbB0sbDomUebzqep9-jmyoM
     scenes-app-inbox-scoutconfigform--dry-run--light:
-        hash: v1.k794b7964.4a01a0a88d4fc031b44960d52c93a1dfa2ad6a10d68661850444ce496d744298.cjLEjfbtQYJAT5zbHLBkOADZ3RkaRPGukRCG781nVoQ
+        hash: v1.k794b7964.3d80db76a30f87d08c14c7e960a489b2edc28b8fa4f53d8800eee2b3eb0c0e1a.PdNvZ6maeIjeVz2j9NLplqhRgbaJcc_lOFmuSDG3xFM
     scenes-app-inbox-scoutconfigform--live--dark:
-        hash: v1.k794b7964.462c4cbfe7592968d9c82b2fd69ef07735ba8ced891c34a9d9d1d0e3bc4bf776.MG5RQ1DeROS8UiVEL_hsGNf2stSlsTAwQp0MZcwn5Mk
+        hash: v1.k794b7964.5e2b3305afaeea7e7e616095463ce9e5b40474e315d3dbe88017dc2e89d20114.Qww9YMKmZonzXGbkD-nd5HvSPBruwSE3M6Q9sSApJLg
     scenes-app-inbox-scoutconfigform--live--light:
-        hash: v1.k794b7964.c246f46b27e1d29ba3b29d3272ccc6e71b03cfc34f167d1de8985ebc3795e2b7.2Us1Q6Li99J0AJ5xjFUCTqtLC-WDO0yOUb_CbLsaPJM
+        hash: v1.k794b7964.683afd1ad5be8d554575eaeef169502740bc638f236445b47a0275ebd977fb39.7u4_FN6FBaMo8YDEeb3GFi6vTg1XlvR7uErqJJLBZCI
     scenes-app-inbox-scoutmcpserverspicker--create-dialog-variant--dark:
         hash: v1.k794b7964.afe2203f4dd53373a3203fcfa611b5b65555341bdc2fc7fd73c15c2d83914600.O4kSRnOgICuQDkyD2HJCwBXdzE-KwsfzWT98nm43_5A
     scenes-app-inbox-scoutmcpserverspicker--create-dialog-variant--light:

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutConfigControls.stories.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutConfigControls.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<typeof ScoutConfigForm> = {
     title: 'Scenes-App/Inbox/ScoutConfigForm',
     component: ScoutConfigForm,
     parameters: {
-        featureFlags: { [FEATURE_FLAGS.PRODUCT_AUTONOMY]: true },
+        featureFlags: { [FEATURE_FLAGS.PRODUCT_AUTONOMY]: true, [FEATURE_FLAGS.SCOUTS_MODEL_CONFIG]: true },
     },
 }
 export default meta

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutConfigControls.test.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutConfigControls.test.tsx
@@ -2,6 +2,9 @@ import '@testing-library/jest-dom'
 
 import { cleanup, fireEvent, render } from '@testing-library/react'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -43,7 +46,12 @@ describe('ScoutConfigForm', () => {
         },
     })
 
-    beforeEach(() => initKeaTests())
+    beforeEach(() => {
+        // featureFlagLogic persists to localStorage, which jsdom keeps across tests — without
+        // clearing, a flag set in one test leaks into the next test's mount-time state.
+        localStorage.clear()
+        initKeaTests()
+    })
     afterEach(cleanup)
 
     const emitSwitchLabel = 'signals-scout-general write signals to the inbox'
@@ -103,6 +111,30 @@ describe('ScoutConfigForm', () => {
 
         expect(container.querySelector('input[type="time"]')).toBeNull()
         expect(getByText('Custom (0 9 * * 1-5)')).toBeTruthy()
+        unmount()
+    })
+
+    // Guards the pin's wire values: a model option must patch the raw model id (not its display
+    // label), and Default must patch null (not '') — the backend treats null as "clear the pin".
+    it('pins a model from the dropdown and clears the pin via Default', () => {
+        featureFlagLogic.mount()
+        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.SCOUTS_MODEL_CONFIG], {
+            [FEATURE_FLAGS.SCOUTS_MODEL_CONFIG]: true,
+        })
+        const onUpdate = jest.fn()
+        const modelSelectLabel = 'signals-scout-general model'
+        const { getByLabelText, getByText, rerender, unmount } = render(
+            <ScoutConfigForm config={config} onUpdate={onUpdate} />
+        )
+
+        fireEvent.click(getByLabelText(modelSelectLabel))
+        fireEvent.click(getByText('GPT-5.6 Luna'))
+        expect(onUpdate).toHaveBeenCalledWith('config-1', { model: 'gpt-5.6-luna' })
+
+        rerender(<ScoutConfigForm config={{ ...config, model: 'gpt-5.6-luna' }} onUpdate={onUpdate} />)
+        fireEvent.click(getByLabelText(modelSelectLabel))
+        fireEvent.click(getByText('Default'))
+        expect(onUpdate).toHaveBeenLastCalledWith('config-1', { model: null })
         unmount()
     })
 

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutConfigControls.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutConfigControls.tsx
@@ -33,6 +33,15 @@ interface ScoutConfigControlsProps {
     updating?: boolean
 }
 
+// The models the picker offers, a deliberate subset of the Tasks catalog the backend
+// validates pins against — growing this list is a frontend-only change.
+const SCOUT_MODEL_OPTIONS: { value: string | null; label: string }[] = [
+    { value: null, label: 'Default' },
+    { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
+    { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
+    { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
+]
+
 interface ScoutConfigFormProps extends ScoutConfigControlsProps {
     onDelete?: (configId: string) => void
     /** True while this scout's delete request is in flight — disables the delete button. */
@@ -192,23 +201,26 @@ export function ScoutConfigForm({
                     <div className="flex flex-col min-w-0">
                         <span className="text-xs text-default">Model</span>
                         <span className="text-[11.5px] text-muted">
-                            The model this scout runs on. Pick a more capable model for harder tasks. Leave empty to use
-                            the default.
+                            The model this scout runs on. Pick a more capable model for harder tasks.
                         </span>
                     </div>
-                    <LemonInput
-                        key={config.model ?? 'unset'}
+                    <LemonSelect
                         size="small"
-                        placeholder="Default"
-                        defaultValue={config.model ?? ''}
+                        value={config.model ?? null}
+                        // A pin stored via the API can name a catalog model the picker doesn't offer;
+                        // keep it selected (hidden from the menu) so opening the picker doesn't lose it.
+                        options={
+                            config.model && !SCOUT_MODEL_OPTIONS.some((option) => option.value === config.model)
+                                ? [...SCOUT_MODEL_OPTIONS, { value: config.model, label: config.model, hidden: true }]
+                                : SCOUT_MODEL_OPTIONS
+                        }
                         // Editable while the scout is disabled for the same reason as network access:
                         // a newly enabled scout is immediately due, so the model must be settable first.
                         disabledReason={updating ? 'Saving scout settings' : undefined}
                         className="w-44"
-                        onBlur={(event) => {
-                            const value = event.currentTarget.value.trim()
-                            if (value !== (config.model ?? '')) {
-                                onUpdate(config.id, { model: value || null })
+                        onChange={(value) => {
+                            if (value !== (config.model ?? null)) {
+                                onUpdate(config.id, { model: value })
                             }
                         }}
                         aria-label={`${config.skill_name} model`}


### PR DESCRIPTION
## Problem

Pinning a scout to a model (the flag-gated Model setting in the inbox scout settings) requires typing a raw model id from memory into a free-text field. There is no way to see which models are available, and a typo only surfaces when the backend rejects the save.

## Changes

- The Model setting is now a dropdown offering Default, GPT-5.6 Luna, GPT-5.6 Terra, and GPT-5.6 Sol.
- Picking Default clears the pin (patches `model: null`), the same wire value as leaving the old input empty.
- A pin stored through the API outside that list stays selected as a hidden option, so opening the picker cannot silently drop it.
- The three models are a deliberate subset of the Tasks catalog the backend already validates pins against, so growing the list later is a frontend-only change.
- Mechanical: the ScoutConfigForm stories turn on the `scouts-model-config` flag, so the row now renders in visual regression.

The dropdown was rendered and verified in Storybook (open menu shows Default plus the three models). This sandbox cannot run `hogli pr:upload-image`, so no screenshot is embedded; the rendered images were handed to the session owner.

## How did you test this code?

- Added one jest case to `ScoutConfigControls.test.tsx`: picking a model patches the raw model id, and picking Default patches `model: null`. These are the wire values the backend distinguishes, and no existing test rendered the flag-gated model row.
- Ran the changed test file locally; all 7 cases pass.
- Rendered the Live story in Storybook with a headless browser and opened the dropdown.
- Not run: the full jest suite and backend suites (CI covers them). The whole-app `tsgo` check reported no errors in signals files; the only errors in this sandbox were pre-existing `@posthog/hogvm` module-resolution failures in 4 unrelated files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the Model setting is behind the `scouts-model-config` dogfood flag and has no doc page.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-ui-components, /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions. The options are hardcoded in the frontend rather than fetched from the Tasks model catalogue, per the request to allow just three models for now; the backend pin validation (`scout_model_pin_catalog`) is unchanged and already accepts all three ids.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y49pfak48pE1nvEtRm2y1)_