### PR TITLE
feat(error-tracking): enable issue assignment MCP tool

### DIFF
--- a/products/error_tracking/backend/presentation/views/issues.py
+++ b/products/error_tracking/backend/presentation/views/issues.py
@@ -80,6 +80,55 @@ class ErrorTrackingIssueReadSerializer(serializers.Serializer):
     cohort = ErrorTrackingIssueCohortReadSerializer(allow_null=True)
 
 
+@extend_schema_field(
+    {"oneOf": [{"type": "integer"}, {"type": "string"}]},
+    component_name="ErrorTrackingIssueAssigneeId",
+)
+class ErrorTrackingIssueAssigneeIdField(serializers.Field):
+    def to_internal_value(self, data: object) -> int | str:
+        if isinstance(data, bool) or not isinstance(data, int | str):
+            raise serializers.ValidationError("Expected a user ID or role UUID.")
+        return data
+
+    def to_representation(self, value: object) -> int | str:
+        return value if isinstance(value, int | str) else str(value)
+
+
+class ErrorTrackingIssueAssigneeWriteSerializer(serializers.Serializer):
+    id = ErrorTrackingIssueAssigneeIdField(help_text="User ID or role UUID to assign the issue to.")
+    type = serializers.ChoiceField(
+        choices=["user", "role"],
+        help_text="Assignment target type: user or role.",
+    )
+
+    def validate(self, attrs: dict[str, object]) -> dict[str, object]:
+        assignee_id = attrs["id"]
+        if attrs["type"] == "user":
+            try:
+                attrs["id"] = int(str(assignee_id))
+            except (TypeError, ValueError):
+                raise serializers.ValidationError({"id": "Provide a numeric user ID."})
+        else:
+            try:
+                attrs["id"] = str(UUID(str(assignee_id)))
+            except ValueError:
+                raise serializers.ValidationError({"id": "Provide a valid role UUID."})
+        return attrs
+
+
+class ErrorTrackingIssueAssignRequestSerializer(serializers.Serializer):
+    assignee = ErrorTrackingIssueAssigneeWriteSerializer(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="Assignment target. Set to null or omit to remove the current assignment.",
+    )
+
+
+class ErrorTrackingIssueAssignResponseSerializer(serializers.Serializer):
+    success = serializers.BooleanField(help_text="Whether the assignment update completed successfully.")
+
+
 class ErrorTrackingIssueWriteSerializer(serializers.Serializer):
     status = serializers.ChoiceField(
         choices=WRITABLE_ISSUE_STATUSES,
@@ -246,14 +295,17 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
             raise NotFound("Issue not found")
         return Response({"success": True, "new_issue_ids": [str(i) for i in new_issue_ids]})
 
+    @validated_request(
+        request_serializer=ErrorTrackingIssueAssignRequestSerializer,
+        responses={200: OpenApiResponse(response=ErrorTrackingIssueAssignResponseSerializer)},
+    )
     @action(methods=["PATCH"], detail=True)
-    def assign(self, request: request.Request, *args: object, pk: object = None, **kwargs: object) -> Response:
-        assignee = request.data.get("assignee", None)
+    def assign(self, request: ValidatedRequest, *args: object, pk: object = None, **kwargs: object) -> Response:
         try:
             issues_facade.assign_issue(
                 self.team.id,
                 UUID(str(pk)),
-                assignee,
+                request.validated_data["assignee"],
                 user=request.user,
                 was_impersonated=is_impersonated(request),
             )

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -6,6 +6,7 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import ANY, Mock, patch
 
 from django.db import connection
+from django.test import SimpleTestCase
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
@@ -33,6 +34,7 @@ from products.error_tracking.backend.models import (
     ErrorTrackingStackFrame,
     ErrorTrackingSymbolSet,
 )
+from products.error_tracking.backend.presentation.views.issues import ErrorTrackingIssueAssignRequestSerializer
 
 TEST_BUCKET = "test_storage_bucket-TestErrorTracking"
 
@@ -40,6 +42,22 @@ TEST_BUCKET = "test_storage_bucket-TestErrorTracking"
 def get_path_to(fixture_file: str) -> str:
     file_dir = os.path.dirname(__file__)
     return os.path.join(file_dir, "fixtures", fixture_file)
+
+
+class TestErrorTrackingIssueAssignRequestSerializer(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("user", "not-a-user-id"),
+            ("role", "not-a-role-id"),
+        ]
+    )
+    def test_rejects_invalid_assignee_id(self, assignee_type: str, assignee_id: str) -> None:
+        serializer = ErrorTrackingIssueAssignRequestSerializer(
+            data={"assignee": {"id": assignee_id, "type": assignee_type}}
+        )
+
+        assert not serializer.is_valid()
+        assert "id" in serializer.errors["assignee"]
 
 
 class TestErrorTracking(APIBaseTest):
