### PR TITLE
fix(taxonomic-filter): stop offering "not seen yet" for an excluded event

### DIFF
--- a/.agents/skills/modifying-taxonomic-filter/SKILL.md
+++ b/.agents/skills/modifying-taxonomic-filter/SKILL.md
@@ -140,9 +140,15 @@ The rebuild is opt-in in exactly **two consumer wrappers**:
 `TaxonomicPopover.tsx` and
 `PropertyFilters/components/TaxonomicPropertyFilter.tsx`. Both check
 `TAXONOMIC_FILTER_MENU_REBUILD` and render `<TaxonomicFilterMenu>` or the
-legacy `<TaxonomicFilter>`. Call sites that build their own popover (e.g.
-`ActionFilterRow`) never see the rebuild — so "does this reach the
-rebuild?" depends on the call site, not a single global switch.
+legacy `<TaxonomicFilter>`. A call site reaching one of those wrappers can
+still land on the legacy path: `TaxonomicPopover` renders the rebuild only
+when `newMenuSupportsCallSite` holds (`!allowClear && closeOnChange && ref
+== null`), because the rebuilt menu cannot honour those three capabilities.
+So "does this reach the rebuild?" depends on the wrapper _and_ the props
+that call site passes, not a single global switch — `ActionFilterRow` goes
+through `TaxonomicPopover` and passes none of the three, so it does reach
+the rebuild. Only a call site that hand-rolls its own popover around
+`<TaxonomicFilter>` bypasses the wrappers entirely.
 
 **Touching tab/group rendering means testing all three surfaces.**
 

