### PR TITLE
fix(cohorts): look up a person's cohorts via HogQL instead of raw SQL

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1292,7 +1292,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             person = get_person_by_pk_or_uuid(self.team_id, request.GET["person_id"], distinct_id_limit=0)
         if person is None:
             raise NotFound()
-        cohort_ids = get_all_cohort_ids_by_person_uuid(str(person.uuid), team.pk)
+        cohort_ids = get_all_cohort_ids_by_person_uuid(str(person.uuid), team)
 
         # nosemgrep: idor-lookup-without-team, idor-taint-user-input-to-model-get (IDs from team-scoped ClickHouse query)
         cohorts = Cohort.objects.filter(pk__in=cohort_ids, deleted=False)

--- a/products/cohorts/backend/models/sql.py
+++ b/products/cohorts/backend/models/sql.py
@@ -43,20 +43,6 @@ FROM (
 SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'auto'
 """
 
-GET_COHORTS_BY_PERSON_UUID = """
-SELECT cohort_id, argMax(version, version) as latest_version
-  FROM cohortpeople
-  WHERE team_id = %(team_id)s AND person_id = %(person_id)s
-  GROUP BY cohort_id
-  HAVING argMax(sign, version) > 0
-"""
-
-GET_STATIC_COHORTPEOPLE_BY_PERSON_UUID = f"""
-SELECT DISTINCT cohort_id
-FROM {PERSON_STATIC_COHORT_TABLE}
-WHERE team_id = %(team_id)s AND person_id = %(person_id)s
-"""
-
 GET_COHORTPEOPLE_BY_COHORT_ID = """
 SELECT DISTINCT person_id
 FROM cohortpeople

--- a/products/cohorts/backend/models/util.py
+++ b/products/cohorts/backend/models/util.py
@@ -18,7 +18,13 @@ from pydantic import ValidationError as PydanticValidationError
 from rest_framework.exceptions import ValidationError
 
 from posthog.hogql import ast
-from posthog.hogql.constants import HogQLGlobalSettings, LimitContext, get_default_hogql_global_settings
+from posthog.hogql.constants import (
+    MAX_SELECT_RETURNED_ROWS,
+    HogQLGlobalSettings,
+    LimitContext,
+    get_default_hogql_global_settings,
+)
+from posthog.hogql.database.database import Database
 from posthog.hogql.hogql import HogQLContext
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.printer import prepare_and_print_ast
@@ -51,12 +57,7 @@ from posthog.schema_migrations.upgrade import upgrade
 from products.cohorts.backend.models.calculation_history import CohortCalculationHistory
 from products.cohorts.backend.models.cohort import Cohort, CohortOrEmpty
 from products.cohorts.backend.models.dependencies import get_cohort_dependents
-from products.cohorts.backend.models.sql import (
-    GET_COHORT_SIZE_SQL,
-    GET_COHORTS_BY_PERSON_UUID,
-    GET_STATIC_COHORTPEOPLE_BY_PERSON_UUID,
-    RECALCULATE_COHORT_BY_ID,
-)
+from products.cohorts.backend.models.sql import GET_COHORT_SIZE_SQL, RECALCULATE_COHORT_BY_ID
 
 if TYPE_CHECKING:
     from posthog.personhog_client import ReadConsistency
@@ -906,11 +907,30 @@ def simplified_cohort_filter_properties(cohort: Cohort, team: Team, is_negated=F
         return cohort.properties
 
 
-def _get_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> list[int]:
+def _get_cohort_ids_by_person_uuid(uuid: str, team: Team, database: Database) -> list[int]:
+    # Deferred: posthog.hogql.query reaches posthog.models.property.util, which imports this module.
+    from posthog.hogql.query import execute_hogql_query  # noqa: PLC0415
+
     tag_queries(product=ProductKey.COHORTS, name="get_cohort_ids_by_person_uuid", feature=Feature.COHORT)
-    res = sync_execute(GET_COHORTS_BY_PERSON_UUID, {"person_id": uuid, "team_id": team_id})
+    res = execute_hogql_query(
+        """
+        SELECT cohort_id, argMax(version, version) AS latest_version
+        FROM raw_cohort_people
+        WHERE person_id = {person_id}
+        GROUP BY cohort_id
+        HAVING argMax(sign, version) > 0
+        LIMIT {limit}
+        """,
+        placeholders={
+            "person_id": ast.Constant(value=uuid),
+            "limit": ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
+        },
+        team=team,
+        query_type="get_cohort_ids_by_person_uuid",
+        context=HogQLContext(team_id=team.pk, database=database),
+    ).results
     cohort_ids_from_cohortperson = [row[0] for row in res]
-    cohorts = Cohort.objects.filter(deleted=False, team_id=team_id, pk__in=cohort_ids_from_cohortperson)
+    cohorts = Cohort.objects.filter(deleted=False, team_id=team.pk, pk__in=cohort_ids_from_cohortperson)
     values_list_result = cohorts.values_list("id", "version")
     id_latest_version_map = dict(values_list_result)
     cohort_ids = []
@@ -926,16 +946,32 @@ def _get_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> list[int]:
     return cohort_ids
 
 
-def _get_static_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> list[int]:
+def _get_static_cohort_ids_by_person_uuid(uuid: str, team: Team, database: Database) -> list[int]:
+    # Deferred: posthog.hogql.query reaches posthog.models.property.util, which imports this module.
+    from posthog.hogql.query import execute_hogql_query  # noqa: PLC0415
+
     tag_queries(product=ProductKey.COHORTS, name="get_static_cohort_ids_by_person_uuid", feature=Feature.COHORT)
-    res = sync_execute(GET_STATIC_COHORTPEOPLE_BY_PERSON_UUID, {"person_id": uuid, "team_id": team_id})
+    res = execute_hogql_query(
+        "SELECT DISTINCT cohort_id FROM static_cohort_people WHERE person_id = {person_id} LIMIT {limit}",
+        placeholders={
+            "person_id": ast.Constant(value=uuid),
+            "limit": ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
+        },
+        team=team,
+        query_type="get_static_cohort_ids_by_person_uuid",
+        context=HogQLContext(team_id=team.pk, database=database),
+    ).results
     return [row[0] for row in res]
 
 
-def get_all_cohort_ids_by_person_uuid(uuid: str, team_id: int) -> list[int]:
-    with tags_context(team_id=team_id):
-        cohort_ids = _get_cohort_ids_by_person_uuid(uuid, team_id)
-        static_cohort_ids = _get_static_cohort_ids_by_person_uuid(uuid, team_id)
+def get_all_cohort_ids_by_person_uuid(uuid: str, team: Team) -> list[int]:
+    with tags_context(team_id=team.pk):
+        # Both lookups run per request, so build the team's HogQL database once and share it.
+        # Each execute_hogql_query call would otherwise build its own, and the build cost
+        # scales with the team's warehouse size.
+        database = Database.create_for(team=team)
+        cohort_ids = _get_cohort_ids_by_person_uuid(uuid, team, database)
+        static_cohort_ids = _get_static_cohort_ids_by_person_uuid(uuid, team, database)
     return [*cohort_ids, *static_cohort_ids]
 
 


### PR DESCRIPTION
## Problem

The quarterly goal is that no request path queries ClickHouse outside HogQL. The person page's cohort list (`GET /api/person/cohorts`) still ran two hand-written ClickHouse queries, one for calculated cohorts and one for static cohorts.

## Changes

Both lookups now run through HogQL, over `raw_cohort_people` and `static_cohort_people`, and print the same statements the deleted SQL constants held. The calculated-cohort query keeps `argMax(sign, version) > 0` per cohort and the Python-side check that the latest ClickHouse version matches the cohort's Postgres version, so the endpoint returns the same cohorts.

The friendlier `cohort_people` lazy table was not used. It filters on Postgres (cohort_id, version) pairs and ignores `sign`, so it would return people removed in the current version. That is a latent gap in the HogQL table itself, noted here and not fixed.

Two queries run per request, so the function builds the HogQL database once and passes it to both. Each query carries an explicit `LIMIT 50000`, because HogQL adds `LIMIT 100` to a query without one, which would truncate the list for a person in more than a hundred cohorts; the old SQL had no limit. `get_all_cohort_ids_by_person_uuid` now takes the `Team` instead of `team_id`, since the executor needs it, and the two SQL constants are deleted.

## How did you test this code?

Ran the existing person cohorts API tests locally (`test_person.py -k cohorts`, `test_person_personhog.py -k cohorts`). They cover version rollover (a person in v0 but not in v1 is not returned), static cohorts, and the nested project URL. No new test: the rollover test already catches a wrong dedup, and nothing in the codebase writes `sign = -1` rows, so a sign test would encode behavior no production path exercises.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal query path, the API contract is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5), session https://claude.ai/code/session_01TaCixguF9sHxhQcKxMFjVB; skills invoked: /writing-tests, /writing-code-comments, /improving-drf-endpoints, /writing-pr-descriptions. One of several sibling PRs that port the remaining raw-SQL request paths to HogQL; each is independent.
