### PR TITLE
fix(data-imports): read a non-mapping job_inputs as legacy ingest mode

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_source_manager.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_source_manager.py
@@ -299,6 +299,7 @@ class TestBufferedGating:
         [
             ("source_never_flipped", {}),
             ("no_job_inputs", {"job_inputs": None}),
+            ("job_inputs_not_a_mapping", {"job_inputs": "buffered"}),
             ("companion_lane", {"job_inputs": {"cdc_ingest_mode": "buffered"}, "cdc_table_mode": "cdc_only"}),
             ("still_snapshotting", {"job_inputs": {"cdc_ingest_mode": "buffered"}, "cdc_mode": "snapshot"}),
         ]

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/types.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/types.py
@@ -16,8 +16,11 @@ IngestMode = Literal["legacy", "buffered"]
 
 def parse_ingest_mode(job_inputs: Mapping[str, Any] | None) -> IngestMode:
     """Anything unrecognized reads as legacy: an unknown value must not route a source onto a
-    path it was never flipped to."""
-    return "buffered" if (job_inputs or {}).get("cdc_ingest_mode") == "buffered" else "legacy"
+    path it was never flipped to. `job_inputs` decrypts from EncryptedJSONField, so it is not
+    always a mapping — a non-mapping value is unrecognized too, not an error."""
+    if not isinstance(job_inputs, Mapping):
+        return "legacy"
+    return "buffered" if job_inputs.get("cdc_ingest_mode") == "buffered" else "legacy"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Problem

- A buffered-CDC source whose credentials decrypt to a non-mapping value fails its scheduled sync: the pipeline-version check raises `AttributeError: 'str' object has no attribute 'get'` before the sync can run. Seen firing on a data-warehouse import, [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a053d7-871d-7461-99ad-d1b720bcf1a9).
- `check_pipeline_version_activity` calls `scheduled_sync_consumes_buffer`, which passes `source.job_inputs` to `parse_ingest_mode`.
- `job_inputs` comes from an `EncryptedJSONField`, so it is not always a dict. `parse_ingest_mode` did `(job_inputs or {}).get(...)`, and a non-empty string is truthy with no `.get`.

## Changes

- A source with a non-mapping `job_inputs` now stays on the legacy path instead of crashing the sync.
- `parse_ingest_mode` returns `legacy` for any non-mapping value, the same result it already gives for `None` and unrecognized modes. Its docstring already said "anything unrecognized reads as legacy".
- The guard mirrors the `isinstance(job_inputs, dict)` check the `ExternalDataSource` model already applies to the same field.

## How did you test this code?

- Added a parameterized case to `TestBufferedGating.test_the_scheduled_sync_is_not_forced_off_the_flag_for` with a string `job_inputs`. It exercises `scheduled_sync_consumes_buffer` end to end and fails with the reported `AttributeError` before this fix.
- Ran that class locally; the new case and the existing ones pass.
- Not run: the database-backed warehouse import suites, which need Postgres and ClickHouse this sandbox has no access to.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Read the stack trace into `parse_ingest_mode`, traced the call path from `check_pipeline_version_activity`, and confirmed `job_inputs` is an `EncryptedJSONField` whose value the model itself already guards for non-dict shapes. Concluded this is our bug (shared code mishandling a data shape), not a user or upstream condition, so it is a code fix rather than a `NonRetryableErrors` entry.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
