### PR TITLE
feat(workflows): show started and completed runs in overview sparkline

### DIFF
--- a/frontend/src/lib/components/AppMetrics/AppMetricsSparkline.tsx
+++ b/frontend/src/lib/components/AppMetrics/AppMetricsSparkline.tsx
@@ -14,6 +14,8 @@ export interface AppMetricsSparklineProps extends AppMetricsLogicProps {
     successMetricNames?: string[]
     /** Optional display labels keyed by series name (e.g. `{ rows_synced: 'Rows synced' }`). */
     metricLabels?: Record<string, string>
+    /** Optional vars.scss color names keyed by series name; takes precedence over `successMetricNames`. */
+    metricColors?: Record<string, string>
 }
 
 const DEFAULT_SUCCESS_METRIC_NAMES = ['success']
@@ -21,6 +23,7 @@ const DEFAULT_SUCCESS_METRIC_NAMES = ['success']
 export function AppMetricsSparkline({
     successMetricNames,
     metricLabels,
+    metricColors,
     ...props
 }: AppMetricsSparklineProps): JSX.Element {
     const logic = appMetricsLogic(props)
@@ -52,12 +55,12 @@ export function AppMetricsSparkline({
 
         return (
             sortedSeries?.map((s) => ({
-                color: successNames.includes(s.name) ? 'success' : 'danger',
+                color: metricColors?.[s.name] ?? (successNames.includes(s.name) ? 'success' : 'danger'),
                 name: metricLabels?.[s.name] ?? s.name,
                 values: s.values,
             })) || []
         )
-    }, [appMetricsTrends, params, successMetricNames, metricLabels])
+    }, [appMetricsTrends, params, successMetricNames, metricLabels, metricColors])
 
     const labels = appMetricsTrends?.labels || []
 

--- a/frontend/src/lib/components/AppMetrics/AppMetricsSparkline.tsx
+++ b/frontend/src/lib/components/AppMetrics/AppMetricsSparkline.tsx
@@ -16,6 +16,8 @@ export interface AppMetricsSparklineProps extends AppMetricsLogicProps {
     metricLabels?: Record<string, string>
     /** Optional vars.scss color names keyed by series name; takes precedence over `successMetricNames`. */
     metricColors?: Record<string, string>
+    /** Bars stack their series. Pass `'line'` when series overlap and a summed height would mislead. @default 'bar' */
+    type?: 'bar' | 'line'
 }
 
 const DEFAULT_SUCCESS_METRIC_NAMES = ['success']
@@ -24,6 +26,7 @@ export function AppMetricsSparkline({
     successMetricNames,
     metricLabels,
     metricColors,
+    type,
     ...props
 }: AppMetricsSparklineProps): JSX.Element {
     const logic = appMetricsLogic(props)
@@ -71,7 +74,7 @@ export function AppMetricsSparkline({
             ) : !appMetricsTrends || appMetricsTrendsLoading ? (
                 <LemonSkeleton className="h-8 max-w-24" />
             ) : (
-                <Sparkline labels={labels} data={displayData} className="h-8 max-w-24" />
+                <Sparkline labels={labels} data={displayData} type={type} className="h-8 max-w-24" />
             )}
         </div>
     )

--- a/frontend/src/lib/components/AppMetrics/appMetricsLogic.ts
+++ b/frontend/src/lib/components/AppMetrics/appMetricsLogic.ts
@@ -30,6 +30,8 @@ const DEFAULT_INTERVAL = 'day'
 export type AppMetricsCommonParams = {
     appSource?: string
     appSourceId?: string
+    /** Match all app_source_ids starting with this prefix (e.g. `<hog flow id>/` for versioned hog flow metrics). */
+    appSourceIdPrefix?: string
     instanceId?: string
     metricName?: string | string[]
     metricKind?: string | string[]
@@ -79,6 +81,11 @@ export type AppMetricsTotalsResponse = Record<
     }
 >
 
