### PR TITLE
fix(postgres): guide users who paste host:port into the host field

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -73,6 +73,11 @@ _HOST_IS_URL_ERROR = (
     "password, port, or path."
 )
 
+_HOST_HAS_PORT_ERROR = (
+    "Enter just the hostname in the host field (for example, db.example.com). Put the port number "
+    "in the port field instead."
+)
+
 # ENETUNREACH / EHOSTUNREACH at connect time: the host resolved to a public address PostHog can't
 # route to. The common cause is a host that only accepts IPv6 (PostHog egresses over IPv4) — for
 # example a Supabase direct-connection host — or a firewall dropping PostHog's IPs. Deterministic
@@ -1210,6 +1215,13 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         # credentials). Catch it early with an actionable message that never reflects the input.
         if "://" in config.host:
             return False, _HOST_IS_URL_ERROR
+
+        # A bare "host:port" pasted into the host field (no scheme, so the URL guard above misses it)
+        # otherwise fails DNS with a confusing "check the spelling" message that echoes the value
+        # back. A bare IPv6 literal has several colons, so guard only the single-colon host:port shape.
+        host_value = config.host.strip()
+        if host_value.count(":") == 1 and not host_value.startswith("["):
+            return False, _HOST_HAS_PORT_ERROR
 
         valid_host, host_errors = self.is_database_host_valid(
             config.host, team_id, using_ssh_tunnel=self.ssh_tunnel_enabled(config)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -3844,6 +3844,35 @@ class TestValidateCredentialsErrorMapping:
         assert host not in (error or "")
         assert "hostname" in (error or "")
 
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "db.example.com:5432",  # host:port pasted into the host field
+            "db.example.com:",  # trailing colon with an empty port
+        ],
+    )
+    def test_port_in_host_field_rejected_before_dns(self, source, host):
+        config = source.parse_config(
+            {
+                "host": host,
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "public",
+            }
+        )
+        with (
+            mock.patch.object(source, "ssh_tunnel_is_valid", return_value=(True, None)),
+            mock.patch.object(source, "is_database_host_valid", side_effect=AssertionError("should not resolve")),
+            mock.patch.object(source, "get_schemas", side_effect=AssertionError("should not connect")),
+        ):
+            valid, error = source.validate_credentials(config, team_id=1)
+
+        assert valid is False
+        assert host not in (error or "")
+        assert "port field" in (error or "")
+
 
 class TestPostgresSchemaDiscovery:
     def _mock_connection(self, *fetchall_results: list[tuple[object, ...]]):


### PR DESCRIPTION
## Problem

A user setting up a Postgres (or Supabase) source who types the host and port together in the host field (`db.example.com:5432`, or a stray trailing colon) gets told to check that the host is "spelled correctly and reachable", with the value echoed back. The host looks correct to them, so the message gives no way forward. The port belongs in the separate port field.

The existing guard only catches a full URL or connection string (it keys on `://`), so a bare `host:port` slips through to DNS resolution and fails there.

## Changes

- A `host:port` value in the host field now returns "Enter just the hostname in the host field ... Put the port number in the port field instead" before any DNS lookup.
- The guard triggers on the single-colon `host:port` shape and skips the echo-the-value DNS error.
- A bare IPv6 literal (several colons) is left untouched, so it still resolves as before.

## How did you test this code?

Added a parametrized case (`host:port` and a trailing-colon variant) next to the existing URL-guard test. It catches the regression where a port in the host field reaches DNS and surfaces the spelling error; the existing case only covered a scheme-prefixed URL. The test also asserts the input is never echoed back.

Ran the Postgres host-guard cases locally: 4 passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of data-warehouse source-creation failures surfaced this class of error. Authored by an agent (Claude) via the PostHog Desktop task runner. Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.

The guard sits next to the existing URL guard and reuses its wording style, so host-format problems read consistently. It matches only a single colon to avoid rejecting bare IPv6 literals.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
