### PR TITLE
feat(error-tracking): support issue severity property

### DIFF
--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2014,6 +2014,17 @@
             "label": "Issue name",
             "type": "String"
         },
+        "$issue_severity": {
+            "description": "The severity assigned when this exception creates an error tracking issue.",
+            "examples": [
+                "low",
+                "medium",
+                "high",
+                "critical"
+            ],
+            "label": "Issue severity",
+            "type": "String"
+        },
         "$last_posthog_reset": {
             "description": "The timestamp of the last call to `Reset` in the web SDK. This can be useful for debugging.",
             "ignored_in_assistant": true,
@@ -7004,6 +7015,17 @@
         "$issue_name": {
             "description": "The name of the error tracking issue this exception belongs to.",
             "label": "Issue name",
+            "type": "String"
+        },
+        "$issue_severity": {
+            "description": "The severity assigned when this exception creates an error tracking issue.",
+            "examples": [
+                "low",
+                "medium",
+                "high",
+                "critical"
+            ],
+            "label": "Issue severity",
             "type": "String"
         },
         "$last_posthog_reset": {

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -3417,6 +3417,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "The description of the error tracking issue this exception belongs to.",
             "type": "String",
         },
+        "$issue_severity": {
+            "label": "Issue severity",
+            "description": "The severity assigned when this exception creates an error tracking issue.",
+            "examples": ["low", "medium", "high", "critical"],
+            "type": "String",
+        },
         "$exception_release": {
             "label": "Exception release",
             "description": "The release associated with this exception event.",

--- a/rust/cymbal/src/modes/processing/issue_resolution.rs
+++ b/rust/cymbal/src/modes/processing/issue_resolution.rs
@@ -102,12 +102,16 @@ impl FromStr for IssueSeverity {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "low" => Ok(Self::Low),
-            "medium" => Ok(Self::Medium),
-            "high" => Ok(Self::High),
-            "critical" => Ok(Self::Critical),
-            _ => Err(()),
+        if value.eq_ignore_ascii_case("low") {
+            Ok(Self::Low)
+        } else if value.eq_ignore_ascii_case("medium") {
+            Ok(Self::Medium)
+        } else if value.eq_ignore_ascii_case("high") {
+            Ok(Self::High)
+        } else if value.eq_ignore_ascii_case("critical") {
+            Ok(Self::Critical)
+        } else {
+            Err(())
         }
     }
 }

--- a/rust/cymbal/src/modes/processing/issue_resolution.rs
+++ b/rust/cymbal/src/modes/processing/issue_resolution.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use chrono::{DateTime, Utc};
 use common_kafka::kafka_producer::{
@@ -96,6 +96,20 @@ pub enum IssueSeverity {
     Medium,
     High,
     Critical,
+}
+
+impl FromStr for IssueSeverity {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "low" => Ok(Self::Low),
+            "medium" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "critical" => Ok(Self::Critical),
+            _ => Err(()),
+        }
+    }
 }
 
 pub(crate) fn infer_issue_severity(

--- a/rust/cymbal/src/modes/processing/stages/linking/issue.rs
+++ b/rust/cymbal/src/modes/processing/stages/linking/issue.rs
@@ -292,10 +292,12 @@ async fn resolve_issue(
         team_id,
         name.to_string(),
         description.to_string(),
-        infer_issue_severity(
-            event_properties.exception_level(),
-            event_properties.exception_handled(),
-        ),
+        event_properties.proposed_issue_severity().or_else(|| {
+            infer_issue_severity(
+                event_properties.exception_level(),
+                event_properties.exception_handled(),
+            )
+        }),
         &mut *txn,
     )
     .await?;
@@ -405,6 +407,9 @@ async fn process_event_severity(
     issue: &mut Issue,
     exception_properties: &ExceptionEvent<Fingerprinted>,
 ) -> Result<(), UnhandledError> {
+    if exception_properties.proposed_issue_severity().is_some() {
+        return Ok(());
+    }
     let processed_properties = exception_properties.processed_properties(issue);
     if let Some(severity) =
         try_severity_rules(connection, team_manager, issue, &processed_properties).await?

--- a/rust/cymbal/src/modes/processing/stages/rate_limiting/mod.rs
+++ b/rust/cymbal/src/modes/processing/stages/rate_limiting/mod.rs
@@ -662,6 +662,7 @@ mod tests {
             exception_list: ExceptionList(vec![]),
             proposed_issue_name: None,
             proposed_issue_description: None,
+            proposed_issue_severity: None,
             debug_images: vec![],
             props: HashMap::new(),
             uuid: Uuid::now_v7(),

--- a/rust/cymbal/src/modes/processing/types/exception_event.rs
+++ b/rust/cymbal/src/modes/processing/types/exception_event.rs
@@ -8,7 +8,7 @@ use crate::{
     error::EventError,
     fingerprinting::{Fingerprint, FingerprintRecordPart, FingerprintVersion},
     frames::releases::{ReleaseInfo, ReleaseRecord},
-    issue_resolution::Issue,
+    issue_resolution::{Issue, IssueSeverity},
     langs::native::DebugImage,
     modes::processing::normalization::normalize_wire_order,
     recursively_sanitize_properties,
@@ -179,6 +179,7 @@ pub struct ExceptionEvent<S> {
     pub(crate) props: HashMap<String, Value>,
     pub(crate) proposed_issue_name: Option<String>,
     pub(crate) proposed_issue_description: Option<String>,
+    pub(crate) proposed_issue_severity: Option<IssueSeverity>,
     pub(crate) state: S,
 }
 
@@ -193,6 +194,7 @@ impl<S> ExceptionEvent<S> {
             props: self.props,
             proposed_issue_name: self.proposed_issue_name,
             proposed_issue_description: self.proposed_issue_description,
+            proposed_issue_severity: self.proposed_issue_severity,
             state: transform(self.state),
         }
     }
@@ -244,6 +246,10 @@ impl<S> ExceptionEvent<S> {
 
     pub fn proposed_issue_description(&self) -> Option<&str> {
         self.proposed_issue_description.as_deref()
+    }
+
+    pub fn proposed_issue_severity(&self) -> Option<IssueSeverity> {
+        self.proposed_issue_severity
     }
 }
 
@@ -402,6 +408,7 @@ impl ExceptionEvent<Finalized> {
             props,
             proposed_issue_name,
             proposed_issue_description,
+            proposed_issue_severity,
             state,
             ..
         } = self;
@@ -463,6 +470,12 @@ impl ExceptionEvent<Finalized> {
         if let Some(description) = proposed_issue_description {
             map.insert("$issue_description".into(), Value::String(description));
         }
+        if let Some(severity) = proposed_issue_severity {
+            map.insert(
+                "$issue_severity".into(),
+                Value::String(severity.to_string()),
+            );
+        }
         if !debug_images.is_empty() {
             map.insert(
                 "$debug_images".into(),
@@ -514,6 +527,12 @@ impl<S> ExceptionEvent<S> {
                 Value::String(description.clone()),
             );
         }
+        if let Some(severity) = self.proposed_issue_severity {
+            map.insert(
+                "$issue_severity".into(),
+                Value::String(severity.to_string()),
+            );
+        }
         if !self.debug_images.is_empty() {
             map.insert(
                 "$debug_images".into(),
@@ -558,13 +577,20 @@ impl<S> ExceptionEvent<S> {
         fingerprint: &SelectedFingerprint,
         issue_id: Uuid,
     ) -> ProcessedExceptionProperties {
+        let mut other = self.props.clone();
+        if let Some(severity) = self.proposed_issue_severity {
+            other.insert(
+                "$issue_severity".into(),
+                Value::String(severity.to_string()),
+            );
+        }
         ProcessedExceptionProperties(ProcessedExceptionPropertiesWire {
             exception_list: self.exception_list.clone(),
             fingerprint: fingerprint.value.clone(),
             fingerprint_version: fingerprint.version,
             fingerprint_record: fingerprint.record.clone(),
             issue_id,
-            other: self.props.clone(),
+            other,
             handled: metadata.handled,
             release: metadata.release.clone(),
             types: metadata.types.clone(),
@@ -628,6 +654,11 @@ impl TryFrom<AnyEvent> for ExceptionEvent<Parsed> {
         let lib_version = raw.other.get("$lib_version").and_then(Value::as_str);
         let legacy_order_exception_list =
             normalize_wire_order(&mut raw.exception_list, lib, lib_version);
+        let proposed_issue_severity = raw
+            .issue_severity
+            .as_ref()
+            .and_then(Value::as_str)
+            .and_then(|severity| severity.parse().ok());
 
         Ok(ExceptionEvent {
             uuid: event.uuid,
@@ -638,6 +669,7 @@ impl TryFrom<AnyEvent> for ExceptionEvent<Parsed> {
             props: raw.other,
             proposed_issue_name: raw.issue_name,
             proposed_issue_description: raw.issue_description,
+            proposed_issue_severity,
             state: Parsed {
                 client_fingerprint: raw.fingerprint,
                 legacy_order_exception_list,
@@ -687,6 +719,7 @@ mod tests {
             props: HashMap::from([("passthrough".to_string(), Value::Bool(true))]),
             proposed_issue_name: None,
             proposed_issue_description: None,
+            proposed_issue_severity: None,
             state: Resolved {
                 metadata: ResolvedMetadata {
                     sources: vec![],

--- a/rust/cymbal/src/modes/processing/types/exception_event.rs
+++ b/rust/cymbal/src/modes/processing/types/exception_event.rs
@@ -654,11 +654,17 @@ impl TryFrom<AnyEvent> for ExceptionEvent<Parsed> {
         let lib_version = raw.other.get("$lib_version").and_then(Value::as_str);
         let legacy_order_exception_list =
             normalize_wire_order(&mut raw.exception_list, lib, lib_version);
-        let proposed_issue_severity = raw
-            .issue_severity
-            .as_ref()
+        let proposed_issue_severity: Option<IssueSeverity> = raw
+            .other
+            .get("$issue_severity")
             .and_then(Value::as_str)
             .and_then(|severity| severity.parse().ok());
+        if let Some(severity) = proposed_issue_severity {
+            raw.other.insert(
+                "$issue_severity".to_string(),
+                Value::String(severity.to_string()),
+            );
+        }
 
         Ok(ExceptionEvent {
             uuid: event.uuid,

--- a/rust/cymbal/src/modes/processing/types/mod.rs
+++ b/rust/cymbal/src/modes/processing/types/mod.rs
@@ -113,8 +113,6 @@ pub struct RawExceptionProperties {
     pub issue_name: Option<String>,
     #[serde(rename = "$issue_description", skip_serializing_if = "Option::is_none")]
     pub issue_description: Option<String>,
-    #[serde(rename = "$issue_severity", skip_serializing_if = "Option::is_none")]
-    pub issue_severity: Option<Value>,
     #[serde(rename = "$exception_handled", skip_serializing_if = "Option::is_none")]
     pub handled: Option<bool>,
     #[serde(

--- a/rust/cymbal/src/modes/processing/types/mod.rs
+++ b/rust/cymbal/src/modes/processing/types/mod.rs
@@ -113,6 +113,8 @@ pub struct RawExceptionProperties {
     pub issue_name: Option<String>,
     #[serde(rename = "$issue_description", skip_serializing_if = "Option::is_none")]
     pub issue_description: Option<String>,
+    #[serde(rename = "$issue_severity", skip_serializing_if = "Option::is_none")]
+    pub issue_severity: Option<Value>,
     #[serde(rename = "$exception_handled", skip_serializing_if = "Option::is_none")]
     pub handled: Option<bool>,
     #[serde(

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -523,7 +523,12 @@ async fn issue_severity_property_controls_only_new_issues_and_falls_back_when_in
     input.properties["$issue_severity"] = json!("urgent");
     let (status, body): (_, SuccessResponse) = harness.post_event(&input).await;
     assert!(status.is_success());
-    let invalid_issue_id = body.take_properties().issue_id();
+    let invalid_event = body.take_properties();
+    assert_eq!(
+        invalid_event.properties().get("$issue_severity"),
+        Some(&json!("urgent"))
+    );
+    let invalid_issue_id = invalid_event.issue_id();
     let fallback_severity: Option<String> =
         sqlx::query_scalar("SELECT severity FROM posthog_errortrackingissue WHERE id = $1")
             .bind(invalid_issue_id)

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -477,6 +477,63 @@ async fn severity_rule_overrides_inference_only_for_new_issue(db: PgPool) {
 }
 
 #[sqlx::test(migrations = "./tests/test_migrations")]
+async fn issue_severity_property_controls_only_new_issues_and_falls_back_when_invalid(db: PgPool) {
+    let harness = TestHarness::new(db);
+    insert_severity_rule(&harness.db, "critical", json!(["_H", 1, 29, 38])).await;
+    let mut input = make_event_with_options(
+        vec![make_exception("TypeError", "cannot read property")],
+        Some("issue-severity-property"),
+        Some(false),
+    );
+    input.properties["$exception_level"] = json!("fatal");
+    input.properties["$issue_severity"] = json!("high");
+
+    let (status, body): (_, SuccessResponse) = harness.post_event(&input).await;
+    assert!(status.is_success());
+    let event = body.take_properties();
+    let issue_id = event.issue_id();
+    assert_eq!(
+        event.properties().get("$issue_severity"),
+        Some(&json!("high"))
+    );
+    let initial_severity: Option<String> =
+        sqlx::query_scalar("SELECT severity FROM posthog_errortrackingissue WHERE id = $1")
+            .bind(issue_id)
+            .fetch_one(&harness.db)
+            .await
+            .unwrap();
+    assert_eq!(initial_severity.as_deref(), Some("high"));
+
+    sqlx::query("UPDATE posthog_errortrackingissue SET severity = 'low' WHERE id = $1")
+        .bind(issue_id)
+        .execute(&harness.db)
+        .await
+        .unwrap();
+    let (status, _): (_, SuccessResponse) = harness.post_event(&input).await;
+    assert!(status.is_success());
+    let existing_severity: Option<String> =
+        sqlx::query_scalar("SELECT severity FROM posthog_errortrackingissue WHERE id = $1")
+            .bind(issue_id)
+            .fetch_one(&harness.db)
+            .await
+            .unwrap();
+    assert_eq!(existing_severity.as_deref(), Some("low"));
+
+    input.properties["$exception_fingerprint"] = json!("invalid-issue-severity");
+    input.properties["$issue_severity"] = json!("urgent");
+    let (status, body): (_, SuccessResponse) = harness.post_event(&input).await;
+    assert!(status.is_success());
+    let invalid_issue_id = body.take_properties().issue_id();
+    let fallback_severity: Option<String> =
+        sqlx::query_scalar("SELECT severity FROM posthog_errortrackingissue WHERE id = $1")
+            .bind(invalid_issue_id)
+            .fetch_one(&harness.db)
+            .await
+            .unwrap();
+    assert_eq!(fallback_severity.as_deref(), Some("critical"));
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
 async fn unmatched_severity_rule_preserves_inference(db: PgPool) {
     let harness = TestHarness::new(db);
     insert_severity_rule(&harness.db, "low", json!(["_H", 1, 30, 38])).await;

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -486,7 +486,7 @@ async fn issue_severity_property_controls_only_new_issues_and_falls_back_when_in
         Some(false),
     );
     input.properties["$exception_level"] = json!("fatal");
-    input.properties["$issue_severity"] = json!("high");
+    input.properties["$issue_severity"] = json!("HIGH");
 
     let (status, body): (_, SuccessResponse) = harness.post_event(&input).await;
     assert!(status.is_success());

--- a/rust/property-defs-rs/src/api/v1/constants.rs
+++ b/rust/property-defs-rs/src/api/v1/constants.rs
@@ -66,7 +66,7 @@ pub const EVENTS_HIDDEN_PROPERTY_DEFINITIONS: [&str; 14] = [
 // **IMPORTANT** we need to keep this in sync the w/Django original!! see below for more details:
 // https://github.com/PostHog/posthog/blob/master/posthog/taxonomy/property_definition_api.py#L326-L339
 // https://github.com/PostHog/posthog/blob/master/posthog/taxonomy/taxonomy.py#L1627-L1631
-pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 243] = [
+pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 244] = [
     (
         "$last_posthog_reset",
         "timestamp of last call to `reset` in the web sdk",
@@ -122,6 +122,7 @@ pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 243] = [
     ("$debug_images", "debug images"),
     ("$issue_name", "issue name"),
     ("$issue_description", "issue description"),
+    ("$issue_severity", "issue severity"),
     ("$exception_handled", "exception was handled"),
     ("$cymbal_errors", "exception processing errors"),
     (


### PR DESCRIPTION
## Problem

SDKs cannot set an error tracking issue's initial severity directly.

Cymbal currently derives severity from exception metadata and severity rules.

## Changes

- Exception events can set `$issue_severity` to `low`, `medium`, `high`, or `critical` case-insensitively when they create an issue.
- Cymbal stores accepted values in lowercase.
- The property takes priority over severity rules and inferred severity.
- Later events cannot overwrite an existing issue's severity.
- Invalid values remain available in event properties.
- Invalid values fall back to severity rules or inference.
- The event taxonomy and property definitions recognize `$issue_severity`.
- No screenshot: this changes ingestion behavior and property metadata, not a fixed UI state.

## How did you test this code?

- `SQLX_OFFLINE=true RUST_TEST_THREADS=1 hogli test rust/cymbal/tests/event.rs` covers normalization, preservation, precedence, fallback, and existing issue protection.
- `SQLX_OFFLINE=true hogli test rust/property-defs-rs` covers the property definition registry.
- Clippy checked both affected Rust crates with warnings denied.
- `hogli ci:preflight --fix` checked the changed files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The event property taxonomy documents the supported severity values and new-issue behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi authored the change with repository tools. The session link is unavailable.

Skills invoked: `/error-tracking`, `/writing-tests`, `/writing-user-facing-copy`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.
