### PR TITLE
fix(posthog_ai): keep follow-up turns streaming after the first one

### DIFF
--- a/products/posthog_ai/frontend/AGENTS.md
+++ b/products/posthog_ai/frontend/AGENTS.md
@@ -120,8 +120,10 @@ The heart of the surface:
   the last Redis stream id via `Last-Event-ID` (capped exponential backoff + cumulative cap). Connection
   state (the `stream-end` sentinel, the resume cursor, the proxy token budget) belongs to one connection:
   every `openSseForRun` starts it fresh, and the cursor is dropped when the run being opened differs from
-  the one it came from. A run can outlive its stream (the sentinel lands, the reconnect budget runs out),
-  so `pushHumanMessage` reopens a closed connection — a follow-up turn has nothing to stream into otherwise.
+  the one it came from. A run can outlive its stream, so `pushHumanMessage` reopens a connection whose
+  reconnect budget ran out — a follow-up turn has nothing to stream into otherwise. It does **not** reopen
+  after the `stream-end` sentinel: that run's Redis stream holds a completion entry the server stops at and
+  refuses to write past, so only a successor run can carry the next turn.
 - **Ordered, append-only `log` is the single source of truth** — every wire frame (plus a few synthetic
   client entries) is appended, never keyed or per-entry deduped — with one exception: superseded
   `tool_call_update` frames are field-wise merged per `toolCallId` (`appendToRunLog`). Each update carries

--- a/products/posthog_ai/frontend/AGENTS.md
+++ b/products/posthog_ai/frontend/AGENTS.md
@@ -117,7 +117,11 @@ It must stay **free of the Max scene and conversation orchestration**. Do not im
 The heart of the surface:
 
 - **SSE connection** — a `fetch` body reader pumped through `eventsource-parser`; a reconnect resumes after
-  the last Redis stream id via `Last-Event-ID` (capped exponential backoff + cumulative cap).
+  the last Redis stream id via `Last-Event-ID` (capped exponential backoff + cumulative cap). Connection
+  state (the `stream-end` sentinel, the resume cursor, the proxy token budget) belongs to one connection:
+  every `openSseForRun` starts it fresh, and the cursor is dropped when the run being opened differs from
+  the one it came from. A run can outlive its stream (the sentinel lands, the reconnect budget runs out),
+  so `pushHumanMessage` reopens a closed connection — a follow-up turn has nothing to stream into otherwise.
 - **Ordered, append-only `log` is the single source of truth** — every wire frame (plus a few synthetic
   client entries) is appended, never keyed or per-entry deduped — with one exception: superseded
   `tool_call_update` frames are field-wise merged per `toolCallId` (`appendToRunLog`). Each update carries

--- a/products/posthog_ai/frontend/AGENTS.md
+++ b/products/posthog_ai/frontend/AGENTS.md
@@ -120,10 +120,13 @@ The heart of the surface:
   the last Redis stream id via `Last-Event-ID` (capped exponential backoff + cumulative cap). Connection
   state (the `stream-end` sentinel, the resume cursor, the proxy token budget) belongs to one connection:
   every `openSseForRun` starts it fresh, and the cursor is dropped when the run being opened differs from
-  the one it came from. A run can outlive its stream, so `pushHumanMessage` reopens a connection whose
-  reconnect budget ran out — a follow-up turn has nothing to stream into otherwise. It does **not** reopen
-  after the `stream-end` sentinel: that run's Redis stream holds a completion entry the server stops at and
-  refuses to write past, so only a successor run can carry the next turn.
+  the one it came from. A send never revives a dead stream, and three things make that harder than it
+  looks: after the `stream-end` sentinel the run's Redis stream holds a completion entry the server stops
+  at and refuses to write past, so only a successor run can carry the next turn; `sseStatus: 'error'`
+  covers a failed history bootstrap as well as an exhausted reconnect budget, and the bootstrap case has
+  already dropped buffered frames whose ids advanced the resume cursor; and a reopen inherits the spent
+  reconnect budgets, so its first drop gives up at once. A user-initiated recovery needs its own action,
+  its own budgets, and a log-completeness precondition.
 - **Ordered, append-only `log` is the single source of truth** — every wire frame (plus a few synthetic
   client entries) is appended, never keyed or per-entry deduped — with one exception: superseded
   `tool_call_update` frames are field-wise merged per `toolCallId` (`appendToRunLog`). Each update carries

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -1911,43 +1911,51 @@ describe('runStreamLogic', () => {
         })
     })
 
