### PR TITLE
fix(flags): clarify the feature flag taxonomy descriptions

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1597,7 +1597,7 @@
             "label": "External click URL"
         },
         "$feature_flag": {
-            "description": "The feature flag that was called.\n\nWarning! This only works in combination with the $feature_flag_called event. If you want to filter other events, try \"Active feature flags\".",
+            "description": "The key of the feature flag that was evaluated, sent only on \"Feature flag called\" events. To find other events where a flag was active, use \"Active feature flags\".",
             "examples": [
                 "beta-feature"
             ],
@@ -2321,6 +2321,17 @@
         "$mcp_response": {
             "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
             "label": "MCP response"
+        },
+        "$mcp_scope_preset": {
+            "description": "Which kind of caller minted the token behind an MCP request, worked out from its scope set. 'scout' is a Signals scout run, 'research' is a read-only report-research run, 'implementation' is a write-capable implementation run, 'sandbox' is any other server-minted run (a task started from the desktop app or the pipeline before the scratchpad scopes tell research and implementation apart), and 'user' is a person's own token. Stamped on every event by PostHog's own MCP server. Use it to split scratchpad and notes usage by caller, for example to measure scout scratchpad adoption apart from ordinary users.",
+            "examples": [
+                "scout",
+                "research",
+                "implementation",
+                "sandbox",
+                "user"
+            ],
+            "label": "MCP scope preset"
         },
         "$mcp_server_name": {
             "description": "The advertised name of the MCP server that handled the request.",
@@ -4006,10 +4017,7 @@
             "label": "Feature enrollment"
         },
         "$feature_flag_called": {
-            "description": "The feature flag that was called.\n\nWarning! This only works in combination with the $feature_flag event. If you want to filter other events, try \"Active feature flags\".",
-            "examples": [
-                "beta-feature"
-            ],
+            "description": "Sent when a feature flag is evaluated. The flag key is in the \"Feature flag\" property, and the value it returned is in \"Feature flag response\".",
             "ignored_in_assistant": true,
             "label": "Feature flag called",
             "primary_property": "$feature_flag"
@@ -4542,6 +4550,17 @@
         "$mcp_response": {
             "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
             "label": "MCP response"
+        },
+        "$mcp_scope_preset": {
+            "description": "Which kind of caller minted the token behind an MCP request, worked out from its scope set. 'scout' is a Signals scout run, 'research' is a read-only report-research run, 'implementation' is a write-capable implementation run, 'sandbox' is any other server-minted run (a task started from the desktop app or the pipeline before the scratchpad scopes tell research and implementation apart), and 'user' is a person's own token. Stamped on every event by PostHog's own MCP server. Use it to split scratchpad and notes usage by caller, for example to measure scout scratchpad adoption apart from ordinary users.",
+            "examples": [
+                "scout",
+                "research",
+                "implementation",
+                "sandbox",
+                "user"
+            ],
+            "label": "MCP scope preset"
         },
         "$mcp_server_name": {
             "description": "The advertised name of the MCP server that handled the request.",
@@ -6177,7 +6196,7 @@
             "label": "External click URL"
         },
         "$feature_flag": {
-            "description": "The feature flag that was called.\n\nWarning! This only works in combination with the $feature_flag_called event. If you want to filter other events, try \"Active feature flags\".",
+            "description": "The key of the feature flag that was evaluated, sent only on \"Feature flag called\" events. To find other events where a flag was active, use \"Active feature flags\".",
             "examples": [
                 "beta-feature"
             ],
@@ -7318,6 +7337,17 @@
         "$mcp_response": {
             "description": "The response the MCP server returned. Large strings and sensitive keys are redacted before capture.",
             "label": "MCP response"
+        },
+        "$mcp_scope_preset": {
+            "description": "Which kind of caller minted the token behind an MCP request, worked out from its scope set. 'scout' is a Signals scout run, 'research' is a read-only report-research run, 'implementation' is a write-capable implementation run, 'sandbox' is any other server-minted run (a task started from the desktop app or the pipeline before the scratchpad scopes tell research and implementation apart), and 'user' is a person's own token. Stamped on every event by PostHog's own MCP server. Use it to split scratchpad and notes usage by caller, for example to measure scout scratchpad adoption apart from ordinary users.",
+            "examples": [
+                "scout",
+                "research",
+                "implementation",
+                "sandbox",
+                "user"
+            ],
+            "label": "MCP scope preset"
         },
         "$mcp_server_name": {
             "description": "The advertised name of the MCP server that handled the request.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1597,7 +1597,7 @@
             "label": "External click URL"
         },
         "$feature_flag": {
-            "description": "The key of the feature flag that was evaluated, sent only on \"Feature flag called\" events. To find other events where a flag was active, use \"Active feature flags\".",
+            "description": "The key of the feature flag, sent on \"Feature flag called\" and \"Feature enrollment\" events. To find other events where a flag was active, use \"Active feature flags\".",
             "examples": [
                 "beta-feature"
             ],
@@ -6196,7 +6196,7 @@
             "label": "External click URL"
         },
         "$feature_flag": {
-            "description": "The key of the feature flag that was evaluated, sent only on \"Feature flag called\" events. To find other events where a flag was active, use \"Active feature flags\".",
+            "description": "The key of the feature flag, sent on \"Feature flag called\" and \"Feature enrollment\" events. To find other events where a flag was active, use \"Active feature flags\".",
             "examples": [
                 "beta-feature"
             ],

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -176,10 +176,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$feature_flag_called": {
             "label": "Feature flag called",
-            "description": (
-                'The feature flag that was called.\n\nWarning! This only works in combination with the $feature_flag event. If you want to filter other events, try "Active feature flags".'
-            ),
-            "examples": ["beta-feature"],
+            "description": 'Sent when a feature flag is evaluated. The flag key is in the "Feature flag" property, and the value it returned is in "Feature flag response".',
             "ignored_in_assistant": True,  # Mostly irrelevant product-wise
             "primary_property": "$feature_flag",
         },
@@ -1744,7 +1741,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$feature_flag": {
             "label": "Feature flag",
-            "description": 'The feature flag that was called.\n\nWarning! This only works in combination with the $feature_flag_called event. If you want to filter other events, try "Active feature flags".',
+            "description": 'The key of the feature flag that was evaluated, sent only on "Feature flag called" events. To find other events where a flag was active, use "Active feature flags".',
             "examples": ["beta-feature"],
         },
         "$feature_flag_reason": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1741,7 +1741,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$feature_flag": {
             "label": "Feature flag",
-            "description": 'The key of the feature flag that was evaluated, sent only on "Feature flag called" events. To find other events where a flag was active, use "Active feature flags".',
+            "description": 'The key of the feature flag, sent on "Feature flag called" and "Feature enrollment" events. To find other events where a flag was active, use "Active feature flags".',
             "examples": ["beta-feature"],
         },
         "$feature_flag_reason": {


### PR DESCRIPTION
## Problem

Anyone filtering events by the "Feature flag" property was told to stop using it, by a warning that had the property backwards.

- The description read "The feature flag that was called", which describes an event, and never said the property holds the flag key.
- It claimed the property only works with the `$feature_flag_called` event. The property also rides `$feature_enrollment_update`: PostHog's own Early Access Features page filters on exactly that pairing, in [the CDP destination filter](https://github.com/PostHog/posthog/blob/e51fb6239619/products/early_access_features/frontend/EarlyAccessFeature.tsx#L208-L224) and [the opted-in person list](https://github.com/PostHog/posthog/blob/e51fb6239619/products/early_access_features/frontend/EarlyAccessFeature.tsx#L811-L830).
- The "Feature flag called" event carried a copy of that same text with the property names swapped. It described an event as a flag key, then warned the event only works alongside `$feature_flag`, a property always present on it.
- That event also offered `beta-feature` as an example of itself. That is a flag key, and `DefinitionPopover.tsx:153` renders it to users as "Example: beta-feature".

These strings reach the taxonomic filter, the definition popovers, and Max. `ee/hogai/summarizers/property_filters.py:113` feeds the description into the taxonomy prompt, and `$feature_flag` has no `description_llm` override, so Max planned against the wrong constraint too.

## Changes

- The "Feature flag" property now names the flag key and names both events that carry it, so the Early Access Features filter no longer reads as impossible.
- Its pointer to "Active feature flags" now says those events are ones where a flag was active, matching what that property holds.
- The "Feature flag called" event now says when it fires and where to find the flag key and the returned value.
- The definition popover stops showing "Example: beta-feature" for the "Feature flag called" event. The property keeps that example, which is where a flag key belongs.
- Regenerating `core-filter-definitions-by-group.json` also picks up `$mcp_scope_preset`, which reached `taxonomy.py` in #91361 without a matching build. Those three hunks carry no source change and can be skipped when reviewing.

Text only. No logic changes.

> [!NOTE]
> `$experiment_exposure` also carries `$feature_flag`, but `EXPERIMENT_EXPOSURE_DUPLICATION_TEAMS` defaults to empty, so no team sends it today. The description needs revisiting when that rollout widens.

### Before and after

| Entry | Before | After |
| --- | --- | --- |
| `$feature_flag` property | "The feature flag that was called. Warning! This only works in combination with the $feature_flag_called event…" | "The key of the feature flag, sent on "Feature flag called" and "Feature enrollment" events…" |
| `$feature_flag_called` event | "The feature flag that was called. Warning! This only works in combination with the $feature_flag event…" | "Sent when a feature flag is evaluated. The flag key is in the "Feature flag" property…" |

No screenshots: the change is the text of two taxonomy entries, and the surfaces that render them are unchanged.

## How did you test this code?

- `hogli test posthog/taxonomy/test/` passes. No test asserted the old strings, so none needed updating.
- Running `bin/build-taxonomy-json.py` twice produces a byte-identical file, so the committed JSON is exact generator output.
- `hogli ci:preflight --strict` reports zero failures.
- No new tests. These are description strings with no branching behavior, so a test asserting the copy would only restate it and would fail on the next deliberate wording change.
- Not checked: the rendered popover in a running app, and the repo-wide mypy run that CI performs.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/simplify`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/create-pr`, `/review-code`.

The session started from the opposite premise: that the original warning was stale because `$feature_flag` rides every event while a flag is active. Reading the code showed that belief conflated it with `$feature/<key>` and `$active_feature_flags`, which are the properties stamped on every event. So the constraint was kept and the framing fixed. A later review pass found the constraint was still too narrow, because it missed `$feature_enrollment_update`. The first commit's wording was wrong in that direction, and the second commit corrects it.

Follow-ups found while reviewing, none of them in this PR:

- The taxonomy JSON drift check is commented out at `.github/workflows/ci-python.yml:257-261`, and `hogli ci:preflight` has no equivalent, so nothing catches a `taxonomy.py` edit that ships without regenerating. #91361 is the live example.
- `$client_session_initial_utm_content` (`taxonomy.py:1902-1906`) has the same copy-paste defect this PR fixes: it is labeled "Initial UTM source" with a UTM Source description, while its examples belong to `utm_content`.
- 19 of 43 person-property descriptions derived at `taxonomy.py:3928-3960` lack terminal punctuation, so they render as run-ons: "Google Click ID Data from the first time this user was seen."

Nothing here draws on non-public material. Every fact came from this repository.