@@ -834,6 +852,17 @@ class TestErrorTracking(APIBaseTest):
         )
         # cannot assign issues from other teams
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_rejects_unknown_assignee_type(self) -> None:
+        issue = self.create_issue()
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/assign",
+            data={"assignee": {"id": self.user.id, "type": "team"}},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not ErrorTrackingIssueAssignment.objects.filter(issue=issue).exists()
 
     @patch("products.error_tracking.backend.logic.issue_mutations.sync_issues_to_clickhouse")
     @patch("products.error_tracking.backend.logic.issue_mutations.dispatch_issue_assigned_realtime")

--- a/products/error_tracking/frontend/generated/api.schemas.ts
+++ b/products/error_tracking/frontend/generated/api.schemas.ts
@@ -836,23 +836,26 @@ export interface PatchedErrorTrackingIssueWriteApi {
     description?: string | null
 }
 
-/**
- * Read-only serializer for issue contract types returned by the facade.
- */
-export interface PatchedErrorTrackingIssueReadApi {
-    id?: string
-    status?: string
-    /** Issue severity, or null when no severity is assigned. */
-    severity?: ErrorTrackingIssueSeverityApi | null
-    /** @nullable */
-    name?: string | null
-    /** @nullable */
-    description?: string | null
-    /** @nullable */
-    first_seen?: string | null
-    assignee?: ErrorTrackingIssueAssigneeReadApi | null
-    external_issues?: ErrorTrackingExternalReferenceResultApi[]
-    cohort?: ErrorTrackingIssueCohortReadApi | null
+export type ErrorTrackingIssueAssigneeIdApi = number | string
+
+export interface ErrorTrackingIssueAssigneeWriteApi {
+    /** User ID or role UUID to assign the issue to. */
+    id: ErrorTrackingIssueAssigneeIdApi
+    /** Assignment target type: user or role.
+     *
+     * * `user` - user
+     * * `role` - role */
+    type: AssigneeTypeEnumApi
+}
+
+export interface PatchedErrorTrackingIssueAssignRequestApi {
+    /** Assignment target. Set to null or omit to remove the current assignment. */
+    assignee?: ErrorTrackingIssueAssigneeWriteApi | null
+}
+
+export interface ErrorTrackingIssueAssignResponseApi {
+    /** Whether the assignment update completed successfully. */
+    success: boolean
 }
 
 export interface ErrorTrackingIssueMergeRequestApi {

--- a/products/error_tracking/frontend/generated/api.ts
+++ b/products/error_tracking/frontend/generated/api.ts
@@ -32,6 +32,7 @@ import type {
     ErrorTrackingGroupingRuleCreateRequestApi,
     ErrorTrackingGroupingRuleListResponseApi,
     ErrorTrackingGroupingRuleUpdateRequestApi,
+    ErrorTrackingIssueAssignResponseApi,
     ErrorTrackingIssueDetailApi,
     ErrorTrackingIssueEventsQueryRequestApi,
     ErrorTrackingIssueEventsResponseApi,
@@ -91,7 +92,7 @@ import type {
     PatchedErrorTrackingBypassRuleUpdateRequestApi,
     PatchedErrorTrackingGroupingRuleApi,
     PatchedErrorTrackingGroupingRuleUpdateRequestApi,
-    PatchedErrorTrackingIssueReadApi,
+    PatchedErrorTrackingIssueAssignRequestApi,
     PatchedErrorTrackingIssueWriteApi,
     PatchedErrorTrackingReleaseUpdateRequestApi,
     PatchedErrorTrackingSettingsApi,
@@ -919,15 +920,18 @@ export const getErrorTrackingIssuesAssignPartialUpdateUrl = (projectId: string, 
 export const errorTrackingIssuesAssignPartialUpdate = async (
     projectId: string,
     id: string,
-    patchedErrorTrackingIssueReadApi?: NonReadonly<PatchedErrorTrackingIssueReadApi>,
+    patchedErrorTrackingIssueAssignRequestApi?: PatchedErrorTrackingIssueAssignRequestApi,
     options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getErrorTrackingIssuesAssignPartialUpdateUrl(projectId, id), {
-        ...options,
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedErrorTrackingIssueReadApi),
-    })
+): Promise<ErrorTrackingIssueAssignResponseApi> => {
+    return apiMutator<ErrorTrackingIssueAssignResponseApi>(
+        getErrorTrackingIssuesAssignPartialUpdateUrl(projectId, id),
+        {
+            ...options,
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(patchedErrorTrackingIssueAssignRequestApi),
+        }
+    )
 }
 
 export const getErrorTrackingIssuesCohortUpdateUrl = (projectId: string, id: string) => {

--- a/products/error_tracking/frontend/generated/api.zod.ts
+++ b/products/error_tracking/frontend/generated/api.zod.ts
@@ -275,60 +275,21 @@ export const ErrorTrackingIssuesPartialUpdateBody = /* @__PURE__ */ zod.object({
     description: zod.string().nullish().describe('Optional issue description.'),
 })
 
-export const ErrorTrackingIssuesAssignPartialUpdateBody = /* @__PURE__ */ zod
-    .object({
-        id: zod.uuid().optional(),
-        status: zod.string().optional(),
-        severity: zod
-            .union([zod.enum(['low', 'medium', 'high', 'critical']), zod.null()])
-            .optional()
-            .describe('Issue severity, or null when no severity is assigned.'),
-        name: zod.string().nullish(),
-        description: zod.string().nullish(),
-        first_seen: zod.iso.datetime({ offset: true }).nullish(),
-        assignee: zod
-            .union([
-                zod.object({
-                    id: zod.union([zod.number(), zod.string(), zod.null()]),
-                    type: zod.string(),
-                }),
-                zod.null(),
-            ])
-            .optional(),
-        external_issues: zod
-            .array(
-                zod
-                    .object({
-                        id: zod.uuid().describe('Unique ID of the external reference.'),
-                        integration: zod
-                            .object({
-                                id: zod.number().describe('ID of the integration backing this external reference.'),
-                                kind: zod
-                                    .string()
-                                    .describe("Integration provider, e.g. 'github', 'gitlab', 'linear', or 'jira'."),
-                                display_name: zod
-                                    .string()
-                                    .describe('Human-readable name of the connected integration.'),
-                            })
-                            .describe('The connected integration this reference was created through.'),
-                        external_url: zod
-                            .string()
-                            .describe("URL of the linked external issue in the provider's system."),
-                    })
-                    .describe('Read-only shape of an external reference, shared by every response.')
-            )
-            .optional(),
-        cohort: zod
-            .union([
-                zod.object({
-                    id: zod.number(),
-                    name: zod.string(),
-                }),
-                zod.null(),
-            ])
-            .optional(),
-    })
-    .describe('Read-only serializer for issue contract types returned by the facade.')
+export const ErrorTrackingIssuesAssignPartialUpdateBody = /* @__PURE__ */ zod.object({
+    assignee: zod
+        .union([
+            zod.object({
+                id: zod.union([zod.number(), zod.string()]).describe('User ID or role UUID to assign the issue to.'),
+                type: zod
+                    .enum(['user', 'role'])
+                    .describe('\* `user` - user\n\* `role` - role')
+                    .describe('Assignment target type: user or role.\n\n\* `user` - user\n\* `role` - role'),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Assignment target. Set to null or omit to remove the current assignment.'),
+})
 
 export const ErrorTrackingIssuesCohortUpdateBody = /* @__PURE__ */ zod
     .object({

--- a/products/error_tracking/mcp/tools.yaml
+++ b/products/error_tracking/mcp/tools.yaml
@@ -235,7 +235,18 @@ tools:
         enabled: false
     error-tracking-issues-assign-partial-update:
         operation: error_tracking_issues_assign_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - error_tracking:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Assign error tracking issue
+        description: >
+            Assign an error tracking issue to an organization member or role. Provide the issue ID as `id` and set
+            `assignee` to a user with a numeric ID or a role with a UUID. Set `assignee` to null to remove the current
+            assignment.
     error-tracking-issues-bulk-create:
         operation: error_tracking_issues_bulk_create
         enabled: false
@@ -296,8 +307,8 @@ tools:
         enrich_url: '{id}'
         title: Update error tracking issue
         description: >
-            Update an error tracking issue. Can change status (active, resolved, suppressed), assign to a user, or
-            update description.
+            Update an error tracking issue's status, severity, name, or description. Use
+            `error-tracking-issues-assign-partial-update` to change its assignee.
         ui_app: error-issue
     error-tracking-issues-retrieve:
         operation: error_tracking_issues_retrieve

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -3547,6 +3547,20 @@
             "readOnlyHint": false
         }
     },
+    "error-tracking-issues-assign-partial-update": {
+        "description": "Assign an error tracking issue to an organization member or role. Provide the issue ID as `id` and set `assignee` to a user with a numeric ID or a role with a UUID. Set `assignee` to null to remove the current assignment.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Assign error tracking issue",
+        "title": "Assign error tracking issue",
+        "required_scopes": ["error_tracking:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "error-tracking-issues-merge-create": {
         "description": "Merge one or more error tracking issues into an existing target issue. Provide the target issue as `id` and the issues to merge into it as `ids`.",
         "category": "Error tracking",
@@ -3562,7 +3576,7 @@
         }
     },
     "error-tracking-issues-partial-update": {
-        "description": "Update an error tracking issue. Can change status (active, resolved, suppressed), assign to a user, or update description.",
+        "description": "Update an error tracking issue's status, severity, name, or description. Use `error-tracking-issues-assign-partial-update` to change its assignee.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Update error tracking issue",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -3576,6 +3576,20 @@
             "readOnlyHint": false
         }
     },
+    "error-tracking-issues-assign-partial-update": {
+        "description": "Assign an error tracking issue to an organization member or role. Provide the issue ID as `id` and set `assignee` to a user with a numeric ID or a role with a UUID. Set `assignee` to null to remove the current assignment.",
+        "category": "Error tracking",
+        "feature": "error_tracking",
+        "summary": "Assign error tracking issue",
+        "title": "Assign error tracking issue",
+        "required_scopes": ["error_tracking:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "error-tracking-issues-merge-create": {
         "description": "Merge one or more error tracking issues into an existing target issue. Provide the target issue as `id` and the issues to merge into it as `ids`.",
         "category": "Error tracking",
@@ -3591,7 +3605,7 @@
         }
     },
     "error-tracking-issues-partial-update": {
-        "description": "Update an error tracking issue. Can change status (active, resolved, suppressed), assign to a user, or update description.",
+        "description": "Update an error tracking issue's status, severity, name, or description. Use `error-tracking-issues-assign-partial-update` to change its assignee.",
         "category": "Error tracking",
         "feature": "error_tracking",
         "summary": "Update error tracking issue",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -31191,9 +31191,26 @@ export namespace Schemas {
       sessions?: number;
     }
 
+    export interface ErrorTrackingIssueAssignResponse {
+      /** Whether the assignment update completed successfully. */
+      success: boolean;
+    }
+
+    export type ErrorTrackingIssueAssigneeId = number | string;
+
     export interface ErrorTrackingIssueAssigneeRead {
       readonly id: number | string | null;
       type: string;
+    }
+
+    export interface ErrorTrackingIssueAssigneeWrite {
+      /** User ID or role UUID to assign the issue to. */
+      id: ErrorTrackingIssueAssigneeId;
+      /** Assignment target type: user or role.
+       *
+       * * `user` - user
+       * * `role` - role */
+      type: AssigneeTypeEnum;
     }
 
     export interface ErrorTrackingIssueCohortRead {
@@ -61203,23 +61220,9 @@ export namespace Schemas {
       filters?: PropertyGroupFilterValue | null;
     }
 
-    /**
-     * Read-only serializer for issue contract types returned by the facade.
-     */
-    export interface PatchedErrorTrackingIssueRead {
-      id?: string;
-      status?: string;
-      /** Issue severity, or null when no severity is assigned. */
-      severity?: ErrorTrackingIssueSeverity | null;
-      /** @nullable */
-      name?: string | null;
-      /** @nullable */
-      description?: string | null;
-      /** @nullable */
-      first_seen?: string | null;
-      assignee?: ErrorTrackingIssueAssigneeRead | null;
-      external_issues?: ErrorTrackingExternalReferenceResult[];
-      cohort?: ErrorTrackingIssueCohortRead | null;
+    export interface PatchedErrorTrackingIssueAssignRequest {
+      /** Assignment target. Set to null or omit to remove the current assignment. */
+      assignee?: ErrorTrackingIssueAssigneeWrite | null;
     }
 
     export interface PatchedErrorTrackingIssueWrite {

--- a/services/mcp/src/generated/error_tracking/api.ts
+++ b/services/mcp/src/generated/error_tracking/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 27 enabled ops
+ * PostHog API - MCP 28 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -8022,6 +8022,31 @@ export const ErrorTrackingIssuesPartialUpdateBody = /* @__PURE__ */ zod.object({
         .describe('Issue severity to set, or null to remove the assigned severity.'),
     name: zod.string().nullish().describe('Optional issue display name.'),
     description: zod.string().nullish().describe('Optional issue description.'),
+})
+
+export const ErrorTrackingIssuesAssignPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const ErrorTrackingIssuesAssignPartialUpdateBody = /* @__PURE__ */ zod.object({
+    assignee: zod
+        .union([
+            zod.object({
+                id: zod.union([zod.number(), zod.string()]).describe('User ID or role UUID to assign the issue to.'),
+                type: zod
+                    .enum(['user', 'role'])
+                    .describe('\* `user` - user\n\* `role` - role')
+                    .describe('Assignment target type: user or role.\n\n\* `user` - user\n\* `role` - role'),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Assignment target. Set to null or omit to remove the current assignment.'),
 })
 
 export const ErrorTrackingIssuesMergeCreateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -13,6 +13,8 @@ import {
     ErrorTrackingGroupingRulesCreateBody,
     ErrorTrackingGroupingRulesUpdateBody,
     ErrorTrackingGroupingRulesUpdateParams,
+    ErrorTrackingIssuesAssignPartialUpdateBody,
+    ErrorTrackingIssuesAssignPartialUpdateParams,
     ErrorTrackingIssuesMergeCreateBody,
     ErrorTrackingIssuesMergeCreateParams,
     ErrorTrackingIssuesPartialUpdateBody,
@@ -250,6 +252,31 @@ const errorTrackingGroupingRulesUpdate = (): ToolBase<typeof ErrorTrackingGroupi
         const result = await context.api.request<unknown>({
             method: 'PUT',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/grouping_rules/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const ErrorTrackingIssuesAssignPartialUpdateSchema = ErrorTrackingIssuesAssignPartialUpdateParams.omit({
+    project_id: true,
+}).extend(ErrorTrackingIssuesAssignPartialUpdateBody.shape)
+
+const errorTrackingIssuesAssignPartialUpdate = (): ToolBase<
+    typeof ErrorTrackingIssuesAssignPartialUpdateSchema,
+    Schemas.ErrorTrackingIssueAssignResponse
+> => ({
+    name: 'error-tracking-issues-assign-partial-update',
+    schema: ErrorTrackingIssuesAssignPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof ErrorTrackingIssuesAssignPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.assignee !== undefined) {
+            body['assignee'] = params.assignee
+        }
+        const result = await context.api.request<Schemas.ErrorTrackingIssueAssignResponse>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/error_tracking/issues/${encodeURIComponent(String(params.id))}/assign/`,
             body,
         })
         return result
@@ -851,6 +878,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'error-tracking-grouping-rules-create': errorTrackingGroupingRulesCreate,
     'error-tracking-grouping-rules-list': errorTrackingGroupingRulesList,
     'error-tracking-grouping-rules-update': errorTrackingGroupingRulesUpdate,
+    'error-tracking-issues-assign-partial-update': errorTrackingIssuesAssignPartialUpdate,
     'error-tracking-issues-merge-create': errorTrackingIssuesMergeCreate,
     'error-tracking-issues-partial-update': errorTrackingIssuesPartialUpdate,
     'error-tracking-issues-split-create': errorTrackingIssuesSplitCreate,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-issues-assign-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/error-tracking-issues-assign-partial-update.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "assignee": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "id": {
+                            "anyOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ],
+                            "description": "User ID or role UUID to assign the issue to."
+                        },
+                        "type": {
+                            "description": "Assignment target type: user or role.\n\n* `user` - user\n* `role` - role",
+                            "enum": ["user", "role"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["id", "type"],
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Assignment target. Set to null or omit to remove the current assignment."
+        },
+        "id": {
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Loop agents cannot assign or unassign Error tracking issues through the PostHog MCP server.

The generic issue partial-update schema omits `assignee`. DRF discards an assignee-only body into empty validated data, so the request makes no change.

The existing dedicated assignment endpoint accepts untyped request bodies, so generated clients cannot describe valid user and role targets.

```mermaid
flowchart LR
    A{{Loop agent}} --> B[No assignment tool]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B phGray;
```

## Changes

- Loop agents can assign issues to organization members or roles and remove existing assignments through MCP.
- The MCP tool uses the dedicated assignment action, preserving validation, activity logs, notifications, and ClickHouse synchronization.
- The assignment endpoint validates target types, numeric user IDs, and role UUIDs before applying existing organization checks.
- OpenAPI clients and MCP handlers are regenerated mechanically. This PR has no visible UI changes.

```mermaid
flowchart LR
    A{{Loop agent}} --> B[MCP assignment tool] --> C[Typed assignment endpoint] --> D[Issue assignment]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B,C phRed;
    class D phYellow;
```

## How did you test this code?

- Added serializer tests for malformed user IDs and role UUIDs, guarding against unhandled assignment requests.
- Added an API regression test for unknown target types. Its local run was blocked during setup by ClickHouse native connection resets.
- Ran Ruff, repo-wide mypy, OpenAPI generation, frontend and MCP typechecks, and MCP tool-name validation locally.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing documentation changes. The MCP tool definition contains the agent-facing contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi implemented the scoped change with repository file, shell, and jj tools. No public session link is available.

Skills invoked: `/error-tracking`, `/improving-drf-endpoints`, `/implementing-mcp-tools`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.

The diff contains only repository-derived context and invented invalid identifiers used by tests.
