### PR TITLE
fix(workflows): truncate long descriptions in list views

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
@@ -1,6 +1,8 @@
 import clsx from 'clsx'
 import { ReactNode, useEffect, useRef, useState } from 'react'
 
+import { useResizeObserver } from 'lib/hooks/useResizeObserver'
+
 import { LemonMarkdown } from '../LemonMarkdown'
 import { Link, LinkProps } from '../Link'
 
@@ -30,7 +32,13 @@ export function LemonTableLink({
         </div>
     )
     const descriptionBlock = description ? (
-        <LemonTableLinkDescription description={description} truncate={truncateDescription} />
+        // Keyed by the text so a row reused for a different record (LemonTable falls back to index
+        // keys) doesn't carry over the previous record's expanded state.
+        <LemonTableLinkDescription
+            key={typeof description === 'string' ? description : undefined}
+            description={description}
+            truncate={truncateDescription}
+        />
     ) : null
 
     if (!props.to) {
@@ -75,18 +83,20 @@ function LemonTableLinkDescription({
     const contentRef = useRef<HTMLDivElement | null>(null)
     const [expanded, setExpanded] = useState(false)
     const [isOverflowing, setIsOverflowing] = useState(false)
+    // The column resizes with the scene (e.g. opening a side panel), which changes the line count.
+    const { width: contentWidth } = useResizeObserver({ ref: contentRef })
 
     useEffect(() => {
         if (truncate && !expanded && contentRef.current) {
             setIsOverflowing(contentRef.current.scrollHeight > contentRef.current.clientHeight)
         }
-    }, [truncate, expanded, description])
+    }, [truncate, expanded, description, contentWidth])
 
     return (
         <div className="text-xs text-tertiary mt-1">
             <div ref={contentRef} className={clsx(truncate && !expanded && 'line-clamp-2')}>
                 {typeof description === 'string' ? (
-                    <LemonMarkdown className="max-w-[30rem]" lowKeyHeadings>
+                    <LemonMarkdown className="max-w-[30rem]" lowKeyHeadings disableImages>
                         {description}
                     </LemonMarkdown>
                 ) : (
@@ -97,6 +107,7 @@ function LemonTableLinkDescription({
                 <Link
                     onClick={() => setExpanded(!expanded)}
                     className="text-xs"
+                    aria-expanded={expanded}
                     data-attr="lemon-table-link-description-toggle"
                 >
                     {expanded ? 'Show less' : 'Show more'}

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { ReactNode } from 'react'
+import { ReactNode, useEffect, useRef, useState } from 'react'
 
 import { LemonMarkdown } from '../LemonMarkdown'
 import { Link, LinkProps } from '../Link'
@@ -12,7 +12,7 @@ interface LemonTableLinkContentProps {
      * instead of overflowing. The title itself must carry a `truncate` class for the ellipsis to show.
      */
     truncateTitle?: boolean
-    /** Clamp the description to two lines instead of rendering it at full height. */
+    /** Clamp the description to two lines, with a "Show more" toggle when it overflows. */
     truncateDescription?: boolean
 }
 
@@ -24,52 +24,84 @@ export function LemonTableLink({
     ...props
 }: Pick<LinkProps, 'to' | 'onClick' | 'target' | 'className' | 'targetBlankIcon'> &
     LemonTableLinkContentProps): JSX.Element {
+    const titleRow = (
+        <div className={clsx('flex flex-row items-center font-semibold text-sm gap-1', truncateTitle && 'min-w-0')}>
+            {title}
+        </div>
+    )
+    const descriptionBlock = description ? (
+        <LemonTableLinkDescription description={description} truncate={truncateDescription} />
+    ) : null
+
     if (!props.to) {
         return (
-            <LemonTableLinkContent
-                title={title}
-                description={description}
-                truncateTitle={truncateTitle}
-                truncateDescription={truncateDescription}
-            />
+            <div className={clsx('flex flex-col py-1', truncateTitle && 'min-w-0')}>
+                {titleRow}
+                {descriptionBlock}
+            </div>
+        )
+    }
+
+    if (truncateDescription) {
+        // The "Show more" toggle is a button, which can't nest inside the anchor, so a clamped
+        // description sits next to the link instead of inside it.
+        return (
+            <div className={clsx('flex flex-col py-1', truncateTitle && 'min-w-0')}>
+                <Link subtle {...props} className={clsx(props.className, truncateTitle && 'block min-w-0')}>
+                    {titleRow}
+                </Link>
+                {descriptionBlock}
+            </div>
         )
     }
 
     return (
         <Link subtle {...props} className={clsx(props.className, truncateTitle && 'block min-w-0')}>
-            <LemonTableLinkContent
-                title={title}
-                description={description}
-                truncateTitle={truncateTitle}
-                truncateDescription={truncateDescription}
-            />
+            <div className={clsx('flex flex-col py-1', truncateTitle && 'min-w-0')}>
+                {titleRow}
+                {descriptionBlock}
+            </div>
         </Link>
     )
 }
 
-function LemonTableLinkContent({
-    title,
+function LemonTableLinkDescription({
     description,
-    truncateTitle,
-    truncateDescription,
-}: LemonTableLinkContentProps): JSX.Element {
-    return (
-        <div className={clsx('flex flex-col py-1', truncateTitle && 'min-w-0')}>
-            <div className={clsx('flex flex-row items-center font-semibold text-sm gap-1', truncateTitle && 'min-w-0')}>
-                {title}
-            </div>
+    truncate,
+}: {
+    description: ReactNode
+    truncate?: boolean
+}): JSX.Element {
+    const contentRef = useRef<HTMLDivElement | null>(null)
+    const [expanded, setExpanded] = useState(false)
+    const [isOverflowing, setIsOverflowing] = useState(false)
 
-            {description ? (
-                <div className={clsx('text-xs text-tertiary mt-1', truncateDescription && 'line-clamp-2')}>
-                    {typeof description === 'string' ? (
-                        <LemonMarkdown className="max-w-[30rem]" lowKeyHeadings>
-                            {description}
-                        </LemonMarkdown>
-                    ) : (
-                        description
-                    )}
-                </div>
-            ) : null}
+    useEffect(() => {
+        if (truncate && !expanded && contentRef.current) {
+            setIsOverflowing(contentRef.current.scrollHeight > contentRef.current.clientHeight)
+        }
+    }, [truncate, expanded, description])
+
+    return (
+        <div className="text-xs text-tertiary mt-1">
+            <div ref={contentRef} className={clsx(truncate && !expanded && 'line-clamp-2')}>
+                {typeof description === 'string' ? (
+                    <LemonMarkdown className="max-w-[30rem]" lowKeyHeadings>
+                        {description}
+                    </LemonMarkdown>
+                ) : (
+                    description
+                )}
+            </div>
+            {truncate && (isOverflowing || expanded) && (
+                <Link
+                    onClick={() => setExpanded(!expanded)}
+                    className="text-xs"
+                    data-attr="lemon-table-link-description-toggle"
+                >
+                    {expanded ? 'Show less' : 'Show more'}
+                </Link>
+            )}
         </div>
     )
 }

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTableLink.tsx
@@ -12,27 +12,47 @@ interface LemonTableLinkContentProps {
      * instead of overflowing. The title itself must carry a `truncate` class for the ellipsis to show.
      */
     truncateTitle?: boolean
+    /** Clamp the description to two lines instead of rendering it at full height. */
+    truncateDescription?: boolean
 }
 
 export function LemonTableLink({
     title,
     description,
     truncateTitle,
+    truncateDescription,
     ...props
 }: Pick<LinkProps, 'to' | 'onClick' | 'target' | 'className' | 'targetBlankIcon'> &
     LemonTableLinkContentProps): JSX.Element {
     if (!props.to) {
-        return <LemonTableLinkContent title={title} description={description} truncateTitle={truncateTitle} />
+        return (
+            <LemonTableLinkContent
+                title={title}
+                description={description}
+                truncateTitle={truncateTitle}
+                truncateDescription={truncateDescription}
+            />
+        )
     }
 
     return (
         <Link subtle {...props} className={clsx(props.className, truncateTitle && 'block min-w-0')}>
-            <LemonTableLinkContent title={title} description={description} truncateTitle={truncateTitle} />
+            <LemonTableLinkContent
+                title={title}
+                description={description}
+                truncateTitle={truncateTitle}
+                truncateDescription={truncateDescription}
+            />
         </Link>
     )
 }
 
-function LemonTableLinkContent({ title, description, truncateTitle }: LemonTableLinkContentProps): JSX.Element {
+function LemonTableLinkContent({
+    title,
+    description,
+    truncateTitle,
+    truncateDescription,
+}: LemonTableLinkContentProps): JSX.Element {
     return (
         <div className={clsx('flex flex-col py-1', truncateTitle && 'min-w-0')}>
             <div className={clsx('flex flex-row items-center font-semibold text-sm gap-1', truncateTitle && 'min-w-0')}>
@@ -40,7 +60,7 @@ function LemonTableLinkContent({ title, description, truncateTitle }: LemonTable
             </div>
 
             {description ? (
-                <div className="text-xs text-tertiary mt-1">
+                <div className={clsx('text-xs text-tertiary mt-1', truncateDescription && 'line-clamp-2')}>
                     {typeof description === 'string' ? (
                         <LemonMarkdown className="max-w-[30rem]" lowKeyHeadings>
                             {description}

--- a/frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx
+++ b/frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx
@@ -102,6 +102,7 @@ export function DataPipelinesHogFunctions({
                     type={kind}
                     additionalTypes={additionalKinds}
                     manualFunctions={manualFunctions}
+                    truncateDescriptions
                 />
             </SceneSection>
             <SceneDivider />

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -116,6 +116,7 @@ export function HogFunctionList({
     onDeleteHogFunction,
     onEditHogFunction,
     returnTo,
+    truncateDescriptions = false,
     ...props
 }: HogFunctionListLogicProps & {
     extraControls?: JSX.Element
@@ -124,6 +125,8 @@ export function HogFunctionList({
     onDeleteHogFunction?: (hogFunction: HogFunctionType) => void
     onEditHogFunction?: (hogFunction: HogFunctionType) => void
     returnTo?: string
+    /** Clamp long descriptions to two lines with a "Show more" toggle. */
+    truncateDescriptions?: boolean
 }): JSX.Element {
     const { loading, filteredHogFunctions, filters, hogFunctions, hiddenHogFunctions } = useValues(
         hogFunctionsListLogic(props)
@@ -176,7 +179,7 @@ export function HogFunctionList({
                                 </>
                             }
                             description={hogFunction.description}
-                            truncateDescription
+                            truncateDescription={truncateDescriptions}
                         />
                     )
                 },
@@ -325,6 +328,7 @@ export function HogFunctionList({
         onDeleteHogFunction,
         onEditHogFunction,
         returnTo,
+        truncateDescriptions,
     ]) // oxlint-disable-line react-hooks/exhaustive-deps
 
     return (

--- a/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
+++ b/frontend/src/scenes/hog-functions/list/HogFunctionsList.tsx
@@ -176,6 +176,7 @@ export function HogFunctionList({
                                 </>
                             }
                             description={hogFunction.description}
+                            truncateDescription
                         />
                     )
                 },

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -172,6 +172,7 @@ export function WorkflowsTable(): JSX.Element {
                         to={urls.workflow(item.id, 'workflow')}
                         title={item.name}
                         description={item.description}
+                        truncateDescription
                     />
                 )
             },


### PR DESCRIPTION
## Problem

Workflow and destination descriptions render at full height in the list tables. Agents writing workflows tend to be verbose, so a few paragraph-long descriptions blow up the rows and push the rest of the list off the screen.

## Changes

- Descriptions in the workflows list and the data pipelines lists (destinations, transformations, site apps) now clamp to two lines. A "Show more" / "Show less" toggle appears when the text actually overflows.
- `LemonTableLink` gains an opt-in `truncateDescription` prop; `HogFunctionList` plumbs it through as `truncateDescriptions`, set only by the pipelines scene. Alerts, notifications, sources, and every other table keep their current markup.
- The toggle is a real button and cannot nest inside the row's anchor, so a clamped description sits next to the link instead of inside it. Clicking the description no longer navigates; clicking the title still does.
- Overflow is re-measured on column resize, and expansion state is keyed to the text so a filtered or sorted row cannot inherit another row's expanded state.
- Mechanical: description markdown now renders with `disableImages` (house pattern for list descriptions), and the toggle carries `aria-expanded`.

No screenshot: the agent session has no browser access. The change is the two-line clamp plus the toggle described above.

## How did you test this code?

- Verified manually in local dev, seeded with ~700-character agent-style workflow descriptions: long descriptions clamp and expand via the toggle, a short one renders unchanged with no toggle.
- No new automated tests: the change is presentational markup. Frontend typecheck and lint pass locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session; skills invoked: /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions.
- The first commit shipped the clamp only; the toggle came after the human reviewed the clamp on a local instance and asked for a way to read the full text.
- The third commit addresses bot review findings: stale overflow on resize, expanded state leaking across index-keyed rows, truncation reaching all seven `HogFunctionList` surfaces instead of the pipelines lists, remote images in description markdown, and a missing `aria-expanded`. Not addressed: removing clipped markdown links from the tab order, which needs content-level truncation and is out of proportion here.
- Manual verification above was done by the human on their local instance.
