### PR TITLE
fix(context-layer): evaluate the dream lane flag as the enabling user

### DIFF
--- a/products/context_layer/backend/temporal/dreaming.py
+++ b/products/context_layer/backend/temporal/dreaming.py
@@ -81,14 +81,23 @@ def _fetch_dream_candidates() -> list[str]:
     # Least-recently-dreamt first (never-dreamt before that): when more orgs are
     # due than the cap, the cap rotates through the fleet instead of permanently
     # starving whoever sorts last.
-    for config in ContextLayerConfig.objects.filter(dreaming_paused=False).order_by(
-        F("last_dream_started_at").asc(nulls_first=True), "created_at"
+    for config in (
+        ContextLayerConfig.objects.filter(dreaming_paused=False)
+        .select_related("created_by")
+        .order_by(F("last_dream_started_at").asc(nulls_first=True), "created_at")
     ):
         if config.last_dream_started_at is not None and config.last_dream_started_at.date() >= today:
             continue
+        # The flag is user-targeted (dogfood targets the enabling user's
+        # email), and the enable route gated the org with the requesting
+        # user's identity. Evaluating as the organization id never matches a
+        # user-targeted flag, so the lane would starve silently.
+        enabling_distinct_id = config.created_by.distinct_id if config.created_by else None
+        if not enabling_distinct_id:
+            continue
         organization_id = str(config.organization_id)
         if not context_layer_facade.is_context_layer_enabled(
-            organization_id=organization_id, distinct_id=organization_id
+            organization_id=organization_id, distinct_id=enabling_distinct_id
         ):
             continue
         candidates.append(organization_id)
@@ -106,7 +115,9 @@ def _fetch_dream_candidates() -> list[str]:
 @activity.defn
 async def fetch_dream_candidates() -> list[str]:
     """Organizations due a dream tonight: wiki exists, lane not paused, no
-    dream started today, and the flag still on."""
+    dream started today, and the flag still on for the user who enabled the
+    wiki (the flag is user-targeted, so the lane evaluates it with that
+    user's identity)."""
     return await sync_to_async(_fetch_dream_candidates, thread_sensitive=False)()
 
 

--- a/products/context_layer/backend/test/test_dreaming.py
+++ b/products/context_layer/backend/test/test_dreaming.py
@@ -58,8 +58,12 @@ class TestDreamPrompt(SimpleTestCase):
 
 class TestDreamCandidates(SimpleTestCase):
     def test_fetch_candidates_caps_each_tick_at_one_thousand(self) -> None:
-        configs = [MagicMock(last_dream_started_at=None, organization_id=index) for index in range(1001)]
+        configs = [
+            MagicMock(last_dream_started_at=None, organization_id=index, created_by=MagicMock(distinct_id="d"))
+            for index in range(1001)
+        ]
         queryset = MagicMock()
+        queryset.select_related.return_value = queryset
         queryset.order_by.return_value = configs
 
         with (
@@ -89,6 +93,21 @@ class TestDreamingLane(BaseTest):
         flag_mock.return_value = True
         config = self._config()
         assert dreaming._fetch_dream_candidates() == [str(config.organization_id)]
+
+    @patch("products.context_layer.backend.temporal.dreaming.context_layer_facade.is_context_layer_enabled")
+    def test_fetch_candidates_evaluates_the_flag_as_the_enabling_user(self, flag_mock) -> None:
+        # The flag is user-targeted (dogfood targets the enabling user's email),
+        # and the enable route gated the org with the requesting user's identity;
+        # evaluating as the organization id never matches and the lane starves silently.
+        self._config()
+        assert dreaming._fetch_dream_candidates() == [str(self.organization.id)]
+        assert flag_mock.call_args.kwargs["distinct_id"] == self.user.distinct_id
+
+    @patch("products.context_layer.backend.temporal.dreaming.context_layer_facade.is_context_layer_enabled")
+    def test_fetch_candidates_skips_orgs_with_no_enabling_user(self, flag_mock) -> None:
+        self._config(created_by=None)
+        assert dreaming._fetch_dream_candidates() == []
+        flag_mock.assert_not_called()
 
     @patch("products.context_layer.backend.temporal.dreaming.context_layer_facade.is_context_layer_enabled")
     def test_fetch_candidates_skips_paused_dreamt_today_and_flag_off(self, flag_mock) -> None:


### PR DESCRIPTION
## Problem

- Organizations with the context layer enabled stopped getting nightly dreams, with no error and no lane pause.
- On dogfood, no dream has run since the 2026-08-27 seed run.
- The nightly coordinator filters orgs through the `context-layer` flag using the **organization id** as the distinct id.
- The flag is user-targeted (dogfood targets the enabling user's email), so that evaluation returns `no_condition_match` and the org is skipped silently: no dispatch, no failure event, no circuit-breaker pause.
- The seed run on 2026-08-27 still fired, because the bootstrap dream dispatches without the candidate check.

## Changes

- The dream coordinator now evaluates the `context-layer` flag with the distinct id of the user who enabled the wiki, matching how the enable route gated the org (it evaluates with the requesting user's identity).
- Orgs whose enabling user is gone, or has no distinct id, are skipped instead of evaluated: the flag is fail-closed.
- Mechanical: the candidate query selects the enabling user in the same pass, and the dispatch docstring names the identity the flag is evaluated with.

## How did you test this code?

- New regression tests, first run red then green after the fix: the candidate fetch must call the flag with the enabling user's distinct id, and must skip orgs with no enabling user. No existing test covered the identity the flag is evaluated with.
- Production evidence for the diagnosis (not checked: that tonight's scheduled tick dispatches, which only deploy can show): flag evaluation for the org id identity returns `no_condition_match`, verified with `feature-flags-test-evaluation-create` on the dogfood flag, and the last `context layer dream dispatched` event in project 2 is the 2026-08-27 seed run.
- `pytest products/context_layer/backend/test/test_dreaming.py` passes locally (13 tests). Not run: the full backend matrix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal dispatch behavior, no user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a dogfood report that this org had no dream in 3 days and whether one could be triggered manually. Tools: PostHog MCP (tasks, events, flag test-evaluation), git, pytest. Skills invoked: `/writing-pr-descriptions`, `/writing-tests`. Root cause found by comparing the coordinator's flag evaluation identity with the flag's targeting; the fix reuses the enable path's identity instead of inventing a lane-specific flag. A manual trigger was not added: re-calling the enable endpoint already fires a one-off bootstrap dream, and a Dreams-tab trigger button stays a separate product decision.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*