### PR TITLE
fix(error-tracking): repair severity state ingestion

### DIFF
--- a/posthog/clickhouse/hcl/golden/local-multi/ingestion_small.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/ingestion_small.hcl
@@ -1164,6 +1164,59 @@ database "posthog" {
     }
   }
 
+  table "writable_error_tracking_fingerprint_issue_state" {
+    column "team_id" {
+      type = "Int64"
+    }
+    column "fingerprint" {
+      type = "String"
+    }
+    column "issue_id" {
+      type = "UUID"
+    }
+    column "issue_name" {
+      type = "Nullable(String)"
+    }
+    column "issue_description" {
+      type = "Nullable(String)"
+    }
+    column "issue_status" {
+      type = "String"
+    }
+    column "issue_severity" {
+      type = "Nullable(String)"
+    }
+    column "assigned_user_id" {
+      type = "Nullable(Int64)"
+    }
+    column "assigned_role_id" {
+      type = "Nullable(UUID)"
+    }
+    column "first_seen" {
+      type = "DateTime64(3, 'UTC')"
+    }
+    column "is_deleted" {
+      type = "Int8"
+    }
+    column "version" {
+      type = "Int64"
+    }
+    column "_timestamp" {
+      type = "DateTime"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_partition" {
+      type = "UInt64"
+    }
+    engine "distributed" {
+      cluster_name    = "aux"
+      remote_database = "posthog"
+      remote_table    = "raw_error_tracking_fingerprint_issue_state"
+    }
+  }
+
   table "writable_error_tracking_issue_fingerprint_embeddings" {
     column "team_id" {
       type = "Int64"

--- a/posthog/clickhouse/hcl/manifest.hcl
+++ b/posthog/clickhouse/hcl/manifest.hcl
@@ -62,10 +62,10 @@ role "ai_events" {
 # hosts the ingestion_warnings store; prod-us adds the Distributed proxy onto the data
 # cluster. prod goldens are dump-baselined (not live-verifiable here).
 role "aux" {
-  env "local-multi"   { layers = ["roles/shared", "roles/coshared/aux_data", "roles/auxiliary/shared", "roles/auxiliary/local"] }
-  env "dev"     { layers = ["roles/shared", "roles/coshared/custom_metrics", "roles/coshared/aux_data", "roles/coshared/ingestion_warnings_store", "roles/auxiliary/shared", "roles/auxiliary/prod", "roles/auxiliary/dev"] }
-  env "prod-us" { layers = ["roles/shared", "roles/coshared/custom_metrics", "roles/coshared/aux_data", "roles/coshared/ingestion_warnings_store", "roles/auxiliary/shared", "roles/auxiliary/prod", "roles/auxiliary/prod-us"] }
-  env "prod-eu" { layers = ["roles/shared", "roles/coshared/custom_metrics", "roles/coshared/aux_data", "roles/coshared/ingestion_warnings_store", "roles/auxiliary/shared", "roles/auxiliary/prod", "roles/auxiliary/prod-eu"] }
+  env "local-multi"   { layers = ["roles/shared", "roles/coshared/aux_data", "roles/coshared/aux_small", "roles/auxiliary/shared", "roles/auxiliary/local"] }
+  env "dev"     { layers = ["roles/shared", "roles/coshared/custom_metrics", "roles/coshared/aux_data", "roles/coshared/aux_small", "roles/coshared/ingestion_warnings_store", "roles/auxiliary/shared", "roles/auxiliary/prod", "roles/auxiliary/dev"] }
+  env "prod-us" { layers = ["roles/shared", "roles/coshared/custom_metrics", "roles/coshared/aux_data", "roles/coshared/aux_small", "roles/coshared/ingestion_warnings_store", "roles/auxiliary/shared", "roles/auxiliary/prod", "roles/auxiliary/prod-us"] }
+  env "prod-eu" { layers = ["roles/shared", "roles/coshared/custom_metrics", "roles/coshared/aux_data", "roles/coshared/aux_small", "roles/coshared/ingestion_warnings_store", "roles/auxiliary/shared", "roles/auxiliary/prod", "roles/auxiliary/prod-eu"] }
 }
 
 # SESSIONS satellite: the local node runs only the shared query_log_archive path
@@ -115,7 +115,7 @@ role "events" {
 }
 
 role "small" {
-  env "local-multi" { layers = ["roles/shared/qla.hcl", "roles/coshared/log_entries_write", "roles/coshared/session_replay_write", "roles/ingestion_small/local"] }
+  env "local-multi" { layers = ["roles/shared/qla.hcl", "roles/coshared/aux_small", "roles/coshared/log_entries_write", "roles/coshared/session_replay_write", "roles/ingestion_small/local"] }
 }
 
 role "medium" {
@@ -127,7 +127,7 @@ role "medium" {
 # and not MULTINODE_CLICKHOUSE. Composed as the deduped union of the local-multi stacks it
 # hosts, so any name two of those roles declare fails this load instead of drifting.
 role "all" {
-  env "local-single" { layers = ["roles/shared", "roles/coshared/custom_metrics", "roles/ops/shared", "roles/ops/local", "roles/logs/base", "roles/logs/traces", "roles/logs/traces_kafka_metrics", "roles/logs/metrics", "roles/logs/local", "roles/coshared/ai_events_data", "roles/ai_events/shared", "roles/ai_events/local", "roles/coshared/aux_data", "roles/auxiliary/shared", "roles/auxiliary/local", "roles/coshared/sessions_data", "roles/coshared/tophog", "roles/coshared/events_recent", "roles/coshared/events_recent_write", "roles/coshared/batch_exports_data", "roles/coshared/ingestion_warnings_store", "roles/coshared/events_json_write", "roles/coshared/log_entries_write", "roles/coshared/session_replay_write", "roles/data/shared", "roles/data/local", "roles/ingestion_events/local", "roles/ingestion_events/local-single", "roles/ingestion_small/local", "roles/ingestion_medium/local"] }
+  env "local-single" { layers = ["roles/shared", "roles/coshared/custom_metrics", "roles/ops/shared", "roles/ops/local", "roles/logs/base", "roles/logs/traces", "roles/logs/traces_kafka_metrics", "roles/logs/metrics", "roles/logs/local", "roles/coshared/ai_events_data", "roles/ai_events/shared", "roles/ai_events/local", "roles/coshared/aux_data", "roles/coshared/aux_small", "roles/auxiliary/shared", "roles/auxiliary/local", "roles/coshared/sessions_data", "roles/coshared/tophog", "roles/coshared/events_recent", "roles/coshared/events_recent_write", "roles/coshared/batch_exports_data", "roles/coshared/ingestion_warnings_store", "roles/coshared/events_json_write", "roles/coshared/log_entries_write", "roles/coshared/session_replay_write", "roles/data/shared", "roles/data/local", "roles/ingestion_events/local", "roles/ingestion_events/local-single", "roles/ingestion_small/local", "roles/ingestion_medium/local"] }
 }
 
 # role "endpoints" {

--- a/posthog/clickhouse/hcl/roles/auxiliary/shared/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/auxiliary/shared/tables.hcl
@@ -663,58 +663,6 @@ database "posthog" {
       version_column = "computed_at"
     }
   }
-  table "writable_error_tracking_fingerprint_issue_state" {
-    column "team_id" {
-      type = "Int64"
-    }
-    column "fingerprint" {
-      type = "String"
-    }
-    column "issue_id" {
-      type = "UUID"
-    }
-    column "issue_name" {
-      type = "Nullable(String)"
-    }
-    column "issue_description" {
-      type = "Nullable(String)"
-    }
-    column "issue_status" {
-      type = "String"
-    }
-    column "issue_severity" {
-      type = "Nullable(String)"
-    }
-    column "assigned_user_id" {
-      type = "Nullable(Int64)"
-    }
-    column "assigned_role_id" {
-      type = "Nullable(UUID)"
-    }
-    column "first_seen" {
-      type = "DateTime64(3, 'UTC')"
-    }
-    column "is_deleted" {
-      type = "Int8"
-    }
-    column "version" {
-      type = "Int64"
-    }
-    column "_timestamp" {
-      type = "DateTime"
-    }
-    column "_offset" {
-      type = "UInt64"
-    }
-    column "_partition" {
-      type = "UInt64"
-    }
-    engine "distributed" {
-      cluster_name    = "aux"
-      remote_database = "posthog"
-      remote_table    = "raw_error_tracking_fingerprint_issue_state"
-    }
-  }
   materialized_view "hog_invocation_results_mv" {
     to_table = "posthog.hog_invocation_results_data"
     query    = file("sql/hog_invocation_results_mv.sql")

--- a/posthog/clickhouse/hcl/roles/coshared/aux_small/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/coshared/aux_small/tables.hcl
@@ -1,0 +1,54 @@
+database "posthog" {
+  table "writable_error_tracking_fingerprint_issue_state" {
+    column "team_id" {
+      type = "Int64"
+    }
+    column "fingerprint" {
+      type = "String"
+    }
+    column "issue_id" {
+      type = "UUID"
+    }
+    column "issue_name" {
+      type = "Nullable(String)"
+    }
+    column "issue_description" {
+      type = "Nullable(String)"
+    }
+    column "issue_status" {
+      type = "String"
+    }
+    column "issue_severity" {
+      type = "Nullable(String)"
+    }
+    column "assigned_user_id" {
+      type = "Nullable(Int64)"
+    }
+    column "assigned_role_id" {
+      type = "Nullable(UUID)"
+    }
+    column "first_seen" {
+      type = "DateTime64(3, 'UTC')"
+    }
+    column "is_deleted" {
+      type = "Int8"
+    }
+    column "version" {
+      type = "Int64"
+    }
+    column "_timestamp" {
+      type = "DateTime"
+    }
+    column "_offset" {
+      type = "UInt64"
+    }
+    column "_partition" {
+      type = "UInt64"
+    }
+    engine "distributed" {
+      cluster_name    = "aux"
+      remote_database = "posthog"
+      remote_table    = "raw_error_tracking_fingerprint_issue_state"
+    }
+  }
+}

--- a/posthog/clickhouse/hcl/sql/local-multi/ingestion_small.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/ingestion_small.sql
@@ -341,6 +341,23 @@ CREATE TABLE posthog.writable_duplicate_events (
   _offset UInt64,
   _partition UInt64
 ) ENGINE = Distributed('posthog_single_shard', 'posthog', 'duplicate_events');
+CREATE TABLE posthog.writable_error_tracking_fingerprint_issue_state (
+  team_id Int64,
+  fingerprint String,
+  issue_id UUID,
+  issue_name Nullable(String),
+  issue_description Nullable(String),
+  issue_status String,
+  issue_severity Nullable(String),
+  assigned_user_id Nullable(Int64),
+  assigned_role_id Nullable(UUID),
+  first_seen DateTime64(3, 'UTC'),
+  is_deleted Int8,
+  version Int64,
+  _timestamp DateTime,
+  _offset UInt64,
+  _partition UInt64
+) ENGINE = Distributed('aux', 'posthog', 'raw_error_tracking_fingerprint_issue_state');
 CREATE TABLE posthog.writable_error_tracking_issue_fingerprint_embeddings (
   team_id Int64,
   model_name LowCardinality(String),

--- a/posthog/clickhouse/migrations/0312_reapply_error_tracking_issue_severity.py
+++ b/posthog/clickhouse/migrations/0312_reapply_error_tracking_issue_severity.py
@@ -1,0 +1,47 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.run_mode import run_mode
+
+from products.error_tracking.backend.sql import (
+    DROP_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS_KAFKA_TABLE_SQL,
+    DROP_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS_MV_SQL,
+    ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS_MV_SQL,
+    KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS_TABLE_SQL,
+    WRITABLE_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_TABLE_SQL,
+)
+
+operations = [
+    run_sql_with_exceptions(
+        WRITABLE_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+        require_hosts=True,
+    ),
+    run_sql_with_exceptions(
+        "ALTER TABLE writable_error_tracking_fingerprint_issue_state "
+        "ADD COLUMN IF NOT EXISTS issue_severity Nullable(String) AFTER issue_status",
+        node_roles=[NodeRole.INGESTION_SMALL],
+        sharded=False,
+        is_alter_on_replicated_table=False,
+    ),
+] + (
+    [
+        run_sql_with_exceptions(
+            DROP_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS_MV_SQL,
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            DROP_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS_KAFKA_TABLE_SQL,
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS_TABLE_SQL(),
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+        run_sql_with_exceptions(
+            ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS_MV_SQL(),
+            node_roles=[NodeRole.INGESTION_SMALL],
+        ),
+    ]
+    if run_mode().is_deployed_cloud
+    else []
+)

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0311_drop_log_attributes_mvs
+0312_reapply_error_tracking_issue_severity


### PR DESCRIPTION
## Problem

Error Tracking issue severity can disappear from issue lists even when the issue has a severity.

Cymbal publishes `issue_severity`, but the ingestion-small ClickHouse schema does not read or forward that field.

```mermaid
flowchart LR
    A{{Cymbal}} --> B[Kafka topic]
    B --> C[Kafka engine without severity]
    C --> D[Materialized view without severity]
    D --> E[(Issue state)]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B phYellow;
    class C,D phRed;
    class E phGray;
```

## Changes

- Issue lists retain severity for newly ingested issues after the schema deploys.
- The writable table gains the nullable severity column before the consumer starts forwarding it.
- The Kafka engine gains the field needed to deserialize the existing Cymbal payload.
- The materialized view gains the field needed to copy severity into stored issue state.
- The migration recreates the consumer objects because existing clusters keep their creation-time schemas.
- The HCL definitions keep new and reconciled clusters aligned with the repaired runtime schema.
- The shared writable definition moves to an auxiliary-and-small layer because both node roles need the same table.
- The golden HCL and SQL files are generated artifacts that verify each role composition.

> [!NOTE]
> The migration does not drop stored issue state. It only recreates the Kafka consumer table and materialized view with the same consumer group.

```mermaid
flowchart LR
    A{{Cymbal}} --> B[Kafka topic]
    B --> C[Kafka engine with severity]
    C --> D[Materialized view with severity]
    D --> E[(Issue state with severity)]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B phYellow;
    class C,D phBlue;
    class E phGray;
```

## How did you test this code?

- `posthog/clickhouse/test/test_migrations.py` validates the migration metadata and SQL safety rules.
- `posthog/clickhouse/hcl/check.sh` validates every generated role composition and SQL artifact.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This restores existing severity behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi authored this change with the repository file, shell, and testing tools. The human directed the investigation and implementation.

Skills: `/error-tracking`, `/clickhouse-migrations`, `/writing-tests`, `/announcing-behavior-changes`, `/running-ci-preflight`, `/stacking-prs`, and `/writing-pr-descriptions`.
