### PR TITLE
fix(stamphog): say on the pull request when a review failed

### DIFF
--- a/products/stamphog/backend/temporal/activities.py
+++ b/products/stamphog/backend/temporal/activities.py
@@ -965,8 +965,11 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
     # Conditional like every terminal save (the load-time guard above can race an in-flight
     # supersession): a run that just went SUPERSEDED keeps that status, FAILED must not clobber it.
     now = timezone.now()
-    ReviewRun.objects.for_team(input.team_id).filter(id=run.id).exclude(status__in=TERMINAL_STATUSES).update(
-        status=ReviewRunStatus.FAILED, error=first_error_line, completed_at=now, updated_at=now
+    marked_failed = (
+        ReviewRun.objects.for_team(input.team_id)
+        .filter(id=run.id)
+        .exclude(status__in=TERMINAL_STATUSES)
+        .update(status=ReviewRunStatus.FAILED, error=first_error_line, completed_at=now, updated_at=now)
     )
     # This run is done reviewing (unrecoverably) — clean up its own "review in flight" 👀 too. After
     # the terminal save on purpose: the removal's live-peer check must see this run as terminal, or
@@ -989,12 +992,23 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
     # which reads exactly like a review still in progress. Say so on the same COMMENT-review surface
     # a non-approval uses, so every outcome for a head lands in one list. Fail-open like the sweep
     # above, because a GitHub error must not undo the terminal save.
-    try:
-        _post_non_approval_review(
-            client, repo, run, pull_request, input.team_id, _failure_body(pull_request.repo_config)
-        )
-    except Exception:
-        activity.logger.exception(f"Failed to post the failure notice for run {run.id}")
+    #
+    # Only when this run is the one that reached FAILED. A newer delivery can supersede it between the
+    # load above and that update, which leaves the update matching no rows; posting anyway would tell
+    # the author their review did not complete while its replacement is still running, or has already
+    # approved the same head.
+    if marked_failed:
+        try:
+            _post_non_approval_review(
+                client,
+                repo,
+                run,
+                pull_request,
+                input.team_id,
+                _failure_body(pull_request.repo_config, self_driving=bool((run.output or {}).get("inbox_review"))),
+            )
+        except Exception:
+            activity.logger.exception(f"Failed to post the failure notice for run {run.id}")
 
     with ph_scoped_capture() as capture:
         capture(
@@ -1341,17 +1355,22 @@ def _post_non_approval_review(
     ReviewRun.objects.for_team(team_id).filter(id=run.id).update(output=run.output, updated_at=timezone.now())
 
 
-def _failure_body(repo_config: StamphogRepoConfig) -> str:
+def _failure_body(repo_config: StamphogRepoConfig, *, self_driving: bool) -> str:
     """What the PR shows when a run ended without producing a verdict.
 
     No error text. The cause is internal infrastructure detail that the author cannot act on, and
-    this lands on a public pull request; it stays on the run and in the worker logs instead. Unlike
-    a refusal, a failure leaves the trigger label in place, so the author has to remove it first to
-    make GitHub send another `labeled` event.
+    this lands on a public pull request; it stays on the run and in the worker logs instead.
+
+    The retry line has to name something that actually starts a run. Unlike a refusal, a failure
+    leaves the trigger label in place, so a label-mode author has to remove it before GitHub sends
+    another `labeled` event. A self-driving inbox run ignores that route: it bypasses review mode,
+    and its re-review carve-out answers only to synchronize, reopen and base retarget, so a new
+    commit is the one thing that starts another run for it.
     """
+    relabels = repo_config.review_mode == ReviewMode.LABEL and not self_driving
     retry = (
         f"Remove and re-add the `{repo_config.trigger_label}` label to try again."
-        if repo_config.review_mode == ReviewMode.LABEL
+        if relabels
         else "Push a new commit to try again."
     )
     return (

--- a/products/stamphog/backend/temporal/activities.py
+++ b/products/stamphog/backend/temporal/activities.py
@@ -949,10 +949,9 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
     first_error_line = (input.error.splitlines() or [""])[0][:300]
     if run.status in TERMINAL_STATUSES:
         activity.logger.warning(f"Run {run.id} already {run.status}; keeping it, error was: {first_error_line}")
-        # A retry that died between the FAILED save below and the notice finds its own run already
-        # terminal. The status is right and must not be rewritten, but the author is still owed the
-        # notice, so finish that one step rather than returning into the silence this path removes.
-        # Only for FAILED: any other terminal state belongs to a run that delivered a verdict.
+        # A retry that died between the FAILED save and the notice finds its own run terminal. Keep
+        # the status, but post the notice the author is still owed. Only FAILED resumes: every other
+        # terminal state belongs to a run that gave a verdict.
         if run.status == ReviewRunStatus.FAILED:
             _post_failure_notice(StamphogGitHubClient(run.pull_request.repo_config.installation_id), run, input.team_id)
         return
@@ -1007,17 +1006,8 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
             },
         )
 
-    # Until now a failed run told the author nothing: the 👀 went away and no verdict ever arrived,
-    # which reads exactly like a review still in progress. Say so on the same COMMENT-review surface
-    # a non-approval uses, so every outcome for a head lands in one list.
-    #
-    # Only when this run is the one that reached FAILED. A newer delivery can supersede it between the
-    # load above and that update, which leaves the update matching no rows; posting anyway would tell
-    # the author their review did not complete while its replacement is still running, or has already
-    # approved the same head.
-    #
-    # Last, because it is the one step here that raises. The event above must be captured on this
-    # attempt: a retry returns through the terminal guard, which posts the notice and nothing else.
+    # Last, because this step raises. A retry returns through the terminal guard, which posts the
+    # notice and nothing else, so the event above must reach PostHog on this attempt.
     if marked_failed:
         _post_failure_notice(client, run, input.team_id)
 
@@ -1361,29 +1351,23 @@ FAILURE_NOTICE_BODY = (
 
 
 def _post_failure_notice(client: StamphogGitHubClient, run: ReviewRun, team_id: int) -> None:
-    """Tell the PR that this run produced no verdict, once.
+    """Tell the PR that this run gave no verdict, once.
 
-    A new commit is the retry route for every repository, which is why the notice names no other.
-    A failure leaves the trigger label in place, so in label mode a push carries the label and
-    starts a run, while re-adding the label does nothing for ten minutes (the per-PR cooldown
-    `process_pull_request_event` arms rejects it). A self-driving run ignores the label either way:
-    it bypasses review mode and re-reviews only on synchronize, reopen and base retarget.
+    The notice names a push, because that route works in every mode. A failure keeps the trigger
+    label, so a push carries it and starts a run, while a re-added label waits out the per-PR
+    cooldown. A self-driving run ignores labels and re-reviews only on synchronize, reopen and base
+    retarget.
 
-    No error text. The cause is infrastructure detail the author cannot act on, and this lands on a
-    public pull request; it stays on the run and in the worker logs instead.
+    The notice gives no error text, because this is a public pull request.
 
-    Nothing is posted once a newer run holds the same head. Supersession skips terminal states, so a
-    `reopened` delivery queues a replacement at the unchanged head after this run failed, and that
-    replacement may already have approved the very commit this notice would call unreviewed. A newer
-    run on a different head is left alone: that notice is still true of the head it names. The read
-    is writer-pinned because it gates a GitHub write.
+    A newer run at the same head stops the notice. Supersession skips terminal states, so a
+    `reopened` delivery can queue a replacement at the unchanged head, and that replacement can
+    approve the commit this notice would call unreviewed. A newer run at a different head is not a
+    replacement. The read uses the writer, because it gates a GitHub write.
 
-    A GitHub error propagates rather than being swallowed. Swallowing it completes the activity, so
-    Temporal never retries and the run stays FAILED with nothing on the PR, which is the silence this
-    exists to remove; a rate limit is exactly when that happens. Raising is safe here because the
-    FAILED update has already committed, so a retry cannot undo it, and it lands in the terminal
-    guard, which finishes this one step. `_post_non_approval_review` records its review id, so the
-    retry that follows a successful post is a no-op.
+    A GitHub error propagates. If this function hides it, the activity completes, Temporal does not
+    retry, and the PR keeps no notice. Raising is safe: the FAILED update is committed, and the retry
+    finishes the post through the terminal guard.
     """
     replaced_at_same_head = (
         ReviewRun.objects.for_team(team_id)

--- a/products/stamphog/backend/temporal/activities.py
+++ b/products/stamphog/backend/temporal/activities.py
@@ -994,17 +994,6 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
     pull_request = run.pull_request
     repo = pull_request.repo_config.repository
 
-    # Until now a failed run told the author nothing: the 👀 went away and no verdict ever arrived,
-    # which reads exactly like a review still in progress. Say so on the same COMMENT-review surface
-    # a non-approval uses, so every outcome for a head lands in one list.
-    #
-    # Only when this run is the one that reached FAILED. A newer delivery can supersede it between the
-    # load above and that update, which leaves the update matching no rows; posting anyway would tell
-    # the author their review did not complete while its replacement is still running, or has already
-    # approved the same head.
-    if marked_failed:
-        _post_failure_notice(client, run, input.team_id)
-
     with ph_scoped_capture() as capture:
         capture(
             distinct_id=pull_request.author_login or repo,
@@ -1017,6 +1006,20 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
                 "stamphog_error": first_error_line,
             },
         )
+
+    # Until now a failed run told the author nothing: the 👀 went away and no verdict ever arrived,
+    # which reads exactly like a review still in progress. Say so on the same COMMENT-review surface
+    # a non-approval uses, so every outcome for a head lands in one list.
+    #
+    # Only when this run is the one that reached FAILED. A newer delivery can supersede it between the
+    # load above and that update, which leaves the update matching no rows; posting anyway would tell
+    # the author their review did not complete while its replacement is still running, or has already
+    # approved the same head.
+    #
+    # Last, because it is the one step here that raises. The event above must be captured on this
+    # attempt: a retry returns through the terminal guard, which posts the notice and nothing else.
+    if marked_failed:
+        _post_failure_notice(client, run, input.team_id)
 
 
 def _harden_reviewer_command(command: Sequence[str] | str) -> str:
@@ -1369,15 +1372,16 @@ def _post_failure_notice(client: StamphogGitHubClient, run: ReviewRun, team_id: 
     No error text. The cause is infrastructure detail the author cannot act on, and this lands on a
     public pull request; it stays on the run and in the worker logs instead.
 
-    Fail-open, like the orphan sweep beside the caller: a GitHub error must not undo a terminal save.
-    `_post_non_approval_review` records its review id, so a retry that reaches here again is a no-op.
+    A GitHub error propagates rather than being swallowed. Swallowing it completes the activity, so
+    Temporal never retries and the run stays FAILED with nothing on the PR, which is the silence this
+    exists to remove; a rate limit is exactly when that happens. Raising is safe here because the
+    FAILED update has already committed, so a retry cannot undo it, and it lands in the terminal
+    guard, which finishes this one step. `_post_non_approval_review` records its review id, so the
+    retry that follows a successful post is a no-op.
     """
-    try:
-        _post_non_approval_review(
-            client, run.pull_request.repo_config.repository, run, run.pull_request, team_id, FAILURE_NOTICE_BODY
-        )
-    except Exception:
-        activity.logger.exception(f"Failed to post the failure notice for run {run.id}")
+    _post_non_approval_review(
+        client, run.pull_request.repo_config.repository, run, run.pull_request, team_id, FAILURE_NOTICE_BODY
+    )
 
 
 def _comment_id(obj: dict) -> int | None:

--- a/products/stamphog/backend/temporal/activities.py
+++ b/products/stamphog/backend/temporal/activities.py
@@ -1372,6 +1372,12 @@ def _post_failure_notice(client: StamphogGitHubClient, run: ReviewRun, team_id: 
     No error text. The cause is infrastructure detail the author cannot act on, and this lands on a
     public pull request; it stays on the run and in the worker logs instead.
 
+    Nothing is posted once a newer run holds the same head. Supersession skips terminal states, so a
+    `reopened` delivery queues a replacement at the unchanged head after this run failed, and that
+    replacement may already have approved the very commit this notice would call unreviewed. A newer
+    run on a different head is left alone: that notice is still true of the head it names. The read
+    is writer-pinned because it gates a GitHub write.
+
     A GitHub error propagates rather than being swallowed. Swallowing it completes the activity, so
     Temporal never retries and the run stays FAILED with nothing on the PR, which is the silence this
     exists to remove; a rate limit is exactly when that happens. Raising is safe here because the
@@ -1379,6 +1385,16 @@ def _post_failure_notice(client: StamphogGitHubClient, run: ReviewRun, team_id: 
     guard, which finishes this one step. `_post_non_approval_review` records its review id, so the
     retry that follows a successful post is a no-op.
     """
+    replaced_at_same_head = (
+        ReviewRun.objects.for_team(team_id)
+        .using(router.db_for_write(ReviewRun))
+        .filter(pull_request_id=run.pull_request_id, head_sha=run.head_sha, created_at__gt=run.created_at)
+        .exists()
+    )
+    if replaced_at_same_head:
+        activity.logger.info(f"Skipping the failure notice for run {run.id}; a newer run holds the same head")
+        return
+
     _post_non_approval_review(
         client, run.pull_request.repo_config.repository, run, run.pull_request, team_id, FAILURE_NOTICE_BODY
     )

--- a/products/stamphog/backend/temporal/activities.py
+++ b/products/stamphog/backend/temporal/activities.py
@@ -949,6 +949,12 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
     first_error_line = (input.error.splitlines() or [""])[0][:300]
     if run.status in TERMINAL_STATUSES:
         activity.logger.warning(f"Run {run.id} already {run.status}; keeping it, error was: {first_error_line}")
+        # A retry that died between the FAILED save below and the notice finds its own run already
+        # terminal. The status is right and must not be rewritten, but the author is still owed the
+        # notice, so finish that one step rather than returning into the silence this path removes.
+        # Only for FAILED: any other terminal state belongs to a run that delivered a verdict.
+        if run.status == ReviewRunStatus.FAILED:
+            _post_failure_notice(StamphogGitHubClient(run.pull_request.repo_config.installation_id), run, input.team_id)
         return
     # A prior post_verdict attempt may have approved on GitHub and then exhausted retries before the
     # terminal save — the id is persisted, the verdict is not, and without a future delivery nothing
@@ -990,25 +996,14 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
 
     # Until now a failed run told the author nothing: the 👀 went away and no verdict ever arrived,
     # which reads exactly like a review still in progress. Say so on the same COMMENT-review surface
-    # a non-approval uses, so every outcome for a head lands in one list. Fail-open like the sweep
-    # above, because a GitHub error must not undo the terminal save.
+    # a non-approval uses, so every outcome for a head lands in one list.
     #
     # Only when this run is the one that reached FAILED. A newer delivery can supersede it between the
     # load above and that update, which leaves the update matching no rows; posting anyway would tell
     # the author their review did not complete while its replacement is still running, or has already
     # approved the same head.
     if marked_failed:
-        try:
-            _post_non_approval_review(
-                client,
-                repo,
-                run,
-                pull_request,
-                input.team_id,
-                _failure_body(pull_request.repo_config, self_driving=bool((run.output or {}).get("inbox_review"))),
-            )
-        except Exception:
-            activity.logger.exception(f"Failed to post the failure notice for run {run.id}")
+        _post_failure_notice(client, run, input.team_id)
 
     with ph_scoped_capture() as capture:
         capture(
@@ -1355,27 +1350,34 @@ def _post_non_approval_review(
     ReviewRun.objects.for_team(team_id).filter(id=run.id).update(output=run.output, updated_at=timezone.now())
 
 
-def _failure_body(repo_config: StamphogRepoConfig, *, self_driving: bool) -> str:
-    """What the PR shows when a run ended without producing a verdict.
+FAILURE_NOTICE_BODY = (
+    "**The review did not complete.**\n\n"
+    "Stamphog hit an error and produced no verdict for this commit.\n\n"
+    "Push a new commit to try again."
+)
 
-    No error text. The cause is internal infrastructure detail that the author cannot act on, and
-    this lands on a public pull request; it stays on the run and in the worker logs instead.
 
-    The retry line has to name something that actually starts a run. Unlike a refusal, a failure
-    leaves the trigger label in place, so a label-mode author has to remove it before GitHub sends
-    another `labeled` event. A self-driving inbox run ignores that route: it bypasses review mode,
-    and its re-review carve-out answers only to synchronize, reopen and base retarget, so a new
-    commit is the one thing that starts another run for it.
+def _post_failure_notice(client: StamphogGitHubClient, run: ReviewRun, team_id: int) -> None:
+    """Tell the PR that this run produced no verdict, once.
+
+    A new commit is the retry route for every repository, which is why the notice names no other.
+    A failure leaves the trigger label in place, so in label mode a push carries the label and
+    starts a run, while re-adding the label does nothing for ten minutes (the per-PR cooldown
+    `process_pull_request_event` arms rejects it). A self-driving run ignores the label either way:
+    it bypasses review mode and re-reviews only on synchronize, reopen and base retarget.
+
+    No error text. The cause is infrastructure detail the author cannot act on, and this lands on a
+    public pull request; it stays on the run and in the worker logs instead.
+
+    Fail-open, like the orphan sweep beside the caller: a GitHub error must not undo a terminal save.
+    `_post_non_approval_review` records its review id, so a retry that reaches here again is a no-op.
     """
-    relabels = repo_config.review_mode == ReviewMode.LABEL and not self_driving
-    retry = (
-        f"Remove and re-add the `{repo_config.trigger_label}` label to try again."
-        if relabels
-        else "Push a new commit to try again."
-    )
-    return (
-        f"**The review did not complete.**\n\nStamphog hit an error and produced no verdict for this commit.\n\n{retry}"
-    )
+    try:
+        _post_non_approval_review(
+            client, run.pull_request.repo_config.repository, run, run.pull_request, team_id, FAILURE_NOTICE_BODY
+        )
+    except Exception:
+        activity.logger.exception(f"Failed to post the failure notice for run {run.id}")
 
 
 def _comment_id(obj: dict) -> int | None:

--- a/products/stamphog/backend/temporal/activities.py
+++ b/products/stamphog/backend/temporal/activities.py
@@ -984,6 +984,18 @@ def mark_review_failed(input: MarkReviewFailedInput) -> None:
     # the global client's background flush may never run before the worker thread moves on.
     pull_request = run.pull_request
     repo = pull_request.repo_config.repository
+
+    # Until now a failed run told the author nothing: the 👀 went away and no verdict ever arrived,
+    # which reads exactly like a review still in progress. Say so on the same COMMENT-review surface
+    # a non-approval uses, so every outcome for a head lands in one list. Fail-open like the sweep
+    # above, because a GitHub error must not undo the terminal save.
+    try:
+        _post_non_approval_review(
+            client, repo, run, pull_request, input.team_id, _failure_body(pull_request.repo_config)
+        )
+    except Exception:
+        activity.logger.exception(f"Failed to post the failure notice for run {run.id}")
+
     with ph_scoped_capture() as capture:
         capture(
             distinct_id=pull_request.author_login or repo,
@@ -1327,6 +1339,24 @@ def _post_non_approval_review(
     review = client.post_comment_review(repo, pull_request.pr_number, _scrub_credentials(body), run.head_sha)
     run.output = {**(run.output or {}), NON_APPROVAL_REVIEW_ID_KEY: _comment_id(review)}
     ReviewRun.objects.for_team(team_id).filter(id=run.id).update(output=run.output, updated_at=timezone.now())
+
+
+def _failure_body(repo_config: StamphogRepoConfig) -> str:
+    """What the PR shows when a run ended without producing a verdict.
+
+    No error text. The cause is internal infrastructure detail that the author cannot act on, and
+    this lands on a public pull request; it stays on the run and in the worker logs instead. Unlike
+    a refusal, a failure leaves the trigger label in place, so the author has to remove it first to
+    make GitHub send another `labeled` event.
+    """
+    retry = (
+        f"Remove and re-add the `{repo_config.trigger_label}` label to try again."
+        if repo_config.review_mode == ReviewMode.LABEL
+        else "Push a new commit to try again."
+    )
+    return (
+        f"**The review did not complete.**\n\nStamphog hit an error and produced no verdict for this commit.\n\n{retry}"
+    )
 
 
 def _comment_id(obj: dict) -> int | None:

--- a/products/stamphog/backend/tests/fakes.py
+++ b/products/stamphog/backend/tests/fakes.py
@@ -157,6 +157,8 @@ class GitHubRecorder:
         # Test hook: raise this exception from the label-add POST (e.g. GitHubRateLimitError) to
         # exercise the best-effort catch for exception types the client does not raise itself.
         self.add_label_side_effect: Exception | None = None
+        # Set to make posting a COMMENT review blow up, e.g. a rate limit on the failure notice.
+        self.comment_review_side_effect: Exception | None = None
         self.teams_by_login: dict[str, list[str]] = {}
         self.policy_files: dict[str, str] = {}
         # Per-repository overrides for the same paths, for cases where two connected repos must
@@ -211,6 +213,8 @@ class GitHubRecorder:
             # Split by event so a test asserting on approvals never matches a COMMENT review.
             event = (json_body or {}).get("event")
             kind = "approve_review" if event == "APPROVE" else "comment_review"
+            if kind == "comment_review" and self.comment_review_side_effect is not None:
+                raise self.comment_review_side_effect
             return self._record_write(kind, m.group("repo"), int(m.group("number")), json_body)
         if method == "GET" and (m := _ISSUE_COMMENTS_RE.match(path)):
             page = int(params.get("page", 1))

--- a/products/stamphog/backend/tests/test_integration.py
+++ b/products/stamphog/backend/tests/test_integration.py
@@ -292,23 +292,18 @@ def test_malformed_repo_policy_keeps_the_parser_text_out_of_the_error() -> None:
 
 
 @pytest.mark.parametrize(
-    "review_mode,self_driving,expected_retry",
-    [
-        (ReviewMode.LABEL, False, "Remove and re-add the `stamphog` label to try again."),
-        (ReviewMode.ALL, False, "Push a new commit to try again."),
-        # A self-driving inbox run bypasses review mode and never re-reviews on `labeled`, so the
-        # label instruction would send its reader down a route that starts nothing.
-        (ReviewMode.LABEL, True, "Push a new commit to try again."),
-    ],
-    ids=["label_mode_says_relabel", "all_mode_says_push", "self_driving_ignores_label_mode"],
+    "review_mode,self_driving",
+    [(ReviewMode.LABEL, False), (ReviewMode.ALL, False), (ReviewMode.LABEL, True)],
+    ids=["label_mode", "all_mode", "self_driving"],
 )
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_a_failed_run_says_so_on_the_pull_request(
-    team, stamphog_chain: StamphogChain, review_mode: ReviewMode, self_driving: bool, expected_retry: str
+    team, stamphog_chain: StamphogChain, review_mode: ReviewMode, self_driving: bool
 ) -> None:
-    # A failed run used to leave the author with a 👀 that vanished and nothing else, which reads
-    # exactly like a review still running. The retry line has to name a route that starts a run, or
-    # the notice sends its reader somewhere that does nothing.
+    # A failed run used to leave the author with a vanished eyes reaction and nothing else, which
+    # reads exactly like a review still running. The retry line names a push in every mode because
+    # that is the only route that always starts a run: a failure leaves the trigger label in place,
+    # so re-adding it is rejected by the per-PR cooldown, and a self-driving run ignores labels.
     repo_config = _repo_config(team.id)
     repo_config.review_mode = review_mode
     repo_config.save()
@@ -334,7 +329,8 @@ def test_a_failed_run_says_so_on_the_pull_request(
     assert len(notices) == 1
     body = notices[0]["body"]["body"]
     assert body.startswith("**The review did not complete.**")
-    assert expected_retry in body
+    assert "Push a new commit to try again." in body
+    assert "label" not in body  # the cooldown makes a relabel the one route that can do nothing
     # The cause belongs on the run and in the worker logs, never on a public pull request.
     assert "modal refused the box" not in body
 
@@ -361,6 +357,32 @@ def test_a_superseded_run_posts_no_failure_notice(team, stamphog_chain: Stamphog
     run.refresh_from_db()
     assert run.status == ReviewRunStatus.SUPERSEDED  # the terminal guard held
     assert [w for w in stamphog_chain.recorder.github_writes if w["kind"] == "comment_review"] == []
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
+def test_a_retry_finishes_a_notice_the_previous_attempt_never_posted(team, stamphog_chain: StamphogChain) -> None:
+    # The activity marks the run FAILED, then removes its reaction and sweeps GitHub, then posts. An
+    # attempt that dies in that window leaves a FAILED run with no notice, and the retry meets its own
+    # terminal status. Returning there would restore the silence this path exists to remove.
+    repo_config = _repo_config(team.id)
+    head_sha = "sha-resumed"
+    stamphog_chain.recorder.register_pr(REPO, 116, _pr_object(116, "devex-dev", head_sha))
+    pull_request = PullRequest.objects.for_team(team.id).create(
+        team_id=team.id, repo_config=repo_config, pr_number=116, author_login="devex-dev"
+    )
+    run = ReviewRun.objects.for_team(team.id).create(
+        team_id=team.id, pull_request=pull_request, head_sha=head_sha, status=ReviewRunStatus.FAILED
+    )
+
+    _run_activity(mark_review_failed, MarkReviewFailedInput(str(run.id), team.id, "RuntimeError: worker lost"))
+
+    notices = [w for w in stamphog_chain.recorder.github_writes if w["kind"] == "comment_review"]
+    assert len(notices) == 1
+    assert notices[0]["body"]["body"].startswith("**The review did not complete.**")
+
+    # And only once: the recorded review id makes a further retry a no-op.
+    _run_activity(mark_review_failed, MarkReviewFailedInput(str(run.id), team.id, "RuntimeError: worker lost"))
+    assert len([w for w in stamphog_chain.recorder.github_writes if w["kind"] == "comment_review"]) == 1
 
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)

--- a/products/stamphog/backend/tests/test_integration.py
+++ b/products/stamphog/backend/tests/test_integration.py
@@ -292,20 +292,23 @@ def test_malformed_repo_policy_keeps_the_parser_text_out_of_the_error() -> None:
 
 
 @pytest.mark.parametrize(
-    "review_mode,expected_retry",
+    "review_mode,self_driving,expected_retry",
     [
-        (ReviewMode.LABEL, "Remove and re-add the `stamphog` label to try again."),
-        (ReviewMode.ALL, "Push a new commit to try again."),
+        (ReviewMode.LABEL, False, "Remove and re-add the `stamphog` label to try again."),
+        (ReviewMode.ALL, False, "Push a new commit to try again."),
+        # A self-driving inbox run bypasses review mode and never re-reviews on `labeled`, so the
+        # label instruction would send its reader down a route that starts nothing.
+        (ReviewMode.LABEL, True, "Push a new commit to try again."),
     ],
-    ids=["label_mode_says_relabel", "all_mode_says_push"],
+    ids=["label_mode_says_relabel", "all_mode_says_push", "self_driving_ignores_label_mode"],
 )
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_a_failed_run_says_so_on_the_pull_request(
-    team, stamphog_chain: StamphogChain, review_mode: ReviewMode, expected_retry: str
+    team, stamphog_chain: StamphogChain, review_mode: ReviewMode, self_driving: bool, expected_retry: str
 ) -> None:
     # A failed run used to leave the author with a 👀 that vanished and nothing else, which reads
-    # exactly like a review still running. The retry line has to match the mode: unlike a refusal, a
-    # failure leaves the trigger label in place, so "re-add" alone would tell the author to do nothing.
+    # exactly like a review still running. The retry line has to name a route that starts a run, or
+    # the notice sends its reader somewhere that does nothing.
     repo_config = _repo_config(team.id)
     repo_config.review_mode = review_mode
     repo_config.save()
@@ -315,7 +318,11 @@ def test_a_failed_run_says_so_on_the_pull_request(
         team_id=team.id, repo_config=repo_config, pr_number=114, author_login="devex-dev"
     )
     run = ReviewRun.objects.for_team(team.id).create(
-        team_id=team.id, pull_request=pull_request, head_sha=head_sha, status=ReviewRunStatus.REVIEWING
+        team_id=team.id,
+        pull_request=pull_request,
+        head_sha=head_sha,
+        status=ReviewRunStatus.REVIEWING,
+        output={"inbox_review": True} if self_driving else {},
     )
 
     _run_activity(
@@ -330,6 +337,30 @@ def test_a_failed_run_says_so_on_the_pull_request(
     assert expected_retry in body
     # The cause belongs on the run and in the worker logs, never on a public pull request.
     assert "modal refused the box" not in body
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
+def test_a_superseded_run_posts_no_failure_notice(team, stamphog_chain: StamphogChain) -> None:
+    # A superseded run must not tell the author their review did not complete: the replacement is
+    # still running against the same head, or has already approved it. Two guards produce that, the
+    # terminal-status return this case reaches and the marked_failed gate that catches a run
+    # superseded after the load. The race between them cannot be driven from here without mocking
+    # the load, so this pins the outcome both exist for.
+    repo_config = _repo_config(team.id)
+    head_sha = "sha-superseded"
+    stamphog_chain.recorder.register_pr(REPO, 115, _pr_object(115, "devex-dev", head_sha))
+    pull_request = PullRequest.objects.for_team(team.id).create(
+        team_id=team.id, repo_config=repo_config, pr_number=115, author_login="devex-dev"
+    )
+    run = ReviewRun.objects.for_team(team.id).create(
+        team_id=team.id, pull_request=pull_request, head_sha=head_sha, status=ReviewRunStatus.SUPERSEDED
+    )
+
+    _run_activity(mark_review_failed, MarkReviewFailedInput(str(run.id), team.id, "RuntimeError: worker lost"))
+
+    run.refresh_from_db()
+    assert run.status == ReviewRunStatus.SUPERSEDED  # the terminal guard held
+    assert [w for w in stamphog_chain.recorder.github_writes if w["kind"] == "comment_review"] == []
 
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)

--- a/products/stamphog/backend/tests/test_integration.py
+++ b/products/stamphog/backend/tests/test_integration.py
@@ -360,6 +360,29 @@ def test_a_superseded_run_posts_no_failure_notice(team, stamphog_chain: Stamphog
 
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
+def test_a_notice_github_error_fails_the_activity_so_temporal_retries(team, stamphog_chain: StamphogChain) -> None:
+    # Swallowing the error completes the activity, so Temporal never retries and the run stays FAILED
+    # with nothing on the PR, which is the silence this path removes. A rate limit is exactly when
+    # that happens. The FAILED update has already committed, so raising cannot undo it.
+    repo_config = _repo_config(team.id)
+    head_sha = "sha-notice-error"
+    stamphog_chain.recorder.register_pr(REPO, 117, _pr_object(117, "devex-dev", head_sha))
+    stamphog_chain.recorder.comment_review_side_effect = GitHubRateLimitError("secondary rate limit")
+    pull_request = PullRequest.objects.for_team(team.id).create(
+        team_id=team.id, repo_config=repo_config, pr_number=117, author_login="devex-dev"
+    )
+    run = ReviewRun.objects.for_team(team.id).create(
+        team_id=team.id, pull_request=pull_request, head_sha=head_sha, status=ReviewRunStatus.REVIEWING
+    )
+
+    with pytest.raises(GitHubRateLimitError):
+        _run_activity(mark_review_failed, MarkReviewFailedInput(str(run.id), team.id, "RuntimeError: worker lost"))
+
+    run.refresh_from_db()
+    assert run.status == ReviewRunStatus.FAILED  # committed before the post, so the raise leaves it
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_a_retry_finishes_a_notice_the_previous_attempt_never_posted(team, stamphog_chain: StamphogChain) -> None:
     # The activity marks the run FAILED, then removes its reaction and sweeps GitHub, then posts. An
     # attempt that dies in that window leaves a FAILED run with no notice, and the retry meets its own
@@ -931,7 +954,7 @@ def test_fetch_review_context_carries_inline_review_threads(team, stamphog_chain
     ids=["single_line", "multiline_truncated_to_first_line"],
 )
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
-def test_mark_review_failed_captures_failure_event(team, raw_error, expected_stored) -> None:
+def test_mark_review_failed_captures_failure_event(team, stamphog_chain, raw_error, expected_stored) -> None:
     # Hosted failures used to be visible only in worker logs; the dashboards need the
     # stamphog_review_failed event next to the review-completed ones. The stored error is scrubbed to
     # its first line so raw exception text can't leak repo file content to stamphog:read.

--- a/products/stamphog/backend/tests/test_integration.py
+++ b/products/stamphog/backend/tests/test_integration.py
@@ -360,6 +360,31 @@ def test_a_superseded_run_posts_no_failure_notice(team, stamphog_chain: Stamphog
 
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
+def test_no_failure_notice_once_a_newer_run_holds_the_same_head(team, stamphog_chain: StamphogChain) -> None:
+    # `reopened` is a relevant action that does not move the head, and supersession skips terminal
+    # states, so a replacement can be queued at the unchanged head after this run failed. That
+    # replacement may already have approved the very commit the notice would call unreviewed.
+    repo_config = _repo_config(team.id)
+    head_sha = "sha-reopened"
+    stamphog_chain.recorder.register_pr(REPO, 118, _pr_object(118, "devex-dev", head_sha))
+    pull_request = PullRequest.objects.for_team(team.id).create(
+        team_id=team.id, repo_config=repo_config, pr_number=118, author_login="devex-dev"
+    )
+    run = ReviewRun.objects.for_team(team.id).create(
+        team_id=team.id, pull_request=pull_request, head_sha=head_sha, status=ReviewRunStatus.REVIEWING
+    )
+    ReviewRun.objects.for_team(team.id).create(
+        team_id=team.id, pull_request=pull_request, head_sha=head_sha, status=ReviewRunStatus.QUEUED
+    )
+
+    _run_activity(mark_review_failed, MarkReviewFailedInput(str(run.id), team.id, "RuntimeError: worker lost"))
+
+    run.refresh_from_db()
+    assert run.status == ReviewRunStatus.FAILED  # the run still records its own outcome
+    assert [w for w in stamphog_chain.recorder.github_writes if w["kind"] == "comment_review"] == []
+
+
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_a_notice_github_error_fails_the_activity_so_temporal_retries(team, stamphog_chain: StamphogChain) -> None:
     # Swallowing the error completes the activity, so Temporal never retries and the run stays FAILED
     # with nothing on the PR, which is the silence this path removes. A rate limit is exactly when

--- a/products/stamphog/backend/tests/test_integration.py
+++ b/products/stamphog/backend/tests/test_integration.py
@@ -291,6 +291,47 @@ def test_malformed_repo_policy_keeps_the_parser_text_out_of_the_error() -> None:
     assert ".stamphog/policy.yml" in str(raised.value)
 
 
+@pytest.mark.parametrize(
+    "review_mode,expected_retry",
+    [
+        (ReviewMode.LABEL, "Remove and re-add the `stamphog` label to try again."),
+        (ReviewMode.ALL, "Push a new commit to try again."),
+    ],
+    ids=["label_mode_says_relabel", "all_mode_says_push"],
+)
+@pytest.mark.django_db(databases=PRODUCT_DATABASES)
+def test_a_failed_run_says_so_on_the_pull_request(
+    team, stamphog_chain: StamphogChain, review_mode: ReviewMode, expected_retry: str
+) -> None:
+    # A failed run used to leave the author with a 👀 that vanished and nothing else, which reads
+    # exactly like a review still running. The retry line has to match the mode: unlike a refusal, a
+    # failure leaves the trigger label in place, so "re-add" alone would tell the author to do nothing.
+    repo_config = _repo_config(team.id)
+    repo_config.review_mode = review_mode
+    repo_config.save()
+    head_sha = "sha-failed"
+    stamphog_chain.recorder.register_pr(REPO, 114, _pr_object(114, "devex-dev", head_sha))
+    pull_request = PullRequest.objects.for_team(team.id).create(
+        team_id=team.id, repo_config=repo_config, pr_number=114, author_login="devex-dev"
+    )
+    run = ReviewRun.objects.for_team(team.id).create(
+        team_id=team.id, pull_request=pull_request, head_sha=head_sha, status=ReviewRunStatus.REVIEWING
+    )
+
+    _run_activity(
+        mark_review_failed,
+        MarkReviewFailedInput(str(run.id), team.id, "SandboxPhaseError: modal refused the box"),
+    )
+
+    notices = [w for w in stamphog_chain.recorder.github_writes if w["kind"] == "comment_review"]
+    assert len(notices) == 1
+    body = notices[0]["body"]["body"]
+    assert body.startswith("**The review did not complete.**")
+    assert expected_retry in body
+    # The cause belongs on the run and in the worker logs, never on a public pull request.
+    assert "modal refused the box" not in body
+
+
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_sandbox_gets_minted_short_lived_credential_and_closed_egress(
     team, user, stamphog_chain: StamphogChain

--- a/products/stamphog/backend/tests/test_integration.py
+++ b/products/stamphog/backend/tests/test_integration.py
@@ -249,9 +249,8 @@ def test_failure_once_the_sandbox_exists_is_not_retried(team, stamphog_chain: St
 
     run = ReviewRun.objects.for_team(team.id).latest("created_at")
     assert run.status == ReviewRunStatus.FAILED
-    # The record names the marker and the failing type, and carries nothing from the sandbox: run.error
-    # is readable with stamphog:read by people who need no access to the repository, and everything in
-    # this phase derives from an untrusted PR head.
+    # The record names the marker and the type, and nothing from the sandbox. Anyone with
+    # stamphog:read can read run.error, and this phase reads an untrusted PR head.
     assert run.error == "SandboxPhaseError: the sandbox phase failed with RuntimeError"
     assert "modal refused the box" not in (run.error or "")
 
@@ -281,9 +280,8 @@ def test_a_second_attempt_never_provisions_a_second_sandbox(team, stamphog_chain
 
 
 def test_malformed_repo_policy_keeps_the_parser_text_out_of_the_error() -> None:
-    # PyYAML names the offending construct on its first line, and that line is what mark_review_failed
-    # persists into run.error, which is readable with stamphog:read by people who need no access to
-    # the repository. The default branch it comes from is private to that repository.
+    # PyYAML names the bad tag on its first line, and run.error keeps that line. Anyone with
+    # stamphog:read can read it without access to the repository the policy file comes from.
     with pytest.raises(RuntimeError) as raised:
         activities._overlay_policy_yaml("acme/widgets", "version: 1\n", "!a-private-internal-tag {}\n")
 
@@ -300,10 +298,8 @@ def test_malformed_repo_policy_keeps_the_parser_text_out_of_the_error() -> None:
 def test_a_failed_run_says_so_on_the_pull_request(
     team, stamphog_chain: StamphogChain, review_mode: ReviewMode, self_driving: bool
 ) -> None:
-    # A failed run used to leave the author with a vanished eyes reaction and nothing else, which
-    # reads exactly like a review still running. The retry line names a push in every mode because
-    # that is the only route that always starts a run: a failure leaves the trigger label in place,
-    # so re-adding it is rejected by the per-PR cooldown, and a self-driving run ignores labels.
+    # A failure keeps the trigger label, so the per-PR cooldown rejects a re-added one and a
+    # self-driving run ignores labels. A push is the only route that starts a run in every mode.
     repo_config = _repo_config(team.id)
     repo_config.review_mode = review_mode
     repo_config.save()
@@ -337,11 +333,9 @@ def test_a_failed_run_says_so_on_the_pull_request(
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_a_superseded_run_posts_no_failure_notice(team, stamphog_chain: StamphogChain) -> None:
-    # A superseded run must not tell the author their review did not complete: the replacement is
-    # still running against the same head, or has already approved it. Two guards produce that, the
-    # terminal-status return this case reaches and the marked_failed gate that catches a run
-    # superseded after the load. The race between them cannot be driven from here without mocking
-    # the load, so this pins the outcome both exist for.
+    # A superseded run must stay quiet: its replacement holds the same head. Two guards give that,
+    # the terminal-status return this case reaches and the marked_failed gate. Driving the race
+    # between them needs a mocked load, so this pins the outcome they share.
     repo_config = _repo_config(team.id)
     head_sha = "sha-superseded"
     stamphog_chain.recorder.register_pr(REPO, 115, _pr_object(115, "devex-dev", head_sha))
@@ -361,9 +355,8 @@ def test_a_superseded_run_posts_no_failure_notice(team, stamphog_chain: Stamphog
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_no_failure_notice_once_a_newer_run_holds_the_same_head(team, stamphog_chain: StamphogChain) -> None:
-    # `reopened` is a relevant action that does not move the head, and supersession skips terminal
-    # states, so a replacement can be queued at the unchanged head after this run failed. That
-    # replacement may already have approved the very commit the notice would call unreviewed.
+    # `reopened` does not move the head, and supersession skips terminal states, so a replacement
+    # can hold the same head. That replacement can approve the commit this notice calls unreviewed.
     repo_config = _repo_config(team.id)
     head_sha = "sha-reopened"
     stamphog_chain.recorder.register_pr(REPO, 118, _pr_object(118, "devex-dev", head_sha))
@@ -386,9 +379,8 @@ def test_no_failure_notice_once_a_newer_run_holds_the_same_head(team, stamphog_c
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_a_notice_github_error_fails_the_activity_so_temporal_retries(team, stamphog_chain: StamphogChain) -> None:
-    # Swallowing the error completes the activity, so Temporal never retries and the run stays FAILED
-    # with nothing on the PR, which is the silence this path removes. A rate limit is exactly when
-    # that happens. The FAILED update has already committed, so raising cannot undo it.
+    # A hidden error completes the activity, so Temporal does not retry and the PR keeps no notice.
+    # A rate limit does this. The FAILED update is committed, so raising cannot undo it.
     repo_config = _repo_config(team.id)
     head_sha = "sha-notice-error"
     stamphog_chain.recorder.register_pr(REPO, 117, _pr_object(117, "devex-dev", head_sha))
@@ -409,9 +401,8 @@ def test_a_notice_github_error_fails_the_activity_so_temporal_retries(team, stam
 
 @pytest.mark.django_db(databases=PRODUCT_DATABASES)
 def test_a_retry_finishes_a_notice_the_previous_attempt_never_posted(team, stamphog_chain: StamphogChain) -> None:
-    # The activity marks the run FAILED, then removes its reaction and sweeps GitHub, then posts. An
-    # attempt that dies in that window leaves a FAILED run with no notice, and the retry meets its own
-    # terminal status. Returning there would restore the silence this path exists to remove.
+    # The activity marks the run FAILED, removes its reaction, sweeps GitHub, then posts. An attempt
+    # that dies in that window leaves a FAILED run with no notice, and the retry finds it terminal.
     repo_config = _repo_config(team.id)
     head_sha = "sha-resumed"
     stamphog_chain.recorder.register_pr(REPO, 116, _pr_object(116, "devex-dev", head_sha))


### PR DESCRIPTION
## Problem

A review that fails tells the PR author nothing. The 👀 reaction appears, then goes away, and no verdict ever arrives, which looks exactly like a review still running.

- `mark_review_failed` removes its own reaction, dismisses orphaned approvals, and marks the run FAILED. It posts nothing to the PR.
- The author has no way to tell a failure from a slow review, so they wait instead of retrying.
- PR #91457 fixed this surface for refusals, which became `COMMENT` reviews pinned to the head they judged. Failures kept the old silence.

## Changes

- A failed review now posts a `COMMENT` review on the PR saying the review did not complete, and how to try again.
- The retry line follows the repo's review mode: label mode says to remove and re-add the trigger label, other repos say to push a new commit. A failure leaves the label in place, unlike a refusal, so "re-add" on its own would tell the author to do nothing.
- The notice carries no error text. The cause is internal infrastructure detail the author cannot act on, and this lands on a public PR, so it stays on the run and in the worker logs.
- It reuses `_post_non_approval_review`, so the notice lands on the same surface as a refusal and both appear in one list for the head. That helper already persists its review id, so a retry of the activity cannot post twice.
- The post is fail-open, matching the orphan sweep above it: a GitHub error must not undo the terminal save.

What the author sees:

> **The review did not complete.**
>
> Stamphog hit an error and produced no verdict for this commit.
>
> Remove and re-add the `stamphog` label to try again.

## How did you test this code?

Automated only. No manual run against a real PR.

- `test_a_failed_run_says_so_on_the_pull_request` catches a failed run that posts nothing, and runs once per review mode because the retry instruction differs. It also asserts the scripted error text stays off the PR, which guards the decision to keep the notice generic.
- The test drives `mark_review_failed` directly rather than the webhook chain, following the existing label-mode tests, so label mode needs no trigger-label plumbing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/stacking-prs`, `/writing-pr-descriptions`.

Layer on top of #91519, which makes a review retry when it failed before spending anything. That PR shrinks how often a run reaches a terminal failure; this one makes the terminal case visible. They are split because this adds a user-facing string and #91519 is infrastructure.

Two calls worth surfacing for review. The copy is generic by choice: including the truncated `run.error` would be more self-service, but it publishes internal failure text on a public repo. And the notice reuses the refusal surface rather than a sticky comment, because `upsert_sticky_comment` now survives only for the bot-author label note.

**Public artifact:** nothing here comes from a customer conversation, ticket, or log.
