### PR TITLE
fix(error-tracking): make state backfill replace stale rows

### DIFF
--- a/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
+++ b/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
@@ -37,7 +37,7 @@ from posthog.kafka_client.client import ClickhouseProducer
 from posthog.kafka_client.topics import KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE
 from posthog.models.event.util import format_clickhouse_timestamp
 
-from products.error_tracking.backend.models import ErrorTrackingIssueFingerprintV2
+from products.error_tracking.backend.models import ErrorTrackingIssueFingerprintV2, _clickhouse_status
 from products.error_tracking.backend.sql import INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE
 
 logger = structlog.get_logger(__name__)
@@ -199,7 +199,7 @@ class Command(BaseCommand):
             "issue_id": str(issue.id),
             "issue_name": issue.name,
             "issue_description": issue.description,
-            "issue_status": issue.status,
+            "issue_status": _clickhouse_status(issue.status),
             "issue_severity": issue.severity,
             "assigned_user_id": assigned_user_id,
             "assigned_role_id": assigned_role_id,

--- a/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
+++ b/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
@@ -29,11 +29,12 @@ from __future__ import annotations
 import time
 import logging
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 import structlog
 
 from posthog.kafka_client.client import ClickhouseProducer
+from posthog.kafka_client.routing import flush_all_producers
 from posthog.kafka_client.topics import KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE
 from posthog.models.event.util import format_clickhouse_timestamp
 
@@ -43,6 +44,7 @@ from products.error_tracking.backend.sql import INSERT_ERROR_TRACKING_FINGERPRIN
 logger = structlog.get_logger(__name__)
 
 DEFAULT_BATCH_SIZE = 5000
+FLUSH_TIMEOUT_SECONDS = 5 * 60
 
 
 class Command(BaseCommand):
@@ -146,7 +148,17 @@ class Command(BaseCommand):
                         elapsed_s=round(elapsed),
                     )
 
+        # produce() only enqueues; flush before exit so queued records actually land in Kafka.
+        logger.info("backfill_flushing", timeout_s=FLUSH_TIMEOUT_SECONDS)
+        undelivered = flush_all_producers(FLUSH_TIMEOUT_SECONDS)
+
         elapsed = time.monotonic() - start_time
