### PR TITLE
fix(mcp): tag events with the canonical ai_product property

### DIFF
--- a/services/mcp/src/cli/context.ts
+++ b/services/mcp/src/cli/context.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto'
 
 import { ApiClient } from '@/api/client'
 import { MemoryCache } from '@/lib/cache/MemoryCache'
+import { MCP_AI_PRODUCT_PROPERTIES } from '@/lib/constants'
 import { getPostHogClient } from '@/lib/posthog'
 import { buildMCPAnalyticsGroups, buildMCPContextProperties } from '@/lib/posthog/analytics'
 import type { AnalyticsEvent } from '@/lib/posthog/analytics'
@@ -84,7 +85,7 @@ export async function buildCliContext(config: CliConfig): Promise<Context> {
                         event,
                         ...(Object.keys(groups).length > 0 ? { groups } : {}),
                         properties: {
-                            $ai_product: 'mcp',
+                            ...MCP_AI_PRODUCT_PROPERTIES,
                             $mcp_source: 'posthog_cli',
                             $mcp_client_name: 'posthog-cli',
                             $mcp_consumer: 'posthog-cli',

--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -4,7 +4,7 @@ import type { MCPAnalyticsIntentSource } from '@posthog/mcp-analytics'
 
 import type { McpAuthFailure } from '@/lib/auth-errors'
 import { classifyAuthMethod } from '@/lib/auth-method'
-import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
+import { MCP_AI_PRODUCT_PROPERTIES, MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { resolveEventSource } from '@/lib/event-source'
 import { gatewayServerSlug, isGatewayToolName, THIRD_PARTY_TOOL_CATEGORY } from '@/lib/gateway-tools'
 import { getPostHogClient } from '@/lib/posthog'
@@ -40,7 +40,7 @@ function buildBaseProperties(
     const clientIdentity = getEffectiveMCPClientIdentity(requestContext, state.sessionContext)
 
     const properties: Record<string, unknown> = {
-        $ai_product: 'mcp',
+        ...MCP_AI_PRODUCT_PROPERTIES,
         // The same property `posthog/event_usage.py` stamps on product events, so an MCP call
         // and the API work it causes land in one breakdown. Distinct from `$mcp_source`, which
         // names the emitting SDK rather than the surface.
@@ -416,7 +416,7 @@ export function trackAuthFailure(props: RequestProperties, failure: McpAuthFailu
             distinctId: props.userHash,
             event: '$mcp_auth_failed',
             properties: {
-                $ai_product: 'mcp',
+                ...MCP_AI_PRODUCT_PROPERTIES,
                 // Resolved without scopes — the request never authenticated, so nothing can
                 // vouch for a declared consumer and anything unproven lands as `mcp`.
                 source: resolveEventSource({

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -1,5 +1,5 @@
 import { ApiClient } from '@/api/client'
-import { MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
+import { MCP_AI_PRODUCT_PROPERTIES, MCP_ANALYTICS_SOURCE, MCP_SERVER_NAME, MCP_SERVER_VERSION } from '@/lib/constants'
 import { wrapError } from '@/lib/errors'
 import { getPostHogClient } from '@/lib/posthog'
 import {
@@ -216,7 +216,7 @@ export class RequestContext {
         sessionContext: MCPSessionContext | null = this.sessionContext
     ): Record<string, unknown> {
         return {
-            $ai_product: 'mcp',
+            ...MCP_AI_PRODUCT_PROPERTIES,
             $mcp_source: MCP_ANALYTICS_SOURCE,
             $mcp_server_name: MCP_SERVER_NAME,
             $mcp_server_version: MCP_SERVER_VERSION,

--- a/services/mcp/src/lib/constants.ts
+++ b/services/mcp/src/lib/constants.ts
@@ -23,6 +23,16 @@ export const MCP_SERVER_NAME = 'PostHog'
 export const MCP_SERVER_VERSION = '1.0.0'
 export const MCP_ANALYTICS_SOURCE = 'posthog_mcp_analytics'
 
+// Which product an AI generation came from, emitted under both names. `ai_product` is the name the
+// rest of PostHog sets and reads: `ee/hogai/llm.py` defaults it, and the usage report and usage
+// slash command filter on it. `$ai_product` is the name this server has always sent. A consumer
+// that reads only the canonical name would otherwise miss every generation this server captures.
+export const MCP_AI_PRODUCT = 'mcp'
+export const MCP_AI_PRODUCT_PROPERTIES = {
+    ai_product: MCP_AI_PRODUCT,
+    $ai_product: MCP_AI_PRODUCT,
+} as const
+
 // Claude Code truncates a server's `instructions` payload at this many characters — silently,
 // mid-token, with nothing the model can act on. The compact single-exec payload is sized to
 // fit, and the tool-domain index absorbs whatever budget the fixed sections leave.

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -224,6 +224,7 @@ describe('RequestContext', () => {
 
             const result = ctx.buildClientProperties()
             expect(result).toMatchObject({
+                ai_product: 'mcp',
                 $ai_product: 'mcp',
                 $mcp_source: 'posthog_mcp_analytics',
                 $mcp_server_name: 'PostHog',
@@ -299,6 +300,7 @@ describe('RequestContext', () => {
 
             const result = ctx.buildClientProperties()
             expect(result).toMatchObject({
+                ai_product: 'mcp',
                 $ai_product: 'mcp',
                 $mcp_source: 'posthog_mcp_analytics',
                 $mcp_server_name: 'PostHog',


### PR DESCRIPTION
## Problem

Anyone breaking AI generations down by product in AI observability silently loses every MCP generation, and the breakdown looks complete while it does it.

- `ai_product` is the name the rest of PostHog sets and reads. `ee/hogai/llm.py` defaults it for every `MaxChat*` caller, and `posthog/tasks/usage_report.py` and the usage slash command filter on it.
- The MCP server sets `$ai_product` instead, and nothing else sets that name.
- A consumer has to know both names. One that reads only the canonical name attributes MCP traffic to nothing rather than failing loudly.

## Changes

- A breakdown on `ai_product` now includes MCP traffic, because MCP analytics events carry that property alongside `$ai_product`.
- `$ai_product` stays on every event, so existing MCP queries and dashboards keep working.
- Billing is unaffected. `usage_report.py` filters on an explicit list of product values that does not contain `mcp`, so no generation becomes billable.
- Mechanical: the pair moves into one `MCP_AI_PRODUCT_PROPERTIES` constant in `lib/constants.ts`, spread at the four capture sites.

Nothing a person sees changes. This only affects how captured events are tagged.

> [!NOTE]
> This corrects the tagging going forward. Events already captured keep the old shape, so a query over a window that spans this deploy still needs both names.

## How did you test this code?

Two existing assertions in `tests/hono/request-context.test.ts` gained the canonical property. They fail if a later change drops `ai_product` and reintroduces exactly the gap this PR closes. No new test function was added, since both cases already covered the property block.

Ran the `vitest.hono.config.mts` suite, which covers all four changed capture sites.

Not run: the integration and workers suites, which this change does not reach. No event was captured against a real project from this sandbox, so the tagging is verified in tests rather than in ingested data.

`typecheck` reports 83 errors on this branch and 83 on `master`. They come from the unbuilt `@posthog/quill` workspace, and none sits in a changed file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1788055418438759?thread_ts=1788055418.438759&cid=C0BLK2ZEUSH) that started as an investigation into an AI observability consumer reporting spend against the wrong caller.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- The first direction considered was renaming `ai_product` to `$ai_product` in the backend, to match the `$ai_*` schema. That is why this PR goes the other way: `usage_report.py` reads `ai_product` for billing credits, so renaming it would break AI billing. Adding the canonical name to the one divergent emitter is additive and leaves every existing reader working.
- The consumer that prompted this had a second, unrelated cause, so this PR is not a complete fix for it.
- The diff carries no session material. Every identifier in it already exists in this repository.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BLK2ZEUSH/p1788055418438759?thread_ts=1788055418.438759&cid=C0BLK2ZEUSH)*
