### PR TITLE
chore(ingestion-consumer): add driver-model implementation plan

### DIFF
--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -35,6 +35,7 @@ Rules:
 - Prepare, implement, and cleanup changes do not change behavior. The e2e tests must pass without edits.
 - Only a switchover may change behavior. Some do not (a switchover with identical output is still staged and reversible).
 - Old code is deleted in cleanup, never edited.
+- Dead code is deleted before a seam is carved around it.
 - A cycle's cleanup lands only after its switchover holds on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
 - The commit sentinel and the key-order sentinel stay enabled through every cycle.
@@ -54,28 +55,30 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 | 2 | 1 frontier commits | Switchover | Run the ledger in shadow mode |
 | 3 | 1 frontier commits | Switchover | Commit from the ledger frontier |
 | 4 | 1 frontier commits | Cleanup | Delete the old commit computation |
-| 5 | 2 per-key order | Prepare | Demux polls into groups |
-| 6 | 2 per-key order | Prepare | Encapsulate the worker batcher |
-| 7 | 2 per-key order | Prepare | Extract the scheduler seam |
-| 8 | 2 per-key order | Implement | Build the key-table scheduler |
-| 9 | 2 per-key order | Switchover | Switch to the key-table scheduler |
-| 10 | 2 per-key order | Cleanup | Delete the old scheduler |
-| 11 | 2 per-key order | Cleanup | Remove the stream fences |
-| 12 | 2 per-key order | Cleanup | Collapse the batcher into one event loop |
-| 13 | 3 decoupled commits | Switchover | Complete polls in any order |
-| 14 | 3 decoupled commits | Cleanup | Delete the ordered completion path |
-| 15 | 4 bounded replay | Implement | Add the budget accounting |
-| 16 | 4 bounded replay | Switchover | Enable the budget |
-| 17 | 4 bounded replay | Cleanup | Remove the batch window |
-| 18 | 5 target-sized requests | Implement | Add the packer |
-| 19 | 5 target-sized requests | Switchover | Set the packing targets |
-| 20 | 6 adaptive concurrency | Implement | Add the governor |
-| 21 | 6 adaptive concurrency | Switchover | Enable RTT adaptation |
-| 22 | 6 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
-| 23 | 7 clean handoff | Prepare | Add revoke and drained markers |
-| 24 | 7 clean handoff | Implement | Build the drain |
-| 25 | 7 clean handoff | Switchover | Enable the drain |
-| 26 | 7 clean handoff | Cleanup | Delete the no-drain path |
+| 5 | 2 per-key order | Prepare | Delete the dead eager flush |
+| 6 | 2 per-key order | Prepare | Extract fence-safe send resolution |
+| 7 | 2 per-key order | Prepare | Demux polls into groups |
+| 8 | 2 per-key order | Prepare | Encapsulate the worker batcher |
+| 9 | 2 per-key order | Prepare | Extract the scheduler seam |
+| 10 | 2 per-key order | Implement | Build the key-table scheduler |
+| 11 | 2 per-key order | Switchover | Switch to the key-table scheduler |
+| 12 | 2 per-key order | Cleanup | Delete the old scheduler |
+| 13 | 2 per-key order | Cleanup | Remove the stream fences |
+| 14 | 2 per-key order | Cleanup | Collapse the batcher into one event loop |
+| 15 | 3 decoupled commits | Switchover | Complete polls in any order |
+| 16 | 3 decoupled commits | Cleanup | Delete the ordered completion path |
+| 17 | 4 bounded replay | Implement | Add the budget accounting |
+| 18 | 4 bounded replay | Switchover | Enable the budget |
+| 19 | 4 bounded replay | Cleanup | Remove the batch window |
+| 20 | 5 target-sized requests | Implement | Add the packer |
+| 21 | 5 target-sized requests | Switchover | Set the packing targets |
+| 22 | 6 adaptive concurrency | Implement | Add the governor |
+| 23 | 6 adaptive concurrency | Switchover | Enable RTT adaptation |
+| 24 | 6 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
+| 25 | 7 clean handoff | Prepare | Add revoke and drained markers |
+| 26 | 7 clean handoff | Implement | Build the drain |
+| 27 | 7 clean handoff | Switchover | Enable the drain |
+| 28 | 7 clean handoff | Cleanup | Delete the no-drain path |
 
 ## Cycle 1: commits come from the frontier
 
@@ -88,7 +91,7 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 15.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 17.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` removes the contiguous done prefix and returns the highest removed offset.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
@@ -151,7 +154,38 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 
 Outcome: at most one outstanding request per key is the only ordering mechanism. Pins, the stash, and the flush paths are gone.
 
-### 5. Demux polls into groups (prepare)
+### 5. Delete the dead eager flush (prepare)
+
+**Task:** Remove the eager deferred flush. The flag that enables it is off everywhere.
+
+**Goal:** One send origin fewer before any seam is carved.
+
+- `DISPATCHER_EAGER_DEFERRED_FLUSH` is default off, and no deployment sets it. Confirm against a fresh charts checkout before this ships.
+- The completion-time flush already does all the draining in production. Behavior does not change.
+- Carrying the eager path through the seam extraction would preserve code that does not run.
+
+**Interfaces:**
+
+- Remove `EagerFlush`, `run_eager_flush_loop`, `send_eager_flush`, and `DISPATCHER_EAGER_DEFERRED_FLUSH`.
+- Modify `Dispatcher`: remove `set_eager_flush_sender`, `release_next_groups`, `eager_flush_*`, `take_eager_accepted`, and the eager pending and accepted accounting.
+
+### 6. Extract fence-safe send resolution (prepare)
+
+**Task:** Move the send-and-resolve protocol into one helper. Every send path uses it.
+
+**Goal:** Fence handling exists in one place and cannot be forgotten.
+
+- The protocol is spread over the scatter and flush paths today: begin the send at the ordering point, await the pending send, then resolve.
+- On success: ack the key offsets, resolve the dispatcher state, record health.
+- On failure: defer the messages, then drop the `fence_guard`, then resolve, then record health. This order is the contract. A guard dropped early lets newer work leapfrog a fenced failure.
+- No behavior change. The helper encodes the current order.
+
+**Interfaces:**
+
+- Add a resolve helper in `consumer.rs` that owns the success and failure sequences.
+- Modify `scatter` and the flush path to call it. `SendError` and `PendingSubBatch` do not change.
+
+### 7. Demux polls into groups (prepare)
 
 **Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
 
@@ -159,7 +193,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 
 - Group messages per partition first, then per routing key. Keep offset order inside each group.
 - The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
-- Change 6 submits them to the batcher as the accumulator.
+- Change 8 submits them to the batcher as the accumulator.
 
 **Interfaces:**
 
@@ -167,7 +201,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Modify `CollectedBatch`: carries `Vec<Group>` instead of a flat message list.
 - Modify `Dispatcher::assign_and_send`: takes groups and flattens them. `group_messages_by_routing_key` moves to the collect path.
 
-### 6. Encapsulate the worker batcher (prepare)
+### 8. Encapsulate the worker batcher (prepare)
 
 **Task:** Put today's dispatch machinery behind one boundary. The consumer loop and the batcher exchange plain values.
 
@@ -177,22 +211,22 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Interface out: one completion event per group, with its partition, offsets, and accepted count.
 - This is the design doc's boundary: accumulators in, completions out. It is the final shape and does not change again.
 - No batch identity crosses the boundary. The facade mints an internal batch id per accumulator for the old machinery and the wire request. The consumer correlates completions by partition and offset — the same key the ledger uses.
-- The facade breaks each resolved send into its groups. The resolution paths already carry them (`routing_keys`, `key_offsets`), and a send is all-or-nothing.
-- Move inside the boundary: assignment, scatter, the deferred flush, the eager flush, the worker registry, the router, and the stream runners.
+- The facade breaks each resolved send into its groups. The resolve helper (change 6) already carries them (`routing_keys`, `key_offsets`), and a send is all-or-nothing.
+- Move inside the boundary: assignment, scatter, the deferred flush, the resolve helper, the worker registry, the router, and the stream runners.
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion, not redesign.
 - The consumer loop keeps: poll collection, commits, the sentinels, and the batch window. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
-- Changes 7 and 8 carve the scheduler seam inside this boundary.
+- Changes 9 and 10 carve the scheduler seam inside this boundary.
 
 **Interfaces:**
 
 - Add `Accumulator`: one poll's groups, in poll order.
 - Add `Batcher` in `batcher.rs`: `submit(Accumulator)` in, a channel of `GroupCompletion` out. It owns `Dispatcher`, `GrpcTransport`, `WorkerRegistry`, and the send tasks. It mints batch ids internally.
 - Add `GroupCompletion`: partition, offsets, accepted count. No batch id.
-- Modify `IngestionConsumer`: drop `scatter`, `flush_deferred`, and the eager-flush loop — they move into the batcher. Keep collect, commit, and the window. Correlate completions to polls by partition and offset.
+- Modify `IngestionConsumer`: drop `scatter` and `flush_deferred` — they move into the batcher. Keep collect, commit, and the window. Correlate completions to polls by partition and offset.
 - Modify `main.rs`: construct one `Batcher`. The consumer no longer sees the dispatcher or the transport.
-- Internalize `Dispatcher`'s resolve and accounting methods (`on_sub_batch_*`, `defer_failed`, `eager_flush_*`, `take_eager_accepted`): only the batcher calls them.
+- Internalize `Dispatcher`'s resolve methods (`on_sub_batch_*`, `defer_failed`): only the batcher calls them.
 
-### 7. Extract the scheduler seam (prepare)
+### 9. Extract the scheduler seam (prepare)
 
 **Task:** Move every ordering and placement decision inside the batcher behind one interface. Keep the current semantics.
 
@@ -201,7 +235,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - The scheduler decides which runs may go to a worker now, and where. Nothing else in the batcher decides that.
 - Interface in: events. A group arrives. A request settles, with success or failure. A retry deadline fires.
 - Interface out: dispatches. One dispatch is one run of one key on one worker.
-- The first implementation preserves today's semantics: pins, the stash, deferral on drain, the flush pacing, and the eager release. This is code motion from `assign`, `flush_deferred`, `on_sub_batch_resolved`, and the eager path.
+- The first implementation preserves today's semantics: pins, the stash, deferral on drain, and the flush pacing. This is code motion from `assign`, `flush_deferred`, and `on_sub_batch_resolved`.
 - The plumbing (tasks, channels, the mutex) stays as it is. Only the decisions move.
 - The seam makes today's implicit ordering rules explicit and reviewable in one place.
 
@@ -209,10 +243,10 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 
 - Add the `Scheduler` trait in `scheduler.rs`: `on_groups`, `on_settled`, `on_deadline` in; `Vec<Dispatch>` out.
 - Add `Dispatch`: one run of one key, with the chosen worker.
-- Add `PinStashScheduler`: the current semantics, moved out of `Dispatcher::assign`, `flush_deferred`, `on_sub_batch_resolved`, and the eager release. It owns `PinTable` and `Stash` unchanged.
+- Add `PinStashScheduler`: the current semantics, moved out of `Dispatcher::assign`, `flush_deferred`, and `on_sub_batch_resolved`. It owns `PinTable` and `Stash` unchanged.
 - Modify `Dispatcher`: shrinks to plumbing — the lock, in-flight load, metrics, and seam calls.
 
-### 8. Build the key-table scheduler (implement)
+### 10. Build the key-table scheduler (implement)
 
 **Task:** Write the target scheduler as a second implementation of the seam. Do not select it.
 
@@ -229,7 +263,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 
 - Add `KeyTableScheduler` and `KeyTable` in `key_table.rs`: per-key FIFO, outstanding flag, parked list. Implements `Scheduler`. Tests only, no production callers.
 
-### 9. Switch to the key-table scheduler (switchover)
+### 11. Switch to the key-table scheduler (switchover)
 
 **Task:** Select the key-table scheduler with config. Canary one lane, then roll out.
 
@@ -247,28 +281,28 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Modify the batcher construction: select `KeyTableScheduler` or `PinStashScheduler`.
 - No interface shapes change.
 
-### 10. Delete the old scheduler (cleanup)
+### 12. Delete the old scheduler (cleanup)
 
-**Task:** Remove the old scheduler implementation after change 9 holds on all lanes.
+**Task:** Remove the old scheduler implementation after change 11 holds on all lanes.
 
 **Goal:** The old concurrency goes in one deletion, not in edits.
 
-- Removes: the pin table, the stash, both flush drivers, the eager-flush channel and its credits, `DISPATCHER_EAGER_DEFERRED_FLUSH`, and the scheduler switch.
-- The plan never edits this machinery. It is isolated in change 7, bypassed in change 9, and deleted here.
+- Removes: the pin table, the stash, the completion-time flush, and the scheduler switch.
+- The plan never edits this machinery. It is isolated in change 9, bypassed in change 11, and deleted here.
 
 **Interfaces:**
 
-- Remove `PinStashScheduler`, `PinTable`, `Stash`, `sticky_pin_for`, `EagerFlush`, and the eager credits.
-- Remove from `Config`: `DISPATCHER_EAGER_DEFERRED_FLUSH` and the scheduler selection.
-- Modify `Dispatcher`: remove the dead resolve plumbing (`clears_deferral`, `send_failed`, the flush drivers).
+- Remove `PinStashScheduler`, `PinTable`, `Stash`, and `sticky_pin_for`.
+- Remove the scheduler selection from `Config`.
+- Modify `Dispatcher`: remove the dead resolve plumbing (`clears_deferral`, `send_failed`, the flush driver).
 
-### 11. Remove the stream fences (cleanup)
+### 13. Remove the stream fences (cleanup)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- After change 10, the scheduler blocks every key with a failed request: the key is not runnable, so no newer send for it can enter a stream.
+- After change 12, the scheduler blocks every key with a failed request: the key is not runnable, so no newer send for it can enter a stream.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
@@ -278,7 +312,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Modify `SendError`: drop the fence-guard field.
 - Keep `TransportError` and the `WorkerStreamRunner` reconnect logic.
 
-### 12. Collapse the batcher into one event loop (cleanup)
+### 14. Collapse the batcher into one event loop (cleanup)
 
 **Task:** Move the scheduler and its plumbing into one single-owner task.
 
@@ -297,7 +331,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 
 Outcome: commits advance per partition as groups complete. Needs cycles 1 and 2.
 
-### 13. Complete polls in any order (switchover)
+### 15. Complete polls in any order (switchover)
 
 **Task:** Add a completion mode, `ordered` or `any`. In `any` mode, mark the ledger per group and stop waiting for whole polls.
 
@@ -315,7 +349,7 @@ Outcome: commits advance per partition as groups complete. Needs cycles 1 and 2.
 - Modify `Config`: add the completion mode.
 - Modify `IngestionConsumer::process`: in `any` mode, select over `GroupCompletion` events. The ordered path stays for rollback.
 
-### 14. Delete the ordered completion path (cleanup)
+### 16. Delete the ordered completion path (cleanup)
 
 **Task:** Remove the ordered completion path after `any` holds on all lanes.
 
@@ -323,13 +357,13 @@ Outcome: commits advance per partition as groups complete. Needs cycles 1 and 2.
 
 **Interfaces:**
 
-- Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 6, and the completion mode from `Config`.
+- Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 8, and the completion mode from `Config`.
 
 ## Cycle 4: replay exposure is bounded by B
 
 Outcome: uncommitted work never exceeds the budget, in events and bytes. The batch window is gone.
 
-### 15. Add the budget accounting (implement)
+### 17. Add the budget accounting (implement)
 
 **Task:** Track uncommitted work in events and bytes. Ship with no budget set: the window still governs alone.
 
@@ -345,13 +379,14 @@ Outcome: uncommitted work never exceeds the budget, in events and bytes. The bat
 - Modify `Config`: add the budget, default unset.
 - Modify `IngestionConsumer`: track charge and refund through `OffsetLedger`. No polling change while the budget is unset.
 
-### 16. Enable the budget (switchover)
+### 18. Enable the budget (switchover)
 
 **Task:** Set the budget per lane. Pause the poll at the limit and resume on refund.
 
 **Goal:** Replay exposure is bounded directly.
 
 - A charts values PR sets the budget lane by lane. The window and the budget both bound work during the transition.
+- Derive the first values from the current config: events near the batch size times the window, bytes from the byte bound. The effective bound then does not change at the switchover.
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
 - Watch the pause gauge and consumer lag. Rollback is unsetting the values.
 
@@ -359,7 +394,7 @@ Outcome: uncommitted work never exceeds the budget, in events and bytes. The bat
 
 - None in this repository. Config values only.
 
-### 17. Remove the batch window (cleanup)
+### 19. Remove the batch window (cleanup)
 
 **Task:** Remove `max_in_flight_batches` after the budget holds on all lanes.
 
@@ -373,7 +408,7 @@ Outcome: uncommitted work never exceeds the budget, in events and bytes. The bat
 
 Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup: body splitting stays as a defence.
 
-### 18. Add the packer (implement)
+### 20. Add the packer (implement)
 
 **Task:** Add the packer to the scheduler, with target size T and `PACK_LATENCY_BUDGET`. Ship with the pack budget at zero: send-on-arrival, behavior unchanged.
 
@@ -391,7 +426,7 @@ Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup:
 - Modify `Dispatch`: one request may carry runs from several keys.
 - Modify `Config`: add T and `PACK_LATENCY_BUDGET`, default zero. The worker proto does not change.
 
-### 19. Set the packing targets (switchover)
+### 21. Set the packing targets (switchover)
 
 **Task:** Set T and the pack budget per lane.
 
@@ -408,7 +443,7 @@ Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup:
 
 Outcome: request RTT governs the number of requests in flight.
 
-### 20. Add the governor (implement)
+### 22. Add the governor (implement)
 
 **Task:** Add the permit pool and the RTT EWMA. Ship with adaptation off: permits mirror the current per-worker cap.
 
@@ -425,7 +460,7 @@ Outcome: request RTT governs the number of requests in flight.
 - Add `Governor` in the batcher loop: the permit pool and the RTT EWMA, adaptation off.
 - Modify `Config`: add `REQUEST_LATENCY_BUDGET`, the permit bounds, and `DEPTH_MAX`.
 
-### 21. Enable RTT adaptation (switchover)
+### 23. Enable RTT adaptation (switchover)
 
 **Task:** Turn adaptation on. Request RTT governs the permit pool.
 
@@ -438,7 +473,7 @@ Outcome: request RTT governs the number of requests in flight.
 
 - Modify `Config`: enable adaptation.
 
-### 22. Remove the fixed per-worker cap (cleanup)
+### 24. Remove the fixed per-worker cap (cleanup)
 
 **Task:** Remove the per-worker `max_unacked` cap after adaptation holds on all lanes.
 
@@ -452,7 +487,7 @@ Outcome: request RTT governs the number of requests in flight.
 
 Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 2.
 
-### 23. Add revoke and drained markers (prepare)
+### 25. Add revoke and drained markers (prepare)
 
 **Task:** Extend the batcher boundary with a revoke marker in and a drained marker out. Nothing consumes them yet.
 
@@ -462,7 +497,7 @@ Outcome: a revocation drains in bounded time, and a wedged partition fails the p
 
 - Modify `Batcher`: add the marker types to the submit and completion channels. `GroupCompletion` does not change shape.
 
-### 24. Build the drain (implement)
+### 26. Build the drain (implement)
 
 **Task:** Implement the drain sequence from section 4 of the design doc, behind a config switch that ships off.
 
@@ -481,7 +516,7 @@ Outcome: a revocation drains in bounded time, and a wedged partition fails the p
 - Modify `IngestionConsumer` and `OffsetLedger`: the final commit, the refund of abandoned charge, and the stall deadline.
 - Modify `Config`: add the drain switch, default off.
 
-### 25. Enable the drain (switchover)
+### 27. Enable the drain (switchover)
 
 **Task:** Turn the drain on. Canary one lane through a rebalance.
 
@@ -493,7 +528,7 @@ Outcome: a revocation drains in bounded time, and a wedged partition fails the p
 
 - Modify `Config`: enable the drain.
 
-### 26. Delete the no-drain path (cleanup)
+### 28. Delete the no-drain path (cleanup)
 
 **Task:** Remove the no-drain revoke path after the drain holds on all lanes.
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -24,19 +24,25 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - A change is a structure change or a logic change, never both.
 - A structure change does not change behavior. The e2e tests must pass without edits.
 - Structure prepares logic. Every logic change comes after the structure changes that make it small. A new implementation ships unselected in a structure change; a logic change selects it.
+- Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
 - A logic change ships behind a config switch when a switch is possible. When a switch is not possible, it ships as a canary on one lane.
 - Old code is deleted, not edited. When a cutover holds on all lanes, one structure change removes the old implementation whole.
 - The commit sentinel and the key-order sentinel stay enabled through the migration. They verify each step in production.
 
 ## Changes
 
-Part 1 prepares the structure (changes 1 to 5).
+Part 1 prepares the structure (changes 1 to 6).
 Behavior does not change.
-The offset ledger and the key-table batcher are both built here, tested, and left unselected.
+The offset ledger and the key-table scheduler are both built here, tested, and left unselected.
 
-Part 2 cuts over and simplifies (changes 6 to 14).
+Part 2 cuts over and simplifies (changes 7 to 16).
 Each cutover is a switch flip made small by part 1, with the switch as the rollback.
 Each deletion follows its cutover.
+
+The swap unit inside the batcher is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
+That is where the complexity concentrates — the pins, the stash, and the flush interplay.
+Placement (P2C, aperture) and send execution (stream runners) already match the target design and are not rebuilt.
+The single-owner event loop is only plumbing once the scheduler is simple, so it moves last.
 
 | # | Type | Change |
 | --- | --- | --- |
@@ -44,16 +50,18 @@ Each deletion follows its cutover.
 | 2 | Structure | Run the ledger in shadow mode |
 | 3 | Structure | Demux polls into groups |
 | 4 | Structure | Encapsulate the worker batcher |
-| 5 | Structure | Build the key-table batcher |
-| 6 | Structure | Commit from the ledger frontier |
-| 7 | Logic | Switch to the key-table batcher |
-| 8 | Structure | Delete the old batcher implementation |
-| 9 | Structure | Remove the stream fences |
-| 10 | Logic | Complete batches in any order |
-| 11 | Logic | Replace the batch window with budget B |
-| 12 | Logic | Pack requests toward target T |
-| 13 | Logic | Add the RTT dispatch governor |
-| 14 | Logic | Add the bounded revocation drain |
+| 5 | Structure | Extract the scheduler seam |
+| 6 | Structure | Build the key-table scheduler |
+| 7 | Structure | Commit from the ledger frontier |
+| 8 | Logic | Switch to the key-table scheduler |
+| 9 | Structure | Delete the old scheduler |
+| 10 | Structure | Remove the stream fences |
+| 11 | Structure | Collapse the batcher into one event loop |
+| 12 | Logic | Complete batches in any order |
+| 13 | Logic | Replace the batch window with budget B |
+| 14 | Logic | Pack requests toward target T |
+| 15 | Logic | Add the RTT dispatch governor |
+| 16 | Logic | Add the bounded revocation drain |
 
 ### 1. Add the offset ledger module (structure)
 
@@ -62,7 +70,7 @@ Each deletion follows its cutover.
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 11.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 13.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` removes the contiguous done prefix and returns the highest removed offset.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
@@ -74,7 +82,7 @@ Each deletion follows its cutover.
 
 **Goal:** Prove the ledger against production traffic before it owns the commits.
 
-- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 6 ships `active`.
+- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 7 ships `active`.
 - Charge every delivered offset into its partition ledger during `collect_batch`.
 - When a batch completes, mark all its offsets complete.
 - At each commit, compare the partition's frontier with the offset the current path commits. With oldest-first completion, the two must be equal.
@@ -104,22 +112,35 @@ Each deletion follows its cutover.
 - Move inside the boundary: assignment, scatter, the deferred flush, the eager flush, the worker registry, the router, and the stream runners.
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion, not redesign.
 - The consumer loop keeps: poll collection, commits, the sentinels, and the batch window. It aggregates group completions per batch, so completion and commit behavior do not change.
-- The boundary is the seam for change 5: two implementations can stand behind it.
+- Changes 5 and 6 carve the scheduler seam inside this boundary.
 
-### 5. Build the key-table batcher (structure)
+### 5. Extract the scheduler seam (structure)
 
-**Task:** Write the target batcher as a second implementation behind the change-4 boundary. Do not select it.
+**Task:** Move every ordering and placement decision inside the batcher behind one interface. Keep the current semantics.
 
-**Goal:** The replacement exists, fully tested, before any behavior changes.
+**Goal:** Isolate the decision core from the plumbing, so the smallest valuable piece can swap.
 
-- One single-owner event loop task. State is task-local. There is no shared mutex. Events: accumulators, request settlements, deadlines. This is the batcher of the design doc.
-- The key table: one FIFO queue per key. A key is runnable when it has queued work and no outstanding request. Dispatch takes one contiguous run and marks the key outstanding.
-- A settlement clears the outstanding flag and dispatches the key's next run. A failed request returns its runs to the front of their key queues.
+- The scheduler decides which runs may go to a worker now, and where. Nothing else in the batcher decides that.
+- Interface in: events. A group arrives. A request settles, with success or failure. A retry deadline fires.
+- Interface out: dispatches. One dispatch is one run of one key on one worker.
+- The first implementation preserves today's semantics: pins, the stash, deferral on drain, the flush pacing, and the eager release. This is code motion from `assign`, `flush_deferred`, `on_sub_batch_resolved`, and the eager path.
+- The plumbing (tasks, channels, the mutex) stays as it is. Only the decisions move.
+- The seam makes today's implicit ordering rules explicit and reviewable in one place.
+
+### 6. Build the key-table scheduler (structure)
+
+**Task:** Write the target scheduler as a second implementation of the seam. Do not select it.
+
+**Goal:** The replacement for the ordering core exists, fully tested, before any behavior changes.
+
+- The key table: one FIFO queue per key. A key is runnable when it has queued work and no outstanding request.
+- On arrival: enqueue, and dispatch one contiguous run when the key is runnable. Dispatch marks the key outstanding.
+- On settlement: clear the flag. Success dispatches the key's next run. Failure returns the run to the front of its queue.
 - A parked-retry deadline covers the keys no settlement can release: unroutable groups, and keys behind a failed send.
-- Route each request with the existing P2C and aperture. There is no pin table and no stickiness.
-- The boundary is values in, values out. Test the batcher deterministically without Kafka: submit groups, script settlements and failures, assert per-key order and completions.
+- Placement is stateless: the existing P2C and aperture pick a worker per dispatch. There are no pins.
+- The seam is events in, dispatches out. Test the scheduler deterministically: script arrivals, settlements, and failures. Assert per-key order.
 
-### 6. Commit from the ledger frontier (structure)
+### 7. Commit from the ledger frontier (structure)
 
 **Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first batch completion.
 
@@ -131,49 +152,60 @@ Each deletion follows its cutover.
 - Rollback is the config switch back to `shadow`.
 - Delete the old commit computation after `active` holds on all lanes.
 
-### 7. Switch to the key-table batcher (logic)
+### 8. Switch to the key-table scheduler (logic)
 
-**Task:** Select the key-table batcher with config. Canary one lane, then roll out.
+**Task:** Select the key-table scheduler with config. Canary one lane, then roll out.
 
 **Goal:** One ordering rule replaces pins, the stash, and the flush paths.
 
+- The switch changes the ordering rule and nothing else. Placement, transport, and completion accounting do not change in this PR.
 - At most one outstanding request per key preserves per-key order. Nothing else does, and nothing else must.
 - This is proposal 2 of the design doc: sticky pins are removed. Measure worker key-cache locality before and after (open question 3).
 - Watch: the key-order sentinel, ack latency, and the no-progress watchdog.
-- Rollback is the config switch back to the old implementation.
+- Rollback is the config switch back to the old scheduler.
 
-### 8. Delete the old batcher implementation (structure)
+### 9. Delete the old scheduler (structure)
 
-**Task:** Remove the old implementation after change 7 holds on all lanes.
+**Task:** Remove the old scheduler implementation after change 8 holds on all lanes.
 
 **Goal:** The old concurrency goes in one deletion, not in edits.
 
-- Removes: the pin table, the stash, the eager-flush channel and its credits, the completion-time flush, `DISPATCHER_EAGER_DEFERRED_FLUSH`, and the implementation switch.
-- The plan never edits this machinery. It is encapsulated in change 4, bypassed in change 7, and deleted here.
+- Removes: the pin table, the stash, both flush drivers, the eager-flush channel and its credits, `DISPATCHER_EAGER_DEFERRED_FLUSH`, and the scheduler switch.
+- The plan never edits this machinery. It is isolated in change 5, bypassed in change 8, and deleted here.
 
-### 9. Remove the stream fences (structure)
+### 10. Remove the stream fences (structure)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- After change 8, one send origin exists. A key with a failed request is not runnable. No newer send for that key can enter a stream.
+- After change 9, the scheduler blocks every key with a failed request: the key is not runnable, so no newer send for it can enter a stream.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
-### 10. Complete batches in any order (logic)
+### 11. Collapse the batcher into one event loop (structure)
+
+**Task:** Move the scheduler and its plumbing into one single-owner task.
+
+**Goal:** Remove the mutex and the callback structure.
+
+- The seam's events become the loop's events: accumulators, settlements, deadlines. The scheduler is already event-shaped, so the loop owns it directly.
+- State becomes task-local. The worker-health snapshot stays the only shared read.
+- This is the batcher event loop of the design doc. It is plumbing now: the decisions it drives are already simple.
+
+### 12. Complete batches in any order (logic)
 
 **Task:** Replace the oldest-first await with completion events.
 
 **Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
 
-- Changes 6 and 8 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
+- Changes 7 and 9 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
 - Mark each group's offsets in the ledger when its completion event arrives. Stop aggregating completions per batch before commits.
 - The frontier gates each partition's commit.
 - Keep `max_in_flight_batches` as the bound on outstanding work. A batch slot frees when all its groups are accepted.
 - Behavior change: commit timing decouples across partitions and batches. Replay exposure stays inside the batch window.
 
-### 11. Replace the batch window with budget B (logic)
+### 13. Replace the batch window with budget B (logic)
 
 **Task:** Poll only while uncommitted work is below B. B counts events and bytes.
 
@@ -185,9 +217,9 @@ Each deletion follows its cutover.
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
 - New config: the budget in events and in bytes.
 
-### 12. Pack requests toward target T (logic)
+### 14. Pack requests toward target T (logic)
 
-**Task:** Add the packer to the key-table batcher, with target size T and `PACK_LATENCY_BUDGET`.
+**Task:** Add the packer to the scheduler, with target size T and `PACK_LATENCY_BUDGET`.
 
 **Goal:** Request size becomes deliberate. Fan-out becomes demand-driven.
 
@@ -198,7 +230,7 @@ Each deletion follows its cutover.
 - Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
 - Check the worker side first: a request now spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 
-### 13. Add the RTT dispatch governor (logic)
+### 15. Add the RTT dispatch governor (logic)
 
 **Task:** Replace the fixed per-worker un-acked cap with a permit pool that request RTT governs.
 
@@ -210,7 +242,7 @@ Each deletion follows its cutover.
 - Keep the 503 backoff in the transport. Exclude 503 waits from the RTT signal.
 - Cap each stream channel at `DEPTH_MAX`.
 
-### 14. Add the bounded revocation drain (logic)
+### 16. Add the bounded revocation drain (logic)
 
 **Task:** Implement the drain sequence from section 4 of the design doc.
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -28,19 +28,23 @@ These components stay as they are: the stream runners, the P2C router, the apert
 
 ## Changes
 
+The ledger track comes first (changes 1 to 3).
+It is isolated from the dispatch path, and shadow mode tests it against the current implementation in production before the cutover.
+
 | # | Type | Change |
 | --- | --- | --- |
 | 1 | Structure | Add the offset ledger module |
-| 2 | Structure | Demux polls into groups |
+| 2 | Structure | Run the ledger in shadow mode |
 | 3 | Structure | Commit from the ledger frontier |
-| 4 | Logic | Complete batches in any order |
-| 5 | Logic | Route every group through the key table |
-| 6 | Structure | Remove the stream fences |
-| 7 | Logic | Replace the batch window with budget B |
-| 8 | Structure | Split into two single-owner event loops |
-| 9 | Logic | Pack requests toward target T |
-| 10 | Logic | Add the RTT dispatch governor |
-| 11 | Logic | Add the bounded revocation drain |
+| 4 | Structure | Demux polls into groups |
+| 5 | Logic | Complete batches in any order |
+| 6 | Logic | Route every group through the key table |
+| 7 | Structure | Remove the stream fences |
+| 8 | Logic | Replace the batch window with budget B |
+| 9 | Structure | Split into two single-owner event loops |
+| 10 | Logic | Pack requests toward target T |
+| 11 | Logic | Add the RTT dispatch governor |
+| 12 | Logic | Add the bounded revocation drain |
 
 ### 1. Add the offset ledger module (structure)
 
