### PR TITLE
chore(desktop): note posthog/code is archived in posthog-desktop skill

### DIFF
--- a/.agents/skills/posthog-desktop/SKILL.md
+++ b/.agents/skills/posthog-desktop/SKILL.md
@@ -2,8 +2,9 @@
 name: posthog-desktop
 description: >
   Scopes work to the desktop app at products/desktop — a nested standalone pnpm/turbo/Biome
-  workspace imported from PostHog/code, not part of the root frontend or Django build. Use when
-  the user says /posthog-desktop, or works on the Electron desktop app, apps/code, apps/web,
+  workspace imported from the now-archived PostHog/code repo, with posthog/posthog the only
+  source of truth for PRs, CI and publishing, and not part of the root frontend or Django build.
+  Use when the user says /posthog-desktop, or works on the Electron desktop app, apps/code, apps/web,
   apps/mobile, packages/core, packages/ui, packages/workspace-server, @posthog/api-client,
   @posthog/agent, or the agent framework. Pins the working directory to products/desktop, swaps
   in that tree's toolchain and conventions in place of the monorepo's, and defines the few paths
@@ -12,10 +13,12 @@ description: >
 
 # Working in products/desktop
 
-`products/desktop/` is the PostHog desktop app (Electron + agent framework), imported from
-PostHog/code and kept as a **nested standalone workspace**: own `pnpm-workspace.yaml`, own
-lockfile, own Biome config, Node 22. It is excluded from the root `pnpm-workspace.yaml`, from
-ruff/mypy, from root Jest, from oxlint/oxfmt, from stylelint and from pytest.
+`products/desktop/` is the PostHog desktop app (Electron + agent framework), imported from the
+now-archived PostHog/code repo and kept as a **nested standalone workspace**: own
+`pnpm-workspace.yaml`, own lockfile, own Biome config, Node 22. It is excluded from the root
+`pnpm-workspace.yaml`, from ruff/mypy, from root Jest, from oxlint/oxfmt, from stylelint and
+from pytest. posthog/posthog is the only source of truth: PRs, CI and publishing all happen
+here, never in PostHog/code.
 
 **Read [`products/desktop/AGENTS.md`](../../../products/desktop/AGENTS.md) before writing code
 in this tree.** It is the source of truth for architecture, layer boundaries, DI, and style.


### PR DESCRIPTION
## Problem

An agent that reads only the `posthog-desktop` skill description believes PostHog/code is a live repo, and can target it for a desktop PR or a workflow change. We ain't there no more.

