### PR TITLE
fix(signals): read inbox impressions from raw properties in the ranking dag

### DIFF
--- a/products/signals/dags/inbox_ranking/dataset/queries.py
+++ b/products/signals/dags/inbox_ranking/dataset/queries.py
@@ -107,6 +107,11 @@ def valid_report_uuids(report_ids: set[str | None]) -> set[str]:
 # training row nor stamp a feedback label onto a real report.
 FEEDBACK_SENTIMENTS_SQL = "toString(properties.sentiment) IN ('positive', 'negative')"
 
+# `impressions` is read from the raw properties JSON rather than as `properties.impressions`. HogQL
+# casts a property with its project-wide property definition type, and other events in the dogfood
+# project send `impressions` as a number, which types the definition as Numeric and turns the array
+# into a Float64 cast that JSONExtractArrayRaw rejects. The raw read does not depend on that type.
+#
 # The feedback filter rides as a second predicate rather than its own UNION branch so the whole
 # select keeps one sort-key-aligned `event IN (...)` scan.
 LABELED_REPORT_IDS_SQL = f"""
@@ -114,7 +119,7 @@ SELECT DISTINCT report_id
 FROM (
     SELECT JSONExtractString(imp, 'report_id') AS report_id
     FROM events
-    ARRAY JOIN JSONExtractArrayRaw(coalesce(properties.impressions, '[]')) AS imp
+    ARRAY JOIN JSONExtractArrayRaw(properties, 'impressions') AS imp
     WHERE event = 'Inbox reports impressed'
       AND timestamp >= toDateTime({{labels_epoch}}) AND timestamp < toDateTime({{snapshot_end}})
     UNION ALL
@@ -263,7 +268,7 @@ SELECT
     min({_IMPRESSION_RANK}) AS best_impression_rank,
     argMax(JSONExtract(imp, 'source_products', 'Array(String)'), timestamp) AS source_products
 FROM events
-ARRAY JOIN JSONExtractArrayRaw(coalesce(properties.impressions, '[]')) AS imp
+ARRAY JOIN JSONExtractArrayRaw(properties, 'impressions') AS imp
 WHERE event = 'Inbox reports impressed'
   AND timestamp >= toDateTime({{labels_epoch}}) AND timestamp < toDateTime({{snapshot_end}})
 GROUP BY report_id

--- a/products/signals/dags/inbox_ranking/tests/test_dataset.py
+++ b/products/signals/dags/inbox_ranking/tests/test_dataset.py
@@ -7,6 +7,7 @@ from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event
 import pyarrow as pa
 from parameterized import parameterized
 
+from products.event_definitions.backend.models.property_definition import PropertyDefinition
 from products.signals.backend.models import SignalReport
 from products.signals.dags.inbox_ranking import common
 from products.signals.dags.inbox_ranking.dataset.dag import (
@@ -16,8 +17,10 @@ from products.signals.dags.inbox_ranking.dataset.dag import (
     spine_report_filter,
 )
 from products.signals.dags.inbox_ranking.dataset.queries import (
+    IMPRESSIONS_SQL,
     LABEL_DEFAULTS,
     LABEL_STREAMS,
+    LABELED_REPORT_IDS_SQL,
     STATUS_COLUMNS,
     STATUS_SQL,
     hogql_rows,
@@ -349,6 +352,27 @@ class TestSpineInclusion(BaseTest):
         assert in_spine == {promoted, born_visible}
         assert promoted_after_cutoff not in in_spine
         assert created_after_cutoff not in in_spine
+
+
+class TestImpressionsStream(ClickhouseTestMixin, BaseTest):
+    @parameterized.expand([("labeled_ids", LABELED_REPORT_IDS_SQL), ("impressions", IMPRESSIONS_SQL)])
+    def test_impressions_survive_a_numeric_property_definition(self, _name, sql):
+        # Another event in the same project sending `impressions` as a number types the project-wide
+        # definition as Numeric, which made HogQL cast the impressions array to Float64 and fail
+        # the query with a ClickHouse type error.
+        PropertyDefinition.objects.create(
+            team=self.team, name="impressions", property_type="Numeric", type=PropertyDefinition.Type.EVENT
+        )
+        _create_event(
+            team=self.team,
+            event="Inbox reports impressed",
+            distinct_id="user-1",
+            timestamp=T1,
+            properties={"impressions": [{"report_id": UUID_A, "rank": 1, "source_products": ["error_tracking"]}]},
+        )
+
+        rows = hogql_rows(sql, team=self.team, query_type="test", snapshot_end=SNAPSHOT_END)
+        assert [row[0] for row in rows] == [UUID_A]
 
 
 class TestStatusStream(ClickhouseTestMixin, BaseTest):


### PR DESCRIPTION
## Problem

The inbox ranking dataset job has failed every day since 2026-08-27, so the training job finds no snapshot and no ranking model candidate has been produced.

- The `inbox_report_state` and `inbox_report_labels` assets read `properties.impressions` as a JSON array.
- HogQL casts a property with the type of its project-wide property definition.
- Since 2026-08-26 the `signal_emission_started` and `signal_emitted` events in the dogfood project carry `impressions` as a number (the Google Search Console opportunities source flattens it from `extra`).
- That typed the `impressions` definition as Numeric, so `coalesce(properties.impressions, '[]')` became a `Variant(Float64, String)` that `JSONExtractArrayRaw` rejects.
- Failing runs: [dataset dt=2026-08-27](https://posthog.dagster.cloud/prod-us/runs/f41079a7-d610-4ff7-8e19-873539cb2284), [dataset dt=2026-08-28](https://posthog.dagster.cloud/prod-us/runs/92b3c427-e2c6-488f-8d42-1af1d35f67bc), [training dt=2026-08-28](https://posthog.dagster.cloud/prod-us/runs/a1149749-ee0a-46be-857e-ae1aed256e0a).

## Changes

- The two impression `ARRAY JOIN`s in `dataset/queries.py` now read `JSONExtractArrayRaw(properties, 'impressions')` from the raw properties JSON, so the property definition type no longer affects the query.
- The output of both queries is unchanged. Nothing user-visible changes.
- Renaming the numeric `impressions` key on the emitter side was rejected as the only fix: the dag would still break the next time any event reuses the name.

> [!NOTE]
> The 2026-08-26 to 2026-08-28 dataset partitions stay missing. The next training tick only requires its own day, so the first candidate lands at the first 06:00 UTC tick after the 02:30 UTC dataset run succeeds.

## How did you test this code?

- Added `TestImpressionsStream` in `tests/test_dataset.py`, parameterized over both SQL strings: a Numeric `impressions` property definition plus one impression event must still yield the report id. On the old query it reproduces the production ClickHouse error verbatim.
- Verified the raw-properties form against the dogfood project by hand: it returns the same impression units and reports as before for the last day.
- Not run: the dag against S3.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5), [session](https://claude.ai/code/session_01Rj263A33ge7A6jXdJ7CknT). Diagnosed via the Dagster Cloud MCP (run logs) and the PostHog MCP (`execute-sql` on the dogfood project to find the event sending `impressions` as a number). Skills invoked: `/phs inbox-ranking`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. Ran `hogli ci:preflight --fix` and repo-wide mypy before pushing.
