### PR TITLE
fix(gitlab): guide users when the project path has a stray slash

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py
@@ -190,11 +190,13 @@ def validate_credentials(
     if not project or not project.strip():
         return False, "Missing project id or path"
 
-    # GitLab addresses a project by its numeric id or a group/project path. A pasted URL or a bare
-    # group name otherwise URL-encodes into a nonsense path, 404s, and gets reported as "not found
-    # or not accessible with this token" — which points the user at the token rather than the format.
+    # GitLab addresses a project by its numeric id or a group/project path. A pasted URL, a bare
+    # group name, or a stray leading, trailing, or doubled slash otherwise URL-encodes into a
+    # nonsense path, 404s, and gets reported as "not found or not accessible with this token", which
+    # points the user at the token rather than the format.
     project_ref = project.strip()
-    if "://" in project_ref or ("/" not in project_ref and not project_ref.isdigit()):
+    segments = project_ref.split("/")
+    if not project_ref.isdigit() and ("://" in project_ref or len(segments) < 2 or not all(segments)):
         return (
             False,
             "Enter the project as group/project (for example, mygroup/myproject) or its numeric project ID, not a full URL.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab.py
@@ -286,6 +286,9 @@ class TestValidateCredentials:
             "https://gitlab.com/mygroup/",  # pasted URL
             "mygroup",  # bare group, no project and not a numeric id
             "some-dashboard",  # bare name
+            "/myproject",  # leading slash: encodes to an empty group segment
+            "mygroup/",  # trailing slash: encodes to an empty project segment
+            "mygroup//myproject",  # doubled slash: encodes to an empty middle segment
         ],
     )
     def test_malformed_project_gets_format_guidance(self, project):


### PR DESCRIPTION
## Problem

A user setting up a GitLab source who enters the project with a stray slash (a leading `/myproject`, a trailing `mygroup/`, or a doubled `mygroup//myproject`) is told the project is "not found or not accessible with this token". That blames their token, but the real problem is the project format, so they retry with a new token and fail again.

The pre-request format guard already catches pasted URLs and bare group names, but a value with a slash slipped through, URL-encoded into a nonsense path, and 404'd into that misleading message.

## Changes

- A GitLab project entered with a stray slash now returns the existing format guidance ("Enter the project as group/project ... or its numeric project ID") instead of the token error.
- The guard now requires a numeric id or a group/project path whose segments are all non-empty, which covers the leading, trailing, and doubled-slash cases the old check missed.
- A numeric project id and a normal group/project path still reach the API unchanged.

## How did you test this code?

Added three cases (leading, trailing, doubled slash) to the existing `test_malformed_project_gets_format_guidance` parametrization. They catch the regression where a slash-bearing but malformed project path reaches the API and surfaces the token error; no existing case exercised a value that contains a slash yet is still malformed.

Ran the GitLab suite's format cases locally: 7 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of data-warehouse source-creation failures surfaced this misclassified error. Authored by an agent (Claude) via the PostHog Desktop task runner. Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.

The fix reuses the existing format-guidance string rather than adding a new message, so the same problem reads the same way across the malformed-input cases.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
