### PR TITLE
feat(tasks): benjamin-plus toggle behind a feature flag

### DIFF
--- a/posthog/temporal/common/worker.py
+++ b/posthog/temporal/common/worker.py
@@ -81,6 +81,8 @@ from products.tasks.backend.facade.temporal import (
     TASKS_LATENCY_HISTOGRAM_METRICS,
     TASKS_RUN_TOKENS_HISTOGRAM_BUCKETS,
     TASKS_RUN_TOKENS_HISTOGRAM_METRICS,
+    TASKS_RUN_TURNS_HISTOGRAM_BUCKETS,
+    TASKS_RUN_TURNS_HISTOGRAM_METRICS,
 )
 
 logger = get_write_only_logger()
@@ -294,6 +296,7 @@ async def create_worker(
         )
         | dict(zip(TASKS_LATENCY_HISTOGRAM_METRICS, itertools.repeat(TASKS_LATENCY_HISTOGRAM_BUCKETS)))
         | dict(zip(TASKS_RUN_TOKENS_HISTOGRAM_METRICS, itertools.repeat(TASKS_RUN_TOKENS_HISTOGRAM_BUCKETS)))
+        | dict(zip(TASKS_RUN_TURNS_HISTOGRAM_METRICS, itertools.repeat(TASKS_RUN_TURNS_HISTOGRAM_BUCKETS)))
         | dict(
             zip(
                 EVAL_REPORTS_LATENCY_HISTOGRAM_METRICS,

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -213,6 +213,7 @@ TASK_SIGNALS_CLONING_BLOBLESS_FEATURE_FLAG = "task-signals-cloning-blobless"
 # enabling this flag disables it fleet-wide — over any per-run override — without
 # an image rebuild.
 RTK_DISABLED_FEATURE_FLAG = "tasks-rtk-disabled"
+BENJAMIN_FEATURE_FLAG = "task-cloud-run-benjamin-plus"
 # Gates whether long-running process_task runs continue-as-new to bound history/replay cost.
 CONTINUE_AS_NEW_FEATURE_FLAG = "tasks-cloud-run-continue-as-new"
 PR_BABYSIT_SNAPSHOT_FEATURE_FLAG = "tasks-pr-babysit-snapshot"

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -400,6 +400,7 @@ _TASK_RUN_PUBLIC_STATE_KEYS = frozenset(
     {
         "ai_stage",
         "auto_publish",
+        "benjamin_enabled",
         "context_window",
         "custom_image_id",
         "fast_mode",
@@ -2228,6 +2229,9 @@ _PROTECTED_RUN_STATE_KEYS = frozenset(
         "provider",
         "model",
         "reasoning_effort",
+        "rtk_effective",
+        "benjamin_effective",
+        "usage_metrics_recorded",
     }
 )
 
@@ -4600,6 +4604,7 @@ def bootstrap_task_run(
         "context_window": context_window,
         "fast_mode": fast_mode,
         "rtk_enabled": validated_data.get("rtk_enabled"),
+        "benjamin_enabled": validated_data.get("benjamin_enabled"),
     }.items():
         if value is not None:
             extra_state = extra_state or {}
@@ -6902,13 +6907,14 @@ def run_task(
     if pending_user_artifact_ids and not is_pi_task:
         extra_state = extra_state or {}
         extra_state["pending_user_artifact_ids"] = pending_user_artifact_ids
-    if initial_permission_mode is not None:
-        extra_state = extra_state or {}
-        extra_state["initial_permission_mode"] = initial_permission_mode
-    rtk_enabled = validated_data.get("rtk_enabled")
-    if rtk_enabled is not None:
-        extra_state = extra_state or {}
-        extra_state["rtk_enabled"] = rtk_enabled
+    for key, value in (
+        ("initial_permission_mode", initial_permission_mode),
+        ("rtk_enabled", validated_data.get("rtk_enabled")),
+        ("benjamin_enabled", validated_data.get("benjamin_enabled")),
+    ):
+        if value is not None:
+            extra_state = extra_state or {}
+            extra_state[key] = value
 
     if resume_from_run_id:
         assert previous_run is not None and previous_state is not None

--- a/products/tasks/backend/facade/temporal.py
+++ b/products/tasks/backend/facade/temporal.py
@@ -21,6 +21,8 @@ from products.tasks.backend.temporal.metrics import (
     TASKS_LATENCY_HISTOGRAM_METRICS,
     TASKS_RUN_TOKENS_HISTOGRAM_BUCKETS,
     TASKS_RUN_TOKENS_HISTOGRAM_METRICS,
+    TASKS_RUN_TURNS_HISTOGRAM_BUCKETS,
+    TASKS_RUN_TURNS_HISTOGRAM_METRICS,
 )
 from products.tasks.backend.temporal.process_task.activities.post_slack_update import (
     PostSlackUpdateInput,
@@ -34,6 +36,8 @@ __all__ = [
     "TASKS_LATENCY_HISTOGRAM_METRICS",
     "TASKS_RUN_TOKENS_HISTOGRAM_BUCKETS",
     "TASKS_RUN_TOKENS_HISTOGRAM_METRICS",
+    "TASKS_RUN_TURNS_HISTOGRAM_BUCKETS",
+    "TASKS_RUN_TURNS_HISTOGRAM_METRICS",
     "WORKFLOWS",
     "PostSlackUpdateInput",
     "ProcessTaskWorkflow",

--- a/products/tasks/backend/logic/services/agent_server_launcher.py
+++ b/products/tasks/backend/logic/services/agent_server_launcher.py
@@ -102,6 +102,7 @@ class AgentServerLaunchMixin(SandboxBase):
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
         rtk_enabled: bool = True,
+        benjamin_enabled: bool = False,
         peer_messaging: bool = False,
         posthog_exec_permission_regex: str | None = None,
     ) -> str:
@@ -121,6 +122,7 @@ class AgentServerLaunchMixin(SandboxBase):
             event_ingest_url=event_ingest_url,
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             rtk_enabled=rtk_enabled,
+            benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
@@ -241,6 +243,7 @@ class AgentServerLaunchMixin(SandboxBase):
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
         rtk_enabled: bool = True,
+        benjamin_enabled: bool = False,
         peer_messaging: bool = False,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
@@ -324,6 +327,7 @@ class AgentServerLaunchMixin(SandboxBase):
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
             rtk_enabled=rtk_enabled,
+            benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
             posthog_exec_permission_regex=exec_permission_regex,
         )

--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -883,6 +883,7 @@ class DockerSandbox(SandboxBase):
         event_ingest_keep_stream_open: bool = False,
         repo_ready_file: str | None = None,
         rtk_enabled: bool = True,
+        benjamin_enabled: bool = False,
         peer_messaging: bool = False,
         posthog_exec_permission_regex: str | None = None,
     ) -> str:
@@ -906,6 +907,7 @@ class DockerSandbox(SandboxBase):
             event_ingest_url=event_ingest_url,
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             rtk_enabled=rtk_enabled,
+            benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
         )
         create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
@@ -1000,6 +1002,7 @@ class DockerSandbox(SandboxBase):
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
         rtk_enabled: bool = True,
+        benjamin_enabled: bool = False,
         peer_messaging: bool = False,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
@@ -1078,6 +1081,7 @@ class DockerSandbox(SandboxBase):
             event_ingest_keep_stream_open=event_ingest_keep_stream_open,
             repo_ready_file=repo_ready_file,
             rtk_enabled=rtk_enabled,
+            benjamin_enabled=benjamin_enabled,
             peer_messaging=peer_messaging,
             posthog_exec_permission_regex=exec_permission_regex,
         )
@@ -1134,6 +1138,7 @@ class DockerSandbox(SandboxBase):
                 event_ingest_keep_stream_open=event_ingest_keep_stream_open,
                 repo_ready_file=repo_ready_file,
                 rtk_enabled=rtk_enabled,
+                benjamin_enabled=benjamin_enabled,
                 peer_messaging=peer_messaging,
                 posthog_exec_permission_regex=exec_permission_regex,
             )

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -270,6 +270,7 @@ def build_agent_runtime_env_prefix(
     event_ingest_url: str | None = None,
     event_ingest_keep_stream_open: bool = False,
     rtk_enabled: bool = True,
+    benjamin_enabled: bool = False,
     peer_messaging: bool = False,
 ) -> str:
     env_vars = {
@@ -291,6 +292,7 @@ def build_agent_runtime_env_prefix(
         # Set explicitly in both states: "0" opts the run out, "1" pins auto-detection on
         # even if a stale env value survives in a resumed sandbox.
         "POSTHOG_RTK": "1" if rtk_enabled else "0",
+        "POSTHOG_BENJAMIN": "1" if benjamin_enabled else "0",
         # Exposure gate for the peer-messaging tools (PR: agent peer messaging). Set in
         # both states so a stale "1" in a resumed sandbox can't outlive a flag rollback;
         # the peers endpoints re-check authorization server-side regardless.
@@ -546,6 +548,7 @@ class SandboxBase(ABC):
         repo_ready_file: str | None = None,
         wait_for_health: bool = True,
         rtk_enabled: bool = True,
+        benjamin_enabled: bool = False,
         peer_messaging: bool = False,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -655,13 +655,16 @@ class TestModalSandboxAgentServer:
             assert "POSTHOG_CODE_FAST_MODE" not in command
 
     @pytest.mark.parametrize(
-        "rtk_enabled, expected_env",
+        "toggles, expected_env",
         [
-            (True, "POSTHOG_RTK=1"),
-            (False, "POSTHOG_RTK=0"),
+            ({"rtk_enabled": True}, "POSTHOG_RTK=1"),
+            ({"rtk_enabled": False}, "POSTHOG_RTK=0"),
+            ({"benjamin_enabled": True}, "POSTHOG_BENJAMIN=1"),
+            ({"benjamin_enabled": False}, "POSTHOG_BENJAMIN=0"),
+            ({}, "POSTHOG_BENJAMIN=0"),
         ],
     )
-    def test_start_agent_server_rtk_env(self, mock_sandbox: Any, rtk_enabled, expected_env):
+    def test_start_agent_server_toggle_env(self, mock_sandbox: Any, toggles, expected_env):
         mock_sandbox.execute = MagicMock(
             return_value=ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
         )
@@ -671,7 +674,7 @@ class TestModalSandboxAgentServer:
             task_id="task-123",
             run_id="run-456",
             mode="background",
-            rtk_enabled=rtk_enabled,
+            **toggles,
         )
 
         command = _agent_server_launch_command(mock_sandbox.execute)

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -2544,12 +2544,18 @@ class TaskRun(models.Model):
                 error=str(e),
             )
 
