### PR TITLE
feat(workflows): fix overview sparkline and add type/trigger filters

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6670,6 +6670,9 @@ const api = {
             search?: string
             status?: HogFlow['status']
             created_by?: string
+            type?: 'messaging' | 'automation'
+            /** JSON-encoded object the stored trigger must contain, e.g. `{"type":"batch"}`. */
+            trigger?: string
             limit?: number
             offset?: number
         }): Promise<CountedPaginatedResponse<HogFlow>> {

--- a/frontend/src/lib/components/AppMetrics/AppMetricsSparkline.tsx
+++ b/frontend/src/lib/components/AppMetrics/AppMetricsSparkline.tsx
@@ -14,6 +14,8 @@ export interface AppMetricsSparklineProps extends AppMetricsLogicProps {
     successMetricNames?: string[]
     /** Optional display labels keyed by series name (e.g. `{ rows_synced: 'Rows synced' }`). */
     metricLabels?: Record<string, string>
+    /** Optional vars.scss color names keyed by series name; takes precedence over `successMetricNames`. */
+    metricColors?: Record<string, string>
 }
 
 const DEFAULT_SUCCESS_METRIC_NAMES = ['success']
@@ -21,6 +23,7 @@ const DEFAULT_SUCCESS_METRIC_NAMES = ['success']
 export function AppMetricsSparkline({
     successMetricNames,
     metricLabels,
+    metricColors,
     ...props
 }: AppMetricsSparklineProps): JSX.Element {
     const logic = appMetricsLogic(props)
@@ -52,12 +55,12 @@ export function AppMetricsSparkline({
 
         return (
             sortedSeries?.map((s) => ({
-                color: successNames.includes(s.name) ? 'success' : 'danger',
+                color: metricColors?.[s.name] ?? (successNames.includes(s.name) ? 'success' : 'danger'),
                 name: metricLabels?.[s.name] ?? s.name,
                 values: s.values,
             })) || []
         )
-    }, [appMetricsTrends, params, successMetricNames, metricLabels])
+    }, [appMetricsTrends, params, successMetricNames, metricLabels, metricColors])
 
     const labels = appMetricsTrends?.labels || []
 

--- a/frontend/src/lib/components/AppMetrics/appMetricsLogic.ts
+++ b/frontend/src/lib/components/AppMetrics/appMetricsLogic.ts
@@ -30,6 +30,8 @@ const DEFAULT_INTERVAL = 'day'
 export type AppMetricsCommonParams = {
     appSource?: string
     appSourceId?: string
+    /** Match all app_source_ids starting with this prefix (e.g. `<hog flow id>/` for versioned hog flow metrics). */
+    appSourceIdPrefix?: string
     instanceId?: string
     metricName?: string | string[]
     metricKind?: string | string[]
@@ -79,6 +81,11 @@ export type AppMetricsTotalsResponse = Record<
     }
 >
 
