### PR TITLE
fix(honeybadger): follow relative pagination links

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/honeybadger/honeybadger.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/honeybadger/honeybadger.py
@@ -3,7 +3,7 @@ import dataclasses
 from collections.abc import Iterator
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode, urljoin, urlparse
 
 import requests
 from structlog.types import FilteringBoundLogger
@@ -84,15 +84,20 @@ def _to_unix_timestamp(value: Any) -> int:
     reraise=True,
 )
 def _fetch_page(session: requests.Session, url: str, logger: FilteringBoundLogger) -> dict:
+    # Honeybadger paginates with a root-relative `links.next` (e.g. /v2/projects/1/faults?page=2),
+    # so resolve against the API base before validating the origin. A foreign absolute URL keeps
+    # its own netloc through urljoin, so it is still refused below.
+    resolved_url = urljoin(HONEYBADGER_BASE_URL, url)
+
     # Every fetched URL — including `links.next` from responses and resume URLs replayed from
     # Redis — must stay on the Honeybadger API origin: the session carries the user's token as
     # Basic auth, so following a foreign URL would hand the credential to that host (and is an
     # SSRF primitive).
-    parsed = urlparse(url)
+    parsed = urlparse(resolved_url)
     if parsed.scheme != _API_ORIGIN.scheme or parsed.netloc != _API_ORIGIN.netloc:
         raise ValueError(f"Refusing to fetch non-Honeybadger URL: {url}")
 
-    response = session.get(url, timeout=REQUEST_TIMEOUT)
+    response = session.get(resolved_url, timeout=REQUEST_TIMEOUT)
 
     # Honeybadger signals both auth failure and rate-limit exhaustion with a 403; only the
     # rate-limited one carries an exhausted X-RateLimit-Remaining header. Sleep toward the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/honeybadger/tests/test_honeybadger.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/honeybadger/tests/test_honeybadger.py
@@ -201,6 +201,17 @@ class TestHoneybadger:
             _fetch_page_once(session, url, MagicMock())
         session.get.assert_not_called()
 
+    def test_fetch_page_resolves_relative_next_url(self) -> None:
+        # Honeybadger's `links.next` is root-relative; it must be resolved against the API base
+        # and fetched, not refused as off-origin.
+        session = MagicMock()
+        session.get.return_value = _response({"results": [{"id": 1}]})
+        result = _fetch_page_once(session, "/v2/projects/1/faults?limit=25&page=2", MagicMock())
+        assert result == {"results": [{"id": 1}]}
+        session.get.assert_called_once_with(
+            f"{HONEYBADGER_BASE_URL}/projects/1/faults?limit=25&page=2", timeout=mock.ANY
+        )
+
     @pytest.mark.parametrize(("status", "expected"), [(200, True), (403, False)])
     def test_validate_credentials(self, status: int, expected: bool) -> None:
         session = MagicMock()


### PR DESCRIPTION
## Problem

- A Honeybadger warehouse sync fails on the second page of any list that spans more than one page, so accounts with more than 25 faults, projects, or notices never finish importing.
- The [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a054bc-2315-7252-a327-eb92e90fe183) shows a `ValueError` from `_fetch_page`, affecting several teams.
- Honeybadger paginates with a root-relative `links.next` (for example `/v2/projects/<id>/faults?limit=25&page=2`).
- The origin guard in `_fetch_page` parsed that relative URL as-is, saw an empty scheme and netloc, and refused it as off-origin.

## Changes

- The sync now follows relative pagination links and walks every page.
- `_fetch_page` resolves the URL against the Honeybadger API base with `urljoin` before the origin check.
- The SSRF guard is unchanged in effect: a foreign absolute URL keeps its own netloc through `urljoin`, so it is still refused before the credentialed session is used.

## How did you test this code?

- Added `test_fetch_page_resolves_relative_next_url`: a root-relative `links.next` is resolved to the absolute API URL and fetched, rather than raising `ValueError`. No existing test covered a relative next link; the off-origin refusal tests only asserted foreign absolute URLs stay rejected, which still holds.
- Ran the source's test module locally; the new case and the existing origin-refusal and pagination tests pass.
- Not run: the full warehouse import suite against a live Honeybadger account, which this environment cannot reach.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the linked error tracking issue. Confirmed the failure originates in `honeybadger.py:_fetch_page`, read the pagination and resumable-state code paths, and classified it as a fixable bug rather than a user or upstream error: the refused URL is a legitimate Honeybadger pagination link, not a credential or permission failure.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
