### PR TITLE
feat(ingestion-consumer): redeliver only the remainder of partial acks

### DIFF
--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -270,6 +270,14 @@ pub struct Config {
     #[envconfig(from = "INGESTION_WORKER_PER_KEY_SERIALIZATION", default = "false")]
     pub ingestion_worker_per_key_serialization: bool,
 
+    /// After this many consecutive budget-limited (timed-out) attempts, a
+    /// message's next resend goes out with no budget, degrading it to
+    /// watchdog-only semantics. Without the escalation, a message that never
+    /// fits the budget would redeliver forever — the deferral path has no
+    /// attempt cap. 0 disables escalation.
+    #[envconfig(from = "INGESTION_WORKER_UNBUDGETED_RESEND_ATTEMPTS", default = "3")]
+    pub ingestion_worker_unbudgeted_resend_attempts: u32,
+
     // ---- Worker discovery ----
     /// How the worker pool is discovered: `static` (use WORKER_ADDRESSES — the
     /// co-located sidecar default) or `endpointslice` (watch a Kubernetes

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -246,6 +246,16 @@ pub struct Config {
     #[envconfig(from = "INGESTION_WORKER_STREAM_ACK_TIMEOUT_MS", default = "60000")]
     pub ingestion_worker_stream_ack_timeout_ms: u64,
 
+    /// Soft time budget stamped on every sub-batch (milliseconds), enforced
+    /// by the worker: past it the worker stops starting new work, lets
+    /// in-flight steps finish, and acks PARTIAL so the consumer redelivers
+    /// only the unfinished remainder. 0 sends no budget, which keeps today's
+    /// semantics. When set, size it well under
+    /// INGESTION_WORKER_STREAM_ACK_TIMEOUT_MS (suggested half): the ack
+    /// watchdog stays the system's hard limit. gRPC transport only.
+    #[envconfig(from = "INGESTION_WORKER_SUB_BATCH_SOFT_BUDGET_MS", default = "0")]
+    pub ingestion_worker_sub_batch_soft_budget_ms: u64,
+
     // ---- Worker discovery ----
     /// How the worker pool is discovered: `static` (use WORKER_ADDRESSES — the
     /// co-located sidecar default) or `endpointslice` (watch a Kubernetes

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -252,9 +252,23 @@ pub struct Config {
     /// only the unfinished remainder. 0 sends no budget, which keeps today's
     /// semantics. When set, size it well under
     /// INGESTION_WORKER_STREAM_ACK_TIMEOUT_MS (suggested half): the ack
-    /// watchdog stays the system's hard limit. gRPC transport only.
+    /// watchdog stays the system's hard limit. A non-zero budget also turns
+    /// on per-key serialization (INGESTION_WORKER_PER_KEY_SERIALIZATION),
+    /// the ordering precondition for partial redelivery. gRPC transport only.
     #[envconfig(from = "INGESTION_WORKER_SUB_BATCH_SOFT_BUDGET_MS", default = "0")]
     pub ingestion_worker_sub_batch_soft_budget_ms: u64,
+
+    /// Hold every routing key to at most one in-flight sub-batch: new groups
+    /// for a pinned key defer until the key's previous send is acked, and the
+    /// eager release chains them at ack speed. This is the ordering
+    /// precondition for budget enforcement, so a non-zero
+    /// INGESTION_WORKER_SUB_BATCH_SOFT_BUDGET_MS turns it on regardless of
+    /// this flag; on its own it lets the hold's throughput cost be measured
+    /// before budgets are enabled. Pair it with
+    /// DISPATCHER_EAGER_DEFERRED_FLUSH, otherwise held groups drain only at
+    /// batch completion.
+    #[envconfig(from = "INGESTION_WORKER_PER_KEY_SERIALIZATION", default = "false")]
+    pub ingestion_worker_per_key_serialization: bool,
 
     // ---- Worker discovery ----
     /// How the worker pool is discovered: `static` (use WORKER_ADDRESSES — the

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -565,12 +565,12 @@ impl IngestionConsumer {
         } = pending;
 
         match pending.wait().await {
-            Ok(accepted) => {
+            Ok(outcome) => {
                 dispatcher.on_sub_batch_acked(&key_offsets);
                 // Credit before the resolve: the resolve may hand the batch's
                 // completion the all-clear, which must already see this
                 // acceptance in the ledger.
-                dispatcher.eager_flush_accepted(&batch_id, accepted);
+                dispatcher.eager_flush_accepted(&batch_id, outcome.accepted);
                 dispatcher.on_sub_batch_resolved(
                     &worker,
                     message_count,
@@ -755,7 +755,7 @@ impl IngestionConsumer {
 
             handles.push(tokio::spawn(async move {
                 match pending.wait().await {
-                    Ok(accepted) => {
+                    Ok(outcome) => {
                         // Advance ACK high-water marks before the resolve, which
                         // may evict the keys' sentinel state.
                         dispatcher.on_sub_batch_acked(&key_offsets);
@@ -767,7 +767,7 @@ impl IngestionConsumer {
                             false,
                         );
                         dispatcher.record_send_outcome(&worker, false);
-                        accepted
+                        outcome.accepted
                     }
                     Err(send_err) => {
                         // Re-defer the failed messages first, so the ref-count drop

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -17,7 +17,7 @@ use crate::config::Config;
 use crate::debug_recorder::{record_if, DebugEventKind, DebugRecorder, PartitionOffset};
 use crate::discovery::DiscoveryMode;
 use crate::dispatcher::{key_offsets_of, Dispatcher, EagerFlush, KeyOffset, SubBatch};
-use crate::grpc_transport::{GrpcTransport, PendingWorkerStreamSend};
+use crate::grpc_transport::{GrpcTransport, PendingWorkerStreamSend, SendOptions};
 use crate::order_sentinel::{CommitSentinel, OffsetSpan, SentinelContext};
 use crate::transport::SendError;
 use crate::types::SerializedKafkaMessage;
@@ -648,9 +648,15 @@ impl IngestionConsumer {
             messages,
             routing_keys,
             key_offsets,
+            unbudgeted,
         } = sub_batch;
         let message_count = messages.len();
-        let pending = transport.begin_send(&worker, batch_id, messages, replay);
+        let pending = transport.begin_send(
+            &worker,
+            batch_id,
+            messages,
+            SendOptions { replay, unbudgeted },
+        );
         PendingSubBatch {
             worker,
             routing_keys,

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -16,7 +16,7 @@ use tracing::{error, info, warn};
 use crate::config::Config;
 use crate::debug_recorder::{record_if, DebugEventKind, DebugRecorder, PartitionOffset};
 use crate::discovery::DiscoveryMode;
-use crate::dispatcher::{Dispatcher, EagerFlush, KeyOffset, SubBatch};
+use crate::dispatcher::{key_offsets_of, Dispatcher, EagerFlush, KeyOffset, SubBatch};
 use crate::grpc_transport::{GrpcTransport, PendingWorkerStreamSend};
 use crate::order_sentinel::{CommitSentinel, OffsetSpan, SentinelContext};
 use crate::transport::SendError;
@@ -565,7 +565,7 @@ impl IngestionConsumer {
         } = pending;
 
         match pending.wait().await {
-            Ok(outcome) => {
+            Ok(outcome) if outcome.timed_out.is_empty() => {
                 dispatcher.on_sub_batch_acked(&key_offsets);
                 // Credit before the resolve: the resolve may hand the batch's
                 // completion the all-clear, which must already see this
@@ -578,6 +578,23 @@ impl IngestionConsumer {
                     true,
                     false,
                 );
+                dispatcher.record_send_outcome(&worker, false);
+            }
+            Ok(outcome) => {
+                // Partial ack on the eager path: stash the remainder before
+                // crediting the acceptance, so the owning batch never
+                // observes a moment with no unfinished flush work while the
+                // remainder is neither stashed nor pending.
+                dispatcher.on_sub_batch_acked(&key_offsets_of(&outcome.completed));
+                dispatcher.on_sub_batch_partial(
+                    &batch_id,
+                    &worker,
+                    message_count,
+                    &routing_keys,
+                    outcome.timed_out,
+                    true,
+                );
+                dispatcher.eager_flush_accepted(&batch_id, outcome.accepted);
                 dispatcher.record_send_outcome(&worker, false);
             }
             Err(send_err) => {
@@ -755,7 +772,7 @@ impl IngestionConsumer {
 
             handles.push(tokio::spawn(async move {
                 match pending.wait().await {
-                    Ok(outcome) => {
+                    Ok(outcome) if outcome.timed_out.is_empty() => {
                         // Advance ACK high-water marks before the resolve, which
                         // may evict the keys' sentinel state.
                         dispatcher.on_sub_batch_acked(&key_offsets);
@@ -765,6 +782,24 @@ impl IngestionConsumer {
                             &routing_keys,
                             from_flush,
                             false,
+                        );
+                        dispatcher.record_send_outcome(&worker, false);
+                        outcome.accepted
+                    }
+                    Ok(outcome) => {
+                        // Partial ack: watermarks advance from the completed
+                        // subset only, and the timed-out remainder stashes
+                        // under the owning batch for in-order redelivery. A
+                        // partial ack is a healthy worker enforcing the
+                        // budget, not a fault.
+                        dispatcher.on_sub_batch_acked(&key_offsets_of(&outcome.completed));
+                        dispatcher.on_sub_batch_partial(
+                            &bid,
+                            &worker,
+                            message_count,
+                            &routing_keys,
+                            outcome.timed_out,
+                            from_flush,
                         );
                         dispatcher.record_send_outcome(&worker, false);
                         outcome.accepted

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 
 use k8s_awareness::PeerTracker;
@@ -64,6 +64,9 @@ pub struct SubBatch {
     /// Per-key max offsets. Pass back to `Dispatcher::on_sub_batch_acked` on
     /// a successful ACK (only) so the order sentinel tracks ACK progress.
     pub key_offsets: Vec<KeyOffset>,
+    /// Send with no time budget: a key in this sub-batch reached the
+    /// escalated-resend threshold (see `set_unbudgeted_resend_attempts`).
+    pub unbudgeted: bool,
 }
 
 /// Sticky pin for one routing key. Tracks which worker owns the key and how
@@ -93,6 +96,13 @@ struct PinTable {
     /// Batch id → messages accepted via eager flushes, credited to the batch's
     /// total at completion (`take_eager_accepted`).
     eager_accepted: HashMap<String, u32>,
+    /// Routing key → consecutive budget-limited (timed-out) attempts. At the
+    /// escalation threshold the key's next resend goes out unbudgeted, so a
+    /// message that never fits the budget degrades to watchdog-only
+    /// semantics instead of redelivering forever. Cleared on any resolve for
+    /// the key that carried no timeout, and on pin eviction, so the map is
+    /// bounded like the pin table.
+    timeout_attempts: HashMap<String, u32>,
 }
 
 impl PinTable {
@@ -103,6 +113,7 @@ impl PinTable {
             stash: Stash::new(),
             eager_pending: HashMap::new(),
             eager_accepted: HashMap::new(),
+            timeout_attempts: HashMap::new(),
         }
     }
 }
@@ -125,6 +136,7 @@ struct WorkerSubBatchBuilder {
     messages: Vec<SerializedKafkaMessage>,
     routing_keys: Vec<String>,
     key_offsets: Vec<KeyOffset>,
+    unbudgeted: bool,
 }
 
 impl WorkerSubBatchBuilder {
@@ -147,7 +159,11 @@ impl WorkerAssignments {
         Self::default()
     }
 
-    fn add_group(&mut self, worker: WorkerId, group: MessageGroup) {
+    /// `escalated` marks the group's key as past the unbudgeted-resend
+    /// threshold; one escalated group makes the whole sub-batch unbudgeted,
+    /// which is benign for the co-packed groups (they just keep today's
+    /// watchdog-only semantics for one send).
+    fn add_group(&mut self, worker: WorkerId, group: MessageGroup, escalated: bool) {
         let builder = self
             .by_worker
             .entry(worker)
@@ -155,7 +171,9 @@ impl WorkerAssignments {
                 messages: Vec::new(),
                 routing_keys: Vec::new(),
                 key_offsets: Vec::new(),
+                unbudgeted: false,
             });
+        builder.unbudgeted |= escalated;
 
         // Only keyed messages participate in the key-order sentinel: an
         // unkeyed message lives on an arbitrary partition and is grouped under
@@ -204,6 +222,7 @@ impl WorkerAssignments {
                 messages: builder.messages,
                 routing_keys: builder.routing_keys,
                 key_offsets: builder.key_offsets,
+                unbudgeted: builder.unbudgeted,
             })
             .collect()
     }
@@ -246,6 +265,9 @@ pub struct Dispatcher {
     /// key's new group defers behind its un-acked send instead of riding the
     /// pin onto the worker stream. See `set_per_key_serialization`.
     per_key_serialization: AtomicBool,
+    /// Consecutive timed-out attempts after which a key's resend goes out
+    /// unbudgeted. 0 never escalates. See `set_unbudgeted_resend_attempts`.
+    unbudgeted_resend_attempts: AtomicU32,
 }
 
 impl Dispatcher {
@@ -265,6 +287,7 @@ impl Dispatcher {
             debug_recorder: None,
             eager_flush_tx: Mutex::new(None),
             per_key_serialization: AtomicBool::new(false),
+            unbudgeted_resend_attempts: AtomicU32::new(0),
         }
     }
 
@@ -284,6 +307,7 @@ impl Dispatcher {
             debug_recorder: None,
             eager_flush_tx: Mutex::new(None),
             per_key_serialization: AtomicBool::new(false),
+            unbudgeted_resend_attempts: AtomicU32::new(0),
         }
     }
 
@@ -326,6 +350,17 @@ impl Dispatcher {
     /// order. Must be on while a sub-batch soft budget is sent.
     pub fn set_per_key_serialization(&self, enabled: bool) {
         self.per_key_serialization.store(enabled, Ordering::Relaxed);
+    }
+
+    /// After this many consecutive timed-out attempts, a key's resend goes
+    /// out unbudgeted (the sub-batch is marked and the transport stamps
+    /// `soft_budget_ms = 0`), degrading that message to watchdog-only
+    /// semantics. Without it, a message that never fits the budget would
+    /// redeliver forever — the deferral path has no attempt cap. 0 disables
+    /// escalation.
+    pub fn set_unbudgeted_resend_attempts(&self, attempts: u32) {
+        self.unbudgeted_resend_attempts
+            .store(attempts, Ordering::Relaxed);
     }
 
     /// Point-in-time load/pin/stash snapshot for the debug UI.
@@ -463,7 +498,7 @@ impl Dispatcher {
                         &group.messages,
                         SendKind::Fresh,
                     );
-                    assignments.add_group(worker, group);
+                    assignments.add_group(worker, group, false);
                 }
                 Some(worker) => {
                     // Pinned to a draining/dead worker, the key already has
@@ -570,7 +605,7 @@ impl Dispatcher {
             );
             self.key_sentinel
                 .note_sent(&group.routing_key, &group.messages, SendKind::Fresh);
-            assignments.add_group(worker, group);
+            assignments.add_group(worker, group, false);
         }
         drop(router);
 
@@ -836,6 +871,7 @@ impl Dispatcher {
             .map(|w| (w.clone(), table.in_flight.get(w).copied().unwrap_or(0)))
             .collect();
         let mut assignments = WorkerAssignments::new();
+        let escalation_threshold = self.unbudgeted_resend_attempts.load(Ordering::Relaxed);
 
         let mut router = self.router.lock().unwrap();
         for group in groups {
@@ -883,12 +919,18 @@ impl Dispatcher {
             }
             self.key_sentinel
                 .note_sent(&group.routing_key, &group.messages, SendKind::Resend);
+            let escalated =
+                escalated_key(&table.timeout_attempts, &group.routing_key, escalation_threshold);
+            if escalated {
+                counter!("ingestion_consumer_budget_escalations_total").increment(1);
+            }
             assignments.add_group(
                 worker,
                 MessageGroup {
                     routing_key: group.routing_key,
                     messages: group.messages,
                 },
+                escalated,
             );
         }
         drop(router);
@@ -948,6 +990,13 @@ impl Dispatcher {
         send_failed: bool,
     ) {
         let mut table = self.pin_table.lock().unwrap();
+        if !send_failed {
+            // A full ack means every message fit the budget: escalation
+            // counts restart. A failed send says nothing about the budget.
+            for key in routing_keys {
+                table.timeout_attempts.remove(key);
+            }
+        }
         self.resolve_locked(
             &mut table,
             worker,
@@ -992,7 +1041,13 @@ impl Dispatcher {
         let mut table = self.pin_table.lock().unwrap();
         let GroupedMessages { groups, .. } = group_messages_by_routing_key(timed_out);
         let deferred_count = groups.len() as u64;
+        let mut timed_out_keys: Vec<String> = Vec::with_capacity(groups.len());
         for group in groups {
+            *table
+                .timeout_attempts
+                .entry(group.routing_key.clone())
+                .or_insert(0) += 1;
+            timed_out_keys.push(group.routing_key.clone());
             table.stash.defer(
                 batch_id,
                 DeferredGroup {
@@ -1000,6 +1055,13 @@ impl Dispatcher {
                     messages: group.messages,
                 },
             );
+        }
+        // A key that completed this round fits the budget again: its
+        // escalation count restarts.
+        for key in routing_keys {
+            if !timed_out_keys.iter().any(|timed| timed == key) {
+                table.timeout_attempts.remove(key);
+            }
         }
         if deferred_count > 0 {
             counter!(
@@ -1080,6 +1142,7 @@ impl Dispatcher {
                 pin.ref_count = pin.ref_count.saturating_sub(1);
                 if pin.ref_count == 0 && !still_deferring {
                     table.pins.remove(key);
+                    table.timeout_attempts.remove(key);
                     // All sends for the key resolved and nothing is deferred —
                     // its order-sentinel history has nothing left to check.
                     self.key_sentinel.evict(key);
@@ -1177,6 +1240,14 @@ impl Dispatcher {
             }
             self.key_sentinel
                 .note_sent(key, &messages, SendKind::Resend);
+            let escalated = escalated_key(
+                &table.timeout_attempts,
+                key,
+                self.unbudgeted_resend_attempts.load(Ordering::Relaxed),
+            );
+            if escalated {
+                counter!("ingestion_consumer_budget_escalations_total").increment(1);
+            }
             let mut assignments = WorkerAssignments::new();
             assignments.add_group(
                 worker.clone(),
@@ -1184,6 +1255,7 @@ impl Dispatcher {
                     routing_key: key.clone(),
                     messages,
                 },
+                escalated,
             );
             *table.in_flight.entry(worker.clone()).or_insert(0) += message_count;
             *table.eager_pending.entry(owning_batch.clone()).or_insert(0) += 1;
@@ -1279,6 +1351,11 @@ fn sticky_pin_for(
         return None;
     }
     Some(worker)
+}
+
+/// Whether the key reached the unbudgeted-resend threshold (0 disables).
+fn escalated_key(attempts: &HashMap<String, u32>, routing_key: &str, threshold: u32) -> bool {
+    threshold > 0 && attempts.get(routing_key).is_some_and(|&n| n >= threshold)
 }
 
 /// Add `count` to a worker's working load for this round, if it is a candidate.
@@ -1458,6 +1535,7 @@ mod tests {
                 routing_key: "tok:user-1".to_string(),
                 messages: make_msgs(&["tok:user-1"]),
             },
+                false,
         );
         assignments.add_group(
             wid(1),
@@ -1465,6 +1543,7 @@ mod tests {
                 routing_key: "tok:user-2".to_string(),
                 messages: make_msgs(&["tok:user-2"]),
             },
+                false,
         );
 
         assert_eq!(
@@ -1494,6 +1573,7 @@ mod tests {
                 routing_key: "tok:user-1".to_string(),
                 messages: vec![make_msg_at("tok:user-1", 100)],
             },
+                false,
         );
         let sub_batches = assignments.into_sub_batches();
         assert_eq!(sub_batches[0].key_offsets.len(), 1);
@@ -1508,6 +1588,7 @@ mod tests {
                 routing_key: ":7:42".to_string(),
                 messages: vec![make_unkeyed_msg()],
             },
+                false,
         );
         assert!(assignments.into_sub_batches()[0].key_offsets.is_empty());
     }
@@ -2359,6 +2440,62 @@ mod tests {
         let newer = dispatcher.flush_deferred("batch-2");
         assert_eq!(newer.len(), 1);
         assert_eq!(newer[0].messages[0].offset, 4);
+    }
+
+    #[test]
+    fn test_repeated_timeouts_escalate_the_resend_to_unbudgeted() {
+        // A message that never fits the budget must not redeliver forever: at
+        // the threshold its resend goes out unbudgeted, degrading that one
+        // send to watchdog-only semantics.
+        let dispatcher = Dispatcher::new(healthy_registry(1));
+        dispatcher.set_per_key_serialization(true);
+        dispatcher.set_unbudgeted_resend_attempts(2);
+        dispatcher.register_batch("batch-1");
+
+        let b1 = dispatcher.assign("batch-1", vec![make_msg_at("t:a", 1)]);
+        let worker = b1[0].worker.clone();
+
+        // First timeout: the retry keeps its budget.
+        dispatcher.on_sub_batch_partial(
+            "batch-1",
+            &worker,
+            1,
+            &b1[0].routing_keys,
+            vec![make_msg_at("t:a", 1)],
+            false,
+        );
+        let retry = dispatcher.flush_deferred("batch-1");
+        assert!(
+            !retry[0].unbudgeted,
+            "below the threshold the resend keeps its budget"
+        );
+
+        // Second timeout reaches the threshold: the resend escalates.
+        dispatcher.on_sub_batch_partial(
+            "batch-1",
+            &retry[0].worker,
+            1,
+            &retry[0].routing_keys,
+            vec![make_msg_at("t:a", 1)],
+            true,
+        );
+        let escalated = dispatcher.flush_deferred("batch-1");
+        assert!(
+            escalated[0].unbudgeted,
+            "at the threshold the resend goes out unbudgeted"
+        );
+
+        // The unbudgeted send completes: the key fully resolves and its
+        // escalation state clears with the pin.
+        dispatcher.on_sub_batch_acked(&escalated[0].key_offsets);
+        dispatcher.on_sub_batch_resolved(
+            &escalated[0].worker,
+            1,
+            &escalated[0].routing_keys,
+            true,
+            false,
+        );
+        assert_eq!(dispatcher.pin_count(), 0);
     }
 
     #[test]

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -27,6 +27,31 @@ pub struct KeyOffset {
     pub max_offset: i64,
 }
 
+/// Per-key max offsets over the keyed messages of `messages`, for advancing
+/// the order sentinel's ACK watermarks. On a partial ack the caller passes
+/// only the completed subset: the full sub-batch's precomputed offsets would
+/// advance a watermark past unprocessed offsets, and the remainder's
+/// redelivery would then flag as a resend-after-ack violation.
+pub fn key_offsets_of(messages: &[SerializedKafkaMessage]) -> Vec<KeyOffset> {
+    let mut max_offsets: HashMap<&str, i64> = HashMap::new();
+    for message in messages {
+        let Some(key) = message.key.as_deref() else {
+            continue;
+        };
+        let entry = max_offsets.entry(key).or_insert(message.offset);
+        if message.offset > *entry {
+            *entry = message.offset;
+        }
+    }
+    max_offsets
+        .into_iter()
+        .map(|(routing_key, max_offset)| KeyOffset {
+            routing_key: routing_key.to_string(),
+            max_offset,
+        })
+        .collect()
+}
+
 /// A slice of a batch assigned to one worker, carrying the messages and the
 /// routing keys they belong to. Routing keys are needed to decrement pin
 /// ref-counts when the sub-batch resolves.
@@ -923,7 +948,99 @@ impl Dispatcher {
         send_failed: bool,
     ) {
         let mut table = self.pin_table.lock().unwrap();
+        self.resolve_locked(
+            &mut table,
+            worker,
+            message_count,
+            routing_keys,
+            clears_deferral,
+            send_failed,
+        );
+        drop(table);
 
+        record_if(&self.debug_recorder, || DebugEventKind::SubBatchResolved {
+            worker: worker.to_string(),
+            messages: message_count,
+            routing_keys: routing_keys.len(),
+            cleared_deferral: clears_deferral,
+        });
+    }
+
+    /// Resolve a partially acked sub-batch: stash the timed-out remainder for
+    /// redelivery, then settle the send, in one lock scope so no newer
+    /// assignment can slip between the stash and the ref-count drop. The
+    /// stash entry queues at the owning batch's sequence, ahead of any newer
+    /// group the key deferred meanwhile, and the resolve's eager release
+    /// re-routes the remainder immediately (the send did not fail, so there
+    /// is no flapping-worker loop to avoid).
+    ///
+    /// Sound only under per-key serialization: with two in-flight sub-batches
+    /// for one key, the newer one may already carry the key's later messages,
+    /// and the stashed remainder would replay behind them.
+    pub fn on_sub_batch_partial(
+        &self,
+        batch_id: &str,
+        worker: &WorkerId,
+        message_count: usize,
+        routing_keys: &[String],
+        timed_out: Vec<SerializedKafkaMessage>,
+        clears_deferral: bool,
+    ) {
+        counter!("ingestion_consumer_messages_timed_out_total")
+            .increment(timed_out.len() as u64);
+
+        let mut table = self.pin_table.lock().unwrap();
+        let GroupedMessages { groups, .. } = group_messages_by_routing_key(timed_out);
+        let deferred_count = groups.len() as u64;
+        for group in groups {
+            table.stash.defer(
+                batch_id,
+                DeferredGroup {
+                    routing_key: group.routing_key,
+                    messages: group.messages,
+                },
+            );
+        }
+        if deferred_count > 0 {
+            counter!(
+                "ingestion_consumer_dispatcher_deferred_groups_total",
+                "reason" => "timed_out",
+            )
+            .increment(deferred_count);
+            record_if(&self.debug_recorder, || DebugEventKind::Deferred {
+                batch_id: batch_id.to_string(),
+                reason: "timed_out",
+                groups: deferred_count,
+            });
+        }
+        record_stash_gauges(&table.stash);
+        self.resolve_locked(
+            &mut table,
+            worker,
+            message_count,
+            routing_keys,
+            clears_deferral,
+            false,
+        );
+        drop(table);
+
+        record_if(&self.debug_recorder, || DebugEventKind::SubBatchResolved {
+            worker: worker.to_string(),
+            messages: message_count,
+            routing_keys: routing_keys.len(),
+            cleared_deferral: clears_deferral,
+        });
+    }
+
+    fn resolve_locked(
+        &self,
+        table: &mut PinTable,
+        worker: &WorkerId,
+        message_count: usize,
+        routing_keys: &[String],
+        clears_deferral: bool,
+        send_failed: bool,
+    ) {
         let now_zero = match table.in_flight.get_mut(worker) {
             Some(load) => {
                 *load = load.saturating_sub(message_count);
@@ -979,7 +1096,7 @@ impl Dispatcher {
 
         if let Some(tx) = eager_tx {
             if !release_keys.is_empty() {
-                self.release_next_groups(&mut table, &tx, &release_keys);
+                self.release_next_groups(table, &tx, &release_keys);
             }
         }
 
@@ -992,14 +1109,6 @@ impl Dispatcher {
         }
 
         gauge!("ingestion_consumer_dispatcher_pins_total").set(table.pins.len() as f64);
-        drop(table);
-
-        record_if(&self.debug_recorder, || DebugEventKind::SubBatchResolved {
-            worker: worker.to_string(),
-            messages: message_count,
-            routing_keys: routing_keys.len(),
-            cleared_deferral: clears_deferral,
-        });
     }
 
     /// Record the outcome of a send attempt for passive health tracking.
@@ -2170,6 +2279,120 @@ mod tests {
         let flush = rx.try_recv().expect("the ack releases the held group");
         assert_eq!(flush.batch_id, "batch-2");
         assert_eq!(flush.sub_batch.messages[0].offset, 2);
+    }
+
+    #[test]
+    fn test_key_offsets_of_takes_max_offset_of_keyed_messages() {
+        let mut offsets = key_offsets_of(&[
+            make_msg_at("t:a", 5),
+            make_msg_at("t:a", 3),
+            make_unkeyed_msg(),
+        ]);
+        assert_eq!(offsets.len(), 1, "unkeyed messages carry no watermark");
+        let offset = offsets.pop().unwrap();
+        assert_eq!(offset.routing_key, "t:a");
+        assert_eq!(offset.max_offset, 5);
+    }
+
+    #[test]
+    fn test_partial_resolve_releases_completed_keys_and_stashes_the_remainder() {
+        // A partial ack must release the fully-completed keys (pin evicted,
+        // new groups route fresh) while the timed-out remainder stays owned
+        // by its batch and replays ahead of the key's newer groups.
+        let dispatcher = Dispatcher::new(healthy_registry(1));
+        dispatcher.set_per_key_serialization(true);
+        dispatcher.register_batch("batch-1");
+        dispatcher.register_batch("batch-2");
+
+        let b1 = dispatcher.assign(
+            "batch-1",
+            vec![
+                make_msg_at("t:a", 1),
+                make_msg_at("t:a", 2),
+                make_msg_at("t:b", 3),
+            ],
+        );
+        assert_eq!(b1.len(), 1, "one worker takes the whole batch");
+        let worker = b1[0].worker.clone();
+
+        // The budget cut t:a's second message; t:a offset 1 and t:b completed.
+        dispatcher.on_sub_batch_acked(&key_offsets_of(&[
+            make_msg_at("t:a", 1),
+            make_msg_at("t:b", 3),
+        ]));
+        dispatcher.on_sub_batch_partial(
+            "batch-1",
+            &worker,
+            3,
+            &b1[0].routing_keys,
+            vec![make_msg_at("t:a", 2)],
+            false,
+        );
+
+        assert_eq!(dispatcher.stashed_messages(), 1);
+        assert_eq!(dispatcher.total_in_flight(), 0);
+        assert!(dispatcher.has_deferred("batch-1"));
+
+        // t:b resolved fully, so a new group routes immediately; t:a still
+        // has the stashed remainder, so a new group defers behind it.
+        let b2 = dispatcher.assign(
+            "batch-2",
+            vec![make_msg_at("t:a", 4), make_msg_at("t:b", 5)],
+        );
+        assert_eq!(b2.len(), 1);
+        assert_eq!(b2[0].routing_keys, vec!["t:b".to_string()]);
+        assert_eq!(dispatcher.stashed_messages(), 2);
+
+        // The completion-time flush replays the remainder first, then the
+        // newer group.
+        let replay = dispatcher.flush_deferred("batch-1");
+        assert_eq!(replay.len(), 1);
+        assert_eq!(replay[0].messages[0].offset, 2);
+        dispatcher.on_sub_batch_acked(&replay[0].key_offsets);
+        dispatcher.on_sub_batch_resolved(
+            &replay[0].worker,
+            1,
+            &replay[0].routing_keys,
+            true,
+            false,
+        );
+        let newer = dispatcher.flush_deferred("batch-2");
+        assert_eq!(newer.len(), 1);
+        assert_eq!(newer[0].messages[0].offset, 4);
+    }
+
+    #[test]
+    fn test_partial_resolve_eagerly_redelivers_the_remainder() {
+        // With eager flushing on, the timed-out remainder re-routes the
+        // moment the partial ack resolves, without waiting for the owning
+        // batch's completion-time flush.
+        let dispatcher = Dispatcher::new(healthy_registry(1));
+        dispatcher.set_per_key_serialization(true);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        dispatcher.set_eager_flush_sender(tx);
+        dispatcher.register_batch("batch-1");
+
+        let b1 = dispatcher.assign(
+            "batch-1",
+            vec![make_msg_at("t:a", 1), make_msg_at("t:a", 2)],
+        );
+        dispatcher.on_sub_batch_acked(&key_offsets_of(&[make_msg_at("t:a", 1)]));
+        dispatcher.on_sub_batch_partial(
+            "batch-1",
+            &b1[0].worker,
+            2,
+            &b1[0].routing_keys,
+            vec![make_msg_at("t:a", 2)],
+            false,
+        );
+
+        let flush = rx.try_recv().expect("remainder released at ack speed");
+        assert_eq!(flush.batch_id, "batch-1");
+        assert_eq!(flush.sub_batch.messages[0].offset, 2);
+        assert!(
+            dispatcher.has_unfinished_flush("batch-1"),
+            "the batch waits on the redelivery"
+        );
     }
 
     #[test]

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -687,7 +687,9 @@ impl Dispatcher {
             batch_id: batch_id.to_string(),
             routing_keys,
             sub_batches: assignments.sub_batch_infos(),
-            deferred_groups: drain_deferred_count + cascade_deferred_count + serialized_deferred_count,
+            deferred_groups: drain_deferred_count
+                + cascade_deferred_count
+                + serialized_deferred_count,
             unroutable_groups: unroutable_deferred_count,
         });
 
@@ -919,8 +921,11 @@ impl Dispatcher {
             }
             self.key_sentinel
                 .note_sent(&group.routing_key, &group.messages, SendKind::Resend);
-            let escalated =
-                escalated_key(&table.timeout_attempts, &group.routing_key, escalation_threshold);
+            let escalated = escalated_key(
+                &table.timeout_attempts,
+                &group.routing_key,
+                escalation_threshold,
+            );
             if escalated {
                 counter!("ingestion_consumer_budget_escalations_total").increment(1);
             }
@@ -1035,8 +1040,7 @@ impl Dispatcher {
         timed_out: Vec<SerializedKafkaMessage>,
         clears_deferral: bool,
     ) {
-        counter!("ingestion_consumer_messages_timed_out_total")
-            .increment(timed_out.len() as u64);
+        counter!("ingestion_consumer_messages_timed_out_total").increment(timed_out.len() as u64);
 
         let mut table = self.pin_table.lock().unwrap();
         let GroupedMessages { groups, .. } = group_messages_by_routing_key(timed_out);
@@ -1535,7 +1539,7 @@ mod tests {
                 routing_key: "tok:user-1".to_string(),
                 messages: make_msgs(&["tok:user-1"]),
             },
-                false,
+            false,
         );
         assignments.add_group(
             wid(1),
@@ -1543,7 +1547,7 @@ mod tests {
                 routing_key: "tok:user-2".to_string(),
                 messages: make_msgs(&["tok:user-2"]),
             },
-                false,
+            false,
         );
 
         assert_eq!(
@@ -1573,7 +1577,7 @@ mod tests {
                 routing_key: "tok:user-1".to_string(),
                 messages: vec![make_msg_at("tok:user-1", 100)],
             },
-                false,
+            false,
         );
         let sub_batches = assignments.into_sub_batches();
         assert_eq!(sub_batches[0].key_offsets.len(), 1);
@@ -1588,7 +1592,7 @@ mod tests {
                 routing_key: ":7:42".to_string(),
                 messages: vec![make_unkeyed_msg()],
             },
-                false,
+            false,
         );
         assert!(assignments.into_sub_batches()[0].key_offsets.is_empty());
     }

--- a/rust/ingestion-consumer/src/dispatcher.rs
+++ b/rust/ingestion-consumer/src/dispatcher.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use k8s_awareness::PeerTracker;
@@ -216,6 +217,10 @@ pub struct Dispatcher {
     /// Channel to the consumer's eager-flush send task. `None` disables eager
     /// release (the completion-time flush then does all the draining).
     eager_flush_tx: Mutex<Option<UnboundedSender<EagerFlush>>>,
+    /// Hold every routing key to at most one in-flight sub-batch: a pinned
+    /// key's new group defers behind its un-acked send instead of riding the
+    /// pin onto the worker stream. See `set_per_key_serialization`.
+    per_key_serialization: AtomicBool,
 }
 
 impl Dispatcher {
@@ -234,6 +239,7 @@ impl Dispatcher {
             aperture: None,
             debug_recorder: None,
             eager_flush_tx: Mutex::new(None),
+            per_key_serialization: AtomicBool::new(false),
         }
     }
 
@@ -252,6 +258,7 @@ impl Dispatcher {
             aperture: None,
             debug_recorder: None,
             eager_flush_tx: Mutex::new(None),
+            per_key_serialization: AtomicBool::new(false),
         }
     }
 
@@ -280,6 +287,20 @@ impl Dispatcher {
     /// batch's completion-time flush.
     pub fn set_eager_flush_sender(&self, tx: UnboundedSender<EagerFlush>) {
         *self.eager_flush_tx.lock().unwrap() = Some(tx);
+    }
+
+    /// Hold every routing key to at most one in-flight sub-batch. With the
+    /// hold on, a pinned key's new group defers behind its un-acked send, and
+    /// the eager release chains the key's groups at ack speed instead of
+    /// pipelining them onto the worker stream.
+    ///
+    /// This is the ordering precondition for partial acks: when two
+    /// sub-batches of one key are in flight and the older one is acked
+    /// PARTIAL, its timed-out remainder would redeliver behind the newer
+    /// sub-batch's completed messages and the key's writes would land out of
+    /// order. Must be on while a sub-batch soft budget is sent.
+    pub fn set_per_key_serialization(&self, enabled: bool) {
+        self.per_key_serialization.store(enabled, Ordering::Relaxed);
     }
 
     /// Point-in-time load/pin/stash snapshot for the debug UI.
@@ -395,13 +416,16 @@ impl Dispatcher {
         let mut unpinned_groups: Vec<MessageGroup> = Vec::new();
         let mut drain_deferred_count = 0u64;
         let mut cascade_deferred_count = 0u64;
+        let mut serialized_deferred_count = 0u64;
         let mut unroutable_deferred_count = 0u64;
+        let serialize_keys = self.per_key_serialization.load(Ordering::Relaxed);
 
         for group in key_groups {
             let pinned_worker = table.pins.get(&group.routing_key).map(|p| p.worker.clone());
             match pinned_worker {
                 Some(worker)
-                    if !table.stash.is_deferring(&group.routing_key)
+                    if !serialize_keys
+                        && !table.stash.is_deferring(&group.routing_key)
                         && !self.registry.is_dead(&worker)
                         && !self.registry.is_draining(&worker) =>
                 {
@@ -416,16 +440,23 @@ impl Dispatcher {
                     );
                     assignments.add_group(worker, group);
                 }
-                Some(_) => {
-                    // Pinned to a draining/dead worker, or the key already has
-                    // deferred groups pending — defer so newer messages can't
-                    // race ahead of the key's earlier in-flight/deferred ones.
-                    // A key that is already deferring counts as cascade
-                    // (queued behind its own deferred work) regardless of the
-                    // pinned worker's state, so the seed (drain) and the
-                    // amplification (cascade) are measured separately.
+                Some(worker) => {
+                    // Pinned to a draining/dead worker, the key already has
+                    // deferred groups pending, or per-key serialization holds
+                    // the key behind its un-acked send — defer so newer
+                    // messages can't race ahead of the key's earlier
+                    // in-flight/deferred ones. A key that is already deferring
+                    // counts as cascade (queued behind its own deferred work)
+                    // regardless of the pinned worker's state, so the seed
+                    // (drain) and the amplification (cascade) are measured
+                    // separately.
                     if table.stash.is_deferring(&group.routing_key) {
                         cascade_deferred_count += 1;
+                    } else if serialize_keys
+                        && !self.registry.is_dead(&worker)
+                        && !self.registry.is_draining(&worker)
+                    {
+                        serialized_deferred_count += 1;
                     } else {
                         drain_deferred_count += 1;
                     }
@@ -547,6 +578,13 @@ impl Dispatcher {
             )
             .increment(cascade_deferred_count);
         }
+        if serialized_deferred_count > 0 {
+            counter!(
+                "ingestion_consumer_dispatcher_deferred_groups_total",
+                "reason" => "serialized",
+            )
+            .increment(serialized_deferred_count);
+        }
         if unroutable_deferred_count > 0 {
             counter!(
                 "ingestion_consumer_dispatcher_deferred_groups_total",
@@ -571,6 +609,13 @@ impl Dispatcher {
                 groups: cascade_deferred_count,
             });
         }
+        if serialized_deferred_count > 0 {
+            record_if(&self.debug_recorder, || DebugEventKind::Deferred {
+                batch_id: batch_id.to_string(),
+                reason: "serialized",
+                groups: serialized_deferred_count,
+            });
+        }
         if unroutable_deferred_count > 0 {
             record_if(&self.debug_recorder, || DebugEventKind::Deferred {
                 batch_id: batch_id.to_string(),
@@ -582,7 +627,7 @@ impl Dispatcher {
             batch_id: batch_id.to_string(),
             routing_keys,
             sub_batches: assignments.sub_batch_infos(),
-            deferred_groups: drain_deferred_count + cascade_deferred_count,
+            deferred_groups: drain_deferred_count + cascade_deferred_count + serialized_deferred_count,
             unroutable_groups: unroutable_deferred_count,
         });
 
@@ -2069,6 +2114,62 @@ mod tests {
             assert!(!dispatcher.has_unfinished_flush(batch));
             assert_eq!(dispatcher.take_eager_accepted(batch), 1);
         }
+    }
+
+    #[test]
+    fn test_serialized_key_holds_new_groups_until_the_send_resolves() {
+        // The one-in-flight-sub-batch-per-key hold: with serialization on, a
+        // pinned key's next group must not ride the pin onto the stream while
+        // the previous send is un-acked. This is the ordering precondition
+        // for partial-ack redelivery.
+        let dispatcher = Dispatcher::new(healthy_registry(1));
+        dispatcher.set_per_key_serialization(true);
+        dispatcher.register_batch("batch-1");
+        dispatcher.register_batch("batch-2");
+
+        let b1 = dispatcher.assign("batch-1", vec![make_msg_at("t:a", 1)]);
+        assert_eq!(b1.len(), 1, "fresh key routes immediately");
+
+        let b2 = dispatcher.assign(
+            "batch-2",
+            vec![make_msg_at("t:a", 2), make_msg_at("t:b", 3)],
+        );
+        assert_eq!(b2.len(), 1, "only the fresh key routes");
+        assert_eq!(b2[0].routing_keys, vec!["t:b".to_string()]);
+        assert_eq!(
+            dispatcher.stashed_messages(),
+            1,
+            "the pinned key holds behind its un-acked send"
+        );
+
+        dispatcher.on_sub_batch_acked(&b1[0].key_offsets);
+        dispatcher.on_sub_batch_resolved(&b1[0].worker, 1, &b1[0].routing_keys, false, false);
+        let flushed = dispatcher.flush_deferred("batch-2");
+        assert_eq!(flushed.len(), 1, "the held group flushes after the ack");
+        assert_eq!(flushed[0].messages[0].offset, 2);
+    }
+
+    #[test]
+    fn test_serialized_hold_releases_eagerly_at_ack() {
+        // With the hold on, a hot key's consecutive groups drain at ack speed
+        // through the eager release instead of pipelining onto the stream.
+        let dispatcher = Dispatcher::new(healthy_registry(1));
+        dispatcher.set_per_key_serialization(true);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        dispatcher.set_eager_flush_sender(tx);
+        dispatcher.register_batch("batch-1");
+        dispatcher.register_batch("batch-2");
+
+        let b1 = dispatcher.assign("batch-1", vec![make_msg_at("t:a", 1)]);
+        assert!(dispatcher
+            .assign("batch-2", vec![make_msg_at("t:a", 2)])
+            .is_empty());
+
+        dispatcher.on_sub_batch_acked(&b1[0].key_offsets);
+        dispatcher.on_sub_batch_resolved(&b1[0].worker, 1, &b1[0].routing_keys, false, false);
+        let flush = rx.try_recv().expect("the ack releases the held group");
+        assert_eq!(flush.batch_id, "batch-2");
+        assert_eq!(flush.sub_batch.messages[0].offset, 2);
     }
 
     #[test]

--- a/rust/ingestion-consumer/src/grpc_transport.rs
+++ b/rust/ingestion-consumer/src/grpc_transport.rs
@@ -195,16 +195,38 @@ struct WorkerStreamItem {
     messages: Vec<SerializedKafkaMessage>,
     replay: bool,
     /// Send this frame with `soft_budget_ms = 0` regardless of the configured
-    /// budget. Set for every chunk of a size-split sub-batch: chunks are
-    /// separate frames with separate budgets on the worker, so a budget cut in
-    /// one chunk while a later chunk carries the same routing key would let
-    /// the key's newer messages complete ahead of its timed-out older ones.
+    /// budget. Set for an escalated resend, and for every chunk of a
+    /// size-split sub-batch: chunks are separate frames with separate budgets
+    /// on the worker, so a budget cut in one chunk while a later chunk
+    /// carries the same routing key would let the key's newer messages
+    /// complete ahead of its timed-out older ones.
     unbudgeted: bool,
     reply: oneshot::Sender<StreamReply>,
 }
 
 struct WorkerStream {
     tx: mpsc::UnboundedSender<WorkerStreamItem>,
+}
+
+/// Per-send options for [`GrpcTransport::begin_send`].
+#[derive(Clone, Copy, Default)]
+pub struct SendOptions {
+    /// The send may repeat previously delivered messages (a retry or flush
+    /// path); the worker's sentinel counts repeats as replays.
+    pub replay: bool,
+    /// Send with `soft_budget_ms = 0` regardless of the configured budget:
+    /// the escalation path for messages that repeatedly outlive it.
+    pub unbudgeted: bool,
+}
+
+impl SendOptions {
+    /// A replaying send with the configured budget (the common retry shape).
+    pub fn replay() -> Self {
+        Self {
+            replay: true,
+            unbudgeted: false,
+        }
+    }
 }
 
 /// How a worker's gRPC address is derived from its HTTP URL.
@@ -296,7 +318,7 @@ impl GrpcTransport {
         worker_url: &str,
         batch_id: &str,
         messages: Vec<SerializedKafkaMessage>,
-        replay: bool,
+        options: SendOptions,
     ) -> PendingWorkerStreamSend {
         let chunks = split_by_size(messages, self.max_body_bytes);
         if chunks.len() > 1 {
@@ -306,7 +328,7 @@ impl GrpcTransport {
             )
             .increment((chunks.len() - 1) as u64);
         }
-        let split = chunks.len() > 1;
+        let unbudgeted = options.unbudgeted || chunks.len() > 1;
         let stream = self.worker_stream_for(worker_url);
         let receivers = chunks
             .into_iter()
@@ -315,8 +337,8 @@ impl GrpcTransport {
                 let item = WorkerStreamItem {
                     batch_id: batch_id.to_string(),
                     messages,
-                    replay,
-                    unbudgeted: split,
+                    replay: options.replay,
+                    unbudgeted,
                     reply,
                 };
                 if let Err(send_err) = stream.tx.send(item) {

--- a/rust/ingestion-consumer/src/grpc_transport.rs
+++ b/rust/ingestion-consumer/src/grpc_transport.rs
@@ -43,7 +43,7 @@ use dashmap::DashMap;
 use ingestion_worker_proto::ingestion::worker::v1::worker_ingest_client::WorkerIngestClient;
 use ingestion_worker_proto::ingestion::worker::v1::{
     ingest_stream_request, ingest_stream_response, IngestStreamRequest, IngestStreamResponse,
-    KafkaMessage, StreamHello, SubBatch, SubBatchStatus,
+    KafkaMessage, StreamHello, SubBatch, SubBatchAck, SubBatchStatus,
 };
 use metrics::{counter, gauge, histogram};
 use prost::Message;
@@ -330,6 +330,10 @@ struct LedgerEntry {
     deadline: tokio::time::Instant,
     /// When the sub-batch went on the wire, for the send-to-ack latency histogram.
     sent_at: std::time::Instant,
+    /// Whether the frame carried a non-zero soft budget. Only a budgeted
+    /// frame may be acked PARTIAL; a partial ack for an unbudgeted frame is a
+    /// protocol violation and fences.
+    budgeted: bool,
     /// The worker's accepted count once acked. The entry stays in the ledger
     /// until every earlier entry is acked too, so a fence still reaches it.
     acked: Option<u32>,
@@ -550,6 +554,11 @@ impl WorkerStreamRunner {
             let Some(item) = item else { break };
             let seq = *next_seq;
             *next_seq += 1;
+            let soft_budget_ms = if item.unbudgeted {
+                0
+            } else {
+                self.soft_budget_ms
+            };
             let request = IngestStreamRequest {
                 msg: Some(ingest_stream_request::Msg::SubBatch(SubBatch {
                     seq,
@@ -557,11 +566,7 @@ impl WorkerStreamRunner {
                     messages: item.messages.iter().map(to_proto_message).collect(),
                     replay: item.replay,
                     assignment_epoch: self.assignment_epoch.load(Ordering::Relaxed),
-                    soft_budget_ms: if item.unbudgeted {
-                        0
-                    } else {
-                        self.soft_budget_ms
-                    },
+                    soft_budget_ms,
                 })),
             };
             // tonic gzips the frame after this point, so only the raw size is observable here.
@@ -574,6 +579,7 @@ impl WorkerStreamRunner {
                 item,
                 deadline,
                 sent_at: std::time::Instant::now(),
+                budgeted: soft_budget_ms > 0,
                 acked: None,
             });
             if !sent {
@@ -683,7 +689,8 @@ impl WorkerStreamRunner {
             );
             return Err(self.fence(None, ledger, queue, "sub-batch nacked"));
         }
-        if response.status != SubBatchStatus::Ok as i32 {
+        let is_partial = response.status == SubBatchStatus::Partial as i32;
+        if response.status != SubBatchStatus::Ok as i32 && !is_partial {
             // BUSY, or any status this consumer predates: transient
             // backpressure, not a fault. Fence in order (the ordered stream
             // cannot retry one sub-batch in place) but as retriable, so the
@@ -698,12 +705,43 @@ impl WorkerStreamRunner {
         }
         let was_full = ledger.len() >= self.max_unacked;
         let Some(entry) = ledger
-            .iter_mut()
+            .iter()
             .find(|e| e.seq == response.seq && e.acked.is_none())
         else {
             warn!(worker = %self.worker_url, seq = response.seq, "Ack for unknown seq — fencing worker stream");
             return Err(self.fence(None, ledger, queue, "unknown ack seq"));
         };
+        // Fail closed on the disposition shape: proto3 cannot distinguish an
+        // unset list from an empty one, so acceptance is never derived from
+        // `timed_out` without these checks — a worker bug becomes a fence and
+        // a replay instead of silently lost messages.
+        if let Some(reason) = ack_shape_error(entry.item.messages.len(), entry.budgeted, &response)
+        {
+            warn!(
+                worker = %self.worker_url,
+                seq = response.seq,
+                status = response.status,
+                reason,
+                "Invalid ack shape — fencing worker stream"
+            );
+            return Err(self.fence(None, ledger, queue, reason));
+        }
+        if is_partial {
+            // Fence in order as retriable: the whole sub-batch, acked prefix
+            // included, replays through the deferral path, which is ordinary
+            // at-least-once redelivery.
+            warn!(
+                worker = %self.worker_url,
+                seq = response.seq,
+                timed_out = response.timed_out.len(),
+                "Partial ack — fencing worker stream as retriable"
+            );
+            return Err(self.fence_with(true, None, ledger, queue, "partial ack"));
+        }
+        let entry = ledger
+            .iter_mut()
+            .find(|e| e.seq == response.seq && e.acked.is_none())
+            .expect("entry found above");
         entry.acked = Some(response.accepted);
         self.record_send_duration(entry);
         counter!(
@@ -864,6 +902,36 @@ enum StreamEnd {
     Failed(Fence),
     /// The stream ended cleanly with nothing outstanding.
     Idle,
+}
+
+/// Validate an OK or PARTIAL ack's disposition shape against the frame it
+/// resolves, returning the fence reason on a violation. PARTIAL requires a
+/// budgeted frame, a non-empty `timed_out` list of unique in-range indices,
+/// and `accepted + timed_out.len()` covering the frame exactly; OK requires
+/// the list empty.
+fn ack_shape_error(message_count: usize, budgeted: bool, ack: &SubBatchAck) -> Option<&'static str> {
+    if ack.status != SubBatchStatus::Partial as i32 {
+        return (!ack.timed_out.is_empty()).then_some("timed_out on a non-partial ack");
+    }
+    if !budgeted {
+        // This consumer sent no budget on the frame (none configured, or a
+        // split chunk), so the worker had nothing to time out.
+        return Some("partial ack for an unbudgeted sub-batch");
+    }
+    if ack.timed_out.is_empty() {
+        return Some("partial ack with no timed_out entries");
+    }
+    let mut seen = vec![false; message_count];
+    for &index in &ack.timed_out {
+        match seen.get_mut(index as usize) {
+            Some(slot) if !*slot => *slot = true,
+            _ => return Some("partial ack with an out-of-range or duplicate index"),
+        }
+    }
+    if ack.accepted as usize + ack.timed_out.len() != message_count {
+        return Some("partial ack dispositions do not cover the sub-batch");
+    }
+    None
 }
 
 fn to_proto_message(message: &SerializedKafkaMessage) -> KafkaMessage {

--- a/rust/ingestion-consumer/src/grpc_transport.rs
+++ b/rust/ingestion-consumer/src/grpc_transport.rs
@@ -399,9 +399,16 @@ struct LedgerEntry {
     /// frame may be acked PARTIAL; a partial ack for an unbudgeted frame is a
     /// protocol violation and fences.
     budgeted: bool,
-    /// The worker's accepted count once acked. The entry stays in the ledger
-    /// until every earlier entry is acked too, so a fence still reaches it.
-    acked: Option<u32>,
+    /// The worker's ack once received. The entry stays in the ledger until
+    /// every earlier entry is acked too, so a fence still reaches it.
+    acked: Option<RecordedAck>,
+}
+
+/// A validated ack recorded in the ledger, awaiting prefix resolution.
+struct RecordedAck {
+    accepted: u32,
+    /// Chunk-local indices of timed-out messages; empty on a full ack.
+    timed_out: Vec<u32>,
 }
 
 /// An open stream: the request sender and the worker's ack stream.
@@ -792,22 +799,27 @@ impl WorkerStreamRunner {
             return Err(self.fence(None, ledger, queue, reason));
         }
         if is_partial {
-            // Fence in order as retriable: the whole sub-batch, acked prefix
-            // included, replays through the deferral path, which is ordinary
-            // at-least-once redelivery.
-            warn!(
+            counter!(
+                "ingestion_consumer_partial_acks_total",
+                "worker" => self.worker_url.clone(),
+            )
+            .increment(1);
+            info!(
                 worker = %self.worker_url,
                 seq = response.seq,
+                accepted = response.accepted,
                 timed_out = response.timed_out.len(),
-                "Partial ack — fencing worker stream as retriable"
+                "Partial ack — the budget cut off part of the sub-batch"
             );
-            return Err(self.fence_with(true, None, ledger, queue, "partial ack"));
         }
         let entry = ledger
             .iter_mut()
             .find(|e| e.seq == response.seq && e.acked.is_none())
             .expect("entry found above");
-        entry.acked = Some(response.accepted);
+        entry.acked = Some(RecordedAck {
+            accepted: response.accepted,
+            timed_out: response.timed_out,
+        });
         self.record_send_duration(entry);
         counter!(
             "ingestion_consumer_transport_requests_total",
@@ -820,13 +832,13 @@ impl WorkerStreamRunner {
         // release its keys first.
         while ledger.front().is_some_and(|e| e.acked.is_some()) {
             let entry = ledger.pop_front().expect("front is present");
-            let accepted = entry.acked.expect("front is acked");
+            let recorded = entry.acked.expect("front is acked");
             let WorkerStreamItem {
                 reply, messages, ..
             } = entry.item;
             let _ = reply.send(Ok(Accepted {
-                accepted,
-                timed_out: Vec::new(),
+                accepted: recorded.accepted,
+                timed_out: recorded.timed_out,
                 messages,
             }));
         }

--- a/rust/ingestion-consumer/src/grpc_transport.rs
+++ b/rust/ingestion-consumer/src/grpc_transport.rs
@@ -57,14 +57,27 @@ use crate::transport::{
 };
 use crate::types::SerializedKafkaMessage;
 
-/// An acked chunk: the worker's accepted count, with the messages handed
-/// back so a split send can reassemble the whole sub-batch on failure.
+/// An acked chunk: the worker's accepted count and timed-out indices
+/// (chunk-local, in send order), with the messages handed back so a split
+/// send can reassemble the whole sub-batch on failure.
 struct Accepted {
     accepted: u32,
+    timed_out: Vec<u32>,
     messages: Vec<SerializedKafkaMessage>,
 }
 
 type StreamReply = Result<Accepted, SendError>;
+
+/// Resolution of a send whose ack arrived. `accepted` counts the messages
+/// the worker processed and acked. On a partial ack, `timed_out` carries the
+/// messages the worker's budget cut off and `completed` the acked remainder,
+/// both in send order; on a full ack both are empty.
+#[derive(Debug)]
+pub struct SendOutcome {
+    pub accepted: u32,
+    pub completed: Vec<SerializedKafkaMessage>,
+    pub timed_out: Vec<SerializedKafkaMessage>,
+}
 
 /// An enqueued sub-batch awaiting its acks; resolves like an HTTP send. A
 /// sub-batch over the size cap rides the stream as several consecutive
@@ -74,13 +87,16 @@ pub struct PendingWorkerStreamSend {
 }
 
 impl PendingWorkerStreamSend {
-    /// All-or-nothing: `Ok` only when every
-    /// chunk was accepted; on any failure the `SendError` carries back the
-    /// full original message set, in order, so the caller defers all of it.
-    /// Already-accepted chunks then replay, which is ordinary at-least-once.
-    pub async fn wait(self) -> Result<u32, SendError> {
-        let mut accepted_total = 0u32;
-        let mut messages: Vec<SerializedKafkaMessage> = Vec::new();
+    /// `Ok` only when every chunk was acked; on any failure the `SendError`
+    /// carries back the full original message set, in order, so the caller
+    /// defers all of it. Already-accepted chunks then replay, which is
+    /// ordinary at-least-once. An `Ok` outcome may still be partial: the
+    /// worker's budget cut off some messages, listed in
+    /// [`SendOutcome::timed_out`] with chunk-local indices already mapped
+    /// back to sub-batch positions.
+    pub async fn wait(self) -> Result<SendOutcome, SendError> {
+        let mut resolved: Vec<Accepted> = Vec::new();
+        let mut failed_messages: Vec<SerializedKafkaMessage> = Vec::new();
         let mut failure: Option<SendError> = None;
         for rx in self.chunks {
             let reply = match rx.await {
@@ -96,12 +112,15 @@ impl PendingWorkerStreamSend {
                 }),
             };
             match reply {
-                Ok(accepted) => {
-                    accepted_total += accepted.accepted;
-                    messages.extend(accepted.messages);
-                }
+                Ok(accepted) if failure.is_none() => resolved.push(accepted),
+                Ok(accepted) => failed_messages.extend(accepted.messages),
                 Err(mut err) => {
-                    messages.extend(std::mem::take(&mut err.messages));
+                    // The failure set carries every chunk's messages in send
+                    // order, resolved ones included.
+                    for chunk in resolved.drain(..) {
+                        failed_messages.extend(chunk.messages);
+                    }
+                    failed_messages.extend(std::mem::take(&mut err.messages));
                     match &mut failure {
                         // Keep the first failure's error; fold later guards
                         // into it so the stream fences until all are stashed.
@@ -115,14 +134,60 @@ impl PendingWorkerStreamSend {
                 }
             }
         }
-        match failure {
-            None => Ok(accepted_total),
-            Some(mut err) => {
-                err.messages = messages;
-                Err(err)
-            }
+        if let Some(mut err) = failure {
+            err.messages = failed_messages;
+            return Err(err);
+        }
+        let accepted = resolved.iter().map(|chunk| chunk.accepted).sum();
+        if resolved.iter().all(|chunk| chunk.timed_out.is_empty()) {
+            return Ok(SendOutcome {
+                accepted,
+                completed: Vec::new(),
+                timed_out: Vec::new(),
+            });
+        }
+        let mut completed = Vec::new();
+        let mut timed_out = Vec::new();
+        for chunk in resolved {
+            let (chunk_completed, chunk_timed_out) =
+                partition_by_timed_out(chunk.messages, &chunk.timed_out);
+            completed.extend(chunk_completed);
+            timed_out.extend(chunk_timed_out);
+        }
+        Ok(SendOutcome {
+            accepted,
+            completed,
+            timed_out,
+        })
+    }
+}
+
+/// Split a chunk's messages into (completed, timed out) per the ack's
+/// chunk-local indices, preserving send order in both halves. Indices were
+/// validated against the chunk on receipt (see `ack_shape_error`).
+fn partition_by_timed_out(
+    messages: Vec<SerializedKafkaMessage>,
+    timed_out: &[u32],
+) -> (Vec<SerializedKafkaMessage>, Vec<SerializedKafkaMessage>) {
+    if timed_out.is_empty() {
+        return (messages, Vec::new());
+    }
+    let mut cut = vec![false; messages.len()];
+    for &index in timed_out {
+        if let Some(slot) = cut.get_mut(index as usize) {
+            *slot = true;
         }
     }
+    let mut completed = Vec::with_capacity(messages.len() - timed_out.len());
+    let mut timed = Vec::with_capacity(timed_out.len());
+    for (index, message) in messages.into_iter().enumerate() {
+        if cut[index] {
+            timed.push(message);
+        } else {
+            completed.push(message);
+        }
+    }
+    (completed, timed)
 }
 
 struct WorkerStreamItem {
@@ -759,7 +824,11 @@ impl WorkerStreamRunner {
             let WorkerStreamItem {
                 reply, messages, ..
             } = entry.item;
-            let _ = reply.send(Ok(Accepted { accepted, messages }));
+            let _ = reply.send(Ok(Accepted {
+                accepted,
+                timed_out: Vec::new(),
+                messages,
+            }));
         }
         if was_full && ledger.len() < self.max_unacked && !queue.is_empty() {
             counter!(

--- a/rust/ingestion-consumer/src/grpc_transport.rs
+++ b/rust/ingestion-consumer/src/grpc_transport.rs
@@ -1012,7 +1012,11 @@ enum StreamEnd {
 /// budgeted frame, a non-empty `timed_out` list of unique in-range indices,
 /// and `accepted + timed_out.len()` covering the frame exactly; OK requires
 /// the list empty.
-fn ack_shape_error(message_count: usize, budgeted: bool, ack: &SubBatchAck) -> Option<&'static str> {
+fn ack_shape_error(
+    message_count: usize,
+    budgeted: bool,
+    ack: &SubBatchAck,
+) -> Option<&'static str> {
     if ack.status != SubBatchStatus::Partial as i32 {
         return (!ack.timed_out.is_empty()).then_some("timed_out on a non-partial ack");
     }

--- a/rust/ingestion-consumer/src/grpc_transport.rs
+++ b/rust/ingestion-consumer/src/grpc_transport.rs
@@ -129,6 +129,12 @@ struct WorkerStreamItem {
     batch_id: String,
     messages: Vec<SerializedKafkaMessage>,
     replay: bool,
+    /// Send this frame with `soft_budget_ms = 0` regardless of the configured
+    /// budget. Set for every chunk of a size-split sub-batch: chunks are
+    /// separate frames with separate budgets on the worker, so a budget cut in
+    /// one chunk while a later chunk carries the same routing key would let
+    /// the key's newer messages complete ahead of its timed-out older ones.
+    unbudgeted: bool,
     reply: oneshot::Sender<StreamReply>,
 }
 
@@ -168,6 +174,9 @@ pub struct GrpcTransport {
     /// consecutive chunks (see `begin_send`), so no frame crosses the worker's
     /// message limit.
     max_body_bytes: usize,
+    /// Soft time budget stamped on every sub-batch frame (milliseconds).
+    /// 0 sends no budget, so the worker never times work out.
+    soft_budget_ms: u64,
 }
 
 impl GrpcTransport {
@@ -180,6 +189,7 @@ impl GrpcTransport {
             max_unacked,
             ack_timeout,
             max_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            soft_budget_ms: 0,
             assignment_epoch: Arc::new(AtomicU64::new(1)),
             probe_client: reqwest::Client::builder()
                 .timeout(readiness::PROBE_TIMEOUT)
@@ -197,6 +207,15 @@ impl GrpcTransport {
     pub fn set_max_body_bytes(&mut self, bytes: usize) {
         assert!(bytes > 0, "max_body_bytes must be > 0");
         self.max_body_bytes = bytes;
+    }
+
+    /// Set the soft time budget stamped on every sub-batch (milliseconds).
+    /// 0 sends no budget. The worker enforces what it is sent: past the
+    /// budget it stops starting new work and acks the sub-batch PARTIAL, so
+    /// size it well under the ack watchdog, which stays the hard limit.
+    /// Call before the transport is shared.
+    pub fn set_soft_budget_ms(&mut self, ms: u64) {
+        self.soft_budget_ms = ms;
     }
 
     /// Enqueue a sub-batch on the worker's stream. Synchronous on purpose: call
@@ -222,6 +241,7 @@ impl GrpcTransport {
             )
             .increment((chunks.len() - 1) as u64);
         }
+        let split = chunks.len() > 1;
         let stream = self.worker_stream_for(worker_url);
         let receivers = chunks
             .into_iter()
@@ -231,6 +251,7 @@ impl GrpcTransport {
                     batch_id: batch_id.to_string(),
                     messages,
                     replay,
+                    unbudgeted: split,
                     reply,
                 };
                 if let Err(send_err) = stream.tx.send(item) {
@@ -268,6 +289,7 @@ impl GrpcTransport {
             consumer_id: self.consumer_id.clone(),
             max_unacked: self.max_unacked,
             ack_timeout: self.ack_timeout,
+            soft_budget_ms: self.soft_budget_ms,
             assignment_epoch: Arc::clone(&self.assignment_epoch),
         };
         tokio::spawn(async move { runner.run(rx).await });
@@ -328,6 +350,7 @@ struct WorkerStreamRunner {
     consumer_id: String,
     max_unacked: usize,
     ack_timeout: Duration,
+    soft_budget_ms: u64,
     assignment_epoch: Arc<AtomicU64>,
 }
 
@@ -534,7 +557,11 @@ impl WorkerStreamRunner {
                     messages: item.messages.iter().map(to_proto_message).collect(),
                     replay: item.replay,
                     assignment_epoch: self.assignment_epoch.load(Ordering::Relaxed),
-                    soft_budget_ms: 0,
+                    soft_budget_ms: if item.unbudgeted {
+                        0
+                    } else {
+                        self.soft_budget_ms
+                    },
                 })),
             };
             // tonic gzips the frame after this point, so only the raw size is observable here.

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -245,6 +245,7 @@ async fn async_main(config: Config) -> Result<()> {
         Duration::from_millis(config.ingestion_worker_stream_ack_timeout_ms),
     );
     transport.set_max_body_bytes(config.transport_max_body_bytes);
+    transport.set_soft_budget_ms(config.ingestion_worker_sub_batch_soft_budget_ms);
     let transport = Arc::new(transport);
 
     // Select the worker discovery provider and start it (static applies the

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -222,6 +222,25 @@ async fn async_main(config: Config) -> Result<()> {
     if let Some(recorder) = &debug_recorder {
         dispatcher.set_debug_recorder(Arc::clone(recorder));
     }
+    // A sub-batch soft budget requires the hold: a PARTIAL ack redelivers a
+    // key's remainder, which must not land behind the key's newer in-flight
+    // sub-batches.
+    let per_key_serialization = config.ingestion_worker_per_key_serialization
+        || config.ingestion_worker_sub_batch_soft_budget_ms > 0;
+    dispatcher.set_per_key_serialization(per_key_serialization);
+    if per_key_serialization {
+        info!(
+            soft_budget_ms = config.ingestion_worker_sub_batch_soft_budget_ms,
+            eager_deferred_flush = config.dispatcher_eager_deferred_flush,
+            "Per-key serialization enabled: one in-flight sub-batch per routing key"
+        );
+        if !config.dispatcher_eager_deferred_flush {
+            warn!(
+                "Per-key serialization without DISPATCHER_EAGER_DEFERRED_FLUSH: held groups \
+                 drain only at batch completion, which serializes hot keys on batch latency"
+            );
+        }
+    }
     match &peer_tracker {
         Some(tracker) => dispatcher.set_aperture(Arc::clone(tracker), config.min_aperture),
         None if config.routing_strategy == RoutingStrategy::Aperture => {

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -228,8 +228,7 @@ async fn async_main(config: Config) -> Result<()> {
     let per_key_serialization = config.ingestion_worker_per_key_serialization
         || config.ingestion_worker_sub_batch_soft_budget_ms > 0;
     dispatcher.set_per_key_serialization(per_key_serialization);
-    dispatcher
-        .set_unbudgeted_resend_attempts(config.ingestion_worker_unbudgeted_resend_attempts);
+    dispatcher.set_unbudgeted_resend_attempts(config.ingestion_worker_unbudgeted_resend_attempts);
     if per_key_serialization {
         info!(
             soft_budget_ms = config.ingestion_worker_sub_batch_soft_budget_ms,

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -228,6 +228,8 @@ async fn async_main(config: Config) -> Result<()> {
     let per_key_serialization = config.ingestion_worker_per_key_serialization
         || config.ingestion_worker_sub_batch_soft_budget_ms > 0;
     dispatcher.set_per_key_serialization(per_key_serialization);
+    dispatcher
+        .set_unbudgeted_resend_attempts(config.ingestion_worker_unbudgeted_resend_attempts);
     if per_key_serialization {
         info!(
             soft_budget_ms = config.ingestion_worker_sub_batch_soft_budget_ms,

--- a/rust/ingestion-consumer/tests/e2e_integration_test.rs
+++ b/rust/ingestion-consumer/tests/e2e_integration_test.rs
@@ -150,6 +150,9 @@ struct FakeWorker {
     /// When set, the next sub-batch is ingested in full but reports one
     /// message fewer than sent — a partial-acceptance contract violation.
     pub underreport_once: Arc<AtomicBool>,
+    /// When set, the next sub-batch is acked PARTIAL: the last message is not
+    /// processed and comes back in `timed_out`, modeling a soft-budget cut.
+    pub timeout_last_once: Arc<AtomicBool>,
     /// Number of sub-batches that have reached the handler. Counted before
     /// the gate, so a test can observe a batch is in-flight even while held.
     arrived: Arc<AtomicUsize>,
@@ -185,6 +188,7 @@ impl FakeWorker {
         let ack_lost_once = Arc::new(AtomicBool::new(false));
         let reject_4xx = Arc::new(AtomicBool::new(false));
         let underreport_once = Arc::new(AtomicBool::new(false));
+        let timeout_last_once = Arc::new(AtomicBool::new(false));
         let arrived = Arc::new(AtomicUsize::new(0));
         let gate = Arc::new(tokio::sync::Mutex::new(()));
 
@@ -230,6 +234,7 @@ impl FakeWorker {
             ack_lost_once: Arc::clone(&ack_lost_once),
             reject_4xx: Arc::clone(&reject_4xx),
             underreport_once: Arc::clone(&underreport_once),
+            timeout_last_once: Arc::clone(&timeout_last_once),
             arrived: Arc::clone(&arrived),
             gate: Arc::clone(&gate),
             delivery_log,
@@ -257,6 +262,7 @@ impl FakeWorker {
             ack_lost_once,
             reject_4xx,
             underreport_once,
+            timeout_last_once,
             arrived,
             gate,
             _task: task,
@@ -304,6 +310,7 @@ struct FakeWorkerGrpc {
     ack_lost_once: Arc<AtomicBool>,
     reject_4xx: Arc<AtomicBool>,
     underreport_once: Arc<AtomicBool>,
+    timeout_last_once: Arc<AtomicBool>,
     arrived: Arc<AtomicUsize>,
     gate: Arc<tokio::sync::Mutex<()>>,
     delivery_log: Option<DeliveryLog>,
@@ -328,6 +335,7 @@ impl WorkerIngestService for FakeWorkerGrpc {
         let ack_lost_once = Arc::clone(&self.ack_lost_once);
         let reject_4xx = Arc::clone(&self.reject_4xx);
         let underreport_once = Arc::clone(&self.underreport_once);
+        let timeout_last_once = Arc::clone(&self.timeout_last_once);
         let arrived = Arc::clone(&self.arrived);
         let gate = Arc::clone(&self.gate);
         let delivery_log = self.delivery_log.clone();
@@ -368,7 +376,7 @@ impl WorkerIngestService for FakeWorkerGrpc {
                     nack(&tx, sub_batch.seq, "poison batch");
                     return;
                 }
-                let entries: Vec<(String, usize)> = sub_batch
+                let mut entries: Vec<(String, usize)> = sub_batch
                     .messages
                     .iter()
                     .map(|msg| {
@@ -382,6 +390,26 @@ impl WorkerIngestService for FakeWorkerGrpc {
                         (did, seq)
                     })
                     .collect();
+                // A soft-budget cut: the last message is not processed (not
+                // recorded), and the ack is PARTIAL with its index timed out.
+                if timeout_last_once.swap(false, Ordering::SeqCst) && !entries.is_empty() {
+                    entries.pop();
+                    let cut = entries.len() as u32;
+                    received.lock().unwrap().extend(entries.iter().cloned());
+                    if let Some(log) = &delivery_log {
+                        log.lock().unwrap().extend(entries);
+                    }
+                    let _ = tx.send(Ok(IngestStreamResponse {
+                        msg: Some(ingest_stream_response::Msg::Ack(SubBatchAck {
+                            seq: sub_batch.seq,
+                            status: SubBatchStatus::Partial as i32,
+                            accepted: cut,
+                            error: String::new(),
+                            timed_out: vec![cut],
+                        })),
+                    }));
+                    continue;
+                }
                 received.lock().unwrap().extend(entries.iter().cloned());
                 batch_sizes.lock().unwrap().push(sub_batch.messages.len());
                 if let Some(log) = &delivery_log {
@@ -561,6 +589,25 @@ impl Harness {
         .await
     }
 
+    /// Like `start`, but with a sub-batch soft budget stamped on the wire and
+    /// the machinery enforcement requires: per-key serialization and eager
+    /// deferred flushing. The budget value itself only needs to be non-zero —
+    /// the FakeWorker acks PARTIAL on demand, not on a clock.
+    async fn start_budgeted(topic: &str, partitions: i32, worker_count: usize) -> Self {
+        Self::start_full(
+            topic,
+            partitions,
+            worker_count,
+            1,
+            Duration::from_secs(60),
+            fast_registry_config(),
+            0,
+            ComponentOptions::new(),
+            30_000,
+        )
+        .await
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn start_inner(
         topic: &str,
@@ -571,6 +618,32 @@ impl Harness {
         registry_config: WorkerRegistryConfig,
         batch_size_bytes: usize,
         component_options: ComponentOptions,
+    ) -> Self {
+        Self::start_full(
+            topic,
+            partitions,
+            worker_count,
+            max_in_flight,
+            deferred_flush_timeout,
+            registry_config,
+            batch_size_bytes,
+            component_options,
+            0,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn start_full(
+        topic: &str,
+        partitions: i32,
+        worker_count: usize,
+        max_in_flight: usize,
+        deferred_flush_timeout: Duration,
+        registry_config: WorkerRegistryConfig,
+        batch_size_bytes: usize,
+        component_options: ComponentOptions,
+        soft_budget_ms: u64,
     ) -> Self {
         create_topic(topic, partitions).await;
 
@@ -586,9 +659,14 @@ impl Harness {
         Arc::clone(&registry).start_probing(probe_token.clone());
 
         let dispatcher = Arc::new(Dispatcher::new(Arc::clone(&registry)));
+        if soft_budget_ms > 0 {
+            dispatcher.set_per_key_serialization(true);
+        }
         let registry_for_test = Arc::clone(&registry);
         let dispatcher_for_test = Arc::clone(&dispatcher);
-        let transport = Arc::new(test_transport());
+        let mut grpc_transport = test_transport();
+        grpc_transport.set_soft_budget_ms(soft_budget_ms);
+        let transport = Arc::new(grpc_transport);
         spawn_reaper(
             Arc::clone(&registry),
             Arc::clone(&transport),
@@ -620,7 +698,7 @@ impl Harness {
                 group_id: "e2e-test".to_string(),
                 deferred_flush_timeout,
                 debug_recorder: None,
-                eager_deferred_flush: false,
+                eager_deferred_flush: soft_budget_ms > 0,
             },
             handle,
         );
@@ -842,6 +920,35 @@ async fn messages_per_distinct_id_arrive_in_order() {
 /// (the second crosses it). The count cap alone cannot express that, which is
 /// the regression: a lane whose events are large gets the memory of a full
 /// count batch no matter how the count is tuned.
+/// A worker cutting a sub-batch short (PARTIAL ack) triggers redelivery of
+/// only the unfinished remainder: everything arrives exactly once and the
+/// key's order is preserved. A duplicate of the acked prefix here would mean
+/// the consumer replayed the whole sub-batch instead of the remainder.
+#[tokio::test]
+async fn partial_ack_redelivers_only_the_remainder_in_order() {
+    let topic = format!("e2e-partial-{}", Uuid::new_v4());
+    let harness = Harness::start_budgeted(&topic, 1, 1).await;
+
+    // Arm before producing so the first sub-batch takes the cut.
+    harness.workers[0]
+        .timeout_last_once
+        .store(true, Ordering::SeqCst);
+
+    let producer = make_producer();
+    for seq in 0..4usize {
+        produce(&producer, &topic, 0, "tok", "user-1", seq).await;
+    }
+
+    harness.wait_for(4, Duration::from_secs(15)).await;
+    let seqs = harness.workers[0].seqs_for("user-1");
+    assert_eq!(
+        seqs,
+        vec![0, 1, 2, 3],
+        "in order, nothing lost, nothing duplicated"
+    );
+    harness.stop().await;
+}
+
 #[tokio::test]
 async fn byte_bound_caps_batches_below_the_count_bound() {
     let topic = format!("e2e-bytecap-{}", Uuid::new_v4());

--- a/rust/ingestion-consumer/tests/e2e_integration_test.rs
+++ b/rust/ingestion-consumer/tests/e2e_integration_test.rs
@@ -26,7 +26,7 @@ use uuid::Uuid;
 use ingestion_consumer::consumer::{IngestionConsumer, IngestionConsumerOptions};
 use ingestion_consumer::discovery::reconcile_membership;
 use ingestion_consumer::dispatcher::Dispatcher;
-use ingestion_consumer::grpc_transport::{GrpcPort, GrpcTransport};
+use ingestion_consumer::grpc_transport::{GrpcPort, GrpcTransport, SendOptions};
 use ingestion_consumer::order_sentinel::SentinelContext;
 use ingestion_consumer::types::SerializedKafkaMessage;
 use ingestion_consumer::worker_registry::{
@@ -1714,7 +1714,7 @@ async fn drain_defer_flush_delivers_to_survivor_over_stream() {
     let pinned_idx = workers.iter().position(|w| w.url == pinned_url).unwrap();
     let survivor_idx = 1 - pinned_idx;
     transport
-        .begin_send(&pinned_url, "batch-1", b1[0].messages.clone(), false)
+        .begin_send(&pinned_url, "batch-1", b1[0].messages.clone(), SendOptions::default())
         .wait()
         .await
         .expect("batch-1 send");
@@ -1747,7 +1747,7 @@ async fn drain_defer_flush_delivers_to_survivor_over_stream() {
             f2[0].worker.as_ref(),
             "batch-2",
             f2[0].messages.clone(),
-            false,
+            SendOptions::default(),
         )
         .wait()
         .await

--- a/rust/ingestion-consumer/tests/e2e_integration_test.rs
+++ b/rust/ingestion-consumer/tests/e2e_integration_test.rs
@@ -1821,7 +1821,12 @@ async fn drain_defer_flush_delivers_to_survivor_over_stream() {
     let pinned_idx = workers.iter().position(|w| w.url == pinned_url).unwrap();
     let survivor_idx = 1 - pinned_idx;
     transport
-        .begin_send(&pinned_url, "batch-1", b1[0].messages.clone(), SendOptions::default())
+        .begin_send(
+            &pinned_url,
+            "batch-1",
+            b1[0].messages.clone(),
+            SendOptions::default(),
+        )
         .wait()
         .await
         .expect("batch-1 send");

--- a/rust/ingestion-consumer/tests/grpc_transport_test.rs
+++ b/rust/ingestion-consumer/tests/grpc_transport_test.rs
@@ -44,7 +44,10 @@ enum AckMode {
 /// Manual mode: the test drives the worker's acks through this.
 #[derive(Clone)]
 enum ManualAck {
-    Ok { seq: u64, accepted: u32 },
+    Ok {
+        seq: u64,
+        accepted: u32,
+    },
     Nack(u64),
     /// Send this ack frame exactly as given, for protocol-violation tests.
     Raw(SubBatchAck),
@@ -269,7 +272,14 @@ async fn sub_batches_reach_the_worker_in_enqueue_order() {
     // Enqueue three sub-batches back to back — more than the un-acked cap, so
     // ordering must survive the ledger pacing too.
     let pending: Vec<_> = (0..3)
-        .map(|i| transport.begin_send(&url, &format!("batch-{i}"), vec![msg("d1", i)], SendOptions::default()))
+        .map(|i| {
+            transport.begin_send(
+                &url,
+                &format!("batch-{i}"),
+                vec![msg("d1", i)],
+                SendOptions::default(),
+            )
+        })
         .collect();
     for (i, p) in pending.into_iter().enumerate() {
         let outcome = p.wait().await.expect("send should succeed");
@@ -294,7 +304,12 @@ async fn out_of_order_acks_resolve_the_right_sends() {
     );
     let url = worker_url(mock.addr);
 
-    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], SendOptions::default());
+    let first = transport.begin_send(
+        &url,
+        "batch-1",
+        vec![msg("d1", 1), msg("d1", 2)],
+        SendOptions::default(),
+    );
     let second = transport.begin_send(&url, "batch-2", vec![msg("d2", 3)], SendOptions::default());
 
     // Wait until both are on the wire, then ack seq 2 before seq 1 with
@@ -657,7 +672,12 @@ async fn a_stuck_oldest_sub_batch_fences_even_while_siblings_keep_acking() {
     let url = worker_url(mock.addr);
 
     // Enqueued first, so it is seq 1 — the one the worker never acks.
-    let stuck = transport.begin_send(&url, "batch-stuck", vec![msg("d1", 1)], SendOptions::default());
+    let stuck = transport.begin_send(
+        &url,
+        "batch-stuck",
+        vec![msg("d1", 1)],
+        SendOptions::default(),
+    );
 
     // Keep feeding siblings faster than the ack timeout. Each is acked and
     // drained (the worker stream holds at most one alongside the stuck entry), so a
@@ -794,7 +814,12 @@ async fn send_and_ack_raw(ack: SubBatchAck) -> Result<SendOutcome, SendError> {
     transport.set_soft_budget_ms(30_000);
     let url = worker_url(mock.addr);
 
-    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], SendOptions::default());
+    let pending = transport.begin_send(
+        &url,
+        "batch-1",
+        vec![msg("d1", 1), msg("d1", 2)],
+        SendOptions::default(),
+    );
     wait_for_received(&mock, 1).await;
     ack_tx.send(ManualAck::Raw(ack)).unwrap();
     pending.wait().await
@@ -867,7 +892,11 @@ async fn malformed_partial_acks_fence_with_the_messages_returned() {
             matches!(err.error, TransportError::WorkerStreamFailed(_)),
             "{case}: fences as a fault, not backpressure"
         );
-        assert_eq!(err.messages.len(), 2, "{case}: messages come back for replay");
+        assert_eq!(
+            err.messages.len(),
+            2,
+            "{case}: messages come back for replay"
+        );
     }
 }
 
@@ -934,7 +963,12 @@ async fn a_partial_ack_for_an_unbudgeted_sub_batch_fences() {
     );
     let url = worker_url(mock.addr);
 
-    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], SendOptions::default());
+    let pending = transport.begin_send(
+        &url,
+        "batch-1",
+        vec![msg("d1", 1), msg("d1", 2)],
+        SendOptions::default(),
+    );
     wait_for_received(&mock, 1).await;
     ack_tx
         .send(ManualAck::Raw(SubBatchAck {

--- a/rust/ingestion-consumer/tests/grpc_transport_test.rs
+++ b/rust/ingestion-consumer/tests/grpc_transport_test.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ingestion_consumer::grpc_transport::{GrpcPort, GrpcTransport, SendOutcome};
+use ingestion_consumer::grpc_transport::{GrpcPort, GrpcTransport, SendOptions, SendOutcome};
 use ingestion_consumer::transport::{SendError, TransportError};
 use ingestion_consumer::types::SerializedKafkaMessage;
 use ingestion_worker_proto::ingestion::worker::v1::worker_ingest_server::{
@@ -269,7 +269,7 @@ async fn sub_batches_reach_the_worker_in_enqueue_order() {
     // Enqueue three sub-batches back to back — more than the un-acked cap, so
     // ordering must survive the ledger pacing too.
     let pending: Vec<_> = (0..3)
-        .map(|i| transport.begin_send(&url, &format!("batch-{i}"), vec![msg("d1", i)], false))
+        .map(|i| transport.begin_send(&url, &format!("batch-{i}"), vec![msg("d1", i)], SendOptions::default()))
         .collect();
     for (i, p) in pending.into_iter().enumerate() {
         let outcome = p.wait().await.expect("send should succeed");
@@ -294,8 +294,8 @@ async fn out_of_order_acks_resolve_the_right_sends() {
     );
     let url = worker_url(mock.addr);
 
-    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], false);
-    let second = transport.begin_send(&url, "batch-2", vec![msg("d2", 3)], false);
+    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], SendOptions::default());
+    let second = transport.begin_send(&url, "batch-2", vec![msg("d2", 3)], SendOptions::default());
 
     // Wait until both are on the wire, then ack seq 2 before seq 1 with
     // distinct counts — each pending must get its own, and the later one
@@ -350,8 +350,8 @@ async fn a_failure_fences_a_later_sub_batch_the_worker_already_acked() {
     );
     let url = worker_url(mock.addr);
 
-    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
-    let second = transport.begin_send(&url, "batch-2", vec![msg("d1", 2)], false);
+    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::default());
+    let second = transport.begin_send(&url, "batch-2", vec![msg("d1", 2)], SendOptions::default());
     wait_for_received(&mock, 2).await;
 
     ack_tx
@@ -396,7 +396,7 @@ async fn sends_enqueued_during_a_fence_are_fenced_until_the_callers_stash() {
     );
     let url = worker_url(mock.addr);
 
-    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
+    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::default());
     let first_err = first.wait().await.expect_err("nacked send must fail");
     let guard = first_err
         .fence_guard
@@ -404,7 +404,7 @@ async fn sends_enqueued_during_a_fence_are_fenced_until_the_callers_stash() {
 
     // Enqueued while the fence is unacknowledged: fails without riding a
     // stream.
-    let second = transport.begin_send(&url, "batch-2", vec![msg("d1", 2)], false);
+    let second = transport.begin_send(&url, "batch-2", vec![msg("d1", 2)], SendOptions::default());
     let second_err = tokio::time::timeout(Duration::from_secs(2), second.wait())
         .await
         .expect("a send during a fence must fail promptly")
@@ -420,7 +420,7 @@ async fn sends_enqueued_during_a_fence_are_fenced_until_the_callers_stash() {
     // worker on a fresh stream.
     drop(guard);
     drop(second_err);
-    let third = transport.begin_send(&url, "batch-3", vec![msg("d1", 3)], false);
+    let third = transport.begin_send(&url, "batch-3", vec![msg("d1", 3)], SendOptions::default());
     let _ = tokio::time::timeout(Duration::from_secs(5), third.wait())
         .await
         .expect("the worker stream must resume once the fence is released");
@@ -454,7 +454,7 @@ async fn an_oversized_sub_batch_rides_the_stream_as_ordered_chunks() {
         &url,
         "batch-1",
         vec![msg("d1", 1), msg("d1", 2), msg("d1", 3)],
-        false,
+        SendOptions::default(),
     );
     let outcome = pending.wait().await.expect("all chunks accepted");
     assert_eq!(outcome.accepted, 3, "accepted counts sum across chunks");
@@ -501,7 +501,7 @@ async fn a_failed_chunk_hands_back_the_whole_sub_batch() {
         &url,
         "batch-1",
         vec![msg("d1", 1), msg("d1", 2), msg("d1", 3)],
-        false,
+        SendOptions::default(),
     );
     let err = pending
         .wait()
@@ -533,9 +533,9 @@ async fn a_nack_fences_everything_outstanding_in_order() {
 
     // With max_unacked=1, the second and third wait in the queue behind the
     // first — the nack must fence all three.
-    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
-    let second = transport.begin_send(&url, "batch-2", vec![msg("d1", 2)], false);
-    let third = transport.begin_send(&url, "batch-3", vec![msg("d2", 3)], false);
+    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::default());
+    let second = transport.begin_send(&url, "batch-2", vec![msg("d1", 2)], SendOptions::default());
+    let third = transport.begin_send(&url, "batch-3", vec![msg("d2", 3)], SendOptions::default());
 
     let first_err = first.wait().await.expect_err("nacked send must fail");
     assert_eq!(first_err.messages.len(), 1);
@@ -574,7 +574,7 @@ async fn the_worker_stream_reconnects_with_a_new_stream_epoch_after_a_fence() {
     );
     let url = worker_url(mock.addr);
 
-    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
+    let first = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::default());
     first.wait().await.expect_err("nacked");
 
     // The retry (as the deferral path would issue it) lands on a fresh stream
@@ -583,7 +583,7 @@ async fn the_worker_stream_reconnects_with_a_new_stream_epoch_after_a_fence() {
     // NEW stream... so use a different worker mode expectation: the second
     // stream's seq-1 sub-batch is nacked again by this mock, which is fine —
     // what we assert is the reconnect (two hellos, increasing epochs).
-    let retry = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], true);
+    let retry = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::replay());
     retry
         .wait()
         .await
@@ -607,7 +607,7 @@ async fn a_dead_worker_fences_instead_of_hanging() {
         "http://127.0.0.1:9001",
         "batch-1",
         vec![msg("d1", 1)],
-        false,
+        SendOptions::default(),
     );
     let err = tokio::time::timeout(Duration::from_secs(10), pending.wait())
         .await
@@ -631,7 +631,7 @@ async fn a_worker_that_stops_acking_fences_after_the_watchdog_window() {
     );
     let url = worker_url(mock.addr);
 
-    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
+    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::default());
     let err = tokio::time::timeout(Duration::from_secs(10), pending.wait())
         .await
         .expect("watchdog must fence, not wait forever")
@@ -657,7 +657,7 @@ async fn a_stuck_oldest_sub_batch_fences_even_while_siblings_keep_acking() {
     let url = worker_url(mock.addr);
 
     // Enqueued first, so it is seq 1 — the one the worker never acks.
-    let stuck = transport.begin_send(&url, "batch-stuck", vec![msg("d1", 1)], false);
+    let stuck = transport.begin_send(&url, "batch-stuck", vec![msg("d1", 1)], SendOptions::default());
 
     // Keep feeding siblings faster than the ack timeout. Each is acked and
     // drained (the worker stream holds at most one alongside the stuck entry), so a
@@ -671,7 +671,7 @@ async fn a_stuck_oldest_sub_batch_fences_even_while_siblings_keep_acking() {
                     &url,
                     &format!("sibling-{i}"),
                     vec![msg("d2", 100 + i)],
-                    false,
+                    SendOptions::default(),
                 );
                 tokio::time::sleep(Duration::from_millis(80)).await;
             }
@@ -705,7 +705,7 @@ async fn removing_a_worker_fences_its_in_flight_send_with_messages() {
     );
     let url = worker_url(mock.addr);
 
-    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
+    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::default());
     // Wait until the send is on the wire (in the worker stream's ledger) before reaping.
     for _ in 0..200 {
         if mock.received.lock().await.len() == 1 {
@@ -745,7 +745,7 @@ async fn the_soft_budget_rides_frames_but_not_split_chunks() {
     transport.set_soft_budget_ms(30_000);
     let url = worker_url(mock.addr);
 
-    let single = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
+    let single = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::default());
     single.wait().await.expect("send should succeed");
 
     // Frame size cap in bytes. One `msg()` estimates to ~143 bytes, so this
@@ -755,16 +755,28 @@ async fn the_soft_budget_rides_frames_but_not_split_chunks() {
         &url,
         "batch-2",
         vec![msg("d1", 2), msg("d1", 3), msg("d1", 4)],
-        false,
+        SendOptions::default(),
     );
     split.wait().await.expect("all chunks accepted");
+
+    // An escalated resend opts out of the budget explicitly.
+    let escalated = transport.begin_send(
+        &url,
+        "batch-3",
+        vec![msg("d1", 5)],
+        SendOptions {
+            replay: true,
+            unbudgeted: true,
+        },
+    );
+    escalated.wait().await.expect("send should succeed");
 
     let received = mock.received.lock().await;
     let budgets: Vec<u64> = received.iter().map(|s| s.soft_budget_ms).collect();
     assert_eq!(
         budgets,
-        vec![30_000, 0, 0, 0],
-        "one budgeted frame, then three unbudgeted split chunks"
+        vec![30_000, 0, 0, 0, 0],
+        "one budgeted frame, three unbudgeted split chunks, one escalated send"
     );
 }
 
@@ -782,7 +794,7 @@ async fn send_and_ack_raw(ack: SubBatchAck) -> Result<SendOutcome, SendError> {
     transport.set_soft_budget_ms(30_000);
     let url = worker_url(mock.addr);
 
-    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], false);
+    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], SendOptions::default());
     wait_for_received(&mock, 1).await;
     ack_tx.send(ManualAck::Raw(ack)).unwrap();
     pending.wait().await
@@ -878,7 +890,7 @@ async fn a_partial_ack_resolves_with_the_timed_out_remainder() {
         &url,
         "batch-1",
         vec![msg("d1", 1), msg("d1", 2), msg("d2", 3)],
-        false,
+        SendOptions::default(),
     );
     wait_for_received(&mock, 1).await;
     ack_tx
@@ -898,7 +910,7 @@ async fn a_partial_ack_resolves_with_the_timed_out_remainder() {
     assert_eq!(timed_out, vec![2, 3], "remainder comes back in send order");
 
     // The stream is not fenced: the next send goes through and acks.
-    let next = transport.begin_send(&url, "batch-2", vec![msg("d3", 4)], false);
+    let next = transport.begin_send(&url, "batch-2", vec![msg("d3", 4)], SendOptions::default());
     wait_for_received(&mock, 2).await;
     ack_tx
         .send(ManualAck::Ok {
@@ -922,7 +934,7 @@ async fn a_partial_ack_for_an_unbudgeted_sub_batch_fences() {
     );
     let url = worker_url(mock.addr);
 
-    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], false);
+    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], SendOptions::default());
     wait_for_received(&mock, 1).await;
     ack_tx
         .send(ManualAck::Raw(SubBatchAck {
@@ -952,7 +964,7 @@ async fn a_busy_status_fences_as_retriable_with_messages() {
     );
     let url = worker_url(mock.addr);
 
-    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
+    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], SendOptions::default());
     let err = pending
         .wait()
         .await

--- a/rust/ingestion-consumer/tests/grpc_transport_test.rs
+++ b/rust/ingestion-consumer/tests/grpc_transport_test.rs
@@ -860,6 +860,56 @@ async fn malformed_partial_acks_fence_with_the_messages_returned() {
 }
 
 #[tokio::test]
+async fn a_partial_ack_resolves_with_the_timed_out_remainder() {
+    // A valid PARTIAL resolves the send instead of fencing: the caller gets
+    // the accepted count, the completed messages, and the timed-out
+    // remainder in send order, and the stream keeps working.
+    let (ack_tx, ack_rx) = mpsc::unbounded_channel();
+    let mock = start_mock(AckMode::Manual, Some(ack_rx)).await;
+    let mut transport = GrpcTransport::new(
+        GrpcPort::Fixed(mock.addr.port()),
+        2,
+        Duration::from_secs(30),
+    );
+    transport.set_soft_budget_ms(30_000);
+    let url = worker_url(mock.addr);
+
+    let pending = transport.begin_send(
+        &url,
+        "batch-1",
+        vec![msg("d1", 1), msg("d1", 2), msg("d2", 3)],
+        false,
+    );
+    wait_for_received(&mock, 1).await;
+    ack_tx
+        .send(ManualAck::Raw(SubBatchAck {
+            seq: 1,
+            status: SubBatchStatus::Partial as i32,
+            accepted: 1,
+            error: String::new(),
+            timed_out: vec![1, 2],
+        }))
+        .unwrap();
+    let outcome = pending.wait().await.expect("partial resolves, not fences");
+    assert_eq!(outcome.accepted, 1);
+    let completed: Vec<i64> = outcome.completed.iter().map(|m| m.offset).collect();
+    let timed_out: Vec<i64> = outcome.timed_out.iter().map(|m| m.offset).collect();
+    assert_eq!(completed, vec![1]);
+    assert_eq!(timed_out, vec![2, 3], "remainder comes back in send order");
+
+    // The stream is not fenced: the next send goes through and acks.
+    let next = transport.begin_send(&url, "batch-2", vec![msg("d3", 4)], false);
+    wait_for_received(&mock, 2).await;
+    ack_tx
+        .send(ManualAck::Ok {
+            seq: 2,
+            accepted: 1,
+        })
+        .unwrap();
+    assert_eq!(next.wait().await.expect("stream still healthy").accepted, 1);
+}
+
+#[tokio::test]
 async fn a_partial_ack_for_an_unbudgeted_sub_batch_fences() {
     // This consumer sent no budget, so the worker had nothing to time out; a
     // PARTIAL here is a protocol violation, not backpressure.

--- a/rust/ingestion-consumer/tests/grpc_transport_test.rs
+++ b/rust/ingestion-consumer/tests/grpc_transport_test.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ingestion_consumer::grpc_transport::{GrpcPort, GrpcTransport};
-use ingestion_consumer::transport::TransportError;
+use ingestion_consumer::transport::{SendError, TransportError};
 use ingestion_consumer::types::SerializedKafkaMessage;
 use ingestion_worker_proto::ingestion::worker::v1::worker_ingest_server::{
     WorkerIngest, WorkerIngestServer,
@@ -42,10 +42,12 @@ enum AckMode {
 }
 
 /// Manual mode: the test drives the worker's acks through this.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum ManualAck {
     Ok { seq: u64, accepted: u32 },
     Nack(u64),
+    /// Send this ack frame exactly as given, for protocol-violation tests.
+    Raw(SubBatchAck),
 }
 
 type ManualAcks = Arc<Mutex<Option<mpsc::UnboundedReceiver<ManualAck>>>>;
@@ -99,6 +101,7 @@ impl WorkerIngest for MockWorker {
                                 error: "poisoned".to_string(),
                                 timed_out: vec![],
                             },
+                            ManualAck::Raw(ack) => ack,
                         };
                         let _ = tx.send(Ok(IngestStreamResponse {
                             msg: Some(ingest_stream_response::Msg::Ack(ack)),
@@ -763,6 +766,127 @@ async fn the_soft_budget_rides_frames_but_not_split_chunks() {
         vec![30_000, 0, 0, 0],
         "one budgeted frame, then three unbudgeted split chunks"
     );
+}
+
+/// Drive one manual-mode round trip: send a two-message budgeted sub-batch
+/// (seq 1), wait for it to reach the worker, answer with `ack`, and return
+/// the send's outcome.
+async fn send_and_ack_raw(ack: SubBatchAck) -> Result<u32, SendError> {
+    let (ack_tx, ack_rx) = mpsc::unbounded_channel();
+    let mock = start_mock(AckMode::Manual, Some(ack_rx)).await;
+    let mut transport = GrpcTransport::new(
+        GrpcPort::Fixed(mock.addr.port()),
+        2,
+        Duration::from_secs(30),
+    );
+    transport.set_soft_budget_ms(30_000);
+    let url = worker_url(mock.addr);
+
+    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], false);
+    wait_for_received(&mock, 1).await;
+    ack_tx.send(ManualAck::Raw(ack)).unwrap();
+    pending.wait().await
+}
+
+#[tokio::test]
+async fn malformed_partial_acks_fence_with_the_messages_returned() {
+    // Fail closed: an ack whose dispositions don't cover the sub-batch (or
+    // that claims timeouts outside a PARTIAL) must fence and hand the
+    // messages back for replay. Trusting it instead would silently lose the
+    // messages the list mis-describes.
+    let cases: Vec<(&str, SubBatchAck)> = vec![
+        (
+            "partial with no timed_out entries",
+            SubBatchAck {
+                seq: 1,
+                status: SubBatchStatus::Partial as i32,
+                accepted: 2,
+                error: String::new(),
+                timed_out: vec![],
+            },
+        ),
+        (
+            "partial with an out-of-range index",
+            SubBatchAck {
+                seq: 1,
+                status: SubBatchStatus::Partial as i32,
+                accepted: 1,
+                error: String::new(),
+                timed_out: vec![5],
+            },
+        ),
+        (
+            "partial with a duplicate index",
+            SubBatchAck {
+                seq: 1,
+                status: SubBatchStatus::Partial as i32,
+                accepted: 0,
+                error: String::new(),
+                timed_out: vec![1, 1],
+            },
+        ),
+        (
+            "partial whose counts do not cover the sub-batch",
+            SubBatchAck {
+                seq: 1,
+                status: SubBatchStatus::Partial as i32,
+                accepted: 2,
+                error: String::new(),
+                timed_out: vec![1],
+            },
+        ),
+        (
+            "ok carrying timed_out entries",
+            SubBatchAck {
+                seq: 1,
+                status: SubBatchStatus::Ok as i32,
+                accepted: 2,
+                error: String::new(),
+                timed_out: vec![1],
+            },
+        ),
+    ];
+    for (case, ack) in cases {
+        let err = match send_and_ack_raw(ack).await {
+            Ok(accepted) => panic!("{case}: must fail the send, got accepted={accepted}"),
+            Err(err) => err,
+        };
+        assert!(
+            matches!(err.error, TransportError::WorkerStreamFailed(_)),
+            "{case}: fences as a fault, not backpressure"
+        );
+        assert_eq!(err.messages.len(), 2, "{case}: messages come back for replay");
+    }
+}
+
+#[tokio::test]
+async fn a_partial_ack_for_an_unbudgeted_sub_batch_fences() {
+    // This consumer sent no budget, so the worker had nothing to time out; a
+    // PARTIAL here is a protocol violation, not backpressure.
+    let (ack_tx, ack_rx) = mpsc::unbounded_channel();
+    let mock = start_mock(AckMode::Manual, Some(ack_rx)).await;
+    let transport = GrpcTransport::new(
+        GrpcPort::Fixed(mock.addr.port()),
+        2,
+        Duration::from_secs(30),
+    );
+    let url = worker_url(mock.addr);
+
+    let pending = transport.begin_send(&url, "batch-1", vec![msg("d1", 1), msg("d1", 2)], false);
+    wait_for_received(&mock, 1).await;
+    ack_tx
+        .send(ManualAck::Raw(SubBatchAck {
+            seq: 1,
+            status: SubBatchStatus::Partial as i32,
+            accepted: 1,
+            error: String::new(),
+            timed_out: vec![1],
+        }))
+        .unwrap();
+
+    let err = pending.wait().await.expect_err("protocol violation fences");
+    assert!(matches!(err.error, TransportError::WorkerStreamFailed(_)));
+    assert_eq!(err.messages.len(), 2, "messages come back for replay");
 }
 
 #[tokio::test]

--- a/rust/ingestion-consumer/tests/grpc_transport_test.rs
+++ b/rust/ingestion-consumer/tests/grpc_transport_test.rs
@@ -727,6 +727,45 @@ async fn removing_a_worker_fences_its_in_flight_send_with_messages() {
 }
 
 #[tokio::test]
+async fn the_soft_budget_rides_frames_but_not_split_chunks() {
+    // The worker derives its time budget from the wire alone, so a configured
+    // budget must reach every frame. A size-split sub-batch is the exception:
+    // its chunks are separate frames with separate budgets, and a budget cut
+    // in one chunk while a later chunk carries the same key would reorder the
+    // key. Split chunks must go out unbudgeted.
+    let mock = start_mock(AckMode::Immediate, None).await;
+    let mut transport = GrpcTransport::new(
+        GrpcPort::Fixed(mock.addr.port()),
+        2,
+        Duration::from_secs(30),
+    );
+    transport.set_soft_budget_ms(30_000);
+    let url = worker_url(mock.addr);
+
+    let single = transport.begin_send(&url, "batch-1", vec![msg("d1", 1)], false);
+    single.wait().await.expect("send should succeed");
+
+    // Frame size cap in bytes. One `msg()` estimates to ~143 bytes, so this
+    // fits exactly one message per frame and three messages become three frames.
+    transport.set_max_body_bytes(200);
+    let split = transport.begin_send(
+        &url,
+        "batch-2",
+        vec![msg("d1", 2), msg("d1", 3), msg("d1", 4)],
+        false,
+    );
+    split.wait().await.expect("all chunks accepted");
+
+    let received = mock.received.lock().await;
+    let budgets: Vec<u64> = received.iter().map(|s| s.soft_budget_ms).collect();
+    assert_eq!(
+        budgets,
+        vec![30_000, 0, 0, 0],
+        "one budgeted frame, then three unbudgeted split chunks"
+    );
+}
+
+#[tokio::test]
 async fn a_busy_status_fences_as_retriable_with_messages() {
     // A worker reporting busy is applying backpressure, not failing: the fenced
     // sends must carry their messages (to replay) and classify as retriable, so

--- a/rust/ingestion-consumer/tests/grpc_transport_test.rs
+++ b/rust/ingestion-consumer/tests/grpc_transport_test.rs
@@ -10,7 +10,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ingestion_consumer::grpc_transport::{GrpcPort, GrpcTransport};
+use ingestion_consumer::grpc_transport::{GrpcPort, GrpcTransport, SendOutcome};
 use ingestion_consumer::transport::{SendError, TransportError};
 use ingestion_consumer::types::SerializedKafkaMessage;
 use ingestion_worker_proto::ingestion::worker::v1::worker_ingest_server::{
@@ -272,8 +272,8 @@ async fn sub_batches_reach_the_worker_in_enqueue_order() {
         .map(|i| transport.begin_send(&url, &format!("batch-{i}"), vec![msg("d1", i)], false))
         .collect();
     for (i, p) in pending.into_iter().enumerate() {
-        let accepted = p.wait().await.expect("send should succeed");
-        assert_eq!(accepted, 1, "sub-batch {i}");
+        let outcome = p.wait().await.expect("send should succeed");
+        assert_eq!(outcome.accepted, 1, "sub-batch {i}");
     }
 
     let received = mock.received.lock().await;
@@ -319,8 +319,8 @@ async fn out_of_order_acks_resolve_the_right_sends() {
             accepted: 2,
         })
         .unwrap();
-    assert_eq!(first.wait().await.expect("first ack"), 2);
-    assert_eq!(second.await.unwrap().expect("second ack"), 1);
+    assert_eq!(first.wait().await.expect("first ack").accepted, 2);
+    assert_eq!(second.await.unwrap().expect("second ack").accepted, 1);
 }
 
 async fn wait_for_received(mock: &MockHandle, count: usize) {
@@ -456,8 +456,8 @@ async fn an_oversized_sub_batch_rides_the_stream_as_ordered_chunks() {
         vec![msg("d1", 1), msg("d1", 2), msg("d1", 3)],
         false,
     );
-    let accepted = pending.wait().await.expect("all chunks accepted");
-    assert_eq!(accepted, 3, "accepted counts sum across chunks");
+    let outcome = pending.wait().await.expect("all chunks accepted");
+    assert_eq!(outcome.accepted, 3, "accepted counts sum across chunks");
 
     let received = mock.received.lock().await;
     let frames: Vec<(u64, &str, Vec<i64>)> = received
@@ -771,7 +771,7 @@ async fn the_soft_budget_rides_frames_but_not_split_chunks() {
 /// Drive one manual-mode round trip: send a two-message budgeted sub-batch
 /// (seq 1), wait for it to reach the worker, answer with `ack`, and return
 /// the send's outcome.
-async fn send_and_ack_raw(ack: SubBatchAck) -> Result<u32, SendError> {
+async fn send_and_ack_raw(ack: SubBatchAck) -> Result<SendOutcome, SendError> {
     let (ack_tx, ack_rx) = mpsc::unbounded_channel();
     let mock = start_mock(AckMode::Manual, Some(ack_rx)).await;
     let mut transport = GrpcTransport::new(
@@ -848,7 +848,7 @@ async fn malformed_partial_acks_fence_with_the_messages_returned() {
     ];
     for (case, ack) in cases {
         let err = match send_and_ack_raw(ack).await {
-            Ok(accepted) => panic!("{case}: must fail the send, got accepted={accepted}"),
+            Ok(outcome) => panic!("{case}: must fail the send, got {outcome:?}"),
             Err(err) => err,
         };
         assert!(


### PR DESCRIPTION
## Problem

- When a worker cannot finish a sub-batch in time, the consumer replays the whole stream tail while the original worker keeps working: duplicate downstream produce plus person-row contention exactly where the pipeline was already slow.
- #89995 teaches the worker to enforce a per-sub-batch soft time budget and ack PARTIAL, naming the messages the budget cut off. The consumer does not read that ack yet, so budgets stay unsent.
- This PR is the consumer half, as a prototype for design review. It is stacked on #89995 (base branch `pl/ingestion/batch-time-budgets`), which carries the proto changes and the worker-side enforcement.

## Changes

- The consumer now redelivers only the unfinished remainder of a timed-out sub-batch, in order, instead of replaying everything behind it. Inert by default: no budget is sent until `INGESTION_WORKER_SUB_BATCH_SOFT_BUDGET_MS` is set.
- One routing key never has two sub-batches in flight once budgets are on. This is the ordering precondition for partial redelivery: with two in flight, a stashed remainder would replay behind the key's newer messages.
  - The hold reuses the existing stash and cascade rule; the eager release then chains a held key's groups at ack speed, so a hot key goes from stream pipelining to one round trip per group.
  - `INGESTION_WORKER_PER_KEY_SERIALIZATION` turns the hold on without a budget, to measure its throughput cost first. A non-zero budget forces it.
- A PARTIAL ack resolves as a mixed result: watermarks advance from the completed subset only, and the remainder stashes under its owning batch, where the batch-sequence ordering already replays it ahead of newer groups.
- PARTIAL parsing is fail-closed: empty or out-of-range dispositions, counts that do not cover the sub-batch, or a PARTIAL for a frame this consumer sent unbudgeted all fence the stream and replay, like FAILED.
- A size-split send goes out unbudgeted. This deviates from the plan's chunk-index remapping on purpose: chunks are separate frames with separate budgets, so a cut in one chunk while a later chunk carries the same key would complete newer messages ahead of timed-out older ones.
- After `INGESTION_WORKER_UNBUDGETED_RESEND_ATTEMPTS` consecutive timeouts (default 3), a key's resend goes out unbudgeted, so a message that never fits the budget degrades to today's watchdog-only semantics instead of redelivering forever.
- Mechanical: `begin_send` takes a `SendOptions` struct, and `wait()` returns a `SendOutcome` instead of a count.

> [!NOTE]
> Review commit by commit: each lands one concern and keeps the tree green. Nothing user-visible changes; this is ingestion infrastructure.

## How did you test this code?

- `cargo test -p ingestion-consumer` (lib, gRPC transport, dispatcher and Kafka-backed e2e suites) locally, all green.
- New coverage, one regression each:
  - budget stamping: a configured budget that never reaches the wire, and a split chunk that carries one.
  - serialization hold: a pinned key's second batch riding the pin while the first send is un-acked.
  - fail-closed parsing: a malformed PARTIAL being trusted and silently losing the mis-described messages.
  - mixed resolve: a partial ack releasing timed-out keys (reorder) or holding completed keys (stall); the remainder not re-routing at ack speed.
  - escalation: a never-fitting message redelivering forever, and escalation state surviving a full ack.
  - e2e: a partial ack replaying the acked prefix (duplicates) or dropping the remainder (loss), end to end through Kafka.
- Not run: `hogli review` (the command is not available in this checkout).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: consumer-internal config, documented in `config.rs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code implemented the consumer phase of the ingestion batch time budgets design (#89995) from its commit-by-commit plan.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Decisions made in session: merged master into the #89995 base branch first (master removed the HTTP transport and re-keyed routing, which this work builds on), then stacked this PR on it; and replaced the planned chunk-index remapping with split-implies-unbudgeted after finding the cross-chunk reorder hazard (reasoning in Changes).
- All code and fixtures were written from repository context only.
