### PR TITLE
fix(dashboards): keep saved filters when a save did not touch them

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -172,7 +172,7 @@ describe('dashboardLogic', () => {
                 ...dashboardResult(10, [tileFromInsight(insights['800'])]),
             },
             11: {
-                ...dashboardResult(11, [], { date_from: '-24h' }),
+                ...dashboardResult(11, [tileFromInsight(insights['175'])], { date_from: '-24h' }),
             },
             13: {
                 ...dashboardResult(13, []),
@@ -529,6 +529,52 @@ describe('dashboardLogic', () => {
                 expect.objectContaining({
                     filters: expect.objectContaining({ date_from: '-7d' }),
                 })
+            )
+        })
+
+        // Dashboard 11 has '-24h' saved; the URL below carries a different, temporary '-7d' override.
+        // A save that never touched the filter bar must leave the saved '-24h' alone, or a shared
+        // link plus any layout nudge silently rewrites the dashboard's filters for the whole team.
+        it.each([
+            ['a tile is moved', DashboardEventSource.SceneCommonButtons, { date_from: '-24h' }],
+            [
+                'edit mode is opened from the overrides banner',
+                DashboardEventSource.DashboardHeaderOverridesBanner,
+                { date_from: '-7d', date_to: null },
+            ],
+        ])('saving when %s persists the expected filters', async (_name, entrySource, expectedFilters) => {
+            logic.unmount()
+            router.actions.push('/dashboard/11', {
+                [dashboardUtils.SEARCH_PARAM_FILTERS_KEY]: JSON.stringify({ date_from: '-7d', date_to: null }),
+            })
+            logic = dashboardLogic({ id: 11 })
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.setDashboardMode(DashboardMode.Edit, entrySource)
+            }).toFinishAllListeners()
+
+            const currentLayouts = logic.values.layouts
+            const movedTileId = String(logic.values.dashboard!.tiles[0].id)
+            await expectLogic(logic, () => {
+                logic.actions.updateLayouts({
+                    ...currentLayouts,
+                    sm: currentLayouts.sm?.map((layout) =>
+                        layout.i === movedTileId ? { ...layout, x: (layout.x ?? 0) + 1 } : layout
+                    ),
+                } as any)
+            }).toFinishAllListeners()
+
+            jest.spyOn(api, 'update')
+
+            await expectLogic(logic, () => {
+                logic.actions.saveEditModeChanges()
+            }).toFinishAllListeners()
+
+            expect(api.update).toHaveBeenCalledWith(
+                `api/environments/${MOCK_TEAM_ID}/dashboards/11`,
+                expect.objectContaining({ filters: expectedFilters })
             )
         })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.testHelpers.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.testHelpers.ts
