### PR TITLE
fix(hubspot): classify persistent 401-after-token-refresh as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
@@ -132,11 +132,13 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             **missing_scope_errors,
             "missing or invalid refresh token": "Your HubSpot connection is invalid or expired. Please reconnect it.",
             "missing or unknown hub id": None,
-            # HubSpot's CRM API returns 401/403 when the OAuth grant can't read the requested object
-            # (token revoked, or the connected app is missing a scope like `crm.objects.companies.read`).
-            # `fetch_data` already refreshes the access token once on a 401; if the retried request is
-            # still rejected, the credentials genuinely lack access and retrying can't recover. Match the
-            # stable host, not the per-object URL path (companies/deals/contacts/...), which varies.
+            # Raised by helpers._get after tenacity exhausts all 5 retry attempts where every attempt
+            # got a 401: the code refreshes the access token each time but HubSpot keeps rejecting it.
+            # A persistent 401 after token refresh means the OAuth grant is fundamentally broken
+            # (revoked, app deleted, permissions withdrawn) — Temporal retrying the activity can't help.
+            "Hubspot API 401 - refreshed token, retrying:": "Your HubSpot credentials are no longer authorized. Please reconnect your HubSpot account and ensure it has the required permissions, then try again.",
+            # HubSpot's CRM API may also surface 401 through raise_for_status() in other fetch paths.
+            # Match the stable host prefix, not the per-object URL path, which varies by endpoint.
             "401 Client Error: Unauthorized for url: https://api.hubapi.com": "Your HubSpot credentials are no longer authorized. Please reconnect your HubSpot account and ensure it has the required permissions, then try again.",
             "403 Client Error: Forbidden for url: https://api.hubapi.com": "Your HubSpot credentials do not have permission to access this data. Please reconnect your HubSpot account and ensure it has the required permissions, then try again.",
             # Raised by source_for_pipeline when the source config carries no refresh token at all

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -396,7 +396,11 @@ class TestApiVersion:
 @pytest.mark.parametrize(
     "error_msg",
     [
-        # Raised by fetch_data when a token refresh succeeds but the retried request is still rejected
+        # helpers._get exhausted all 5 tenacity retries on a 401 — token refresh succeeded each
+        # time but HubSpot kept rejecting the request, indicating broken OAuth credentials.
+        "Hubspot API 401 - refreshed token, retrying: url=https://api.hubapi.com/crm/v3/properties/tickets",
+        "Hubspot API 401 - refreshed token, retrying: url=https://api.hubapi.com/crm/v3/properties/contacts",
+        # raise_for_status() 401/403 from other fetch paths
         "401 Client Error: Unauthorized for url: https://api.hubapi.com/crm/v3/properties/companies",
         "401 Client Error: Unauthorized for url: https://api.hubapi.com/crm/v3/properties/deals",
         "403 Client Error: Forbidden for url: https://api.hubapi.com/crm/v3/objects/contacts",


### PR DESCRIPTION
## Problem

A HubSpot sync whose OAuth credentials have been revoked or expired keeps triggering Temporal activity retries instead of stopping with an actionable message. The sync surfaces in error tracking as an unhandled \`HubspotRetryableError\` rather than resolving to a clear "reconnect your account" failure.

\`helpers._get\` raises \`HubspotRetryableError("Hubspot API 401 - refreshed token, retrying: url=...")\` after each 401 response — it refreshes the access token and signals tenacity to retry. After 5 retries all returning 401, tenacity re-raises that exception. The existing non-retryable pattern \`"401 Client Error: Unauthorized"\` matches the format from \`requests.raise_for_status()\`, but the \`if r.status_code == 401:\` branch fires before \`raise_for_status()\` runs, so that path is never reached for a 401. No existing pattern matches the actual re-raised message.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/01a05016-5d19-7a01-b5f2-d6d2690c920b

## Changes

- Customers whose HubSpot OAuth grant was revoked or expired now see "Your HubSpot credentials are no longer authorized. Please reconnect." rather than their sync failing with an unhandled error.
- \`get_non_retryable_errors()\` maps the stable prefix \`"Hubspot API 401 - refreshed token, retrying:"\` to the reconnect message. Mechanical.
- Updated the comment on the existing \`"401 Client Error: Unauthorized"\` entry to clarify which code path actually produces it. Mechanical.

## How did you test this code?

Two new parametrized cases added to \`test_unauthorized_error_is_non_retryable\` — the exact message observed in the live error event, and a second endpoint variant. These catch a regression where the pattern is removed or the prefix is changed without a matching test update.

All 146 tests in \`test_source_routing.py\` pass. Database-backed and ClickHouse-backed suites were not run (not required for this change).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs cover internal error classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Generated by PostHog Desktop. Skills invoked: \`/writing-pr-descriptions\`, \`/writing-tests\`. Investigation confirmed the error originates in \`helpers.py:182\` inside \`_get()\` (within \`fetch_data()\`), which raises \`HubspotRetryableError\` with a distinct message format. The fix adds the actual surfaced pattern. No duplicate PRs were found addressing this error in the hubspot source.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*