### PR TITLE
fix(llm-gateway): correct GLM 5.3 Baseten context window

### DIFF
--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
@@ -38,9 +38,6 @@ BASETEN_GLM_COST: Final[ModelCost] = {
     "supports_prompt_caching": True,
 }
 
-# Placeholder: the GLM 5.2 contract rate, pending Baseten listing GLM 5.3. The pin below
-# blocks any automatic correction, so confirm the real contract rate here BEFORE creating
-# the posthog-code-glm-53-model flag (see the README's GLM 5.3 go-live note).
 BASETEN_GLM53_COST: Final[ModelCost] = {
     "litellm_provider": "baseten",
     "mode": "chat",

--- a/services/llm-gateway/src/llm_gateway/services/model_registry.py
+++ b/services/llm-gateway/src/llm_gateway/services/model_registry.py
@@ -33,8 +33,7 @@ _CLOUDFLARE_PROVIDER: Final[str] = "cloudflare"
 _CLOUDFLARE_DEFAULT_CONTEXT_WINDOW: Final[int] = 128_000
 _BASETEN_CONTEXT_WINDOWS: Final[dict[str, int]] = {
     BASETEN_DEEPSEEK_PUBLIC_MODEL: 1_048_000,
-    # Placeholder pending confirmation against the Baseten deployment.
-    BASETEN_GLM53_PUBLIC_MODEL: 200_000,
+    BASETEN_GLM53_PUBLIC_MODEL: 1_048_576,
     BASETEN_GLM53_FLASH_PUBLIC_MODEL: 1_000_000,
 }
 

--- a/services/llm-gateway/tests/test_model_registry.py
+++ b/services/llm-gateway/tests/test_model_registry.py
@@ -385,7 +385,7 @@ class TestBasetenModelAdvertising:
         ("model_id", "context_window", "allowed_products"),
         [
             ("deepseek-ai/deepseek-v4-flash-0731", 1_048_000, ("review_hog", "posthog_code")),
-            ("zai-org/glm-5.3", 200_000, ("review_hog", "posthog_code")),
+            ("zai-org/glm-5.3", 1_048_576, ("review_hog", "posthog_code")),
             ("zai-org/glm-5.3-flash", 1_000_000, ("review_hog", "posthog_code")),
         ],
     )


### PR DESCRIPTION
## Problem

GLM 5.3 callers see a 200,000-token context window, but that isn't mapped correctly.

## Changes

- Pins GLM 5.3's Baseten context window to 1,048,576, matching upstream listing