@@ -43,9 +43,12 @@ export const dashboardResult = (
     tiles: DashboardTile<QueryBasedInsightModel>[],
     filters: Partial<DashboardFilter> = {}
 ): DashboardType<QueryBasedInsightModel> => {
+    const dashboardFilters = { ...dashboardJson.filters, ...filters }
     return {
         ...dashboardJson,
-        filters: { ...dashboardJson.filters, ...filters },
+        filters: dashboardFilters,
+        // The API serves the saved filters under both keys, and the frontend reads only this one.
+        persisted_filters: Object.keys(dashboardFilters).length ? dashboardFilters : null,
         id: dashboardId,
         tiles,
     }

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -149,6 +149,7 @@ import {
     getInsightWithRetry,
     isLayoutEditEventSource,
     isRefreshRejectionStub,
+    isSaveEditModeEventSource,
     layoutsByTile,
     parseURLFilters,
     parseURLVariables,
@@ -296,6 +297,7 @@ export interface dashboardLogicValues {
     dashboardWidgetsEnabled: boolean
     dataColorTheme: DataColorTheme | null
     dataColorThemeId: number | null
+    editModeEntrySource: DashboardEventSource | null
     effectiveBreakdownColors: BreakdownColorConfig[]
     effectiveDashboardVariableOverrides: {
         [x: string]: HogQLVariable
@@ -310,6 +312,7 @@ export interface dashboardLogicValues {
     error404: boolean
     externalFilters: DashboardFilter
     filtersOverrideForLoad: DashboardFilter
+    filtersTouchedThisEditSession: boolean
     hasIntermittentFilters: boolean
     hasUnsavedColorChanges: boolean
     hasUnsavedLayoutChanges: boolean
@@ -372,6 +375,7 @@ export interface dashboardLogicValues {
         variables?: unknown
     } | null
     urlVariables: Record<string, HogQLVariable>
+    variablesTouchedThisEditSession: boolean
     widgetRefreshStatus: Record<
         number,
         {
@@ -1041,6 +1045,23 @@ export interface dashboardLogicMeta {
         ) => {
             [x: string]: HogQLVariable
         }
+        filtersTouchedThisEditSession: (
+            hasIntermittentFilters: boolean,
+            urlFilters: DashboardFilter,
+            urlSearchParamsAtEditModeEntry: {
+                filters?: unknown
+                variables?: unknown
+            } | null,
+            editModeEntrySource: any
+        ) => boolean
+        variablesTouchedThisEditSession: (
+            searchParams: Record<string, any>,
+            urlSearchParamsAtEditModeEntry: {
+                filters?: unknown
+                variables?: unknown
+            } | null,
+            editModeEntrySource: any
+        ) => boolean
         hasUnsavedLayoutChanges: (
             dashboard: DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>> | null,
             dashboardLayouts: Record<
@@ -1528,11 +1549,17 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         const persistedBreakdownColors = currentDashboard.breakdown_colors || []
                         const persistedThemeId = currentDashboard.data_color_theme_id ?? null
 
-                        const filtersChanged = !equal(persistedFilters, values.effectiveEditBarFilters || {})
-                        const variablesChanged = !equal(
-                            persistedVariables,
-                            values.effectiveDashboardVariableOverrides || {}
-                        )
+                        // Only adopt what the bar shows when this edit session actually touched it —
+                        // otherwise keep what's saved, so URL overrides don't ride along on a save.
+                        const filtersToSave = values.filtersTouchedThisEditSession
+                            ? values.effectiveEditBarFilters || {}
+                            : persistedFilters
+                        const variablesToSave = values.variablesTouchedThisEditSession
+                            ? values.effectiveDashboardVariableOverrides || {}
+                            : persistedVariables
+
+                        const filtersChanged = !equal(persistedFilters, filtersToSave)
+                        const variablesChanged = !equal(persistedVariables, variablesToSave)
                         // While tiles are still loading, or an errored/aborted tile is missing its
                         // results, the visible breakdown values are incomplete, so fresh auto
                         // assignments and stale-entry pruning would both act on partial data.
@@ -1574,8 +1601,8 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         const updatedDashboard: DashboardType<InsightModel> = await api.update(
                             `api/environments/${values.currentTeamId}/dashboards/${props.id}`,
                             {
-                                filters: values.effectiveEditBarFilters,
-                                variables: values.effectiveDashboardVariableOverrides,
+                                filters: filtersToSave,
+                                variables: variablesToSave,
                                 breakdown_colors: breakdownColorsToSave,
                                 data_color_theme_id: values.dataColorThemeId,
                                 tiles: layoutsToUpdate,
@@ -2230,12 +2257,31 @@ export const dashboardLogic = kea<dashboardLogicType>([
             {
                 setUrlSearchParamsAtEditModeEntry: (_, { snapshot }) => snapshot,
                 setDashboardMode: (snapshot, { mode, source }) => {
-                    if (mode === null && source !== DashboardEventSource.DashboardHeaderDiscardChanges) {
+                    if (
+                        mode === null &&
+                        source !== DashboardEventSource.DashboardHeaderDiscardChanges &&
+                        !isSaveEditModeEventSource(source)
+                    ) {
                         return null
                     }
                     return snapshot
                 },
                 restoreUrlStateAtEditModeEntry: () => null,
+                saveEditModeChangesSuccess: () => null,
+            },
+        ],
+        // Which control opened the current edit session. Save reads it to tell a deliberate "adopt
+        // these overrides" entry from the overrides banner apart from an edit that merely happens to
+        // have overrides in the URL.
+        editModeEntrySource: [
+            null as DashboardEventSource | null,
+            {
+                setDashboardMode: (state, { mode, source }) => {
+                    if (mode === DashboardMode.Edit) {
+                        return state ?? source
+                    }
+                    return isSaveEditModeEventSource(source) ? state : null
+                },
                 saveEditModeChangesSuccess: () => null,
             },
         ],
@@ -2624,6 +2670,39 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 ...dashboard?.persisted_variables,
                 ...urlVariables,
             }),
+        ],
+        // Overrides arriving in the URL (a shared link, a bookmark) look exactly like saved filters in
+        // the edit bar, and the banner that says otherwise is hidden in edit mode. Compare against the
+        // URL as it stood when this edit session opened, so saving a layout or color change can't
+        // quietly adopt someone else's temporary view as the dashboard's saved one.
+        filtersTouchedThisEditSession: [
+            (s) => [s.hasIntermittentFilters, s.urlFilters, s.urlSearchParamsAtEditModeEntry, s.editModeEntrySource],
+            (
+                hasIntermittentFilters: boolean,
+                urlFilters: DashboardFilter,
+                snapshot: { filters?: unknown; variables?: unknown } | null,
+                entrySource: DashboardEventSource | null
+            ): boolean =>
+                hasIntermittentFilters ||
+                entrySource === DashboardEventSource.DashboardHeaderOverridesBanner ||
+                // No snapshot means the edit session didn't record a baseline, so fall back to saving
+                // whatever the bar shows rather than silently dropping a real edit.
+                snapshot === null ||
+                !equal(urlFilters, parseURLFilters({ [SEARCH_PARAM_FILTERS_KEY]: snapshot.filters })),
+        ],
+        variablesTouchedThisEditSession: [
+            (s) => [router.selectors.searchParams, s.urlSearchParamsAtEditModeEntry, s.editModeEntrySource],
+            (
+                searchParams: Record<string, any>,
+                snapshot: { filters?: unknown; variables?: unknown } | null,
+                entrySource: DashboardEventSource | null
+            ): boolean =>
+                entrySource === DashboardEventSource.DashboardHeaderOverridesBanner ||
+                snapshot === null ||
+                !equal(
+                    parseURLVariables(searchParams),
+                    parseURLVariables({ [SEARCH_PARAM_QUERY_VARIABLES_KEY]: snapshot.variables })
+                ),
         ],
         hasUnsavedLayoutChanges: [
             (s) => [s.dashboard, s.dashboardLayouts],
@@ -4436,12 +4515,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     action: RefreshDashboardItemsAction.Refresh,
                     forceRefresh: false,
                 })
-            } else if (
-                mode === null &&
-                (source === DashboardEventSource.DashboardHeaderSaveDashboard ||
-                    source === DashboardEventSource.SceneCommonButtons ||
-                    source === DashboardEventSource.DashboardInsightColorsModal)
-            ) {
+            } else if (mode === null && isSaveEditModeEventSource(source)) {
                 // save edit mode changes when exiting via Save button, E key/Edit layout button,
                 // or the colors modal's Save button
                 // Pending name/description are included in the saveEditModeChanges PATCH

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -506,3 +506,17 @@ export function shouldSnapshotUrlAtEditModeEntry(source: DashboardEventSource | 
             source === DashboardEventSource.DashboardHeaderOverridesBanner)
     )
 }
+
+const SAVE_EDIT_MODE_EVENT_SOURCES = new Set<DashboardEventSource>([
+    DashboardEventSource.DashboardHeaderSaveDashboard,
+    DashboardEventSource.SceneCommonButtons,
+    DashboardEventSource.DashboardInsightColorsModal,
+])
+
+/**
+ * Sources that leave edit mode by saving. Reducers run before listeners, so edit-session state the
+ * save needs has to survive these and be cleared once the save has read it.
+ */
+export function isSaveEditModeEventSource(source: DashboardEventSource | null): boolean {
+    return source !== null && SAVE_EDIT_MODE_EVENT_SOURCES.has(source)
+}


### PR DESCRIPTION
## Problem

A dashboard's saved filters get replaced for everyone in the project when one person opens the dashboard from a link that carries filter overrides and then saves anything at all — a moved tile, a breakdown color, a theme. The next person to open the dashboard sees a date range nobody chose, and whoever set the original one reads it as their filters not sticking.

Overrides arrive in the URL as `query_filters` from a shared link or a bookmark. In the edit bar they render exactly like saved filters, and the "you are viewing this dashboard with filter overrides" banner hides as soon as edit mode opens. So the person saving gets no signal that the bar holds someone else's temporary view.

`saveEditModeChanges` sent `effectiveEditBarFilters`, which layers the URL overrides on top of the saved filters. Any save that changed a layout or a color therefore also wrote the overrides. Dashboard variables took the same path through `effectiveDashboardVariableOverrides`.

Reported through support. [Originating thread](https://posthog.slack.com/archives/C0ASU43UAMS/p1788048917070689).

## Changes

- A save keeps the dashboard's saved filters when the edit session never touched the filter bar. Moving a tile no longer changes what anyone else sees.
- Opening edit mode from the overrides banner still adopts the overrides on save. That stays the one deliberate way to promote a link's filters to the dashboard.
- Dashboard variables follow the same rule, through the same two lines in the save payload.
- The edit session compares against the URL as it stood when edit mode opened, held in the existing `urlSearchParamsAtEditModeEntry` snapshot. Comparing against the saved filters instead cannot work, because a previewed edit and an inherited override both differ from what is saved.
- That snapshot now survives the three sources that exit edit mode by saving. Reducers run before listeners, so it was already cleared by the time the save read it.
- Mechanical: those three sources move into a shared `isSaveEditModeEventSource` helper, replacing an inlined list. The Jest dashboard helper sets `persisted_filters`, which is the key the frontend actually reads.

Nothing looks different. No UI changed, so there is no screenshot to show.

> [!NOTE]
> A dashboard whose saved filters were already overwritten this way keeps the overwritten value. This stops it happening again; it does not restore anything.

## How did you test this code?

Two parameterized cases in `dashboardLogic.test.ts`, covering a save whose edit session entered from a layout control and one that entered from the overrides banner.

The first case catches the regression: reverting the save payload to `effectiveEditBarFilters` makes it fail, with the PATCH carrying the URL's date range instead of the saved one. No existing test asserted anything about the filters in the save payload when the URL held overrides. The second case guards the promote path against an over-broad fix, and passes either way by design.

Not run: the app itself. This sandbox has no dev stack, so there was no manual click-through.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Left unassigned deliberately: the work was directed by a person, but this session had no verified GitHub handle for them, and guessing one assigns a stranger. The requester should assign themselves.

Written by Claude Code (PostHog Desktop) from a support report of dashboard filters not persisting. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The report read as a plain save bug, so the first pass traced the save path looking for one and found it sound and well covered. Product analytics on dashboard filter use then showed most filter edits never reach a save at all, which reframed the complaint and pointed at how a dashboard's filters change without their owner acting. That led to the URL override path, which reproduced on the first attempt.

Two things are deliberately out of scope. The larger finding is that dashboard filters apply instantly but persist only for whoever presses Save, and that Save writes one filter state shared by the whole project — a design question for the owning team, not a fix. `/simplify` was not run; the diff stayed small enough to review directly.