-    def effective_rtk(self) -> bool | None:
-        """rtk posture for analytics: the launch-persisted effective value, falling
+    def _effective_toggle(self, name: str) -> bool | None:
+        """Toggle posture for analytics: the launch-persisted effective value, falling
         back to the user's explicit override for runs that never launched."""
         state = self.state if isinstance(self.state, dict) else {}
-        rtk = state.get("rtk_effective", state.get("rtk_enabled"))
-        return rtk if isinstance(rtk, bool) else None
+        value = state.get(f"{name}_effective", state.get(f"{name}_enabled"))
+        return value if isinstance(value, bool) else None
+
+    def effective_rtk(self) -> bool | None:
+        return self._effective_toggle("rtk")
+
+    def effective_benjamin(self) -> bool | None:
+        return self._effective_toggle("benjamin")
 
     def _analytics_usage_properties(self) -> dict:
         """Token usage and rtk posture for analytics events.
@@ -2576,6 +2582,12 @@ class TaskRun(models.Model):
         rtk = self.effective_rtk()
         if rtk is not None:
             props["rtk_enabled"] = rtk
+        benjamin = self.effective_benjamin()
+        if benjamin is not None:
+            props["benjamin_enabled"] = benjamin
+        benjamin_version = state.get("benjamin_version")
+        if isinstance(benjamin_version, str) and benjamin_version:
+            props["benjamin_version"] = benjamin_version
         return props
 
     def capture_event(

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -3015,6 +3015,16 @@ class TaskRunCreateRequestSerializer(ImportedMcpServersFieldMixin, RelayedMcpSer
             "follows the server-side default (enabled); false opts this run out."
         ),
     )
+    benjamin_enabled = serializers.BooleanField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted "
+            "or null lets the server decide from the feature flag; true or false pins the choice "
+            "for this run."
+        ),
+    )
 
     def validate(self, attrs):
         errors: dict[str, str] = {}
@@ -3194,6 +3204,16 @@ class TaskRunBootstrapCreateRequestSerializer(
         help_text=(
             "Whether rtk command-output compression is enabled for this run. Omitted or null "
             "follows the server-side default (enabled); false opts this run out."
+        ),
+    )
+    benjamin_enabled = serializers.BooleanField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted "
+            "or null lets the server decide from the feature flag; true or false pins the choice "
+            "for this run."
         ),
     )
 

--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -8,6 +8,8 @@ import posthoganalytics
 from temporalio import activity, workflow
 from temporalio.common import MetricMeter
 
+from products.tasks.backend.logic.services.model_catalogue import runtime_adapter_for
+
 Attributes = dict[str, str | int | float | bool]
 
 TASKS_LATENCY_HISTOGRAM_METRICS = (
@@ -50,6 +52,19 @@ TASKS_RUN_TOKENS_HISTOGRAM_BUCKETS = [
     25_000_000.0,
     50_000_000.0,
     100_000_000.0,
+]
+
+TASKS_RUN_TURNS_HISTOGRAM_METRICS = ("tasks_run_turns",)
+TASKS_RUN_TURNS_HISTOGRAM_BUCKETS = [
+    1.0,
+    2.0,
+    4.0,
+    8.0,
+    16.0,
+    32.0,
+    64.0,
+    128.0,
+    256.0,
 ]
 
 _RUN_TOKEN_KINDS = {
@@ -108,6 +123,13 @@ def _runtime_adapter_label(value: str | None) -> str:
     if not value:
         return "unknown"
     return value if value in _ALLOWED_RUNTIME_ADAPTERS else "other"
+
+
+def _model_label(value: str | None) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return "unknown"
+    normalized = value.strip().lower()
+    return normalized if runtime_adapter_for(normalized) else "other"
 
 
 def resume_mode_label(*, same_run_resume: bool, using_modal_snapshot: bool) -> str:
@@ -196,6 +218,8 @@ def record_run_token_usage(
     origin_product: str | None,
     run_environment: str | None,
     rtk_enabled: bool | None,
+    benjamin_enabled: bool | None,
+    model: str | None,
     runtime_adapter: str | None,
     status: str | None,
 ) -> None:
@@ -208,6 +232,8 @@ def record_run_token_usage(
             "origin_product": origin_product or "unknown",
             "run_environment": run_environment or "unknown",
             "rtk_enabled": _bool_label(rtk_enabled),
+            "benjamin_enabled": _bool_label(benjamin_enabled),
+            "model": _model_label(model),
             "runtime_adapter": _runtime_adapter_label(runtime_adapter),
             "status": status or "unknown",
         }
@@ -218,12 +244,14 @@ def record_run_token_usage(
                     "tasks_run_tokens_total",
                     "Token expenditure of terminal task runs, by token kind",
                 ).add(int(value))
-        total = usage.get("total_tokens")
-        if isinstance(total, int | float) and not isinstance(total, bool) and total > 0:
-            _metric_meter(base_attributes).create_histogram(
-                "tasks_run_total_tokens",
-                "Total tokens spent per terminal task run",
-            ).record(int(total))
+        meter = _metric_meter(base_attributes)
+        for name, description, key in (
+            ("tasks_run_total_tokens", "Total tokens spent per terminal task run", "total_tokens"),
+            ("tasks_run_turns", "Agent turns per terminal task run", "turns"),
+        ):
+            value = usage.get(key)
+            if isinstance(value, int | float) and not isinstance(value, bool) and value > 0:
+                meter.create_histogram(name, description).record(int(value))
     except Exception:
         pass
 

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -1,3 +1,5 @@
+import json
+import hashlib
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -15,6 +17,7 @@ from products.tasks.backend.constants import (
     AGENT_OTEL_TELEMETRY_STATE_KEY,
     AGENT_PEER_MESSAGING_FEATURE_FLAG,
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
+    BENJAMIN_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
     DESKTOP_WORKSPACE_WARM_FEATURE_FLAG,
     DEV_STACK_IMAGE_NAME,
@@ -134,6 +137,7 @@ class TaskProcessingContext:
     # The kill-switch flag wins over everything; otherwise a per-run state override
     # (the user's toggle) applies. Captured at workflow start so it's stable across retries.
     rtk_enabled: bool = True
+    benjamin_enabled: bool = False
     # Captured at workflow start so the continue_as_new trigger is deterministic across replay.
     continue_as_new_enabled: bool = False
     continue_as_new_history_threshold: int = 0
@@ -436,6 +440,66 @@ def _is_rtk_enabled(
         return state_override
 
     return True
+
+
+def _is_benjamin_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    origin_product: str | None = None,
+    state: dict | None = None,
+) -> bool:
+    run_state = state or {}
+    launched_value = run_state.get("benjamin_effective")
+    if isinstance(launched_value, bool):
+        return launched_value
+
+    state_override = run_state.get("benjamin_enabled")
+    if isinstance(state_override, bool):
+        return state_override
+
+    try:
+        payload = posthoganalytics.get_feature_flag_payload(
+            BENJAMIN_FEATURE_FLAG,
+            distinct_id=distinct_id,
+            groups={"organization": organization_id},
+            group_properties={"organization": {"id": organization_id}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+        fraction = _benjamin_rollout_fraction(payload, origin_product)
+    except Exception as e:
+        log_with_activity_context("benjamin_flag_check_failed", run_id=run_id, error=str(e))
+        return False
+
+    if fraction <= 0:
+        return False
+    if fraction >= 1:
+        return True
+    bucket = int(hashlib.sha256(f"{BENJAMIN_FEATURE_FLAG}:{run_id}".encode()).hexdigest()[:16], 16) / 2**64
+    return bucket < fraction
+
+
+def _benjamin_rollout_fraction(payload: object, origin_product: str | None) -> float:
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return 0.0
+    if not isinstance(payload, dict):
+        return 0.0
+
+    origins = payload.get("origins")
+    if isinstance(origins, dict) and origin_product in origins:
+        return _benjamin_fraction_value(origins[origin_product])
+    return _benjamin_fraction_value(payload.get("default"))
+
+
+def _benjamin_fraction_value(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return 0.0
+    return float(value)
 
 
 def _is_sandbox_event_ingest_enabled(
@@ -1258,10 +1322,17 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         run_id=run_id,
         state=state,
     )
+    benjamin_enabled = _is_benjamin_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        origin_product=task.origin_product,
+        state=state,
+    )
     emit_agent_log(
         run_id,
         "debug",
-        f"rtk_enabled: {rtk_enabled} for this task run",
+        f"rtk_enabled: {rtk_enabled}, benjamin_enabled: {benjamin_enabled} for this task run",
     )
     # The same test that mints the token's interactive-run marker: user-started signals runs get
     # a finite wall-clock ceiling because their inference is unbilled and the generic interactive
@@ -1378,6 +1449,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         agent_proxy_keep_stream_open=agent_proxy_keep_stream_open,
         custom_image_name=custom_image_name,
         rtk_enabled=rtk_enabled,
+        benjamin_enabled=benjamin_enabled,
         continue_as_new_enabled=_is_continue_as_new_enabled(
             distinct_id=distinct_id,
             organization_id=organization_id,

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -546,6 +546,7 @@ def _invoke_start_agent_server(
             repo_ready_file=repo_ready_file,
             wait_for_health=False,
             rtk_enabled=ctx.rtk_enabled,
+            benjamin_enabled=ctx.benjamin_enabled,
             peer_messaging=ctx.peer_messaging_enabled,
         )
 
@@ -569,9 +570,12 @@ def _record_agent_server_launch(sandbox: SandboxBase, ctx: TaskProcessingContext
     if params.mcp_configs and params.actor_user_id is not None:
         mark_sandbox_mcp_session(sandbox.id, params.actor_user_id)
     try:
-        TaskRun.update_state_atomic(ctx.run_id, updates={"rtk_effective": ctx.rtk_enabled})
+        TaskRun.update_state_atomic(
+            ctx.run_id,
+            updates={"rtk_effective": ctx.rtk_enabled, "benjamin_effective": ctx.benjamin_enabled},
+        )
     except Exception:
-        logger.warning("persist_rtk_effective_failed", run_id=ctx.run_id, exc_info=True)
+        logger.warning("persist_effective_toggles_failed", run_id=ctx.run_id, exc_info=True)
 
 
 def _spawn_post_ready_diagnostics(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -13,6 +13,7 @@ from posthog.models.user_integration import UserIntegration
 
 from products.tasks.backend.constants import (
     AGENT_PROXY_KEEP_STREAM_OPEN_FEATURE_FLAG,
+    BENJAMIN_FEATURE_FLAG,
     CONTINUE_AS_NEW_FEATURE_FLAG,
     DESKTOP_WORKSPACE_WARM_FEATURE_FLAG,
     DEV_STACK_IMAGE_NAME,
@@ -34,6 +35,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     VmSandboxDecision,
     _is_agent_otel_telemetry_enabled,
     _is_agent_proxy_keep_stream_open_enabled,
+    _is_benjamin_enabled,
     _is_burstable_sandbox_resources_enabled,
     _is_continue_as_new_enabled,
     _is_desktop_workspace_warm_enabled,
@@ -48,6 +50,10 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
 from products.tasks.backend.temporal.process_task.utils import get_actor_distinct_id
 
 VM_FLAG_PAYLOAD_TARGET = "products.tasks.backend.constants.posthoganalytics.get_feature_flag_payload"
+BENJAMIN_PAYLOAD_TARGET = (
+    "products.tasks.backend.temporal.process_task.activities."
+    "get_task_processing_context.posthoganalytics.get_feature_flag_payload"
+)
 
 
 @pytest.mark.parametrize(
@@ -853,6 +859,120 @@ class TestGetTaskProcessingContextActivity:
                     organization_id="organization-id",
                     run_id="run-id",
                     state={"rtk_enabled": False},
+                )
+                is False
+            )
+
+    @pytest.mark.parametrize("launched_value", [True, False])
+    def test_benjamin_launch_persisted_value_pins_later_resolutions(self, launched_value):
+        with patch(BENJAMIN_PAYLOAD_TARGET) as payload_mock:
+            assert (
+                _is_benjamin_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    origin_product=Task.OriginProduct.USER_CREATED,
+                    state={"benjamin_effective": launched_value, "benjamin_enabled": not launched_value},
+                )
+                is launched_value
+            )
+
+        payload_mock.assert_not_called()
+
+    @pytest.mark.parametrize("state_override", [True, False])
+    def test_benjamin_state_override_wins_without_consulting_the_flag(self, state_override):
+        with patch(BENJAMIN_PAYLOAD_TARGET) as payload_mock:
+            assert (
+                _is_benjamin_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    origin_product=Task.OriginProduct.USER_CREATED,
+                    state={"benjamin_enabled": state_override},
+                )
+                is state_override
+            )
+
+        payload_mock.assert_not_called()
+
+    def test_benjamin_disabled_when_flag_serves_no_payload(self):
+        with patch(BENJAMIN_PAYLOAD_TARGET, return_value=None) as payload_mock:
+            assert (
+                _is_benjamin_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    origin_product=Task.OriginProduct.USER_CREATED,
+                )
+                is False
+            )
+
+        payload_mock.assert_called_once_with(
+            BENJAMIN_FEATURE_FLAG,
+            distinct_id="distinct-id",
+            groups={"organization": "organization-id"},
+            group_properties={"organization": {"id": "organization-id"}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+
+    @pytest.mark.parametrize(
+        "payload, origin_product, expected",
+        [
+            ({"origins": {"user_created": 1}}, Task.OriginProduct.USER_CREATED, True),
+            ({"origins": {"user_created": 0}}, Task.OriginProduct.USER_CREATED, False),
+            ({"origins": {"slack": 1}, "default": 0}, Task.OriginProduct.USER_CREATED, False),
+            ({"origins": {"slack": 0}, "default": 1}, Task.OriginProduct.SLACK, False),
+            ({"origins": {}, "default": 1}, Task.OriginProduct.USER_CREATED, True),
+            ({"default": 1}, None, True),
+            ('{"default": 1}', Task.OriginProduct.USER_CREATED, True),
+            ("not json at all", Task.OriginProduct.USER_CREATED, False),
+            ({"default": "1"}, Task.OriginProduct.USER_CREATED, False),
+            ({"origins": ["user_created"]}, Task.OriginProduct.USER_CREATED, False),
+            (None, Task.OriginProduct.USER_CREATED, False),
+        ],
+    )
+    def test_benjamin_applies_the_payload_rollout_fraction(self, payload, origin_product, expected):
+        with patch(BENJAMIN_PAYLOAD_TARGET, return_value=payload):
+            assert (
+                _is_benjamin_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    origin_product=origin_product,
+                )
+                is expected
+            )
+
+    @pytest.mark.parametrize(
+        "run_id, fraction, expected",
+        [
+            ("run-a", 0.77, False),
+            ("run-a", 0.78, True),
+            ("run-b", 0.04, True),
+            ("run-b", 0.03, False),
+        ],
+    )
+    def test_benjamin_buckets_runs_deterministically_by_run_id(self, run_id, fraction, expected):
+        with patch(BENJAMIN_PAYLOAD_TARGET, return_value={"default": fraction}):
+            assert (
+                _is_benjamin_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id=run_id,
+                    origin_product=Task.OriginProduct.USER_CREATED,
+                )
+                is expected
+            )
+
+    def test_benjamin_fails_closed_on_flag_error(self):
+        with patch(BENJAMIN_PAYLOAD_TARGET, side_effect=RuntimeError("flag service failed")):
+            assert (
+                _is_benjamin_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    origin_product=Task.OriginProduct.USER_CREATED,
                 )
                 is False
             )

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -8,15 +8,45 @@ from temporalio.exceptions import ApplicationError
 from temporalio.testing import ActivityEnvironment
 
 from products.tasks.backend.models import Loop, Task, TaskRun
+from products.tasks.backend.temporal.metrics import record_run_token_usage
 from products.tasks.backend.temporal.process_task.activities.update_task_run_status import (
     SANDBOX_GONE_STATE_KEY,
     TIMED_OUT_INACTIVITY_STATE_KEY,
     TIMED_OUT_WALL_CLOCK_STATE_KEY,
+    USAGE_METRICS_RECORDED_STATE_KEY,
     UpdateTaskRunStatusInput,
     update_task_run_status,
 )
 
 TOKEN_USAGE = {"input_tokens": 1200, "output_tokens": 300, "total_tokens": 1500, "turns": 3}
+
+
+class _RecordingMetric:
+    def __init__(self, sink, name, attributes):
+        self.sink = sink
+        self.name = name
+        self.attributes = attributes
+
+    def record(self, value):
+        self.sink.append((self.name, value, self.attributes))
+
+    def add(self, value):
+        self.sink.append((self.name, value, self.attributes))
+
+
+class _RecordingMetricMeter:
+    def __init__(self, sink, attributes=None):
+        self.sink = sink
+        self.attributes = dict(attributes or {})
+
+    def with_additional_attributes(self, additional_attributes):
+        return _RecordingMetricMeter(self.sink, {**self.attributes, **dict(additional_attributes)})
+
+    def create_counter(self, name, description=None, unit=None):
+        return _RecordingMetric(self.sink, name, self.attributes)
+
+    def create_histogram(self, name, description=None, unit=None):
+        return _RecordingMetric(self.sink, name, self.attributes)
 
 
 async def _run_update_task_run_status(
@@ -213,6 +243,9 @@ class TestUpdateTaskRunStatusActivity:
             **(test_task_run.state or {}),
             "token_usage": dict(TOKEN_USAGE),
             "rtk_effective": True,
+            "benjamin_effective": True,
+            "benjamin_version": "2026.08.1",
+            "model": "gpt-5.6-sol",
             "runtime_adapter": "codex",
         }
         test_task_run.save(update_fields=["state"])
@@ -231,12 +264,38 @@ class TestUpdateTaskRunStatusActivity:
         assert props["total_tokens"] == 1500
         assert props["usage_turns"] == 3
         assert props["rtk_enabled"] is True
+        assert props["benjamin_enabled"] is True
+        assert props["benjamin_version"] == "2026.08.1"
         assert props["run_environment"] == test_task_run.environment
         assert props["termination_reason"] is None
         mock_record.assert_called_once()
         assert mock_record.call_args.kwargs["rtk_enabled"] is True
+        assert mock_record.call_args.kwargs["benjamin_enabled"] is True
+        assert mock_record.call_args.kwargs["model"] == "gpt-5.6-sol"
         assert mock_record.call_args.kwargs["runtime_adapter"] == "codex"
         assert mock_record.call_args.kwargs["status"] == status
+        test_task_run.refresh_from_db()
+        assert test_task_run.state[USAGE_METRICS_RECORDED_STATE_KEY] is True
+
+    @pytest.mark.django_db(transaction=True)
+    @patch("products.tasks.backend.temporal.process_task.activities.update_task_run_status.record_run_token_usage")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_agent_terminalized_run_still_records_usage_metrics_once(
+        self, mock_capture, mock_record, activity_environment, test_task_run
+    ):
+        test_task_run.status = TaskRun.Status.COMPLETED
+        test_task_run.state = {**(test_task_run.state or {}), "token_usage": dict(TOKEN_USAGE)}
+        test_task_run.save(update_fields=["status", "state"])
+
+        input_data = UpdateTaskRunStatusInput(run_id=str(test_task_run.id), status=TaskRun.Status.COMPLETED)
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+
+        mock_record.assert_called_once()
+        assert mock_record.call_args.kwargs["status"] == TaskRun.Status.COMPLETED
+        test_task_run.refresh_from_db()
+        assert test_task_run.state[USAGE_METRICS_RECORDED_STATE_KEY] is True
+        assert [c for c in mock_capture.call_args_list if c.kwargs.get("event") == "task_run_completed"] == []
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.parametrize(
@@ -498,3 +557,51 @@ class TestUpdateTaskRunStatusActivity:
 
         after = REGISTRY.get_sample_value("posthog_tasks_wizard_run_unbound_total", labels) or 0.0
         assert after == before + expected_delta
+
+
+class TestRecordRunTokenUsageMetrics:
+    def _record(self, activity_environment, **overrides):
+        recorded: list = []
+        activity_environment.metric_meter = _RecordingMetricMeter(recorded)
+        kwargs = {
+            "origin_product": "user_created",
+            "run_environment": "cloud",
+            "rtk_enabled": True,
+            "benjamin_enabled": True,
+            "model": "gpt-5.6-sol",
+            "runtime_adapter": "codex",
+            "status": "completed",
+            **overrides,
+        }
+        activity_environment.run(record_run_token_usage, dict(TOKEN_USAGE), **kwargs)
+        return recorded
+
+    def test_records_turns_alongside_tokens(self, activity_environment):
+        recorded = self._record(activity_environment)
+
+        turns = [entry for entry in recorded if entry[0] == "tasks_run_turns"]
+        assert len(turns) == 1
+        assert turns[0][1] == 3
+        assert turns[0][2]["benjamin_enabled"] == "true"
+        assert turns[0][2]["model"] == "gpt-5.6-sol"
+
+    @pytest.mark.parametrize(
+        "model, expected",
+        [
+            ("gpt-5.6-sol", "gpt-5.6-sol"),
+            ("Claude-Sonnet-5", "claude-sonnet-5"),
+            ("some-unreleased-model", "other"),
+            ("", "unknown"),
+            (None, "unknown"),
+        ],
+    )
+    def test_model_attribute_is_bounded_to_the_catalogue(self, activity_environment, model, expected):
+        recorded = self._record(activity_environment, model=model)
+
+        assert {entry[2]["model"] for entry in recorded} == {expected}
+
+    @pytest.mark.parametrize("benjamin_enabled, expected", [(True, "true"), (False, "false"), (None, "unknown")])
+    def test_benjamin_attribute_labels_every_posture(self, activity_environment, benjamin_enabled, expected):
+        recorded = self._record(activity_environment, benjamin_enabled=benjamin_enabled)
+
+        assert {entry[2]["benjamin_enabled"] for entry in recorded} == {expected}

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -25,6 +25,7 @@ TIMED_OUT_INACTIVITY_STATE_KEY = "timed_out_inactivity"
 TIMED_OUT_WALL_CLOCK_STATE_KEY = "timed_out_wall_clock"
 # TaskRun.state marker for runs terminalized because their sandbox disappeared.
 SANDBOX_GONE_STATE_KEY = "sandbox_gone"
+USAGE_METRICS_RECORDED_STATE_KEY = "usage_metrics_recorded"
 
 # Allowlist for `timeout_marker` so the activity never writes an arbitrary state key.
 _TERMINAL_STATE_MARKERS = (
@@ -122,8 +123,10 @@ def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
     if input.status in _TERMINAL_STATUSES and old_status != input.status:
         task_run.close_ci_progress_step()
 
-    if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED] and old_status != input.status:
-        _capture_terminal_analytics(task_run, input)
+    if input.status in [TaskRun.Status.COMPLETED, TaskRun.Status.FAILED]:
+        if old_status != input.status:
+            _capture_terminal_analytics(task_run, input)
+        _record_terminal_token_usage(task_run, input)
 
     if input.timed_out_inactivity and old_status != input.status:
         task_run.task.soft_delete_if_unclaimed_prewarm(task_run)
@@ -227,7 +230,7 @@ def _is_first_chat_run_of_task(task_run: TaskRun, state: dict[str, Any]) -> bool
 
 
 def _capture_terminal_analytics(task_run: TaskRun, input: UpdateTaskRunStatusInput) -> None:
-    """Emit the terminal analytics event and token-expenditure metrics.
+    """Emit the terminal analytics events.
 
     This activity performs the DB status transition, so it is the single canonical
     emitter of the terminal analytics events for workflow-driven runs — the workflow
@@ -265,18 +268,28 @@ def _capture_terminal_analytics(task_run: TaskRun, input: UpdateTaskRunStatusInp
             )
 
         _capture_posthog_ai_chat_analytics(task_run, input, termination_reason=termination_reason)
-
-        state = task_run.state if isinstance(task_run.state, dict) else {}
-        usage = state.get("token_usage")
-        if isinstance(usage, dict):
-            adapter = state.get("runtime_adapter")
-            record_run_token_usage(
-                usage,
-                origin_product=task_run.task.origin_product,
-                run_environment=task_run.environment,
-                rtk_enabled=task_run.effective_rtk(),
-                runtime_adapter=adapter if isinstance(adapter, str) else None,
-                status=input.status,
-            )
     except Exception:
         activity.logger.warning(f"Failed to capture terminal analytics for run {task_run.id}", exc_info=True)
+
+
+def _record_terminal_token_usage(task_run: TaskRun, input: UpdateTaskRunStatusInput) -> None:
+    try:
+        state = task_run.state if isinstance(task_run.state, dict) else {}
+        usage = state.get("token_usage")
+        if not isinstance(usage, dict) or state.get(USAGE_METRICS_RECORDED_STATE_KEY):
+            return
+        adapter = state.get("runtime_adapter")
+        model = state.get("model")
+        task_run.state = TaskRun.update_state_atomic(task_run.id, updates={USAGE_METRICS_RECORDED_STATE_KEY: True})
+        record_run_token_usage(
+            usage,
+            origin_product=task_run.task.origin_product,
+            run_environment=task_run.environment,
+            rtk_enabled=task_run.effective_rtk(),
+            benjamin_enabled=task_run.effective_benjamin(),
+            model=model if isinstance(model, str) else None,
+            runtime_adapter=adapter if isinstance(adapter, str) else None,
+            status=input.status,
+        )
+    except Exception:
+        activity.logger.warning(f"Failed to record token usage for run {task_run.id}", exc_info=True)

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3353,31 +3353,39 @@ class TestTaskAPI(BaseTaskAPITest):
         assert "initial_permission_mode" not in (task_run.state or {})
         mock_workflow.assert_called_once()
 
-    @parameterized.expand([(True,), (False,)])
+    @parameterized.expand(
+        [
+            ("rtk_enabled", True),
+            ("rtk_enabled", False),
+            ("benjamin_enabled", True),
+            ("benjamin_enabled", False),
+        ]
+    )
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
-    def test_run_endpoint_persists_rtk_enabled(self, rtk_enabled, mock_workflow):
+    def test_run_endpoint_persists_agent_toggle(self, field, value, mock_workflow):
         task = self.create_task()
 
         response = self.client.post(
             f"/api/projects/@current/tasks/{task.id}/run/",
-            {"rtk_enabled": rtk_enabled},
+            {field: value},
             format="json",
         )
 
         assert response.status_code == status.HTTP_200_OK
         task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
-        assert task_run.state["rtk_enabled"] is rtk_enabled
+        assert task_run.state[field] is value
         mock_workflow.assert_called_once()
 
+    @parameterized.expand([("rtk_enabled",), ("benjamin_enabled",)])
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
-    def test_run_endpoint_omits_rtk_enabled_when_not_set(self, mock_workflow):
+    def test_run_endpoint_omits_agent_toggle_when_not_set(self, field, mock_workflow):
         task = self.create_task()
 
         response = self.client.post(f"/api/projects/@current/tasks/{task.id}/run/")
 
         assert response.status_code == status.HTTP_200_OK
         task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
-        assert "rtk_enabled" not in (task_run.state or {})
+        assert field not in (task_run.state or {})
         mock_workflow.assert_called_once()
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
@@ -5387,6 +5395,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
                 "provider": "anthropic",
                 "model": "claude-sonnet-5",
                 "reasoning_effort": "low",
+                "rtk_effective": True,
+                "benjamin_effective": True,
+                "usage_metrics_recorded": True,
                 "loop_terminal_bookkeeping_complete": True,
                 "analysis_target_repository": "posthog/posthog",
                 "analysis_target_custom_image_id": "img-real",
@@ -5448,6 +5459,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
                     "provider": "openai",
                     "model": "claude-opus-4-8",
                     "reasoning_effort": "high",
+                    "rtk_effective": False,
+                    "benjamin_effective": False,
+                    "usage_metrics_recorded": False,
                     "loop_terminal_bookkeeping_complete": False,
                     # server-stamped analysis insight attribution; a forged value would
                     # misattribute the captured insight event to another repository / image
@@ -5495,6 +5509,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
         assert run.state["provider"] == "anthropic"
         assert run.state["model"] == "claude-sonnet-5"
         assert run.state["reasoning_effort"] == "low"
+        assert run.state["rtk_effective"] is True
+        assert run.state["benjamin_effective"] is True
+        assert run.state["usage_metrics_recorded"] is True
         assert run.state["loop_terminal_bookkeeping_complete"] is True
         assert run.state["analysis_target_repository"] == "posthog/posthog"  # cannot forge attribution
         assert run.state["analysis_target_custom_image_id"] == "img-real"
@@ -5528,6 +5545,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
                     "provider",
                     "model",
                     "reasoning_effort",
+                    "rtk_effective",
+                    "benjamin_effective",
+                    "usage_metrics_recorded",
                     "loop_terminal_bookkeeping_complete",
                     "analysis_target_repository",
                     "analysis_target_custom_image_id",
@@ -5563,6 +5583,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
         assert run.state["provider"] == "anthropic"  # protected key survives removal
         assert run.state["model"] == "claude-sonnet-5"  # protected key survives removal
         assert run.state["reasoning_effort"] == "low"  # protected key survives removal
+        assert run.state["rtk_effective"] is True  # protected key survives removal
+        assert run.state["benjamin_effective"] is True  # protected key survives removal
+        assert run.state["usage_metrics_recorded"] is True  # protected key survives removal
         assert run.state["loop_terminal_bookkeeping_complete"] is True
         assert run.state["analysis_target_repository"] == "posthog/posthog"  # protected key survives removal
         assert run.state["analysis_target_custom_image_id"] == "img-real"

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -2626,6 +2626,11 @@ export interface ClaudeTaskRunCreateSchemaApi {
      * @nullable
      */
     rtk_enabled?: boolean | null
+    /**
+     * Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.
+     * @nullable
+     */
+    benjamin_enabled?: boolean | null
 }
 
 /**
@@ -2747,6 +2752,11 @@ export interface CodexTaskRunCreateSchemaApi {
      * @nullable
      */
     rtk_enabled?: boolean | null
+    /**
+     * Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.
+     * @nullable
+     */
+    benjamin_enabled?: boolean | null
 }
 
 export interface TaskRunResumeRequestSchemaApi {
@@ -3113,6 +3123,11 @@ export interface TaskRunBootstrapCreateRequestApi {
      * @nullable
      */
     rtk_enabled?: boolean | null
+    /**
+     * Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.
+     * @nullable
+     */
+    benjamin_enabled?: boolean | null
 }
 
 /**

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1836,6 +1836,12 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 .describe(
                     'Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.'
                 ),
+            benjamin_enabled: zod
+                .boolean()
+                .nullish()
+                .describe(
+                    'Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.'
+                ),
         })
         .describe('Request body for creating a new task run'),
     zod
@@ -1982,6 +1988,12 @@ export const TasksRunCreateBody = /* @__PURE__ */ zod.union([
                 .nullish()
                 .describe(
                     'Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.'
+                ),
+            benjamin_enabled: zod
+                .boolean()
+                .nullish()
+                .describe(
+                    'Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.'
                 ),
         })
         .describe('Request body for creating a new task run'),
@@ -2421,6 +2433,12 @@ export const TasksRunsCreateBody = /* @__PURE__ */ zod
             .nullish()
             .describe(
                 'Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.'
+            ),
+        benjamin_enabled: zod
+            .boolean()
+            .nullish()
+            .describe(
+                'Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.'
             ),
     })
     .describe('Request body for creating a task run without starting execution yet.')

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17556,6 +17556,11 @@ export namespace Schemas {
          * @nullable
          */
       rtk_enabled?: boolean | null;
+      /**
+         * Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.
+         * @nullable
+         */
+      benjamin_enabled?: boolean | null;
     }
 
     export type ClickhouseEventProperties = { [key: string]: unknown };
@@ -17946,6 +17951,11 @@ export namespace Schemas {
          * @nullable
          */
       rtk_enabled?: boolean | null;
+      /**
+         * Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.
+         * @nullable
+         */
+      benjamin_enabled?: boolean | null;
     }
 
     export type PropertyGroupOperator = typeof PropertyGroupOperator[keyof typeof PropertyGroupOperator];
@@ -83643,6 +83653,11 @@ export namespace Schemas {
          * @nullable
          */
       rtk_enabled?: boolean | null;
+      /**
+         * Whether the Benjamin-Plus token-efficiency instruction applies to this run. Omitted or null lets the server decide from the feature flag; true or false pins the choice for this run.
+         * @nullable
+         */
+      benjamin_enabled?: boolean | null;
     }
 
     export interface TaskRunCancelRequest {


### PR DESCRIPTION
## Problem

Let's improve token efficiency via Benjamin-Plus, from [JetBrains/benjamin-plus-skill](https://github.com/JetBrains/benjamin-plus-skill).

## Changes

- A run can now opt into Benjamin-Plus, or opt out, with `benjamin_enabled` on the task-create and run-create endpoints
- The server decides from the `task-cloud-run-benjamin-plus` flag
- The sandbox receives `POSTHOG_BENJAMIN=1` or `POSTHOG_BENJAMIN=0`, set in both states so a stale value in a resumed sandbox cannot outlive a rollback.
- `task_run_completed` and `task_run_failed` now carry `benjamin_enabled`, plus `benjamin_version` once the agent reports one.
- The token metrics carry two new attributes, `benjamin_enabled` and `model`, so token spend splits by posture and by model. A new `tasks_run_turns` histogram records the turn count on the same attributes.

