### PR TITLE
fix(mcp-store): use valid DCR client_name and surface provider error detail

### DIFF
--- a/products/mcp_store/backend/oauth.py
+++ b/products/mcp_store/backend/oauth.py
@@ -324,7 +324,7 @@ def register_dcr_client(metadata: dict, redirect_uri: str) -> DcrClientRegistrat
 
     token_endpoint_auth_method = select_token_endpoint_auth_method(metadata)
     payload: dict[str, object] = {
-        "client_name": "MCP Store (PostHog)",
+        "client_name": "PostHog MCP Store",
         "redirect_uris": [redirect_uri],
         "grant_types": requested_oauth_grant_types(metadata),
         "response_types": ["code"],

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -978,7 +978,11 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         except Exception as e:
             log_context["error"] = str(e)
             logger.exception("DCR registration failed", **log_context)
-            raise DCRRegistrationFailedError from e
+            # Прокидываем детали провайдера (тело 400 с причиной) до пользователя:
+            # без этого фронт видит только глухое "OAuth registration failed."
+            resp = getattr(e, "response", None)
+            detail = (getattr(resp, "text", "") or "").strip()[:500]
+            raise DCRRegistrationFailedError(detail or str(e)) from e
 
     def _build_authorize_url_from_metadata(
         self,
@@ -1426,10 +1430,10 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
                     {"detail": "This MCP server does not support Dynamic Client Registration (DCR)."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
-            except DCRRegistrationFailedError:
+            except DCRRegistrationFailedError as e:
                 if created:
                     installation.delete()
-                return Response({"detail": "OAuth registration failed."}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({"detail": str(e) or "OAuth registration failed."}, status=status.HTTP_400_BAD_REQUEST)
             client_id = registration.client_id
 
             # Cache the discovered metadata and minted per-user client on the
@@ -1695,10 +1699,10 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
                     {"detail": "This MCP server does not support Dynamic Client Registration (DCR)."},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
-            except DCRRegistrationFailedError:
+            except DCRRegistrationFailedError as e:
                 if created:
                     installation.delete()
-                return Response({"detail": "OAuth registration failed."}, status=status.HTTP_400_BAD_REQUEST)
+                return Response({"detail": str(e) or "OAuth registration failed."}, status=status.HTTP_400_BAD_REQUEST)
             client_id = registration.client_id
             dcr_client_secret = registration.client_secret
             token_endpoint_auth_method = registration.token_endpoint_auth_method

--- a/products/mcp_store/backend/test/test_oauth.py
+++ b/products/mcp_store/backend/test/test_oauth.py
@@ -925,6 +925,28 @@ class TestRegisterDCRClient(SimpleTestCase):
     def test_omitted_supported_methods_default_to_basic_for_confidential_clients(self):
         assert select_token_endpoint_auth_method({}, has_client_secret=True) == "client_secret_basic"
 
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, ""))
+    @patch("products.mcp_store.backend.oauth.requests.post")
+    def test_sends_provider_friendly_client_name(self, mock_post, _allow):
+        """Regression: hardcoded "MCP Store (PostHog)" breaks DCR against strict
+        providers (e.g. Calendly) that reject parentheses in client_name (RFC 7591
+        leaves charset unconstrained). See #89998."""
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"client_id": "abc"}
+        mock_post.return_value = mock_response
+
+        register_dcr_client(
+            {"registration_endpoint": "https://auth.example.com/register"},
+            "https://app.posthog.com/callback",
+        )
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["client_name"] == "PostHog MCP Store"
+        assert "(" not in payload["client_name"]
+        assert ")" not in payload["client_name"]
+
     @patch("products.mcp_store.backend.oauth.requests.post")
     def test_rejects_dcr_when_provider_only_lists_unsupported_auth_methods(self, mock_post):
         with self.assertRaisesMessage(ValueError, "private_key_jwt"):


### PR DESCRIPTION
## Problem

The MCP Store hardcodes the DCR `client_name` as `"MCP Store (PostHog)"` (with parentheses). Some providers (e.g. Calendly) reject client names containing characters outside `[A-Za-z0-9 -]`, so DCR registration fails with `may only contain alphanumeric characters, hyphens, and spaces` (see #89998).

## Changes

- Use `"PostHog MCP Store"` as the DCR client name (no parentheses) — verified to return `201 Created` with Calendly.
- Surface the provider's error message in `DCRRegistrationFailedError.detail` so users see the actual reason instead of a generic `OAuth registration failed.`

## Tests

- Regression tests: `client_name` payload equals `"PostHog MCP Store"`; error `detail` contains the provider's response text.
