### PR TITLE
chore(ci): run fork frontend typechecking on Depot

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,7 +6,6 @@ self-hosted-runner:
         - depot-ubuntu-24.04-4
         - depot-ubuntu-24.04-8
         - depot-macos-15
-        - ubuntu-24.04-8core
 
 # The vendored .github/actions/paths-filter emits one output per filter name at
 # runtime, but action.yml can only declare the static `changes` output, so

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -638,15 +638,15 @@ jobs:
         # runner (ubuntu-latest and depot-ubuntu-24.04-4 alike). Peak tracks the type graph,
         # not parallelism or lib checking: skipLibCheck is already on, GOMAXPROCS and
         # declaration:false change nothing, and dropping all of products/ from include removes
-        # only 891 of 13703 files because imports pull them back in. Both runners below give
-        # the job 32 GB. Talk to #team-devex before changing.
+        # only 891 of 13703 files because imports pull them back in. 32 GB is the next rung
+        # on Depot's ladder. Talk to #team-devex before changing.
         #
-        # Forks get a GitHub-hosted larger runner instead of Depot: this job runs
-        # `pnpm install`, so a fork PR controls lifecycle scripts, and Depot runners inject
-        # shared cache credentials ambiently (see _rust-build-images.yml, which skips sccache
-        # creds for the same reason). GitHub warns against exposing a larger runner with a
-        # static IP range to fork pull requests, so keep this runner's group off static IPs.
-        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-8' || 'ubuntu-24.04-8core' }}
+        # Fork PRs use this runner too. GitHub-hosted runners for public repos top out at
+        # 16 GB, and a larger-runner label that no org admin has provisioned queues forever.
+        # Forks already run `pnpm install` on Depot in ci-storybook.yml and ci-backend.yml,
+        # and Depot Cache is repository-scoped with no branch isolation on every label, so
+        # this job exposes nothing those jobs do not.
+        runs-on: depot-ubuntu-24.04-8
         # Kea typegen invalidates on changes to any logic plus everything that depends on it.
         # For changes to shared core (TaxonomicFilter, Insight, etc.) the dependent set is
         # large, so the budget must fit a cache miss on top of the baseline build.


### PR DESCRIPTION
## Problem

Fork PRs that touch frontend code never get a green check. `Frontend typechecking` waits forever for a runner labelled `ubuntu-24.04-8core`, which nobody ever created. #87792 pointed forks at that label on Aug 25 and every fork run since is stuck ([example](https://github.com/PostHog/posthog/actions/runs/33211906362/job/98987555374)).

## Changes

- Forks now typecheck on `depot-ubuntu-24.04-8`, the same 32 GB runner internal PRs use.
- #87792 kept forks off Depot because the job runs `pnpm install`. Forks already do that on Depot in Storybook and Backend CI, so nothing new is exposed.
- Going back to `ubuntu-latest` is not an option: 16 GB OOM-kills tsgo.
- Drops the unused label from the actionlint allowlist.

## How did you test this code?

`hogli lint:workflows` and `actionlint` pass. The job itself can only be verified after merge, since PR runs use the workflow from master.