+const appSourceIdPrefixPattern = (prefix: string): string => {
+    // Escape LIKE wildcards so the prefix matches literally.
+    return prefix.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_') + '%'
+}
+
 export const loadAppMetricsTotals = async (
     request: AppMetricsTotalsRequest,
     timezone: string
@@ -95,6 +102,10 @@ export const loadAppMetricsTotals = async (
 
     if (request.appSourceId) {
         query = (query + hogql`\nAND app_source_id = ${request.appSourceId}`) as HogQLQueryString
+    }
+    if (request.appSourceIdPrefix) {
+        query = (query +
+            hogql`\nAND app_source_id LIKE ${appSourceIdPrefixPattern(request.appSourceIdPrefix)}`) as HogQLQueryString
     }
     if (typeof request.instanceId === 'string') {
         query = (query + hogql`\nAND instance_id = ${request.instanceId}`) as HogQLQueryString
@@ -204,6 +215,10 @@ const loadAppMetricsTimeSeries = async (
 
     if (request.appSourceId) {
         query = (query + hogql`\nAND app_source_id = ${request.appSourceId}`) as HogQLQueryString
+    }
+    if (request.appSourceIdPrefix) {
+        query = (query +
+            hogql`\nAND app_source_id LIKE ${appSourceIdPrefixPattern(request.appSourceIdPrefix)}`) as HogQLQueryString
     }
     if (typeof request.instanceId === 'string') {
         query = (query + hogql`\nAND instance_id = ${request.instanceId}`) as HogQLQueryString

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -118,6 +118,7 @@ from products.workflows.backend.api.message_assets import (
 from products.workflows.backend.api.publish_impact import build_publish_impact
 from products.workflows.backend.models.hog_flow.hog_flow import (
     BILLABLE_ACTION_TYPES,
+    MESSAGING_ACTION_TYPES,
     PERSON_DEPENDENT_ACTION_TYPES,
     ROW_SCOPED_TRIGGER_TYPES,
     SUPPORTED_ACTION_TYPES,
@@ -3227,6 +3228,17 @@ class HogFlowViewSet(
                 except ValueError:
                     raise exceptions.ValidationError({"created_by": "Must be a valid user uuid"})
                 queryset = queryset.filter(created_by__uuid=created_by)
+
+            workflow_type = self.request.GET.get("type")
+            if workflow_type:
+                if workflow_type not in ("messaging", "automation"):
+                    raise exceptions.ValidationError({"type": "Must be one of: messaging, automation"})
+                messaging_q = Q()
+                for action_type in MESSAGING_ACTION_TYPES:
+                    messaging_q |= Q(actions__contains=[{"type": action_type}])
+                queryset = (
+                    queryset.filter(messaging_q) if workflow_type == "messaging" else queryset.exclude(messaging_q)
+                )
 
         if self.request.GET.get("trigger"):
             try:

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -239,6 +239,40 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 200, response.json()
         assert {flow["name"] for flow in response.json()["results"]} == {"Theirs"}
 
+    @parameterized.expand(
+        [
+            ("messaging", "messaging", {"Email drip", "Push blast"}),
+            ("automation", "automation", {"Webhook sync"}),
+        ]
+    )
+    def test_list_filter_by_workflow_type(self, _name, workflow_type, expected_names):
+        HogFlow.objects.create(
+            team=self.team,
+            name="Email drip",
+            created_by=self.user,
+            actions=[{"id": "a", "type": "function_email", "config": {}}],
+        )
+        HogFlow.objects.create(
+            team=self.team,
+            name="Push blast",
+            created_by=self.user,
+            actions=[{"id": "a", "type": "function_push", "config": {}}],
+        )
+        HogFlow.objects.create(
+            team=self.team,
+            name="Webhook sync",
+            created_by=self.user,
+            actions=[{"id": "a", "type": "function", "config": {}}],
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows?type={workflow_type}")
+        assert response.status_code == 200, response.json()
+        assert {flow["name"] for flow in response.json()["results"]} == expected_names
+
+    def test_list_filter_by_workflow_type_rejects_unknown_value(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows?type=campaign")
+        assert response.status_code == 400
+
     def test_mcp_list_is_metadata_only_and_hides_action_secrets(self):
         # A webhook action whose headers carry a bearer token — the kind of credential-like value
         # that must not leak from a workflow *listing*.

--- a/products/workflows/backend/models/hog_flow/hog_flow.py
+++ b/products/workflows/backend/models/hog_flow/hog_flow.py
@@ -65,6 +65,16 @@ BILLABLE_ACTION_TYPES: Final[set[str]] = {
     "function_push",  # Push notification actions
 }
 
+# Action types that send a message to a person. A workflow containing at least one of these is a
+# "messaging" workflow; everything else is an "automation". Keep in sync with the frontend's
+# WorkflowTypeTag (products/workflows/frontend/Workflows/WorkflowsTable.tsx), which renders the
+# same split, and the list API's `type` filter, which queries on it.
+MESSAGING_ACTION_TYPES: Final[list[str]] = [
+    "function_email",
+    "function_sms",
+    "function_push",
+]
+
 # Action types that read person data and therefore cannot be used in person-less ("row-scoped")
 # workflows such as those triggered by a data warehouse table row sync. Keep in sync with the
 # frontend's PERSON_DEPENDENT_ACTION_TYPES.

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -236,15 +236,16 @@ export function WorkflowsTable(): JSX.Element {
                     <Link to={urls.workflow(id, 'metrics')}>
                         <AppMetricsSparkline
                             logicKey={id}
-                            successMetricNames={['triggered']}
-                            metricLabels={{ triggered: 'Started', failed: 'Failed' }}
+                            metricLabels={{ triggered: 'Started', succeeded: 'Completed', failed: 'Failed' }}
+                            // Same colors as the workflow metrics tab: triggered is blue there too.
+                            metricColors={{ triggered: 'blue', succeeded: 'success', failed: 'danger' }}
                             forceParams={{
                                 // The versioned mirror keys every run's metrics (including batch runs,
                                 // which the plain hog_flow source keys under the batch job id) as
                                 // `<flow id>/<version>`, so a prefix match covers all activity.
                                 appSource: 'hog_flow_version',
                                 appSourceIdPrefix: `${id}/`,
-                                metricName: ['triggered', 'failed'],
+                                metricName: ['triggered', 'succeeded', 'failed'],
                                 breakdownBy: 'metric_name',
                                 interval: 'day',
                                 dateFrom: '-7d',

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -24,7 +24,13 @@ import { getHogFlowStep } from './hogflows/steps/HogFlowSteps'
 import { HogFlow } from './hogflows/types'
 import { newWorkflowLogic } from './newWorkflowLogic'
 import { workflowLogic } from './workflowLogic'
-import { WorkflowStatusFilter, workflowsLogic } from './workflowsLogic'
+import {
+    WORKFLOW_TRIGGER_TYPE_OPTIONS,
+    WorkflowStatusFilter,
+    WorkflowTriggerTypeFilter,
+    WorkflowTypeFilter,
+    workflowsLogic,
+} from './workflowsLogic'
 
 const STATUS_CONFIG: Record<string, { label: string; type: 'success' | 'default' | 'muted' }> = {
     active: { label: 'Active', type: 'success' },
@@ -34,8 +40,10 @@ const STATUS_CONFIG: Record<string, { label: string; type: 'success' | 'default'
 
 function WorkflowTypeTag({ workflow }: { workflow: HogFlow }): JSX.Element {
     const hasMessagingAction = useMemo(() => {
+        // Keep in sync with MESSAGING_ACTION_TYPES in products/workflows/backend/models/hog_flow/hog_flow.py,
+        // which the list API's `type` filter uses - the tag and the filter must agree on what "Messaging" is.
         return workflow.actions.some((action) => {
-            return ['function_email', 'function_sms', 'function_slack'].includes(action.type)
+            return ['function_email', 'function_sms', 'function_push'].includes(action.type)
         })
     }, [workflow.actions])
 
@@ -228,11 +236,16 @@ export function WorkflowsTable(): JSX.Element {
                     <Link to={urls.workflow(id, 'metrics')}>
                         <AppMetricsSparkline
                             logicKey={id}
+                            successMetricNames={['triggered']}
+                            metricLabels={{ triggered: 'Started', failed: 'Failed' }}
                             forceParams={{
-                                appSource: 'hog_flow',
-                                appSourceId: id,
-                                metricKind: ['success', 'failure'],
-                                breakdownBy: 'metric_kind',
+                                // The versioned mirror keys every run's metrics (including batch runs,
+                                // which the plain hog_flow source keys under the batch job id) as
+                                // `<flow id>/<version>`, so a prefix match covers all activity.
+                                appSource: 'hog_flow_version',
+                                appSourceIdPrefix: `${id}/`,
+                                metricName: ['triggered', 'failed'],
+                                breakdownBy: 'metric_name',
                                 interval: 'day',
                                 dateFrom: '-7d',
                             }}
@@ -334,6 +347,8 @@ export function WorkflowsTable(): JSX.Element {
         !filters.search &&
         !filters.createdBy &&
         filters.status === 'all' &&
+        filters.type === 'all' &&
+        filters.triggerType === 'all' &&
         // An empty page is not an empty project, so never offer onboarding while paging
         filters.page === 1
 
@@ -362,7 +377,7 @@ export function WorkflowsTable(): JSX.Element {
                             onChange={(search) => setFilters({ search })}
                             value={filters.search}
                         />
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 flex-wrap">
                             <span>
                                 <b>Status</b>
                             </span>
@@ -377,6 +392,30 @@ export function WorkflowsTable(): JSX.Element {
                                     { label: 'Archived', value: 'archived' },
                                 ]}
                                 value={filters.status}
+                            />
+                            <span className="ml-1">
+                                <b>Type</b>
+                            </span>
+                            <LemonSelect
+                                dropdownMatchSelectWidth={false}
+                                size="small"
+                                onChange={(value) => setFilters({ type: value as WorkflowTypeFilter })}
+                                options={[
+                                    { label: 'All', value: 'all' },
+                                    { label: 'Messaging', value: 'messaging' },
+                                    { label: 'Automation', value: 'automation' },
+                                ]}
+                                value={filters.type}
+                            />
+                            <span className="ml-1">
+                                <b>Trigger</b>
+                            </span>
+                            <LemonSelect
+                                dropdownMatchSelectWidth={false}
+                                size="small"
+                                onChange={(value) => setFilters({ triggerType: value as WorkflowTriggerTypeFilter })}
+                                options={WORKFLOW_TRIGGER_TYPE_OPTIONS}
+                                value={filters.triggerType}
                             />
                             <span className="ml-1">
                                 <b>Created by</b>

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -16,16 +16,47 @@ export type WorkflowStatusFilter = 'all' | 'active' | 'draft' | 'archived'
 
 const WORKFLOW_STATUS_FILTERS: WorkflowStatusFilter[] = ['all', 'active', 'draft', 'archived']
 
+export type WorkflowTypeFilter = 'all' | 'messaging' | 'automation'
+
+const WORKFLOW_TYPE_FILTERS: WorkflowTypeFilter[] = ['all', 'messaging', 'automation']
+
+export type WorkflowTriggerTypeFilter = 'all' | (NonNullable<HogFlow['trigger']> extends { type: infer T } ? T : never)
+
+// Keep in sync with TRIGGER_TYPES in products/workflows/backend/models/hog_flow/hog_flow.py.
+export const WORKFLOW_TRIGGER_TYPE_OPTIONS: { value: WorkflowTriggerTypeFilter; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'event', label: 'Event' },
+    { value: 'schedule', label: 'Schedule' },
+    { value: 'manual', label: 'Manual' },
+    { value: 'batch', label: 'Batch' },
+    { value: 'webhook', label: 'Webhook' },
+    { value: 'tracking_pixel', label: 'Tracking pixel' },
+    { value: 'data-warehouse-table', label: 'Data warehouse table' },
+    { value: 'data-warehouse-view', label: 'Data warehouse view' },
+    { value: 'slack-message', label: 'Slack message' },
+]
+
+const WORKFLOW_TRIGGER_TYPE_FILTERS = WORKFLOW_TRIGGER_TYPE_OPTIONS.map((option) => option.value)
+
 export const WORKFLOWS_PER_PAGE = 30
 
 export interface WorkflowsFilters {
     search: string
     createdBy: string | null
     status: WorkflowStatusFilter
+    type: WorkflowTypeFilter
+    triggerType: WorkflowTriggerTypeFilter
     page: number
 }
 
-const DEFAULT_FILTERS: WorkflowsFilters = { search: '', createdBy: null, status: 'all', page: 1 }
+const DEFAULT_FILTERS: WorkflowsFilters = {
+    search: '',
+    createdBy: null,
+    status: 'all',
+    type: 'all',
+    triggerType: 'all',
+    page: 1,
+}
 
 type WorkflowsResult = CountedPaginatedResponse<HogFlow>
 
@@ -33,6 +64,8 @@ interface WorkflowsListParams {
     search?: string
     status?: HogFlow['status']
     created_by?: string
+    type?: Exclude<WorkflowTypeFilter, 'all'>
+    trigger?: string
     limit: number
     offset: number
 }
@@ -383,6 +416,9 @@ export const workflowsLogic = kea<workflowsLogicType>([
                 search: filters.search || undefined,
                 status: filters.status !== 'all' ? filters.status : undefined,
                 created_by: filters.createdBy || undefined,
+                type: filters.type !== 'all' ? filters.type : undefined,
+                // The API filters triggers by JSON containment, so the type goes over as a JSON object.
+                trigger: filters.triggerType !== 'all' ? JSON.stringify({ type: filters.triggerType }) : undefined,
                 limit: WORKFLOWS_PER_PAGE,
                 offset: filters.page ? (filters.page - 1) * WORKFLOWS_PER_PAGE : 0,
             }),
@@ -474,6 +510,8 @@ export const workflowsLogic = kea<workflowsLogicType>([
             setOrDelete('search', values.filters.search)
             setOrDelete('created_by', values.filters.createdBy)
             setOrDelete('status', values.filters.status !== 'all' ? values.filters.status : null)
+            setOrDelete('type', values.filters.type !== 'all' ? values.filters.type : null)
+            setOrDelete('trigger_type', values.filters.triggerType !== 'all' ? values.filters.triggerType : null)
             setOrDelete('page', values.filters.page > 1 ? values.filters.page : null)
 
             return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
@@ -486,10 +524,14 @@ export const workflowsLogic = kea<workflowsLogicType>([
     urlToAction(({ actions, values }) => ({
         [urls.workflows()]: (_, searchParams) => {
             const status = searchParams['status']
+            const type = searchParams['type']
+            const triggerType = searchParams['trigger_type']
             const parsed: WorkflowsFilters = {
                 search: searchParams['search'] ? String(searchParams['search']) : '',
                 createdBy: searchParams['created_by'] ? String(searchParams['created_by']) : null,
                 status: WORKFLOW_STATUS_FILTERS.includes(status) ? status : 'all',
+                type: WORKFLOW_TYPE_FILTERS.includes(type) ? type : 'all',
+                triggerType: WORKFLOW_TRIGGER_TYPE_FILTERS.includes(triggerType) ? triggerType : 'all',
                 // Anything unparseable, zero, or negative falls back to page 1 rather than reaching
                 // the offset maths as NaN or a negative number.
                 page: Math.max(1, parseInt(String(searchParams['page'])) || 1),


### PR DESCRIPTION
## Problem

The "Last 7 days" sparkline on the workflows overview is empty for batch sends: batch runs record their metrics under the batch job id, not the workflow id, and the query only asked for completions anyway. After a 1000-person dispatch yesterday there is no way to tell from the list whether that workflow ran at all.

The list also only filters by status. Once email automations, transactional email, internal workflows, and campaigns all live here, that is not enough to find anything.

## Changes

- The sparkline now shows runs started (blue), completed (green), and failed (red) per day, matching the metrics tab colors. It queries the `hog_flow_version` metrics mirror with an `app_source_id` prefix match (`<workflow id>/`), which is the one keying that batch runs and all workflow versions share. The mirror ships metrics since Aug 5, so a full 7 days of data exists in production.
- The list gets Type (Messaging / Automation) and Trigger filters next to Status, both synced to the URL. Trigger filtering reuses the API's existing JSON-containment `trigger` param; the Type filter is new server-side so pagination stays correct.
- The Messaging/Automation tag previously checked for a `function_slack` action type that does not exist and ignored push. Tag and filter now share one definition (email, SMS, push), so push-only workflows show "Messaging" for the first time.
- Mechanical: `appMetricsLogic` gains an `appSourceIdPrefix` param (LIKE with escaped wildcards), used only by the workflows table.

No screenshot: the agent session has no browser access.

## How did you test this code?

- Three new backend cases in `test_hog_flow.py` cover the `type` filter: messaging and automation each return only their workflows (guards against inverting the JSONB containment branch), and an unknown value returns 400. They pass locally along with the neighboring list-filter tests.
- Sparkline verified against local ClickHouse: a workflow edited across versions has `triggered` rows under `<id>/10`, `<id>/11`, `<id>/18`, and the prefix query aggregates them.
- Frontend typecheck, lint, and ruff pass locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session; skills invoked: /improving-drf-endpoints, /writing-tests, /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions.
- The sparkline design settled on the versioned mirror after tracing where batch runs record metrics (keyed on the batch job id in the plain `hog_flow` source, per `cdp-cyclotron-worker-batch-resolve.consumer.ts`); the alternative of re-keying batch metrics in the Node worker was rejected as it would double-count on the per-job metrics pages.
- Local verification data was invented; no customer data involved.

