### PR TITLE
feat(csp): label self-hosted CSP reports instead of dropping them

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1310,6 +1310,13 @@
             ],
             "label": "Script sample"
         },
+        "$csp_self_hosted": {
+            "description": "Set when the report came from a self-hosted PostHog install that reports to PostHog Cloud. Only ever set on PostHog's own project.",
+            "examples": [
+                true
+            ],
+            "label": "Self-hosted install"
+        },
         "$csp_source_file": {
             "description": "The source file where the violation occurred.",
             "examples": [
@@ -2332,6 +2339,17 @@
         "$mcp_response": {
             "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
             "label": "MCP response"
+        },
+        "$mcp_scope_preset": {
+            "description": "Which kind of caller minted the token behind an MCP request, worked out from its scope set. 'scout' is a Signals scout run, 'research' is a read-only report-research run, 'implementation' is a write-capable implementation run, 'sandbox' is any other server-minted run (a task started from the desktop app or the pipeline before the scratchpad scopes tell research and implementation apart), and 'user' is a person's own token. Stamped on every event by PostHog's own MCP server. Use it to split scratchpad and notes usage by caller, for example to measure scout scratchpad adoption apart from ordinary users.",
+            "examples": [
+                "scout",
+                "research",
+                "implementation",
+                "sandbox",
+                "user"
+            ],
+            "label": "MCP scope preset"
         },
         "$mcp_server_name": {
             "description": "The advertised name of the MCP server that handled the request.",
@@ -4554,6 +4572,17 @@
             "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
             "label": "MCP response"
         },
+        "$mcp_scope_preset": {
+            "description": "Which kind of caller minted the token behind an MCP request, worked out from its scope set. 'scout' is a Signals scout run, 'research' is a read-only report-research run, 'implementation' is a write-capable implementation run, 'sandbox' is any other server-minted run (a task started from the desktop app or the pipeline before the scratchpad scopes tell research and implementation apart), and 'user' is a person's own token. Stamped on every event by PostHog's own MCP server. Use it to split scratchpad and notes usage by caller, for example to measure scout scratchpad adoption apart from ordinary users.",
+            "examples": [
+                "scout",
+                "research",
+                "implementation",
+                "sandbox",
+                "user"
+            ],
+            "label": "MCP scope preset"
+        },
         "$mcp_server_name": {
             "description": "The advertised name of the MCP server that handled the request.",
             "examples": [
@@ -5900,6 +5929,13 @@
                 "eval('alert(1)')"
             ],
             "label": "Script sample"
+        },
+        "$csp_self_hosted": {
+            "description": "Set when the report came from a self-hosted PostHog install that reports to PostHog Cloud. Only ever set on PostHog's own project.",
+            "examples": [
+                true
+            ],
+            "label": "Self-hosted install"
         },
         "$csp_source_file": {
             "description": "The source file where the violation occurred.",
@@ -7340,6 +7376,17 @@
         "$mcp_response": {
             "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
             "label": "MCP response"
+        },
+        "$mcp_scope_preset": {
+            "description": "Which kind of caller minted the token behind an MCP request, worked out from its scope set. 'scout' is a Signals scout run, 'research' is a read-only report-research run, 'implementation' is a write-capable implementation run, 'sandbox' is any other server-minted run (a task started from the desktop app or the pipeline before the scratchpad scopes tell research and implementation apart), and 'user' is a person's own token. Stamped on every event by PostHog's own MCP server. Use it to split scratchpad and notes usage by caller, for example to measure scout scratchpad adoption apart from ordinary users.",
+            "examples": [
+                "scout",
+                "research",
+                "implementation",
+                "sandbox",
+                "user"
+            ],
+            "label": "MCP scope preset"
         },
         "$mcp_server_name": {
             "description": "The advertised name of the MCP server that handled the request.",

--- a/frontend/src/taxonomy/taxonomy.tsx
+++ b/frontend/src/taxonomy/taxonomy.tsx
@@ -111,6 +111,7 @@ export const POSTHOG_EVENT_PROMOTED_PROPERTIES = {
         '$csp_raw_report',
         '$csp_script_sample',
         '$csp_user_agent',
+        '$csp_self_hosted',
     ],
     $set: ['$set', '$set_once'],
     $exception: ['$exception_functions', '$exception_sources', '$exception_types', '$exception_values'],

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -61,6 +61,11 @@ def _drop_self_hosted_reports(reports: list[dict[str, object]], token: Optional[
     own project token until the operator upgrades. Customers configure this endpoint with their
     own project token, so the token separates the two; the document URL alone cannot.
 
+    The token gate is what protects customers: a report on any other token returns below, from
+    any domain. The document URL then splits what is left, because Cloud's own app sends with
+    this token too — a PostHog or local host is Cloud reporting on itself and has to survive.
+    So that second check only ever keeps more than the token gate alone would.
+
     `CSP_DROP_SELF_HOSTED_REPORTS` gates the drop itself. While it is off the classifier still
     runs and records `would_drop`, so the counter shows what enabling it costs before it costs it.
 

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -55,23 +55,23 @@ CSP_REPORT_TYPES_MAPPING_TABLE = """
 
 
 def _drop_self_hosted_reports(reports: list[dict[str, object]], token: Optional[str]) -> list[dict[str, object]]:
-    """Ignore reports that a self-hosted PostHog install sent to Cloud.
+    """Ignore reports that a legacy self-hosted PostHog install sent to Cloud.
 
-    Self-hosted installs run the same `CSPMiddleware` as Cloud, so they report with PostHog's
-    own project token until the operator upgrades. Customers configure this endpoint with their
-    own project token, so the token separates the two; the document URL alone cannot.
+    Three sources reach this endpoint:
 
-    The token gate is what protects customers: a report on any other token returns below, from
-    any domain. The document URL then splits what is left, because Cloud's own app sends with
-    this token too — a PostHog or local host is Cloud reporting on itself and has to survive.
-    So that second check only ever keeps more than the token gate alone would.
+    - A customer's site, on their own team token. Kept, from any domain.
+    - Cloud's own app, on PostHog's token from a PostHog or local host. Kept.
+    - A self-hosted install, on PostHog's token because it runs PostHog's own `CSPMiddleware`,
+      from the operator's own host. Dropped.
 
-    `CSP_DROP_SELF_HOSTED_REPORTS` gates the drop itself. While it is off the classifier still
-    runs and records `would_drop`, so the counter shows what enabling it costs before it costs it.
+    Only the token tells the first case from the other two, so the token gate runs first and is
+    what protects customers. The document URL then splits Cloud's own app from self-hosted.
+
+    `CSP_DROP_SELF_HOSTED_REPORTS` gates the drop. While it is off the classifier still records
+    `would_drop`, so the counter shows what enabling it costs before it costs it.
 
     Call this after sampling, never before. Sampling discards most violations, so classifying
-    first would count reports that never become events and overstate the counter by the inverse
-    of the sample rate.
+    first would overstate the counter by the inverse of the sample rate.
     """
     if not is_cloud():
         return reports

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -12,7 +12,7 @@ import structlog
 from prometheus_client import Counter
 from rest_framework import status
 
-from posthog.cloud_utils import is_cloud
+from posthog.cloud_utils import is_cloud, is_hobby_url
 from posthog.exceptions import generate_exception_response
 from posthog.models.utils import uuid7
 from posthog.sampling import sample_on_property
@@ -45,38 +45,16 @@ CSP_REPORT_TYPES_MAPPING_TABLE = """
 | `$csp_report_type`         | top-level `type`                     | `"csp-violation"` constant         |
 """
 
-_POSTHOG_DOCUMENT_DOMAINS = ("posthog.com", "posthog.dev")
-
-
-def _is_non_posthog_document_url(document_url: object) -> bool:
-    if not isinstance(document_url, str):
-        return False
-
-    try:
-        hostname = urlsplit(document_url).hostname
-    except ValueError:
-        return False
-
-    if hostname is None:
-        return False
-
-    return not any(hostname == domain or hostname.endswith(f".{domain}") for domain in _POSTHOG_DOCUMENT_DOMAINS)
-
 
 def _filter_reports_by_origin(reports: list[dict[str, object]]) -> list[dict[str, object]]:
     if not is_cloud():
         return reports
 
-    accepted_reports = []
-    dropped_reports = 0
-    for report in reports:
-        if _is_non_posthog_document_url(report.get("document_url")):
-            dropped_reports += 1
-        else:
-            accepted_reports.append(report)
+    accepted_reports = [report for report in reports if not is_hobby_url(report.get("document_url"))]
+    dropped_reports = len(reports) - len(accepted_reports)
 
     if dropped_reports:
-        CSP_REPORT_REJECTED.labels(reason="non_posthog_origin").inc(dropped_reports)
+        CSP_REPORT_REJECTED.labels(reason="hobby_origin").inc(dropped_reports)
 
     return accepted_reports
 

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -12,9 +12,11 @@ import structlog
 from prometheus_client import Counter
 from rest_framework import status
 
+from posthog.api.utils import get_token
 from posthog.cloud_utils import is_cloud, is_hobby_url
 from posthog.exceptions import generate_exception_response
 from posthog.models.utils import uuid7
+from posthog.ph_client import PH_US_API_KEY
 from posthog.sampling import sample_on_property
 from posthog.utils_cors import cors_response
 
@@ -46,15 +48,21 @@ CSP_REPORT_TYPES_MAPPING_TABLE = """
 """
 
 
-def _filter_reports_by_origin(reports: list[dict[str, object]]) -> list[dict[str, object]]:
-    if not is_cloud():
+def _drop_self_hosted_reports(reports: list[dict[str, object]], token: Optional[str]) -> list[dict[str, object]]:
+    """Ignore reports that a self-hosted PostHog install sent to Cloud.
+
+    Self-hosted installs run the same `CSPMiddleware` as Cloud, so they report with PostHog's
+    own project token until the operator upgrades. Customers configure this endpoint with their
+    own project token, so the token separates the two; the document URL alone cannot.
+    """
+    if not is_cloud() or token != PH_US_API_KEY:
         return reports
 
     accepted_reports = [report for report in reports if not is_hobby_url(report.get("document_url"))]
     dropped_reports = len(reports) - len(accepted_reports)
 
     if dropped_reports:
-        CSP_REPORT_REJECTED.labels(reason="hobby_origin").inc(dropped_reports)
+        CSP_REPORT_REJECTED.labels(reason="self_hosted_origin").inc(dropped_reports)
 
     return accepted_reports
 
@@ -285,6 +293,7 @@ def process_csp_report(request):
                 CSP_REPORT_REJECTED.labels(reason="too_many_reports").inc()
                 raise CSPReportTooLarge(f"CSP report bundle of {report_count} reports exceeds the limit")
 
+        token = get_token(csp_data, request)
         distinct_id = request.GET.get("distinct_id") or str(uuid7())
         session_id = request.GET.get("session_id") or str(uuid7())
         version = request.GET.get("v") or "unknown"
@@ -304,7 +313,7 @@ def process_csp_report(request):
             else:
                 raise ValueError("Invalid CSP report")
 
-            accepted_reports = _filter_reports_by_origin([properties])
+            accepted_reports = _drop_self_hosted_reports([properties], token)
             if not accepted_reports:
                 return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
             properties = accepted_reports[0]
@@ -336,11 +345,11 @@ def process_csp_report(request):
             else:
                 raise ValueError("Invalid CSP report")
 
-            violations_props = _filter_reports_by_origin(
-                [parse_report_to(item) for item in items if is_csp_violation(item)]
+            violations_props = _drop_self_hosted_reports(
+                [parse_report_to(item) for item in items if is_csp_violation(item)], token
             )
-            crash_props = _filter_reports_by_origin(
-                [parse_crash_report(item) for item in items if is_crash_report(item)]
+            crash_props = _drop_self_hosted_reports(
+                [parse_crash_report(item) for item in items if is_crash_report(item)], token
             )
 
             if not violations_props and not crash_props:

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -28,6 +28,12 @@ CSP_REPORT_REJECTED = Counter(
     labelnames=["reason"],
 )
 
+CSP_SELF_HOSTED_FILTER = Counter(
+    "csp_report_self_hosted_filter",
+    "CSP reports seen by the self-hosted origin filter on Cloud, by decision.",
+    labelnames=["decision"],
+)
+
 CSP_REPORT_TYPES_MAPPING_TABLE = """
 | Normalized Key             | report-to format                     | report-uri format                  |
 | -------------------------- | ------------------------------------ | ---------------------------------- |
@@ -54,17 +60,26 @@ def _drop_self_hosted_reports(reports: list[dict[str, object]], token: Optional[
     Self-hosted installs run the same `CSPMiddleware` as Cloud, so they report with PostHog's
     own project token until the operator upgrades. Customers configure this endpoint with their
     own project token, so the token separates the two; the document URL alone cannot.
+
+    `CSP_DROP_SELF_HOSTED_REPORTS` gates the drop itself. While it is off the classifier still
+    runs and records `would_drop`, so the counter shows what enabling it costs before it costs it.
     """
-    if not is_cloud() or token != PH_US_API_KEY:
+    if not is_cloud():
         return reports
 
+    if token != PH_US_API_KEY:
+        CSP_SELF_HOSTED_FILTER.labels(decision="kept").inc(len(reports))
+        return reports
+
+    enforcing = settings.CSP_DROP_SELF_HOSTED_REPORTS
     accepted_reports = [report for report in reports if not is_hobby_url(report.get("document_url"))]
-    dropped_reports = len(reports) - len(accepted_reports)
+    self_hosted_reports = len(reports) - len(accepted_reports)
 
-    if dropped_reports:
-        CSP_REPORT_REJECTED.labels(reason="self_hosted_origin").inc(dropped_reports)
+    CSP_SELF_HOSTED_FILTER.labels(decision="kept").inc(len(accepted_reports))
+    if self_hosted_reports:
+        CSP_SELF_HOSTED_FILTER.labels(decision="dropped" if enforcing else "would_drop").inc(self_hosted_reports)
 
-    return accepted_reports
+    return accepted_reports if enforcing else reports
 
 
 def sample_csp_report(properties: dict, percent: float, add_metadata: bool = False) -> bool:

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -28,12 +28,6 @@ CSP_REPORT_REJECTED = Counter(
     labelnames=["reason"],
 )
 
-CSP_SELF_HOSTED_FILTER = Counter(
-    "csp_report_self_hosted_filter",
-    "CSP reports seen by the self-hosted origin filter on Cloud, by decision.",
-    labelnames=["decision"],
-)
-
 CSP_REPORT_TYPES_MAPPING_TABLE = """
 | Normalized Key             | report-to format                     | report-uri format                  |
 | -------------------------- | ------------------------------------ | ---------------------------------- |
@@ -54,41 +48,35 @@ CSP_REPORT_TYPES_MAPPING_TABLE = """
 """
 
 
-def _drop_self_hosted_reports(reports: list[dict[str, object]], token: Optional[str]) -> list[dict[str, object]]:
-    """Ignore reports that a legacy self-hosted PostHog install sent to Cloud.
+SELF_HOSTED_REPORT_KEY = "self_hosted"
+
+
+def _label_self_hosted_reports(reports: list[dict[str, object]], token: Optional[str]) -> None:
+    """Mark, in place, the reports that a legacy self-hosted PostHog install sent to Cloud.
 
     Three sources reach this endpoint:
 
-    - A customer's site, on their own team token. Kept, from any domain.
-    - Cloud's own app, on PostHog's token from a PostHog or local host. Kept.
+    - A customer's site, on their own team token, from any domain.
+    - PostHog's own app or website, on PostHog's token from a host in
+      `POSTHOG_OWNED_HOST_SUFFIXES` or a local host. More than Cloud: we also reach the app over
+      a tailnet and preview the website on Vercel.
     - A self-hosted install, on PostHog's token because it runs PostHog's own `CSPMiddleware`,
-      from the operator's own host. Dropped.
+      from the operator's own host. This is the one we label.
 
-    Only the token tells the first case from the other two, so the token gate runs first and is
-    what protects customers. The document URL then splits Cloud's own app from self-hosted.
+    Only the token tells the first case from the other two, so it is checked first. The document
+    URL then splits PostHog's own hosts from a self-hosted install.
 
-    `CSP_DROP_SELF_HOSTED_REPORTS` gates the drop. While it is off the classifier still records
-    `would_drop`, so the counter shows what enabling it costs before it costs it.
-
-    Call this after sampling, never before. Sampling discards most violations, so classifying
-    first would overstate the counter by the inverse of the sample rate.
+    Nothing is dropped. A host allowlist cannot be complete, and every host missing from it
+    would have its reports discarded with no trace, so the label carries the classification into
+    the event instead. `$csp_self_hosted` then makes the population countable in PostHog, which
+    is what tracks the volume falling away as operators upgrade past the middleware change.
     """
-    if not is_cloud():
-        return reports
+    if not is_cloud() or token != PH_US_API_KEY:
+        return
 
-    if token != PH_US_API_KEY:
-        CSP_SELF_HOSTED_FILTER.labels(decision="kept").inc(len(reports))
-        return reports
-
-    enforcing = settings.CSP_DROP_SELF_HOSTED_REPORTS
-    accepted_reports = [report for report in reports if not is_hobby_url(report.get("document_url"))]
-    self_hosted_reports = len(reports) - len(accepted_reports)
-
-    CSP_SELF_HOSTED_FILTER.labels(decision="kept").inc(len(accepted_reports))
-    if self_hosted_reports:
-        CSP_SELF_HOSTED_FILTER.labels(decision="dropped" if enforcing else "would_drop").inc(self_hosted_reports)
-
-    return accepted_reports if enforcing else reports
+    for report in reports:
+        if is_hobby_url(report.get("document_url")):
+            report[SELF_HOSTED_REPORT_KEY] = True
 
 
 def sample_csp_report(properties: dict, percent: float, add_metadata: bool = False) -> bool:
@@ -345,8 +333,7 @@ def process_csp_report(request):
                 )
                 return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
 
-            if not _drop_self_hosted_reports([properties], token):
-                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
+            _label_self_hosted_reports([properties], token)
 
             return (
                 build_csp_event(
@@ -378,15 +365,14 @@ def process_csp_report(request):
                 if sample_csp_report(prop, sample_rate, add_metadata=True):
                     sampled_violations.append(prop)
 
+            _label_self_hosted_reports(sampled_violations, token)
+            _label_self_hosted_reports(crash_props, token)
+
             # Crash reports skip sampling: they are rare and each one is a dead tab, so
             # applying the CSP sample rate would silently discard most of the signal.
             events = [
-                build_csp_event(prop, distinct_id, session_id, version, user_agent)
-                for prop in _drop_self_hosted_reports(sampled_violations, token)
-            ] + [
-                build_crash_event(prop, distinct_id, session_id, user_agent)
-                for prop in _drop_self_hosted_reports(crash_props, token)
-            ]
+                build_csp_event(prop, distinct_id, session_id, version, user_agent) for prop in sampled_violations
+            ] + [build_crash_event(prop, distinct_id, session_id, user_agent) for prop in crash_props]
 
             if not events:
                 logger.warning(

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -63,6 +63,10 @@ def _drop_self_hosted_reports(reports: list[dict[str, object]], token: Optional[
 
     `CSP_DROP_SELF_HOSTED_REPORTS` gates the drop itself. While it is off the classifier still
     runs and records `would_drop`, so the counter shows what enabling it costs before it costs it.
+
+    Call this after sampling, never before. Sampling discards most violations, so classifying
+    first would count reports that never become events and overstate the counter by the inverse
+    of the sample rate.
     """
     if not is_cloud():
         return reports
@@ -328,17 +332,15 @@ def process_csp_report(request):
             else:
                 raise ValueError("Invalid CSP report")
 
-            accepted_reports = _drop_self_hosted_reports([properties], token)
-            if not accepted_reports:
-                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
-            properties = accepted_reports[0]
-
             if not sample_csp_report(properties, sample_rate, add_metadata=True):
                 logger.warning(
                     "CSP report sampled out - report-uri format",
                     document_url=properties.get("document_url"),
                     sample_rate=sample_rate,
                 )
+                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
+
+            if not _drop_self_hosted_reports([properties], token):
                 return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
 
             return (
@@ -360,12 +362,8 @@ def process_csp_report(request):
             else:
                 raise ValueError("Invalid CSP report")
 
-            violations_props = _drop_self_hosted_reports(
-                [parse_report_to(item) for item in items if is_csp_violation(item)], token
-            )
-            crash_props = _drop_self_hosted_reports(
-                [parse_crash_report(item) for item in items if is_crash_report(item)], token
-            )
+            violations_props = [parse_report_to(item) for item in items if is_csp_violation(item)]
+            crash_props = [parse_crash_report(item) for item in items if is_crash_report(item)]
 
             if not violations_props and not crash_props:
                 return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
@@ -378,8 +376,12 @@ def process_csp_report(request):
             # Crash reports skip sampling: they are rare and each one is a dead tab, so
             # applying the CSP sample rate would silently discard most of the signal.
             events = [
-                build_csp_event(prop, distinct_id, session_id, version, user_agent) for prop in sampled_violations
-            ] + [build_crash_event(prop, distinct_id, session_id, user_agent) for prop in crash_props]
+                build_csp_event(prop, distinct_id, session_id, version, user_agent)
+                for prop in _drop_self_hosted_reports(sampled_violations, token)
+            ] + [
+                build_crash_event(prop, distinct_id, session_id, user_agent)
+                for prop in _drop_self_hosted_reports(crash_props, token)
+            ]
 
             if not events:
                 logger.warning(

--- a/posthog/api/csp.py
+++ b/posthog/api/csp.py
@@ -12,6 +12,7 @@ import structlog
 from prometheus_client import Counter
 from rest_framework import status
 
+from posthog.cloud_utils import is_cloud
 from posthog.exceptions import generate_exception_response
 from posthog.models.utils import uuid7
 from posthog.sampling import sample_on_property
@@ -43,6 +44,41 @@ CSP_REPORT_TYPES_MAPPING_TABLE = """
 | `$csp_user_agent`          | top-level `user_agent`               | not available                      |
 | `$csp_report_type`         | top-level `type`                     | `"csp-violation"` constant         |
 """
+
+_POSTHOG_DOCUMENT_DOMAINS = ("posthog.com", "posthog.dev")
+
+
+def _is_non_posthog_document_url(document_url: object) -> bool:
+    if not isinstance(document_url, str):
+        return False
+
+    try:
+        hostname = urlsplit(document_url).hostname
+    except ValueError:
+        return False
+
+    if hostname is None:
+        return False
+
+    return not any(hostname == domain or hostname.endswith(f".{domain}") for domain in _POSTHOG_DOCUMENT_DOMAINS)
+
+
+def _filter_reports_by_origin(reports: list[dict[str, object]]) -> list[dict[str, object]]:
+    if not is_cloud():
+        return reports
+
+    accepted_reports = []
+    dropped_reports = 0
+    for report in reports:
+        if _is_non_posthog_document_url(report.get("document_url")):
+            dropped_reports += 1
+        else:
+            accepted_reports.append(report)
+
+    if dropped_reports:
+        CSP_REPORT_REJECTED.labels(reason="non_posthog_origin").inc(dropped_reports)
+
+    return accepted_reports
 
 
 def sample_csp_report(properties: dict, percent: float, add_metadata: bool = False) -> bool:
@@ -290,6 +326,11 @@ def process_csp_report(request):
             else:
                 raise ValueError("Invalid CSP report")
 
+            accepted_reports = _filter_reports_by_origin([properties])
+            if not accepted_reports:
+                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
+            properties = accepted_reports[0]
+
             if not sample_csp_report(properties, sample_rate, add_metadata=True):
                 logger.warning(
                     "CSP report sampled out - report-uri format",
@@ -317,8 +358,15 @@ def process_csp_report(request):
             else:
                 raise ValueError("Invalid CSP report")
 
-            violations_props = [parse_report_to(item) for item in items if is_csp_violation(item)]
-            crash_props = [parse_crash_report(item) for item in items if is_crash_report(item)]
+            violations_props = _filter_reports_by_origin(
+                [parse_report_to(item) for item in items if is_csp_violation(item)]
+            )
+            crash_props = _filter_reports_by_origin(
+                [parse_crash_report(item) for item in items if is_crash_report(item)]
+            )
+
+            if not violations_props and not crash_props:
+                return None, cors_response(request, HttpResponse(status=status.HTTP_204_NO_CONTENT))
 
             sampled_violations = []
             for prop in violations_props:

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -10,7 +10,7 @@ from parameterized import parameterized
 from rest_framework import status
 from structlog.testing import capture_logs
 
-from posthog.api.csp import CSP_REPORT_REJECTED, CSP_SELF_HOSTED_FILTER
+from posthog.api.csp import CSP_REPORT_REJECTED
 from posthog.ph_client import PH_US_API_KEY
 
 SINGLE_VIOLATION_REPORT_URI = {
@@ -123,24 +123,43 @@ class TestCspReport(BaseTest):
 
     @parameterized.expand(
         [
-            ("report_uri_self_hosted", "application/csp-report", SINGLE_VIOLATION_REPORT_URI, True),
-            ("report_to_self_hosted", "application/reports+json", [SINGLE_VIOLATION_REPORT_TO], True),
-            ("crash_self_hosted", "application/reports+json", [CRASH_REPORT], True),
-            ("report_uri_customer", "application/csp-report", SINGLE_VIOLATION_REPORT_URI, False),
-            ("report_to_customer", "application/reports+json", [SINGLE_VIOLATION_REPORT_TO], False),
-            ("crash_customer", "application/reports+json", [CRASH_REPORT], False),
+            ("report_uri_self_hosted", "application/csp-report", SINGLE_VIOLATION_REPORT_URI, "$csp_self_hosted", True),
+            (
+                "report_to_self_hosted",
+                "application/reports+json",
+                [SINGLE_VIOLATION_REPORT_TO],
+                "$csp_self_hosted",
+                True,
+            ),
+            (
+                "crash_self_hosted",
+                "application/reports+json",
+                [CRASH_REPORT],
+                "$browser_crash_self_hosted",
+                True,
+            ),
+            ("report_uri_customer", "application/csp-report", SINGLE_VIOLATION_REPORT_URI, "$csp_self_hosted", False),
+            (
+                "report_to_customer",
+                "application/reports+json",
+                [SINGLE_VIOLATION_REPORT_TO],
+                "$csp_self_hosted",
+                False,
+            ),
+            ("crash_customer", "application/reports+json", [CRASH_REPORT], "$browser_crash_self_hosted", False),
         ]
     )
-    def test_cloud_drops_non_posthog_documents_only_for_the_self_hosted_token(
-        self, _name, content_type, payload, self_hosted_token
+    def test_cloud_labels_self_hosted_reports_only_for_the_posthog_token(
+        self, _name, content_type, payload, label, posthog_token
     ):
-        token = PH_US_API_KEY if self_hosted_token else self.team.api_token
+        # The label is how the self-hosted population stays countable, so it must land on
+        # PostHog's own token and never on a customer's, whose document URL is their own domain.
+        token = PH_US_API_KEY if posthog_token else self.team.api_token
 
         with (
-            self.settings(CLOUD_DEPLOYMENT="US", CSP_DROP_SELF_HOSTED_REPORTS=True),
+            self.settings(CLOUD_DEPLOYMENT="US"),
             patch("posthog.api.report.capture_batch_internal") as mock_batch_capture,
             patch("posthog.api.report.capture_internal") as mock_capture,
-            patch("posthog.api.report.csp_report_buffer") as mock_buffer,
         ):
             mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
             mock_capture.return_value = MagicMock(raise_for_status=MagicMock())
@@ -152,54 +171,14 @@ class TestCspReport(BaseTest):
             )
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        assert (mock_batch_capture.called or mock_capture.called) is not self_hosted_token
-        mock_buffer.enqueue.assert_not_called()
-
-    @parameterized.expand(
-        [
-            ("report_uri", "application/csp-report", SINGLE_VIOLATION_REPORT_URI),
-            ("report_to", "application/reports+json", [SINGLE_VIOLATION_REPORT_TO]),
-        ]
-    )
-    def test_cloud_does_not_count_a_self_hosted_violation_that_sampling_discarded(self, _name, content_type, payload):
-        # The counter sizes the drop before we enable it, so it has to match ingested volume.
-        # Classifying before sampling would overstate it by the inverse of the sample rate.
-        would_drop_before = CSP_SELF_HOSTED_FILTER.labels(decision="would_drop")._value.get()
-
-        with (
-            self.settings(CLOUD_DEPLOYMENT="US"),
-            patch("posthog.api.report.capture_batch_internal") as mock_batch_capture,
-            patch("posthog.api.report.capture_internal") as mock_capture,
-        ):
-            response = self.client.post(
-                f"/report/?token={PH_US_API_KEY}&sample_rate=0",
-                data=json.dumps(payload),
-                content_type=content_type,
-            )
-
-        assert response.status_code == status.HTTP_204_NO_CONTENT
-        assert not mock_batch_capture.called and not mock_capture.called
-        assert CSP_SELF_HOSTED_FILTER.labels(decision="would_drop")._value.get() == would_drop_before
+        if mock_batch_capture.called:
+            properties = mock_batch_capture.call_args.kwargs["events"][0]["properties"]
+        else:
+            properties = mock_capture.call_args.kwargs["properties"]
+        assert properties.get(label, False) is posthog_token
 
     @patch("posthog.api.report.capture_batch_internal")
-    def test_cloud_counts_but_keeps_self_hosted_reports_while_the_drop_is_off(self, mock_batch_capture):
-        mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
-        would_drop_before = CSP_SELF_HOSTED_FILTER.labels(decision="would_drop")._value.get()
-
-        with self.settings(CLOUD_DEPLOYMENT="US"):
-            response = self.client.post(
-                f"/report/?token={PH_US_API_KEY}",
-                data=json.dumps([SINGLE_VIOLATION_REPORT_TO]),
-                content_type="application/reports+json",
-            )
-
-        assert response.status_code == status.HTTP_204_NO_CONTENT
-        events = mock_batch_capture.call_args.kwargs["events"]
-        assert [event["properties"]["$current_url"] for event in events] == ["https://example.com/foo/bar"]
-        assert CSP_SELF_HOSTED_FILTER.labels(decision="would_drop")._value.get() - would_drop_before == 1
-
-    @patch("posthog.api.report.capture_batch_internal")
-    def test_cloud_keeps_non_hobby_reports_from_a_mixed_bundle(self, mock_batch_capture):
+    def test_cloud_labels_only_the_self_hosted_reports_in_a_mixed_bundle(self, mock_batch_capture):
         mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
         posthog_violation = {
             **SINGLE_VIOLATION_REPORT_TO,
@@ -215,7 +194,7 @@ class TestCspReport(BaseTest):
         }
         posthog_crash = {**CRASH_REPORT, "url": "https://eu.posthog.com/project/1"}
 
-        with self.settings(CLOUD_DEPLOYMENT="US", CSP_DROP_SELF_HOSTED_REPORTS=True):
+        with self.settings(CLOUD_DEPLOYMENT="US"):
             response = self.client.post(
                 f"/report/?token={PH_US_API_KEY}",
                 data=json.dumps(
@@ -233,11 +212,20 @@ class TestCspReport(BaseTest):
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         events = mock_batch_capture.call_args.kwargs["events"]
-        assert [event["properties"]["$current_url"] for event in events] == [
-            "https://app.dev.posthog.dev/project/1",
-            None,
-            "http://localhost:8010/project/1",
-            "https://eu.posthog.com/project/1",
+        # Every report is ingested. Only the two on a host outside PostHog's own carry the label.
+        assert [
+            (
+                event["properties"]["$current_url"],
+                event["properties"].get("$csp_self_hosted", event["properties"].get("$browser_crash_self_hosted")),
+            )
+            for event in events
+        ] == [
+            ("https://example.com/foo/bar", True),
+            ("https://app.dev.posthog.dev/project/1", None),
+            (None, None),
+            ("http://localhost:8010/project/1", None),
+            ("https://app.example.com/dashboard/1", True),
+            ("https://eu.posthog.com/project/1", None),
         ]
 
     @patch("posthog.api.report.capture_batch_internal")

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -10,7 +10,7 @@ from parameterized import parameterized
 from rest_framework import status
 from structlog.testing import capture_logs
 
-from posthog.api.csp import CSP_REPORT_REJECTED
+from posthog.api.csp import CSP_REPORT_REJECTED, CSP_SELF_HOSTED_FILTER
 from posthog.ph_client import PH_US_API_KEY
 
 SINGLE_VIOLATION_REPORT_URI = {
@@ -137,7 +137,7 @@ class TestCspReport(BaseTest):
         token = PH_US_API_KEY if self_hosted_token else self.team.api_token
 
         with (
-            self.settings(CLOUD_DEPLOYMENT="US"),
+            self.settings(CLOUD_DEPLOYMENT="US", CSP_DROP_SELF_HOSTED_REPORTS=True),
             patch("posthog.api.report.capture_batch_internal") as mock_batch_capture,
             patch("posthog.api.report.capture_internal") as mock_capture,
             patch("posthog.api.report.csp_report_buffer") as mock_buffer,
@@ -156,6 +156,23 @@ class TestCspReport(BaseTest):
         mock_buffer.enqueue.assert_not_called()
 
     @patch("posthog.api.report.capture_batch_internal")
+    def test_cloud_counts_but_keeps_self_hosted_reports_while_the_drop_is_off(self, mock_batch_capture):
+        mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
+        would_drop_before = CSP_SELF_HOSTED_FILTER.labels(decision="would_drop")._value.get()
+
+        with self.settings(CLOUD_DEPLOYMENT="US"):
+            response = self.client.post(
+                f"/report/?token={PH_US_API_KEY}",
+                data=json.dumps([SINGLE_VIOLATION_REPORT_TO]),
+                content_type="application/reports+json",
+            )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        events = mock_batch_capture.call_args.kwargs["events"]
+        assert [event["properties"]["$current_url"] for event in events] == ["https://example.com/foo/bar"]
+        assert CSP_SELF_HOSTED_FILTER.labels(decision="would_drop")._value.get() - would_drop_before == 1
+
+    @patch("posthog.api.report.capture_batch_internal")
     def test_cloud_keeps_non_hobby_reports_from_a_mixed_bundle(self, mock_batch_capture):
         mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
         posthog_violation = {
@@ -172,7 +189,7 @@ class TestCspReport(BaseTest):
         }
         posthog_crash = {**CRASH_REPORT, "url": "https://eu.posthog.com/project/1"}
 
-        with self.settings(CLOUD_DEPLOYMENT="US"):
+        with self.settings(CLOUD_DEPLOYMENT="US", CSP_DROP_SELF_HOSTED_REPORTS=True):
             response = self.client.post(
                 f"/report/?token={PH_US_API_KEY}",
                 data=json.dumps(

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -11,6 +11,7 @@ from rest_framework import status
 from structlog.testing import capture_logs
 
 from posthog.api.csp import CSP_REPORT_REJECTED
+from posthog.ph_client import PH_US_API_KEY
 
 SINGLE_VIOLATION_REPORT_URI = {
     "csp-report": {
@@ -122,27 +123,36 @@ class TestCspReport(BaseTest):
 
     @parameterized.expand(
         [
-            ("report_uri", "application/csp-report", SINGLE_VIOLATION_REPORT_URI),
-            ("report_to", "application/reports+json", [SINGLE_VIOLATION_REPORT_TO]),
-            ("crash", "application/reports+json", [CRASH_REPORT]),
+            ("report_uri_self_hosted", "application/csp-report", SINGLE_VIOLATION_REPORT_URI, True),
+            ("report_to_self_hosted", "application/reports+json", [SINGLE_VIOLATION_REPORT_TO], True),
+            ("crash_self_hosted", "application/reports+json", [CRASH_REPORT], True),
+            ("report_uri_customer", "application/csp-report", SINGLE_VIOLATION_REPORT_URI, False),
+            ("report_to_customer", "application/reports+json", [SINGLE_VIOLATION_REPORT_TO], False),
+            ("crash_customer", "application/reports+json", [CRASH_REPORT], False),
         ]
     )
-    def test_cloud_drops_reports_from_non_posthog_documents(self, _name, content_type, payload):
+    def test_cloud_drops_non_posthog_documents_only_for_the_self_hosted_token(
+        self, _name, content_type, payload, self_hosted_token
+    ):
+        token = PH_US_API_KEY if self_hosted_token else self.team.api_token
+
         with (
             self.settings(CLOUD_DEPLOYMENT="US"),
             patch("posthog.api.report.capture_batch_internal") as mock_batch_capture,
             patch("posthog.api.report.capture_internal") as mock_capture,
             patch("posthog.api.report.csp_report_buffer") as mock_buffer,
         ):
+            mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
+            mock_capture.return_value = MagicMock(raise_for_status=MagicMock())
+
             response = self.client.post(
-                f"/report/?token={self.team.api_token}",
+                f"/report/?token={token}",
                 data=json.dumps(payload),
                 content_type=content_type,
             )
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        mock_batch_capture.assert_not_called()
-        mock_capture.assert_not_called()
+        assert (mock_batch_capture.called or mock_capture.called) is not self_hosted_token
         mock_buffer.enqueue.assert_not_called()
 
     @patch("posthog.api.report.capture_batch_internal")
@@ -164,7 +174,7 @@ class TestCspReport(BaseTest):
 
         with self.settings(CLOUD_DEPLOYMENT="US"):
             response = self.client.post(
-                f"/report/?token={self.team.api_token}",
+                f"/report/?token={PH_US_API_KEY}",
                 data=json.dumps(
                     [
                         SINGLE_VIOLATION_REPORT_TO,

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -118,6 +118,67 @@ class TestCspReport(BaseTest):
         mock_buffer.enqueue.assert_not_called()
         assert CSP_REPORT_REJECTED.labels(reason=expected_reason)._value.get() - rejected_before == 1
 
+    @parameterized.expand(
+        [
+            ("report_uri", "application/csp-report", SINGLE_VIOLATION_REPORT_URI),
+            ("report_to", "application/reports+json", [SINGLE_VIOLATION_REPORT_TO]),
+            ("crash", "application/reports+json", [CRASH_REPORT]),
+        ]
+    )
+    def test_cloud_drops_reports_from_non_posthog_documents(self, _name, content_type, payload):
+        with (
+            self.settings(CLOUD_DEPLOYMENT="US"),
+            patch("posthog.api.report.capture_batch_internal") as mock_batch_capture,
+            patch("posthog.api.report.capture_internal") as mock_capture,
+            patch("posthog.api.report.csp_report_buffer") as mock_buffer,
+        ):
+            response = self.client.post(
+                f"/report/?token={self.team.api_token}",
+                data=json.dumps(payload),
+                content_type=content_type,
+            )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_batch_capture.assert_not_called()
+        mock_capture.assert_not_called()
+        mock_buffer.enqueue.assert_not_called()
+
+    @patch("posthog.api.report.capture_batch_internal")
+    def test_cloud_keeps_posthog_and_unknown_reports_from_a_mixed_bundle(self, mock_batch_capture):
+        mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
+        posthog_violation = {
+            **SINGLE_VIOLATION_REPORT_TO,
+            "body": {
+                **SINGLE_VIOLATION_REPORT_TO["body"],
+                "documentURL": "https://app.dev.posthog.dev/project/1",
+            },
+        }
+        unknown_origin_violation = {"type": "csp-violation", "body": {"effectiveDirective": "script-src"}}
+        posthog_crash = {**CRASH_REPORT, "url": "https://eu.posthog.com/project/1"}
+
+        with self.settings(CLOUD_DEPLOYMENT="US"):
+            response = self.client.post(
+                f"/report/?token={self.team.api_token}",
+                data=json.dumps(
+                    [
+                        SINGLE_VIOLATION_REPORT_TO,
+                        posthog_violation,
+                        unknown_origin_violation,
+                        CRASH_REPORT,
+                        posthog_crash,
+                    ]
+                ),
+                content_type="application/reports+json",
+            )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        events = mock_batch_capture.call_args.kwargs["events"]
+        assert [event["properties"]["$current_url"] for event in events] == [
+            "https://app.dev.posthog.dev/project/1",
+            None,
+            "https://eu.posthog.com/project/1",
+        ]
+
     @patch("posthog.api.report.capture_batch_internal")
     def test_mixed_report_types_not_rejected_by_violation_count_cap(self, mock_batch_capture):
         # A reports+json bundle can legitimately carry non-CSP report types (deprecation,

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -155,6 +155,32 @@ class TestCspReport(BaseTest):
         assert (mock_batch_capture.called or mock_capture.called) is not self_hosted_token
         mock_buffer.enqueue.assert_not_called()
 
+    @parameterized.expand(
+        [
+            ("report_uri", "application/csp-report", SINGLE_VIOLATION_REPORT_URI),
+            ("report_to", "application/reports+json", [SINGLE_VIOLATION_REPORT_TO]),
+        ]
+    )
+    def test_cloud_does_not_count_a_self_hosted_violation_that_sampling_discarded(self, _name, content_type, payload):
+        # The counter sizes the drop before we enable it, so it has to match ingested volume.
+        # Classifying before sampling would overstate it by the inverse of the sample rate.
+        would_drop_before = CSP_SELF_HOSTED_FILTER.labels(decision="would_drop")._value.get()
+
+        with (
+            self.settings(CLOUD_DEPLOYMENT="US"),
+            patch("posthog.api.report.capture_batch_internal") as mock_batch_capture,
+            patch("posthog.api.report.capture_internal") as mock_capture,
+        ):
+            response = self.client.post(
+                f"/report/?token={PH_US_API_KEY}&sample_rate=0",
+                data=json.dumps(payload),
+                content_type=content_type,
+            )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not mock_batch_capture.called and not mock_capture.called
+        assert CSP_SELF_HOSTED_FILTER.labels(decision="would_drop")._value.get() == would_drop_before
+
     @patch("posthog.api.report.capture_batch_internal")
     def test_cloud_counts_but_keeps_self_hosted_reports_while_the_drop_is_off(self, mock_batch_capture):
         mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -19,12 +19,14 @@ SINGLE_VIOLATION_REPORT_URI = {
     }
 }
 
+SINGLE_VIOLATION_REPORT_TO_BODY = {
+    "documentURL": "https://example.com/foo/bar",
+    "effectiveDirective": "script-src",
+}
+
 SINGLE_VIOLATION_REPORT_TO = {
     "type": "csp-violation",
-    "body": {
-        "documentURL": "https://example.com/foo/bar",
-        "effectiveDirective": "script-src",
-    },
+    "body": SINGLE_VIOLATION_REPORT_TO_BODY,
 }
 
 NON_VIOLATION_REPORT = {
@@ -149,14 +151,14 @@ class TestCspReport(BaseTest):
         posthog_violation = {
             **SINGLE_VIOLATION_REPORT_TO,
             "body": {
-                **SINGLE_VIOLATION_REPORT_TO["body"],
+                **SINGLE_VIOLATION_REPORT_TO_BODY,
                 "documentURL": "https://app.dev.posthog.dev/project/1",
             },
         }
         unknown_origin_violation = {"type": "csp-violation", "body": {"effectiveDirective": "script-src"}}
         local_violation = {
             **SINGLE_VIOLATION_REPORT_TO,
-            "body": {**SINGLE_VIOLATION_REPORT_TO["body"], "documentURL": "http://localhost:8010/project/1"},
+            "body": {**SINGLE_VIOLATION_REPORT_TO_BODY, "documentURL": "http://localhost:8010/project/1"},
         }
         posthog_crash = {**CRASH_REPORT, "url": "https://eu.posthog.com/project/1"}
 

--- a/posthog/api/test/test_report.py
+++ b/posthog/api/test/test_report.py
@@ -144,7 +144,7 @@ class TestCspReport(BaseTest):
         mock_buffer.enqueue.assert_not_called()
 
     @patch("posthog.api.report.capture_batch_internal")
-    def test_cloud_keeps_posthog_and_unknown_reports_from_a_mixed_bundle(self, mock_batch_capture):
+    def test_cloud_keeps_non_hobby_reports_from_a_mixed_bundle(self, mock_batch_capture):
         mock_batch_capture.return_value = MagicMock(raise_for_status=MagicMock())
         posthog_violation = {
             **SINGLE_VIOLATION_REPORT_TO,
@@ -154,6 +154,10 @@ class TestCspReport(BaseTest):
             },
         }
         unknown_origin_violation = {"type": "csp-violation", "body": {"effectiveDirective": "script-src"}}
+        local_violation = {
+            **SINGLE_VIOLATION_REPORT_TO,
+            "body": {**SINGLE_VIOLATION_REPORT_TO["body"], "documentURL": "http://localhost:8010/project/1"},
+        }
         posthog_crash = {**CRASH_REPORT, "url": "https://eu.posthog.com/project/1"}
 
         with self.settings(CLOUD_DEPLOYMENT="US"):
@@ -164,6 +168,7 @@ class TestCspReport(BaseTest):
                         SINGLE_VIOLATION_REPORT_TO,
                         posthog_violation,
                         unknown_origin_violation,
+                        local_violation,
                         CRASH_REPORT,
                         posthog_crash,
                     ]
@@ -176,6 +181,7 @@ class TestCspReport(BaseTest):
         assert [event["properties"]["$current_url"] for event in events] == [
             "https://app.dev.posthog.dev/project/1",
             None,
+            "http://localhost:8010/project/1",
             "https://eu.posthog.com/project/1",
         ]
 

--- a/posthog/cloud_utils.py
+++ b/posthog/cloud_utils.py
@@ -59,6 +59,10 @@ def is_hobby_url(url: object) -> bool:
     if parsed_url.scheme not in ("http", "https") or hostname is None:
         return False
 
+    # Browsers report `location.host` as `localhost.` for `http://localhost./`, and an FQDN
+    # trailing dot must not defeat the localhost, loopback, and Cloud-domain checks below.
+    hostname = hostname.rstrip(".")
+
     if hostname == "localhost" or hostname.endswith(".localhost"):
         return False
 

--- a/posthog/cloud_utils.py
+++ b/posthog/cloud_utils.py
@@ -1,6 +1,8 @@
 import os
 from datetime import timedelta
+from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import urlsplit
 
 from django.conf import settings
 from django.db.utils import ProgrammingError
@@ -15,6 +17,8 @@ if TYPE_CHECKING:
 is_cloud_cached: Optional[bool] = None
 is_instance_licensed_cached: Optional[bool] = None
 instance_license_cached: Optional["License"] = None
+
+_CLOUD_DOMAINS = ("posthog.com", "posthog.dev")
 
 
 def _run_mode() -> RunMode:
@@ -40,6 +44,31 @@ def is_dev_mode() -> bool:
 def is_hobby() -> bool:
     """Self-hosted install: neither cloud nor local dev. Mirrors `isHobby` in preflightLogic."""
     return _run_mode().is_hobby
+
+
+def is_hobby_url(url: object) -> bool:
+    if not isinstance(url, str):
+        return False
+
+    try:
+        parsed_url = urlsplit(url)
+        hostname = parsed_url.hostname
+    except ValueError:
+        return False
+
+    if parsed_url.scheme not in ("http", "https") or hostname is None:
+        return False
+
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        return False
+
+    try:
+        if ip_address(hostname).is_loopback:
+            return False
+    except ValueError:
+        pass
+
+    return not any(hostname == domain or hostname.endswith(f".{domain}") for domain in _CLOUD_DOMAINS)
 
 
 def is_ci() -> bool:

--- a/posthog/cloud_utils.py
+++ b/posthog/cloud_utils.py
@@ -18,7 +18,10 @@ is_cloud_cached: Optional[bool] = None
 is_instance_licensed_cached: Optional[bool] = None
 instance_license_cached: Optional["License"] = None
 
-_CLOUD_DOMAINS = ("posthog.com", "posthog.dev")
+
+def _posthog_owned_host_suffixes() -> list[str]:
+    """Read from `django.conf.settings`, so `override_settings` applies."""
+    return settings.POSTHOG_OWNED_HOST_SUFFIXES
 
 
 def _run_mode() -> RunMode:
@@ -60,7 +63,7 @@ def is_hobby_url(url: object) -> bool:
         return False
 
     # Browsers report `location.host` as `localhost.` for `http://localhost./`, and an FQDN
-    # trailing dot must not defeat the localhost, loopback, and Cloud-domain checks below.
+    # trailing dot must not defeat the localhost, loopback, and owned-host checks below.
     hostname = hostname.rstrip(".")
 
     if hostname == "localhost" or hostname.endswith(".localhost"):
@@ -72,7 +75,7 @@ def is_hobby_url(url: object) -> bool:
     except ValueError:
         pass
 
-    return not any(hostname == domain or hostname.endswith(f".{domain}") for domain in _CLOUD_DOMAINS)
+    return not any(hostname == suffix or hostname.endswith(f".{suffix}") for suffix in _posthog_owned_host_suffixes())
 
 
 def is_ci() -> bool:

--- a/posthog/settings/base_variables.py
+++ b/posthog/settings/base_variables.py
@@ -3,7 +3,7 @@ import sys
 
 import structlog
 
-from posthog.settings.utils import assert_debug_not_in_production, get_from_env, str_to_bool
+from posthog.settings.utils import assert_debug_not_in_production, get_from_env, get_list, str_to_bool
 
 logger = structlog.get_logger(__name__)
 
@@ -44,6 +44,17 @@ Possible values:
 - `E2E` for **e2e tests**.
 - Unset for **self-hosted** environments.
 """
+
+# Host suffixes that PostHog serves its own app or website from. `is_hobby_url` treats a document
+# URL under one of these as PostHog's own, which keeps the `$csp_self_hosted` label off our own
+# CSP reports. Cloud is `posthog.com` and `posthog.dev`, but we also reach the app over a Tailscale
+# tailnet (`ts.net`) and preview the website on Vercel (`vercel.app`).
+# Add a host here when PostHog starts serving from it, or its reports get labelled as someone
+# else's. The last two are shared suffixes, so a self-hosted install on one goes unlabelled.
+# That is the harmless direction: nothing is dropped either way, so a wide entry only undercounts.
+POSTHOG_OWNED_HOST_SUFFIXES: list[str] = get_list(
+    os.getenv("POSTHOG_OWNED_HOST_SUFFIXES", "posthog.com,posthog.dev,ts.net,vercel.app")
+)
 COMPACT_IN_REGION: str = get_from_env("COMPACT_IN_REGION", "US")
 SELF_CAPTURE: bool = get_from_env("SELF_CAPTURE", DEBUG and not DEMO, type_cast=str_to_bool)
 E2E_TESTING: bool = get_from_env(

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -104,6 +104,14 @@ CSP_REPORT_ENDPOINT: str | None = os.getenv("CSP_REPORT_ENDPOINT")
 CSP_REPORT_MAX_BODY_BYTES = get_from_env("CSP_REPORT_MAX_BODY_BYTES", type_cast=int, default=256 * 1024)
 CSP_REPORT_MAX_REPORTS = get_from_env("CSP_REPORT_MAX_REPORTS", type_cast=int, default=100)
 
+# Self-hosted report drop: when enabled, Cloud discards a report that carries PostHog's own
+# project token from a document URL that is not a PostHog or local host — a legacy self-hosted
+# install reporting to Cloud. Off = dry run: the classifier still runs and the
+# `csp_report_self_hosted_filter` counter records `would_drop`, but every report is ingested.
+# Validate the counter against expected volumes before turning this on, because a
+# misclassification here silently discards customer reports.
+CSP_DROP_SELF_HOSTED_REPORTS = get_from_env("CSP_DROP_SELF_HOSTED_REPORTS", False, type_cast=str_to_bool)
+
 # Buffered CSP capture-forward: when enabled, /report/ enqueues accepted reports to a
 # bounded in-process buffer and returns 204 immediately; a background thread batches
 # them to capture-rs. Keeps request-worker hold time independent of capture-rs latency,

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -104,15 +104,6 @@ CSP_REPORT_ENDPOINT: str | None = os.getenv("CSP_REPORT_ENDPOINT")
 CSP_REPORT_MAX_BODY_BYTES = get_from_env("CSP_REPORT_MAX_BODY_BYTES", type_cast=int, default=256 * 1024)
 CSP_REPORT_MAX_REPORTS = get_from_env("CSP_REPORT_MAX_REPORTS", type_cast=int, default=100)
 
-# Self-hosted report drop. Cloud only considers dropping a report that arrives on PostHog's own
-# project token, so a customer's report is always kept. Of the reports on PostHog's token, a
-# PostHog or local document URL is Cloud's own app and is kept, and any other host is a legacy
-# self-hosted install and is dropped. See `_drop_self_hosted_reports` in `posthog/api/csp.py`.
-# Off = dry run: the classifier runs and the `csp_report_self_hosted_filter` counter records
-# `would_drop`, but every report is ingested. Check the counter in production before enabling,
-# because a misclassification silently discards reports.
-CSP_DROP_SELF_HOSTED_REPORTS = get_from_env("CSP_DROP_SELF_HOSTED_REPORTS", False, type_cast=str_to_bool)
-
 # Buffered CSP capture-forward: when enabled, /report/ enqueues accepted reports to a
 # bounded in-process buffer and returns 204 immediately; a background thread batches
 # them to capture-rs. Keeps request-worker hold time independent of capture-rs latency,

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -104,12 +104,14 @@ CSP_REPORT_ENDPOINT: str | None = os.getenv("CSP_REPORT_ENDPOINT")
 CSP_REPORT_MAX_BODY_BYTES = get_from_env("CSP_REPORT_MAX_BODY_BYTES", type_cast=int, default=256 * 1024)
 CSP_REPORT_MAX_REPORTS = get_from_env("CSP_REPORT_MAX_REPORTS", type_cast=int, default=100)
 
-# Self-hosted report drop: when enabled, Cloud discards a report that carries PostHog's own
-# project token from a document URL that is not a PostHog or local host — a legacy self-hosted
-# install reporting to Cloud. Off = dry run: the classifier still runs and the
-# `csp_report_self_hosted_filter` counter records `would_drop`, but every report is ingested.
-# Validate the counter against expected volumes before turning this on, because a
-# misclassification here silently discards customer reports.
+# Self-hosted report drop: when enabled, Cloud discards a report only if it carries PostHog's
+# own project token. A customer configures this endpoint with their own team's token, so a
+# customer report never reaches the drop, whatever domain it comes from. Among the reports that
+# do carry PostHog's token, a PostHog or local document URL means Cloud's own app, which is
+# kept; any other host means a legacy self-hosted install reporting to Cloud.
+# Off = dry run: the classifier still runs and the `csp_report_self_hosted_filter` counter
+# records `would_drop`, but every report is ingested. Validate the counter against expected
+# volumes before turning this on, because a misclassification here silently discards reports.
 CSP_DROP_SELF_HOSTED_REPORTS = get_from_env("CSP_DROP_SELF_HOSTED_REPORTS", False, type_cast=str_to_bool)
 
 # Buffered CSP capture-forward: when enabled, /report/ enqueues accepted reports to a

--- a/posthog/settings/ingestion.py
+++ b/posthog/settings/ingestion.py
@@ -104,14 +104,13 @@ CSP_REPORT_ENDPOINT: str | None = os.getenv("CSP_REPORT_ENDPOINT")
 CSP_REPORT_MAX_BODY_BYTES = get_from_env("CSP_REPORT_MAX_BODY_BYTES", type_cast=int, default=256 * 1024)
 CSP_REPORT_MAX_REPORTS = get_from_env("CSP_REPORT_MAX_REPORTS", type_cast=int, default=100)
 
-# Self-hosted report drop: when enabled, Cloud discards a report only if it carries PostHog's
-# own project token. A customer configures this endpoint with their own team's token, so a
-# customer report never reaches the drop, whatever domain it comes from. Among the reports that
-# do carry PostHog's token, a PostHog or local document URL means Cloud's own app, which is
-# kept; any other host means a legacy self-hosted install reporting to Cloud.
-# Off = dry run: the classifier still runs and the `csp_report_self_hosted_filter` counter
-# records `would_drop`, but every report is ingested. Validate the counter against expected
-# volumes before turning this on, because a misclassification here silently discards reports.
+# Self-hosted report drop. Cloud only considers dropping a report that arrives on PostHog's own
+# project token, so a customer's report is always kept. Of the reports on PostHog's token, a
+# PostHog or local document URL is Cloud's own app and is kept, and any other host is a legacy
+# self-hosted install and is dropped. See `_drop_self_hosted_reports` in `posthog/api/csp.py`.
+# Off = dry run: the classifier runs and the `csp_report_self_hosted_filter` counter records
+# `would_drop`, but every report is ingested. Check the counter in production before enabling,
+# because a misclassification silently discards reports.
 CSP_DROP_SELF_HOSTED_REPORTS = get_from_env("CSP_DROP_SELF_HOSTED_REPORTS", False, type_cast=str_to_bool)
 
 # Buffered CSP capture-forward: when enabled, /report/ enqueues accepted reports to a

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -3161,6 +3161,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Raw CSP report",
             "description": "The raw CSP report as received from the browser.",
         },
+        "$csp_self_hosted": {
+            "label": "Self-hosted install",
+            "description": "Set when the report came from a self-hosted PostHog install that reports to PostHog Cloud. Only ever set on PostHog's own project.",
+            "examples": [True],
+        },
         "$csp_referrer": {
             "label": "CSP Referrer",
             "description": "The referrer of the CSP report if available.",

--- a/posthog/test/test_run_mode.py
+++ b/posthog/test/test_run_mode.py
@@ -87,6 +87,12 @@ class TestCloudUtilsRunMode(SimpleTestCase):
             ("ipv6_loopback", "http://[::1]:8010/project/1", False),
             ("hobby", "https://posthog.example.com/project/1", True),
             ("similar_domain", "https://notposthog.com/project/1", True),
+            # Browsers can report a trailing-dot host (`localhost.`, `us.posthog.com.`); it must
+            # not defeat the localhost, loopback, and Cloud-domain checks.
+            ("cloud_trailing_dot", "https://eu.posthog.com./project/1", False),
+            ("deployed_dev_trailing_dot", "https://app.dev.posthog.dev./project/1", False),
+            ("localhost_trailing_dot", "http://localhost.:8010/project/1", False),
+            ("ipv4_loopback_trailing_dot", "http://127.0.0.1./project/1", False),
             ("missing", None, False),
             ("malformed", "https://[", False),
         ]

--- a/posthog/test/test_run_mode.py
+++ b/posthog/test/test_run_mode.py
@@ -95,6 +95,9 @@ class TestCloudUtilsRunMode(SimpleTestCase):
             ("ipv4_loopback_trailing_dot", "http://127.0.0.1./project/1", False),
             ("missing", None, False),
             ("malformed", "https://[", False),
+            # Chrome reports `about` as the document URL for a violation inside an `about:blank`
+            # frame. The report is valid but names no origin, so it must not be treated as hobby.
+            ("about_blank_frame", "about", False),
         ]
     )
     def test_identifies_hobby_url(self, _name: str, url: str | None, expected: bool) -> None:

--- a/posthog/test/test_run_mode.py
+++ b/posthog/test/test_run_mode.py
@@ -99,7 +99,18 @@ class TestCloudUtilsRunMode(SimpleTestCase):
             # page's CSP, so its violations report `about` as the document URL. The report is
             # valid and comes from PostHog's own app, so it must not be treated as hobby.
             ("about_blank_frame", "about", False),
+            # PostHog also serves the app over a Tailscale tailnet and previews the website on
+            # Vercel. Both are PostHog's own, so neither can be treated as hobby.
+            ("tailnet", "https://dev-box.tailnet-example.ts.net/project/1", False),
+            ("vercel_preview", "https://posthog-git-branch-example.vercel.app/docs", False),
         ]
     )
     def test_identifies_hobby_url(self, _name: str, url: str | None, expected: bool) -> None:
         self.assertEqual(is_hobby_url(url), expected)
+
+    def test_reads_owned_host_suffixes_from_settings(self) -> None:
+        # Operators add a host PostHog starts serving from without a deploy, so the suffixes have
+        # to come from settings rather than a module constant.
+        with override_settings(POSTHOG_OWNED_HOST_SUFFIXES=["example.com"]):
+            self.assertFalse(is_hobby_url("https://app.example.com/project/1"))
+            self.assertTrue(is_hobby_url("https://eu.posthog.com/project/1"))

--- a/posthog/test/test_run_mode.py
+++ b/posthog/test/test_run_mode.py
@@ -95,8 +95,9 @@ class TestCloudUtilsRunMode(SimpleTestCase):
             ("ipv4_loopback_trailing_dot", "http://127.0.0.1./project/1", False),
             ("missing", None, False),
             ("malformed", "https://[", False),
-            # Chrome reports `about` as the document URL for a violation inside an `about:blank`
-            # frame. The report is valid but names no origin, so it must not be treated as hobby.
+            # The replay player renders a recording into an `about:blank` iframe that inherits the
+            # page's CSP, so its violations report `about` as the document URL. The report is
+            # valid and comes from PostHog's own app, so it must not be treated as hobby.
             ("about_blank_frame", "about", False),
         ]
     )

--- a/posthog/test/test_run_mode.py
+++ b/posthog/test/test_run_mode.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 
-from posthog.cloud_utils import is_cloud, is_hobby
+from posthog.cloud_utils import is_cloud, is_hobby, is_hobby_url
 from posthog.run_mode import RunMode, derive_run_mode, run_mode
 
 
@@ -76,3 +76,20 @@ class TestCloudUtilsRunMode(SimpleTestCase):
         with override_settings(CLOUD_DEPLOYMENT=cloud_deployment, DEBUG=debug):
             self.assertEqual(is_cloud(), cloud)
             self.assertEqual(is_hobby(), hobby)
+
+    @parameterized.expand(
+        [
+            ("cloud", "https://eu.posthog.com/project/1", False),
+            ("cloud_subdomain", "https://app.posthog.com/project/1", False),
+            ("deployed_dev", "https://app.dev.posthog.dev/project/1", False),
+            ("localhost", "http://localhost:8010/project/1", False),
+            ("ipv4_loopback", "http://127.0.0.1:8010/project/1", False),
+            ("ipv6_loopback", "http://[::1]:8010/project/1", False),
+            ("hobby", "https://posthog.example.com/project/1", True),
+            ("similar_domain", "https://notposthog.com/project/1", True),
+            ("missing", None, False),
+            ("malformed", "https://[", False),
+        ]
+    )
+    def test_identifies_hobby_url(self, _name: str, url: str | None, expected: bool) -> None:
+        self.assertEqual(is_hobby_url(url), expected)


### PR DESCRIPTION
## Problem

CSP violations in PostHog's own project mix our own reports with reports from self-hosted installs, and nothing tells them apart.

**Why:** operators of existing self-hosted instances report to PostHog Cloud until they upgrade past [#91314](https://github.com/PostHog/posthog/pull/91314). PostHog cannot act on those reports, and the operators did not choose to send them here.

[#91314](https://github.com/PostHog/posthog/pull/91314) already stops this at source: `csp_report_endpoint()` returns an empty endpoint off Cloud, so an upgraded install sends no reporting endpoint at all. This PR covers the installs still running older code, and changes no policy.

## Changes

- Anyone filtering CSP violations gets a new property, `$csp_self_hosted`, that marks a report from a self-hosted install. The population becomes countable, so its volume can be tracked and alerted on as operators upgrade.
- Nothing is dropped. Every report still reaches capture, from every source.
- The project token decides the label. Only a report on PostHog's own project token can be labelled, and a customer's report never carries that token.
- PostHog's tailnet and Vercel preview hosts now count as our own. `POSTHOG_OWNED_HOST_SUFFIXES` holds the list, so a host PostHog starts serving from needs no deploy.
- Mechanical: the taxonomy JSON is regenerated, which also picks up one unrelated entry that had drifted.

### Why a label and not a drop

An earlier revision of this branch dropped the reports, behind a setting. The drop needed an allowlist of PostHog's own hosts, and any host missing from that list had its reports discarded with no trace.

One week of production reports found three categories of PostHog's own traffic the allowlist had missed: a Tailscale tailnet serving the app, Vercel preview deploys of the website, and ngrok tunnels. Three misses in one sample is weak evidence that the fourth does not exist.

The costs are not symmetric. A wrong drop silently deletes the security signal that report-only CSP exists to collect. A wrong label only misattributes a report that is still there. So the classification now rides on the event instead of gating it.

A denylist of known self-hosted hosts was the other option. The reporting hosts are a long tail rather than a concentrated set, and new ones appear every week, so a denylist would lag permanently and never complete.

### Every case Cloud sees

| Report from | Token | Document URL | Result |
| --- | --- | --- | --- |
| A Cloud customer's site | Their own team token | Their own domain | Ingested, no label |
| Cloud's own app | PostHog's token | `us.posthog.com`, `eu.posthog.com` | Ingested, no label |
| PostHog's app over a tailnet | PostHog's token | `*.ts.net` | Ingested, no label |
| A website preview deploy | PostHog's token | `*.vercel.app` | Ingested, no label |
| A PostHog developer's machine | PostHog's token | `localhost` | Ingested, no label |
| The replay player's iframe | PostHog's token | `about`, so no host | Ingested, no label |
| A legacy self-hosted install | PostHog's token | The operator's own domain | Ingested, labelled |

Reading down the Token column, no value a customer can send reaches the label.

Before:

```mermaid
flowchart LR
    A[Browser] --> B[PostHog Cloud report endpoint]
    B --> C[CSP event capture]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phRed;
    class C phBlue;
```

After:

```mermaid
flowchart LR
    A[Browser] --> B[PostHog Cloud report endpoint]
    B --> C{PostHog's own project token}
    C -->|No| F[Capture report]
    C -->|Yes| D{PostHog or local document URL}
    D -->|Yes| F
    D -->|No| G[Capture report with csp_self_hosted]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phRed;
    class F,G phBlue;
    class C,D phGray;
```

No layout or component changes, so there is nothing to screenshot. The one visible difference is `$csp_self_hosted` appearing in the property list for `$csp_violation`.

## How did you test this code?

- The endpoint test in `posthog/api/test/test_report.py` runs both tokens across the report-uri, report-to, and crash shapes. Its customer-token cases catch the regression review found on the first revision: a report from a customer domain must reach capture unlabelled.
- The mixed-bundle case asserts every report in one bundle is ingested, and that only the two from a host outside PostHog's own carry the label. A change that starts dropping again fails here.
- `posthog/test/test_run_mode.py` covers the tailnet and Vercel hosts, and asserts the suffix list comes from settings rather than a constant.
- Three tests went away with the setting they guarded: two on counter-versus-sampling ordering, one on the dry-run default. Neither behavior exists now, and the ordering they protected cannot change the outcome when nothing is dropped.
- Not run: the frontend suites. The only frontend change is one string in a taxonomy list.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. `$csp_self_hosted` is only ever set on PostHog's own project, so it is not something a customer or a self-hosted operator sees.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Desktop updated the PR under human direction, addressing review findings from Codex, PostHog Review, and lricoy.
- Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.
- The design changed twice under review. The first revision decided on document URL alone, which drops every customer's reports. The second gated a token-based drop behind a setting. The author then asked whether a denylist or an allowlist would beat the heuristic, and production data showed the allowlist was already incomplete, so the drop became a label.
- The reviewer-suggested alternative, matching the team's authorized URLs, was rejected: it needs a team lookup in the ingestion hot path and misses customers who never configured authorized URLs.
- The rebase onto master dropped this branch's `CSPMiddleware` change. Master builds the report endpoint centrally in `csp_report_endpoint()`, so the token literal the branch replaced no longer exists. Master's endpoint still carries `PH_US_API_KEY`, which is what the token gate matches on.
- The declined `consider` finding no longer applies. A PostHog developer serving local PostHog over an ngrok tunnel gets a mislabelled report rather than a discarded one.
- The public diff contains no customer data or private operational details.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