@@ -49,12 +53,39 @@ These components stay as they are: the stream runners, the P2C router, the apert
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 7.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 8.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` removes the contiguous done prefix and returns the highest removed offset.
 - Completions can arrive in any order. The frontier moves only over completed slots.
-- Add property tests: out-of-order completion, monotonic frontier, ring capacity.
+- Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
+- Add property tests: out-of-order completion, monotonic frontier, offset gaps, ring capacity.
 
-### 2. Demux polls into groups (structure)
+### 2. Run the ledger in shadow mode (structure)
+
+**Task:** Wire the ledger next to the commit path. Compare its frontier with each real commit. Do not change what the consumer commits.
+
+**Goal:** Prove the ledger against production traffic before it owns the commits.
+
+- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 3 ships `active`.
+- Charge every delivered offset into its partition ledger during `collect_batch`.
+- When a batch completes, mark all its offsets complete.
+- At each commit, compare the partition's frontier with the offset the current path commits. With oldest-first completion, the two must be equal.
+- On a mismatch: increment a counter and log the partition with both offsets. Do not block the commit.
+- On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
+- Soak on all lanes. The exit criterion is a mismatch count of zero across deploys and rebalances.
+
+### 3. Commit from the ledger frontier (structure)
+
+**Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first batch completion.
+
+**Goal:** The frontier produces the same commits as the old code, and change 2 already proved that.
+
+- Commit each partition's frontier instead of the batch's max offset.
+- With oldest-first completion, the output is identical to the old path.
+- The commit sentinel stays on and checks contiguity and monotonicity.
+- Rollback is the config switch back to `shadow`.
+- Delete the old commit computation after `active` holds on all lanes.
+
+### 4. Demux polls into groups (structure)
 
 **Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
 
@@ -64,19 +95,7 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
 - Later changes use the group as the unit of dispatch and completion.
 
-### 3. Commit from the ledger frontier (structure)
-
-**Task:** Wire the ledger into the commit path. Keep oldest-first batch completion.
-
-**Goal:** The frontier produces the same commits as the current code, and the sentinel proves it.
-
-- Charge every delivered offset into its partition ledger during `collect_batch`.
-- When a batch completes, mark all its offsets complete.
-- Commit the frontier of each partition instead of the batch's max offset.
-- With oldest-first completion, the frontier equals the old commit point. The output is identical.
-- The commit sentinel stays on and checks contiguity and monotonicity.
-
-### 4. Complete batches in any order (logic)
+### 5. Complete batches in any order (logic)
 
 **Task:** Replace the oldest-first await with completion events.
 
@@ -88,7 +107,7 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - Keep `max_in_flight_batches` as the bound on outstanding work.
 - Behavior change: commit timing decouples across partitions. Replay exposure stays inside the batch window.
 
-### 5. Route every group through the key table (logic)
+### 6. Route every group through the key table (logic)
 
 **Task:** Enqueue all groups into per-key FIFO queues. Dispatch only runnable keys. Remove the sticky pins.
 
@@ -104,17 +123,17 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - Route each request with the existing P2C and aperture. There is no stickiness.
 - This is proposal 2 of the design doc. Ship it as a canary on one lane. Measure worker key-cache locality before and after (open question 3).
 
-### 6. Remove the stream fences (structure)
+### 7. Remove the stream fences (structure)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- After change 5, one send origin exists. A key with a failed request is not runnable. No newer send for that key can enter a stream.
+- After change 6, one send origin exists. A key with a failed request is not runnable. No newer send for that key can enter a stream.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
-### 7. Replace the batch window with budget B (logic)
+### 8. Replace the batch window with budget B (logic)
 
 **Task:** Poll only while uncommitted work is below B. B counts events and bytes.
 
@@ -126,7 +145,7 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
 - New config: the budget in events and in bytes.
 
-### 8. Split into two single-owner event loops (structure)
+### 9. Split into two single-owner event loops (structure)
 
 **Task:** Move the key table, dispatch, and settlement into one batcher task. The consumer loop and the batcher exchange accumulators and completions over channels.
 
@@ -136,7 +155,7 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - Select order in each loop: clocks and rebalance events first, completions next, polls last.
 - The worker-health snapshot stays the only shared read.
 
-### 9. Pack requests toward target T (logic)
+### 10. Pack requests toward target T (logic)
 
 **Task:** Add the packer, with target size T and `PACK_LATENCY_BUDGET`.
 
@@ -149,7 +168,7 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
 - Check the worker side first: a request now spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 
-### 10. Add the RTT dispatch governor (logic)
+### 11. Add the RTT dispatch governor (logic)
 
 **Task:** Replace the fixed per-worker un-acked cap with a permit pool that request RTT governs.
 
@@ -161,7 +180,7 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - Keep the 503 backoff in the transport. Exclude 503 waits from the RTT signal.
 - Cap each stream channel at `DEPTH_MAX`.
 
-### 11. Add the bounded revocation drain (logic)
+### 12. Add the bounded revocation drain (logic)
 
 **Task:** Implement the drain sequence from section 4 of the design doc.
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -5,6 +5,8 @@ Status: **draft, for discussion**.
 This plan implements the [driver-model redesign](https://github.com/PostHog/posthog/blob/pl/ingestion/consumer-redesign-doc/rust/ingestion-consumer/docs/driver-model.md) ([#89277](https://github.com/PostHog/posthog/pull/89277)) in small steps.
 Each step is one PR.
 
+Implementation reference: [Jose's `kafka-consumer-loop` branch](https://github.com/PostHog/posthog/compare/master...jose-sequeira/kafka-consumer-loop). It is a source of tested shared primitives, not a stack to merge whole: its first commit extracts the Kafka consumer config builder, while its second also includes primitives scheduled for later cycles. Reuse the config extraction and the cycle-2 ledger representation deliberately; leave the accumulator, budget, partition-driver, commit-manager, and drain work to their named cycles below.
+
 ## Starting point
 
 The plan starts from current master.
@@ -17,6 +19,17 @@ An assignment epoch also exists.
 A rebalance increments it, and every sub-batch carries it.
 
 These components stay as they are: the stream runners, the P2C (power-of-two-choices) router, the aperture, the worker registry, the commit sentinel, the commit monitor, and the key-order sentinel.
+
+## Initial PR stacks
+
+Both stacks start from this plan branch ([#91468](https://github.com/PostHog/posthog/pull/91468)), so the reviewed design and implementation history stay together. Within a stack, each PR is based on the preceding PR.
+
+| Stack | Branch sequence | Scope |
+| --- | --- | --- |
+| Cycle 1 | `c1-delete-eager-flush` -> `c1-fence-safe-send-resolution` | Changes 1 and 2, one PR per plan step. |
+| Cycle 2 | `c2-common-ledger` -> `c2-ledger-shadow` -> `c2-ledger-active` -> `c2-ledger-cleanup` | Changes 3 through 6, one PR per plan step. |
+
+The stacks are independent: cycle 2 can begin without cycle 1. The merge gates remain part of the plan: change 5 cannot merge until change 4 has soaked with a zero mismatch counter, and change 6 cannot merge until change 5 is stable on every lane. Draft PRs may be prepared earlier, but they must not collapse those gates.
 
 ## The cycle model
 
@@ -65,7 +78,7 @@ A change that adds metrics lists their names.
 | --- | --- | --- | --- |
 | 1 | 1 one resolve protocol | Cleanup | Delete the dead eager flush |
 | 2 | 1 one resolve protocol | Prepare | Extract fence-safe send resolution |
-| 3 | 2 frontier commits | Implement | Add the offset ledger module |
+| 3 | 2 frontier commits | Implement | Add the common Kafka consumer crate and offset ledger |
 | 4 | 2 frontier commits | Verify | Run the ledger in shadow mode |
 | 5 | 2 frontier commits | Switchover | Commit from the ledger frontier |
 | 6 | 2 frontier commits | Cleanup | Delete the old commit computation |
@@ -139,11 +152,15 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 **Verify:** change 4 compares the frontier with every real commit on all lanes.
 Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across deploys and rebalances, and `ingestion_consumer_ledger_uncommitted_offsets` returns toward zero when a lane is idle — the ring drains.
 
-### 3. Add the offset ledger module (implement)
+### 3. Add the common Kafka consumer crate and offset ledger (implement)
 
-**Task:** Create `ledger.rs` with a per-partition offset ring. Do not wire it in.
+**Task:** Create `rust/common/kafka-consumer` and add `ledger.rs` with a per-partition offset ring. Do not wire it into a consumer yet.
 
-**Goal:** Make commit contiguity a property of a data structure.
+**Goal:** Make commit contiguity a reusable property of a data structure, not a feature of the ingestion consumer.
+
+- Start from the config extraction in [Jose's branch](https://github.com/PostHog/posthog/compare/master...jose-sequeira/kafka-consumer-loop): move the current consumer config builder unchanged into `common-kafka-consumer`, retain its fixture coverage, and make `ingestion-consumer` depend on it.
+- Copy only the cycle-2 domain primitives from Jose's second commit into the new crate: the offset wrapper and the charge carried by a ledger slot. Adapt its `OffsetLedger` representation to this plan's `complete`, non-mutating `frontier`, and consuming `take_frontier` contract: Jose's current `complete` advances and removes the prefix, so it cannot be copied unchanged into the shadow comparison.
+- Do not take `Accumulator`, `Budget`, `PartitionDriver`, `PartitionManager`, or `CommitManager`; those implement later cycles and would make this PR cross several plan boundaries. The ledger module must not depend on `rdkafka`, `ingestion-consumer`, or service-specific metrics. The shared config module may retain its `rdkafka` dependency.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
 - Each slot records: complete or not, event count, byte count. The counts serve the budget in change 24.
@@ -156,7 +173,9 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 
 **Interfaces:**
 
-- Add `OffsetLedger` in `ledger.rs`: `charge`, `complete`, `frontier` (non-mutating), `take_frontier` (consuming). No callers yet. The name avoids a clash with the stream runner's internal un-acked ledger.
+- Add workspace crate `common-kafka-consumer`, exporting the shared config builder, `Offset`, `Charge`, and `OffsetLedger`.
+- Add `OffsetLedger` in `ledger.rs`: `charge`, `complete`, `frontier` (non-mutating), `take_frontier` (consuming). No runtime callers yet. The name avoids a clash with the stream runner's internal un-acked ledger.
+- Modify `ingestion-consumer` to import the moved config builder from the common crate.
 
 ### 4. Run the ledger in shadow mode (verify)
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -110,7 +110,7 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 
 - Group messages per partition first, then per routing key. Keep offset order inside each group.
 - The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
-- Change 4 uses the groups as the unit of the batcher interface.
+- Change 4 submits them to the batcher as the accumulator.
 
 **Interfaces:**
 
@@ -124,19 +124,22 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 
 **Goal:** The dispatch concurrency becomes an implementation detail behind one interface.
 
-- Interface in: one poll's groups, submitted on the consumer loop in poll order.
-- Interface out: one completion event per group, with its partition, offsets, and accepted count. This is the final shape. The interface does not change again.
+- Interface in: one accumulator per poll — the poll's demuxed groups, submitted on the consumer loop in poll order.
+- Interface out: one completion event per group, with its partition, offsets, and accepted count.
+- This is the design doc's boundary: accumulators in, completions out. It is the final shape and does not change again.
+- No batch identity crosses the boundary. The facade mints an internal batch id per accumulator for the old machinery and the wire request. The consumer correlates completions by partition and offset — the same key the ledger uses.
 - The facade breaks each resolved send into its groups. The resolution paths already carry them (`routing_keys`, `key_offsets`), and a send is all-or-nothing.
 - Move inside the boundary: assignment, scatter, the deferred flush, the eager flush, the worker registry, the router, and the stream runners.
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion, not redesign.
-- The consumer loop keeps: poll collection, commits, the sentinels, and the batch window. It aggregates group completions per batch, so completion and commit behavior do not change.
+- The consumer loop keeps: poll collection, commits, the sentinels, and the batch window. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
 - Changes 5 and 6 carve the scheduler seam inside this boundary.
 
 **Interfaces:**
 
-- Add `Batcher` in `batcher.rs`: `submit(batch_id, Vec<Group>)` in, a channel of `GroupCompletion` out. It owns `Dispatcher`, `GrpcTransport`, `WorkerRegistry`, and the send tasks.
-- Add `GroupCompletion`: batch id, partition, offsets, accepted count.
-- Modify `IngestionConsumer`: drop `scatter`, `flush_deferred`, and the eager-flush loop — they move into the batcher. Keep collect, commit, and the window. Aggregate completions per batch.
+- Add `Accumulator`: one poll's groups, in poll order.
+- Add `Batcher` in `batcher.rs`: `submit(Accumulator)` in, a channel of `GroupCompletion` out. It owns `Dispatcher`, `GrpcTransport`, `WorkerRegistry`, and the send tasks. It mints batch ids internally.
+- Add `GroupCompletion`: partition, offsets, accepted count. No batch id.
+- Modify `IngestionConsumer`: drop `scatter`, `flush_deferred`, and the eager-flush loop — they move into the batcher. Keep collect, commit, and the window. Correlate completions to polls by partition and offset.
 - Modify `main.rs`: construct one `Batcher`. The consumer no longer sees the dispatcher or the transport.
 - Internalize `Dispatcher`'s resolve and accounting methods (`on_sub_batch_*`, `defer_failed`, `eager_flush_*`, `take_eager_accepted`): only the batcher calls them.
 
@@ -265,14 +268,14 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 **Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
 
 - Changes 7 and 9 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
-- Mark each group's offsets in the ledger when its completion event arrives. Stop aggregating completions per batch before commits.
+- Mark each group's offsets in the ledger when its completion event arrives. Stop aggregating completions per poll before commits.
 - The frontier gates each partition's commit.
 - Keep `max_in_flight_batches` as the bound on outstanding work. A batch slot frees when all its groups are accepted.
 - Behavior change: commit timing decouples across partitions and batches. Replay exposure stays inside the batch window.
 
 **Interfaces:**
 
-- Modify `IngestionConsumer::process`: select over `GroupCompletion` events. Remove the ordered `InFlightBatch` queue and the per-batch aggregation from change 4.
+- Modify `IngestionConsumer::process`: select over `GroupCompletion` events. Remove the ordered `InFlightBatch` queue and the per-poll aggregation from change 4.
 - Modify the batch bookkeeping: a batch is only a window slot that frees when its groups are accepted.
 
 ### 13. Replace the batch window with budget B (logic)

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -22,23 +22,26 @@ These components stay as they are: the stream runners, the P2C router, the apert
 
 Work proceeds in cycles.
 Each cycle delivers one outcome: a property of the system that holds from then on.
-A cycle has four phases:
+A cycle has five phases:
 
 1. **Prepare**: structure changes that carve the seams. No behavior change.
 2. **Implement**: build the new component, fully tested, not selected.
-3. **Switchover**: config selects the new component. Staged where possible: shadow, then canary, then all lanes. The config is the rollback.
-4. **Cleanup**: one deletion removes the old component and the switch.
+3. **Verify**: prove the new component against production before it takes over. A verify change adds observation only: a shadow comparison, a gauge, a dry-run report. Verification with no new code is a soak with a stated exit criterion, not a PR.
+4. **Switchover**: config selects the new component. Canary one lane, then all lanes. The config is the rollback.
+5. **Cleanup**: one deletion removes the old component and the switch.
 
 Rules:
 
 - Each change is one PR.
-- Prepare, implement, and cleanup changes do not change behavior. The e2e tests must pass without edits.
+- Prepare, implement, verify, and cleanup changes do not change behavior. The e2e tests must pass without edits.
 - Only a switchover may change behavior. Some do not (a switchover with identical output is still staged and reversible).
+- Every cycle names its verify evidence: the metrics to read and the exit criterion.
 - Old code is deleted in cleanup, never edited.
 - Dead code is deleted before a seam is carved around it. A cleanup of a switch that never shipped can open a cycle (change 1).
 - A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 13).
 - A cycle's cleanup lands only after its switchover holds on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
+- A change must not alter the meaning of an existing metric. Metrics of deleted machinery are deleted with it.
 - The commit sentinel and the key-order sentinel stay enabled through every cycle.
 
 Cycle 1 lands first: two fast, behavior-preserving complexity wins with no dependency on anything else.
@@ -50,13 +53,14 @@ That is where the complexity concentrates — the pins, the stash, and the flush
 The single-owner event loop follows as its own outcome (cycle 4), once the scheduler is simple.
 
 Each change ends with its interface impact: the types it adds, modifies, or removes.
+A change that adds metrics lists their names.
 
 | # | Cycle | Phase | Change |
 | --- | --- | --- | --- |
 | 1 | 1 one resolve protocol | Cleanup | Delete the dead eager flush |
 | 2 | 1 one resolve protocol | Prepare | Extract fence-safe send resolution |
 | 3 | 2 frontier commits | Implement | Add the offset ledger module |
-| 4 | 2 frontier commits | Switchover | Run the ledger in shadow mode |
+| 4 | 2 frontier commits | Verify | Run the ledger in shadow mode |
 | 5 | 2 frontier commits | Switchover | Commit from the ledger frontier |
 | 6 | 2 frontier commits | Cleanup | Delete the old commit computation |
 | 7 | 3 per-key order | Prepare | Demux polls into groups |
@@ -87,13 +91,15 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 Outcome: the eager send path is gone, and every send resolves through one fence-safe helper.
 This cycle has no switchover: the eager flush was never enabled, and the helper encodes the current order.
 
+**Verify:** the e2e suite. Both changes preserve behavior. The stash gauges (`ingestion_consumer_dispatcher_stashed_*`) must not change shape after the eager deletion.
+
 ### 1. Delete the dead eager flush (cleanup)
 
 **Task:** Remove the eager deferred flush. The flag that enables it is off everywhere.
 
 **Goal:** One send origin fewer before any seam is carved.
 
-- `DISPATCHER_EAGER_DEFERRED_FLUSH` is default off, and no deployment sets it. Confirm against a fresh charts checkout before this ships.
+- `DISPATCHER_EAGER_DEFERRED_FLUSH` is default off, and no deployment sets it. Confirm against a fresh charts checkout and the live deployments before this ships.
 - The completion-time flush already does all the draining in production. Behavior does not change.
 - Carrying the eager path through the seam extraction would preserve code that does not run.
 
@@ -122,6 +128,9 @@ This cycle has no switchover: the eager flush was never enabled, and the helper 
 
 Outcome: commit contiguity is a property of a data structure, not of completion order.
 
+**Verify:** change 4 compares the frontier with every real commit on all lanes.
+Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across deploys and rebalances, and `ingestion_consumer_ledger_uncommitted_offsets` returns toward zero when a lane is idle — the ring drains.
+
 ### 3. Add the offset ledger module (implement)
 
 **Task:** Create `ledger.rs` with a per-partition offset ring. Do not wire it in.
@@ -141,7 +150,7 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 
 - Add `OffsetLedger` in `ledger.rs`: `charge`, `complete`, `frontier` (non-mutating), `take_frontier` (consuming). No callers yet. The name avoids a clash with the stream runner's internal un-acked ledger.
 
-### 4. Run the ledger in shadow mode (switchover)
+### 4. Run the ledger in shadow mode (verify)
 
 **Task:** Wire the ledger next to the commit path. Compare its frontier with each real commit. Do not change what the consumer commits.
 
@@ -154,13 +163,18 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 - After the comparison, call `take_frontier` at the same commit point. The ledger drains identically in shadow and active modes. Without this, the shadow ring grows without bound.
 - On a mismatch: increment a counter and log the partition with both offsets. Do not block the commit.
 - On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
-- Soak on all lanes. The exit criterion is a mismatch count of zero across deploys and rebalances.
+- Soak on all lanes until the cycle's exit criterion holds.
 
 **Interfaces:**
 
 - Modify `Config`: add the ledger mode.
 - Modify `IngestionConsumer`: own one `OffsetLedger` per partition. Charge in `collect_batch`, complete on poll completion, compare in `commit_offsets`.
 - Modify the revoke path (`SentinelContext`): drop revoked partitions' ledgers.
+
+**Metrics:**
+
+- Add `ingestion_consumer_ledger_mismatch_total` (counter): frontier vs committed offset disagreement.
+- Add `ingestion_consumer_ledger_uncommitted_offsets` (gauge, per partition): ring depth. Also the leak detector — it must drain at commit points.
 
 ### 5. Commit from the ledger frontier (switchover)
 
@@ -191,10 +205,16 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 
 - Modify `IngestionConsumer::commit_offsets`: frontier only.
 - Modify `Config`: remove the ledger mode.
+- Remove `ingestion_consumer_ledger_mismatch_total`. The comparison it counts is gone; the commit sentinel remains the invariant check.
 
 ## Cycle 3: one rule preserves per-key order
 
 Outcome: at most one outstanding request per key is the only ordering mechanism. Pins, the stash, and the flush paths are gone.
+
+**Verify:** the deterministic seam tests in change 10 script arrivals, settlements, and failures.
+A production shadow is impossible here: the scheduler's decisions change which sends exist, so state diverges immediately.
+The canary in change 11 is the production proof.
+Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transport_duration_seconds` and the `ingestion_consumer_messages_processed_total` rate unchanged, and the no-progress watchdog quiet.
 
 ### 7. Demux polls into groups (prepare)
 
@@ -238,6 +258,10 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Modify `main.rs`: construct one `Batcher` from the existing transport, registry, and router. The consumer no longer sees the dispatcher.
 - Internalize `Dispatcher`'s resolve methods (`on_sub_batch_*`, `defer_failed`): only the batcher calls them.
 
+**Metrics:**
+
+- Add `ingestion_consumer_group_completions_total` (counter) and its accepted-message sum. Cross-check: the sum tracks `ingestion_consumer_messages_processed_total`.
+
 ### 9. Extract the scheduler seam (prepare)
 
 **Task:** Move every ordering and placement decision inside the batcher behind one interface. Keep the current semantics.
@@ -275,6 +299,10 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 
 - Add `KeyTableScheduler` and `KeyTable` in `key_table.rs`: per-key FIFO, outstanding flag, parked list. Implements `Scheduler`. Tests only, no production callers.
 
+**Metrics:**
+
+- Add, emitted when selected: `ingestion_consumer_key_table_keys`, `ingestion_consumer_key_table_queued_messages`, `ingestion_consumer_key_table_outstanding_keys`, `ingestion_consumer_key_table_parked_keys` (gauges), and `ingestion_consumer_parked_retries_total` (counter).
+
 ### 11. Switch to the key-table scheduler (switchover)
 
 **Task:** Select the key-table scheduler with config. Canary one lane, then roll out.
@@ -284,7 +312,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - The switch changes the ordering rule and nothing else. Placement, transport, and completion accounting do not change in this PR.
 - At most one outstanding request per key preserves per-key order. Nothing else does, and nothing else must.
 - This is proposal 2 of the design doc: sticky pins are removed. Measure worker key-cache locality before and after (open question 3).
-- Watch: the key-order sentinel, ack latency, and the no-progress watchdog.
+- Watch the cycle's exit metrics, and the key-table gauges for queue growth.
 - Rollback is the config switch back to the old scheduler.
 
 **Interfaces:**
@@ -307,11 +335,14 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Remove `PinStashScheduler`, `PinTable`, `Stash`, and `sticky_pin_for`.
 - Remove the scheduler selection from `Config`.
 - Modify `Dispatcher`: remove the dead resolve plumbing (`clears_deferral`, `send_failed`, the flush driver).
+- Remove the pin and stash metrics (`ingestion_consumer_dispatcher_pins_total`, `ingestion_consumer_dispatcher_stashed_*`, the deferral counters). The key-table gauges replace them.
 
 ## Cycle 4: the batcher is one single-owner event loop
 
 Outcome: one task owns all batcher state. The mutex and the callback structure are gone.
 This is a deliberate structural outcome, not tidy-up: it is the largest single concurrency simplification in the plan.
+
+**Verify:** the e2e suite and review. The change is behavior-identical, and the consumer-facing metrics must not move.
 
 ### 13. Collapse the batcher into one event loop (structure)
 
@@ -345,10 +376,14 @@ This is a deliberate structural outcome, not tidy-up: it is the largest single c
 - Remove `FenceGuard` from `transport.rs` and `Fence` with its settle loop from `grpc_transport.rs`.
 - Modify `SendError`: drop the fence-guard field.
 - Keep `TransportError` and the `WorkerStreamRunner` reconnect logic.
+- Remove `ingestion_consumer_worker_stream_fenced_sub_batches_total`. Stream teardowns stay counted.
 
 ## Cycle 5: a stalled key stalls only its partition
 
 Outcome: commits advance per partition as groups complete. Needs cycles 2 and 3.
+
+**Verify:** the commit sentinel checks every commit, and `ingestion_consumer_ledger_uncommitted_offsets` shows per-partition frontier lag.
+Exit criterion at the canary: zero sentinel violations, and a stalled partition no longer moves the commit rate of other partitions.
 
 ### 15. Complete polls in any order (switchover)
 
@@ -382,6 +417,9 @@ Outcome: commits advance per partition as groups complete. Needs cycles 2 and 3.
 
 Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-flight admission cap is gone.
 
+**Verify:** change 17's gauges run on all lanes with the budget unset.
+Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admission cap's occupancy, and the pause gauge stays flat at zero.
+
 ### 17. Add the budget accounting (implement)
 
 **Task:** Track uncommitted work in events and bytes. Ship with no budget set: the admission cap still governs alone.
@@ -398,6 +436,11 @@ Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-
 - Modify `Config`: add the budget, default unset.
 - Modify `IngestionConsumer`: track charge and refund through `OffsetLedger`. No polling change while the budget is unset.
 
+**Metrics:**
+
+- Add `ingestion_consumer_budget_outstanding_events` and `ingestion_consumer_budget_outstanding_bytes` (gauges).
+- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 18.
+
 ### 18. Enable the budget (switchover)
 
 **Task:** Set the budget per lane. Pause the poll at the limit and resume on refund.
@@ -407,7 +450,7 @@ Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-
 - A charts values PR sets the budget lane by lane. The admission cap and the budget both bound work during the transition.
 - Derive the first values from the current config: events near the batch size times the cap, bytes from the byte bound. The effective bound then does not change at the switchover.
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
-- Watch the pause gauge and consumer lag. Rollback is unsetting the values.
+- Watch the pause gauge and `ingestion_lag_ms`. Rollback is unsetting the values.
 
 **Interfaces:**
 
@@ -424,10 +467,14 @@ Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-
 **Interfaces:**
 
 - Remove `max_in_flight_batches` from `Config` and the admission bookkeeping from `IngestionConsumer`.
+- Remove `ingestion_consumer_in_flight_batches`. The budget gauges replace it.
 
 ## Cycle 7: workers receive target-sized requests
 
 Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup: body splitting stays as a defence.
+
+**Verify:** with the pack budget at zero, the packer emits on arrival and the e2e suite passes unchanged.
+Exit criterion after the targets: the request-size histograms center near T, and `ingestion_lag_ms` does not regress.
 
 ### 20. Add the packer (implement)
 
@@ -447,6 +494,11 @@ Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup:
 - Modify `Dispatch`: one request may carry runs from several keys.
 - Modify `Config`: add T and `PACK_LATENCY_BUDGET`, default zero. The worker proto does not change.
 
+**Metrics:**
+
+- Add `ingestion_consumer_request_events` and `ingestion_consumer_request_bytes` (histograms): the size of each sent request.
+- Add `ingestion_consumer_pack_emits_total` (counter, reason `arrival`, `full`, or `deadline`).
+
 ### 21. Set the packing targets (switchover)
 
 **Task:** Set T and the pack budget per lane.
@@ -454,7 +506,7 @@ Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup:
 **Goal:** Workers receive target-sized requests.
 
 - A charts values PR sets the targets lane by lane.
-- Watch request size, worker occupancy, and end-to-end latency. Rollback is a pack budget of zero.
+- Watch the request-size histograms, worker occupancy, and end-to-end latency. Rollback is a pack budget of zero.
 
 **Interfaces:**
 
@@ -464,6 +516,9 @@ Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup:
 
 Outcome: request RTT governs the number of requests in flight.
 
+**Verify:** with adaptation off, change 22 reports the decisions it would make.
+Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink signals under induced worker latency and stays quiet under normal load.
+
 ### 22. Add the governor (implement)
 
 **Task:** Add the permit pool and the RTT EWMA. Ship with adaptation off: permits mirror the current per-worker cap.
@@ -472,6 +527,7 @@ Outcome: request RTT governs the number of requests in flight.
 
 - Grow the pool by one when ready work waits, no permit is free, and RTT is within budget.
 - Shrink the pool by one when the RTT EWMA exceeds `REQUEST_LATENCY_BUDGET`.
+- With adaptation off, compute and report every decision without applying it. The signal is verifiable before it constrains.
 - Bound the pool with a configured minimum and maximum.
 - Keep the 503 backoff in the transport. Exclude 503 waits from the RTT signal.
 - Cap each stream channel at `DEPTH_MAX`.
@@ -481,13 +537,18 @@ Outcome: request RTT governs the number of requests in flight.
 - Add `Governor` in the batcher loop: the permit pool and the RTT EWMA, adaptation off.
 - Modify `Config`: add `REQUEST_LATENCY_BUDGET`, the permit bounds, and `DEPTH_MAX`.
 
+**Metrics:**
+
+- Add `ingestion_consumer_governor_permits` (gauge) and `ingestion_consumer_request_rtt_seconds` (gauge, the EWMA).
+- Add `ingestion_consumer_governor_adjustments_total` (counter, direction `grow` or `shrink`). With adaptation off, it counts would-be decisions.
+
 ### 23. Enable RTT adaptation (switchover)
 
 **Task:** Turn adaptation on. Request RTT governs the permit pool.
 
 **Goal:** Concurrency shrinks when the worker pool is unhealthy.
 
-- Canary one lane. Watch permit counts, RTT, and throughput under induced worker latency.
+- Canary one lane. Watch the permit gauge, the RTT EWMA, and throughput under induced worker latency.
 - Rollback is the adaptation switch.
 
 **Interfaces:**
@@ -507,6 +568,9 @@ Outcome: request RTT governs the number of requests in flight.
 ## Cycle 9: partitions hand off cleanly
 
 Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 3.
+
+**Verify:** e2e rebalance tests with the drain on, then the canary rebalance in change 27.
+Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the deadline, and `ingestion_consumer_drain_dropped_messages_total` matches the expected replay volume.
 
 ### 25. Add revoke and drained markers (prepare)
 
@@ -537,13 +601,18 @@ Outcome: a revocation drains in bounded time, and a wedged partition fails the p
 - Modify `IngestionConsumer` and `OffsetLedger`: the final commit, the refund of abandoned charge, and the stall deadline.
 - Modify `Config`: add the drain switch, default off.
 
+**Metrics:**
+
+- Add `ingestion_consumer_drain_duration_seconds` (histogram) and `ingestion_consumer_drain_dropped_messages_total` (counter): drain time and replay volume per revocation.
+- Add `ingestion_consumer_partition_stalls_total` (counter): stall-deadline expiries.
+
 ### 27. Enable the drain (switchover)
 
 **Task:** Turn the drain on. Canary one lane through a rebalance.
 
 **Goal:** Rebalances hand partitions off with a bounded drain.
 
-- Watch rebalance duration, replay volume, and the drained markers. Rollback is the switch.
+- Watch the cycle's exit metrics and the drained markers. Rollback is the switch.
 
 **Interfaces:**
 
@@ -558,6 +627,19 @@ Outcome: a revocation drains in bounded time, and a wedged partition fails the p
 **Interfaces:**
 
 - Remove the no-drain path and the drain switch from `Config`. Keep the epoch checks.
+
+## Monitoring
+
+The steady-state dashboard after the migration:
+
+- Delivery: `ingestion_lag_ms`, the `ingestion_consumer_messages_processed_total` rate, and the two sentinel violation counters, which must stay at zero.
+- Commits: `ingestion_consumer_ledger_uncommitted_offsets` per partition (frontier lag, and the ring-leak detector) and the `ingestion_consumer_offset_commits_total` rate.
+- Scheduling: the key-table gauges and `ingestion_consumer_parked_retries_total`.
+- Admission: the budget gauges and `ingestion_consumer_budget_paused`.
+- Requests: the request-size histograms, `ingestion_consumer_transport_duration_seconds`, `ingestion_consumer_governor_permits`, and `ingestion_consumer_request_rtt_seconds`.
+- Rebalance: `ingestion_consumer_drain_duration_seconds` and `ingestion_consumer_drain_dropped_messages_total`.
+
+The budget occupancy and the request-size histograms are also the worker-autoscaling signals from section 5 of the design doc.
 
 ## Later work
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -99,10 +99,11 @@ Each deletion follows its cutover.
 **Goal:** The dispatch concurrency becomes an implementation detail behind one interface.
 
 - Interface in: one poll's groups, submitted on the consumer loop in poll order.
-- Interface out: one completion event per batch, with the accepted count. Group-level events come later, when the budget needs them.
+- Interface out: one completion event per group, with its partition, offsets, and accepted count. This is the final shape. The interface does not change again.
+- The facade breaks each resolved send into its groups. The resolution paths already carry them (`routing_keys`, `key_offsets`), and a send is all-or-nothing.
 - Move inside the boundary: assignment, scatter, the deferred flush, the eager flush, the worker registry, the router, and the stream runners.
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion, not redesign.
-- The consumer loop keeps: poll collection, commits, the sentinels, and the batch window.
+- The consumer loop keeps: poll collection, commits, the sentinels, and the batch window. It aggregates group completions per batch, so completion and commit behavior do not change.
 - The boundary is the seam for change 5: two implementations can stand behind it.
 
 ### 5. Build the key-table batcher (structure)
@@ -167,10 +168,10 @@ Each deletion follows its cutover.
 **Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
 
 - Changes 6 and 8 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
-- The consumer loop awaits all in-flight batches at once (a completion channel or `FuturesUnordered`).
-- A completed batch marks its offsets in the ledger. The frontier gates each partition's commit.
-- Keep `max_in_flight_batches` as the bound on outstanding work.
-- Behavior change: commit timing decouples across partitions. Replay exposure stays inside the batch window.
+- Mark each group's offsets in the ledger when its completion event arrives. Stop aggregating completions per batch before commits.
+- The frontier gates each partition's commit.
+- Keep `max_in_flight_batches` as the bound on outstanding work. A batch slot frees when all its groups are accepted.
+- Behavior change: commit timing decouples across partitions and batches. Replay exposure stays inside the batch window.
 
 ### 11. Replace the batch window with budget B (logic)
 
@@ -180,7 +181,6 @@ Each deletion follows its cutover.
 
 - Charge each message on poll. The ledger slots already carry the costs (change 1).
 - Refund the charge when the commit that covers the message is issued.
-- Upgrade the batcher interface to group-level completion events, so the ledger marks groups as they settle.
 - Remove `max_in_flight_batches`. The batch reduces to a per-poll accumulator.
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
 - New config: the budget in events and in bytes.

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -68,12 +68,12 @@ A change that adds metrics lists their names.
 | 4 | 2 frontier commits | Verify | Run the ledger in shadow mode |
 | 5 | 2 frontier commits | Switchover | Commit from the ledger frontier |
 | 6 | 2 frontier commits | Cleanup | Delete the old commit computation |
-| 7 | 3 per-key order | Prepare | Demux polls into groups |
-| 8 | 3 per-key order | Prepare | Encapsulate the worker batcher |
-| 9 | 3 per-key order | Prepare | Extract the scheduler seam |
-| 10 | 3 per-key order | Implement | Build the key-table scheduler |
-| 11 | 3 per-key order | Switchover | Switch to the key-table scheduler |
-| 12 | 3 per-key order | Cleanup | Delete the old scheduler |
+| 7 | 3 one request per key | Prepare | Demux polls into groups |
+| 8 | 3 one request per key | Prepare | Encapsulate the worker batcher |
+| 9 | 3 one request per key | Prepare | Extract the scheduler seam |
+| 10 | 3 one request per key | Implement | Build the key-table scheduler |
+| 11 | 3 one request per key | Switchover | Switch to the key-table scheduler |
+| 12 | 3 one request per key | Cleanup | Delete the old scheduler |
 | 13 | 4 target-sized requests | Implement | Add the packer |
 | 14 | 4 target-sized requests | Switchover | Set the packing targets |
 | 15 | 5 partial redelivery | Implement | Add partial settlement and the request time budget |
@@ -214,9 +214,9 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 - Modify `Config`: remove the ledger mode.
 - Remove `ingestion_consumer_ledger_mismatch_total`. The comparison it counts is gone; the commit sentinel remains the invariant check.
 
-## Cycle 3: one rule preserves per-key order
+## Cycle 3: at most one request per key is in flight
 
-Outcome: at most one outstanding request per key is the only ordering mechanism. Pins, the stash, and the flush paths are gone.
+Outcome: the scheduler sends at most one request per key at a time, and that alone preserves per-key order. Pins, the stash, and the flush paths are gone.
 
 **Verify:** the deterministic seam tests in change 10 script arrivals, settlements, and failures.
 A production shadow is impossible here: the scheduler's decisions change which sends exist, so state diverges immediately.
@@ -317,7 +317,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 
 **Task:** Select the key-table scheduler with config. Canary one lane, then roll out.
 
-**Goal:** One ordering rule replaces pins, the stash, and the flush paths.
+**Goal:** At most one in-flight request per key replaces pins, the stash, and the flush paths.
 
 - The switch changes the ordering rule and nothing else. Placement, transport, and completion accounting do not change in this PR.
 - At most one outstanding request per key preserves per-key order. Nothing else does, and nothing else must.

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -53,8 +53,8 @@ Cycle 8 needs cycles 2 and 3.
 The swap unit in cycle 3 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
 That is where the complexity concentrates — the pins, the stash, and the flush interplay.
 Packing follows at once (cycle 4): the performance win depends only on the key-table scheduler, not on the event loop, decoupled commits, or the budget.
