### PR TITLE
fix(insights): make funnel bars open persons outside the insight scene

### DIFF
--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.test.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { BindLogic } from 'kea'
+
+import { clickAtIndex, ensureJsdom, hoverUntilTooltip } from '@posthog/quill-charts/testing'
+
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import funnelTopToBottomFixture from '~/mocks/fixtures/api/projects/team_id/insights/funnelTopToBottom.json'
+import { groupsModel } from '~/models/groupsModel'
+import { dataNodeLogic, type DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
+import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
+import { getCachedResults } from '~/queries/nodes/InsightViz/utils'
+import { NodeKind } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { InsightLogicProps, InsightShortId } from '~/types'
+
+import { FunnelBarHorizontalChart } from './FunnelBarHorizontalChart'
+
+jest.mock('scenes/trends/persons-modal/PersonsModal', () => ({ openPersonsModal: jest.fn() }))
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { openPersonsModal } = require('scenes/trends/persons-modal/PersonsModal')
+
+ensureJsdom()
+
+let uniqueNode = 0
+
+/** Mounts the chart and returns the event wrapper of the first step's bar. */
+async function renderFirstStepBar(inCardView: boolean): Promise<HTMLElement> {
+    const dashboardItemId = `FunnelBarHorizontalChartTest.${uniqueNode++}` as InsightShortId
+    const fixture = funnelTopToBottomFixture as any
+    const source = fixture.query.source
+    const cachedInsight = { ...fixture, short_id: dashboardItemId }
+    const insightProps: InsightLogicProps = { dashboardItemId, doNotLoad: true, cachedInsight }
+    const dataNodeLogicProps: DataNodeLogicProps = {
+        query: source,
+        key: insightVizDataNodeKey(insightProps),
+        cachedResults: getCachedResults(cachedInsight, source),
+        doNotLoad: true,
+    }
+
+    render(
+        <BindLogic logic={insightLogic} props={insightProps}>
+            <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                <FunnelBarHorizontalChart inCardView={inCardView} />
+            </BindLogic>
+        </BindLogic>
+    )
+
+    await waitFor(() => expect(screen.getAllByLabelText(/chart with/i).length).toBeGreaterThan(0), { timeout: 4000 })
+    return screen.getAllByLabelText(/chart with/i)[0].parentElement!
+}
+
+describe('FunnelBarHorizontalChart', () => {
+    beforeEach(() => {
+        initKeaTests()
+        groupsModel.mount()
+        ;(openPersonsModal as jest.Mock).mockClear()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    // A card-view bar used to render the hint while its click handler was withheld, so the tooltip
+    // promised a drill-in that never happened on dashboards, notebooks, and PostHog AI answers.
+    describe.each([
+        ['the insight scene', false],
+        ['a card view', true],
+    ])('in %s', (_surface, inCardView) => {
+        it('opens the persons modal for the bar it invites the user to click', async () => {
+            const bar = await renderFirstStepBar(inCardView)
+
+            const tooltip = await hoverUntilTooltip(bar, 0, 1)
+            expect(tooltip.textContent).toContain('Click to view')
+
+            await clickAtIndex(bar, 0, 1)
+            await waitFor(() => expect(openPersonsModal).toHaveBeenCalled())
+            expect((openPersonsModal as jest.Mock).mock.calls[0][0].query).toMatchObject({
+                kind: NodeKind.FunnelsActorsQuery,
+                funnelStep: 1,
+            })
+        })
+    })
+})

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -40,7 +40,6 @@ const handleChartError = (error: Error, info: ErrorInfo): void => {
 
 export function FunnelBarHorizontalChart({
     showPersonsModal: showPersonsModalProp = true,
-    inCardView,
 }: ChartParams): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
     const theme = useChartTheme()
@@ -63,8 +62,9 @@ export function FunnelBarHorizontalChart({
     const { aggregationLabel } = useValues(groupsModel)
 
     const steps = visibleStepsWithConversionMetrics
+    // One flag drives both the bar's click handler and the tooltip's "Click to view …" hint, so the
+    // hint can never promise a drill-in the bar doesn't do.
     const showPersonsModal = canOpenPersonModal && showPersonsModalProp
-    const interactive = showPersonsModal && !inCardView
     const isUnordered = funnelsFilter?.funnelOrderType === StepOrderValue.UNORDERED
     const hasOptionalSteps = steps.some((_, stepIndex) => isStepOptional(stepIndex + 1))
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
@@ -187,7 +187,7 @@ export function FunnelBarHorizontalChart({
                                             key={bar.series[0].key}
                                             stepData={bar}
                                             theme={theme}
-                                            interactive={interactive}
+                                            interactive={showPersonsModal}
                                             onSegmentClick={onSegmentClick}
                                             renderTooltip={renderTooltip}
                                             onError={handleChartError}
@@ -198,7 +198,7 @@ export function FunnelBarHorizontalChart({
                                     <SingleStepBar
                                         stepData={stepsData[stepIndex]}
                                         theme={theme}
-                                        interactive={interactive}
+                                        interactive={showPersonsModal}
                                         onSegmentClick={onSegmentClick}
                                         renderTooltip={renderTooltip}
                                         onError={handleChartError}


### PR DESCRIPTION
## Problem

Clicking a bar in a funnel did nothing on a dashboard, in a notebook, or in a PostHog AI answer, even though the bar's tooltip said "Click to view persons".

The horizontal funnel bar chart withheld its click handler whenever it rendered outside the insight scene, but the tooltip kept showing the hint. The counts in the step footer right below the bar stayed clickable on those same surfaces, and the vertical funnel layout stayed clickable too, so the dead bar was the odd one out.

## Changes

- A funnel bar now opens the persons modal on every surface where its tooltip offers to, including dashboards and notebooks.
- The bar shows a pointer cursor on those surfaces, matching every other clickable chart.
- One flag now drives both the click handler and the tooltip hint, so the two cannot drift apart again.

Nothing changes on the insight scene, and shared or exported views still have no drill-in, because that is gated separately.

## How did you test this code?

Added `FunnelBarHorizontalChart.test.tsx`, which renders the chart on both surfaces, hovers a bar, and asserts the tooltip offers the drill-in and the click opens step 1's actors. Its card-view case fails on the previous code and passes on this one, which was verified by reverting the fix and rerunning.

The funnel test suites under `products/product_analytics/frontend/insights/funnels/` were run locally and pass. No manual browser testing was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a bug report in Slack. No repo skills applied beyond the repo's own testing guidance.

The report named no surface, so the investigation started by instrumenting both funnel layouts in jsdom and sweeping hover and click positions across every step, breakdown, and compare fixture. The vertical layout drilled in correctly everywhere; the horizontal one drilled in only on the insight scene, which isolated the card-view gate.

The alternative fix was to hide the tooltip hint in card view. Restoring the click won instead, because the neighbouring counts and the other layout already drill in there, so hiding the hint would have removed working behaviour rather than aligned it.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1788109239986729?thread_ts=1788109239.986729&cid=C0368RPHLQH)*
