### PR TITLE
fix(warehouse-sources): stop a lone 403 from blaming a working API key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/source.py
@@ -75,14 +75,29 @@ You can find your API key on the **Developer** page of the [Decagon dashboard](h
         return CANONICAL_DESCRIPTIONS
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
+        # Insertion order matters: the finalization activity surfaces the first matching
+        # pattern's message, so endpoint-specific 403 entries must precede the bare 403 one.
+        # A bare 403 does not establish a key problem, because the same key keeps syncing
+        # sibling tables when Decagon gates an endpoint on an account plan (#87958). The 403
+        # messages therefore point the operator at the sibling-table check instead of the key.
         return {
             "401 Client Error: Unauthorized": (
                 "Decagon rejected the API key. Generate a new key on the Developer page of the "
                 "Decagon dashboard and reconnect."
             ),
+            "403 Client Error: Forbidden for url: https://api.decagon.ai/agent_assist": (
+                "Decagon refused access to the Agent Assist export. If your other Decagon tables "
+                "are syncing, the API key works and your Decagon plan likely does not include "
+                "Agent Assist. Ask Decagon to enable it, then re-enable the sync. If every table "
+                "is failing, generate a new key on the Developer page of the Decagon dashboard "
+                "and reconnect."
+            ),
             "403 Client Error: Forbidden": (
-                "The Decagon API key does not have access to the endpoint behind this table. Check "
-                "the key on the Developer page of the Decagon dashboard and reconnect."
+                "Decagon refused access to the endpoint behind this table. If your other Decagon "
+                "tables are syncing, the API key works and your Decagon plan likely does not "
+                "include this endpoint. Ask Decagon to enable it, then re-enable the sync. If "
+                "every table is failing, generate a new key on the Developer page of the Decagon "
+                "dashboard and reconnect."
             ),
         }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/decagon/tests/test_decagon_source.py
@@ -97,6 +97,43 @@ class TestDecagonSource:
         # exception noise.
         assert error_message_matches(error_msg, self.source.get_retryable_errors())
 
+    @parameterized.expand(
+        [
+            (
+                "agent_assist_403_names_the_plan_gate",
+                "403 Client Error: Forbidden for url: "
+                "https://api.decagon.ai/agent_assist/actions/export?min_timestamp=0",
+                "Agent Assist",
+            ),
+            (
+                "other_endpoint_403_keeps_the_generic_message",
+                "403 Client Error: Forbidden for url: https://api.decagon.ai/tag/all",
+                "endpoint behind this table",
+            ),
+            (
+                "401_still_maps_to_the_key_message",
+                "401 Client Error: Unauthorized for url: https://api.decagon.ai/conversation/export",
+                "rejected the API key",
+            ),
+        ]
+    )
+    def test_non_retryable_errors_surface_the_most_specific_message(
+        self, _name: str, error_msg: str, expected_fragment: str
+    ) -> None:
+        # Mirrors the finalization activity: the first matching pattern in insertion order
+        # decides the message the operator sees, so the agent_assist entry must win over the
+        # bare 403 fallback for its own URL and lose it for every other endpoint.
+        friendly = next(
+            (
+                message
+                for pattern, message in self.source.get_non_retryable_errors().items()
+                if error_message_matches(error_msg, [pattern])
+            ),
+            None,
+        )
+        assert friendly is not None
+        assert expected_fragment in friendly
+
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.decagon.source.validate_decagon_credentials"
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/source.py
@@ -85,7 +85,10 @@ You can create an API key in your Northpass admin panel under **Apps → API Acc
             # An invalid or revoked API key surfaces as an HTTPError when the REST client calls
             # `raise_for_status()`. Retrying can never satisfy a credential problem, so stop the sync.
             "401 Client Error: Unauthorized for url: https://api.northpass.com": "Your Northpass API key is invalid or has been revoked. Create a new key in your Northpass admin panel under Apps → API Access, then reconnect.",
-            "403 Client Error: Forbidden for url: https://api.northpass.com": "Your Northpass API key does not have permission to access this data. Check the key's permissions in your Northpass admin panel, then reconnect.",
+            # A bare 403 does not establish a key problem, because the same key keeps syncing
+            # sibling tables when Northpass gates an endpoint on an account plan (#87959). The
+            # message points the operator at the sibling-table check instead of blaming the key.
+            "403 Client Error: Forbidden for url: https://api.northpass.com": "Northpass refused access to the endpoint behind this table. If your other Northpass tables are syncing, the API key works and your Northpass plan likely does not include this endpoint. Ask Northpass support to enable it, then re-enable the sync. If every table is failing, check the key's permissions in your Northpass admin panel, then reconnect.",
         }
 
     def get_schemas(


### PR DESCRIPTION
## Problem

An operator whose Decagon or Northpass LMS source has one table failing with 403 reads "the API key does not have access", while sibling tables keep syncing on that same key.
The advice cannot work: no key change clears a 403 the vendor ties to an account plan, so the auto-disabled table stays down and the operator loops on reconnects.
`get_non_retryable_errors` in each source maps every 403 to one key-blaming string.

Closes #87958
Closes #87959

## Changes

- Operators now read "refused access to the endpoint behind this table", plus the check that separates the two readings: sibling tables syncing means the key works and the plan likely excludes the endpoint.
- The Decagon Agent Assist export gets its own 403 entry naming the Agent Assist plan gate. It sits before the bare 403 fallback because the first matching pattern decides the surfaced message.
- Northpass keeps its single 403 pattern with the reworded message.
- No sync behavior changes; both 403 shapes stay non-retryable. The diff is message text, one added pattern, and a test.
- A live "N sibling tables synced" figure needs the shared finalization activity, outside the scope both issues set, so the message names the check instead.

## How did you test this code?

- Added one parameterized case set to `test_decagon_source.py`. It fails if the bare 403 fallback shadows the Agent Assist entry (a dict reorder), or if either pattern stops matching the observed error text.
- The existing Northpass matching test covers its unchanged 403 pattern.
- Ran both source test files, ruff, and the repo semgrep rules on the changed files.
- Not run: repo-wide mypy. The change is string literals and a test; no signatures changed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The old message text appears in no doc under `docs/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by an agent in PostHog Desktop, directed by Jake Sciotto (assignee left unset because the session cannot verify a GitHub handle).
Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
Scope decision: both issues describe the same defect in two sources, so one PR carries both; the sibling-status lookup stayed out (framework scope).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