-The governor follows packing (cycle 5): it needs the scheduler's ready queue for its growth signal, and packing first, so RTT (request round-trip time) tunes against comparable requests.
-The request time budget follows (cycle 6): its enforcement precondition is the one-outstanding-request-per-key rule (#89995), and its budget sizes against the packed request size.
+The request time budget follows packing (cycle 5): its enforcement precondition is the one-outstanding-request-per-key rule (#89995), and its budget sizes against the packed request size.
+The governor follows (cycle 6): it needs the scheduler's ready queue for its growth signal, and it comes after packing and the time budget, so RTT (request round-trip time) tunes once, against the final request shape.
 The single-owner event loop follows as its own outcome (cycle 7), once the scheduler is simple.
 
 Each change ends with its interface impact: the types it adds, modifies, or removes.
@@ -76,11 +76,11 @@ A change that adds metrics lists their names.
 | 12 | 3 per-key order | Cleanup | Delete the old scheduler |
 | 13 | 4 target-sized requests | Implement | Add the packer |
 | 14 | 4 target-sized requests | Switchover | Set the packing targets |
-| 15 | 5 adaptive concurrency | Implement | Add the governor |
-| 16 | 5 adaptive concurrency | Switchover | Enable RTT adaptation |
-| 17 | 5 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
-| 18 | 6 partial redelivery | Implement | Add partial settlement and the request time budget |
-| 19 | 6 partial redelivery | Switchover | Set the request time budgets |
+| 15 | 5 partial redelivery | Implement | Add partial settlement and the request time budget |
+| 16 | 5 partial redelivery | Switchover | Set the request time budgets |
+| 17 | 6 adaptive concurrency | Implement | Add the governor |
+| 18 | 6 adaptive concurrency | Switchover | Enable RTT adaptation |
+| 19 | 6 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
 | 20 | 7 single-owner batcher | Structure | Collapse the batcher into one event loop |
 | 21 | 7 single-owner batcher | Cleanup | Remove the stream fences |
 | 22 | 8 decoupled commits | Switchover | Switch completion to group granularity |
@@ -363,7 +363,7 @@ Exit criterion after the targets: the request-size histograms center near T, and
 
 - Check the worker side first: a packed request spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 - Pack runs from multiple runnable keys into one request near T. T counts events and bytes.
-- Emit immediately when the ready work can fill the free stream slots with near-T requests. Otherwise arm the pack deadline. The governor (cycle 5) replaces the slots with permits.
+- Emit immediately when the ready work can fill the free stream slots with near-T requests. Otherwise arm the pack deadline. The governor (cycle 6) replaces the slots with permits.
 - When the deadline expires, emit partial requests. The deadline also bounds the wait when held groups keep polls open: packing adds latency, never a deadlock.
 - Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
 
@@ -391,16 +391,65 @@ Exit criterion after the targets: the request-size histograms center near T, and
 
 - None in this repository. Config values only.
 
-## Cycle 5: concurrency adapts to worker health
+## Cycle 5: a slow request redelivers only its remainder
+
+Outcome: a worker stops a request at the consumer's time budget, acks the finished prefix, and only the remainder redelivers.
+Today one slow message holds every message behind it until the ack watchdog fences the whole stream, and everything unacked replays with duplicate work.
+This budget is time per request. It is not B, the uncommitted-work budget of cycle 9.
+
+It needs #89995 merged on the worker side (`soft_budget_ms` on the wire, the `PARTIAL` ack).
+It needs cycle 3: one outstanding request per key is #89995's stated enforcement precondition.
+It sizes the budget against cycle 4's request size. Its cap on request RTT matters for cycle 6: set `REQUEST_LATENCY_BUDGET` below the soft budget, or the governor never shrinks.
+
+**Verify:** a generous budget on one lane enforces rarely and exercises the real partial-ack path at negligible volume.
+Exit criterion: partial acks resolve and their remainders redeliver in order, zero key-order sentinel violations, and ack-watchdog teardowns (`ingestion_consumer_worker_stream_teardowns_total`) fall.
+
+### 15. Add partial settlement and the request time budget (implement)
+
+**Task:** Teach the transport the `PARTIAL` ack and the scheduler a partial settlement. Ship with no budget set: absent means unlimited, today's behavior.
+
+**Goal:** Partial redelivery exists as one settlement arm, not a new path.
+
+- The stream runner parses `PARTIAL` and resolves the send with the accepted index list, instead of fencing it as busy.
+- The scheduler's partial arm is the failure arm plus a completed prefix: complete each key's finished prefix as group completions, return the remainder to the front of its queue, and keep the key blocked until the redelivery settles.
+- The prototype against the old machinery (#91480) showed the cost of doing this earlier: concurrent polls and per-batch accounting push partial handling through the deferral paths. Behind the key table it is one `on_settled` arm.
+- Stamp `soft_budget_ms` on each request from config. Unset sends no budget.
+
+**Interfaces:**
+
+- Modify the ack handling in `grpc_transport.rs`: parse `PARTIAL`; resolve with the accepted indexes.
+- Modify the settlement types and `KeyTableScheduler::on_settled`: add the partial arm.
+- Modify `Config`: add the soft budget per request, default unset.
+
+**Metrics:**
+
+- Add `ingestion_consumer_request_budget_partials_total` (counter) and `ingestion_consumer_request_budget_timed_out_messages_total` (counter). The names match the wire: a `PARTIAL` ack with a `timed_out` index list.
+
+### 16. Set the request time budgets (switchover)
+
+**Task:** Set the soft budget per lane: first generous, then real.
+
+**Goal:** A slow request costs a partial redelivery, not a fenced stream and a full replay.
+
+- A charts values PR sets the budget lane by lane. The generous stage is the cycle's verify.
+- Watch the partial and timed-out counters, the key-order sentinel, and stream teardowns.
+- Rollback is unsetting the values.
+
+**Interfaces:**
+
+- None in this repository. Config values only.
+
+## Cycle 6: concurrency adapts to worker health
 
 Outcome: request RTT governs the number of requests in flight.
 It needs cycle 4: packing makes request sizes uniform, so the RTT signal tunes against comparable requests.
+It comes after cycle 5, so the governor tunes once, against budget-capped RTT: set `REQUEST_LATENCY_BUDGET` below the soft budget, or it never shrinks.
 The growth signal — ready work waiting on permits — comes from the key-table scheduler's ready queue.
 
-**Verify:** with adaptation off, change 15 reports the decisions it would make.
+**Verify:** with adaptation off, change 17 reports the decisions it would make.
 Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink signals under induced worker latency and stays quiet under normal load.
 
-### 15. Add the governor (implement)
+### 17. Add the governor (implement)
 
 **Task:** Add the permit pool and the RTT EWMA (an exponentially weighted moving average). Ship with adaptation off: permits mirror the current per-worker cap.
 
@@ -424,7 +473,7 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 - Add `ingestion_consumer_governor_permits` (gauge) and `ingestion_consumer_request_rtt_seconds` (gauge, the EWMA).
 - Add `ingestion_consumer_governor_adjustments_total` (counter, direction `grow` or `shrink`). With adaptation off, it counts would-be decisions.
 
-### 16. Enable RTT adaptation (switchover)
+### 18. Enable RTT adaptation (switchover)
 
 **Task:** Turn adaptation on. Request RTT governs the permit pool.
 
@@ -437,7 +486,7 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 
 - Modify `Config`: enable adaptation.
 
-### 17. Remove the fixed per-worker cap (cleanup)
+### 19. Remove the fixed per-worker cap (cleanup)
 
 **Task:** Remove the per-worker `max_unacked` cap after adaptation is stable on all lanes.
 
@@ -446,54 +495,6 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 **Interfaces:**
 
 - Modify `GrpcTransport`: remove the per-worker cap and its config. Stream channels keep `DEPTH_MAX`.
-
-## Cycle 6: a slow request redelivers only its remainder
-
-Outcome: a worker stops a request at the consumer's time budget, acks the finished prefix, and only the remainder redelivers.
-Today one slow message holds every message behind it until the ack watchdog fences the whole stream, and everything unacked replays with duplicate work.
-This budget is time per request. It is not B, the uncommitted-work budget of cycle 9.
-
-It needs #89995 merged on the worker side (`soft_budget_ms` on the wire, the `PARTIAL` ack).
-It needs cycle 3: one outstanding request per key is #89995's stated enforcement precondition.
-It sizes the budget against cycle 4's request size, and its cap on request RTT interacts with cycle 5: tune `REQUEST_LATENCY_BUDGET` below the soft budget, or the governor never shrinks.
-
-**Verify:** a generous budget on one lane enforces rarely and exercises the real partial-ack path at negligible volume.
-Exit criterion: partial acks resolve and their remainders redeliver in order, zero key-order sentinel violations, and ack-watchdog teardowns (`ingestion_consumer_worker_stream_teardowns_total`) fall.
-
-### 18. Add partial settlement and the request time budget (implement)
-
-**Task:** Teach the transport the `PARTIAL` ack and the scheduler a partial settlement. Ship with no budget set: absent means unlimited, today's behavior.
-
-**Goal:** Partial redelivery exists as one settlement arm, not a new path.
-
-- The stream runner parses `PARTIAL` and resolves the send with the accepted index list, instead of fencing it as busy.
-- The scheduler's partial arm is the failure arm plus a completed prefix: complete each key's finished prefix as group completions, return the remainder to the front of its queue, and keep the key blocked until the redelivery settles.
-- The prototype against the old machinery (#91480) showed the cost of doing this earlier: concurrent polls and per-batch accounting push partial handling through the deferral paths. Behind the key table it is one `on_settled` arm.
-- Stamp `soft_budget_ms` on each request from config. Unset sends no budget.
-
-**Interfaces:**
-
-- Modify the ack handling in `grpc_transport.rs`: parse `PARTIAL`; resolve with the accepted indexes.
-- Modify the settlement types and `KeyTableScheduler::on_settled`: add the partial arm.
-- Modify `Config`: add the soft budget per request, default unset.
-
-**Metrics:**
-
-- Add `ingestion_consumer_request_budget_partials_total` (counter) and `ingestion_consumer_request_budget_timed_out_messages_total` (counter). The names match the wire: a `PARTIAL` ack with a `timed_out` index list.
-
-### 19. Set the request time budgets (switchover)
-
-**Task:** Set the soft budget per lane: first generous, then real.
-
-**Goal:** A slow request costs a partial redelivery, not a fenced stream and a full replay.
-
-- A charts values PR sets the budget lane by lane. The generous stage is the cycle's verify.
-- Watch the partial and timed-out counters, the key-order sentinel, and stream teardowns.
-- Rollback is unsetting the values.
-
-**Interfaces:**
-
-- None in this repository. Config values only.
 
 ## Cycle 7: the batcher is one single-owner event loop
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -273,6 +273,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Interface out: dispatches. One dispatch is one run of one key on one worker.
 - The first implementation preserves today's semantics: pins, the stash, deferral on drain, and the flush pacing. This is code motion from `assign`, `flush_deferred`, and `on_sub_batch_resolved`.
 - The plumbing (tasks, channels, the mutex) stays as it is. Only the decisions move.
+- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 13 mechanical: the seam's handlers become the loop's select arms.
 - The seam makes today's implicit ordering rules explicit and reviewable in one place.
 
 **Interfaces:**

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -131,10 +131,10 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
 - Each slot records: complete or not, event count, byte count. The counts serve the budget in change 17.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix up to the frontier.
-- The read/consume split matters: shadow comparison reads `frontier` repeatedly without consuming state. Only an issued commit calls `take_frontier`.
+- The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
-- Add property tests: out-of-order completion, monotonic frontier, `frontier` idempotence, offset gaps, ring capacity.
+- Add property tests: out-of-order completion, monotonic frontier, `frontier` idempotence, the ring drains after `take_frontier`, offset gaps, ring capacity.
 
 **Interfaces:**
 
@@ -150,6 +150,7 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 - Charge every delivered offset into its partition ledger during `collect_batch`.
 - When a poll completes, mark all its offsets complete.
 - At each commit, compare the partition's `frontier` — the non-mutating read — with the offset the current path commits. With oldest-first completion, the two must be equal.
+- After the comparison, call `take_frontier` at the same commit point. The ledger drains identically in shadow and active modes. Without this, the shadow ring grows without bound.
 - On a mismatch: increment a counter and log the partition with both offsets. Do not block the commit.
 - On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
 - Soak on all lanes. The exit criterion is a mismatch count of zero across deploys and rebalances.
@@ -167,7 +168,7 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 **Goal:** The frontier produces the same commits as the old code, and change 4 already proved that.
 
 - Commit each partition's frontier instead of the poll's max offset.
-- Call `take_frontier` only when the commit is issued. Shadow mode keeps reading `frontier` and never consumes.
+- The ledger calls do not change: both modes already charge, complete, compare, and consume at the same points (change 4). This switchover changes only which value the consumer commits.
 - With oldest-first completion, the output is identical to the old path.
 - The commit sentinel stays on and checks contiguity and monotonicity.
 - Rollback is the config switch back to `shadow`.

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -164,7 +164,8 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
 - Each slot records: complete or not, event count, byte count. The counts serve the budget in change 24.
-- Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix up to the frontier.
+- Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns one past the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix below the frontier.
+- The frontier is in Kafka's committed-offset representation: the next offset to read, not the last offset processed. The current commit path already commits in this representation (the poll's max offset plus one), so the frontier is commit-ready as returned — no call site adds or subtracts one.
 - The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka can deliver offsets with gaps: transaction markers occupy offsets that consumers never receive, and compaction keeps offsets while removing records. Our ingestion topics have neither today, and the commit sentinel treats a gap as a real skip (see the caveat on `CommitSentinel`).
@@ -186,7 +187,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 - New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 5 ships `active`.
 - Charge every delivered offset into its partition ledger during `collect_batch`.
 - When a poll completes, mark all its offsets complete.
-- At each commit, compare the partition's `frontier` — the non-mutating read — with the offset the current path commits. With oldest-first completion, the two must be equal.
+- At each commit, compare the partition's `frontier` — the non-mutating read — with the offset the current path commits. Both are next-to-read offsets, so with oldest-first completion the two must be equal, with no offset arithmetic in the comparison.
 - After the comparison, call `take_frontier` at the same commit point. The ledger drains identically in shadow and active modes. Without this, the shadow ring grows without bound.
 - On a mismatch: increment a counter and log the partition with both offsets. Do not block the commit.
 - On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
@@ -209,7 +210,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 
 **Goal:** The frontier produces the same commits as the old code, and change 4 already proved that.
 
-- Commit each partition's frontier instead of the poll's max offset.
+- Commit each partition's frontier instead of the poll's max offset plus one. Both are next-to-read offsets: with oldest-first completion, the committed value does not change.
 - The ledger calls do not change: both modes already charge, complete, compare, and consume at the same points (change 4). This switchover changes only which value the consumer commits.
 - With oldest-first completion, the output is identical to the old path.
 - The commit sentinel stays on and checks contiguity and monotonicity.

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -18,61 +18,77 @@ A rebalance increments it, and every sub-batch carries it.
 
 These components stay as they are: the stream runners, the P2C router, the aperture, the worker registry, the commit sentinel, the commit monitor, and the key-order sentinel.
 
-## Rules for the sequence
+## The cycle model
+
+Work proceeds in cycles.
+Each cycle delivers one outcome: a property of the system that holds from then on.
+A cycle has four phases:
+
+1. **Prepare**: structure changes that carve the seams. No behavior change.
+2. **Implement**: build the new component, fully tested, not selected.
+3. **Switchover**: config selects the new component. Staged where possible: shadow, then canary, then all lanes. The config is the rollback.
+4. **Cleanup**: one deletion removes the old component and the switch.
+
+Rules:
 
 - Each change is one PR.
-- A change is a structure change or a logic change, never both.
-- A structure change does not change behavior. The e2e tests must pass without edits.
-- Structure prepares logic. Every logic change comes after the structure changes that make it small. A new implementation ships unselected in a structure change; a logic change selects it.
+- Prepare, implement, and cleanup changes do not change behavior. The e2e tests must pass without edits.
+- Only a switchover may change behavior. Some do not (a switchover with identical output is still staged and reversible).
+- Old code is deleted in cleanup, never edited.
+- A cycle's cleanup lands only after its switchover holds on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
-- A logic change ships behind a config switch when a switch is possible. When a switch is not possible, it ships as a canary on one lane.
-- Old code is deleted, not edited. When a cutover holds on all lanes, one structure change removes the old implementation whole.
-- The commit sentinel and the key-order sentinel stay enabled through the migration. They verify each step in production.
+- The commit sentinel and the key-order sentinel stay enabled through every cycle.
 
-## Changes
+The cycles run in order, with one exception: cycle 2 does not depend on cycle 1, so it can start while cycle 1 soaks.
+Cycle 3 needs both.
 
-Part 1 prepares the structure (changes 1 to 6).
-Behavior does not change.
-The offset ledger and the key-table scheduler are both built here, tested, and left unselected.
-
-Part 2 cuts over and simplifies (changes 7 to 16).
-Each cutover is a switch flip made small by part 1, with the switch as the rollback.
-Each deletion follows its cutover.
-
-The swap unit inside the batcher is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
+The swap unit in cycle 2 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
 That is where the complexity concentrates — the pins, the stash, and the flush interplay.
-Placement (P2C, aperture) and send execution (stream runners) already match the target design and are not rebuilt.
-The single-owner event loop is only plumbing once the scheduler is simple, so it moves last.
+The single-owner event loop is only plumbing once the scheduler is simple, so it lands as cleanup.
 
 Each change ends with its interface impact: the types it adds, modifies, or removes.
 
-| # | Type | Change |
-| --- | --- | --- |
-| 1 | Structure | Add the offset ledger module |
-| 2 | Structure | Run the ledger in shadow mode |
-| 3 | Structure | Demux polls into groups |
-| 4 | Structure | Encapsulate the worker batcher |
-| 5 | Structure | Extract the scheduler seam |
-| 6 | Structure | Build the key-table scheduler |
-| 7 | Structure | Commit from the ledger frontier |
-| 8 | Logic | Switch to the key-table scheduler |
-| 9 | Structure | Delete the old scheduler |
-| 10 | Structure | Remove the stream fences |
-| 11 | Structure | Collapse the batcher into one event loop |
-| 12 | Logic | Complete batches in any order |
-| 13 | Logic | Replace the batch window with budget B |
-| 14 | Logic | Pack requests toward target T |
-| 15 | Logic | Add the RTT dispatch governor |
-| 16 | Logic | Add the bounded revocation drain |
+| # | Cycle | Phase | Change |
+| --- | --- | --- | --- |
+| 1 | 1 frontier commits | Implement | Add the offset ledger module |
+| 2 | 1 frontier commits | Switchover | Run the ledger in shadow mode |
+| 3 | 1 frontier commits | Switchover | Commit from the ledger frontier |
+| 4 | 1 frontier commits | Cleanup | Delete the old commit computation |
+| 5 | 2 per-key order | Prepare | Demux polls into groups |
+| 6 | 2 per-key order | Prepare | Encapsulate the worker batcher |
+| 7 | 2 per-key order | Prepare | Extract the scheduler seam |
+| 8 | 2 per-key order | Implement | Build the key-table scheduler |
+| 9 | 2 per-key order | Switchover | Switch to the key-table scheduler |
+| 10 | 2 per-key order | Cleanup | Delete the old scheduler |
+| 11 | 2 per-key order | Cleanup | Remove the stream fences |
+| 12 | 2 per-key order | Cleanup | Collapse the batcher into one event loop |
+| 13 | 3 decoupled commits | Switchover | Complete polls in any order |
+| 14 | 3 decoupled commits | Cleanup | Delete the ordered completion path |
+| 15 | 4 bounded replay | Implement | Add the budget accounting |
+| 16 | 4 bounded replay | Switchover | Enable the budget |
+| 17 | 4 bounded replay | Cleanup | Remove the batch window |
+| 18 | 5 target-sized requests | Implement | Add the packer |
+| 19 | 5 target-sized requests | Switchover | Set the packing targets |
+| 20 | 6 adaptive concurrency | Implement | Add the governor |
+| 21 | 6 adaptive concurrency | Switchover | Enable RTT adaptation |
+| 22 | 6 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
+| 23 | 7 clean handoff | Prepare | Add revoke and drained markers |
+| 24 | 7 clean handoff | Implement | Build the drain |
+| 25 | 7 clean handoff | Switchover | Enable the drain |
+| 26 | 7 clean handoff | Cleanup | Delete the no-drain path |
 
-### 1. Add the offset ledger module (structure)
+## Cycle 1: commits come from the frontier
+
+Outcome: commit contiguity is a property of a data structure, not of completion order.
+
+### 1. Add the offset ledger module (implement)
 
 **Task:** Create `ledger.rs` with a per-partition offset ring. Do not wire it in.
 
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 13.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 15.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` removes the contiguous done prefix and returns the highest removed offset.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
@@ -82,15 +98,15 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 
 - Add `OffsetLedger` in `ledger.rs`: `charge`, `complete`, `frontier`. No callers yet. The name avoids a clash with the stream runner's internal un-acked ledger.
 
-### 2. Run the ledger in shadow mode (structure)
+### 2. Run the ledger in shadow mode (switchover)
 
 **Task:** Wire the ledger next to the commit path. Compare its frontier with each real commit. Do not change what the consumer commits.
 
 **Goal:** Prove the ledger against production traffic before it owns the commits.
 
-- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 7 ships `active`.
+- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 3 ships `active`.
 - Charge every delivered offset into its partition ledger during `collect_batch`.
-- When a batch completes, mark all its offsets complete.
+- When a poll completes, mark all its offsets complete.
 - At each commit, compare the partition's frontier with the offset the current path commits. With oldest-first completion, the two must be equal.
 - On a mismatch: increment a counter and log the partition with both offsets. Do not block the commit.
 - On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
@@ -99,10 +115,43 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 **Interfaces:**
 
 - Modify `Config`: add the ledger mode.
-- Modify `IngestionConsumer`: own one `OffsetLedger` per partition. Charge in `collect_batch`, complete on batch completion, compare in `commit_offsets`.
+- Modify `IngestionConsumer`: own one `OffsetLedger` per partition. Charge in `collect_batch`, complete on poll completion, compare in `commit_offsets`.
 - Modify the revoke path (`SentinelContext`): drop revoked partitions' ledgers.
 
-### 3. Demux polls into groups (structure)
+### 3. Commit from the ledger frontier (switchover)
+
+**Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first completion.
+
+**Goal:** The frontier produces the same commits as the old code, and change 2 already proved that.
+
+- Commit each partition's frontier instead of the poll's max offset.
+- With oldest-first completion, the output is identical to the old path.
+- The commit sentinel stays on and checks contiguity and monotonicity.
+- Rollback is the config switch back to `shadow`.
+
+**Interfaces:**
+
+- Modify `Config`: default the ledger mode to `active`.
+- Modify `IngestionConsumer::commit_offsets`: read the committed offset from `OffsetLedger::frontier`. The old computation survives as the shadow comparison until change 4.
+
+### 4. Delete the old commit computation (cleanup)
+
+**Task:** Remove the old commit computation after `active` holds on all lanes.
+
+**Goal:** The frontier is the only commit source.
+
+- Remove the old per-poll commit computation and the shadow comparison.
+
+**Interfaces:**
+
+- Modify `IngestionConsumer::commit_offsets`: frontier only.
+- Modify `Config`: remove the ledger mode.
+
+## Cycle 2: one rule preserves per-key order
+
+Outcome: at most one outstanding request per key is the only ordering mechanism. Pins, the stash, and the flush paths are gone.
+
+### 5. Demux polls into groups (prepare)
 
 **Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
 
@@ -110,7 +159,7 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 
 - Group messages per partition first, then per routing key. Keep offset order inside each group.
 - The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
-- Change 4 submits them to the batcher as the accumulator.
+- Change 6 submits them to the batcher as the accumulator.
 
 **Interfaces:**
 
@@ -118,7 +167,7 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 - Modify `CollectedBatch`: carries `Vec<Group>` instead of a flat message list.
 - Modify `Dispatcher::assign_and_send`: takes groups and flattens them. `group_messages_by_routing_key` moves to the collect path.
 
-### 4. Encapsulate the worker batcher (structure)
+### 6. Encapsulate the worker batcher (prepare)
 
 **Task:** Put today's dispatch machinery behind one boundary. The consumer loop and the batcher exchange plain values.
 
@@ -132,7 +181,7 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 - Move inside the boundary: assignment, scatter, the deferred flush, the eager flush, the worker registry, the router, and the stream runners.
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion, not redesign.
 - The consumer loop keeps: poll collection, commits, the sentinels, and the batch window. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
-- Changes 5 and 6 carve the scheduler seam inside this boundary.
+- Changes 7 and 8 carve the scheduler seam inside this boundary.
 
 **Interfaces:**
 
@@ -143,7 +192,7 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 - Modify `main.rs`: construct one `Batcher`. The consumer no longer sees the dispatcher or the transport.
 - Internalize `Dispatcher`'s resolve and accounting methods (`on_sub_batch_*`, `defer_failed`, `eager_flush_*`, `take_eager_accepted`): only the batcher calls them.
 
-### 5. Extract the scheduler seam (structure)
+### 7. Extract the scheduler seam (prepare)
 
 **Task:** Move every ordering and placement decision inside the batcher behind one interface. Keep the current semantics.
 
@@ -163,7 +212,7 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 - Add `PinStashScheduler`: the current semantics, moved out of `Dispatcher::assign`, `flush_deferred`, `on_sub_batch_resolved`, and the eager release. It owns `PinTable` and `Stash` unchanged.
 - Modify `Dispatcher`: shrinks to plumbing — the lock, in-flight load, metrics, and seam calls.
 
-### 6. Build the key-table scheduler (structure)
+### 8. Build the key-table scheduler (implement)
 
 **Task:** Write the target scheduler as a second implementation of the seam. Do not select it.
 
@@ -180,24 +229,7 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 
 - Add `KeyTableScheduler` and `KeyTable` in `key_table.rs`: per-key FIFO, outstanding flag, parked list. Implements `Scheduler`. Tests only, no production callers.
 
-### 7. Commit from the ledger frontier (structure)
-
-**Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first batch completion.
-
-**Goal:** The frontier produces the same commits as the old code, and change 2 already proved that.
-
-- Commit each partition's frontier instead of the batch's max offset.
-- With oldest-first completion, the output is identical to the old path.
-- The commit sentinel stays on and checks contiguity and monotonicity.
-- Rollback is the config switch back to `shadow`.
-- Delete the old commit computation after `active` holds on all lanes.
-
-**Interfaces:**
-
-- Modify `Config`: default the ledger mode to `active`.
-- Modify `IngestionConsumer::commit_offsets`: read the committed offset from `OffsetLedger::frontier`. The old computation survives only as the shadow comparison, then is deleted.
-
-### 8. Switch to the key-table scheduler (logic)
+### 9. Switch to the key-table scheduler (switchover)
 
 **Task:** Select the key-table scheduler with config. Canary one lane, then roll out.
 
@@ -215,14 +247,14 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 - Modify the batcher construction: select `KeyTableScheduler` or `PinStashScheduler`.
 - No interface shapes change.
 
-### 9. Delete the old scheduler (structure)
+### 10. Delete the old scheduler (cleanup)
 
-**Task:** Remove the old scheduler implementation after change 8 holds on all lanes.
+**Task:** Remove the old scheduler implementation after change 9 holds on all lanes.
 
 **Goal:** The old concurrency goes in one deletion, not in edits.
 
 - Removes: the pin table, the stash, both flush drivers, the eager-flush channel and its credits, `DISPATCHER_EAGER_DEFERRED_FLUSH`, and the scheduler switch.
-- The plan never edits this machinery. It is isolated in change 5, bypassed in change 8, and deleted here.
+- The plan never edits this machinery. It is isolated in change 7, bypassed in change 9, and deleted here.
 
 **Interfaces:**
 
@@ -230,13 +262,13 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 - Remove from `Config`: `DISPATCHER_EAGER_DEFERRED_FLUSH` and the scheduler selection.
 - Modify `Dispatcher`: remove the dead resolve plumbing (`clears_deferral`, `send_failed`, the flush drivers).
 
-### 10. Remove the stream fences (structure)
+### 11. Remove the stream fences (cleanup)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- After change 9, the scheduler blocks every key with a failed request: the key is not runnable, so no newer send for it can enter a stream.
+- After change 10, the scheduler blocks every key with a failed request: the key is not runnable, so no newer send for it can enter a stream.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
@@ -246,7 +278,7 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 - Modify `SendError`: drop the fence-guard field.
 - Keep `TransportError` and the `WorkerStreamRunner` reconnect logic.
 
-### 11. Collapse the batcher into one event loop (structure)
+### 12. Collapse the batcher into one event loop (cleanup)
 
 **Task:** Move the scheduler and its plumbing into one single-owner task.
 
@@ -261,64 +293,126 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 - Modify `Batcher`: one single-owner task replaces the lock, the resolve callbacks, and the per-send tasks. `Dispatcher` dissolves into the loop and is removed.
 - Keep `Scheduler` as the loop's decision component. The consumer-facing interface does not change.
 
-### 12. Complete batches in any order (logic)
+## Cycle 3: a stalled key stalls only its partition
 
-**Task:** Replace the oldest-first await with completion events.
+Outcome: commits advance per partition as groups complete. Needs cycles 1 and 2.
 
-**Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
+### 13. Complete polls in any order (switchover)
 
-- Changes 7 and 9 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
-- Mark each group's offsets in the ledger when its completion event arrives. Stop aggregating completions per poll before commits.
+**Task:** Add a completion mode, `ordered` or `any`. In `any` mode, mark the ledger per group and stop waiting for whole polls.
+
+**Goal:** A stalled key stalls only its own partition. Other partitions continue to commit.
+
+- Cycles 1 and 2 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
+- In `any` mode, mark each group's offsets in the ledger when its completion event arrives. Do not aggregate per poll before commits.
 - The frontier gates each partition's commit.
-- Keep `max_in_flight_batches` as the bound on outstanding work. A batch slot frees when all its groups are accepted.
-- Behavior change: commit timing decouples across partitions and batches. Replay exposure stays inside the batch window.
+- Keep `max_in_flight_batches` as the bound on outstanding work. A poll's slot frees when all its groups are accepted.
+- Behavior change: commit timing decouples across partitions and polls. Replay exposure stays inside the window.
+- Rollback is the mode switch back to `ordered`.
 
 **Interfaces:**
 
-- Modify `IngestionConsumer::process`: select over `GroupCompletion` events. Remove the ordered `InFlightBatch` queue and the per-poll aggregation from change 4.
-- Modify the batch bookkeeping: a batch is only a window slot that frees when its groups are accepted.
+- Modify `Config`: add the completion mode.
+- Modify `IngestionConsumer::process`: in `any` mode, select over `GroupCompletion` events. The ordered path stays for rollback.
 
-### 13. Replace the batch window with budget B (logic)
+### 14. Delete the ordered completion path (cleanup)
 
-**Task:** Poll only while uncommitted work is below B. B counts events and bytes.
+**Task:** Remove the ordered completion path after `any` holds on all lanes.
 
-**Goal:** Bound replay exposure directly. Poll continuously when workers keep up.
+**Goal:** Group completions are the only completion signal.
+
+**Interfaces:**
+
+- Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 6, and the completion mode from `Config`.
+
+## Cycle 4: replay exposure is bounded by B
+
+Outcome: uncommitted work never exceeds the budget, in events and bytes. The batch window is gone.
+
+### 15. Add the budget accounting (implement)
+
+**Task:** Track uncommitted work in events and bytes. Ship with no budget set: the window still governs alone.
+
+**Goal:** The budget exists and reports before it constrains.
 
 - Charge each message on poll. The ledger slots already carry the costs (change 1).
 - Refund the charge when the commit that covers the message is issued.
-- Remove `max_in_flight_batches`. The batch reduces to a per-poll accumulator.
-- Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
-- New config: the budget in events and in bytes.
+- Gauge the outstanding charge per partition and in total.
+- New config: the budget in events and in bytes. Unset means no constraint.
 
 **Interfaces:**
 
-- Modify `Config`: add the budget; remove `max_in_flight_batches`.
-- Modify `IngestionConsumer`: gate polling on the outstanding charge. Refund from `OffsetLedger` on commit. Remove the window-slot bookkeeping from change 12.
+- Modify `Config`: add the budget, default unset.
+- Modify `IngestionConsumer`: track charge and refund through `OffsetLedger`. No polling change while the budget is unset.
 
-### 14. Pack requests toward target T (logic)
+### 16. Enable the budget (switchover)
 
-**Task:** Add the packer to the scheduler, with target size T and `PACK_LATENCY_BUDGET`.
+**Task:** Set the budget per lane. Pause the poll at the limit and resume on refund.
 
-**Goal:** Request size becomes deliberate. Fan-out becomes demand-driven.
+**Goal:** Replay exposure is bounded directly.
 
+- A charts values PR sets the budget lane by lane. The window and the budget both bound work during the transition.
+- Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
+- Watch the pause gauge and consumer lag. Rollback is unsetting the values.
+
+**Interfaces:**
+
+- None in this repository. Config values only.
+
+### 17. Remove the batch window (cleanup)
+
+**Task:** Remove `max_in_flight_batches` after the budget holds on all lanes.
+
+**Goal:** The budget is the only bound. The batch reduces to a per-poll accumulator.
+
+**Interfaces:**
+
+- Remove `max_in_flight_batches` from `Config` and the window bookkeeping from `IngestionConsumer`.
+
+## Cycle 5: workers receive target-sized requests
+
+Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup: body splitting stays as a defence.
+
+### 18. Add the packer (implement)
+
+**Task:** Add the packer to the scheduler, with target size T and `PACK_LATENCY_BUDGET`. Ship with the pack budget at zero: send-on-arrival, behavior unchanged.
+
+**Goal:** The packing machinery exists before it changes any request.
+
+- Check the worker side first: a packed request spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 - Pack runs from multiple runnable keys into one request near T. T counts events and bytes.
 - Emit immediately when the ready work can fill the free permits with near-T requests. Otherwise arm the pack deadline.
 - When the deadline expires, emit partial requests.
-- `PACK_LATENCY_BUDGET = 0` restores send-on-arrival. That is the off switch.
 - Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
-- Check the worker side first: a request now spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 
 **Interfaces:**
 
 - Add `Packer` inside `KeyTableScheduler`.
 - Modify `Dispatch`: one request may carry runs from several keys.
-- Modify `Config`: add T and `PACK_LATENCY_BUDGET`. The worker proto does not change.
+- Modify `Config`: add T and `PACK_LATENCY_BUDGET`, default zero. The worker proto does not change.
 
-### 15. Add the RTT dispatch governor (logic)
+### 19. Set the packing targets (switchover)
 
-**Task:** Replace the fixed per-worker un-acked cap with a permit pool that request RTT governs.
+**Task:** Set T and the pack budget per lane.
 
-**Goal:** Reduce crash exposure when the worker pool is unhealthy.
+**Goal:** Workers receive target-sized requests.
+
+- A charts values PR sets the targets lane by lane.
+- Watch request size, worker occupancy, and end-to-end latency. Rollback is a pack budget of zero.
+
+**Interfaces:**
+
+- None in this repository. Config values only.
+
+## Cycle 6: concurrency adapts to worker health
+
+Outcome: request RTT governs the number of requests in flight.
+
+### 20. Add the governor (implement)
+
+**Task:** Add the permit pool and the RTT EWMA. Ship with adaptation off: permits mirror the current per-worker cap.
+
+**Goal:** The governor exists and observes before it constrains.
 
 - Grow the pool by one when ready work waits, no permit is free, and RTT is within budget.
 - Shrink the pool by one when the RTT EWMA exceeds `REQUEST_LATENCY_BUDGET`.
@@ -328,28 +422,86 @@ Each change ends with its interface impact: the types it adds, modifies, or remo
 
 **Interfaces:**
 
-- Add `Governor` in the batcher loop: the permit pool and the RTT EWMA.
-- Modify `GrpcTransport`: governor permits replace the per-worker `max_unacked` cap. Stream channels get `DEPTH_MAX` capacity.
+- Add `Governor` in the batcher loop: the permit pool and the RTT EWMA, adaptation off.
 - Modify `Config`: add `REQUEST_LATENCY_BUDGET`, the permit bounds, and `DEPTH_MAX`.
 
-### 16. Add the bounded revocation drain (logic)
+### 21. Enable RTT adaptation (switchover)
 
-**Task:** Implement the drain sequence from section 4 of the design doc.
+**Task:** Turn adaptation on. Request RTT governs the permit pool.
 
-**Goal:** A revoked partition hands off cleanly. A wedged partition fails the process instead of hanging forever.
+**Goal:** Concurrency shrinks when the worker pool is unhealthy.
 
-- On revoke, send an in-band marker to the batcher, after earlier accumulators.
+- Canary one lane. Watch permit counts, RTT, and throughput under induced worker latency.
+- Rollback is the adaptation switch.
+
+**Interfaces:**
+
+- Modify `Config`: enable adaptation.
+
+### 22. Remove the fixed per-worker cap (cleanup)
+
+**Task:** Remove the per-worker `max_unacked` cap after adaptation holds on all lanes.
+
+**Goal:** Governor permits are the only in-flight bound.
+
+**Interfaces:**
+
+- Modify `GrpcTransport`: remove the per-worker cap and its config. Stream channels keep `DEPTH_MAX`.
+
+## Cycle 7: partitions hand off cleanly
+
+Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 2.
+
+### 23. Add revoke and drained markers (prepare)
+
+**Task:** Extend the batcher boundary with a revoke marker in and a drained marker out. Nothing consumes them yet.
+
+**Goal:** The boundary carries the drain protocol before any drain logic exists.
+
+**Interfaces:**
+
+- Modify `Batcher`: add the marker types to the submit and completion channels. `GroupCompletion` does not change shape.
+
+### 24. Build the drain (implement)
+
+**Task:** Implement the drain sequence from section 4 of the design doc, behind a config switch that ships off.
+
+**Goal:** The drain exists and is tested. Off means today's behavior: replay without drain.
+
+- On revoke, send the in-band marker to the batcher, after earlier accumulators.
 - The batcher drops queued unsent work for the partition. Kafka replays it for the next owner.
-- Wait only for requests in flight. Send a drained marker after the final completion.
+- Wait only for requests in flight. Send the drained marker after the final completion.
 - The loop issues one final commit, refunds the remaining charge, and unassigns the partition.
 - Check completions against the assignment epoch. The epoch already exists on master.
 - Add a stall deadline per partition. Outside a rebalance, an expired deadline fails the process. Replay is at most B.
 
 **Interfaces:**
 
-- Modify `Batcher`: add a revoke marker input and a drained marker output. `GroupCompletion` does not change shape.
-- Modify `KeyTableScheduler`: drop queued work per partition on revoke.
-- Modify `IngestionConsumer` and `OffsetLedger`: the final commit, the refund of abandoned charge, and the per-partition stall deadline.
+- Modify `KeyTableScheduler`: drop queued work per partition on the revoke marker.
+- Modify `IngestionConsumer` and `OffsetLedger`: the final commit, the refund of abandoned charge, and the stall deadline.
+- Modify `Config`: add the drain switch, default off.
+
+### 25. Enable the drain (switchover)
+
+**Task:** Turn the drain on. Canary one lane through a rebalance.
+
+**Goal:** Rebalances hand partitions off with a bounded drain.
+
+- Watch rebalance duration, replay volume, and the drained markers. Rollback is the switch.
+
+**Interfaces:**
+
+- Modify `Config`: enable the drain.
+
+### 26. Delete the no-drain path (cleanup)
+
+**Task:** Remove the no-drain revoke path after the drain holds on all lanes.
+
+**Goal:** The drain is the only revoke behavior.
+
+**Interfaces:**
+
+- Remove the no-drain path and the drain switch from `Config`. Keep the epoch checks.
 
 ## Later work
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -133,7 +133,8 @@ Outcome: commit contiguity is a property of a data structure, not of completion 
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix up to the frontier.
 - The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
 - Completions can arrive in any order. The frontier moves only over completed slots.
-- Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
+- Kafka can deliver offsets with gaps: transaction markers occupy offsets that consumers never receive, and compaction keeps offsets while removing records. Our ingestion topics have neither today, and the commit sentinel treats a gap as a real skip (see the caveat on `CommitSentinel`).
+- The ledger still defines contiguity over delivered offsets, not offset arithmetic. A legitimate gap can then never wedge the frontier. The sentinel keeps the alert on gaps.
 - Add property tests: out-of-order completion, monotonic frontier, `frontier` idempotence, the ring drains after `take_frontier`, offset gaps, ring capacity.
 
 **Interfaces:**

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -38,19 +38,22 @@ Rules:
 - Every cycle names its verify evidence: the metrics to read and the exit criterion.
 - Old code is deleted in cleanup, never edited.
 - Dead code is deleted before a seam is carved around it. A cleanup of a switch that never shipped can open a cycle (change 1).
-- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 13).
+- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 15).
 - A cycle's cleanup lands only after its switchover holds on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
 - A change must not alter the meaning of an existing metric. Metrics of deleted machinery are deleted with it.
 - The commit sentinel and the key-order sentinel stay enabled through every cycle.
 
 Cycle 1 lands first: two fast, behavior-preserving complexity wins with no dependency on anything else.
-After that, the cycles run in order, with one exception: cycle 3 does not depend on cycle 2, so it can proceed while cycle 2 soaks.
-Cycle 5 needs cycles 2 and 3.
+After that, the cycles run in order, with two exceptions.
+Cycle 3 does not depend on cycle 2, so it can proceed while cycle 2 soaks.
+Cycle 4 needs only cycle 3's switchover, so it can proceed while cycle 3's cleanup soaks.
+Cycle 6 needs cycles 2 and 3.
 
 The swap unit in cycle 3 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
 That is where the complexity concentrates — the pins, the stash, and the flush interplay.
-The single-owner event loop follows as its own outcome (cycle 4), once the scheduler is simple.
+Packing follows at once (cycle 4): the performance win depends only on the key-table scheduler, not on the event loop, decoupled commits, or the budget.
+The single-owner event loop follows as its own outcome (cycle 5), once the scheduler is simple.
 
 Each change ends with its interface impact: the types it adds, modifies, or removes.
 A change that adds metrics lists their names.
@@ -69,15 +72,15 @@ A change that adds metrics lists their names.
 | 10 | 3 per-key order | Implement | Build the key-table scheduler |
 | 11 | 3 per-key order | Switchover | Switch to the key-table scheduler |
 | 12 | 3 per-key order | Cleanup | Delete the old scheduler |
-| 13 | 4 single-owner batcher | Structure | Collapse the batcher into one event loop |
-| 14 | 4 single-owner batcher | Cleanup | Remove the stream fences |
-| 15 | 5 decoupled commits | Switchover | Switch completion to group granularity |
-| 16 | 5 decoupled commits | Cleanup | Delete the per-poll completion path |
-| 17 | 6 bounded replay | Implement | Add the budget accounting |
-| 18 | 6 bounded replay | Switchover | Enable the budget |
-| 19 | 6 bounded replay | Cleanup | Remove the in-flight admission cap |
-| 20 | 7 target-sized requests | Implement | Add the packer |
-| 21 | 7 target-sized requests | Switchover | Set the packing targets |
+| 13 | 4 target-sized requests | Implement | Add the packer |
+| 14 | 4 target-sized requests | Switchover | Set the packing targets |
+| 15 | 5 single-owner batcher | Structure | Collapse the batcher into one event loop |
+| 16 | 5 single-owner batcher | Cleanup | Remove the stream fences |
+| 17 | 6 decoupled commits | Switchover | Switch completion to group granularity |
+| 18 | 6 decoupled commits | Cleanup | Delete the per-poll completion path |
+| 19 | 7 bounded replay | Implement | Add the budget accounting |
+| 20 | 7 bounded replay | Switchover | Enable the budget |
+| 21 | 7 bounded replay | Cleanup | Remove the in-flight admission cap |
 | 22 | 8 adaptive concurrency | Implement | Add the governor |
 | 23 | 8 adaptive concurrency | Switchover | Enable RTT adaptation |
 | 24 | 8 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
@@ -138,7 +141,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 17.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 19.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix up to the frontier.
 - The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
 - Completions can arrive in any order. The frontier moves only over completed slots.
@@ -273,7 +276,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Interface out: dispatches. One dispatch is one run of one key on one worker.
 - The first implementation preserves today's semantics: pins, the stash, deferral on drain, and the flush pacing. This is code motion from `assign`, `flush_deferred`, and `on_sub_batch_resolved`.
 - The plumbing (tasks, channels, the mutex) stays as it is. Only the decisions move.
-- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 13 mechanical: the seam's handlers become the loop's select arms.
+- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 15 mechanical: the seam's handlers become the loop's select arms.
 - The seam makes today's implicit ordering rules explicit and reviewable in one place.
 
 **Interfaces:**
@@ -338,14 +341,60 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Modify `Dispatcher`: remove the dead resolve plumbing (`clears_deferral`, `send_failed`, the flush driver).
 - Remove the pin and stash metrics (`ingestion_consumer_dispatcher_pins_total`, `ingestion_consumer_dispatcher_stashed_*`, the deferral counters). The key-table gauges replace them.
 
-## Cycle 4: the batcher is one single-owner event loop
+## Cycle 4: workers receive target-sized requests
+
+Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup: body splitting stays as a defence.
+This cycle sits directly after the scheduler on purpose: the win depends only on the key-table scheduler.
+It needs cycle 3's switchover on all lanes, and can proceed while cycle 3's cleanup soaks.
+A scheduler rollback also reverts packing: the packer exists only in the key-table scheduler.
+
+**Verify:** with the pack budget at zero, the packer emits on arrival and the e2e suite passes unchanged.
+Exit criterion after the targets: the request-size histograms center near T, and `ingestion_lag_ms` does not regress.
+
+### 13. Add the packer (implement)
+
+**Task:** Add the packer to the scheduler, with target size T and `PACK_LATENCY_BUDGET`. Ship with the pack budget at zero: send-on-arrival, behavior unchanged.
+
+**Goal:** The packing machinery exists before it changes any request.
+
+- Check the worker side first: a packed request spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
+- Pack runs from multiple runnable keys into one request near T. T counts events and bytes.
+- Emit immediately when the ready work can fill the free stream slots with near-T requests. Otherwise arm the pack deadline. The governor later replaces the slots with permits.
+- When the deadline expires, emit partial requests. The deadline also bounds the wait when held groups keep polls open: packing adds latency, never a wedge.
+- Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
+
+**Interfaces:**
+
+- Add `Packer` inside `KeyTableScheduler`.
+- Modify `Dispatch`: one request may carry runs from several keys.
+- Modify `Config`: add T and `PACK_LATENCY_BUDGET`, default zero. The worker proto does not change.
+
+**Metrics:**
+
+- Add `ingestion_consumer_request_events` and `ingestion_consumer_request_bytes` (histograms): the size of each sent request.
+- Add `ingestion_consumer_pack_emits_total` (counter, reason `arrival`, `full`, or `deadline`).
+
+### 14. Set the packing targets (switchover)
+
+**Task:** Set T and the pack budget per lane.
+
+**Goal:** Workers receive target-sized requests.
+
+- A charts values PR sets the targets lane by lane.
+- Watch the request-size histograms, worker occupancy, and end-to-end latency. Rollback is a pack budget of zero.
+
+**Interfaces:**
+
+- None in this repository. Config values only.
+
+## Cycle 5: the batcher is one single-owner event loop
 
 Outcome: one task owns all batcher state. The mutex and the callback structure are gone.
 This is a deliberate structural outcome, not tidy-up: it is the largest single concurrency simplification in the plan.
 
 **Verify:** the e2e suite and review. The change is behavior-identical, and the consumer-facing metrics must not move.
 
-### 13. Collapse the batcher into one event loop (structure)
+### 15. Collapse the batcher into one event loop (structure)
 
 **Task:** Move the scheduler and its plumbing into one single-owner task.
 
@@ -361,13 +410,13 @@ This is a deliberate structural outcome, not tidy-up: it is the largest single c
 - Modify `Batcher`: one single-owner task replaces the lock, the resolve callbacks, and the per-send tasks. `Dispatcher` dissolves into the loop and is removed.
 - Keep `Scheduler` as the loop's decision component. The consumer-facing interface does not change.
 
-### 14. Remove the stream fences (cleanup)
+### 16. Remove the stream fences (cleanup)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 13 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to leapfrog a failure.
+- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 15 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to leapfrog a failure.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - This change is deferrable. With one send origin, fences are inert insurance whose only cost is code.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
@@ -379,14 +428,14 @@ This is a deliberate structural outcome, not tidy-up: it is the largest single c
 - Keep `TransportError` and the `WorkerStreamRunner` reconnect logic.
 - Remove `ingestion_consumer_worker_stream_fenced_sub_batches_total`. Stream teardowns stay counted.
 
-## Cycle 5: a stalled key stalls only its partition
+## Cycle 6: a stalled key stalls only its partition
 
 Outcome: commits advance per partition as groups complete. Needs cycles 2 and 3.
 
 **Verify:** the commit sentinel checks every commit, and `ingestion_consumer_ledger_uncommitted_offsets` shows per-partition frontier lag.
 Exit criterion at the canary: zero sentinel violations, and a stalled partition no longer moves the commit rate of other partitions.
 
-### 15. Switch completion to group granularity (switchover)
+### 17. Switch completion to group granularity (switchover)
 
 **Task:** Add a completion granularity, `poll` or `group`. At `group` granularity, mark the ledger per group and stop waiting for whole polls.
 
@@ -405,7 +454,7 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 - Modify `Config`: add the completion granularity.
 - Modify `IngestionConsumer::process`: at `group` granularity, select over `GroupCompletion` events. The per-poll path stays for rollback.
 
-### 16. Delete the per-poll completion path (cleanup)
+### 18. Delete the per-poll completion path (cleanup)
 
 **Task:** Remove the per-poll completion path after `group` granularity holds on all lanes.
 
@@ -415,14 +464,14 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 
 - Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 8, and the completion granularity from `Config`.
 
-## Cycle 6: replay exposure is bounded by B
+## Cycle 7: replay exposure is bounded by B
 
 Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-flight admission cap is gone.
 
-**Verify:** change 17's gauges run on all lanes with the budget unset.
+**Verify:** change 19's gauges run on all lanes with the budget unset.
 Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admission cap's occupancy, and the pause gauge stays flat at zero.
 
-### 17. Add the budget accounting (implement)
+### 19. Add the budget accounting (implement)
 
 **Task:** Track uncommitted work in events and bytes. Ship with no budget set: the admission cap still governs alone.
 
@@ -441,9 +490,9 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 **Metrics:**
 
 - Add `ingestion_consumer_budget_outstanding_events` and `ingestion_consumer_budget_outstanding_bytes` (gauges).
-- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 18.
+- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 20.
 
-### 18. Enable the budget (switchover)
+### 20. Enable the budget (switchover)
 
 **Task:** Set the budget per lane. Pause the poll at the limit and resume on refund.
 
@@ -458,7 +507,7 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 
 - None in this repository. Config values only.
 
-### 19. Remove the in-flight admission cap (cleanup)
+### 21. Remove the in-flight admission cap (cleanup)
 
 **Task:** Remove `max_in_flight_batches` after the budget holds on all lanes.
 
@@ -470,49 +519,6 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 
 - Remove `max_in_flight_batches` from `Config` and the admission bookkeeping from `IngestionConsumer`.
 - Remove `ingestion_consumer_in_flight_batches`. The budget gauges replace it.
-
-## Cycle 7: workers receive target-sized requests
-
-Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup: body splitting stays as a defence.
-
-**Verify:** with the pack budget at zero, the packer emits on arrival and the e2e suite passes unchanged.
-Exit criterion after the targets: the request-size histograms center near T, and `ingestion_lag_ms` does not regress.
-
-### 20. Add the packer (implement)
-
-**Task:** Add the packer to the scheduler, with target size T and `PACK_LATENCY_BUDGET`. Ship with the pack budget at zero: send-on-arrival, behavior unchanged.
-
-**Goal:** The packing machinery exists before it changes any request.
-
-- Check the worker side first: a packed request spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
-- Pack runs from multiple runnable keys into one request near T. T counts events and bytes.
-- Emit immediately when the ready work can fill the free permits with near-T requests. Otherwise arm the pack deadline.
-- When the deadline expires, emit partial requests.
-- Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
-
-**Interfaces:**
-
-- Add `Packer` inside `KeyTableScheduler`.
-- Modify `Dispatch`: one request may carry runs from several keys.
-- Modify `Config`: add T and `PACK_LATENCY_BUDGET`, default zero. The worker proto does not change.
-
-**Metrics:**
-
-- Add `ingestion_consumer_request_events` and `ingestion_consumer_request_bytes` (histograms): the size of each sent request.
-- Add `ingestion_consumer_pack_emits_total` (counter, reason `arrival`, `full`, or `deadline`).
-
-### 21. Set the packing targets (switchover)
-
-**Task:** Set T and the pack budget per lane.
-
-**Goal:** Workers receive target-sized requests.
-
-- A charts values PR sets the targets lane by lane.
-- Watch the request-size histograms, worker occupancy, and end-to-end latency. Rollback is a pack budget of zero.
-
-**Interfaces:**
-
-- None in this repository. Config values only.
 
 ## Cycle 8: concurrency adapts to worker health
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -31,20 +31,26 @@ These components stay as they are: the stream runners, the P2C router, the apert
 The ledger track comes first (changes 1 to 3).
 It is isolated from the dispatch path, and shadow mode tests it against the current implementation in production before the cutover.
 
+The concurrency track follows (changes 4 to 6).
+Settlement events become the only drain for deferred work, batch completion stops flushing, and then batches complete in any order.
+The order matters: the completion-time flush keeps per-key order only because batches complete oldest first, so it must go before completion order can change.
+
 | # | Type | Change |
 | --- | --- | --- |
 | 1 | Structure | Add the offset ledger module |
 | 2 | Structure | Run the ledger in shadow mode |
 | 3 | Structure | Commit from the ledger frontier |
-| 4 | Structure | Demux polls into groups |
-| 5 | Logic | Complete batches in any order |
-| 6 | Logic | Route every group through the key table |
-| 7 | Structure | Remove the stream fences |
-| 8 | Logic | Replace the batch window with budget B |
-| 9 | Structure | Split into two single-owner event loops |
-| 10 | Logic | Pack requests toward target T |
-| 11 | Logic | Add the RTT dispatch governor |
-| 12 | Logic | Add the bounded revocation drain |
+| 4 | Logic | Drain deferred work on settlement events |
+| 5 | Logic | Batch completion stops flushing |
+| 6 | Logic | Complete batches in any order |
+| 7 | Structure | Demux polls into groups |
+| 8 | Logic | Route every group through the key table |
+| 9 | Structure | Remove the stream fences |
+| 10 | Logic | Replace the batch window with budget B |
+| 11 | Structure | Split into two single-owner event loops |
+| 12 | Logic | Pack requests toward target T |
+| 13 | Logic | Add the RTT dispatch governor |
+| 14 | Logic | Add the bounded revocation drain |
 
 ### 1. Add the offset ledger module (structure)
 
@@ -53,7 +59,7 @@ It is isolated from the dispatch path, and shadow mode tests it against the curr
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 8.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 10.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` removes the contiguous done prefix and returns the highest removed offset.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
@@ -85,7 +91,43 @@ It is isolated from the dispatch path, and shadow mode tests it against the curr
 - Rollback is the config switch back to `shadow`.
 - Delete the old commit computation after `active` holds on all lanes.
 
-### 4. Demux polls into groups (structure)
+### 4. Drain deferred work on settlement events (logic)
+
+**Task:** Make the settlement release reach every deferred group. The completion-time flush stays as the backstop.
+
+**Goal:** Deferred work drains at ack speed, on one primary path.
+
+- The settlement release exists behind `DISPATCHER_EAGER_DEFERRED_FLUSH`, default off and not set in production. A charts PR enables it first. Rollback is that values change.
+- Two cases never see a settlement today: a group that was unroutable (its key had no send in flight), and a key whose failed send suppressed the release.
+- Add a parked-retry deadline for them: a timer retries every deferring key that has no send in flight, with backoff.
+- Count drains per path. After this change, the completion-time flush must find an empty stash in normal operation.
+
+### 5. Batch completion stops flushing (logic)
+
+**Task:** Add a flush mode, `batch` or `settlement`. In `settlement` mode, batch completion waits for its accepted count and does not flush.
+
+**Goal:** Batch completion only waits and counts. One flush path remains.
+
+- In `settlement` mode, a batch completes when its accepted count reaches its batch size. The credit path for settled sends exists (`take_eager_accepted`).
+- Per-key order holds without the oldest-first rule: each key queue orders its entries by batch sequence, and the release always takes the oldest entry.
+- Keep the no-progress watchdog: fail the process when a batch sees no acceptance for a full timeout window.
+- Rollback is the mode switch back to `batch`.
+- Delete `batch` mode after `settlement` holds on all lanes. That removes `flush_deferred` in the consumer and the dispatcher, and `Stash::take_batch`.
+
+### 6. Complete batches in any order (logic)
+
+**Task:** Replace the oldest-first await with completion events.
+
+**Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
+
+- Change 5 is the prerequisite. The completion-time flush kept per-key order only because batches completed oldest first: `Stash::take_batch` on a newer batch pulls a key's entries past an older batch's entries. The settlement release orders by key queue instead.
+- The consumer loop awaits all in-flight batches at once (a completion channel or `FuturesUnordered`).
+- A completed batch marks its offsets in the ledger. The frontier gates each partition's commit.
+- A batch with deferred work no longer blocks the commits of other batches.
+- Keep `max_in_flight_batches` as the bound on outstanding work.
+- Behavior change: commit timing decouples across partitions. Replay exposure stays inside the batch window.
+
+### 7. Demux polls into groups (structure)
 
 **Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
 
@@ -95,19 +137,7 @@ It is isolated from the dispatch path, and shadow mode tests it against the curr
 - The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
 - Later changes use the group as the unit of dispatch and completion.
 
-### 5. Complete batches in any order (logic)
-
-**Task:** Replace the oldest-first await with completion events.
-
-**Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
-
-- The consumer loop awaits all in-flight batches at once (a completion channel or `FuturesUnordered`).
-- A completed batch marks its offsets in the ledger. The frontier gates each partition's commit.
-- A batch with deferred work no longer blocks the commits of other batches.
-- Keep `max_in_flight_batches` as the bound on outstanding work.
-- Behavior change: commit timing decouples across partitions. Replay exposure stays inside the batch window.
-
-### 6. Route every group through the key table (logic)
+### 8. Route every group through the key table (logic)
 
 **Task:** Enqueue all groups into per-key FIFO queues. Dispatch only runnable keys. Remove the sticky pins.
 
@@ -116,24 +146,24 @@ It is isolated from the dispatch path, and shadow mode tests it against the curr
 - Evolve `stash.rs` into the key table. All groups enter it, not only deferred ones.
 - A key is runnable when it has queued work and no outstanding request.
 - Dispatch takes one contiguous run per runnable key and marks the key outstanding.
-- A settlement clears the outstanding flag and dispatches the key's next run. Reuse the eager-flush channel for this path.
+- A settlement clears the outstanding flag and dispatches the key's next run. Change 4 made this the primary drain. This change extends it to all groups.
 - A failed request returns its runs to the front of their key queues.
 - Report completions per group, with partition and offsets. Mark them in the ledger. Delete the per-batch accepted counters.
-- Delete: the pin table, the deferred-flush loop, and the batch-sequence machinery in the stash. Append order is sufficient, because one enqueue site remains, on the consumer loop, in poll order.
+- Delete: the pin table and the batch-sequence machinery in the stash. Append order is sufficient, because one enqueue site remains, on the consumer loop, in poll order.
 - Route each request with the existing P2C and aperture. There is no stickiness.
 - This is proposal 2 of the design doc. Ship it as a canary on one lane. Measure worker key-cache locality before and after (open question 3).
 
-### 7. Remove the stream fences (structure)
+### 9. Remove the stream fences (structure)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- After change 6, one send origin exists. A key with a failed request is not runnable. No newer send for that key can enter a stream.
+- After change 8, one send origin exists. A key with a failed request is not runnable. No newer send for that key can enter a stream.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
-### 8. Replace the batch window with budget B (logic)
+### 10. Replace the batch window with budget B (logic)
 
 **Task:** Poll only while uncommitted work is below B. B counts events and bytes.
 
@@ -145,7 +175,7 @@ It is isolated from the dispatch path, and shadow mode tests it against the curr
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
 - New config: the budget in events and in bytes.
 
-### 9. Split into two single-owner event loops (structure)
+### 11. Split into two single-owner event loops (structure)
 
 **Task:** Move the key table, dispatch, and settlement into one batcher task. The consumer loop and the batcher exchange accumulators and completions over channels.
 
@@ -155,7 +185,7 @@ It is isolated from the dispatch path, and shadow mode tests it against the curr
 - Select order in each loop: clocks and rebalance events first, completions next, polls last.
 - The worker-health snapshot stays the only shared read.
 
-### 10. Pack requests toward target T (logic)
+### 12. Pack requests toward target T (logic)
 
 **Task:** Add the packer, with target size T and `PACK_LATENCY_BUDGET`.
 
@@ -168,7 +198,7 @@ It is isolated from the dispatch path, and shadow mode tests it against the curr
 - Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
 - Check the worker side first: a request now spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 
-### 11. Add the RTT dispatch governor (logic)
+### 13. Add the RTT dispatch governor (logic)
 
 **Task:** Replace the fixed per-worker un-acked cap with a permit pool that request RTT governs.
 
@@ -180,7 +210,7 @@ It is isolated from the dispatch path, and shadow mode tests it against the curr
 - Keep the 503 backoff in the transport. Exclude 503 waits from the RTT signal.
 - Cap each stream channel at `DEPTH_MAX`.
 
-### 12. Add the bounded revocation drain (logic)
+### 14. Add the bounded revocation drain (logic)
 
 **Task:** Implement the drain sequence from section 4 of the design doc.
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -1,0 +1,180 @@
+# Driver-model implementation plan
+
+Status: **draft, for discussion**.
+
+This plan implements the [driver-model redesign](https://github.com/PostHog/posthog/blob/pl/ingestion/consumer-redesign-doc/rust/ingestion-consumer/docs/driver-model.md) (#89277) in small steps.
+Each step is one PR.
+
+## Starting point
+
+The plan starts from current master.
+Master already contains two parts of the design:
+
+- The routing key is the opaque Kafka message key (#90282). A message without a key gets a synthetic per-message key.
+- Each worker has one long-lived ordered gRPC stream (#85238, #90790). The stream runner keeps an un-acked ledger, resolves acks in send order, applies an ack watchdog, and fences on failure.
+
+An assignment epoch also exists.
+A rebalance increments it, and every sub-batch carries it.
+
+These components stay as they are: the stream runners, the P2C router, the aperture, the worker registry, the commit sentinel, the commit monitor, and the key-order sentinel.
+
+## Rules for the sequence
+
+- Each change is one PR.
+- A change is a structure change or a logic change, never both.
+- A structure change does not change behavior. The e2e tests must pass without edits.
+- A logic change ships behind a config flag when a flag is possible. When a flag is not possible, it ships as a canary on one lane.
+- The commit sentinel and the key-order sentinel stay enabled through the migration. They verify each step in production.
+
+## Changes
+
+| # | Type | Change |
+| --- | --- | --- |
+| 1 | Structure | Add the offset ledger module |
+| 2 | Structure | Demux polls into groups |
+| 3 | Structure | Commit from the ledger frontier |
+| 4 | Logic | Complete batches in any order |
+| 5 | Logic | Route every group through the key table |
+| 6 | Structure | Remove the stream fences |
+| 7 | Logic | Replace the batch window with budget B |
+| 8 | Structure | Split into two single-owner event loops |
+| 9 | Logic | Pack requests toward target T |
+| 10 | Logic | Add the RTT dispatch governor |
+| 11 | Logic | Add the bounded revocation drain |
+
+### 1. Add the offset ledger module (structure)
+
+**Task:** Create `ledger.rs` with a per-partition offset ring. Do not wire it in.
+
+**Goal:** Make commit contiguity a property of a data structure.
+
+- One ledger per partition. The ledger is a dense ring of delivered offsets.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 7.
+- Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` removes the contiguous done prefix and returns the highest removed offset.
+- Completions can arrive in any order. The frontier moves only over completed slots.
+- Add property tests: out-of-order completion, monotonic frontier, ring capacity.
+
+### 2. Demux polls into groups (structure)
+
+**Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
+
+**Goal:** Create the accumulator shape from the design doc.
+
+- Group messages per partition first, then per routing key. Keep offset order inside each group.
+- The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
+- Later changes use the group as the unit of dispatch and completion.
+
+### 3. Commit from the ledger frontier (structure)
+
+**Task:** Wire the ledger into the commit path. Keep oldest-first batch completion.
+
+**Goal:** The frontier produces the same commits as the current code, and the sentinel proves it.
+
+- Charge every delivered offset into its partition ledger during `collect_batch`.
+- When a batch completes, mark all its offsets complete.
+- Commit the frontier of each partition instead of the batch's max offset.
+- With oldest-first completion, the frontier equals the old commit point. The output is identical.
+- The commit sentinel stays on and checks contiguity and monotonicity.
+
+### 4. Complete batches in any order (logic)
+
+**Task:** Replace the oldest-first await with completion events.
+
+**Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
+
+- The consumer loop awaits all in-flight batches at once (a completion channel or `FuturesUnordered`).
+- A completed batch marks its offsets in the ledger. The frontier gates each partition's commit.
+- A batch with deferred work no longer blocks the commits of other batches.
+- Keep `max_in_flight_batches` as the bound on outstanding work.
+- Behavior change: commit timing decouples across partitions. Replay exposure stays inside the batch window.
+
+### 5. Route every group through the key table (logic)
+
+**Task:** Enqueue all groups into per-key FIFO queues. Dispatch only runnable keys. Remove the sticky pins.
+
+**Goal:** One ordering rule remains: at most one outstanding request per key.
+
+- Evolve `stash.rs` into the key table. All groups enter it, not only deferred ones.
+- A key is runnable when it has queued work and no outstanding request.
+- Dispatch takes one contiguous run per runnable key and marks the key outstanding.
+- A settlement clears the outstanding flag and dispatches the key's next run. Reuse the eager-flush channel for this path.
+- A failed request returns its runs to the front of their key queues.
+- Report completions per group, with partition and offsets. Mark them in the ledger. Delete the per-batch accepted counters.
+- Delete: the pin table, the deferred-flush loop, and the batch-sequence machinery in the stash. Append order is sufficient, because one enqueue site remains, on the consumer loop, in poll order.
+- Route each request with the existing P2C and aperture. There is no stickiness.
+- This is proposal 2 of the design doc. Ship it as a canary on one lane. Measure worker key-cache locality before and after (open question 3).
+
+### 6. Remove the stream fences (structure)
+
+**Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
+
+**Goal:** Keep only the failure logic the new invariant needs.
+
+- After change 5, one send origin exists. A key with a failed request is not runnable. No newer send for that key can enter a stream.
+- A stream failure returns each request's messages to the key table. That is sufficient.
+- Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
+
+### 7. Replace the batch window with budget B (logic)
+
+**Task:** Poll only while uncommitted work is below B. B counts events and bytes.
+
+**Goal:** Bound replay exposure directly. Poll continuously when workers keep up.
+
+- Charge each message on poll. The ledger slots already carry the costs (change 1).
+- Refund the charge when the commit that covers the message is issued.
+- Remove `max_in_flight_batches`. The batch reduces to a per-poll accumulator.
+- Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
+- New config: the budget in events and in bytes.
+
+### 8. Split into two single-owner event loops (structure)
+
+**Task:** Move the key table, dispatch, and settlement into one batcher task. The consumer loop and the batcher exchange accumulators and completions over channels.
+
+**Goal:** Remove shared mutable state and lock ordering.
+
+- The pin-table mutex disappears. All batcher state is task-local.
+- Select order in each loop: clocks and rebalance events first, completions next, polls last.
+- The worker-health snapshot stays the only shared read.
+
+### 9. Pack requests toward target T (logic)
+
+**Task:** Add the packer, with target size T and `PACK_LATENCY_BUDGET`.
+
+**Goal:** Request size becomes deliberate. Fan-out becomes demand-driven.
+
+- Pack runs from multiple runnable keys into one request near T. T counts events and bytes.
+- Emit immediately when the ready work can fill the free permits with near-T requests. Otherwise arm the pack deadline.
+- When the deadline expires, emit partial requests.
+- `PACK_LATENCY_BUDGET = 0` restores send-on-arrival. That is the off switch.
+- Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
+- Check the worker side first: a request now spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
+
+### 10. Add the RTT dispatch governor (logic)
+
+**Task:** Replace the fixed per-worker un-acked cap with a permit pool that request RTT governs.
+
+**Goal:** Reduce crash exposure when the worker pool is unhealthy.
+
+- Grow the pool by one when ready work waits, no permit is free, and RTT is within budget.
+- Shrink the pool by one when the RTT EWMA exceeds `REQUEST_LATENCY_BUDGET`.
+- Bound the pool with a configured minimum and maximum.
+- Keep the 503 backoff in the transport. Exclude 503 waits from the RTT signal.
+- Cap each stream channel at `DEPTH_MAX`.
+
+### 11. Add the bounded revocation drain (logic)
+
+**Task:** Implement the drain sequence from section 4 of the design doc.
+
+**Goal:** A revoked partition hands off cleanly. A wedged partition fails the process instead of hanging forever.
+
+- On revoke, send an in-band marker to the batcher, after earlier accumulators.
+- The batcher drops queued unsent work for the partition. Kafka replays it for the next owner.
+- Wait only for requests in flight. Send a drained marker after the final completion.
+- The loop issues one final commit, refunds the remaining charge, and unassigns the partition.
+- Check completions against the assignment epoch. The epoch already exists on master.
+- Add a stall deadline per partition. Outside a rebalance, an expired deadline fails the process. Replay is at most B.
+
+## Later work
+
+- The keyless lane: today an unkeyed message gets a synthetic per-message key and its own group. A separate keyless lane per partition can remove that overhead.
+- Partition affinity as a packing hint (open question 6). Measure frontier coupling first.

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -44,6 +44,8 @@ That is where the complexity concentrates — the pins, the stash, and the flush
 Placement (P2C, aperture) and send execution (stream runners) already match the target design and are not rebuilt.
 The single-owner event loop is only plumbing once the scheduler is simple, so it moves last.
 
+Each change ends with its interface impact: the types it adds, modifies, or removes.
+
 | # | Type | Change |
 | --- | --- | --- |
 | 1 | Structure | Add the offset ledger module |
@@ -76,6 +78,10 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
 - Add property tests: out-of-order completion, monotonic frontier, offset gaps, ring capacity.
 
+**Interfaces:**
+
+- Add `OffsetLedger` in `ledger.rs`: `charge`, `complete`, `frontier`. No callers yet. The name avoids a clash with the stream runner's internal un-acked ledger.
+
 ### 2. Run the ledger in shadow mode (structure)
 
 **Task:** Wire the ledger next to the commit path. Compare its frontier with each real commit. Do not change what the consumer commits.
@@ -90,6 +96,12 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
 - Soak on all lanes. The exit criterion is a mismatch count of zero across deploys and rebalances.
 
+**Interfaces:**
+
+- Modify `Config`: add the ledger mode.
+- Modify `IngestionConsumer`: own one `OffsetLedger` per partition. Charge in `collect_batch`, complete on batch completion, compare in `commit_offsets`.
+- Modify the revoke path (`SentinelContext`): drop revoked partitions' ledgers.
+
 ### 3. Demux polls into groups (structure)
 
 **Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
@@ -99,6 +111,12 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - Group messages per partition first, then per routing key. Keep offset order inside each group.
 - The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
 - Change 4 uses the groups as the unit of the batcher interface.
+
+**Interfaces:**
+
+- Add `Group` in `types.rs`: partition, routing key, messages in offset order.
+- Modify `CollectedBatch`: carries `Vec<Group>` instead of a flat message list.
+- Modify `Dispatcher::assign_and_send`: takes groups and flattens them. `group_messages_by_routing_key` moves to the collect path.
 
 ### 4. Encapsulate the worker batcher (structure)
 
@@ -114,6 +132,14 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - The consumer loop keeps: poll collection, commits, the sentinels, and the batch window. It aggregates group completions per batch, so completion and commit behavior do not change.
 - Changes 5 and 6 carve the scheduler seam inside this boundary.
 
+**Interfaces:**
+
+- Add `Batcher` in `batcher.rs`: `submit(batch_id, Vec<Group>)` in, a channel of `GroupCompletion` out. It owns `Dispatcher`, `GrpcTransport`, `WorkerRegistry`, and the send tasks.
+- Add `GroupCompletion`: batch id, partition, offsets, accepted count.
+- Modify `IngestionConsumer`: drop `scatter`, `flush_deferred`, and the eager-flush loop — they move into the batcher. Keep collect, commit, and the window. Aggregate completions per batch.
+- Modify `main.rs`: construct one `Batcher`. The consumer no longer sees the dispatcher or the transport.
+- Internalize `Dispatcher`'s resolve and accounting methods (`on_sub_batch_*`, `defer_failed`, `eager_flush_*`, `take_eager_accepted`): only the batcher calls them.
+
 ### 5. Extract the scheduler seam (structure)
 
 **Task:** Move every ordering and placement decision inside the batcher behind one interface. Keep the current semantics.
@@ -126,6 +152,13 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - The first implementation preserves today's semantics: pins, the stash, deferral on drain, the flush pacing, and the eager release. This is code motion from `assign`, `flush_deferred`, `on_sub_batch_resolved`, and the eager path.
 - The plumbing (tasks, channels, the mutex) stays as it is. Only the decisions move.
 - The seam makes today's implicit ordering rules explicit and reviewable in one place.
+
+**Interfaces:**
+
+- Add the `Scheduler` trait in `scheduler.rs`: `on_groups`, `on_settled`, `on_deadline` in; `Vec<Dispatch>` out.
+- Add `Dispatch`: one run of one key, with the chosen worker.
+- Add `PinStashScheduler`: the current semantics, moved out of `Dispatcher::assign`, `flush_deferred`, `on_sub_batch_resolved`, and the eager release. It owns `PinTable` and `Stash` unchanged.
+- Modify `Dispatcher`: shrinks to plumbing — the lock, in-flight load, metrics, and seam calls.
 
 ### 6. Build the key-table scheduler (structure)
 
@@ -140,6 +173,10 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - Placement is stateless: the existing P2C and aperture pick a worker per dispatch. There are no pins.
 - The seam is events in, dispatches out. Test the scheduler deterministically: script arrivals, settlements, and failures. Assert per-key order.
 
+**Interfaces:**
+
+- Add `KeyTableScheduler` and `KeyTable` in `key_table.rs`: per-key FIFO, outstanding flag, parked list. Implements `Scheduler`. Tests only, no production callers.
+
 ### 7. Commit from the ledger frontier (structure)
 
 **Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first batch completion.
@@ -151,6 +188,11 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - The commit sentinel stays on and checks contiguity and monotonicity.
 - Rollback is the config switch back to `shadow`.
 - Delete the old commit computation after `active` holds on all lanes.
+
+**Interfaces:**
+
+- Modify `Config`: default the ledger mode to `active`.
+- Modify `IngestionConsumer::commit_offsets`: read the committed offset from `OffsetLedger::frontier`. The old computation survives only as the shadow comparison, then is deleted.
 
 ### 8. Switch to the key-table scheduler (logic)
 
@@ -164,6 +206,12 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - Watch: the key-order sentinel, ack latency, and the no-progress watchdog.
 - Rollback is the config switch back to the old scheduler.
 
+**Interfaces:**
+
+- Modify `Config`: add the scheduler selection.
+- Modify the batcher construction: select `KeyTableScheduler` or `PinStashScheduler`.
+- No interface shapes change.
+
 ### 9. Delete the old scheduler (structure)
 
 **Task:** Remove the old scheduler implementation after change 8 holds on all lanes.
@@ -172,6 +220,12 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 
 - Removes: the pin table, the stash, both flush drivers, the eager-flush channel and its credits, `DISPATCHER_EAGER_DEFERRED_FLUSH`, and the scheduler switch.
 - The plan never edits this machinery. It is isolated in change 5, bypassed in change 8, and deleted here.
+
+**Interfaces:**
+
+- Remove `PinStashScheduler`, `PinTable`, `Stash`, `sticky_pin_for`, `EagerFlush`, and the eager credits.
+- Remove from `Config`: `DISPATCHER_EAGER_DEFERRED_FLUSH` and the scheduler selection.
+- Modify `Dispatcher`: remove the dead resolve plumbing (`clears_deferral`, `send_failed`, the flush drivers).
 
 ### 10. Remove the stream fences (structure)
 
@@ -183,6 +237,12 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
+**Interfaces:**
+
+- Remove `FenceGuard` from `transport.rs` and `Fence` with its settle loop from `grpc_transport.rs`.
+- Modify `SendError`: drop the fence-guard field.
+- Keep `TransportError` and the `WorkerStreamRunner` reconnect logic.
+
 ### 11. Collapse the batcher into one event loop (structure)
 
 **Task:** Move the scheduler and its plumbing into one single-owner task.
@@ -192,6 +252,11 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - The seam's events become the loop's events: accumulators, settlements, deadlines. The scheduler is already event-shaped, so the loop owns it directly.
 - State becomes task-local. The worker-health snapshot stays the only shared read.
 - This is the batcher event loop of the design doc. It is plumbing now: the decisions it drives are already simple.
+
+**Interfaces:**
+
+- Modify `Batcher`: one single-owner task replaces the lock, the resolve callbacks, and the per-send tasks. `Dispatcher` dissolves into the loop and is removed.
+- Keep `Scheduler` as the loop's decision component. The consumer-facing interface does not change.
 
 ### 12. Complete batches in any order (logic)
 
@@ -205,6 +270,11 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - Keep `max_in_flight_batches` as the bound on outstanding work. A batch slot frees when all its groups are accepted.
 - Behavior change: commit timing decouples across partitions and batches. Replay exposure stays inside the batch window.
 
+**Interfaces:**
+
+- Modify `IngestionConsumer::process`: select over `GroupCompletion` events. Remove the ordered `InFlightBatch` queue and the per-batch aggregation from change 4.
+- Modify the batch bookkeeping: a batch is only a window slot that frees when its groups are accepted.
+
 ### 13. Replace the batch window with budget B (logic)
 
 **Task:** Poll only while uncommitted work is below B. B counts events and bytes.
@@ -216,6 +286,11 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - Remove `max_in_flight_batches`. The batch reduces to a per-poll accumulator.
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
 - New config: the budget in events and in bytes.
+
+**Interfaces:**
+
+- Modify `Config`: add the budget; remove `max_in_flight_batches`.
+- Modify `IngestionConsumer`: gate polling on the outstanding charge. Refund from `OffsetLedger` on commit. Remove the window-slot bookkeeping from change 12.
 
 ### 14. Pack requests toward target T (logic)
 
@@ -230,6 +305,12 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
 - Check the worker side first: a request now spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 
+**Interfaces:**
+
+- Add `Packer` inside `KeyTableScheduler`.
+- Modify `Dispatch`: one request may carry runs from several keys.
+- Modify `Config`: add T and `PACK_LATENCY_BUDGET`. The worker proto does not change.
+
 ### 15. Add the RTT dispatch governor (logic)
 
 **Task:** Replace the fixed per-worker un-acked cap with a permit pool that request RTT governs.
@@ -241,6 +322,12 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - Bound the pool with a configured minimum and maximum.
 - Keep the 503 backoff in the transport. Exclude 503 waits from the RTT signal.
 - Cap each stream channel at `DEPTH_MAX`.
+
+**Interfaces:**
+
+- Add `Governor` in the batcher loop: the permit pool and the RTT EWMA.
+- Modify `GrpcTransport`: governor permits replace the per-worker `max_unacked` cap. Stream channels get `DEPTH_MAX` capacity.
+- Modify `Config`: add `REQUEST_LATENCY_BUDGET`, the permit bounds, and `DEPTH_MAX`.
 
 ### 16. Add the bounded revocation drain (logic)
 
@@ -254,6 +341,12 @@ The single-owner event loop is only plumbing once the scheduler is simple, so it
 - The loop issues one final commit, refunds the remaining charge, and unassigns the partition.
 - Check completions against the assignment epoch. The epoch already exists on master.
 - Add a stall deadline per partition. Outside a rebalance, an expired deadline fails the process. Replay is at most B.
+
+**Interfaces:**
+
+- Modify `Batcher`: add a revoke marker input and a drained marker output. `GroupCompletion` does not change shape.
+- Modify `KeyTableScheduler`: drop queued work per partition on revoke.
+- Modify `IngestionConsumer` and `OffsetLedger`: the final commit, the refund of abandoned charge, and the per-partition stall deadline.
 
 ## Later work
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -38,7 +38,7 @@ Rules:
 - Every cycle names its verify evidence: the metrics to read and the exit criterion.
 - Old code is deleted in cleanup, never edited.
 - Dead code is deleted before a seam is carved around it. A cleanup of a switch that never shipped can open a cycle (change 1).
-- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 15).
+- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 18).
 - A cycle's cleanup lands only after its switchover holds on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
 - A change must not alter the meaning of an existing metric. Metrics of deleted machinery are deleted with it.
@@ -48,12 +48,13 @@ Cycle 1 lands first: two fast, behavior-preserving complexity wins with no depen
 After that, the cycles run in order, with two exceptions.
 Cycle 3 does not depend on cycle 2, so it can proceed while cycle 2 soaks.
 Cycle 4 needs only cycle 3's switchover, so it can proceed while cycle 3's cleanup soaks.
-Cycle 6 needs cycles 2 and 3.
+Cycle 7 needs cycles 2 and 3.
 
 The swap unit in cycle 3 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
 That is where the complexity concentrates — the pins, the stash, and the flush interplay.
 Packing follows at once (cycle 4): the performance win depends only on the key-table scheduler, not on the event loop, decoupled commits, or the budget.
-The single-owner event loop follows as its own outcome (cycle 5), once the scheduler is simple.
+The governor follows packing (cycle 5): it needs the scheduler's ready queue for its growth signal, and packing first, so RTT tunes against comparable requests.
+The single-owner event loop follows as its own outcome (cycle 6), once the scheduler is simple.
 
 Each change ends with its interface impact: the types it adds, modifies, or removes.
 A change that adds metrics lists their names.
@@ -74,16 +75,16 @@ A change that adds metrics lists their names.
 | 12 | 3 per-key order | Cleanup | Delete the old scheduler |
 | 13 | 4 target-sized requests | Implement | Add the packer |
 | 14 | 4 target-sized requests | Switchover | Set the packing targets |
-| 15 | 5 single-owner batcher | Structure | Collapse the batcher into one event loop |
-| 16 | 5 single-owner batcher | Cleanup | Remove the stream fences |
-| 17 | 6 decoupled commits | Switchover | Switch completion to group granularity |
-| 18 | 6 decoupled commits | Cleanup | Delete the per-poll completion path |
-| 19 | 7 bounded replay | Implement | Add the budget accounting |
-| 20 | 7 bounded replay | Switchover | Enable the budget |
-| 21 | 7 bounded replay | Cleanup | Remove the in-flight admission cap |
-| 22 | 8 adaptive concurrency | Implement | Add the governor |
-| 23 | 8 adaptive concurrency | Switchover | Enable RTT adaptation |
-| 24 | 8 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
+| 15 | 5 adaptive concurrency | Implement | Add the governor |
+| 16 | 5 adaptive concurrency | Switchover | Enable RTT adaptation |
+| 17 | 5 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
+| 18 | 6 single-owner batcher | Structure | Collapse the batcher into one event loop |
+| 19 | 6 single-owner batcher | Cleanup | Remove the stream fences |
+| 20 | 7 decoupled commits | Switchover | Switch completion to group granularity |
+| 21 | 7 decoupled commits | Cleanup | Delete the per-poll completion path |
+| 22 | 8 bounded replay | Implement | Add the budget accounting |
+| 23 | 8 bounded replay | Switchover | Enable the budget |
+| 24 | 8 bounded replay | Cleanup | Remove the in-flight admission cap |
 | 25 | 9 clean handoff | Prepare | Add revoke and drained markers |
 | 26 | 9 clean handoff | Implement | Build the drain |
 | 27 | 9 clean handoff | Switchover | Enable the drain |
@@ -141,7 +142,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 19.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 22.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix up to the frontier.
 - The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
 - Completions can arrive in any order. The frontier moves only over completed slots.
@@ -276,7 +277,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Interface out: dispatches. One dispatch is one run of one key on one worker.
 - The first implementation preserves today's semantics: pins, the stash, deferral on drain, and the flush pacing. This is code motion from `assign`, `flush_deferred`, and `on_sub_batch_resolved`.
 - The plumbing (tasks, channels, the mutex) stays as it is. Only the decisions move.
-- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 15 mechanical: the seam's handlers become the loop's select arms.
+- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 18 mechanical: the seam's handlers become the loop's select arms.
 - The seam makes today's implicit ordering rules explicit and reviewable in one place.
 
 **Interfaces:**
@@ -359,7 +360,7 @@ Exit criterion after the targets: the request-size histograms center near T, and
 
 - Check the worker side first: a packed request spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 - Pack runs from multiple runnable keys into one request near T. T counts events and bytes.
-- Emit immediately when the ready work can fill the free stream slots with near-T requests. Otherwise arm the pack deadline. The governor later replaces the slots with permits.
+- Emit immediately when the ready work can fill the free stream slots with near-T requests. Otherwise arm the pack deadline. The governor (cycle 5) replaces the slots with permits.
 - When the deadline expires, emit partial requests. The deadline also bounds the wait when held groups keep polls open: packing adds latency, never a wedge.
 - Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
 
@@ -387,14 +388,70 @@ Exit criterion after the targets: the request-size histograms center near T, and
 
 - None in this repository. Config values only.
 
-## Cycle 5: the batcher is one single-owner event loop
+## Cycle 5: concurrency adapts to worker health
+
+Outcome: request RTT governs the number of requests in flight.
+It needs cycle 4: packing stabilizes the request unit, so the RTT signal tunes against comparable requests.
+The growth signal — ready work waiting on permits — comes from the key-table scheduler's ready queue.
+
+**Verify:** with adaptation off, change 15 reports the decisions it would make.
+Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink signals under induced worker latency and stays quiet under normal load.
+
+### 15. Add the governor (implement)
+
+**Task:** Add the permit pool and the RTT EWMA. Ship with adaptation off: permits mirror the current per-worker cap.
+
+**Goal:** The governor exists and observes before it constrains.
+
+- The governor gates the pack pass: a dispatch takes a permit, and a settlement returns it. The integration surface is thin, and change 18 later moves the calls into the event loop unchanged.
+- Grow the pool by one when ready work waits, no permit is free, and RTT is within budget.
+- Shrink the pool by one when the RTT EWMA exceeds `REQUEST_LATENCY_BUDGET`.
+- With adaptation off, compute and report every decision without applying it. The signal is verifiable before it constrains.
+- Bound the pool with a configured minimum and maximum.
+- Keep the 503 backoff in the transport. Exclude 503 waits from the RTT signal.
+- Cap each stream channel at `DEPTH_MAX`.
+
+**Interfaces:**
+
+- Add `Governor` in the batcher: the permit pool and the RTT EWMA, adaptation off.
+- Modify `Config`: add `REQUEST_LATENCY_BUDGET`, the permit bounds, and `DEPTH_MAX`.
+
+**Metrics:**
+
+- Add `ingestion_consumer_governor_permits` (gauge) and `ingestion_consumer_request_rtt_seconds` (gauge, the EWMA).
+- Add `ingestion_consumer_governor_adjustments_total` (counter, direction `grow` or `shrink`). With adaptation off, it counts would-be decisions.
+
+### 16. Enable RTT adaptation (switchover)
+
+**Task:** Turn adaptation on. Request RTT governs the permit pool.
+
+**Goal:** Concurrency shrinks when the worker pool is unhealthy.
+
+- Canary one lane. Watch the permit gauge, the RTT EWMA, and throughput under induced worker latency.
+- Rollback is the adaptation switch.
+
+**Interfaces:**
+
+- Modify `Config`: enable adaptation.
+
+### 17. Remove the fixed per-worker cap (cleanup)
+
+**Task:** Remove the per-worker `max_unacked` cap after adaptation holds on all lanes.
+
+**Goal:** Governor permits are the only in-flight bound.
+
+**Interfaces:**
+
+- Modify `GrpcTransport`: remove the per-worker cap and its config. Stream channels keep `DEPTH_MAX`.
+
+## Cycle 6: the batcher is one single-owner event loop
 
 Outcome: one task owns all batcher state. The mutex and the callback structure are gone.
 This is a deliberate structural outcome, not tidy-up: it is the largest single concurrency simplification in the plan.
 
 **Verify:** the e2e suite and review. The change is behavior-identical, and the consumer-facing metrics must not move.
 
-### 15. Collapse the batcher into one event loop (structure)
+### 18. Collapse the batcher into one event loop (structure)
 
 **Task:** Move the scheduler and its plumbing into one single-owner task.
 
@@ -408,15 +465,15 @@ This is a deliberate structural outcome, not tidy-up: it is the largest single c
 **Interfaces:**
 
 - Modify `Batcher`: one single-owner task replaces the lock, the resolve callbacks, and the per-send tasks. `Dispatcher` dissolves into the loop and is removed.
-- Keep `Scheduler` as the loop's decision component. The consumer-facing interface does not change.
+- Keep `Scheduler` and `Governor` as the loop's components. The consumer-facing interface does not change.
 
-### 16. Remove the stream fences (cleanup)
+### 19. Remove the stream fences (cleanup)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 15 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to leapfrog a failure.
+- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 18 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to leapfrog a failure.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - This change is deferrable. With one send origin, fences are inert insurance whose only cost is code.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
@@ -428,14 +485,14 @@ This is a deliberate structural outcome, not tidy-up: it is the largest single c
 - Keep `TransportError` and the `WorkerStreamRunner` reconnect logic.
 - Remove `ingestion_consumer_worker_stream_fenced_sub_batches_total`. Stream teardowns stay counted.
 
-## Cycle 6: a stalled key stalls only its partition
+## Cycle 7: a stalled key stalls only its partition
 
 Outcome: commits advance per partition as groups complete. Needs cycles 2 and 3.
 
 **Verify:** the commit sentinel checks every commit, and `ingestion_consumer_ledger_uncommitted_offsets` shows per-partition frontier lag.
 Exit criterion at the canary: zero sentinel violations, and a stalled partition no longer moves the commit rate of other partitions.
 
-### 17. Switch completion to group granularity (switchover)
+### 20. Switch completion to group granularity (switchover)
 
 **Task:** Add a completion granularity, `poll` or `group`. At `group` granularity, mark the ledger per group and stop waiting for whole polls.
 
@@ -454,7 +511,7 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 - Modify `Config`: add the completion granularity.
 - Modify `IngestionConsumer::process`: at `group` granularity, select over `GroupCompletion` events. The per-poll path stays for rollback.
 
-### 18. Delete the per-poll completion path (cleanup)
+### 21. Delete the per-poll completion path (cleanup)
 
 **Task:** Remove the per-poll completion path after `group` granularity holds on all lanes.
 
@@ -464,14 +521,14 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 
 - Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 8, and the completion granularity from `Config`.
 
-## Cycle 7: replay exposure is bounded by B
+## Cycle 8: replay exposure is bounded by B
 
 Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-flight admission cap is gone.
 
-**Verify:** change 19's gauges run on all lanes with the budget unset.
+**Verify:** change 22's gauges run on all lanes with the budget unset.
 Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admission cap's occupancy, and the pause gauge stays flat at zero.
 
-### 19. Add the budget accounting (implement)
+### 22. Add the budget accounting (implement)
 
 **Task:** Track uncommitted work in events and bytes. Ship with no budget set: the admission cap still governs alone.
 
@@ -490,9 +547,9 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 **Metrics:**
 
 - Add `ingestion_consumer_budget_outstanding_events` and `ingestion_consumer_budget_outstanding_bytes` (gauges).
-- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 20.
+- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 23.
 
-### 20. Enable the budget (switchover)
+### 23. Enable the budget (switchover)
 
 **Task:** Set the budget per lane. Pause the poll at the limit and resume on refund.
 
@@ -507,7 +564,7 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 
 - None in this repository. Config values only.
 
-### 21. Remove the in-flight admission cap (cleanup)
+### 24. Remove the in-flight admission cap (cleanup)
 
 **Task:** Remove `max_in_flight_batches` after the budget holds on all lanes.
 
@@ -519,59 +576,6 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 
 - Remove `max_in_flight_batches` from `Config` and the admission bookkeeping from `IngestionConsumer`.
 - Remove `ingestion_consumer_in_flight_batches`. The budget gauges replace it.
-
-## Cycle 8: concurrency adapts to worker health
-
-Outcome: request RTT governs the number of requests in flight.
-
-**Verify:** with adaptation off, change 22 reports the decisions it would make.
-Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink signals under induced worker latency and stays quiet under normal load.
-
-### 22. Add the governor (implement)
-
-**Task:** Add the permit pool and the RTT EWMA. Ship with adaptation off: permits mirror the current per-worker cap.
-
-**Goal:** The governor exists and observes before it constrains.
-
-- Grow the pool by one when ready work waits, no permit is free, and RTT is within budget.
-- Shrink the pool by one when the RTT EWMA exceeds `REQUEST_LATENCY_BUDGET`.
-- With adaptation off, compute and report every decision without applying it. The signal is verifiable before it constrains.
-- Bound the pool with a configured minimum and maximum.
-- Keep the 503 backoff in the transport. Exclude 503 waits from the RTT signal.
-- Cap each stream channel at `DEPTH_MAX`.
-
-**Interfaces:**
-
-- Add `Governor` in the batcher loop: the permit pool and the RTT EWMA, adaptation off.
-- Modify `Config`: add `REQUEST_LATENCY_BUDGET`, the permit bounds, and `DEPTH_MAX`.
-
-**Metrics:**
-
-- Add `ingestion_consumer_governor_permits` (gauge) and `ingestion_consumer_request_rtt_seconds` (gauge, the EWMA).
-- Add `ingestion_consumer_governor_adjustments_total` (counter, direction `grow` or `shrink`). With adaptation off, it counts would-be decisions.
-
-### 23. Enable RTT adaptation (switchover)
-
-**Task:** Turn adaptation on. Request RTT governs the permit pool.
-
-**Goal:** Concurrency shrinks when the worker pool is unhealthy.
-
-- Canary one lane. Watch the permit gauge, the RTT EWMA, and throughput under induced worker latency.
-- Rollback is the adaptation switch.
-
-**Interfaces:**
-
-- Modify `Config`: enable adaptation.
-
-### 24. Remove the fixed per-worker cap (cleanup)
-
-**Task:** Remove the per-worker `max_unacked` cap after adaptation holds on all lanes.
-
-**Goal:** Governor permits are the only in-flight bound.
-
-**Interfaces:**
-
-- Modify `GrpcTransport`: remove the per-worker cap and its config. Stream channels keep `DEPTH_MAX`.
 
 ## Cycle 9: partitions hand off cleanly
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -254,6 +254,8 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - `GrpcTransport`, `Router`, and `WorkerRegistry` keep their construction and ownership in `main.rs`. The batcher takes shared handles. Readiness gating, discovery reconciliation, the reaper, and the debug endpoints do not change.
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion — moving code without changing it — not redesign.
 - The consumer loop keeps: poll collection, commits, the sentinels, and the admission cap. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
+- The no-progress watchdog survives the move: a poll that gains no completions for the stall window fails the process and replays, exactly as the deferred-flush timeout does today. Every later cycle keeps this bail until cycle 10 adds the per-partition stall deadline.
+- The consumer discards a completion for a partition it no longer owns (the revoke dropped its ledger) and counts it. Cycle 10 replaces this with the assignment-epoch check.
 - Changes 9 and 10 extract the scheduler seam inside this boundary.
 
 **Interfaces:**
@@ -632,6 +634,7 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 ## Cycle 10: partitions hand off cleanly
 
 Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 3.
+Until this cycle, revocation keeps today's behavior: no drain, uncommitted work replays on the new owner, and the old owner's in-flight sends finish as duplicate work. Nothing in cycles 1 to 9 changes that.
 
 **Verify:** e2e rebalance tests with the drain on, then the canary rebalance in change 29.
 Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the deadline, and `ingestion_consumer_drain_dropped_messages_total` matches the expected replay volume.

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -147,12 +147,14 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
 - Each slot records: complete or not, event count, byte count. The counts serve the budget in change 23.
+- The byte count is the payload plus the key plus every header key and value: the bytes the process holds for the message. Today's `CONSUMER_BATCH_SIZE_KB` counts the payload only; the budget is a memory bound, so it counts what is retained.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns one past the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix below the frontier.
 - The frontier is in Kafka's committed-offset representation: the next offset to read, not the last offset processed. The current commit path already commits in this representation (the poll's max offset plus one), so the frontier is commit-ready as returned — no call site adds or subtracts one.
 - The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka can deliver offsets with gaps: transaction markers occupy offsets that consumers never receive, and compaction keeps offsets while removing records. Our ingestion topics have neither today, and the commit sentinel treats a gap as a real skip (see the caveat on `CommitSentinel`).
-- The ledger still defines contiguity over delivered offsets, not offset arithmetic. A legitimate gap can then never block the frontier. The sentinel keeps the alert on gaps.
+- The ledger still defines contiguity over delivered offsets, not offset arithmetic. A legitimate gap can then never block the frontier.
+- The sentinel's gap alert and the ledger's gap handling cannot both stand. Once the frontier owns commits (change 4), a commit that walks over a legitimate gap is correct, and the sentinel would report it as a skip. The ledger therefore counts each gap it walked over (`ingestion_consumer_ledger_gaps_total`), and the sentinel's gap alert retires in change 5. Until then the alert stays, because the ingestion topics have no legitimate gaps today and a gap is still a real skip.
 - Add property tests: out-of-order completion, monotonic frontier, `frontier` idempotence, the ring drains after `take_frontier`, offset gaps, ring capacity.
 
 **Interfaces:**
@@ -186,6 +188,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 
 - Add `ingestion_consumer_ledger_mismatch_total` (counter): frontier vs committed offset disagreement.
 - Add `ingestion_consumer_ledger_uncommitted_offsets` (gauge, per partition): ring depth. It must fall at commit points. A value that only grows is a drain bug (a leak).
+- Add `ingestion_consumer_ledger_gaps_total` (counter): offset gaps the ledger walked over. Expected to stay at zero on the ingestion topics; a non-zero value is the signal the sentinel's gap alert gave before change 5 retires it.
 
 ### 4. Commit from the ledger frontier (switchover)
 
@@ -250,7 +253,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 **Goal:** The dispatch concurrency becomes an implementation detail behind one interface.
 
 - Interface in: one accumulator per poll — the poll's demuxed groups, submitted on the consumer loop in poll order.
-- Interface out: one completion event per group, with its partition, offsets, and accepted count.
+- Interface out: one completion event per group, with its partition, its assignment epoch, its offsets, and its accepted count.
 - This is the design doc's boundary: accumulators in, completions out. It is the final shape and does not change again.
 - No batch identity crosses the boundary. The facade creates an internal batch id per accumulator for the old machinery and the wire request. The consumer correlates completions by partition and offset — the same key the ledger uses.
 - The facade breaks each resolved send into its groups. The send resolution in `scatter` already carries them (`routing_keys` and `key_offsets` on `PendingSubBatch`), and a send is all-or-nothing.
@@ -259,14 +262,14 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion — moving code without changing it — not redesign.
 - The consumer loop keeps: poll collection, commits, the sentinels, and the admission cap. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
 - The no-progress watchdog survives the move: a poll that gains no completions for the stall window fails the process and replays, exactly as the deferred-flush timeout does today. Every later cycle keeps this bail until cycle 10 adds the per-partition stall deadline.
-- The consumer discards a completion for a partition it no longer owns (the revoke dropped its ledger) and counts it. Cycle 10 replaces this with the assignment-epoch check.
+- The consumer discards a completion whose epoch is not the partition's current epoch, and counts it. The epoch already exists on master. Carrying it on the completion from this change closes the window a partition-ownership check leaves open: a partition revoked and reassigned while a group is out gets a new ledger, and the old incarnation's completion must not land in it.
 - Changes 8 and 9 extract the scheduler seam inside this boundary.
 
 **Interfaces:**
 
 - Add `Accumulator`: one poll's groups, in poll order.
 - Add `Batcher` in `batcher.rs`: `submit(Accumulator)` in, a channel of `GroupCompletion` out. It owns `Dispatcher` and the send tasks, and holds shared handles to `GrpcTransport`, `Router`, and `WorkerRegistry`. It creates batch ids internally.
-- Add `GroupCompletion`: partition, offsets, accepted count. No batch id.
+- Add `GroupCompletion`: partition, assignment epoch, offsets, accepted count. No batch id and no messages: the batcher keeps the bodies for retry, and the ledger needs only the offsets.
 - Modify `IngestionConsumer`: drop `scatter` and `flush_deferred` — they move into the batcher. Keep collect, commit, and the admission cap. Correlate completions to polls by partition and offset.
 - Modify `main.rs`: construct one `Batcher` from the existing transport, registry, and router. The consumer no longer sees the dispatcher.
 - Internalize `Dispatcher`'s resolve methods (`on_sub_batch_*`, `defer_failed`): only the batcher calls them.
@@ -595,7 +598,7 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 - Charge each message on poll. The ledger slots already carry the costs (change 2).
 - Refund the charge when the commit that covers the message is issued.
 - Gauge the outstanding charge per partition and in total.
-- New config: the budget in events and in bytes. Unset means no constraint.
+- New config: the budget in events and in bytes, and the low watermark as a fraction of the budget (default 0.8). Unset means no constraint.
 
 **Interfaces:**
 
@@ -615,7 +618,8 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 
 - A charts values PR sets the budget lane by lane. The admission cap and the budget both bound work during the transition.
 - Derive the first values from the current config: events near the batch size times the cap, bytes from the byte bound. The effective bound then does not change at the switchover.
-- Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
+- Pause the assignment when the outstanding charge reaches the budget on either axis. Resume only when it is back at or under the low watermark on both axes. A pause purges librdkafka's fetch queue and a resume refetches it, so a gate that reopens on the first refund refetches on every crossing.
+- Do not stop polling while paused. A paused consumer still serves rebalance callbacks and keeps `max.poll.interval.ms` alive; an unpolled one does neither. When a partition is assigned while the gate is closed, pause it too: an assignment resets librdkafka's pause flags.
 - Watch the pause gauge and `ingestion_lag_ms`. Rollback is unsetting the values.
 
 **Interfaces:**
@@ -640,7 +644,8 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 3.
 Until this cycle, revocation keeps today's behavior: no drain, uncommitted work replays on the new owner, and the old owner's in-flight sends finish as duplicate work. Nothing in cycles 1 to 9 changes that.
 
-**Verify:** e2e rebalance tests with the drain on, then the canary rebalance in change 28.
+**Verify:** rebalance tests with the drain on, then the canary rebalance in change 28.
+rdkafka's `MockCluster` runs cooperative rebalances with no broker container, so the drain ordering is testable in the crate. The mock coordinator delays the first join by 3 s and every later round by `session.timeout.ms` minus one second, so test consumers need a session timeout above 3 s.
 Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the deadline, and `ingestion_consumer_drain_dropped_messages_total` matches the expected replay volume.
 
 ### 26. Add revoke and drained markers (prepare)
@@ -659,17 +664,24 @@ Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the dea
 
 **Goal:** The drain exists and is tested. Off means today's behavior: replay without drain.
 
+- rdkafka runs the rebalance callback inside `poll`, on the task that awaits `recv()`: the consumer loop's own task. The callback must not wait for the drain, because the loop that would end the drain is the one blocked in the callback. On revoke the callback only reports; the loop hands the partitions back later with `incremental_unassign`, which librdkafka allows outside the callback. On assign the callback still calls `incremental_assign` at once; an assignment has nothing to wait for.
 - On revoke, send the in-band marker to the batcher, after earlier accumulators.
 - The batcher drops queued unsent work for the partition. Kafka replays it for the next owner.
 - Wait only for requests in flight. Send the drained marker after the final completion.
-- The loop issues one final commit, refunds the remaining charge, and unassigns the partition.
-- Check completions against the assignment epoch. The epoch already exists on master.
-- Add a stall deadline per partition. Outside a rebalance, an expired deadline fails the process. Replay is at most B.
+- The loop issues one final commit and refunds the remaining charge per partition. It hands the partitions back once every partition in the revoke set has drained, with one `incremental_unassign` carrying the list the callback received. A subset counts as the whole answer, and librdkafka re-revokes the rest in a later round.
+- While a revoke waits for the hand-back, librdkafka pauses every assigned partition, not only the revoked ones. The drain window is a pod-wide fetch pause, bounded by the request timeout. Set the rebalance timeout (`max.poll.interval.ms`) above the request timeout, and keep polling through the wait so the callbacks and the liveness clock keep running.
+- A lost assignment skips the final commit. When `assignment_lost()` is true at the revoke (the session or `max.poll.interval.ms` expired) or the callback reports an error, the broker has fenced the generation and the commit would fail. Drop the partition's ledger, refund its charge, hand it back at once, and still send the marker so the batcher clears its queues. Completions for it die by epoch.
+- Closing the consumer revokes the whole assignment through the same callback, and rdkafka's `Drop` polls until the close completes. A deferred hand-back there never comes and the drop spins forever. A `closing` flag makes the callback answer inline; set it before any path that drops the consumer, the clean shutdown and the fatal-error exit alike.
+- Shutdown is a drain of every assigned partition: a revoke marker per partition through the same path, the final commit per drained marker, then one synchronous commit of every partition's last attempted offset, then close. A drain cut short by the graceful-shutdown deadline replays its un-acked tail, bounded by B.
+- Empty assign events arrive after a hand-back and at the end of a rebalance round. They are no-ops.
+- Check completions against the assignment epoch. The epoch already exists on master and rides on `GroupCompletion` since change 7.
+- Add a stall deadline per partition, reset only when its frontier moves. Outside a rebalance, an expired deadline fails the process. A partition being drained stands down: its wait is bounded by the request timeout. Replay is at most B.
 
 **Interfaces:**
 
 - Modify `KeyTableScheduler`: drop queued work per partition on the revoke marker.
 - Modify `IngestionConsumer` and `OffsetLedger`: the final commit, the refund of abandoned charge, and the stall deadline.
+- Modify `SentinelContext`: override `rebalance` so a revoke reports without unassigning, with the `closing` flag and the lost-assignment path above.
 - Modify `Config`: add the drain switch, default off.
 
 **Metrics:**

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -71,8 +71,8 @@ A change that adds metrics lists their names.
 | 12 | 3 per-key order | Cleanup | Delete the old scheduler |
 | 13 | 4 single-owner batcher | Structure | Collapse the batcher into one event loop |
 | 14 | 4 single-owner batcher | Cleanup | Remove the stream fences |
-| 15 | 5 decoupled commits | Switchover | Complete polls in any order |
-| 16 | 5 decoupled commits | Cleanup | Delete the ordered completion path |
+| 15 | 5 decoupled commits | Switchover | Switch completion to group granularity |
+| 16 | 5 decoupled commits | Cleanup | Delete the per-poll completion path |
 | 17 | 6 bounded replay | Implement | Add the budget accounting |
 | 18 | 6 bounded replay | Switchover | Enable the budget |
 | 19 | 6 bounded replay | Cleanup | Remove the in-flight admission cap |
@@ -386,33 +386,34 @@ Outcome: commits advance per partition as groups complete. Needs cycles 2 and 3.
 **Verify:** the commit sentinel checks every commit, and `ingestion_consumer_ledger_uncommitted_offsets` shows per-partition frontier lag.
 Exit criterion at the canary: zero sentinel violations, and a stalled partition no longer moves the commit rate of other partitions.
 
-### 15. Complete polls in any order (switchover)
+### 15. Switch completion to group granularity (switchover)
 
-**Task:** Add a completion mode, `ordered` or `any`. In `any` mode, mark the ledger per group and stop waiting for whole polls.
+**Task:** Add a completion granularity, `poll` or `group`. At `group` granularity, mark the ledger per group and stop waiting for whole polls.
 
 **Goal:** A stalled key stalls only its own partition. Other partitions continue to commit.
 
+- The granularity names the unit that completes. `poll`: a poll completes as a whole, oldest first — today's behavior. `group`: each group completes on its own, in any order.
 - Cycles 2 and 3 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
-- In `any` mode, mark each group's offsets in the ledger when its completion event arrives. Do not aggregate per poll before commits.
+- At `group` granularity, mark each group's offsets in the ledger when its completion event arrives. Do not aggregate per poll before commits.
 - The frontier gates each partition's commit.
 - Keep `max_in_flight_batches` as the bound on outstanding work. A poll's slot frees when all its groups are accepted.
 - Behavior change: commit timing decouples across partitions and polls. Replay exposure stays inside the admission cap.
-- Rollback is the mode switch back to `ordered`.
+- Rollback is the switch back to `poll`.
 
 **Interfaces:**
 
-- Modify `Config`: add the completion mode.
-- Modify `IngestionConsumer::process`: in `any` mode, select over `GroupCompletion` events. The ordered path stays for rollback.
+- Modify `Config`: add the completion granularity.
+- Modify `IngestionConsumer::process`: at `group` granularity, select over `GroupCompletion` events. The per-poll path stays for rollback.
 
-### 16. Delete the ordered completion path (cleanup)
+### 16. Delete the per-poll completion path (cleanup)
 
-**Task:** Remove the ordered completion path after `any` holds on all lanes.
+**Task:** Remove the per-poll completion path after `group` granularity holds on all lanes.
 
 **Goal:** Group completions are the only completion signal.
 
 **Interfaces:**
 
-- Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 8, and the completion mode from `Config`.
+- Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 8, and the completion granularity from `Config`.
 
 ## Cycle 6: replay exposure is bounded by B
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -16,7 +16,7 @@ Master already contains two parts of the design:
 An assignment epoch also exists.
 A rebalance increments it, and every sub-batch carries it.
 
-These components stay as they are: the stream runners, the P2C router, the aperture, the worker registry, the commit sentinel, the commit monitor, and the key-order sentinel.
+These components stay as they are: the stream runners, the P2C (power-of-two-choices) router, the aperture, the worker registry, the commit sentinel, the commit monitor, and the key-order sentinel.
 
 ## The cycle model
 
@@ -24,9 +24,9 @@ Work proceeds in cycles.
 Each cycle delivers one outcome: a property of the system that holds from then on.
 A cycle has five phases:
 
-1. **Prepare**: structure changes that carve the seams. No behavior change.
+1. **Prepare**: structure changes that extract the seams: the interfaces that later changes swap behind. No behavior change.
 2. **Implement**: build the new component, fully tested, not selected.
-3. **Verify**: prove the new component against production before it takes over. A verify change adds observation only: a shadow comparison, a gauge, a dry-run report. Verification with no new code is a soak with a stated exit criterion, not a PR.
+3. **Verify**: prove the new component against production before it takes over. A verify change adds observation only: a shadow comparison, a gauge, a dry-run report. Verification with no new code is a soak — a watch period in production with no code change — with a stated exit criterion, not a PR.
 4. **Switchover**: config selects the new component. Canary one lane, then all lanes. The config is the rollback.
 5. **Cleanup**: one deletion removes the old component and the switch.
 
@@ -37,14 +37,14 @@ Rules:
 - Only a switchover may change behavior. Some do not (a switchover with identical output is still staged and reversible).
 - Every cycle names its verify evidence: the metrics to read and the exit criterion.
 - Old code is deleted in cleanup, never edited.
-- Dead code is deleted before a seam is carved around it. A cleanup of a switch that never shipped can open a cycle (change 1).
+- Dead code is deleted before a seam is extracted around it. A cleanup of a switch that never shipped can open a cycle (change 1).
 - A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 20).
-- A cycle's cleanup lands only after its switchover holds on all lanes.
+- A cycle's cleanup lands only after its switchover is stable on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
 - A change must not alter the meaning of an existing metric. Metrics of deleted machinery are deleted with it.
 - The commit sentinel and the key-order sentinel stay enabled through every cycle.
 
-Cycle 1 lands first: two fast, behavior-preserving complexity wins with no dependency on anything else.
+Cycle 1 lands first: two fast changes that remove complexity, preserve behavior, and depend on nothing else.
 After that, the cycles run in order, with two exceptions.
 Cycle 3 does not depend on cycle 2, so it can proceed while cycle 2 soaks.
 Cycle 4 needs only cycle 3's switchover, so it can proceed while cycle 3's cleanup soaks.
@@ -53,8 +53,8 @@ Cycle 8 needs cycles 2 and 3.
 The swap unit in cycle 3 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
 That is where the complexity concentrates — the pins, the stash, and the flush interplay.
 Packing follows at once (cycle 4): the performance win depends only on the key-table scheduler, not on the event loop, decoupled commits, or the budget.
-The governor follows packing (cycle 5): it needs the scheduler's ready queue for its growth signal, and packing first, so RTT tunes against comparable requests.
-The request time budget follows (cycle 6): its enforcement precondition is the one-outstanding-request-per-key rule (#89995), and its budget sizes against the packed request unit.
+The governor follows packing (cycle 5): it needs the scheduler's ready queue for its growth signal, and packing first, so RTT (request round-trip time) tunes against comparable requests.
+The request time budget follows (cycle 6): its enforcement precondition is the one-outstanding-request-per-key rule (#89995), and its budget sizes against the packed request size.
 The single-owner event loop follows as its own outcome (cycle 7), once the scheduler is simple.
 
 Each change ends with its interface impact: the types it adds, modifies, or removes.
@@ -79,8 +79,8 @@ A change that adds metrics lists their names.
 | 15 | 5 adaptive concurrency | Implement | Add the governor |
 | 16 | 5 adaptive concurrency | Switchover | Enable RTT adaptation |
 | 17 | 5 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
-| 18 | 6 trimmed slow requests | Implement | Add partial settlement and the request time budget |
-| 19 | 6 trimmed slow requests | Switchover | Set the request time budgets |
+| 18 | 6 partial redelivery | Implement | Add partial settlement and the request time budget |
+| 19 | 6 partial redelivery | Switchover | Set the request time budgets |
 | 20 | 7 single-owner batcher | Structure | Collapse the batcher into one event loop |
 | 21 | 7 single-owner batcher | Cleanup | Remove the stream fences |
 | 22 | 8 decoupled commits | Switchover | Switch completion to group granularity |
@@ -104,7 +104,7 @@ This cycle has no switchover: the eager flush was never enabled, and the helper 
 
 **Task:** Remove the eager deferred flush. The flag that enables it is off everywhere.
 
-**Goal:** One send origin fewer before any seam is carved.
+**Goal:** One send origin fewer before change 9 extracts the scheduler seam.
 
 - `DISPATCHER_EAGER_DEFERRED_FLUSH` is default off, and no deployment sets it. Confirm against a fresh charts checkout and the live deployments before this ships.
 - The completion-time flush already does all the draining in production. Behavior does not change.
@@ -123,7 +123,7 @@ This cycle has no switchover: the eager flush was never enabled, and the helper 
 
 - The protocol is spread over the scatter and flush paths today: begin the send at the ordering point, await the pending send, then resolve.
 - On success: ack the key offsets, resolve the dispatcher state, record health.
-- On failure: defer the messages, then drop the `fence_guard`, then resolve, then record health. This order is the contract. A guard dropped early lets newer work leapfrog a fenced failure.
+- On failure: defer the messages, then drop the `fence_guard`, then resolve, then record health. This order is the contract. A guard dropped early lets newer work overtake a fenced failure.
 - No behavior change. The helper encodes the current order.
 
 **Interfaces:**
@@ -150,7 +150,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 - The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka can deliver offsets with gaps: transaction markers occupy offsets that consumers never receive, and compaction keeps offsets while removing records. Our ingestion topics have neither today, and the commit sentinel treats a gap as a real skip (see the caveat on `CommitSentinel`).
-- The ledger still defines contiguity over delivered offsets, not offset arithmetic. A legitimate gap can then never wedge the frontier. The sentinel keeps the alert on gaps.
+- The ledger still defines contiguity over delivered offsets, not offset arithmetic. A legitimate gap can then never block the frontier. The sentinel keeps the alert on gaps.
 - Add property tests: out-of-order completion, monotonic frontier, `frontier` idempotence, the ring drains after `take_frontier`, offset gaps, ring capacity.
 
 **Interfaces:**
@@ -170,7 +170,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 - After the comparison, call `take_frontier` at the same commit point. The ledger drains identically in shadow and active modes. Without this, the shadow ring grows without bound.
 - On a mismatch: increment a counter and log the partition with both offsets. Do not block the commit.
 - On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
-- Soak on all lanes until the cycle's exit criterion holds.
+- Soak on all lanes until the cycle's exit criterion is met.
 
 **Interfaces:**
 
@@ -181,7 +181,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 **Metrics:**
 
 - Add `ingestion_consumer_ledger_mismatch_total` (counter): frontier vs committed offset disagreement.
-- Add `ingestion_consumer_ledger_uncommitted_offsets` (gauge, per partition): ring depth. Also the leak detector — it must drain at commit points.
+- Add `ingestion_consumer_ledger_uncommitted_offsets` (gauge, per partition): ring depth. It must fall at commit points. A value that only grows is a drain bug (a leak).
 
 ### 5. Commit from the ledger frontier (switchover)
 
@@ -202,7 +202,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 
 ### 6. Delete the old commit computation (cleanup)
 
-**Task:** Remove the old commit computation after `active` holds on all lanes.
+**Task:** Remove the old commit computation after `active` is stable on all lanes.
 
 **Goal:** The frontier is the only commit source.
 
@@ -248,18 +248,18 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Interface in: one accumulator per poll — the poll's demuxed groups, submitted on the consumer loop in poll order.
 - Interface out: one completion event per group, with its partition, offsets, and accepted count.
 - This is the design doc's boundary: accumulators in, completions out. It is the final shape and does not change again.
-- No batch identity crosses the boundary. The facade mints an internal batch id per accumulator for the old machinery and the wire request. The consumer correlates completions by partition and offset — the same key the ledger uses.
+- No batch identity crosses the boundary. The facade creates an internal batch id per accumulator for the old machinery and the wire request. The consumer correlates completions by partition and offset — the same key the ledger uses.
 - The facade breaks each resolved send into its groups. The resolve helper (change 2) already carries them (`routing_keys`, `key_offsets`), and a send is all-or-nothing.
 - Only orchestration moves inside the boundary: assignment, scatter, the deferred flush, and the resolve helper.
 - `GrpcTransport`, `Router`, and `WorkerRegistry` keep their construction and ownership in `main.rs`. The batcher takes shared handles. Readiness gating, discovery reconciliation, the reaper, and the debug endpoints do not change.
-- The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion, not redesign.
+- The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion — moving code without changing it — not redesign.
 - The consumer loop keeps: poll collection, commits, the sentinels, and the admission cap. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
-- Changes 9 and 10 carve the scheduler seam inside this boundary.
+- Changes 9 and 10 extract the scheduler seam inside this boundary.
 
 **Interfaces:**
 
 - Add `Accumulator`: one poll's groups, in poll order.
-- Add `Batcher` in `batcher.rs`: `submit(Accumulator)` in, a channel of `GroupCompletion` out. It owns `Dispatcher` and the send tasks, and holds shared handles to `GrpcTransport`, `Router`, and `WorkerRegistry`. It mints batch ids internally.
+- Add `Batcher` in `batcher.rs`: `submit(Accumulator)` in, a channel of `GroupCompletion` out. It owns `Dispatcher` and the send tasks, and holds shared handles to `GrpcTransport`, `Router`, and `WorkerRegistry`. It creates batch ids internally.
 - Add `GroupCompletion`: partition, offsets, accepted count. No batch id.
 - Modify `IngestionConsumer`: drop `scatter` and `flush_deferred` — they move into the batcher. Keep collect, commit, and the admission cap. Correlate completions to polls by partition and offset.
 - Modify `main.rs`: construct one `Batcher` from the existing transport, registry, and router. The consumer no longer sees the dispatcher.
@@ -331,7 +331,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 
 ### 12. Delete the old scheduler (cleanup)
 
-**Task:** Remove the old scheduler implementation after change 11 holds on all lanes.
+**Task:** Remove the old scheduler implementation after change 11 is stable on all lanes.
 
 **Goal:** The old concurrency goes in one deletion, not in edits.
 
@@ -347,7 +347,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 
 ## Cycle 4: workers receive target-sized requests
 
-Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup: body splitting stays as a defence.
+Outcome: request size tracks target T, and a request forms only when there is work to fill it. No cleanup: body splitting stays as a defence.
 This cycle sits directly after the scheduler on purpose: the win depends only on the key-table scheduler.
 It needs cycle 3's switchover on all lanes, and can proceed while cycle 3's cleanup soaks.
 A scheduler rollback also reverts packing: the packer exists only in the key-table scheduler.
@@ -364,7 +364,7 @@ Exit criterion after the targets: the request-size histograms center near T, and
 - Check the worker side first: a packed request spans polls and keys. Confirm the worker's `concurrentBatches` accounting and the meaning of `batch_id` still hold.
 - Pack runs from multiple runnable keys into one request near T. T counts events and bytes.
 - Emit immediately when the ready work can fill the free stream slots with near-T requests. Otherwise arm the pack deadline. The governor (cycle 5) replaces the slots with permits.
-- When the deadline expires, emit partial requests. The deadline also bounds the wait when held groups keep polls open: packing adds latency, never a wedge.
+- When the deadline expires, emit partial requests. The deadline also bounds the wait when held groups keep polls open: packing adds latency, never a deadlock.
 - Router order inside a pass: fill open requests on healthy workers first, then pick a worker with P2C from the aperture slice. Partition affinity is a tie-breaker only.
 
 **Interfaces:**
@@ -394,7 +394,7 @@ Exit criterion after the targets: the request-size histograms center near T, and
 ## Cycle 5: concurrency adapts to worker health
 
 Outcome: request RTT governs the number of requests in flight.
-It needs cycle 4: packing stabilizes the request unit, so the RTT signal tunes against comparable requests.
+It needs cycle 4: packing makes request sizes uniform, so the RTT signal tunes against comparable requests.
 The growth signal — ready work waiting on permits — comes from the key-table scheduler's ready queue.
 
 **Verify:** with adaptation off, change 15 reports the decisions it would make.
@@ -402,7 +402,7 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 
 ### 15. Add the governor (implement)
 
-**Task:** Add the permit pool and the RTT EWMA. Ship with adaptation off: permits mirror the current per-worker cap.
+**Task:** Add the permit pool and the RTT EWMA (an exponentially weighted moving average). Ship with adaptation off: permits mirror the current per-worker cap.
 
 **Goal:** The governor exists and observes before it constrains.
 
@@ -439,7 +439,7 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 
 ### 17. Remove the fixed per-worker cap (cleanup)
 
-**Task:** Remove the per-worker `max_unacked` cap after adaptation holds on all lanes.
+**Task:** Remove the per-worker `max_unacked` cap after adaptation is stable on all lanes.
 
 **Goal:** Governor permits are the only in-flight bound.
 
@@ -447,18 +447,18 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 
 - Modify `GrpcTransport`: remove the per-worker cap and its config. Stream channels keep `DEPTH_MAX`.
 
-## Cycle 6: a slow spot trims the request, not the tail
+## Cycle 6: a slow request redelivers only its remainder
 
 Outcome: a worker stops a request at the consumer's time budget, acks the finished prefix, and only the remainder redelivers.
-Today a slow spot holds every message behind it until the ack watchdog fences the whole stream, and the tail replays with duplicate work.
+Today one slow message holds every message behind it until the ack watchdog fences the whole stream, and everything unacked replays with duplicate work.
 This budget is time per request. It is not B, the uncommitted-work budget of cycle 9.
 
 It needs #89995 merged on the worker side (`soft_budget_ms` on the wire, the `PARTIAL` ack).
 It needs cycle 3: one outstanding request per key is #89995's stated enforcement precondition.
-It sizes the budget against cycle 4's request unit, and its cap on request RTT interacts with cycle 5: tune `REQUEST_LATENCY_BUDGET` below the soft budget, or the governor never shrinks.
+It sizes the budget against cycle 4's request size, and its cap on request RTT interacts with cycle 5: tune `REQUEST_LATENCY_BUDGET` below the soft budget, or the governor never shrinks.
 
 **Verify:** a generous budget on one lane enforces rarely and exercises the real partial-ack path at negligible volume.
-Exit criterion: partials settle cleanly, zero key-order sentinel violations, and ack-watchdog teardowns (`ingestion_consumer_worker_stream_teardowns_total`) fall.
+Exit criterion: partial acks resolve and their remainders redeliver in order, zero key-order sentinel violations, and ack-watchdog teardowns (`ingestion_consumer_worker_stream_teardowns_total`) fall.
 
 ### 18. Add partial settlement and the request time budget (implement)
 
@@ -479,16 +479,16 @@ Exit criterion: partials settle cleanly, zero key-order sentinel violations, and
 
 **Metrics:**
 
-- Add `ingestion_consumer_request_budget_partials_total` (counter) and `ingestion_consumer_request_budget_trimmed_messages_total` (counter).
+- Add `ingestion_consumer_request_budget_partials_total` (counter) and `ingestion_consumer_request_budget_timed_out_messages_total` (counter). The names match the wire: a `PARTIAL` ack with a `timed_out` index list.
 
 ### 19. Set the request time budgets (switchover)
 
 **Task:** Set the soft budget per lane: first generous, then real.
 
-**Goal:** A slow spot costs one trimmed request, not a fenced stream.
+**Goal:** A slow request costs a partial redelivery, not a fenced stream and a full replay.
 
 - A charts values PR sets the budget lane by lane. The generous stage is the cycle's verify.
-- Watch the partial and trimmed counters, the key-order sentinel, and stream teardowns.
+- Watch the partial and timed-out counters, the key-order sentinel, and stream teardowns.
 - Rollback is unsetting the values.
 
 **Interfaces:**
@@ -498,7 +498,7 @@ Exit criterion: partials settle cleanly, zero key-order sentinel violations, and
 ## Cycle 7: the batcher is one single-owner event loop
 
 Outcome: one task owns all batcher state. The mutex and the callback structure are gone.
-This is a deliberate structural outcome, not tidy-up: it is the largest single concurrency simplification in the plan.
+This is a deliberate structural outcome, not routine cleanup: it is the largest single concurrency simplification in the plan.
 
 **Verify:** the e2e suite and review. The change is behavior-identical, and the consumer-facing metrics must not move.
 
@@ -524,9 +524,9 @@ This is a deliberate structural outcome, not tidy-up: it is the largest single c
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 20 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to leapfrog a failure.
+- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 20 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to overtake a failure.
 - A stream failure returns each request's messages to the key table. That is sufficient.
-- This change is deferrable. With one send origin, fences are inert insurance whose only cost is code.
+- This change is deferrable. With one send origin, fences are redundant protection; their only cost is the code.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
 **Interfaces:**
@@ -564,7 +564,7 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 
 ### 23. Delete the per-poll completion path (cleanup)
 
-**Task:** Remove the per-poll completion path after `group` granularity holds on all lanes.
+**Task:** Remove the per-poll completion path after `group` granularity is stable on all lanes.
 
 **Goal:** Group completions are the only completion signal.
 
@@ -617,7 +617,7 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 
 ### 26. Remove the in-flight admission cap (cleanup)
 
-**Task:** Remove `max_in_flight_batches` after the budget holds on all lanes.
+**Task:** Remove `max_in_flight_batches` after the budget is stable on all lanes.
 
 **Goal:** The budget is the only admission bound.
 
@@ -683,7 +683,7 @@ Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the dea
 
 ### 30. Delete the no-drain path (cleanup)
 
-**Task:** Remove the no-drain revoke path after the drain holds on all lanes.
+**Task:** Remove the no-drain revoke path after the drain is stable on all lanes.
 
 **Goal:** The drain is the only revoke behavior.
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -26,10 +26,10 @@ Both stacks start from this plan branch ([#91468](https://github.com/PostHog/pos
 
 | Stack | Branch sequence | Scope |
 | --- | --- | --- |
-| Cycle 1 | `c1-delete-eager-flush` -> `c1-fence-safe-send-resolution` | Changes 1 and 2, one PR per plan step. |
-| Cycle 2 | `c2-common-ledger` -> `c2-ledger-shadow` -> `c2-ledger-active` -> `c2-ledger-cleanup` | Changes 3 through 6, one PR per plan step. |
+| Cycle 1 | `c1-delete-eager-flush` | Change 1. |
+| Cycle 2 | `c2-common-ledger` -> `c2-ledger-shadow` -> `c2-ledger-active` -> `c2-ledger-cleanup` | Changes 2 through 5, one PR per plan step. |
 
-The stacks are independent: cycle 2 can begin without cycle 1. The merge gates remain part of the plan: change 5 cannot merge until change 4 has soaked with a zero mismatch counter, and change 6 cannot merge until change 5 is stable on every lane. Draft PRs may be prepared earlier, but they must not collapse those gates.
+The stacks are independent: cycle 2 can begin without cycle 1. The merge gates remain part of the plan: change 4 cannot merge until change 3 has soaked with a zero mismatch counter, and change 5 cannot merge until change 4 is stable on every lane. Draft PRs may be prepared earlier, but they must not collapse those gates.
 
 ## The cycle model
 
@@ -51,13 +51,13 @@ Rules:
 - Every cycle names its verify evidence: the metrics to read and the exit criterion.
 - Old code is deleted in cleanup, never edited.
 - Dead code is deleted before a seam is extracted around it. A cleanup of a switch that never shipped can open a cycle (change 1).
-- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 20).
+- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 19).
 - A cycle's cleanup lands only after its switchover is stable on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
 - A change must not alter the meaning of an existing metric. Metrics of deleted machinery are deleted with it.
 - The commit sentinel and the key-order sentinel stay enabled through every cycle.
 
-Cycle 1 lands first: two fast changes that remove complexity, preserve behavior, and depend on nothing else.
+Cycle 1 lands first: one fast change that removes complexity, preserves behavior, and depends on nothing else.
 After that, the cycles run in order, with two exceptions.
 Cycle 3 does not depend on cycle 2, so it can proceed while cycle 2 soaks.
 Cycle 4 needs only cycle 3's switchover, so it can proceed while cycle 3's cleanup soaks.
@@ -76,49 +76,48 @@ A change that adds metrics lists their names.
 
 | # | Cycle | Phase | Change |
 | --- | --- | --- | --- |
-| 1 | 1 one resolve protocol | Cleanup | Delete the dead eager flush |
-| 2 | 1 one resolve protocol | Prepare | Extract fence-safe send resolution |
-| 3 | 2 frontier commits | Implement | Add the common Kafka consumer crate and offset ledger |
-| 4 | 2 frontier commits | Verify | Run the ledger in shadow mode |
-| 5 | 2 frontier commits | Switchover | Commit from the ledger frontier |
-| 6 | 2 frontier commits | Cleanup | Delete the old commit computation |
-| 7 | 3 one request per key | Prepare | Demux polls into groups |
-| 8 | 3 one request per key | Prepare | Encapsulate the worker batcher |
-| 9 | 3 one request per key | Prepare | Extract the scheduler seam |
-| 10 | 3 one request per key | Implement | Build the key-table scheduler |
-| 11 | 3 one request per key | Switchover | Switch to the key-table scheduler |
-| 12 | 3 one request per key | Cleanup | Delete the old scheduler |
-| 13 | 4 target-sized requests | Implement | Add the packer |
-| 14 | 4 target-sized requests | Switchover | Set the packing targets |
-| 15 | 5 partial redelivery | Implement | Add partial settlement and the request time budget |
-| 16 | 5 partial redelivery | Switchover | Set the request time budgets |
-| 17 | 6 adaptive concurrency | Implement | Add the governor |
-| 18 | 6 adaptive concurrency | Switchover | Enable RTT adaptation |
-| 19 | 6 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
-| 20 | 7 single-owner batcher | Structure | Collapse the batcher into one event loop |
-| 21 | 7 single-owner batcher | Cleanup | Remove the stream fences |
-| 22 | 8 decoupled commits | Switchover | Switch completion to group granularity |
-| 23 | 8 decoupled commits | Cleanup | Delete the per-poll completion path |
-| 24 | 9 bounded replay | Implement | Add the budget accounting |
-| 25 | 9 bounded replay | Switchover | Enable the budget |
-| 26 | 9 bounded replay | Cleanup | Remove the in-flight admission cap |
-| 27 | 10 clean handoff | Prepare | Add revoke and drained markers |
-| 28 | 10 clean handoff | Implement | Build the drain |
-| 29 | 10 clean handoff | Switchover | Enable the drain |
-| 30 | 10 clean handoff | Cleanup | Delete the no-drain path |
+| 1 | 1 one send origin | Cleanup | Delete the dead eager flush |
+| 2 | 2 frontier commits | Implement | Add the common Kafka consumer crate and offset ledger |
+| 3 | 2 frontier commits | Verify | Run the ledger in shadow mode |
+| 4 | 2 frontier commits | Switchover | Commit from the ledger frontier |
+| 5 | 2 frontier commits | Cleanup | Delete the old commit computation |
+| 6 | 3 one request per key | Prepare | Demux polls into groups |
+| 7 | 3 one request per key | Prepare | Encapsulate the worker batcher |
+| 8 | 3 one request per key | Prepare | Extract the scheduler seam |
+| 9 | 3 one request per key | Implement | Build the key-table scheduler |
+| 10 | 3 one request per key | Switchover | Switch to the key-table scheduler |
+| 11 | 3 one request per key | Cleanup | Delete the old scheduler |
+| 12 | 4 target-sized requests | Implement | Add the packer |
+| 13 | 4 target-sized requests | Switchover | Set the packing targets |
+| 14 | 5 partial redelivery | Implement | Add partial settlement and the request time budget |
+| 15 | 5 partial redelivery | Switchover | Set the request time budgets |
+| 16 | 6 adaptive concurrency | Implement | Add the governor |
+| 17 | 6 adaptive concurrency | Switchover | Enable RTT adaptation |
+| 18 | 6 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
+| 19 | 7 single-owner batcher | Structure | Collapse the batcher into one event loop |
+| 20 | 7 single-owner batcher | Cleanup | Remove the stream fences |
+| 21 | 8 decoupled commits | Switchover | Switch completion to group granularity |
+| 22 | 8 decoupled commits | Cleanup | Delete the per-poll completion path |
+| 23 | 9 bounded replay | Implement | Add the budget accounting |
+| 24 | 9 bounded replay | Switchover | Enable the budget |
+| 25 | 9 bounded replay | Cleanup | Remove the in-flight admission cap |
+| 26 | 10 clean handoff | Prepare | Add revoke and drained markers |
+| 27 | 10 clean handoff | Implement | Build the drain |
+| 28 | 10 clean handoff | Switchover | Enable the drain |
+| 29 | 10 clean handoff | Cleanup | Delete the no-drain path |
 
-## Cycle 1: one send origin, one resolve protocol
+## Cycle 1: one send origin
 
-Outcome: the eager send path is gone, and every send resolves through one fence-safe helper.
-This cycle has no switchover: the eager flush was never enabled, and the helper encodes the current order.
+Outcome: the eager send path is gone.
+This cycle has no switchover: the eager flush was never enabled.
 
-**Verify:** the e2e suite. Both changes preserve behavior. The stash gauges (`ingestion_consumer_dispatcher_stashed_*`) must not change shape after the eager deletion.
+**Verify:** the e2e suite. The change preserves behavior. The stash gauges (`ingestion_consumer_dispatcher_stashed_*`) must not change shape after the eager deletion.
 
 ### 1. Delete the dead eager flush (cleanup)
 
 **Task:** Remove the eager deferred flush. The flag that enables it is off everywhere.
 
-**Goal:** One send origin fewer before change 9 extracts the scheduler seam.
+**Goal:** One send origin fewer before change 8 extracts the scheduler seam.
 
 - `DISPATCHER_EAGER_DEFERRED_FLUSH` is default off, and no deployment sets it. Confirm against a fresh charts checkout and the live deployments before this ships.
 - The completion-time flush already does all the draining in production. Behavior does not change.
@@ -129,30 +128,14 @@ This cycle has no switchover: the eager flush was never enabled, and the helper 
 - Remove `EagerFlush`, `run_eager_flush_loop`, `send_eager_flush`, and `DISPATCHER_EAGER_DEFERRED_FLUSH`.
 - Modify `Dispatcher`: remove `set_eager_flush_sender`, `release_next_groups`, `eager_flush_*`, `take_eager_accepted`, and the eager pending and accepted accounting.
 
-### 2. Extract fence-safe send resolution (prepare)
-
-**Task:** Move the send-and-resolve protocol into one helper. Every send path uses it.
-
-**Goal:** Fence handling exists in one place and cannot be forgotten.
-
-- The protocol is spread over the scatter and flush paths today: begin the send at the ordering point, await the pending send, then resolve.
-- On success: ack the key offsets, resolve the dispatcher state, record health.
-- On failure: defer the messages, then drop the `fence_guard`, then resolve, then record health. This order is the contract. A guard dropped early lets newer work overtake a fenced failure.
-- No behavior change. The helper encodes the current order.
-
-**Interfaces:**
-
-- Add a resolve helper in `consumer.rs` that owns the success and failure sequences.
-- Modify `scatter` and the flush path to call it. `SendError` and `PendingSubBatch` do not change.
-
 ## Cycle 2: commits come from the frontier
 
 Outcome: commit contiguity is a property of a data structure, not of completion order.
 
-**Verify:** change 4 compares the frontier with every real commit on all lanes.
+**Verify:** change 3 compares the frontier with every real commit on all lanes.
 Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across deploys and rebalances, and `ingestion_consumer_ledger_uncommitted_offsets` returns toward zero when a lane is idle — the ring drains.
 
-### 3. Add the common Kafka consumer crate and offset ledger (implement)
+### 2. Add the common Kafka consumer crate and offset ledger (implement)
 
 **Task:** Create `rust/common/kafka-consumer` and add `ledger.rs` with a per-partition offset ring. Do not wire it into a consumer yet.
 
@@ -163,7 +146,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 - Do not take `Accumulator`, `Budget`, `PartitionDriver`, `PartitionManager`, or `CommitManager`; those implement later cycles and would make this PR cross several plan boundaries. The ledger module must not depend on `rdkafka`, `ingestion-consumer`, or service-specific metrics. The shared config module may retain its `rdkafka` dependency.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 24.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 23.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns one past the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix below the frontier.
 - The frontier is in Kafka's committed-offset representation: the next offset to read, not the last offset processed. The current commit path already commits in this representation (the poll's max offset plus one), so the frontier is commit-ready as returned — no call site adds or subtracts one.
 - The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
@@ -178,13 +161,13 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 - Add `OffsetLedger` in `ledger.rs`: `charge`, `complete`, `frontier` (non-mutating), `take_frontier` (consuming). No runtime callers yet. The name avoids a clash with the stream runner's internal un-acked ledger.
 - Modify `ingestion-consumer` to import the moved config builder from the common crate.
 
-### 4. Run the ledger in shadow mode (verify)
+### 3. Run the ledger in shadow mode (verify)
 
 **Task:** Wire the ledger next to the commit path. Compare its frontier with each real commit. Do not change what the consumer commits.
 
 **Goal:** Prove the ledger against production traffic before it owns the commits.
 
-- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 5 ships `active`.
+- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 4 ships `active`.
 - Charge every delivered offset into its partition ledger during `collect_batch`.
 - When a poll completes, mark all its offsets complete.
 - At each commit, compare the partition's `frontier` — the non-mutating read — with the offset the current path commits. Both are next-to-read offsets, so with oldest-first completion the two must be equal, with no offset arithmetic in the comparison.
@@ -204,14 +187,14 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 - Add `ingestion_consumer_ledger_mismatch_total` (counter): frontier vs committed offset disagreement.
 - Add `ingestion_consumer_ledger_uncommitted_offsets` (gauge, per partition): ring depth. It must fall at commit points. A value that only grows is a drain bug (a leak).
 
-### 5. Commit from the ledger frontier (switchover)
+### 4. Commit from the ledger frontier (switchover)
 
 **Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first completion.
 
-**Goal:** The frontier produces the same commits as the old code, and change 4 already proved that.
+**Goal:** The frontier produces the same commits as the old code, and change 3 already proved that.
 
 - Commit each partition's frontier instead of the poll's max offset plus one. Both are next-to-read offsets: with oldest-first completion, the committed value does not change.
-- The ledger calls do not change: both modes already charge, complete, compare, and consume at the same points (change 4). This switchover changes only which value the consumer commits.
+- The ledger calls do not change: both modes already charge, complete, compare, and consume at the same points (change 3). This switchover changes only which value the consumer commits.
 - With oldest-first completion, the output is identical to the old path.
 - The commit sentinel stays on and checks contiguity and monotonicity.
 - Rollback is the config switch back to `shadow`.
@@ -219,9 +202,9 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 **Interfaces:**
 
 - Modify `Config`: default the ledger mode to `active`.
-- Modify `IngestionConsumer::commit_offsets`: read the committed offset from the ledger. The old computation survives as the shadow comparison until change 6.
+- Modify `IngestionConsumer::commit_offsets`: read the committed offset from the ledger. The old computation survives as the shadow comparison until change 5.
 
-### 6. Delete the old commit computation (cleanup)
+### 5. Delete the old commit computation (cleanup)
 
 **Task:** Remove the old commit computation after `active` is stable on all lanes.
 
@@ -239,12 +222,12 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 
 Outcome: the scheduler sends at most one request per key at a time, and that alone preserves per-key order. Pins, the stash, and the flush paths are gone.
 
-**Verify:** the deterministic seam tests in change 10 script arrivals, settlements, and failures.
+**Verify:** the deterministic seam tests in change 9 script arrivals, settlements, and failures.
 A production shadow is impossible here: the scheduler's decisions change which sends exist, so state diverges immediately.
-The canary in change 11 is the production proof.
+The canary in change 10 is the production proof.
 Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transport_duration_seconds` and the `ingestion_consumer_messages_processed_total` rate unchanged, and the no-progress watchdog quiet.
 
-### 7. Demux polls into groups (prepare)
+### 6. Demux polls into groups (prepare)
 
 **Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
 
@@ -252,7 +235,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 
 - Group messages per partition first, then per routing key. Keep offset order inside each group.
 - The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
-- Change 8 submits them to the batcher as the accumulator.
+- Change 7 submits them to the batcher as the accumulator.
 
 **Interfaces:**
 
@@ -260,7 +243,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Modify `CollectedBatch`: carries `Vec<Group>` instead of a flat message list.
 - Modify `Dispatcher::assign_and_send`: takes groups and flattens them. `group_messages_by_routing_key` moves to the collect path.
 
-### 8. Encapsulate the worker batcher (prepare)
+### 7. Encapsulate the worker batcher (prepare)
 
 **Task:** Put today's dispatch orchestration behind one boundary. The consumer loop and the batcher exchange plain values.
 
@@ -270,14 +253,14 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Interface out: one completion event per group, with its partition, offsets, and accepted count.
 - This is the design doc's boundary: accumulators in, completions out. It is the final shape and does not change again.
 - No batch identity crosses the boundary. The facade creates an internal batch id per accumulator for the old machinery and the wire request. The consumer correlates completions by partition and offset — the same key the ledger uses.
-- The facade breaks each resolved send into its groups. The resolve helper (change 2) already carries them (`routing_keys`, `key_offsets`), and a send is all-or-nothing.
-- Only orchestration moves inside the boundary: assignment, scatter, the deferred flush, and the resolve helper.
+- The facade breaks each resolved send into its groups. The send resolution in `scatter` already carries them (`routing_keys` and `key_offsets` on `PendingSubBatch`), and a send is all-or-nothing.
+- Only orchestration moves inside the boundary: assignment, scatter with its send resolution, and the deferred flush.
 - `GrpcTransport`, `Router`, and `WorkerRegistry` keep their construction and ownership in `main.rs`. The batcher takes shared handles. Readiness gating, discovery reconciliation, the reaper, and the debug endpoints do not change.
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion — moving code without changing it — not redesign.
 - The consumer loop keeps: poll collection, commits, the sentinels, and the admission cap. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
 - The no-progress watchdog survives the move: a poll that gains no completions for the stall window fails the process and replays, exactly as the deferred-flush timeout does today. Every later cycle keeps this bail until cycle 10 adds the per-partition stall deadline.
 - The consumer discards a completion for a partition it no longer owns (the revoke dropped its ledger) and counts it. Cycle 10 replaces this with the assignment-epoch check.
-- Changes 9 and 10 extract the scheduler seam inside this boundary.
+- Changes 8 and 9 extract the scheduler seam inside this boundary.
 
 **Interfaces:**
 
@@ -292,7 +275,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 
 - Add `ingestion_consumer_group_completions_total` (counter) and its accepted-message sum. Cross-check: the sum tracks `ingestion_consumer_messages_processed_total`.
 
-### 9. Extract the scheduler seam (prepare)
+### 8. Extract the scheduler seam (prepare)
 
 **Task:** Move every ordering and placement decision inside the batcher behind one interface. Keep the current semantics.
 
@@ -303,7 +286,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Interface out: dispatches. One dispatch is one run of one key on one worker.
 - The first implementation preserves today's semantics: pins, the stash, deferral on drain, and the flush pacing. This is code motion from `assign`, `flush_deferred`, and `on_sub_batch_resolved`.
 - The plumbing (tasks, channels, the mutex) stays as it is. Only the decisions move.
-- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 20 mechanical: the seam's handlers become the loop's select arms.
+- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 19 mechanical: the seam's handlers become the loop's select arms.
 - The seam makes today's implicit ordering rules explicit and reviewable in one place.
 
 **Interfaces:**
@@ -313,7 +296,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Add `PinStashScheduler`: the current semantics, moved out of `Dispatcher::assign`, `flush_deferred`, and `on_sub_batch_resolved`. It owns `PinTable` and `Stash` unchanged.
 - Modify `Dispatcher`: shrinks to plumbing — the lock, in-flight load, metrics, and seam calls.
 
-### 10. Build the key-table scheduler (implement)
+### 9. Build the key-table scheduler (implement)
 
 **Task:** Write the target scheduler as a second implementation of the seam. Do not select it.
 
@@ -334,7 +317,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 
 - Add, emitted when selected: `ingestion_consumer_key_table_keys`, `ingestion_consumer_key_table_queued_messages`, `ingestion_consumer_key_table_outstanding_keys`, `ingestion_consumer_key_table_parked_keys` (gauges), and `ingestion_consumer_parked_retries_total` (counter).
 
-### 11. Switch to the key-table scheduler (switchover)
+### 10. Switch to the key-table scheduler (switchover)
 
 **Task:** Select the key-table scheduler with config. Canary one lane, then roll out.
 
@@ -352,14 +335,14 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Modify the batcher construction: select `KeyTableScheduler` or `PinStashScheduler`.
 - No interface shapes change.
 
-### 12. Delete the old scheduler (cleanup)
+### 11. Delete the old scheduler (cleanup)
 
-**Task:** Remove the old scheduler implementation after change 11 is stable on all lanes.
+**Task:** Remove the old scheduler implementation after change 10 is stable on all lanes.
 
 **Goal:** The old concurrency goes in one deletion, not in edits.
 
 - Removes: the pin table, the stash, the completion-time flush, and the scheduler switch.
-- The plan never edits this machinery. It is isolated in change 9, bypassed in change 11, and deleted here.
+- The plan never edits this machinery. It is isolated in change 8, bypassed in change 10, and deleted here.
 
 **Interfaces:**
 
@@ -378,7 +361,7 @@ A scheduler rollback also reverts packing: the packer exists only in the key-tab
 **Verify:** with the pack budget at zero, the packer emits on arrival and the e2e suite passes unchanged.
 Exit criterion after the targets: the request-size histograms center near T, and `ingestion_lag_ms` does not regress.
 
-### 13. Add the packer (implement)
+### 12. Add the packer (implement)
 
 **Task:** Add the packer to the scheduler, with target size T and `PACK_LATENCY_BUDGET`. Ship with the pack budget at zero: send-on-arrival, behavior unchanged.
 
@@ -401,7 +384,7 @@ Exit criterion after the targets: the request-size histograms center near T, and
 - Add `ingestion_consumer_request_events` and `ingestion_consumer_request_bytes` (histograms): the size of each sent request.
 - Add `ingestion_consumer_pack_emits_total` (counter, reason `arrival`, `full`, or `deadline`).
 
-### 14. Set the packing targets (switchover)
+### 13. Set the packing targets (switchover)
 
 **Task:** Set T and the pack budget per lane.
 
@@ -427,7 +410,7 @@ It sizes the budget against cycle 4's request size. Its cap on request RTT matte
 **Verify:** a generous budget on one lane enforces rarely and exercises the real partial-ack path at negligible volume.
 Exit criterion: partial acks resolve and their remainders redeliver in order, zero key-order sentinel violations, and ack-watchdog teardowns (`ingestion_consumer_worker_stream_teardowns_total`) fall.
 
-### 15. Add partial settlement and the request time budget (implement)
+### 14. Add partial settlement and the request time budget (implement)
 
 **Task:** Teach the transport the `PARTIAL` ack and the scheduler a partial settlement. Ship with no budget set: absent means unlimited, today's behavior.
 
@@ -448,7 +431,7 @@ Exit criterion: partial acks resolve and their remainders redeliver in order, ze
 
 - Add `ingestion_consumer_request_budget_partials_total` (counter) and `ingestion_consumer_request_budget_timed_out_messages_total` (counter). The names match the wire: a `PARTIAL` ack with a `timed_out` index list.
 
-### 16. Set the request time budgets (switchover)
+### 15. Set the request time budgets (switchover)
 
 **Task:** Set the soft budget per lane: first generous, then real.
 
@@ -469,16 +452,16 @@ It needs cycle 4: packing makes request sizes uniform, so the RTT signal tunes a
 It comes after cycle 5, so the governor tunes once, against budget-capped RTT: set `REQUEST_LATENCY_BUDGET` below the soft budget, or it never shrinks.
 The growth signal — ready work waiting on permits — comes from the key-table scheduler's ready queue.
 
-**Verify:** with adaptation off, change 17 reports the decisions it would make.
+**Verify:** with adaptation off, change 16 reports the decisions it would make.
 Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink signals under induced worker latency and stays quiet under normal load.
 
-### 17. Add the governor (implement)
+### 16. Add the governor (implement)
 
 **Task:** Add the permit pool and the RTT EWMA (an exponentially weighted moving average). Ship with adaptation off: permits mirror the current per-worker cap.
 
 **Goal:** The governor exists and observes before it constrains.
 
-- The governor gates the pack pass: a dispatch takes a permit, and a settlement returns it. The integration surface is thin, and change 20 later moves the calls into the event loop unchanged.
+- The governor gates the pack pass: a dispatch takes a permit, and a settlement returns it. The integration surface is thin, and change 19 later moves the calls into the event loop unchanged.
 - Grow the pool by one when ready work waits, no permit is free, and RTT is within budget.
 - Shrink the pool by one when the RTT EWMA exceeds `REQUEST_LATENCY_BUDGET`.
 - With adaptation off, compute and report every decision without applying it. The signal is verifiable before it constrains.
@@ -496,7 +479,7 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 - Add `ingestion_consumer_governor_permits` (gauge) and `ingestion_consumer_request_rtt_seconds` (gauge, the EWMA).
 - Add `ingestion_consumer_governor_adjustments_total` (counter, direction `grow` or `shrink`). With adaptation off, it counts would-be decisions.
 
-### 18. Enable RTT adaptation (switchover)
+### 17. Enable RTT adaptation (switchover)
 
 **Task:** Turn adaptation on. Request RTT governs the permit pool.
 
@@ -509,7 +492,7 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 
 - Modify `Config`: enable adaptation.
 
-### 19. Remove the fixed per-worker cap (cleanup)
+### 18. Remove the fixed per-worker cap (cleanup)
 
 **Task:** Remove the per-worker `max_unacked` cap after adaptation is stable on all lanes.
 
@@ -526,7 +509,7 @@ This is a deliberate structural outcome, not routine cleanup: it is the largest 
 
 **Verify:** the e2e suite and review. The change is behavior-identical, and the consumer-facing metrics must not move.
 
-### 20. Collapse the batcher into one event loop (structure)
+### 19. Collapse the batcher into one event loop (structure)
 
 **Task:** Move the scheduler and its plumbing into one single-owner task.
 
@@ -542,13 +525,13 @@ This is a deliberate structural outcome, not routine cleanup: it is the largest 
 - Modify `Batcher`: one single-owner task replaces the lock, the resolve callbacks, and the per-send tasks. `Dispatcher` dissolves into the loop and is removed.
 - Keep `Scheduler` and `Governor` as the loop's components. The consumer-facing interface does not change.
 
-### 21. Remove the stream fences (cleanup)
+### 20. Remove the stream fences (cleanup)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 20 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to overtake a failure.
+- Fences go only after the batcher is single-owner. Change 11 makes requeue-before-release a scheduler invariant; change 19 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to overtake a failure.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - This change is deferrable. With one send origin, fences are redundant protection; their only cost is the code.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
@@ -567,7 +550,7 @@ Outcome: commits advance per partition as groups complete. Needs cycles 2 and 3.
 **Verify:** the commit sentinel checks every commit, and `ingestion_consumer_ledger_uncommitted_offsets` shows per-partition frontier lag.
 Exit criterion at the canary: zero sentinel violations, and a stalled partition no longer moves the commit rate of other partitions.
 
-### 22. Switch completion to group granularity (switchover)
+### 21. Switch completion to group granularity (switchover)
 
 **Task:** Add a completion granularity, `poll` or `group`. At `group` granularity, mark the ledger per group and stop waiting for whole polls.
 
@@ -586,7 +569,7 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 - Modify `Config`: add the completion granularity.
 - Modify `IngestionConsumer::process`: at `group` granularity, select over `GroupCompletion` events. The per-poll path stays for rollback.
 
-### 23. Delete the per-poll completion path (cleanup)
+### 22. Delete the per-poll completion path (cleanup)
 
 **Task:** Remove the per-poll completion path after `group` granularity is stable on all lanes.
 
@@ -594,22 +577,22 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 
 **Interfaces:**
 
-- Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 8, and the completion granularity from `Config`.
+- Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 7, and the completion granularity from `Config`.
 
 ## Cycle 9: replay exposure is bounded by B
 
 Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-flight admission cap is gone.
 
-**Verify:** change 24's gauges run on all lanes with the budget unset.
+**Verify:** change 23's gauges run on all lanes with the budget unset.
 Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admission cap's occupancy, and the pause gauge stays flat at zero.
 
-### 24. Add the budget accounting (implement)
+### 23. Add the budget accounting (implement)
 
 **Task:** Track uncommitted work in events and bytes. Ship with no budget set: the admission cap still governs alone.
 
 **Goal:** The budget exists and reports before it constrains.
 
-- Charge each message on poll. The ledger slots already carry the costs (change 3).
+- Charge each message on poll. The ledger slots already carry the costs (change 2).
 - Refund the charge when the commit that covers the message is issued.
 - Gauge the outstanding charge per partition and in total.
 - New config: the budget in events and in bytes. Unset means no constraint.
@@ -622,9 +605,9 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 **Metrics:**
 
 - Add `ingestion_consumer_budget_outstanding_events` and `ingestion_consumer_budget_outstanding_bytes` (gauges).
-- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 25.
+- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 24.
 
-### 25. Enable the budget (switchover)
+### 24. Enable the budget (switchover)
 
 **Task:** Set the budget per lane. Pause the poll at the limit and resume on refund.
 
@@ -639,7 +622,7 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 
 - None in this repository. Config values only.
 
-### 26. Remove the in-flight admission cap (cleanup)
+### 25. Remove the in-flight admission cap (cleanup)
 
 **Task:** Remove `max_in_flight_batches` after the budget is stable on all lanes.
 
@@ -657,10 +640,10 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 3.
 Until this cycle, revocation keeps today's behavior: no drain, uncommitted work replays on the new owner, and the old owner's in-flight sends finish as duplicate work. Nothing in cycles 1 to 9 changes that.
 
-**Verify:** e2e rebalance tests with the drain on, then the canary rebalance in change 29.
+**Verify:** e2e rebalance tests with the drain on, then the canary rebalance in change 28.
 Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the deadline, and `ingestion_consumer_drain_dropped_messages_total` matches the expected replay volume.
 
-### 27. Add revoke and drained markers (prepare)
+### 26. Add revoke and drained markers (prepare)
 
 **Task:** Extend the batcher boundary with a revoke marker in and a drained marker out. Nothing consumes them yet.
 
@@ -670,7 +653,7 @@ Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the dea
 
 - Modify `Batcher`: add the marker types to the submit and completion channels. `GroupCompletion` does not change shape.
 
-### 28. Build the drain (implement)
+### 27. Build the drain (implement)
 
 **Task:** Implement the drain sequence from section 4 of the design doc, behind a config switch that ships off.
 
@@ -694,7 +677,7 @@ Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the dea
 - Add `ingestion_consumer_drain_duration_seconds` (histogram) and `ingestion_consumer_drain_dropped_messages_total` (counter): drain time and replay volume per revocation.
 - Add `ingestion_consumer_partition_stalls_total` (counter): stall-deadline expiries.
 
-### 29. Enable the drain (switchover)
+### 28. Enable the drain (switchover)
 
 **Task:** Turn the drain on. Canary one lane through a rebalance.
 
@@ -706,7 +689,7 @@ Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the dea
 
 - Modify `Config`: enable the drain.
 
-### 30. Delete the no-drain path (cleanup)
+### 29. Delete the no-drain path (cleanup)
 
 **Task:** Remove the no-drain revoke path after the drain is stable on all lanes.
 
@@ -737,7 +720,7 @@ A dashed arrow is an ordering preference: its reason is stated in the target cyc
 
 ```mermaid
 flowchart LR
-    C1["1: one resolve protocol"]
+    C1["1: one send origin"]
     C2["2: frontier commits"]
     C3["3: one request per key"]
     C4["4: target-sized requests"]

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -38,7 +38,7 @@ Rules:
 - Every cycle names its verify evidence: the metrics to read and the exit criterion.
 - Old code is deleted in cleanup, never edited.
 - Dead code is deleted before a seam is carved around it. A cleanup of a switch that never shipped can open a cycle (change 1).
-- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 18).
+- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 20).
 - A cycle's cleanup lands only after its switchover holds on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
 - A change must not alter the meaning of an existing metric. Metrics of deleted machinery are deleted with it.
@@ -48,13 +48,14 @@ Cycle 1 lands first: two fast, behavior-preserving complexity wins with no depen
 After that, the cycles run in order, with two exceptions.
 Cycle 3 does not depend on cycle 2, so it can proceed while cycle 2 soaks.
 Cycle 4 needs only cycle 3's switchover, so it can proceed while cycle 3's cleanup soaks.
-Cycle 7 needs cycles 2 and 3.
+Cycle 8 needs cycles 2 and 3.
 
 The swap unit in cycle 3 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
 That is where the complexity concentrates — the pins, the stash, and the flush interplay.
 Packing follows at once (cycle 4): the performance win depends only on the key-table scheduler, not on the event loop, decoupled commits, or the budget.
 The governor follows packing (cycle 5): it needs the scheduler's ready queue for its growth signal, and packing first, so RTT tunes against comparable requests.
-The single-owner event loop follows as its own outcome (cycle 6), once the scheduler is simple.
+The request time budget follows (cycle 6): its enforcement precondition is the one-outstanding-request-per-key rule (#89995), and its budget sizes against the packed request unit.
+The single-owner event loop follows as its own outcome (cycle 7), once the scheduler is simple.
 
 Each change ends with its interface impact: the types it adds, modifies, or removes.
 A change that adds metrics lists their names.
@@ -78,17 +79,19 @@ A change that adds metrics lists their names.
 | 15 | 5 adaptive concurrency | Implement | Add the governor |
 | 16 | 5 adaptive concurrency | Switchover | Enable RTT adaptation |
 | 17 | 5 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
-| 18 | 6 single-owner batcher | Structure | Collapse the batcher into one event loop |
-| 19 | 6 single-owner batcher | Cleanup | Remove the stream fences |
-| 20 | 7 decoupled commits | Switchover | Switch completion to group granularity |
-| 21 | 7 decoupled commits | Cleanup | Delete the per-poll completion path |
-| 22 | 8 bounded replay | Implement | Add the budget accounting |
-| 23 | 8 bounded replay | Switchover | Enable the budget |
-| 24 | 8 bounded replay | Cleanup | Remove the in-flight admission cap |
-| 25 | 9 clean handoff | Prepare | Add revoke and drained markers |
-| 26 | 9 clean handoff | Implement | Build the drain |
-| 27 | 9 clean handoff | Switchover | Enable the drain |
-| 28 | 9 clean handoff | Cleanup | Delete the no-drain path |
+| 18 | 6 trimmed slow requests | Implement | Add partial settlement and the request time budget |
+| 19 | 6 trimmed slow requests | Switchover | Set the request time budgets |
+| 20 | 7 single-owner batcher | Structure | Collapse the batcher into one event loop |
+| 21 | 7 single-owner batcher | Cleanup | Remove the stream fences |
+| 22 | 8 decoupled commits | Switchover | Switch completion to group granularity |
+| 23 | 8 decoupled commits | Cleanup | Delete the per-poll completion path |
+| 24 | 9 bounded replay | Implement | Add the budget accounting |
+| 25 | 9 bounded replay | Switchover | Enable the budget |
+| 26 | 9 bounded replay | Cleanup | Remove the in-flight admission cap |
+| 27 | 10 clean handoff | Prepare | Add revoke and drained markers |
+| 28 | 10 clean handoff | Implement | Build the drain |
+| 29 | 10 clean handoff | Switchover | Enable the drain |
+| 30 | 10 clean handoff | Cleanup | Delete the no-drain path |
 
 ## Cycle 1: one send origin, one resolve protocol
 
@@ -142,7 +145,7 @@ Exit criterion: `ingestion_consumer_ledger_mismatch_total` stays zero across dep
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 22.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 24.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix up to the frontier.
 - The read/consume split matters: the comparison read is idempotent and cannot consume state by accident. Consumption happens at commit points in every mode, so the ring holds only uncommitted offsets.
 - Completions can arrive in any order. The frontier moves only over completed slots.
@@ -277,7 +280,7 @@ Exit criterion: zero key-order sentinel violations, `ingestion_consumer_transpor
 - Interface out: dispatches. One dispatch is one run of one key on one worker.
 - The first implementation preserves today's semantics: pins, the stash, deferral on drain, and the flush pacing. This is code motion from `assign`, `flush_deferred`, and `on_sub_batch_resolved`.
 - The plumbing (tasks, channels, the mutex) stays as it is. Only the decisions move.
-- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 18 mechanical: the seam's handlers become the loop's select arms.
+- The seam is event-shaped, by design: each call is one event, runs to completion, does no I/O, takes no locks, and returns its effects as data (the dispatches). This shape is what later makes change 20 mechanical: the seam's handlers become the loop's select arms.
 - The seam makes today's implicit ordering rules explicit and reviewable in one place.
 
 **Interfaces:**
@@ -403,7 +406,7 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 
 **Goal:** The governor exists and observes before it constrains.
 
-- The governor gates the pack pass: a dispatch takes a permit, and a settlement returns it. The integration surface is thin, and change 18 later moves the calls into the event loop unchanged.
+- The governor gates the pack pass: a dispatch takes a permit, and a settlement returns it. The integration surface is thin, and change 20 later moves the calls into the event loop unchanged.
 - Grow the pool by one when ready work waits, no permit is free, and RTT is within budget.
 - Shrink the pool by one when the RTT EWMA exceeds `REQUEST_LATENCY_BUDGET`.
 - With adaptation off, compute and report every decision without applying it. The signal is verifiable before it constrains.
@@ -444,14 +447,62 @@ Exit criterion: `ingestion_consumer_governor_adjustments_total` shows shrink sig
 
 - Modify `GrpcTransport`: remove the per-worker cap and its config. Stream channels keep `DEPTH_MAX`.
 
-## Cycle 6: the batcher is one single-owner event loop
+## Cycle 6: a slow spot trims the request, not the tail
+
+Outcome: a worker stops a request at the consumer's time budget, acks the finished prefix, and only the remainder redelivers.
+Today a slow spot holds every message behind it until the ack watchdog fences the whole stream, and the tail replays with duplicate work.
+This budget is time per request. It is not B, the uncommitted-work budget of cycle 9.
+
+It needs #89995 merged on the worker side (`soft_budget_ms` on the wire, the `PARTIAL` ack).
+It needs cycle 3: one outstanding request per key is #89995's stated enforcement precondition.
+It sizes the budget against cycle 4's request unit, and its cap on request RTT interacts with cycle 5: tune `REQUEST_LATENCY_BUDGET` below the soft budget, or the governor never shrinks.
+
+**Verify:** a generous budget on one lane enforces rarely and exercises the real partial-ack path at negligible volume.
+Exit criterion: partials settle cleanly, zero key-order sentinel violations, and ack-watchdog teardowns (`ingestion_consumer_worker_stream_teardowns_total`) fall.
+
+### 18. Add partial settlement and the request time budget (implement)
+
+**Task:** Teach the transport the `PARTIAL` ack and the scheduler a partial settlement. Ship with no budget set: absent means unlimited, today's behavior.
+
+**Goal:** Partial redelivery exists as one settlement arm, not a new path.
+
+- The stream runner parses `PARTIAL` and resolves the send with the accepted index list, instead of fencing it as busy.
+- The scheduler's partial arm is the failure arm plus a completed prefix: complete each key's finished prefix as group completions, return the remainder to the front of its queue, and keep the key blocked until the redelivery settles.
+- The prototype against the old machinery (#91480) showed the cost of doing this earlier: concurrent polls and per-batch accounting push partial handling through the deferral paths. Behind the key table it is one `on_settled` arm.
+- Stamp `soft_budget_ms` on each request from config. Unset sends no budget.
+
+**Interfaces:**
+
+- Modify the ack handling in `grpc_transport.rs`: parse `PARTIAL`; resolve with the accepted indexes.
+- Modify the settlement types and `KeyTableScheduler::on_settled`: add the partial arm.
+- Modify `Config`: add the soft budget per request, default unset.
+
+**Metrics:**
+
+- Add `ingestion_consumer_request_budget_partials_total` (counter) and `ingestion_consumer_request_budget_trimmed_messages_total` (counter).
+
+### 19. Set the request time budgets (switchover)
+
+**Task:** Set the soft budget per lane: first generous, then real.
+
+**Goal:** A slow spot costs one trimmed request, not a fenced stream.
+
+- A charts values PR sets the budget lane by lane. The generous stage is the cycle's verify.
+- Watch the partial and trimmed counters, the key-order sentinel, and stream teardowns.
+- Rollback is unsetting the values.
+
+**Interfaces:**
+
+- None in this repository. Config values only.
+
+## Cycle 7: the batcher is one single-owner event loop
 
 Outcome: one task owns all batcher state. The mutex and the callback structure are gone.
 This is a deliberate structural outcome, not tidy-up: it is the largest single concurrency simplification in the plan.
 
 **Verify:** the e2e suite and review. The change is behavior-identical, and the consumer-facing metrics must not move.
 
-### 18. Collapse the batcher into one event loop (structure)
+### 20. Collapse the batcher into one event loop (structure)
 
 **Task:** Move the scheduler and its plumbing into one single-owner task.
 
@@ -467,13 +518,13 @@ This is a deliberate structural outcome, not tidy-up: it is the largest single c
 - Modify `Batcher`: one single-owner task replaces the lock, the resolve callbacks, and the per-send tasks. `Dispatcher` dissolves into the loop and is removed.
 - Keep `Scheduler` and `Governor` as the loop's components. The consumer-facing interface does not change.
 
-### 19. Remove the stream fences (cleanup)
+### 21. Remove the stream fences (cleanup)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 18 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to leapfrog a failure.
+- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 20 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to leapfrog a failure.
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - This change is deferrable. With one send origin, fences are inert insurance whose only cost is code.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
@@ -485,14 +536,14 @@ This is a deliberate structural outcome, not tidy-up: it is the largest single c
 - Keep `TransportError` and the `WorkerStreamRunner` reconnect logic.
 - Remove `ingestion_consumer_worker_stream_fenced_sub_batches_total`. Stream teardowns stay counted.
 
-## Cycle 7: a stalled key stalls only its partition
+## Cycle 8: a stalled key stalls only its partition
 
 Outcome: commits advance per partition as groups complete. Needs cycles 2 and 3.
 
 **Verify:** the commit sentinel checks every commit, and `ingestion_consumer_ledger_uncommitted_offsets` shows per-partition frontier lag.
 Exit criterion at the canary: zero sentinel violations, and a stalled partition no longer moves the commit rate of other partitions.
 
-### 20. Switch completion to group granularity (switchover)
+### 22. Switch completion to group granularity (switchover)
 
 **Task:** Add a completion granularity, `poll` or `group`. At `group` granularity, mark the ledger per group and stop waiting for whole polls.
 
@@ -511,7 +562,7 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 - Modify `Config`: add the completion granularity.
 - Modify `IngestionConsumer::process`: at `group` granularity, select over `GroupCompletion` events. The per-poll path stays for rollback.
 
-### 21. Delete the per-poll completion path (cleanup)
+### 23. Delete the per-poll completion path (cleanup)
 
 **Task:** Remove the per-poll completion path after `group` granularity holds on all lanes.
 
@@ -521,14 +572,14 @@ Exit criterion at the canary: zero sentinel violations, and a stalled partition 
 
 - Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 8, and the completion granularity from `Config`.
 
-## Cycle 8: replay exposure is bounded by B
+## Cycle 9: replay exposure is bounded by B
 
 Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-flight admission cap is gone.
 
-**Verify:** change 22's gauges run on all lanes with the budget unset.
+**Verify:** change 24's gauges run on all lanes with the budget unset.
 Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admission cap's occupancy, and the pause gauge stays flat at zero.
 
-### 22. Add the budget accounting (implement)
+### 24. Add the budget accounting (implement)
 
 **Task:** Track uncommitted work in events and bytes. Ship with no budget set: the admission cap still governs alone.
 
@@ -547,9 +598,9 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 **Metrics:**
 
 - Add `ingestion_consumer_budget_outstanding_events` and `ingestion_consumer_budget_outstanding_bytes` (gauges).
-- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 23.
+- Add `ingestion_consumer_budget_paused` (gauge, 0 or 1) and `ingestion_consumer_budget_pauses_total` (counter). Both stay flat until change 25.
 
-### 23. Enable the budget (switchover)
+### 25. Enable the budget (switchover)
 
 **Task:** Set the budget per lane. Pause the poll at the limit and resume on refund.
 
@@ -564,7 +615,7 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 
 - None in this repository. Config values only.
 
-### 24. Remove the in-flight admission cap (cleanup)
+### 26. Remove the in-flight admission cap (cleanup)
 
 **Task:** Remove `max_in_flight_batches` after the budget holds on all lanes.
 
@@ -577,14 +628,14 @@ Exit criterion: `ingestion_consumer_budget_outstanding_events` tracks the admiss
 - Remove `max_in_flight_batches` from `Config` and the admission bookkeeping from `IngestionConsumer`.
 - Remove `ingestion_consumer_in_flight_batches`. The budget gauges replace it.
 
-## Cycle 9: partitions hand off cleanly
+## Cycle 10: partitions hand off cleanly
 
 Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 3.
 
-**Verify:** e2e rebalance tests with the drain on, then the canary rebalance in change 27.
+**Verify:** e2e rebalance tests with the drain on, then the canary rebalance in change 29.
 Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the deadline, and `ingestion_consumer_drain_dropped_messages_total` matches the expected replay volume.
 
-### 25. Add revoke and drained markers (prepare)
+### 27. Add revoke and drained markers (prepare)
 
 **Task:** Extend the batcher boundary with a revoke marker in and a drained marker out. Nothing consumes them yet.
 
@@ -594,7 +645,7 @@ Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the dea
 
 - Modify `Batcher`: add the marker types to the submit and completion channels. `GroupCompletion` does not change shape.
 
-### 26. Build the drain (implement)
+### 28. Build the drain (implement)
 
 **Task:** Implement the drain sequence from section 4 of the design doc, behind a config switch that ships off.
 
@@ -618,7 +669,7 @@ Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the dea
 - Add `ingestion_consumer_drain_duration_seconds` (histogram) and `ingestion_consumer_drain_dropped_messages_total` (counter): drain time and replay volume per revocation.
 - Add `ingestion_consumer_partition_stalls_total` (counter): stall-deadline expiries.
 
-### 27. Enable the drain (switchover)
+### 29. Enable the drain (switchover)
 
 **Task:** Turn the drain on. Canary one lane through a rebalance.
 
@@ -630,7 +681,7 @@ Exit criterion: `ingestion_consumer_drain_duration_seconds` stays inside the dea
 
 - Modify `Config`: enable the drain.
 
-### 28. Delete the no-drain path (cleanup)
+### 30. Delete the no-drain path (cleanup)
 
 **Task:** Remove the no-drain revoke path after the drain holds on all lanes.
 
@@ -648,7 +699,7 @@ The steady-state dashboard after the migration:
 - Commits: `ingestion_consumer_ledger_uncommitted_offsets` per partition (frontier lag, and the ring-leak detector) and the `ingestion_consumer_offset_commits_total` rate.
 - Scheduling: the key-table gauges and `ingestion_consumer_parked_retries_total`.
 - Admission: the budget gauges and `ingestion_consumer_budget_paused`.
-- Requests: the request-size histograms, `ingestion_consumer_transport_duration_seconds`, `ingestion_consumer_governor_permits`, and `ingestion_consumer_request_rtt_seconds`.
+- Requests: the request-size histograms, `ingestion_consumer_transport_duration_seconds`, `ingestion_consumer_governor_permits`, `ingestion_consumer_request_rtt_seconds`, and `ingestion_consumer_request_budget_partials_total`.
 - Rebalance: `ingestion_consumer_drain_duration_seconds` and `ingestion_consumer_drain_dropped_messages_total`.
 
 The budget occupancy and the request-size histograms are also the worker-autoscaling signals from section 5 of the design doc.

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -97,10 +97,12 @@ The order matters: the completion-time flush keeps per-key order only because ba
 
 **Goal:** Deferred work drains at ack speed, on one primary path.
 
-- The settlement release exists behind `DISPATCHER_EAGER_DEFERRED_FLUSH`, default off and not set in production. A charts PR enables it first. Rollback is that values change.
+- The eager flush is not removed. It is the settlement dispatch of the target design, under its old name. The design doc maps it: eager flush becomes normal settlement and dispatch.
+- The path exists behind `DISPATCHER_EAGER_DEFERRED_FLUSH`, default off and not set in production. A charts PR enables it first, so the mechanism soaks while the completion-time flush stays as the backstop. Rollback is that values change.
 - Two cases never see a settlement today: a group that was unroutable (its key had no send in flight), and a key whose failed send suppressed the release.
 - Add a parked-retry deadline for them: a timer retries every deferring key that has no send in flight, with backoff.
 - Count drains per path. After this change, the completion-time flush must find an empty stash in normal operation.
+- The flag disappears in change 5: when `batch` mode is deleted, settlement dispatch is the only behavior and there is nothing to toggle.
 
 ### 5. Batch completion stops flushing (logic)
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -23,31 +23,34 @@ These components stay as they are: the stream runners, the P2C router, the apert
 - Each change is one PR.
 - A change is a structure change or a logic change, never both.
 - A structure change does not change behavior. The e2e tests must pass without edits.
-- A logic change ships behind a config flag when a flag is possible. When a flag is not possible, it ships as a canary on one lane.
+- Structure prepares logic. Every logic change comes after the structure changes that make it small. A new implementation ships unselected in a structure change; a logic change selects it.
+- A logic change ships behind a config switch when a switch is possible. When a switch is not possible, it ships as a canary on one lane.
+- Old code is deleted, not edited. When a cutover holds on all lanes, one structure change removes the old implementation whole.
 - The commit sentinel and the key-order sentinel stay enabled through the migration. They verify each step in production.
 
 ## Changes
 
-The ledger track comes first (changes 1 to 3).
-It is isolated from the dispatch path, and shadow mode tests it against the current implementation in production before the cutover.
+Part 1 prepares the structure (changes 1 to 5).
+Behavior does not change.
+The offset ledger and the key-table batcher are both built here, tested, and left unselected.
 
-The concurrency track follows (changes 4 to 6).
-Settlement events become the only drain for deferred work, batch completion stops flushing, and then batches complete in any order.
-The order matters: the completion-time flush keeps per-key order only because batches complete oldest first, so it must go before completion order can change.
+Part 2 cuts over and simplifies (changes 6 to 14).
+Each cutover is a switch flip made small by part 1, with the switch as the rollback.
+Each deletion follows its cutover.
 
 | # | Type | Change |
 | --- | --- | --- |
 | 1 | Structure | Add the offset ledger module |
 | 2 | Structure | Run the ledger in shadow mode |
-| 3 | Structure | Commit from the ledger frontier |
-| 4 | Logic | Drain deferred work on settlement events |
-| 5 | Logic | Batch completion stops flushing |
-| 6 | Logic | Complete batches in any order |
-| 7 | Structure | Demux polls into groups |
-| 8 | Logic | Route every group through the key table |
+| 3 | Structure | Demux polls into groups |
+| 4 | Structure | Encapsulate the worker batcher |
+| 5 | Structure | Build the key-table batcher |
+| 6 | Structure | Commit from the ledger frontier |
+| 7 | Logic | Switch to the key-table batcher |
+| 8 | Structure | Delete the old batcher implementation |
 | 9 | Structure | Remove the stream fences |
-| 10 | Logic | Replace the batch window with budget B |
-| 11 | Structure | Split into two single-owner event loops |
+| 10 | Logic | Complete batches in any order |
+| 11 | Logic | Replace the batch window with budget B |
 | 12 | Logic | Pack requests toward target T |
 | 13 | Logic | Add the RTT dispatch governor |
 | 14 | Logic | Add the bounded revocation drain |
@@ -59,7 +62,7 @@ The order matters: the completion-time flush keeps per-key order only because ba
 **Goal:** Make commit contiguity a property of a data structure.
 
 - One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 10.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 11.
 - Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` removes the contiguous done prefix and returns the highest removed offset.
 - Completions can arrive in any order. The frontier moves only over completed slots.
 - Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
@@ -71,7 +74,7 @@ The order matters: the completion-time flush keeps per-key order only because ba
 
 **Goal:** Prove the ledger against production traffic before it owns the commits.
 
-- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 3 ships `active`.
+- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 6 ships `active`.
 - Charge every delivered offset into its partition ledger during `collect_batch`.
 - When a batch completes, mark all its offsets complete.
 - At each commit, compare the partition's frontier with the offset the current path commits. With oldest-first completion, the two must be equal.
@@ -79,7 +82,43 @@ The order matters: the completion-time flush keeps per-key order only because ba
 - On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
 - Soak on all lanes. The exit criterion is a mismatch count of zero across deploys and rebalances.
 
-### 3. Commit from the ledger frontier (structure)
+### 3. Demux polls into groups (structure)
+
+**Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
+
+**Goal:** Create the accumulator shape from the design doc.
+
+- Group messages per partition first, then per routing key. Keep offset order inside each group.
+- The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
+- Change 4 uses the groups as the unit of the batcher interface.
+
+### 4. Encapsulate the worker batcher (structure)
+
+**Task:** Put today's dispatch machinery behind one boundary. The consumer loop and the batcher exchange plain values.
+
+**Goal:** The dispatch concurrency becomes an implementation detail behind one interface.
+
+- Interface in: one poll's groups, submitted on the consumer loop in poll order.
+- Interface out: one completion event per batch, with the accepted count. Group-level events come later, when the budget needs them.
+- Move inside the boundary: assignment, scatter, the deferred flush, the eager flush, the worker registry, the router, and the stream runners.
+- The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion, not redesign.
+- The consumer loop keeps: poll collection, commits, the sentinels, and the batch window.
+- The boundary is the seam for change 5: two implementations can stand behind it.
+
+### 5. Build the key-table batcher (structure)
+
+**Task:** Write the target batcher as a second implementation behind the change-4 boundary. Do not select it.
+
+**Goal:** The replacement exists, fully tested, before any behavior changes.
+
+- One single-owner event loop task. State is task-local. There is no shared mutex. Events: accumulators, request settlements, deadlines. This is the batcher of the design doc.
+- The key table: one FIFO queue per key. A key is runnable when it has queued work and no outstanding request. Dispatch takes one contiguous run and marks the key outstanding.
+- A settlement clears the outstanding flag and dispatches the key's next run. A failed request returns its runs to the front of their key queues.
+- A parked-retry deadline covers the keys no settlement can release: unroutable groups, and keys behind a failed send.
+- Route each request with the existing P2C and aperture. There is no pin table and no stickiness.
+- The boundary is values in, values out. Test the batcher deterministically without Kafka: submit groups, script settlements and failures, assert per-key order and completions.
+
+### 6. Commit from the ledger frontier (structure)
 
 **Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first batch completion.
 
@@ -91,69 +130,25 @@ The order matters: the completion-time flush keeps per-key order only because ba
 - Rollback is the config switch back to `shadow`.
 - Delete the old commit computation after `active` holds on all lanes.
 
-### 4. Drain deferred work on settlement events (logic)
+### 7. Switch to the key-table batcher (logic)
 
-**Task:** Make the settlement release reach every deferred group. The completion-time flush stays as the backstop.
+**Task:** Select the key-table batcher with config. Canary one lane, then roll out.
 
-**Goal:** Deferred work drains at ack speed, on one primary path.
+**Goal:** One ordering rule replaces pins, the stash, and the flush paths.
 
-- The eager flush is not removed. It is the settlement dispatch of the target design, under its old name. The design doc maps it: eager flush becomes normal settlement and dispatch.
-- The path exists behind `DISPATCHER_EAGER_DEFERRED_FLUSH`, default off and not set in production. A charts PR enables it first, so the mechanism soaks while the completion-time flush stays as the backstop. Rollback is that values change.
-- Two cases never see a settlement today: a group that was unroutable (its key had no send in flight), and a key whose failed send suppressed the release.
-- Add a parked-retry deadline for them: a timer retries every deferring key that has no send in flight, with backoff.
-- Count drains per path. After this change, the completion-time flush must find an empty stash in normal operation.
-- The flag disappears in change 5: when `batch` mode is deleted, settlement dispatch is the only behavior and there is nothing to toggle.
+- At most one outstanding request per key preserves per-key order. Nothing else does, and nothing else must.
+- This is proposal 2 of the design doc: sticky pins are removed. Measure worker key-cache locality before and after (open question 3).
+- Watch: the key-order sentinel, ack latency, and the no-progress watchdog.
+- Rollback is the config switch back to the old implementation.
 
-### 5. Batch completion stops flushing (logic)
+### 8. Delete the old batcher implementation (structure)
 
-**Task:** Add a flush mode, `batch` or `settlement`. In `settlement` mode, batch completion waits for its accepted count and does not flush.
+**Task:** Remove the old implementation after change 7 holds on all lanes.
 
-**Goal:** Batch completion only waits and counts. One flush path remains.
+**Goal:** The old concurrency goes in one deletion, not in edits.
 
-- In `settlement` mode, a batch completes when its accepted count reaches its batch size. The credit path for settled sends exists (`take_eager_accepted`).
-- Per-key order holds without the oldest-first rule: each key queue orders its entries by batch sequence, and the release always takes the oldest entry.
-- Keep the no-progress watchdog: fail the process when a batch sees no acceptance for a full timeout window.
-- Rollback is the mode switch back to `batch`.
-- Delete `batch` mode after `settlement` holds on all lanes. That removes `flush_deferred` in the consumer and the dispatcher, and `Stash::take_batch`.
-
-### 6. Complete batches in any order (logic)
-
-**Task:** Replace the oldest-first await with completion events.
-
-**Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
-
-- Change 5 is the prerequisite. The completion-time flush kept per-key order only because batches completed oldest first: `Stash::take_batch` on a newer batch pulls a key's entries past an older batch's entries. The settlement release orders by key queue instead.
-- The consumer loop awaits all in-flight batches at once (a completion channel or `FuturesUnordered`).
-- A completed batch marks its offsets in the ledger. The frontier gates each partition's commit.
-- A batch with deferred work no longer blocks the commits of other batches.
-- Keep `max_in_flight_batches` as the bound on outstanding work.
-- Behavior change: commit timing decouples across partitions. Replay exposure stays inside the batch window.
-
-### 7. Demux polls into groups (structure)
-
-**Task:** Change `collect_batch` to output groups. A group is one poll's consecutive messages for one routing key on one partition.
-
-**Goal:** Create the accumulator shape from the design doc.
-
-- Group messages per partition first, then per routing key. Keep offset order inside each group.
-- The dispatcher flattens the groups back into one message list. Sub-batch assembly does not change.
-- Later changes use the group as the unit of dispatch and completion.
-
-### 8. Route every group through the key table (logic)
-
-**Task:** Enqueue all groups into per-key FIFO queues. Dispatch only runnable keys. Remove the sticky pins.
-
-**Goal:** One ordering rule remains: at most one outstanding request per key.
-
-- Evolve `stash.rs` into the key table. All groups enter it, not only deferred ones.
-- A key is runnable when it has queued work and no outstanding request.
-- Dispatch takes one contiguous run per runnable key and marks the key outstanding.
-- A settlement clears the outstanding flag and dispatches the key's next run. Change 4 made this the primary drain. This change extends it to all groups.
-- A failed request returns its runs to the front of their key queues.
-- Report completions per group, with partition and offsets. Mark them in the ledger. Delete the per-batch accepted counters.
-- Delete: the pin table and the batch-sequence machinery in the stash. Append order is sufficient, because one enqueue site remains, on the consumer loop, in poll order.
-- Route each request with the existing P2C and aperture. There is no stickiness.
-- This is proposal 2 of the design doc. Ship it as a canary on one lane. Measure worker key-cache locality before and after (open question 3).
+- Removes: the pin table, the stash, the eager-flush channel and its credits, the completion-time flush, `DISPATCHER_EAGER_DEFERRED_FLUSH`, and the implementation switch.
+- The plan never edits this machinery. It is encapsulated in change 4, bypassed in change 7, and deleted here.
 
 ### 9. Remove the stream fences (structure)
 
@@ -165,7 +160,19 @@ The order matters: the completion-time flush keeps per-key order only because ba
 - A stream failure returns each request's messages to the key table. That is sufficient.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
-### 10. Replace the batch window with budget B (logic)
+### 10. Complete batches in any order (logic)
+
+**Task:** Replace the oldest-first await with completion events.
+
+**Goal:** A stalled batch stalls only its own partitions. Other partitions continue to commit.
+
+- Changes 6 and 8 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
+- The consumer loop awaits all in-flight batches at once (a completion channel or `FuturesUnordered`).
+- A completed batch marks its offsets in the ledger. The frontier gates each partition's commit.
+- Keep `max_in_flight_batches` as the bound on outstanding work.
+- Behavior change: commit timing decouples across partitions. Replay exposure stays inside the batch window.
+
+### 11. Replace the batch window with budget B (logic)
 
 **Task:** Poll only while uncommitted work is below B. B counts events and bytes.
 
@@ -173,23 +180,14 @@ The order matters: the completion-time flush keeps per-key order only because ba
 
 - Charge each message on poll. The ledger slots already carry the costs (change 1).
 - Refund the charge when the commit that covers the message is issued.
+- Upgrade the batcher interface to group-level completion events, so the ledger marks groups as they settle.
 - Remove `max_in_flight_batches`. The batch reduces to a per-poll accumulator.
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
 - New config: the budget in events and in bytes.
 
-### 11. Split into two single-owner event loops (structure)
-
-**Task:** Move the key table, dispatch, and settlement into one batcher task. The consumer loop and the batcher exchange accumulators and completions over channels.
-
-**Goal:** Remove shared mutable state and lock ordering.
-
-- The pin-table mutex disappears. All batcher state is task-local.
-- Select order in each loop: clocks and rebalance events first, completions next, polls last.
-- The worker-health snapshot stays the only shared read.
-
 ### 12. Pack requests toward target T (logic)
 
-**Task:** Add the packer, with target size T and `PACK_LATENCY_BUDGET`.
+**Task:** Add the packer to the key-table batcher, with target size T and `PACK_LATENCY_BUDGET`.
 
 **Goal:** Request size becomes deliberate. Fan-out becomes demand-driven.
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -35,126 +35,59 @@ Rules:
 - Prepare, implement, and cleanup changes do not change behavior. The e2e tests must pass without edits.
 - Only a switchover may change behavior. Some do not (a switchover with identical output is still staged and reversible).
 - Old code is deleted in cleanup, never edited.
-- Dead code is deleted before a seam is carved around it.
+- Dead code is deleted before a seam is carved around it. A cleanup of a switch that never shipped can open a cycle (change 1).
+- A structural outcome with no behavior change needs no switchover. Review and the e2e tests control its risk. The table labels such a change Structure (change 13).
 - A cycle's cleanup lands only after its switchover holds on all lanes.
 - Swap the smallest piece that removes the most complexity. Components that already match the target design are not rebuilt.
 - The commit sentinel and the key-order sentinel stay enabled through every cycle.
 
-The cycles run in order, with one exception: cycle 2 does not depend on cycle 1, so it can start while cycle 1 soaks.
-Cycle 3 needs both.
+Cycle 1 lands first: two fast, behavior-preserving complexity wins with no dependency on anything else.
+After that, the cycles run in order, with one exception: cycle 3 does not depend on cycle 2, so it can proceed while cycle 2 soaks.
+Cycle 5 needs cycles 2 and 3.
 
-The swap unit in cycle 2 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
+The swap unit in cycle 3 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
 That is where the complexity concentrates — the pins, the stash, and the flush interplay.
-The single-owner event loop is only plumbing once the scheduler is simple, so it lands as cleanup.
+The single-owner event loop follows as its own outcome (cycle 4), once the scheduler is simple.
 
 Each change ends with its interface impact: the types it adds, modifies, or removes.
 
 | # | Cycle | Phase | Change |
 | --- | --- | --- | --- |
-| 1 | 1 frontier commits | Implement | Add the offset ledger module |
-| 2 | 1 frontier commits | Switchover | Run the ledger in shadow mode |
-| 3 | 1 frontier commits | Switchover | Commit from the ledger frontier |
-| 4 | 1 frontier commits | Cleanup | Delete the old commit computation |
-| 5 | 2 per-key order | Prepare | Delete the dead eager flush |
-| 6 | 2 per-key order | Prepare | Extract fence-safe send resolution |
-| 7 | 2 per-key order | Prepare | Demux polls into groups |
-| 8 | 2 per-key order | Prepare | Encapsulate the worker batcher |
-| 9 | 2 per-key order | Prepare | Extract the scheduler seam |
-| 10 | 2 per-key order | Implement | Build the key-table scheduler |
-| 11 | 2 per-key order | Switchover | Switch to the key-table scheduler |
-| 12 | 2 per-key order | Cleanup | Delete the old scheduler |
-| 13 | 2 per-key order | Cleanup | Remove the stream fences |
-| 14 | 2 per-key order | Cleanup | Collapse the batcher into one event loop |
-| 15 | 3 decoupled commits | Switchover | Complete polls in any order |
-| 16 | 3 decoupled commits | Cleanup | Delete the ordered completion path |
-| 17 | 4 bounded replay | Implement | Add the budget accounting |
-| 18 | 4 bounded replay | Switchover | Enable the budget |
-| 19 | 4 bounded replay | Cleanup | Remove the batch window |
-| 20 | 5 target-sized requests | Implement | Add the packer |
-| 21 | 5 target-sized requests | Switchover | Set the packing targets |
-| 22 | 6 adaptive concurrency | Implement | Add the governor |
-| 23 | 6 adaptive concurrency | Switchover | Enable RTT adaptation |
-| 24 | 6 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
-| 25 | 7 clean handoff | Prepare | Add revoke and drained markers |
-| 26 | 7 clean handoff | Implement | Build the drain |
-| 27 | 7 clean handoff | Switchover | Enable the drain |
-| 28 | 7 clean handoff | Cleanup | Delete the no-drain path |
+| 1 | 1 one resolve protocol | Cleanup | Delete the dead eager flush |
+| 2 | 1 one resolve protocol | Prepare | Extract fence-safe send resolution |
+| 3 | 2 frontier commits | Implement | Add the offset ledger module |
+| 4 | 2 frontier commits | Switchover | Run the ledger in shadow mode |
+| 5 | 2 frontier commits | Switchover | Commit from the ledger frontier |
+| 6 | 2 frontier commits | Cleanup | Delete the old commit computation |
+| 7 | 3 per-key order | Prepare | Demux polls into groups |
+| 8 | 3 per-key order | Prepare | Encapsulate the worker batcher |
+| 9 | 3 per-key order | Prepare | Extract the scheduler seam |
+| 10 | 3 per-key order | Implement | Build the key-table scheduler |
+| 11 | 3 per-key order | Switchover | Switch to the key-table scheduler |
+| 12 | 3 per-key order | Cleanup | Delete the old scheduler |
+| 13 | 4 single-owner batcher | Structure | Collapse the batcher into one event loop |
+| 14 | 4 single-owner batcher | Cleanup | Remove the stream fences |
+| 15 | 5 decoupled commits | Switchover | Complete polls in any order |
+| 16 | 5 decoupled commits | Cleanup | Delete the ordered completion path |
+| 17 | 6 bounded replay | Implement | Add the budget accounting |
+| 18 | 6 bounded replay | Switchover | Enable the budget |
+| 19 | 6 bounded replay | Cleanup | Remove the in-flight admission cap |
+| 20 | 7 target-sized requests | Implement | Add the packer |
+| 21 | 7 target-sized requests | Switchover | Set the packing targets |
+| 22 | 8 adaptive concurrency | Implement | Add the governor |
+| 23 | 8 adaptive concurrency | Switchover | Enable RTT adaptation |
+| 24 | 8 adaptive concurrency | Cleanup | Remove the fixed per-worker cap |
+| 25 | 9 clean handoff | Prepare | Add revoke and drained markers |
+| 26 | 9 clean handoff | Implement | Build the drain |
+| 27 | 9 clean handoff | Switchover | Enable the drain |
+| 28 | 9 clean handoff | Cleanup | Delete the no-drain path |
 
-## Cycle 1: commits come from the frontier
+## Cycle 1: one send origin, one resolve protocol
 
-Outcome: commit contiguity is a property of a data structure, not of completion order.
+Outcome: the eager send path is gone, and every send resolves through one fence-safe helper.
+This cycle has no switchover: the eager flush was never enabled, and the helper encodes the current order.
 
-### 1. Add the offset ledger module (implement)
-
-**Task:** Create `ledger.rs` with a per-partition offset ring. Do not wire it in.
-
-**Goal:** Make commit contiguity a property of a data structure.
-
-- One ledger per partition. The ledger is a dense ring of delivered offsets.
-- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 17.
-- Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` removes the contiguous done prefix and returns the highest removed offset.
-- Completions can arrive in any order. The frontier moves only over completed slots.
-- Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
-- Add property tests: out-of-order completion, monotonic frontier, offset gaps, ring capacity.
-
-**Interfaces:**
-
-- Add `OffsetLedger` in `ledger.rs`: `charge`, `complete`, `frontier`. No callers yet. The name avoids a clash with the stream runner's internal un-acked ledger.
-
-### 2. Run the ledger in shadow mode (switchover)
-
-**Task:** Wire the ledger next to the commit path. Compare its frontier with each real commit. Do not change what the consumer commits.
-
-**Goal:** Prove the ledger against production traffic before it owns the commits.
-
-- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 3 ships `active`.
-- Charge every delivered offset into its partition ledger during `collect_batch`.
-- When a poll completes, mark all its offsets complete.
-- At each commit, compare the partition's frontier with the offset the current path commits. With oldest-first completion, the two must be equal.
-- On a mismatch: increment a counter and log the partition with both offsets. Do not block the commit.
-- On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
-- Soak on all lanes. The exit criterion is a mismatch count of zero across deploys and rebalances.
-
-**Interfaces:**
-
-- Modify `Config`: add the ledger mode.
-- Modify `IngestionConsumer`: own one `OffsetLedger` per partition. Charge in `collect_batch`, complete on poll completion, compare in `commit_offsets`.
-- Modify the revoke path (`SentinelContext`): drop revoked partitions' ledgers.
-
-### 3. Commit from the ledger frontier (switchover)
-
-**Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first completion.
-
-**Goal:** The frontier produces the same commits as the old code, and change 2 already proved that.
-
-- Commit each partition's frontier instead of the poll's max offset.
-- With oldest-first completion, the output is identical to the old path.
-- The commit sentinel stays on and checks contiguity and monotonicity.
-- Rollback is the config switch back to `shadow`.
-
-**Interfaces:**
-
-- Modify `Config`: default the ledger mode to `active`.
-- Modify `IngestionConsumer::commit_offsets`: read the committed offset from `OffsetLedger::frontier`. The old computation survives as the shadow comparison until change 4.
-
-### 4. Delete the old commit computation (cleanup)
-
-**Task:** Remove the old commit computation after `active` holds on all lanes.
-
-**Goal:** The frontier is the only commit source.
-
-- Remove the old per-poll commit computation and the shadow comparison.
-
-**Interfaces:**
-
-- Modify `IngestionConsumer::commit_offsets`: frontier only.
-- Modify `Config`: remove the ledger mode.
-
-## Cycle 2: one rule preserves per-key order
-
-Outcome: at most one outstanding request per key is the only ordering mechanism. Pins, the stash, and the flush paths are gone.
-
-### 5. Delete the dead eager flush (prepare)
+### 1. Delete the dead eager flush (cleanup)
 
 **Task:** Remove the eager deferred flush. The flag that enables it is off everywhere.
 
@@ -169,7 +102,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Remove `EagerFlush`, `run_eager_flush_loop`, `send_eager_flush`, and `DISPATCHER_EAGER_DEFERRED_FLUSH`.
 - Modify `Dispatcher`: remove `set_eager_flush_sender`, `release_next_groups`, `eager_flush_*`, `take_eager_accepted`, and the eager pending and accepted accounting.
 
-### 6. Extract fence-safe send resolution (prepare)
+### 2. Extract fence-safe send resolution (prepare)
 
 **Task:** Move the send-and-resolve protocol into one helper. Every send path uses it.
 
@@ -184,6 +117,82 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 
 - Add a resolve helper in `consumer.rs` that owns the success and failure sequences.
 - Modify `scatter` and the flush path to call it. `SendError` and `PendingSubBatch` do not change.
+
+## Cycle 2: commits come from the frontier
+
+Outcome: commit contiguity is a property of a data structure, not of completion order.
+
+### 3. Add the offset ledger module (implement)
+
+**Task:** Create `ledger.rs` with a per-partition offset ring. Do not wire it in.
+
+**Goal:** Make commit contiguity a property of a data structure.
+
+- One ledger per partition. The ledger is a dense ring of delivered offsets.
+- Each slot records: complete or not, event count, byte count. The counts serve the budget in change 17.
+- Operations: `charge` adds a delivered offset. `complete` marks an offset done. `frontier` returns the highest contiguous done offset and does not mutate. `take_frontier` consumes the done prefix up to the frontier.
+- The read/consume split matters: shadow comparison reads `frontier` repeatedly without consuming state. Only an issued commit calls `take_frontier`.
+- Completions can arrive in any order. The frontier moves only over completed slots.
+- Kafka delivers offsets with gaps (transactions, compaction). Contiguity means the prefix of delivered offsets, not offset arithmetic.
+- Add property tests: out-of-order completion, monotonic frontier, `frontier` idempotence, offset gaps, ring capacity.
+
+**Interfaces:**
+
+- Add `OffsetLedger` in `ledger.rs`: `charge`, `complete`, `frontier` (non-mutating), `take_frontier` (consuming). No callers yet. The name avoids a clash with the stream runner's internal un-acked ledger.
+
+### 4. Run the ledger in shadow mode (switchover)
+
+**Task:** Wire the ledger next to the commit path. Compare its frontier with each real commit. Do not change what the consumer commits.
+
+**Goal:** Prove the ledger against production traffic before it owns the commits.
+
+- New config: the ledger mode, `off`, `shadow`, or `active`. This change ships `shadow`. Change 5 ships `active`.
+- Charge every delivered offset into its partition ledger during `collect_batch`.
+- When a poll completes, mark all its offsets complete.
+- At each commit, compare the partition's `frontier` — the non-mutating read — with the offset the current path commits. With oldest-first completion, the two must be equal.
+- On a mismatch: increment a counter and log the partition with both offsets. Do not block the commit.
+- On revoke, drop the partition's ledger. This mirrors the commit sentinel's `forget_partitions`.
+- Soak on all lanes. The exit criterion is a mismatch count of zero across deploys and rebalances.
+
+**Interfaces:**
+
+- Modify `Config`: add the ledger mode.
+- Modify `IngestionConsumer`: own one `OffsetLedger` per partition. Charge in `collect_batch`, complete on poll completion, compare in `commit_offsets`.
+- Modify the revoke path (`SentinelContext`): drop revoked partitions' ledgers.
+
+### 5. Commit from the ledger frontier (switchover)
+
+**Task:** Set the ledger mode to `active`. The frontier becomes the committed offset. Keep oldest-first completion.
+
+**Goal:** The frontier produces the same commits as the old code, and change 4 already proved that.
+
+- Commit each partition's frontier instead of the poll's max offset.
+- Call `take_frontier` only when the commit is issued. Shadow mode keeps reading `frontier` and never consumes.
+- With oldest-first completion, the output is identical to the old path.
+- The commit sentinel stays on and checks contiguity and monotonicity.
+- Rollback is the config switch back to `shadow`.
+
+**Interfaces:**
+
+- Modify `Config`: default the ledger mode to `active`.
+- Modify `IngestionConsumer::commit_offsets`: read the committed offset from the ledger. The old computation survives as the shadow comparison until change 6.
+
+### 6. Delete the old commit computation (cleanup)
+
+**Task:** Remove the old commit computation after `active` holds on all lanes.
+
+**Goal:** The frontier is the only commit source.
+
+- Remove the old per-poll commit computation and the shadow comparison.
+
+**Interfaces:**
+
+- Modify `IngestionConsumer::commit_offsets`: frontier only.
+- Modify `Config`: remove the ledger mode.
+
+## Cycle 3: one rule preserves per-key order
+
+Outcome: at most one outstanding request per key is the only ordering mechanism. Pins, the stash, and the flush paths are gone.
 
 ### 7. Demux polls into groups (prepare)
 
@@ -203,7 +212,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 
 ### 8. Encapsulate the worker batcher (prepare)
 
-**Task:** Put today's dispatch machinery behind one boundary. The consumer loop and the batcher exchange plain values.
+**Task:** Put today's dispatch orchestration behind one boundary. The consumer loop and the batcher exchange plain values.
 
 **Goal:** The dispatch concurrency becomes an implementation detail behind one interface.
 
@@ -211,19 +220,20 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Interface out: one completion event per group, with its partition, offsets, and accepted count.
 - This is the design doc's boundary: accumulators in, completions out. It is the final shape and does not change again.
 - No batch identity crosses the boundary. The facade mints an internal batch id per accumulator for the old machinery and the wire request. The consumer correlates completions by partition and offset — the same key the ledger uses.
-- The facade breaks each resolved send into its groups. The resolve helper (change 6) already carries them (`routing_keys`, `key_offsets`), and a send is all-or-nothing.
-- Move inside the boundary: assignment, scatter, the deferred flush, the resolve helper, the worker registry, the router, and the stream runners.
+- The facade breaks each resolved send into its groups. The resolve helper (change 2) already carries them (`routing_keys`, `key_offsets`), and a send is all-or-nothing.
+- Only orchestration moves inside the boundary: assignment, scatter, the deferred flush, and the resolve helper.
+- `GrpcTransport`, `Router`, and `WorkerRegistry` keep their construction and ownership in `main.rs`. The batcher takes shared handles. Readiness gating, discovery reconciliation, the reaper, and the debug endpoints do not change.
 - The facade replicates today's behavior exactly, including the oldest-first flush pacing. This is code motion, not redesign.
-- The consumer loop keeps: poll collection, commits, the sentinels, and the batch window. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
+- The consumer loop keeps: poll collection, commits, the sentinels, and the admission cap. It tracks each poll's offset spans and completes the poll when completions cover them, so completion and commit behavior do not change.
 - Changes 9 and 10 carve the scheduler seam inside this boundary.
 
 **Interfaces:**
 
 - Add `Accumulator`: one poll's groups, in poll order.
-- Add `Batcher` in `batcher.rs`: `submit(Accumulator)` in, a channel of `GroupCompletion` out. It owns `Dispatcher`, `GrpcTransport`, `WorkerRegistry`, and the send tasks. It mints batch ids internally.
+- Add `Batcher` in `batcher.rs`: `submit(Accumulator)` in, a channel of `GroupCompletion` out. It owns `Dispatcher` and the send tasks, and holds shared handles to `GrpcTransport`, `Router`, and `WorkerRegistry`. It mints batch ids internally.
 - Add `GroupCompletion`: partition, offsets, accepted count. No batch id.
-- Modify `IngestionConsumer`: drop `scatter` and `flush_deferred` — they move into the batcher. Keep collect, commit, and the window. Correlate completions to polls by partition and offset.
-- Modify `main.rs`: construct one `Batcher`. The consumer no longer sees the dispatcher or the transport.
+- Modify `IngestionConsumer`: drop `scatter` and `flush_deferred` — they move into the batcher. Keep collect, commit, and the admission cap. Correlate completions to polls by partition and offset.
+- Modify `main.rs`: construct one `Batcher` from the existing transport, registry, and router. The consumer no longer sees the dispatcher.
 - Internalize `Dispatcher`'s resolve methods (`on_sub_batch_*`, `defer_failed`): only the batcher calls them.
 
 ### 9. Extract the scheduler seam (prepare)
@@ -254,7 +264,7 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 
 - The key table: one FIFO queue per key. A key is runnable when it has queued work and no outstanding request.
 - On arrival: enqueue, and dispatch one contiguous run when the key is runnable. Dispatch marks the key outstanding.
-- On settlement: clear the flag. Success dispatches the key's next run. Failure returns the run to the front of its queue.
+- On settlement: clear the flag. Success dispatches the key's next run. Failure returns the run to the front of its queue, then clears the flag — requeue before release, in one seam call.
 - A parked-retry deadline covers the keys no settlement can release: unroutable groups, and keys behind a failed send.
 - Placement is stateless: the existing P2C and aperture pick a worker per dispatch. There are no pins.
 - The seam is events in, dispatches out. Test the scheduler deterministically: script arrivals, settlements, and failures. Assert per-key order.
@@ -296,14 +306,36 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Remove the scheduler selection from `Config`.
 - Modify `Dispatcher`: remove the dead resolve plumbing (`clears_deferral`, `send_failed`, the flush driver).
 
-### 13. Remove the stream fences (cleanup)
+## Cycle 4: the batcher is one single-owner event loop
+
+Outcome: one task owns all batcher state. The mutex and the callback structure are gone.
+This is a deliberate structural outcome, not tidy-up: it is the largest single concurrency simplification in the plan.
+
+### 13. Collapse the batcher into one event loop (structure)
+
+**Task:** Move the scheduler and its plumbing into one single-owner task.
+
+**Goal:** Remove the mutex and the callback structure.
+
+- The seam's events become the loop's events: accumulators, settlements, deadlines. The scheduler is already event-shaped, so the loop owns it directly.
+- State becomes task-local. The worker-health snapshot stays the only shared read.
+- This is the batcher event loop of the design doc. The decisions it drives are already simple (cycle 3), so the transformation is mechanical, but it lands as its own reviewed change.
+- No config switch: the change is behavior-identical, and running two plumbing implementations side by side would cost more than it protects. Review and the e2e suite control the risk.
+
+**Interfaces:**
+
+- Modify `Batcher`: one single-owner task replaces the lock, the resolve callbacks, and the per-send tasks. `Dispatcher` dissolves into the loop and is removed.
+- Keep `Scheduler` as the loop's decision component. The consumer-facing interface does not change.
+
+### 14. Remove the stream fences (cleanup)
 
 **Task:** Delete `FenceGuard` and the fence-settle loop from `grpc_transport.rs`.
 
 **Goal:** Keep only the failure logic the new invariant needs.
 
-- After change 12, the scheduler blocks every key with a failed request: the key is not runnable, so no newer send for it can enter a stream.
+- Fences go only after the batcher is single-owner. Change 12 makes requeue-before-release a scheduler invariant; change 13 makes it mechanical: one task performs settlement, requeue, and the next dispatch, so no window exists for a newer send to leapfrog a failure.
 - A stream failure returns each request's messages to the key table. That is sufficient.
+- This change is deferrable. With one send origin, fences are inert insurance whose only cost is code.
 - Keep: retry classification, busy (503) handling, the ack watchdog, and ack-prefix resolution.
 
 **Interfaces:**
@@ -312,24 +344,9 @@ Outcome: at most one outstanding request per key is the only ordering mechanism.
 - Modify `SendError`: drop the fence-guard field.
 - Keep `TransportError` and the `WorkerStreamRunner` reconnect logic.
 
-### 14. Collapse the batcher into one event loop (cleanup)
+## Cycle 5: a stalled key stalls only its partition
 
-**Task:** Move the scheduler and its plumbing into one single-owner task.
-
-**Goal:** Remove the mutex and the callback structure.
-
-- The seam's events become the loop's events: accumulators, settlements, deadlines. The scheduler is already event-shaped, so the loop owns it directly.
-- State becomes task-local. The worker-health snapshot stays the only shared read.
-- This is the batcher event loop of the design doc. It is plumbing now: the decisions it drives are already simple.
-
-**Interfaces:**
-
-- Modify `Batcher`: one single-owner task replaces the lock, the resolve callbacks, and the per-send tasks. `Dispatcher` dissolves into the loop and is removed.
-- Keep `Scheduler` as the loop's decision component. The consumer-facing interface does not change.
-
-## Cycle 3: a stalled key stalls only its partition
-
-Outcome: commits advance per partition as groups complete. Needs cycles 1 and 2.
+Outcome: commits advance per partition as groups complete. Needs cycles 2 and 3.
 
 ### 15. Complete polls in any order (switchover)
 
@@ -337,11 +354,11 @@ Outcome: commits advance per partition as groups complete. Needs cycles 1 and 2.
 
 **Goal:** A stalled key stalls only its own partition. Other partitions continue to commit.
 
-- Cycles 1 and 2 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
+- Cycles 2 and 3 are the prerequisites. Commits come from the frontier, and the old flush, whose per-key order depended on oldest-first completion, is gone. Only commits depend on completion order now, and the frontier gates those.
 - In `any` mode, mark each group's offsets in the ledger when its completion event arrives. Do not aggregate per poll before commits.
 - The frontier gates each partition's commit.
 - Keep `max_in_flight_batches` as the bound on outstanding work. A poll's slot frees when all its groups are accepted.
-- Behavior change: commit timing decouples across partitions and polls. Replay exposure stays inside the window.
+- Behavior change: commit timing decouples across partitions and polls. Replay exposure stays inside the admission cap.
 - Rollback is the mode switch back to `ordered`.
 
 **Interfaces:**
@@ -359,17 +376,17 @@ Outcome: commits advance per partition as groups complete. Needs cycles 1 and 2.
 
 - Remove the ordered `InFlightBatch` queue, the per-poll aggregation from change 8, and the completion mode from `Config`.
 
-## Cycle 4: replay exposure is bounded by B
+## Cycle 6: replay exposure is bounded by B
 
-Outcome: uncommitted work never exceeds the budget, in events and bytes. The batch window is gone.
+Outcome: uncommitted work never exceeds the budget, in events and bytes. The in-flight admission cap is gone.
 
 ### 17. Add the budget accounting (implement)
 
-**Task:** Track uncommitted work in events and bytes. Ship with no budget set: the window still governs alone.
+**Task:** Track uncommitted work in events and bytes. Ship with no budget set: the admission cap still governs alone.
 
 **Goal:** The budget exists and reports before it constrains.
 
-- Charge each message on poll. The ledger slots already carry the costs (change 1).
+- Charge each message on poll. The ledger slots already carry the costs (change 3).
 - Refund the charge when the commit that covers the message is issued.
 - Gauge the outstanding charge per partition and in total.
 - New config: the budget in events and in bytes. Unset means no constraint.
@@ -385,8 +402,8 @@ Outcome: uncommitted work never exceeds the budget, in events and bytes. The bat
 
 **Goal:** Replay exposure is bounded directly.
 
-- A charts values PR sets the budget lane by lane. The window and the budget both bound work during the transition.
-- Derive the first values from the current config: events near the batch size times the window, bytes from the byte bound. The effective bound then does not change at the switchover.
+- A charts values PR sets the budget lane by lane. The admission cap and the budget both bound work during the transition.
+- Derive the first values from the current config: events near the batch size times the cap, bytes from the byte bound. The effective bound then does not change at the switchover.
 - Pause and resume the poll at the budget limit. Do not stop servicing Kafka callbacks.
 - Watch the pause gauge and consumer lag. Rollback is unsetting the values.
 
@@ -394,17 +411,19 @@ Outcome: uncommitted work never exceeds the budget, in events and bytes. The bat
 
 - None in this repository. Config values only.
 
-### 19. Remove the batch window (cleanup)
+### 19. Remove the in-flight admission cap (cleanup)
 
 **Task:** Remove `max_in_flight_batches` after the budget holds on all lanes.
 
-**Goal:** The budget is the only bound. The batch reduces to a per-poll accumulator.
+**Goal:** The budget is the only admission bound.
+
+- Only admission control goes. The collection bounds — batch size and batch timeout — stay: they shape one poll, not the amount of admitted work.
 
 **Interfaces:**
 
-- Remove `max_in_flight_batches` from `Config` and the window bookkeeping from `IngestionConsumer`.
+- Remove `max_in_flight_batches` from `Config` and the admission bookkeeping from `IngestionConsumer`.
 
-## Cycle 5: workers receive target-sized requests
+## Cycle 7: workers receive target-sized requests
 
 Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup: body splitting stays as a defence.
 
@@ -439,7 +458,7 @@ Outcome: request size tracks target T, and fan-out is demand-driven. No cleanup:
 
 - None in this repository. Config values only.
 
-## Cycle 6: concurrency adapts to worker health
+## Cycle 8: concurrency adapts to worker health
 
 Outcome: request RTT governs the number of requests in flight.
 
@@ -483,9 +502,9 @@ Outcome: request RTT governs the number of requests in flight.
 
 - Modify `GrpcTransport`: remove the per-worker cap and its config. Stream channels keep `DEPTH_MAX`.
 
-## Cycle 7: partitions hand off cleanly
+## Cycle 9: partitions hand off cleanly
 
-Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 2.
+Outcome: a revocation drains in bounded time, and a wedged partition fails the process instead of hanging. Needs cycle 3.
 
 ### 25. Add revoke and drained markers (prepare)
 

--- a/rust/ingestion-consumer/docs/driver-model-plan.md
+++ b/rust/ingestion-consumer/docs/driver-model-plan.md
@@ -2,7 +2,7 @@
 
 Status: **draft, for discussion**.
 
-This plan implements the [driver-model redesign](https://github.com/PostHog/posthog/blob/pl/ingestion/consumer-redesign-doc/rust/ingestion-consumer/docs/driver-model.md) (#89277) in small steps.
+This plan implements the [driver-model redesign](https://github.com/PostHog/posthog/blob/pl/ingestion/consumer-redesign-doc/rust/ingestion-consumer/docs/driver-model.md) ([#89277](https://github.com/PostHog/posthog/pull/89277)) in small steps.
 Each step is one PR.
 
 ## Starting point
@@ -10,8 +10,8 @@ Each step is one PR.
 The plan starts from current master.
 Master already contains two parts of the design:
 
-- The routing key is the opaque Kafka message key (#90282). A message without a key gets a synthetic per-message key.
-- Each worker has one long-lived ordered gRPC stream (#85238, #90790). The stream runner keeps an un-acked ledger, resolves acks in send order, applies an ack watchdog, and fences on failure.
+- The routing key is the opaque Kafka message key ([#90282](https://github.com/PostHog/posthog/pull/90282)). A message without a key gets a synthetic per-message key.
+- Each worker has one long-lived ordered gRPC stream ([#85238](https://github.com/PostHog/posthog/pull/85238), [#90790](https://github.com/PostHog/posthog/pull/90790)). The stream runner keeps an un-acked ledger, resolves acks in send order, applies an ack watchdog, and fences on failure.
 
 An assignment epoch also exists.
 A rebalance increments it, and every sub-batch carries it.
@@ -49,11 +49,12 @@ After that, the cycles run in order, with two exceptions.
 Cycle 3 does not depend on cycle 2, so it can proceed while cycle 2 soaks.
 Cycle 4 needs only cycle 3's switchover, so it can proceed while cycle 3's cleanup soaks.
 Cycle 8 needs cycles 2 and 3.
+The numbered order is one valid schedule, not the only one: the [cycle dependency graph](#cycle-dependencies) at the end shows the full ordering freedom.
 
 The swap unit in cycle 3 is the **scheduler**: the decision core that says which runs may go to a worker now, and where.
 That is where the complexity concentrates — the pins, the stash, and the flush interplay.
 Packing follows at once (cycle 4): the performance win depends only on the key-table scheduler, not on the event loop, decoupled commits, or the budget.
-The request time budget follows packing (cycle 5): its enforcement precondition is the one-outstanding-request-per-key rule (#89995), and its budget sizes against the packed request size.
+The request time budget follows packing (cycle 5): its enforcement precondition is the one-outstanding-request-per-key rule ([#89995](https://github.com/PostHog/posthog/pull/89995)), and its budget sizes against the packed request size.
 The governor follows (cycle 6): it needs the scheduler's ready queue for its growth signal, and it comes after packing and the time budget, so RTT (request round-trip time) tunes once, against the final request shape.
 The single-owner event loop follows as its own outcome (cycle 7), once the scheduler is simple.
 
@@ -399,8 +400,8 @@ Outcome: a worker stops a request at the consumer's time budget, acks the finish
 Today one slow message holds every message behind it until the ack watchdog fences the whole stream, and everything unacked replays with duplicate work.
 This budget is time per request. It is not B, the uncommitted-work budget of cycle 9.
 
-It needs #89995 merged on the worker side (`soft_budget_ms` on the wire, the `PARTIAL` ack).
-It needs cycle 3: one outstanding request per key is #89995's stated enforcement precondition.
+It needs [#89995](https://github.com/PostHog/posthog/pull/89995) merged on the worker side (`soft_budget_ms` on the wire, the `PARTIAL` ack).
+It needs cycle 3: one outstanding request per key is [#89995](https://github.com/PostHog/posthog/pull/89995)'s stated enforcement precondition.
 It sizes the budget against cycle 4's request size. Its cap on request RTT matters for cycle 6: set `REQUEST_LATENCY_BUDGET` below the soft budget, or the governor never shrinks.
 
 **Verify:** a generous budget on one lane enforces rarely and exercises the real partial-ack path at negligible volume.
@@ -414,7 +415,7 @@ Exit criterion: partial acks resolve and their remainders redeliver in order, ze
 
 - The stream runner parses `PARTIAL` and resolves the send with the accepted index list, instead of fencing it as busy.
 - The scheduler's partial arm is the failure arm plus a completed prefix: complete each key's finished prefix as group completions, return the remainder to the front of its queue, and keep the key blocked until the redelivery settles.
-- The prototype against the old machinery (#91480) showed the cost of doing this earlier: concurrent polls and per-batch accounting push partial handling through the deferral paths. Behind the key table it is one `on_settled` arm.
+- The prototype against the old machinery ([#91480](https://github.com/PostHog/posthog/pull/91480)) showed the cost of doing this earlier: concurrent polls and per-batch accounting push partial handling through the deferral paths. Behind the key table it is one `on_settled` arm.
 - Stamp `soft_budget_ms` on each request from config. Unset sends no budget.
 
 **Interfaces:**
@@ -707,6 +708,53 @@ The steady-state dashboard after the migration:
 - Rebalance: `ingestion_consumer_drain_duration_seconds` and `ingestion_consumer_drain_dropped_messages_total`.
 
 The budget occupancy and the request-size histograms are also the worker-autoscaling signals from section 5 of the design doc.
+
+## Cycle dependencies
+
+The cycles do not have to run linearly.
+A solid arrow is a hard dependency.
+A dashed arrow is an ordering preference: its reason is stated in the target cycle's intro, and breaking it costs retuning or a larger diff, not correctness.
+
+```mermaid
+flowchart LR
+    C1["1: one resolve protocol"]
+    C2["2: frontier commits"]
+    C3["3: one request per key"]
+    C4["4: target-sized requests"]
+    C5["5: partial redelivery"]
+    C6["6: adaptive concurrency"]
+    C7["7: single-owner batcher"]
+    C8["8: decoupled commits"]
+    C9["9: bounded replay"]
+    C10["10: clean handoff"]
+    PR(["#89995 worker side"])
+
+    C1 --> C3
+    C3 --> C4
+    C3 --> C5
+    C3 --> C6
+    C3 --> C7
+    C3 --> C8
+    C3 --> C10
+    C2 --> C8
+    C2 --> C9
+    PR --> C5
+    C4 -.-> C5
+    C4 -.-> C6
+    C5 -.-> C6
+    C6 -.-> C7
+    C8 -.-> C9
+    C9 -.-> C10
+```
+
+What the graph permits:
+
+- Cycles 1 and 2 start in parallel. Neither depends on the other.
+- After cycle 3, four tracks can run side by side: the request track (4, then 5, then 6), the collapse (7), decoupled commits (8, once cycle 2 is done), and the drain (10).
+- Cycle 9 hard-depends only on cycle 2. The dashed edge from cycle 8 exists because group-level completion makes the refunds fine-grained before the admission cap is removed.
+- The dashed edges into cycle 6 are the tune-once argument: packing makes request sizes uniform, and the time budget caps RTT, so the governor tunes against the final distribution.
+- The dashed edge into cycle 7 saves a move: the loop takes the scheduler, packer, and governor in one transformation instead of re-homing components later.
+- The dashed edge into cycle 10 covers one detail: the drain refunds budget charge, which exists after cycle 9. Without cycle 9 the drain refunds nothing and still works.
 
 ## Later work
 


### PR DESCRIPTION
## Problem

The [driver-model redesign](https://github.com/PostHog/posthog/blob/pl/ingestion/consumer-redesign-doc/rust/ingestion-consumer/docs/driver-model.md) (#89277) describes a target design for the ingestion consumer, but no plan exists to reach it in reviewable steps.

- The design replaces batch-shaped ownership, sticky pins, the stash, and the two flush paths.
- One PR for all of that is not reviewable and not safe to ship.

## Changes

- Adds `rust/ingestion-consumer/docs/driver-model-plan.md`: ten cycles, twenty-nine changes, each change one PR, each listing its interface impact (types added, modified, removed).
- Each cycle delivers one outcome (one send origin, frontier commits, one request per key, target-sized requests, partial redelivery via #89995 request time budgets, adaptive concurrency, a single-owner batcher, decoupled commits, bounded replay, clean handoff) through five phases: prepare, implement, verify, switchover, cleanup — every cycle names its verify metrics and exit criterion, and a Monitoring section lists the steady-state dashboard.
- Prepare, implement, and cleanup never change behavior. Only a switchover does, always behind config, staged (shadow, canary) where possible. Cleanup deletes the old component whole after the switchover holds.
- The swap unit is the scheduler, not the whole batcher: placement (P2C, aperture) and send execution (the gRPC stream runners) already match the target design, so only the decision core swaps, and the single-owner event loop lands as cleanup.
- The plan starts from current master, which already carries two parts of the design: Kafka-key routing (#90282) and ordered per-worker gRPC streams (#85238, #90790).
- Docs only. No code changes.

## How did you test this code?

Docs-only change. No tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This is an internal engineering doc.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Session: https://claude.ai/code/session_01LH5TQdxvhTsPPRqeGf2XSw
- Skills invoked: `/asd-ste100` (the plan follows Simplified Technical English), `/writing-pr-descriptions`.
- The session first mapped the design doc onto the current code (master, not the redesign-doc branch, which predates the gRPC transport).
- Revised across the session on the driver's direction: ledger-first with a shadow mode; "structure prepares logic"; the batcher boundary emits per-group completions with no batch identity; the swap narrowed to the scheduler seam; and the final shape organizes everything into prepare-implement-switchover-cleanup cycles, one outcome per cycle. Two early steps were adopted from a parallel plan draft: delete the dead eager-flush path first, and extract the fence-safe send-resolution protocol before drawing the batcher boundary. The extraction step was dropped later: after the eager deletion one copy of the protocol remains, so a standalone extraction bought nothing, and the batcher encapsulation moves it instead.