+        if undelivered:
+            logger.error(
+                "backfill_flush_incomplete", produced=produced, undelivered=undelivered, elapsed_s=round(elapsed)
+            )
+            raise CommandError(f"Kafka flush left {undelivered} record(s) undelivered; backfill is incomplete.")
+
         logger.info("backfill_complete", produced=produced, elapsed_s=round(elapsed))
 
     def _get_team_ids(

--- a/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
+++ b/products/error_tracking/backend/management/commands/backfill_error_tracking_issue_state.py
@@ -116,13 +116,14 @@ class Command(BaseCommand):
         produced = 0
         since_last_flush = 0
         start_time = time.monotonic()
+        backfill_version = int(time.time() * 1000)
 
         for current_team_id in team_ids:
             team_qs = self._build_queryset(team_id=current_team_id).iterator(chunk_size=batch_size)
             logger.info("backfill_processing_team", team_id=current_team_id, produced_so_far=produced)
 
             for fp in team_qs:
-                data = self._build_row(fp)
+                data = self._build_row(fp, version=backfill_version)
                 producer.produce(
                     sql=INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
                     topic=KAFKA_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
@@ -177,7 +178,7 @@ class Command(BaseCommand):
 
         return qs
 
-    def _build_row(self, fp: ErrorTrackingIssueFingerprintV2) -> dict:
+    def _build_row(self, fp: ErrorTrackingIssueFingerprintV2, *, version: int) -> dict:
         issue = fp.issue
         assignment = getattr(issue, "assignment", None)
 
@@ -191,7 +192,6 @@ class Command(BaseCommand):
 
         first_seen_raw = fp.first_seen or issue.created_at
         first_seen = format_clickhouse_timestamp(first_seen_raw) if first_seen_raw else None
-        version = int(fp.created_at.timestamp() * 1000)
 
         return {
             "team_id": fp.team_id,

--- a/products/error_tracking/backend/management/commands/test/test_backfill_error_tracking_issue_state.py
+++ b/products/error_tracking/backend/management/commands/test/test_backfill_error_tracking_issue_state.py
@@ -1,6 +1,7 @@
 from datetime import UTC
 
 from posthog.test.base import BaseTest, ClickhouseTestMixin
+from unittest.mock import patch
 
 from posthog.clickhouse.client.execute import sync_execute
 from posthog.models import Team
@@ -11,6 +12,7 @@ from products.error_tracking.backend.models import (
     ErrorTrackingIssueAssignment,
     ErrorTrackingIssueFingerprintV2,
 )
+from products.error_tracking.backend.sql import INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE
 
 
 class TestBackfillErrorTrackingIssueState(ClickhouseTestMixin, BaseTest):
@@ -158,19 +160,54 @@ class TestBackfillErrorTrackingIssueState(ClickhouseTestMixin, BaseTest):
         self.assertEqual(self._count_rows(team_mid.pk), 1)
         self.assertEqual(self._count_rows(team_high.pk), 0)
 
-    def test_backfill_version_is_fingerprint_created_at_epoch_ms(self):
-        from datetime import datetime
+    def test_backfill_replaces_newer_existing_state(self):
+        issue = ErrorTrackingIssue.objects.create(
+            team=self.team,
+            name="VersionError",
+            status="active",
+            severity=ErrorTrackingIssue.Severity.HIGH,
+        )
+        fingerprint = ErrorTrackingIssueFingerprintV2.objects.create(
+            team=self.team, issue=issue, fingerprint="fp_version"
+        )
+        existing_version = int(fingerprint.created_at.timestamp() * 1000) + 1_000
+        replacement_version = existing_version + 1_000
+        sync_execute(
+            INSERT_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE,
+            {
+                "team_id": self.team.pk,
+                "fingerprint": fingerprint.fingerprint,
+                "issue_id": str(issue.id),
+                "issue_name": issue.name,
+                "issue_description": issue.description,
+                "issue_status": issue.status,
+                "issue_severity": None,
+                "assigned_user_id": None,
+                "assigned_role_id": None,
+                "first_seen": issue.created_at,
+                "is_deleted": 0,
+                "version": existing_version,
+            },
+        )
 
-        created_at = datetime(2024, 2, 10, 9, 15, 30, tzinfo=UTC)
-        issue = ErrorTrackingIssue.objects.create(team=self.team, name="VersionError", status="active")
-        fp = ErrorTrackingIssueFingerprintV2.objects.create(team=self.team, issue=issue, fingerprint="fp_version")
-        ErrorTrackingIssueFingerprintV2.objects.filter(pk=fp.pk).update(created_at=created_at)
+        with patch(
+            "products.error_tracking.backend.management.commands.backfill_error_tracking_issue_state.time.time",
+            return_value=replacement_version / 1_000,
+        ):
+            self._run_backfill(team_id=self.team.pk)
 
-        self._run_backfill(team_id=self.team.pk)
-
-        rows = self._get_rows(self.team.pk)
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0]["version"], int(created_at.timestamp() * 1000))
+        [(severity, version)] = sync_execute(
+            """
+            SELECT
+                tupleElement(argMax(tuple(issue_severity), version), 1),
+                max(version)
+            FROM error_tracking_fingerprint_issue_state
+            WHERE team_id = %(team_id)s AND fingerprint = %(fingerprint)s
+            """,
+            {"team_id": self.team.pk, "fingerprint": fingerprint.fingerprint},
+        )
+        self.assertEqual(severity, ErrorTrackingIssue.Severity.HIGH)
+        self.assertEqual(version, replacement_version)
 
     def test_backfill_uses_fingerprint_first_seen(self):
         from datetime import datetime

--- a/products/error_tracking/backend/management/commands/test/test_backfill_error_tracking_issue_state.py
+++ b/products/error_tracking/backend/management/commands/test/test_backfill_error_tracking_issue_state.py
@@ -3,6 +3,8 @@ from datetime import UTC
 from posthog.test.base import BaseTest, ClickhouseTestMixin
 from unittest.mock import patch
 
+from parameterized import parameterized
+
 from posthog.clickhouse.client.execute import sync_execute
 from posthog.models import Team
 
@@ -249,3 +251,19 @@ class TestBackfillErrorTrackingIssueState(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(rows), 2)
         self.assertEqual(rows[0]["issue_status"], "active")
         self.assertEqual(rows[1]["issue_status"], "resolved")
+
+    @parameterized.expand(
+        [
+            (ErrorTrackingIssue.Status.ARCHIVED,),
+            (ErrorTrackingIssue.Status.PENDING_RELEASE,),
+        ]
+    )
+    def test_backfill_folds_deprecated_status_to_resolved(self, deprecated_status):
+        issue = ErrorTrackingIssue.objects.create(team=self.team, name="LegacyError", status=deprecated_status)
+        ErrorTrackingIssueFingerprintV2.objects.create(team=self.team, issue=issue, fingerprint="fp_legacy")
+
+        self._run_backfill(team_id=self.team.pk)
+
+        rows = self._get_rows(self.team.pk)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["issue_status"], "resolved")


### PR DESCRIPTION
## Problem

Existing Error Tracking issues can keep missing severity after a repair backfill.

The backfill uses the fingerprint creation time, which is older than the ClickHouse state row it must replace.

## Changes

- Backfilled issues now replace stale ClickHouse rows and restore current severity.
- The command uses one run-start version, so later concurrent issue updates still win.
- This layer changes no frontend code.

> [!NOTE]
> Run `python manage.py backfill_error_tracking_issue_state --live-run` after the bottom migration reaches production.

## How did you test this code?

- The backfill command test suite exercises all existing command behavior.
- The new regression case verifies that a backfill replaces a newer stale row.
- Repo-wide mypy validates the updated command signature.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. The existing internal command keeps the same interface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi authored this change with the repository file, shell, and testing tools. The human directed the investigation and implementation.

Skills: `/error-tracking`, `/clickhouse-migrations`, `/writing-tests`, `/announcing-behavior-changes`, `/running-ci-preflight`, `/stacking-prs`, and `/writing-pr-descriptions`.