+const appSourceIdPrefixPattern = (prefix: string): string => {
+    // Escape LIKE wildcards so the prefix matches literally.
+    return prefix.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_') + '%'
+}
+
 export const loadAppMetricsTotals = async (
     request: AppMetricsTotalsRequest,
     timezone: string
@@ -95,6 +102,10 @@ export const loadAppMetricsTotals = async (
 
     if (request.appSourceId) {
         query = (query + hogql`\nAND app_source_id = ${request.appSourceId}`) as HogQLQueryString
+    }
+    if (request.appSourceIdPrefix) {
+        query = (query +
+            hogql`\nAND app_source_id LIKE ${appSourceIdPrefixPattern(request.appSourceIdPrefix)}`) as HogQLQueryString
     }
     if (typeof request.instanceId === 'string') {
         query = (query + hogql`\nAND instance_id = ${request.instanceId}`) as HogQLQueryString
@@ -204,6 +215,10 @@ const loadAppMetricsTimeSeries = async (
 
     if (request.appSourceId) {
         query = (query + hogql`\nAND app_source_id = ${request.appSourceId}`) as HogQLQueryString
+    }
+    if (request.appSourceIdPrefix) {
+        query = (query +
+            hogql`\nAND app_source_id LIKE ${appSourceIdPrefixPattern(request.appSourceIdPrefix)}`) as HogQLQueryString
     }
     if (typeof request.instanceId === 'string') {
         query = (query + hogql`\nAND instance_id = ${request.instanceId}`) as HogQLQueryString

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -228,6 +228,9 @@ export function WorkflowsTable(): JSX.Element {
                     <Link to={urls.workflow(id, 'metrics')}>
                         <AppMetricsSparkline
                             logicKey={id}
+                            // Lines, not stacked bars: Started counts a run that also lands in
+                            // Completed or Failed the same day, so a stacked total would double-count.
+                            type="line"
                             metricLabels={{ triggered: 'Started', succeeded: 'Completed', failed: 'Failed' }}
                             // Same colors as the workflow metrics tab: triggered is blue there too.
                             metricColors={{ triggered: 'blue', succeeded: 'success', failed: 'danger' }}

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -228,11 +228,17 @@ export function WorkflowsTable(): JSX.Element {
                     <Link to={urls.workflow(id, 'metrics')}>
                         <AppMetricsSparkline
                             logicKey={id}
+                            metricLabels={{ triggered: 'Started', succeeded: 'Completed', failed: 'Failed' }}
+                            // Same colors as the workflow metrics tab: triggered is blue there too.
+                            metricColors={{ triggered: 'blue', succeeded: 'success', failed: 'danger' }}
                             forceParams={{
-                                appSource: 'hog_flow',
-                                appSourceId: id,
-                                metricKind: ['success', 'failure'],
-                                breakdownBy: 'metric_kind',
+                                // The versioned mirror keys every run's metrics (including batch runs,
+                                // which the plain hog_flow source keys under the batch job id) as
+                                // `<flow id>/<version>`, so a prefix match covers all activity.
+                                appSource: 'hog_flow_version',
+                                appSourceIdPrefix: `${id}/`,
+                                metricName: ['triggered', 'succeeded', 'failed'],
+                                breakdownBy: 'metric_name',
                                 interval: 'day',
                                 dateFrom: '-7d',
                             }}

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -237,6 +237,10 @@ export function WorkflowsTable(): JSX.Element {
                                 // `<flow id>/<version>`, so a prefix match covers all activity.
                                 appSource: 'hog_flow_version',
                                 appSourceIdPrefix: `${id}/`,
+                                // Run-level rows carry an empty instance_id; per-action succeeded/failed
+                                // rows carry the action id. Filter to run-level so Completed and Failed
+                                // count runs, not steps. triggered is run-level too, so Started is unaffected.
+                                instanceId: '',
                                 metricName: ['triggered', 'succeeded', 'failed'],
                                 breakdownBy: 'metric_name',
                                 interval: 'day',


### PR DESCRIPTION
## Problem

The "Last 7 days" sparkline on the workflows overview is empty for batch sends: batch runs record their metrics under the batch job id, not the workflow id, and the query only asked for completions anyway. After a 1000-person dispatch yesterday there is no way to tell from the list whether that workflow ran at all.

Replaces the combined #91461; the filter half sits on top as #91466.

## Changes

<img width="1105" height="272" alt="Screenshot 2026-08-31 at 13 06 59" src="https://github.com/user-attachments/assets/8721ec16-1161-4142-8754-ecdc1a4cc7b4" />


- The sparkline now shows runs started (blue), completed (green), and failed (red) per day, matching the metrics tab colors. It queries the `hog_flow_version` metrics mirror with an `app_source_id` prefix match (`<workflow id>/`), which is the one keying that batch runs and all workflow versions share. The mirror ships metrics since Aug 5 (#75100), so a full 7 days of data exists in production.
- Mechanical: `appMetricsLogic` gains an `appSourceIdPrefix` param (LIKE with escaped wildcards) and `AppMetricsSparkline` gains a per-series `metricColors` map; both are opt-in and only the workflows table uses them.

No screenshot: the agent session has no browser access.

## How did you test this code?

- Sparkline verified against local ClickHouse: a workflow edited across versions has `triggered` rows under `<id>/10`, `<id>/11`, `<id>/18`, and the prefix query aggregates them.
- No new automated tests: the change is a query parameter swap plus presentational colors. Frontend typecheck and lint pass locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session; skills invoked: /writing-pr-descriptions, /stacking-prs.
- The design settled on the versioned mirror after tracing where batch runs record metrics (keyed on the batch job id, per `cdp-cyclotron-worker-batch-resolve.consumer.ts`); re-keying batch metrics in the Node worker was rejected as it would double-count on the per-job metrics pages.
- Local verification data was invented; no customer data involved.
