### PR TITLE
feat(warehouse-sources): promote Bing Webmaster Tools source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_webmaster_tools/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_webmaster_tools/source.py
@@ -124,7 +124,7 @@ class BingWebmasterToolsSource(SimpleSource[BingWebmasterToolsSourceConfig]):
 
 Generate an API key in [Bing Webmaster Tools](https://www.bing.com/webmasters) under **Settings > API access > API key**. The key is issued per user and covers every verified site on the account.
 """,
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             iconPath="/static/services/bing_webmaster_tools.png",
             docsUrl="https://posthog.com/docs/cdp/sources/bing-webmaster-tools",
             fields=cast(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_webmaster_tools/tests/test_bing_webmaster_tools_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_webmaster_tools/tests/test_bing_webmaster_tools_source.py
@@ -48,7 +48,7 @@ class TestBingWebmasterToolsSource:
 
         assert config.name.value == "BingWebmasterTools"
         assert config.label == "Bing Webmaster Tools"
-        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.releaseStatus == ReleaseStatus.BETA
         # `unreleasedSource` hides the connector from users entirely; a finished source must not
         # carry it.
         assert not config.unreleasedSource


### PR DESCRIPTION
## Problem

People connecting a data warehouse source saw Bing Webmaster Tools labelled alpha, which reads as new and lightly tested. On live usage it now clears the beta bar (7-day window): the source is connected by 33 teams (threshold 30), and its import error rate is 0.0% (threshold under 5%).

## Changes

- The Bing Webmaster Tools source now shows a beta label instead of alpha in the source catalog.
- `releaseStatus` on the source config goes from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA`. The label is a soft signal on an already-visible source; it does not gate access.
- The source test now asserts `ReleaseStatus.BETA` (mechanical).

No connector behavior, schemas, or sync logic changed.

## How did you test this code?

Ran the source config test, which asserts the release status:

- `test_bing_webmaster_tools_source.py::TestBingWebmasterToolsSource::test_get_source_config` — passes.

Not run: the wider warehouse-sources suites, left to CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Status-only promotion prepared with Claude Code. Invoked `/implementing-warehouse-sources` to confirm where release status lives and the `ReleaseStatus` enum convention, and `/writing-pr-descriptions` for this body. Checked open PRs for a duplicate promotion (source name, `releaseStatus`, `promote`, `beta`, and the maintainer's own open PRs) and found none. The metrics above were supplied as the task context; the committed change carries no session-derived material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
