### PR TITLE
fix(hobby): point recording-api at the session recording v2 s3 store

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -278,6 +278,14 @@ services:
         image: ${REGISTRY_URL}-node:${POSTHOG_NODE_TAG:-latest}
         logging: *default-logging
         environment:
+            # Read side of the session recording V2 blob store. Must point at the same
+            # SeaweedFS the ingestion-sessionreplay writer uses — without these the
+            # service falls back to its localhost:8333 default, so every playback
+            # request 500s with ECONNREFUSED ("We're unable to play this recording").
+            SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'any'
+            SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'any'
+            SESSION_RECORDING_V2_S3_TIMEOUT_MS: 120000
+            SESSION_RECORDING_V2_S3_ENDPOINT: http://seaweedfs:8333
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             # Must resolve to the same value as the web and worker services, which send it as
             # X-Internal-Api-Secret. The JWT signing secret is deliberately left unset here, so hobby
@@ -287,6 +295,7 @@ services:
             - db
             - redis7
             - clickhouse
+            - seaweedfs
 
     ingestion-error-tracking:
         extends:

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -284,7 +284,6 @@ services:
             # request 500s with ECONNREFUSED ("We're unable to play this recording").
             SESSION_RECORDING_V2_S3_ACCESS_KEY_ID: 'any'
             SESSION_RECORDING_V2_S3_SECRET_ACCESS_KEY: 'any'
-            SESSION_RECORDING_V2_S3_TIMEOUT_MS: 120000
             SESSION_RECORDING_V2_S3_ENDPOINT: http://seaweedfs:8333
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             # Must resolve to the same value as the web and worker services, which send it as


### PR DESCRIPTION
## Problem

Self-hosted (hobby) users can record sessions but not watch them: every recording opens to "We're unable to play this recording."

The write path is fine — `worker`, `web`, and `ingestion-sessionreplay` all get `SESSION_RECORDING_V2_S3_*` pointing at `http://seaweedfs:8333`, so blobs land in SeaweedFS. But `recording-api`, the service that reads those blocks back for playback, gets none of them. It falls back to the built-in default `http://localhost:8333` (`nodejs/src/ingestion/pipelines/sessionreplay/config.ts`), dials itself inside its own container, and every `/api/environments/:id/session_recordings/:sid/snapshots?source=blob_v2` request fails with `connect ECONNREFUSED 127.0.0.1:8333` → 500 → the playback error in the UI.

## Changes

- `docker-compose.hobby.yml`: give `recording-api` the endpoint and credentials for the blob store the `ingestion-sessionreplay` writer writes to, so reads target the same store.
- Add `seaweedfs` to its `depends_on`, matching the writer.

Compose-only change, no code touched.

## How did you test this code?

Hit and fixed on a live hobby deployment. Before: `recording-api` logged an S3 config with the localhost endpoint and every snapshots request 500'd with `ECONNREFUSED 127.0.0.1:8333` while blobs verifiably existed in SeaweedFS (capture side healthy). After adding exactly these variables and recreating the container: startup log shows `endpoint http://seaweedfs:8333 bucket posthog`, a direct block fetch (`curl 'http://recording-api:6738/api/projects/1/recordings/<sid>/block?key=session_recordings/...&start_byte=0&end_byte=N'`) returns 200, and recordings play in the UI.

No automated test added — hobby compose wiring isn't covered by the test suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