-    describe('follow-up after the stream ended', () => {
-        // The durable sentinel can land on a run that keeps accepting turns (the successor-run
-        // resume, a proxy that ends its own stream). Nothing else reopens the connection, so
-        // without these the next turn streams into a closed connection and the thread waits on
-        // output that only a page reload surfaces.
-        it('reopens the connection when a follow-up starts a turn on a live run', async () => {
+    describe('follow-up on a dead stream', () => {
+        // A follow-up opens a new turn, and only a live connection delivers it. A stream that failed
+        // retryably can still carry one, so a send reopens it. A stream the durable sentinel closed
+        // cannot: the run's Redis stream holds a completion entry the server stops at and refuses to
+        // write past, so only a successor run carries the next turn.
+        it('reopens after a retryable stream failure so the follow-up has somewhere to stream', async () => {
             jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
             logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
             await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
-            await MockStream.latest().emitMessage(notification('_posthog/turn_complete', {}), '101-0')
-            await MockStream.latest().emitStreamEnd()
-
-            expect(logic.values.sseStatus).toEqual('closed')
+            logic.actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
             const opened = MockStream.connections.length
 
             logic.actions.pushHumanMessage('and one more thing')
 
             expect(MockStream.connections.length).toEqual(opened + 1)
             // Resumes exactly after the last frame the thread carries, so nothing repeats.
-            expect(MockStream.latest().options.lastEventId).toEqual('101-0')
+            expect(MockStream.latest().options.lastEventId).toEqual('100-0')
             expect(logic.values.isThinking).toEqual(true)
         })
 
-        it('leaves a healthy connection alone', async () => {
+        it.each([
+            ['the connection is healthy', async (): Promise<void> => {}],
+            [
+                'the run is terminal',
+                async (): Promise<void> => {
+                    logic.actions.handleTerminalStatus({ status: 'completed' })
+                },
+            ],
+            [
+                'the sentinel closed the stream',
+                async (): Promise<void> => {
+                    await MockStream.latest().emitStreamEnd()
+                },
+            ],
+            [
+                'the stream failed for good',
+                async (): Promise<void> => {
+                    logic.actions.handleStreamError({ errorTitle: 'Task run not found', retryable: false })
+                },
+            ],
+        ])('does not reopen when %s', async (_label, arrive) => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
             logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
             await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
-            const opened = MockStream.connections.length
-
-            logic.actions.pushHumanMessage('and one more thing')
-
-            expect(MockStream.connections.length).toEqual(opened)
-        })
-
-        it('does not reopen a terminal run — its follow-up starts a successor run', async () => {
-            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
-            await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
-            logic.actions.handleTerminalStatus({ status: 'completed' })
+            await arrive()
             const opened = MockStream.connections.length
 
             logic.actions.pushHumanMessage('and one more thing')

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -1911,6 +1911,75 @@ describe('runStreamLogic', () => {
         })
     })
 
+    describe('follow-up after the stream ended', () => {
+        // The durable sentinel can land on a run that keeps accepting turns (the successor-run
+        // resume, a proxy that ends its own stream). Nothing else reopens the connection, so
+        // without these the next turn streams into a closed connection and the thread waits on
+        // output that only a page reload surfaces.
+        it('reopens the connection when a follow-up starts a turn on a live run', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
+            await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
+            await MockStream.latest().emitMessage(notification('_posthog/turn_complete', {}), '101-0')
+            await MockStream.latest().emitStreamEnd()
+
+            expect(logic.values.sseStatus).toEqual('closed')
+            const opened = MockStream.connections.length
+
+            logic.actions.pushHumanMessage('and one more thing')
+
+            expect(MockStream.connections.length).toEqual(opened + 1)
+            // Resumes exactly after the last frame the thread carries, so nothing repeats.
+            expect(MockStream.latest().options.lastEventId).toEqual('101-0')
+            expect(logic.values.isThinking).toEqual(true)
+        })
+
+        it('leaves a healthy connection alone', async () => {
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
+            await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
+            const opened = MockStream.connections.length
+
+            logic.actions.pushHumanMessage('and one more thing')
+
+            expect(MockStream.connections.length).toEqual(opened)
+        })
+
+        it('does not reopen a terminal run — its follow-up starts a successor run', async () => {
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
+            await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
+            logic.actions.handleTerminalStatus({ status: 'completed' })
+            const opened = MockStream.connections.length
+
+            logic.actions.pushHumanMessage('and one more thing')
+
+            expect(MockStream.connections.length).toEqual(opened)
+        })
+
+        it("opens a successor run on fresh connection state, not the finished run's", async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
+            await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
+            await MockStream.latest().emitStreamEnd()
+
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-2', startLatest: false })
+
+            // The cursor addresses the finished run's Redis stream — resuming from it in the
+            // successor's stream can skip that run's opening frames.
+            expect(MockStream.latest().options.lastEventId).toBeUndefined()
+            await MockStream.latest().emitOpen()
+
+            // The finished run's sentinel must not suppress this connection's drop handling.
+            const opened = MockStream.connections.length
+            jest.useFakeTimers()
+            await MockStream.latest().emitClose()
+            await flushPromises()
+            expect(logic.values.sseStatus).toEqual('reconnecting')
+            jest.advanceTimersByTime(2000)
+            expect(MockStream.connections.length).toEqual(opened + 1)
+            jest.useRealTimers()
+        })
+    })
+
     describe('connection teardown', () => {
         // The keyed log store makes duplicate ingestion idempotent, so correctness no longer depends
         // on closing the exact connection a hot reload orphaned (the old EventSource registry is

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -1911,58 +1911,10 @@ describe('runStreamLogic', () => {
         })
     })
 
-    describe('follow-up on a dead stream', () => {
-        // A follow-up opens a new turn, and only a live connection delivers it. A stream that failed
-        // retryably can still carry one, so a send reopens it. A stream the durable sentinel closed
-        // cannot: the run's Redis stream holds a completion entry the server stops at and refuses to
-        // write past, so only a successor run carries the next turn.
-        it('reopens after a retryable stream failure so the follow-up has somewhere to stream', async () => {
-            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
-            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
-            await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
-            logic.actions.handleStreamError({ errorTitle: 'Cloud stream failed', retryable: true })
-            const opened = MockStream.connections.length
-
-            logic.actions.pushHumanMessage('and one more thing')
-
-            expect(MockStream.connections.length).toEqual(opened + 1)
-            // Resumes exactly after the last frame the thread carries, so nothing repeats.
-            expect(MockStream.latest().options.lastEventId).toEqual('100-0')
-            expect(logic.values.isThinking).toEqual(true)
-        })
-
-        it.each([
-            ['the connection is healthy', async (): Promise<void> => {}],
-            [
-                'the run is terminal',
-                async (): Promise<void> => {
-                    logic.actions.handleTerminalStatus({ status: 'completed' })
-                },
-            ],
-            [
-                'the sentinel closed the stream',
-                async (): Promise<void> => {
-                    await MockStream.latest().emitStreamEnd()
-                },
-            ],
-            [
-                'the stream failed for good',
-                async (): Promise<void> => {
-                    logic.actions.handleStreamError({ errorTitle: 'Task run not found', retryable: false })
-                },
-            ],
-        ])('does not reopen when %s', async (_label, arrive) => {
-            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
-            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
-            await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
-            await arrive()
-            const opened = MockStream.connections.length
-
-            logic.actions.pushHumanMessage('and one more thing')
-
-            expect(MockStream.connections.length).toEqual(opened)
-        })
-
+    describe('connection state across runs', () => {
+        // A follow-up on a finished run opens a successor with a stream of its own. The finished
+        // run's sentinel flag and resume cursor must not carry into it: the flag gates the drop
+        // handler, and the cursor addresses a different Redis stream.
         it("opens a successor run on fresh connection state, not the finished run's", async () => {
             jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
             logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
@@ -1971,12 +1923,9 @@ describe('runStreamLogic', () => {
 
             logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-2', startLatest: false })
 
-            // The cursor addresses the finished run's Redis stream — resuming from it in the
-            // successor's stream can skip that run's opening frames.
             expect(MockStream.latest().options.lastEventId).toBeUndefined()
             await MockStream.latest().emitOpen()
 
-            // The finished run's sentinel must not suppress this connection's drop handling.
             const opened = MockStream.connections.length
             jest.useFakeTimers()
             await MockStream.latest().emitClose()
@@ -1985,6 +1934,19 @@ describe('runStreamLogic', () => {
             jest.advanceTimersByTime(2000)
             expect(MockStream.connections.length).toEqual(opened + 1)
             jest.useRealTimers()
+        })
+
+        it('leaves a dead stream closed when a follow-up starts a turn', async () => {
+            jest.spyOn(api.tasks.runs, 'get').mockResolvedValue({ status: 'in_progress' } as any)
+            logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1', startLatest: false })
+            await MockStream.latest().emitMessage(notification('_posthog/run_started', {}), '100-0')
+            await MockStream.latest().emitStreamEnd()
+            expect(logic.values.sseStatus).toEqual('closed')
+            const opened = MockStream.connections.length
+
+            logic.actions.pushHumanMessage('and one more thing')
+
+            expect(MockStream.connections.length).toEqual(opened)
         })
     })
 

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -1855,6 +1855,9 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 sseOpened: () => 'open',
                 sseReconnecting: () => 'reconnecting',
                 closeSse: () => 'closed',
+                // The sentinel tears the connection down without reconnecting, so the stream is no
+                // longer open — say so, rather than leaving a dead connection reading as healthy.
+                streamEnded: () => 'closed',
                 handleStreamError: () => 'error',
                 reset: () => 'idle',
             },
@@ -2481,6 +2484,19 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 return
             }
 
+            // Every open starts a fresh connection. The end sentinel and the proxy re-mint budget
+            // belong to the connection that saw them, so a stale `streamEnded` must not leak into
+            // this one — it suppresses the drop handler, which leaves a dropped stream dead with no
+            // reconnect and no terminal refetch (the thread then waits on a turn nothing delivers).
+            // A stream that really is finished re-delivers the sentinel on this connection.
+            cache.streamEnded = false
+            cache.streamTokenRefreshes = 0
+            const previousRun = cache.activeRun as { taskId: string; runId: string } | undefined
+            if (previousRun && previousRun.runId !== runId) {
+                // The cursor is a Redis id from the previous run's stream — it addresses nothing in
+                // this one, so resuming from it can skip this run's opening frames.
+                cache.lastEventId = undefined
+            }
             // Track the active run so the reconnect loop can refetch it on a drop.
             cache.activeRun = { taskId, runId }
 
@@ -3061,6 +3077,23 @@ export const runStreamLogic = kea<runStreamLogicType>([
             // stamp the turn start for per-turn duration metrics and append it as a `client`-sourced
             // log entry the projection renders in order.
             cache.turnStartedAtMs = Date.now()
+            // The turn needs a live connection to deliver it, and by now the stream may be gone —
+            // the durable sentinel landed on a run that kept accepting turns, or the reconnect
+            // budget ran out. Nothing else reopens it, so the turn would stream into a closed
+            // connection and the thread would wait on output that never arrives. The reopen resumes
+            // from the last-seen cursor, which is exclusive, so nothing already in the thread
+            // repeats. A terminal run is skipped: its follow-up starts a successor run, and the
+            // consumer opens that one.
+            const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
+            const streamRetryable = values.sseStatus === 'error' && values.bootstrapError?.retryable !== false
+            if (
+                !props.replayOnly &&
+                activeRun &&
+                !isTerminalRunStatus(values.currentRunStatus) &&
+                (values.sseStatus === 'closed' || streamRetryable)
+            ) {
+                actions.openSseForRun({ taskId: activeRun.taskId, runId: activeRun.runId, startLatest: true })
+            }
             actions.appendEntries([
                 {
                     entry: {

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -3077,20 +3077,24 @@ export const runStreamLogic = kea<runStreamLogicType>([
             // stamp the turn start for per-turn duration metrics and append it as a `client`-sourced
             // log entry the projection renders in order.
             cache.turnStartedAtMs = Date.now()
-            // The turn needs a live connection to deliver it, and by now the stream may be gone —
-            // the durable sentinel landed on a run that kept accepting turns, or the reconnect
-            // budget ran out. Nothing else reopens it, so the turn would stream into a closed
-            // connection and the thread would wait on output that never arrives. The reopen resumes
-            // from the last-seen cursor, which is exclusive, so nothing already in the thread
-            // repeats. A terminal run is skipped: its follow-up starts a successor run, and the
-            // consumer opens that one.
+            // The turn needs a live connection to deliver it, and the stream can be gone by now: the
+            // reconnect budget ran out and left a retryable error behind. Nothing else reopens it,
+            // so the turn would stream into a dead connection and the thread would wait on output
+            // that never arrives. The reopen resumes from the last-seen cursor, which is exclusive,
+            // so nothing already in the thread repeats.
+            //
+            // A stream the durable sentinel closed is deliberately NOT reopened. The run's Redis
+            // stream holds a completion entry: a reopened connection reads that entry and ends
+            // again, and the backend refuses to write any further event to that stream. Only a
+            // successor run can carry another turn, which is also why a terminal run is skipped —
+            // its follow-up starts that successor and the consumer opens it.
             const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
-            const streamRetryable = values.sseStatus === 'error' && values.bootstrapError?.retryable !== false
+            const streamFailedRetryably = values.sseStatus === 'error' && values.bootstrapError?.retryable !== false
             if (
                 !props.replayOnly &&
                 activeRun &&
-                !isTerminalRunStatus(values.currentRunStatus) &&
-                (values.sseStatus === 'closed' || streamRetryable)
+                streamFailedRetryably &&
+                !isTerminalRunStatus(values.currentRunStatus)
             ) {
                 actions.openSseForRun({ taskId: activeRun.taskId, runId: activeRun.runId, startLatest: true })
             }

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -3077,27 +3077,13 @@ export const runStreamLogic = kea<runStreamLogicType>([
             // stamp the turn start for per-turn duration metrics and append it as a `client`-sourced
             // log entry the projection renders in order.
             cache.turnStartedAtMs = Date.now()
-            // The turn needs a live connection to deliver it, and the stream can be gone by now: the
-            // reconnect budget ran out and left a retryable error behind. Nothing else reopens it,
-            // so the turn would stream into a dead connection and the thread would wait on output
-            // that never arrives. The reopen resumes from the last-seen cursor, which is exclusive,
-            // so nothing already in the thread repeats.
-            //
-            // A stream the durable sentinel closed is deliberately NOT reopened. The run's Redis
-            // stream holds a completion entry: a reopened connection reads that entry and ends
-            // again, and the backend refuses to write any further event to that stream. Only a
-            // successor run can carry another turn, which is also why a terminal run is skipped —
-            // its follow-up starts that successor and the consumer opens it.
-            const activeRun = cache.activeRun as { taskId: string; runId: string } | undefined
-            const streamFailedRetryably = values.sseStatus === 'error' && values.bootstrapError?.retryable !== false
-            if (
-                !props.replayOnly &&
-                activeRun &&
-                streamFailedRetryably &&
-                !isTerminalRunStatus(values.currentRunStatus)
-            ) {
-                actions.openSseForRun({ taskId: activeRun.taskId, runId: activeRun.runId, startLatest: true })
-            }
+            // A send does NOT revive a dead stream, and reviving one is harder than it looks:
+            // `sseStatus: 'error'` covers a failed history bootstrap as well as an exhausted
+            // reconnect budget, and the bootstrap case has already dropped buffered frames whose
+            // ids advanced the resume cursor, so reopening from it silently skips them; a reopen
+            // also inherits the spent reconnect budgets, so the next drop gives up at once. A
+            // stream the durable sentinel closed cannot be revived at all — its Redis stream holds
+            // a completion entry the server stops at and refuses to write past.
             actions.appendEntries([
                 {
                     entry: {


### PR DESCRIPTION
## Problem

- A follow-up message in PostHog AI spins the thinking indicator forever, and the reply appears only after a page reload.
- The first turn is fine. Every turn after it can hang, on the Max thread and the `/tasks` runner alike.
- A follow-up on a finished run opens a successor run with a stream of its own.
- `runStreamLogic` holds connection state on the logic instance rather than the connection: the `stream-end` sentinel flag, the `Last-Event-ID` resume cursor, the proxy token budget.
- `openSseForRun` never cleared that state, so the successor's connection inherited the finished run's.
- The stale sentinel flag gates the drop handler, so a clean EOF on the successor's connection scheduled no reconnect and no status refetch.
- The stale cursor resumed the successor from a Redis id that addresses the previous run's stream.
- A reload recovers because the thread rebuilds from the persisted run log, which is why the content is there afterwards.

## Changes

- A follow-up turn streams live again after the first turn, with no reload.
- `openSseForRun` starts fresh connection state on every open.
- The resume cursor is dropped when the run being opened differs from the run the cursor came from.
- The `stream-end` sentinel sets `sseStatus` to `closed`, so a dead connection stops reading as healthy and the thread stops showing "spinning up" against it.
- Mechanical: the tests and the streaming note in `products/posthog_ai/frontend/AGENTS.md`. No component changed.

Nothing looks different. The same thread and indicator render, and they now receive the frames they were missing. PostHog Visual Review agrees: no visual changes.

> [!NOTE]
> A dead stream is never revived by sending into it, and three separate constraints say why. After the `stream-end` sentinel the run's Redis stream holds a completion entry the server stops at and refuses to write past, so only a successor run can carry the next turn. `sseStatus: 'error'` conflates an exhausted reconnect budget with a failed history bootstrap, and the bootstrap case has already discarded buffered frames whose ids advanced the resume cursor. A reopen also inherits the spent reconnect budgets, so its first drop gives up at once. A user-initiated recovery needs its own action, its own budgets, and a log-completeness precondition — a change worth making on its own, and out of scope here. The constraints are recorded in the surface guide.

## How did you test this code?

- Two tests in `runStreamLogic.test.ts`, under `connection state across runs`. Both fail against master.
- The regression no existing test caught: a successor run opened on a logic instance that already streamed a finished run, where the inherited sentinel flag swallowed the next drop and the inherited cursor addressed the wrong stream.
- The second pins that a send leaves a sentinel-closed stream closed, so the reopen is not re-added.
- Not run: this sandbox has no dev stack or sandbox agent, so the fix was never exercised against a real stream. The Hogbox preview for this PR failed to provision, so that route was not available either.
- Not run: `hogli ci:preflight`, because the sandbox has no Python venv and `uv` cannot fetch cpython 3.13.13. oxlint, oxfmt and the frontend typecheck ran directly on the touched files instead.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The streaming section of `products/posthog_ai/frontend/AGENTS.md` now states that connection state belongs to one connection, and what a future user-initiated recovery has to satisfy. No `docs/` page covers this surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Claude Opus 5) from a bug report of follow-ups loading forever. Skills invoked: `/writing-pr-descriptions`.

The report named no surface, so the session started by reading the send paths of both consumers of `runStreamLogic`, then reproduced the failure at the logic level through the real SSE reader rather than guessing. Two candidate causes died that way.

The first push carried a second, speculative fix beside the real one: a send reopened a stream that had died. PostHog Review showed the sentinel half could never deliver a turn, and Codex then found two defects in the half that remained. Each finding held up against the code, so the whole reopen was removed rather than repaired a third time. What ships is the successor-run repair the original report is about. Greptile also asked for a second retry cycle in the tests; that was declined on the repo's regression threshold and withdrawn.