### PR TITLE
fix(desktop): publish agent to npm from a github-hosted runner

### DIFF
--- a/.github/workflows/desktop-agent-release.yml
+++ b/.github/workflows/desktop-agent-release.yml
@@ -12,7 +12,8 @@ concurrency:
 jobs:
     release:
         name: Publish agent to npm
-        runs-on: depot-ubuntu-24.04-4
+        # npm provenance requires a github-hosted runner; Depot registers as self-hosted
+        runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:
             contents: read


### PR DESCRIPTION
## Problem

Agent releases fail at the npm publish step: v2.4.109 never reached npm ([failing run](https://github.com/PostHog/posthog/actions/runs/33354147909/job/99372978416)).

#91148 moved the release job to a Depot runner. npm rejects provenance publishes from runners that register as self-hosted, so every release since then fails.

## Changes

- The publish job runs on `ubuntu-latest` again, matching the last successful release (v2.4.108).

## How did you test this code?

`bin/hogli lint:workflows` and actionlint pass. Not run: a real release, which needs the next tag cut from master after this merges.