### PR TITLE
fix(session-replay): raise seaweedfs volume cap on the replay store

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -878,7 +878,11 @@ services:
                 echo "SeaweedFS ready with posthog bucket"
                 wait $$WEED_PID
             - --
-        command: ['server', '-s3', '-s3.port=8333', '-dir=/data']
+        # volume.max mirrors the objectstorage service above: SeaweedFS defaults to 8
+        # volume slots, which sustained recording ingestion exhausts long before the disk
+        # is full — writes then fail ("no writable volumes") and the sessionreplay blob
+        # flusher crash-loops on flush timeouts.
+        command: ['server', '-s3', '-s3.port=8333', '-dir=/data', '-volume.max=1000']
 
     duckgres:
         # DuckLake 0.4 + DuckDB 1.5.1, multi-arch (posthog/duckgres@5cfca88)


### PR DESCRIPTION
## Problem

On self-hosted stacks, session replay ingestion eventually stalls forever even with plenty of free disk: recording blob flushes time out and `ingestion-sessionreplay` crash-loops (observed 2,600+ restarts on a hobby deployment with 764 GB free).

Cause: the `seaweedfs` service backing the session recording V2 store runs `weed server` without `-volume.max`, so SeaweedFS caps itself at the default 8 volume slots. Once the `posthog` collection has consumed them, the master reports `Max: 8, Free: 0` — zero writable volumes — and every blob write fails, regardless of actual disk capacity.

The sibling `objectstorage` service in the same file already passes `-volume.max=1000`, with a comment describing this exact failure mode; the replay store just never got the same treatment.

## Changes

- `docker-compose.base.yml`: add `-volume.max=1000` to the `seaweedfs` service command, matching `objectstorage`.

One-line compose change, no code touched.

## How did you test this code?

Reproduced and fixed on a live hobby deployment: with the default cap, master topology (`/dir/status`) showed `Max: 8, Free: 0`, the ingester crash-looped on batch-flush timeouts, and SeaweedFS logged "no writable volumes"-class errors. After adding `-volume.max=1000` and recreating the container, topology showed `Max: 1000, Free: 985`, flush errors stopped, and the ingester's restart count went flat (stable for weeks after).

No automated test added — compose infra wiring isn't covered by the test suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