--- a/frontend/src/lib/components/TaxonomicFilter/headless/AutocompleteInput.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/AutocompleteInput.tsx
@@ -1860,10 +1860,20 @@ export function useTaxonomicAutocompleteShortcutItems(): {
 
         const pinned: TaxonomicAutocompleteEntry[] = (
             pinnedFilterItems as Array<
-                TaxonomicDefinitionTypes & { _pinnedContext?: { sourceGroupType?: TaxonomicFilterGroupType } }
+                TaxonomicDefinitionTypes & {
+                    _pinnedContext?: { sourceGroupType?: TaxonomicFilterGroupType; value?: TaxonomicFilterValue }
+                }
             >
         )
-            .map((item) => buildEntry(item, item._pinnedContext?.sourceGroupType))
+            .map((item) => {
+                const entry = buildEntry(item, item._pinnedContext?.sourceGroupType)
+                // A value the source group excludes must not be offered as a shortcut, the same way
+                // `filterPinnedForContext` drops it from the Pinned tab.
+                if (entry?.group.excludedProperties?.includes(item._pinnedContext?.value as string)) {
+                    return null
+                }
+                return entry
+            })
             .filter((e): e is TaxonomicAutocompleteEntry => e != null)
 
         const suggestedGroup = findGroup(TaxonomicFilterGroupType.SuggestedFilters)

--- a/frontend/src/lib/components/TaxonomicFilter/headless/AutocompleteInput.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/AutocompleteInput.tsx
@@ -1875,8 +1875,9 @@ export function useTaxonomicAutocompleteShortcutItems(): {
                 // never set `group.excludedProperties`, so read that root map keyed by the source group too.
                 const rootExcluded = sourceGroupType ? excludedProperties?.[sourceGroupType] : undefined
                 const isExcluded =
-                    entry?.group.excludedProperties?.includes(pinnedValue as string) ||
-                    rootExcluded?.includes(pinnedValue as string)
+                    pinnedValue != null &&
+                    (entry?.group.excludedProperties?.includes(pinnedValue as string) ||
+                        rootExcluded?.includes(pinnedValue))
                 if (isExcluded) {
                     return null
                 }

--- a/frontend/src/lib/components/TaxonomicFilter/headless/AutocompleteInput.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/AutocompleteInput.tsx
@@ -1839,7 +1839,7 @@ export function useTaxonomicAutocompleteShortcutItems(): {
     pinned: TaxonomicAutocompleteEntry[]
     suggested: TaxonomicAutocompleteEntry[]
 } {
-    const { groups } = useTaxonomicFilterContext()
+    const { groups, excludedProperties } = useTaxonomicFilterContext()
     const { pinnedFilterItems } = useValues(taxonomicFilterPinnedPropertiesLogic)
 
     return useMemo<{ pinned: TaxonomicAutocompleteEntry[]; suggested: TaxonomicAutocompleteEntry[] }>(() => {
@@ -1866,10 +1866,18 @@ export function useTaxonomicAutocompleteShortcutItems(): {
             >
         )
             .map((item) => {
-                const entry = buildEntry(item, item._pinnedContext?.sourceGroupType)
+                const sourceGroupType = item._pinnedContext?.sourceGroupType
+                const pinnedValue = item._pinnedContext?.value
+                const entry = buildEntry(item, sourceGroupType)
                 // A value the source group excludes must not be offered as a shortcut, the same way
-                // `filterPinnedForContext` drops it from the Pinned tab.
-                if (entry?.group.excludedProperties?.includes(item._pinnedContext?.value as string)) {
+                // `filterPinnedForContext` drops it from the Pinned tab. Groups like Logs, Issues, and
+                // Revenue analytics filter their own options from the root `excludedProperties` map and
+                // never set `group.excludedProperties`, so read that root map keyed by the source group too.
+                const rootExcluded = sourceGroupType ? excludedProperties?.[sourceGroupType] : undefined
+                const isExcluded =
+                    entry?.group.excludedProperties?.includes(pinnedValue as string) ||
+                    rootExcluded?.includes(pinnedValue as string)
+                if (isExcluded) {
                     return null
                 }
                 return entry
@@ -1885,7 +1893,7 @@ export function useTaxonomicAutocompleteShortcutItems(): {
             .filter((e): e is TaxonomicAutocompleteEntry => e != null)
 
         return { pinned, suggested }
-    }, [groups, pinnedFilterItems])
+    }, [groups, pinnedFilterItems, excludedProperties])
 }
 
 const DEFAULT_MENU_SHORTCUT_GROUPS: readonly TaxonomicFilterGroupType[] = [

--- a/frontend/src/lib/components/TaxonomicFilter/headless/headless.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/headless/headless.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, render, renderHook, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Provider } from 'kea'
 
@@ -14,8 +14,9 @@ import { PropertyFilterType, PropertyOperator } from '~/types'
 
 import { __clearTaxonomicResourceCache } from '../hooks/useTaxonomicResource'
 import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
+import { taxonomicFilterPinnedPropertiesLogic } from '../taxonomicFilterPinnedPropertiesLogic'
 import { TaxonomicFilterGroupType } from '../types'
-import { TaxonomicFilterHeadless } from './index'
+import { TaxonomicFilterHeadless, useTaxonomicAutocompleteShortcutItems } from './index'
 
 jest.mock('~/queries/query', () => ({
     performQuery: jest.fn(),
@@ -246,5 +247,33 @@ describe('TaxonomicFilterHeadless integration', () => {
         expect(screen.getByTestId('taxonomic-row-recent_filters-1').textContent).toMatch(/Chrome/)
 
         recents.unmount()
+    })
+
+    // A pin outlives the picker it was made in, so without this the shortcut row is another door
+    // to selecting a value the exclusion forbids.
+    it.each([
+        ['$exception', false],
+        ['checkout_started', true],
+    ])('offers the pinned shortcut %p: %p', (pinnedName, expected) => {
+        const pinnedLogic = taxonomicFilterPinnedPropertiesLogic.build()
+        pinnedLogic.mount()
+        pinnedLogic.actions.togglePin(TaxonomicFilterGroupType.Events, 'Events', pinnedName, { name: pinnedName })
+
+        const { result } = renderHook(() => useTaxonomicAutocompleteShortcutItems(), {
+            wrapper: ({ children }) => (
+                <Provider>
+                    <TaxonomicFilterHeadless.Root
+                        taxonomicGroupTypes={[TaxonomicFilterGroupType.Events]}
+                        onChange={onChangeMock}
+                        excludedProperties={{ [TaxonomicFilterGroupType.Events]: ['$exception'] }}
+                    >
+                        {children}
+                    </TaxonomicFilterHeadless.Root>
+                </Provider>
+            ),
+        })
+
+        expect(result.current.pinned.some((e) => e.name === pinnedName)).toBe(expected)
+        pinnedLogic.unmount()
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.test.tsx
@@ -353,7 +353,7 @@ describe('useGroupList', () => {
         it.each([
             ['unseen', true],
             ['$exception', false],
-        ])('allowNonCapturedEvents offers %p for an empty Events search: %p', async (query, expected) => {
+        ])('allowNonCapturedEvents offers %p when nothing matches: %p', async (query, expected) => {
             apiGet.mockResolvedValueOnce({ results: [], count: 0 })
             const group = makeGroup({
                 type: TaxonomicFilterGroupType.Events,
@@ -365,6 +365,8 @@ describe('useGroupList', () => {
             )
             await waitFor(() => expect(result.current.isLoading).toBe(false))
             expect(result.current.showNonCapturedEventOption).toBe(expected)
+            // No rebuild renderer draws the offer row yet, so the empty state is what a person sees.
+            expect(result.current.showEmptyState).toBe(!expected)
         })
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.test.tsx
@@ -348,17 +348,23 @@ describe('useGroupList', () => {
             await waitFor(() => expect(result.current.isLoading).toBe(false))
         })
 
-        it('allowNonCapturedEvents surfaces the option for empty Events search', async () => {
+        // Transformation filters exclude `$exception` while allowing uncaptured events, so an excluded
+        // name must never be offered as "not seen yet".
+        it.each([
+            ['unseen', true],
+            ['$exception', false],
+        ])('allowNonCapturedEvents offers %p for an empty Events search: %p', async (query, expected) => {
             apiGet.mockResolvedValueOnce({ results: [], count: 0 })
             const group = makeGroup({
                 type: TaxonomicFilterGroupType.Events,
                 endpoint: 'api/projects/1/event_definitions',
+                excludedProperties: ['$exception'],
             })
             const { result } = renderHook(() =>
-                useGroupList({ group, searchQuery: 'unseen', allowNonCapturedEvents: true })
+                useGroupList({ group, searchQuery: query, allowNonCapturedEvents: true })
             )
             await waitFor(() => expect(result.current.isLoading).toBe(false))
-            expect(result.current.showNonCapturedEventOption).toBe(true)
+            expect(result.current.showNonCapturedEventOption).toBe(expected)
         })
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
@@ -438,8 +438,8 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
         if (!trimmedSearch || isLoading) {
             return false
         }
-        // A name this picker excludes is not an uncaptured event: offering it would commit the value
-        // the exclusion forbids. Mirrors legacy infiniteListLogic's `showNonCapturedEventOption`.
+        // Offering an excluded name would let it be selected as a non-captured event, committing the
+        // value the exclusion forbids. Mirrors legacy infiniteListLogic's `showNonCapturedEventOption`.
         if (group.excludedProperties?.includes(trimmedSearch)) {
             return false
         }

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useGroupList.ts
@@ -438,9 +438,14 @@ export function useGroupList(input: UseGroupListInput): UseGroupListResult {
         if (!trimmedSearch || isLoading) {
             return false
         }
+        // A name this picker excludes is not an uncaptured event: offering it would commit the value
+        // the exclusion forbids. Mirrors legacy infiniteListLogic's `showNonCapturedEventOption`.
+        if (group.excludedProperties?.includes(trimmedSearch)) {
+            return false
+        }
         const realResults = items.filter((item) => !isQuickFilterItem(item))
         return realResults.length === 0
-    }, [allowNonCapturedEvents, group.type, trimmedSearch, isLoading, items])
+    }, [allowNonCapturedEvents, group.type, group.excludedProperties, trimmedSearch, isLoading, items])
 
     // Empty / loading state checks read array length, not the API-reported
     // total — a remote tab can have count > 0 while still loading its first

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
@@ -65,8 +65,8 @@ export function useTaxonomicLocalOverrides(context: {
         [recentFilterItems, taxonomicGroupTypes, excludedOperators, selectingKeyOnly, excludedProperties]
     )
     const contextFilteredPinnedItems = useMemo(
-        () => filterPinnedForContext(pinnedFilterItems, taxonomicGroupTypes),
-        [pinnedFilterItems, taxonomicGroupTypes]
+        () => filterPinnedForContext(pinnedFilterItems, taxonomicGroupTypes, excludedProperties),
+        [pinnedFilterItems, taxonomicGroupTypes, excludedProperties]
     )
 
     return useCallback(

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -916,6 +916,33 @@ describe('infiniteListLogic', () => {
         })
     })
 
+    // Transformation filters exclude `$exception` while allowing uncaptured events, so an excluded
+    // name must never be offered as "not seen yet".
+    describe('the "not seen yet" option and excluded names', () => {
+        const EXCLUDED_EVENT = '$exception'
+
+        it.each([
+            [EXCLUDED_EVENT, false],
+            ['checkout_started', true],
+        ])('searching %p offers the option: %p', async (query, expected) => {
+            const listLogic = infiniteListLogic({
+                taxonomicFilterLogicKey: `excluded-events-${query}`,
+                listGroupType: TaxonomicFilterGroupType.Events,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Events],
+                showNumericalPropsOnly: false,
+                allowNonCapturedEvents: true,
+                excludedProperties: { [TaxonomicFilterGroupType.Events]: [EXCLUDED_EVENT] },
+            })
+            listLogic.mount()
+
+            await expectLogic(listLogic, () => {
+                listLogic.actions.setSearchQuery(query)
+            })
+                .toFinishAllListeners()
+                .toMatchValues({ showNonCapturedEventOption: expected })
+        })
+    })
+
     describe('data warehouse pin lifecycle', () => {
         beforeEach(() => {
             const databaseLogic = databaseTableListLogic()

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1818,6 +1818,34 @@ describe('infiniteListLogic', () => {
             expect(names).toContain('level')
         })
 
+        it('hides a pinned value that is excluded for its source group', () => {
+            // A pin outlives the picker it was made in, so without this the Pinned tab is a second
+            // door to selecting a value the exclusion forbids.
+            const pinnedLogic = taxonomicFilterPinnedPropertiesLogic.build()
+            pinnedLogic.mount()
+            pinnedLogic.actions.togglePin(TaxonomicFilterGroupType.Events, 'Events', '$exception', {
+                name: '$exception',
+            })
+            pinnedLogic.actions.togglePin(TaxonomicFilterGroupType.Events, 'Events', 'checkout_started', {
+                name: 'checkout_started',
+            })
+
+            const listLogic = infiniteListLogic({
+                taxonomicFilterLogicKey: 'pinned-excluded-test',
+                listGroupType: TaxonomicFilterGroupType.PinnedFilters,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Events, TaxonomicFilterGroupType.PinnedFilters],
+                showNumericalPropsOnly: false,
+                excludedProperties: { [TaxonomicFilterGroupType.Events]: ['$exception'] },
+            })
+            listLogic.mount()
+
+            const names = listLogic.values.contextFilteredPinnedItems
+                .filter((i) => 'name' in i)
+                .map((i) => (i as { name: string }).name)
+            expect(names).not.toContain('$exception')
+            expect(names).toContain('checkout_started')
+        })
+
         it('preserves sourceValue on recent Persons items so the row resolves the correct distinct_id', () => {
             // Persons items are stored stripped ({name, id?}) — distinct_ids is not persisted.
             // The fix in InfiniteListRow falls back to _recentContext.sourceValue instead of

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -520,7 +520,7 @@ export interface infiniteListLogicMeta {
         contextFilteredPinnedItems: (
             pinnedFilterItems: TaxonomicDefinitionTypes[],
             taxonomicGroupTypes: TaxonomicFilterGroupType[],
-            excludedProperties: import('lib/components/TaxonomicFilter/types').TaxonomicFilterGroupValueMap | undefined
+            arg: import('lib/components/TaxonomicFilter/types').TaxonomicFilterGroupValueMap | undefined
         ) => TaxonomicDefinitionTypes[]
         isSoleSubstantiveGroup: (
             listGroupType: TaxonomicFilterGroupType,

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -1285,8 +1285,8 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 if (trimmedSearch.length === 0 || isLoading) {
                     return false
                 }
-                // A name this picker excludes is not an uncaptured event: offering it would commit
-                // the value the exclusion forbids.
+                // Offering an excluded name would let it be selected as a non-captured event,
+                // committing the value the exclusion forbids.
                 if (excludedProperties?.includes(trimmedSearch)) {
                     return false
                 }

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -519,7 +519,8 @@ export interface infiniteListLogicMeta {
         ) => TaxonomicDefinitionTypes[]
         contextFilteredPinnedItems: (
             pinnedFilterItems: TaxonomicDefinitionTypes[],
-            taxonomicGroupTypes: TaxonomicFilterGroupType[]
+            taxonomicGroupTypes: TaxonomicFilterGroupType[],
+            excludedProperties: import('lib/components/TaxonomicFilter/types').TaxonomicFilterGroupValueMap | undefined
         ) => TaxonomicDefinitionTypes[]
         isSoleSubstantiveGroup: (
             listGroupType: TaxonomicFilterGroupType,
@@ -1135,11 +1136,17 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 ),
         ],
         contextFilteredPinnedItems: [
-            (s) => [s.pinnedFilterItems, s.taxonomicGroupTypes],
+            (s) => [
+                s.pinnedFilterItems,
+                s.taxonomicGroupTypes,
+                (_, props: InfiniteListLogicProps) => props.excludedProperties,
+            ],
             (
                 pinnedFilterItems: TaxonomicDefinitionTypes[],
-                taxonomicGroupTypes: TaxonomicFilterGroupType[]
-            ): TaxonomicDefinitionTypes[] => filterPinnedForContext(pinnedFilterItems, taxonomicGroupTypes),
+                taxonomicGroupTypes: TaxonomicFilterGroupType[],
+                excludedProperties: ExcludedProperties | undefined
+            ): TaxonomicDefinitionTypes[] =>
+                filterPinnedForContext(pinnedFilterItems, taxonomicGroupTypes, excludedProperties),
         ],
         // This list is the filter's only substantive (non-meta) group. There are no separate
         // Recent/Pinned tabs leading the filter, so this list floats recent/pinned items to

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -562,7 +562,8 @@ export interface infiniteListLogicMeta {
             listGroupType: TaxonomicFilterGroupType,
             searchQuery: string,
             isLoading: boolean,
-            results: QuickFilterItem[] | (SkeletonItem | TaxonomicDefinitionTypes)[]
+            results: QuickFilterItem[] | (SkeletonItem | TaxonomicDefinitionTypes)[],
+            excludedProperties: string[] | undefined
         ) => boolean
         suggestedFiltersSettling: (
             isSuggestedFilters: boolean,
@@ -1255,13 +1256,21 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
             },
         ],
         showNonCapturedEventOption: [
-            (s) => [s.allowNonCapturedEvents, s.listGroupType, s.searchQuery, s.isLoading, s.results],
+            (s) => [
+                s.allowNonCapturedEvents,
+                s.listGroupType,
+                s.searchQuery,
+                s.isLoading,
+                s.results,
+                s.excludedProperties,
+            ],
             (
                 allowNonCapturedEvents: boolean,
                 listGroupType: TaxonomicFilterGroupType,
                 searchQuery: string,
                 isLoading: boolean,
-                results: TaxonomicDefinitionTypes[]
+                results: TaxonomicDefinitionTypes[],
+                excludedProperties: string[] | undefined
             ): boolean => {
                 if (!allowNonCapturedEvents) {
                     return false
@@ -1272,7 +1281,13 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 ) {
                     return false
                 }
-                if (searchQuery.trim().length === 0 || isLoading) {
+                const trimmedSearch = searchQuery.trim()
+                if (trimmedSearch.length === 0 || isLoading) {
+                    return false
+                }
+                // A name this picker excludes is not an uncaptured event: offering it would commit
+                // the value the exclusion forbids.
+                if (excludedProperties?.includes(trimmedSearch)) {
                     return false
                 }
                 // Keyword-shortcut QuickFilterItems don't represent captured events — ignore them

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -377,11 +377,12 @@ export function TaxonomicFilterMenu({
             mapShortcutItems(
                 filterPinnedForContext(
                     pinnedFilterItems as TaxonomicDefinitionTypes[],
-                    taxonomicGroupTypes
+                    taxonomicGroupTypes,
+                    excludedProperties
                 ) as ShortcutItem[],
                 groups
             ),
-        [pinnedFilterItems, taxonomicGroupTypes, groups]
+        [pinnedFilterItems, taxonomicGroupTypes, groups, excludedProperties]
     )
 
     const hasDwh = groups.some((g) => g.type === TaxonomicFilterGroupType.DataWarehouse)

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
@@ -136,12 +136,28 @@ describe('suggestedContextFilters', () => {
     })
 
     describe.each([
-        ['only in-scope kept', [pinned(Events, 'a'), pinned(Cohorts, 'c')], [Events], ['a']],
-        ['all out-of-scope dropped', [pinned(Cohorts, 'c')], [Events], []],
-        ['empty input', [], [Events], []],
-    ])('filterPinnedForContext — %s', (_label, items, types, expected) => {
+        ['only in-scope kept', [pinned(Events, 'a'), pinned(Cohorts, 'c')], [Events], undefined, ['a']],
+        ['all out-of-scope dropped', [pinned(Cohorts, 'c')], [Events], undefined, []],
+        ['empty input', [], [Events], undefined, []],
+        // A pin outlives the picker it was made in, so without this the Pinned tab is a second door
+        // to selecting a value the exclusion forbids.
+        [
+            'excluded value dropped',
+            [pinned(Events, '$exception'), pinned(Events, 'checkout_started')],
+            [Events],
+            { [Events]: ['$exception'] },
+            ['checkout_started'],
+        ],
+        [
+            'exclusion applies only to its own group',
+            [pinned(Events, '$exception'), pinned(Cohorts, '$exception')],
+            [Events, Cohorts],
+            { [Events]: ['$exception'] },
+            ['$exception'],
+        ],
+    ])('filterPinnedForContext — %s', (_label, items, types, excludedProperties, expected) => {
         it('matches the expected in-scope set', () => {
-            expect(names(filterPinnedForContext(items, types))).toEqual(expected)
+            expect(names(filterPinnedForContext(items, types, excludedProperties))).toEqual(expected)
         })
     })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
@@ -52,16 +52,24 @@ export function filterRecentsForContext(
     return expandRecentsForDisplay(inScope, selectingKeyOnly)
 }
 
-/** Pinned items whose source group is one of the picker's groups. */
+/** Pinned items whose source group is one of the picker's groups, with the group's
+ *  excluded values dropped. */
 export function filterPinnedForContext(
     pinnedFilterItems: TaxonomicDefinitionTypes[],
-    taxonomicGroupTypes: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes: TaxonomicFilterGroupType[],
+    excludedProperties?: ExcludedProperties
 ): TaxonomicDefinitionTypes[] {
     if (!pinnedFilterItems?.length) {
         return []
     }
     const availableTypes = new Set(taxonomicGroupTypes)
-    return pinnedFilterItems.filter(
-        (item) => hasPinnedContext(item) && availableTypes.has(item._pinnedContext.sourceGroupType)
-    )
+    return pinnedFilterItems.filter((item) => {
+        if (!hasPinnedContext(item) || !availableTypes.has(item._pinnedContext.sourceGroupType)) {
+            return false
+        }
+        // A pin outlives the picker it was made in, so a value pinned elsewhere reaches a picker
+        // that forbids it. Recents drop excluded values for the same reason.
+        const excludedValues = excludedProperties?.[item._pinnedContext.sourceGroupType]
+        return !(excludedValues?.length && excludedValues.includes(item._pinnedContext.value))
+    })
 }


### PR DESCRIPTION
## Problem

Someone building a transformation could add an event filter the transformation is not allowed to have, through three separate doors.

**Searching for it.** Transformation filters exclude `$exception` and let you pick events you have not sent yet. Searching `$exception` there offered "Select event: $exception - Not seen yet", and picking it committed the filter the exclusion exists to prevent. The label was wrong too: most teams do send `$exception`, so the picker called a captured event uncaptured.

**Pinning it.** A pin is stored per team and outlives the picker it was made in. Someone who pinned `$exception` anywhere saw it in the Pinned tab of a transformation matcher and could select it there.

**Typing it.** The autocomplete shortcut row offered the same pinned value, through a separate code path from the Pinned tab.

Recents already dropped excluded values. Pinned items never did, on any of these surfaces.

## Changes

- Searching for an excluded name no longer offers to create it as an uncaptured event. Every other search behaves as before.
- An excluded name is refused even when the search returns nothing. A name that is merely absent still gets the offer.
- The Pinned tab and the autocomplete shortcuts drop values the picker excludes, matching what Recents already did.
- The guards land in both picker implementations, since the menu rebuild reimplements this layer rather than sharing it.
- Mechanical: a comment fix in `.agents/skills/modifying-taxonomic-filter/SKILL.md`, and a parameter renamed to match what kea-typegen generates.

Every change removes a row, so there is no before-and-after screenshot to show. You see a difference only when you search for an excluded name, or when one is pinned.

Both picker implementations are reachable from the affected call site. The legacy `InfiniteList` draws the offer row. The rebuild menu does not draw that row yet. The same value feeds its `showEmptyState`, so an excluded search there used to suppress "no results" and showed a blank list.

## How did you test this code?

Automated tests only. This ran in a worktree with no dev stack, so the picker was not exercised by hand.

For the search path, two parameterized tests, one per implementation. Each asserts the excluded name is refused and an ordinary unseen name is still offered:

- `infiniteListLogic.test.ts` covers the legacy selector.
- `useGroupList.test.tsx` extends the existing `allowNonCapturedEvents` test rather than adding a standalone one.

For the pinned path:

- A legacy selector test with a pinned `$exception`.
- Two cases on the shared util, covering an excluded value and an exclusion that must not leak across group types.
- A parameterized test on `useTaxonomicAutocompleteShortcutItems` for the autocomplete row.

No existing test caught any of these. Nothing combined `excludedProperties` with `allowNonCapturedEvents` before, which is the exact pair that produced the bug. Each new test was checked by disabling the guard it covers and confirming that only the excluded case fails.

Not checked: whether the backend honors the `excluded_properties` search param it already receives. That is a separate concern about real result rows, not about this offer.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`.agents/skills/modifying-taxonomic-filter/SKILL.md` said call sites that build their own popover never see the rebuild menu, naming `ActionFilterRow`. That is wrong. `ActionFilterRow` renders `TaxonomicPopover`, whose `newMenuSupportsCallSite` gate holds for its call. So it does reach the rebuild. The passage now explains that reachability depends on the wrapper and on the props a call site passes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) via the `/go` pipeline, resuming a branch that already had its first implementation commit. Skills invoked: `/modifying-taxonomic-filter`, `/simplify`, `/comment-cleanup`, `/writing-pr-descriptions`, `/create-pr`, `/explain-open`, `/plain-writing`, `/followup`.

The pinned and autocomplete gaps both came from review rather than from the original plan. An automated review round found the pinned gap and declined to fix it unattended, leaving the scope call to a person, who chose to fold it in. Two reviewers then found a flaw in the first autocomplete fix. It read the resolved group's `excludedProperties`, which `buildTaxonomicGroups` populates for only four group types, so an exclusion on any other group never reached it.

Another session pushed to this branch mid-work, fixing the same autocomplete gap with a wider check. It reads both the resolved group and the root map. That check is the better one: for `EventProperties`, the group array is a superset of the root map. Its commit was kept, and this work rebased onto it, adding a null guard and the test it lacked.

Two corrections along the way. The first commit message said destination filters exclude `$exception`; it is transformations, gated at `HogFunctionFilters.tsx:157`. A CI drift failure was first reported as unrelated to this branch, and it was not: kea-typegen regenerates a hand-named parameter, so the name had to match its output.

Two review suggestions were declined:

- Routing the new legacy test through the file's `logicWith` helper. Inline construction is that file's dominant pattern, at 26 sites against 8.
- Keying the `useGroupList` memo on the file's stable `excludedPropertiesKey`. Oxlint's exhaustive-deps rule rejects that swap in both directions, and the memo body is one array filter.

Four follow-ups are tracked outside this PR:

- Pinned and recent items still ignore `propertyAllowList`. A reviewer escalated this, and a person decided to warn rather than hard-drop, matching what web analytics already does.
- `AddEventButton.tsx` has the same bug class through its own onChange guard.
- The decision this PR mirrors by hand across five sites could move into a shared `utils/` helper.
- One `as string` cast remains, on a branch no current group type can reach.
