### PR TITLE
feat(desktop): enforce disabled tools in agent sessions

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -2692,7 +2692,11 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
       mcpServers,
       permissionMode,
       posthogExecPermissionRegex,
-      canUseTool: this.createCanUseTool(sessionId, meta?.allowedDomains),
+      canUseTool: this.createCanUseTool(
+        sessionId,
+        meta?.allowedDomains,
+        meta?.disabledTools,
+      ),
       logger: this.logger,
       systemPrompt,
       userProvidedOptions: meta?.claudeCode?.options,
@@ -2707,6 +2711,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
         ...(params.additionalDirectories ?? meta?.additionalRoots ?? []),
       ],
       disableBuiltInTools: meta?.disableBuiltInTools,
+      disabledTools: meta?.disabledTools,
       outputFormat,
       settingsManager,
       onModeChange: this.createOnModeChange(),
@@ -2979,6 +2984,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
   private createCanUseTool(
     sessionId: string,
     allowedDomains?: string[],
+    disabledTools?: string[],
   ): CanUseTool {
     return async (toolName, toolInput, { suggestions, toolUseID, signal }) =>
       canUseTool({
@@ -2996,6 +3002,7 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
           this.updateConfigOption(configId, value),
         applySessionMode: (modeId: string) => this.applySessionMode(modeId),
         allowedDomains,
+        disabledTools,
         emittedToolCalls: this.emittedToolCalls,
         supportsTerminalOutput:
           (

--- a/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -94,6 +94,18 @@ describe("canUseTool MCP approval enforcement", () => {
     }
   });
 
+  it("denies disabled web tools before a permission prompt", async () => {
+    const context = createContext("WebFetch", {
+      toolInput: { url: "https://example.com" },
+      disabledTools: ["WebFetch", "WebSearch"],
+    });
+
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("deny");
+    expect(context.client.requestPermission).not.toHaveBeenCalled();
+  });
+
   it("routes needs_approval MCP tools to permission dialog with descriptive title", async () => {
     setMcpToolApprovalStates({
       mcp__HubSpot__search_crm_objects: "needs_approval",

--- a/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -77,6 +77,7 @@ interface ToolHandlerContext {
   updateConfigOption: (configId: string, value: string) => Promise<void>;
   applySessionMode: (modeId: string) => Promise<void>;
   allowedDomains?: string[];
+  disabledTools?: string[];
   /** Shared with the streamed tool_use path; first emitter wins. */
   emittedToolCalls?: Set<string>;
   supportsTerminalOutput?: boolean;
@@ -804,9 +805,16 @@ function isDomainAllowed(hostname: string, allowedDomains: string[]): boolean {
 export async function canUseTool(
   context: ToolHandlerContext,
 ): Promise<ToolPermissionResult> {
-  const { toolName, toolInput, session, allowedDomains } = context;
+  const { toolName, toolInput, session, allowedDomains, disabledTools } =
+    context;
 
   recordPlanFile(context);
+
+  if (disabledTools?.includes(toolName)) {
+    const message = `Tool "${toolName}" is disabled for this session.`;
+    await emitToolDenial(context, message);
+    return { behavior: "deny", message, interrupt: false };
+  }
 
   // Enforce domain allowlist for web tools
   if (allowedDomains && allowedDomains.length > 0) {

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -49,6 +49,18 @@ function makeParams() {
 }
 
 describe("buildSessionOptions", () => {
+  it("structurally disallows server-owned web tool denials even in bypass mode", () => {
+    const options = buildSessionOptions({
+      ...makeParams(),
+      permissionMode: "bypassPermissions",
+      disabledTools: ["WebFetch", "WebSearch"],
+      userProvidedOptions: { disallowedTools: ["Read"] },
+    });
+
+    expect(options.disallowedTools).toEqual(
+      expect.arrayContaining(["Read", "WebFetch", "WebSearch"]),
+    );
+  });
   it("replaces unprocessable Read images before model delivery", async () => {
     const options = buildSessionOptions(makeParams());
     const hooks = (options.hooks?.PostToolUse ?? []).flatMap(

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -91,6 +91,7 @@ export interface BuildOptionsParams {
   forkSession?: boolean;
   additionalDirectories?: string[];
   disableBuiltInTools?: boolean;
+  disabledTools?: string[];
   outputFormat?: OutputFormat;
   settingsManager: SettingsManager;
   onModeChange?: OnModeChange;
@@ -536,6 +537,10 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     allowDangerouslySkipPermissions: !IS_ROOT || !!process.env.IS_SANDBOX,
     permissionMode: toSdkPermissionMode(params.permissionMode),
     canUseTool: params.canUseTool,
+    disallowedTools: [
+      ...(params.userProvidedOptions?.disallowedTools ?? []),
+      ...(params.disabledTools ?? []),
+    ],
     tools,
     agents,
     extraArgs: {

--- a/products/desktop/packages/agent/src/adapters/claude/types.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/types.ts
@@ -222,6 +222,7 @@ export type NewSessionMeta = {
   persistence?: { taskId?: string; runId?: string; logUrl?: string };
   additionalRoots?: string[];
   allowedDomains?: string[];
+  disabledTools?: string[];
   /** Model ID to use for this session (e.g. "claude-sonnet-4-6") */
   model?: string;
   /** Context window choice for 1M-capable models; unset means the 1M default. */

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -2011,6 +2011,7 @@ export class AgentServer {
       systemPrompt: sessionSystemPrompt,
       ...(this.config.model && { model: this.config.model }),
       allowedDomains: this.config.allowedDomains,
+      disabledTools: this.config.disabledTools,
       jsonSchema: preTask?.json_schema ?? null,
       permissionMode: initialPermissionMode,
       ...(channelMode && { channelMode: true }),

--- a/products/desktop/packages/agent/src/server/bin.ts
+++ b/products/desktop/packages/agent/src/server/bin.ts
@@ -169,6 +169,7 @@ program
     "--allowedDomains <domains>",
     "Comma-separated list of domains allowed for web tools (WebFetch, WebSearch)",
   )
+  .option("--disableWebTools <boolean>", "Disable WebFetch and WebSearch")
   .action(async (options) => {
     const envResult = envSchema.safeParse(process.env);
 
@@ -224,6 +225,12 @@ program
           .map((d: string) => d.trim())
           .filter(Boolean)
       : undefined;
+    const disabledTools = parseBooleanOption(
+      options.disableWebTools,
+      "--disableWebTools",
+    )
+      ? ["WebFetch", "WebSearch"]
+      : undefined;
 
     if (
       env.POSTHOG_CODE_RUNTIME_ADAPTER &&
@@ -271,6 +278,7 @@ program
       baseBranch: options.baseBranch,
       claudeCode,
       allowedDomains,
+      disabledTools,
       piRpcHostPath: fileURLToPath(
         new URL("../pi/rpc-host.js", import.meta.url),
       ),

--- a/products/desktop/packages/agent/src/server/types.ts
+++ b/products/desktop/packages/agent/src/server/types.ts
@@ -55,6 +55,7 @@ export interface AgentServerConfig {
   baseBranch?: string;
   claudeCode?: ClaudeCodeConfig;
   allowedDomains?: string[];
+  disabledTools?: string[];
   piRpcHostPath?: string;
   runtimeAdapter?: Adapter;
   model?: string;


### PR DESCRIPTION
## Problem

Pulse sandbox runs need a server-owned way to disable web research, even when the agent session bypasses interactive permission prompts.

## Changes

- Agent sessions accept a server-owned disabled-tool list.
- Disabled tools reach both the Claude SDK configuration and the permission boundary.
- Web tools are denied before any permission prompt when the runtime disables them.
- Existing user-configured disabled tools remain intact.

Before:

```mermaid
flowchart LR
    S[Server session] --> A[Claude agent]
    A --> W[Web tools available]
    style S fill:#1D4AFF,color:#fff
    style A fill:#F7A501,color:#111
    style W fill:#EEEFE9,color:#111
```

After:

```mermaid
flowchart LR
    S[Server session] --> P[Disabled-tool policy]
    P --> A[Claude agent]
    A --> D[Web tools denied before prompt]
    style S fill:#1D4AFF,color:#fff
    style P fill:#F7A501,color:#111
    style A fill:#F7A501,color:#111
    style D fill:#2E7D32,color:#fff
```

## How did you test this code?

- `pnpm --filter @posthog/agent test`
- `pnpm --filter @posthog/agent typecheck`
- `pnpm lint` completed with pre-existing warnings only.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No public docs update. This layer enforces the credential-free runtime contract documented in the preceding stack layer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop agent implemented and verified this layer using `/posthog-desktop`, `/qa-team`, `/stacking-prs`, and `/writing-pr-descriptions`.

The desktop enforcement was split from the backend layer so each deployable boundary can be reviewed independently. Test data is synthetic and public-safe.