### PR TITLE
feat(workflows): add type and trigger filters to overview list

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6670,6 +6670,9 @@ const api = {
             search?: string
             status?: HogFlow['status']
             created_by?: string
+            type?: 'messaging' | 'automation'
+            /** JSON-encoded object the stored trigger must contain, e.g. `{"type":"batch"}`. */
+            trigger?: string
             limit?: number
             offset?: number
         }): Promise<CountedPaginatedResponse<HogFlow>> {

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -118,6 +118,7 @@ from products.workflows.backend.api.message_assets import (
 from products.workflows.backend.api.publish_impact import build_publish_impact
 from products.workflows.backend.models.hog_flow.hog_flow import (
     BILLABLE_ACTION_TYPES,
+    MESSAGING_ACTION_TYPES,
     PERSON_DEPENDENT_ACTION_TYPES,
     ROW_SCOPED_TRIGGER_TYPES,
     SUPPORTED_ACTION_TYPES,
@@ -3227,6 +3228,17 @@ class HogFlowViewSet(
                 except ValueError:
                     raise exceptions.ValidationError({"created_by": "Must be a valid user uuid"})
                 queryset = queryset.filter(created_by__uuid=created_by)
+
+            workflow_type = self.request.GET.get("type")
+            if workflow_type:
+                if workflow_type not in ("messaging", "automation"):
+                    raise exceptions.ValidationError({"type": "Must be one of: messaging, automation"})
+                messaging_q = Q()
+                for action_type in MESSAGING_ACTION_TYPES:
+                    messaging_q |= Q(actions__contains=[{"type": action_type}])
+                queryset = (
+                    queryset.filter(messaging_q) if workflow_type == "messaging" else queryset.exclude(messaging_q)
+                )
 
         if self.request.GET.get("trigger"):
             try:

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -3092,6 +3092,17 @@ def mint_audience_confirm_token(
                 OpenApiTypes.UUID,
                 description="Filter to workflows created by the user with this uuid.",
             ),
+            OpenApiParameter(
+                "type",
+                OpenApiTypes.STR,
+                enum=["messaging", "automation"],
+                description="Filter by workflow type. `messaging` returns workflows with an email, SMS, or push action; `automation` returns the rest.",
+            ),
+            OpenApiParameter(
+                "trigger",
+                OpenApiTypes.STR,
+                description='Filter by trigger config as a JSON object. Returns workflows whose trigger contains the given object, e.g. {"type": "event"}.',
+            ),
         ]
     )
 )

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -239,6 +239,40 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 200, response.json()
         assert {flow["name"] for flow in response.json()["results"]} == {"Theirs"}
 
+    @parameterized.expand(
+        [
+            ("messaging", "messaging", {"Email drip", "Push blast"}),
+            ("automation", "automation", {"Webhook sync"}),
+        ]
+    )
+    def test_list_filter_by_workflow_type(self, _name, workflow_type, expected_names):
+        HogFlow.objects.create(
+            team=self.team,
+            name="Email drip",
+            created_by=self.user,
+            actions=[{"id": "a", "type": "function_email", "config": {}}],
+        )
+        HogFlow.objects.create(
+            team=self.team,
+            name="Push blast",
+            created_by=self.user,
+            actions=[{"id": "a", "type": "function_push", "config": {}}],
+        )
+        HogFlow.objects.create(
+            team=self.team,
+            name="Webhook sync",
+            created_by=self.user,
+            actions=[{"id": "a", "type": "function", "config": {}}],
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows?type={workflow_type}")
+        assert response.status_code == 200, response.json()
+        assert {flow["name"] for flow in response.json()["results"]} == expected_names
+
+    def test_list_filter_by_workflow_type_rejects_unknown_value(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/hog_flows?type=campaign")
+        assert response.status_code == 400
+
     def test_mcp_list_is_metadata_only_and_hides_action_secrets(self):
         # A webhook action whose headers carry a bearer token — the kind of credential-like value
         # that must not leak from a workflow *listing*.

--- a/products/workflows/backend/models/hog_flow/hog_flow.py
+++ b/products/workflows/backend/models/hog_flow/hog_flow.py
@@ -65,6 +65,16 @@ BILLABLE_ACTION_TYPES: Final[set[str]] = {
     "function_push",  # Push notification actions
 }
 
+# Action types that send a message to a person. A workflow containing at least one of these is a
+# "messaging" workflow; everything else is an "automation". Keep in sync with the frontend's
+# WorkflowTypeTag (products/workflows/frontend/Workflows/WorkflowsTable.tsx), which renders the
+# same split, and the list API's `type` filter, which queries on it.
+MESSAGING_ACTION_TYPES: Final[list[str]] = [
+    "function_email",
+    "function_sms",
+    "function_push",
+]
+
 # Action types that read person data and therefore cannot be used in person-less ("row-scoped")
 # workflows such as those triggered by a data warehouse table row sync. Keep in sync with the
 # frontend's PERSON_DEPENDENT_ACTION_TYPES.

--- a/products/workflows/frontend/Workflows/WorkflowsTable.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowsTable.tsx
@@ -24,7 +24,13 @@ import { getHogFlowStep } from './hogflows/steps/HogFlowSteps'
 import { HogFlow } from './hogflows/types'
 import { newWorkflowLogic } from './newWorkflowLogic'
 import { workflowLogic } from './workflowLogic'
-import { WorkflowStatusFilter, workflowsLogic } from './workflowsLogic'
+import {
+    WORKFLOW_TRIGGER_TYPE_OPTIONS,
+    WorkflowStatusFilter,
+    WorkflowTriggerTypeFilter,
+    WorkflowTypeFilter,
+    workflowsLogic,
+} from './workflowsLogic'
 
 const STATUS_CONFIG: Record<string, { label: string; type: 'success' | 'default' | 'muted' }> = {
     active: { label: 'Active', type: 'success' },
@@ -34,8 +40,10 @@ const STATUS_CONFIG: Record<string, { label: string; type: 'success' | 'default'
 
 function WorkflowTypeTag({ workflow }: { workflow: HogFlow }): JSX.Element {
     const hasMessagingAction = useMemo(() => {
+        // Keep in sync with MESSAGING_ACTION_TYPES in products/workflows/backend/models/hog_flow/hog_flow.py,
+        // which the list API's `type` filter uses - the tag and the filter must agree on what "Messaging" is.
         return workflow.actions.some((action) => {
-            return ['function_email', 'function_sms', 'function_slack'].includes(action.type)
+            return ['function_email', 'function_sms', 'function_push'].includes(action.type)
         })
     }, [workflow.actions])
 
@@ -347,6 +355,8 @@ export function WorkflowsTable(): JSX.Element {
         !filters.search &&
         !filters.createdBy &&
         filters.status === 'all' &&
+        filters.type === 'all' &&
+        filters.triggerType === 'all' &&
         // An empty page is not an empty project, so never offer onboarding while paging
         filters.page === 1
 
@@ -375,7 +385,7 @@ export function WorkflowsTable(): JSX.Element {
                             onChange={(search) => setFilters({ search })}
                             value={filters.search}
                         />
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 flex-wrap">
                             <span>
                                 <b>Status</b>
                             </span>
@@ -390,6 +400,30 @@ export function WorkflowsTable(): JSX.Element {
                                     { label: 'Archived', value: 'archived' },
                                 ]}
                                 value={filters.status}
+                            />
+                            <span className="ml-1">
+                                <b>Type</b>
+                            </span>
+                            <LemonSelect
+                                dropdownMatchSelectWidth={false}
+                                size="small"
+                                onChange={(value) => setFilters({ type: value as WorkflowTypeFilter })}
+                                options={[
+                                    { label: 'All', value: 'all' },
+                                    { label: 'Messaging', value: 'messaging' },
+                                    { label: 'Automation', value: 'automation' },
+                                ]}
+                                value={filters.type}
+                            />
+                            <span className="ml-1">
+                                <b>Trigger</b>
+                            </span>
+                            <LemonSelect
+                                dropdownMatchSelectWidth={false}
+                                size="small"
+                                onChange={(value) => setFilters({ triggerType: value as WorkflowTriggerTypeFilter })}
+                                options={WORKFLOW_TRIGGER_TYPE_OPTIONS}
+                                value={filters.triggerType}
                             />
                             <span className="ml-1">
                                 <b>Created by</b>

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -303,8 +303,12 @@ export const workflowsLogic = kea<workflowsLogicType>([
         workflows: [
             { results: [], count: 0 } as WorkflowsResult,
             {
-                loadWorkflows: async () => {
-                    return await api.hogFlows.getHogFlows(values.paramsFromFilters)
+                loadWorkflows: async (_, breakpoint) => {
+                    const response = await api.hogFlows.getHogFlows(values.paramsFromFilters)
+                    // Drop a response a newer filter change has already superseded, so a slow request
+                    // returning after a faster later one can't leave the table showing the wrong filters.
+                    breakpoint()
+                    return response
                 },
                 toggleWorkflowStatus: async ({ workflow }) => {
                     await api.hogFlows.updateHogFlow(workflow.id, {

--- a/products/workflows/frontend/Workflows/workflowsLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowsLogic.ts
@@ -16,16 +16,47 @@ export type WorkflowStatusFilter = 'all' | 'active' | 'draft' | 'archived'
 
 const WORKFLOW_STATUS_FILTERS: WorkflowStatusFilter[] = ['all', 'active', 'draft', 'archived']
 
+export type WorkflowTypeFilter = 'all' | 'messaging' | 'automation'
+
+const WORKFLOW_TYPE_FILTERS: WorkflowTypeFilter[] = ['all', 'messaging', 'automation']
+
+export type WorkflowTriggerTypeFilter = 'all' | (NonNullable<HogFlow['trigger']> extends { type: infer T } ? T : never)
+
+// Keep in sync with TRIGGER_TYPES in products/workflows/backend/models/hog_flow/hog_flow.py.
+export const WORKFLOW_TRIGGER_TYPE_OPTIONS: { value: WorkflowTriggerTypeFilter; label: string }[] = [
+    { value: 'all', label: 'All' },
+    { value: 'event', label: 'Event' },
+    { value: 'schedule', label: 'Schedule' },
+    { value: 'manual', label: 'Manual' },
+    { value: 'batch', label: 'Batch' },
+    { value: 'webhook', label: 'Webhook' },
+    { value: 'tracking_pixel', label: 'Tracking pixel' },
+    { value: 'data-warehouse-table', label: 'Data warehouse table' },
+    { value: 'data-warehouse-view', label: 'Data warehouse view' },
+    { value: 'slack-message', label: 'Slack message' },
+]
+
+const WORKFLOW_TRIGGER_TYPE_FILTERS = WORKFLOW_TRIGGER_TYPE_OPTIONS.map((option) => option.value)
+
 export const WORKFLOWS_PER_PAGE = 30
 
 export interface WorkflowsFilters {
     search: string
     createdBy: string | null
     status: WorkflowStatusFilter
+    type: WorkflowTypeFilter
+    triggerType: WorkflowTriggerTypeFilter
     page: number
 }
 
-const DEFAULT_FILTERS: WorkflowsFilters = { search: '', createdBy: null, status: 'all', page: 1 }
+const DEFAULT_FILTERS: WorkflowsFilters = {
+    search: '',
+    createdBy: null,
+    status: 'all',
+    type: 'all',
+    triggerType: 'all',
+    page: 1,
+}
 
 type WorkflowsResult = CountedPaginatedResponse<HogFlow>
 
@@ -33,6 +64,8 @@ interface WorkflowsListParams {
     search?: string
     status?: HogFlow['status']
     created_by?: string
+    type?: Exclude<WorkflowTypeFilter, 'all'>
+    trigger?: string
     limit: number
     offset: number
 }
@@ -383,6 +416,9 @@ export const workflowsLogic = kea<workflowsLogicType>([
                 search: filters.search || undefined,
                 status: filters.status !== 'all' ? filters.status : undefined,
                 created_by: filters.createdBy || undefined,
+                type: filters.type !== 'all' ? filters.type : undefined,
+                // The API filters triggers by JSON containment, so the type goes over as a JSON object.
+                trigger: filters.triggerType !== 'all' ? JSON.stringify({ type: filters.triggerType }) : undefined,
                 limit: WORKFLOWS_PER_PAGE,
                 offset: filters.page ? (filters.page - 1) * WORKFLOWS_PER_PAGE : 0,
             }),
@@ -474,6 +510,8 @@ export const workflowsLogic = kea<workflowsLogicType>([
             setOrDelete('search', values.filters.search)
             setOrDelete('created_by', values.filters.createdBy)
             setOrDelete('status', values.filters.status !== 'all' ? values.filters.status : null)
+            setOrDelete('type', values.filters.type !== 'all' ? values.filters.type : null)
+            setOrDelete('trigger_type', values.filters.triggerType !== 'all' ? values.filters.triggerType : null)
             setOrDelete('page', values.filters.page > 1 ? values.filters.page : null)
 
             return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
@@ -486,10 +524,14 @@ export const workflowsLogic = kea<workflowsLogicType>([
     urlToAction(({ actions, values }) => ({
         [urls.workflows()]: (_, searchParams) => {
             const status = searchParams['status']
+            const type = searchParams['type']
+            const triggerType = searchParams['trigger_type']
             const parsed: WorkflowsFilters = {
                 search: searchParams['search'] ? String(searchParams['search']) : '',
                 createdBy: searchParams['created_by'] ? String(searchParams['created_by']) : null,
                 status: WORKFLOW_STATUS_FILTERS.includes(status) ? status : 'all',
+                type: WORKFLOW_TYPE_FILTERS.includes(type) ? type : 'all',
+                triggerType: WORKFLOW_TRIGGER_TYPE_FILTERS.includes(triggerType) ? triggerType : 'all',
                 // Anything unparseable, zero, or negative falls back to page 1 rather than reaching
                 // the offset maths as NaN or a negative number.
                 page: Math.max(1, parseInt(String(searchParams['page'])) || 1),

--- a/products/workflows/frontend/generated/api.schemas.ts
+++ b/products/workflows/frontend/generated/api.schemas.ts
@@ -1529,6 +1529,14 @@ export type HogFlowsListParams = {
      * * `archived` - Archived
      */
     status?: HogFlowsListStatus
+    /**
+     * Filter by trigger config as a JSON object. Returns workflows whose trigger contains the given object, e.g. {"type": "event"}.
+     */
+    trigger?: string
+    /**
+     * Filter by workflow type. `messaging` returns workflows with an email, SMS, or push action; `automation` returns the rest.
+     */
+    type?: HogFlowsListType
     updated_at?: string
 }
 
@@ -1538,6 +1546,13 @@ export const HogFlowsListStatus = {
     Active: 'active',
     Archived: 'archived',
     Draft: 'draft',
+} as const
+
+export type HogFlowsListType = (typeof HogFlowsListType)[keyof typeof HogFlowsListType]
+
+export const HogFlowsListType = {
+    Automation: 'automation',
+    Messaging: 'messaging',
 } as const
 
 export type HogFlowsAssetsRetrieveParams = {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -93760,6 +93760,14 @@ export namespace Schemas {
      * * `archived` - Archived
      */
     status?: HogFlowsListStatus;
+    /**
+     * Filter by trigger config as a JSON object. Returns workflows whose trigger contains the given object, e.g. {"type": "event"}.
+     */
+    trigger?: string;
+    /**
+     * Filter by workflow type. `messaging` returns workflows with an email, SMS, or push action; `automation` returns the rest.
+     */
+    type?: HogFlowsListType;
     updated_at?: string;
     };
 
@@ -93770,6 +93778,14 @@ export namespace Schemas {
       Active: 'active',
       Archived: 'archived',
       Draft: 'draft',
+    } as const;
+
+    export type HogFlowsListType = typeof HogFlowsListType[keyof typeof HogFlowsListType];
+
+
+    export const HogFlowsListType = {
+      Automation: 'automation',
+      Messaging: 'messaging',
     } as const;
 
     export type HogFlowsAssetsRetrieveParams = {

--- a/services/mcp/src/generated/workflows/api.ts
+++ b/services/mcp/src/generated/workflows/api.ts
@@ -27,6 +27,18 @@ export const HogFlowsListQueryParams = /* @__PURE__ */ zod.object({
         .enum(['active', 'archived', 'draft'])
         .optional()
         .describe('\* `draft` - Draft\n\* `active` - Active\n\* `archived` - Archived'),
+    trigger: zod
+        .string()
+        .optional()
+        .describe(
+            'Filter by trigger config as a JSON object. Returns workflows whose trigger contains the given object, e.g. {\"type\": \"event\"}.'
+        ),
+    type: zod
+        .enum(['automation', 'messaging'])
+        .optional()
+        .describe(
+            'Filter by workflow type. `messaging` returns workflows with an email, SMS, or push action; `automation` returns the rest.'
+        ),
     updated_at: zod.iso.datetime({ offset: true }).optional(),
 })
 

--- a/services/mcp/src/tools/generated/workflows.ts
+++ b/services/mcp/src/tools/generated/workflows.ts
@@ -189,6 +189,8 @@ const workflowsList = (): ToolBase<typeof WorkflowsListSchema, WithPostHogUrl<Sc
                     offset: params.offset,
                     search: params.search,
                     status: params.status,
+                    trigger: params.trigger,
+                    type: params.type,
                     updated_at: params.updated_at,
                 },
             })

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/workflows-list.json
@@ -30,6 +30,15 @@
             "enum": ["active", "archived", "draft"],
             "type": "string"
         },
+        "trigger": {
+            "description": "Filter by trigger config as a JSON object. Returns workflows whose trigger contains the given object, e.g. {\"type\": \"event\"}.",
+            "type": "string"
+        },
+        "type": {
+            "description": "Filter by workflow type. `messaging` returns workflows with an email, SMS, or push action; `automation` returns the rest.",
+            "enum": ["automation", "messaging"],
+            "type": "string"
+        },
         "updated_at": {
             "format": "date-time",
             "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",


### PR DESCRIPTION
## Problem

The workflows list only filters by status. Once email automations, transactional email, internal workflows, and campaigns all live here, that is not enough to find anything.

Stacked on #91465 (sparkline fix); replaces the combined #91461.

## Changes


https://github.com/user-attachments/assets/4a8b12d7-18a4-43bc-9507-9f244949c47c


- The list gets Type (Messaging / Automation) and Trigger filters next to Status, both synced to the URL so filtered views are shareable.
- Trigger filtering reuses the API's existing JSON-containment `trigger` param; the Type filter is new server-side so pagination stays correct, backed by a `MESSAGING_ACTION_TYPES` constant on the model.
- The Messaging/Automation tag previously checked for a `function_slack` action type that does not exist and ignored push. Tag and filter now share one definition (email, SMS, push), so push-only workflows show "Messaging" for the first time.

No screenshot: the agent session has no browser access.

## How did you test this code?

- Three new backend cases in `test_hog_flow.py` cover the `type` filter: messaging and automation each return only their workflows (guards against inverting the JSONB containment branch), and an unknown value returns 400. They pass locally along with the neighboring list-filter tests.
- Frontend typecheck, lint, and ruff pass locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session; skills invoked: /improving-drf-endpoints, /writing-tests, /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions, /stacking-prs.
- Test data was invented; no customer data involved.
