### PR TITLE
feat(notebooks): add generated widget browser runtime

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5280,6 +5280,18 @@ snapshots:
         hash: v1.k794b7964.769a69526cf676447319f587f24ed0d2670a137098867f8d3ee87ebda3415a70.3FGS0pbxxcrZUSto8SNCNHEkxaFXH6T8shqpdg5zzlQ
     products-mcp-analytics-routingbar--all-variants--light:
         hash: v1.k794b7964.7f57dacddb48fbad29a8614127d42d54425501b1f7755423d84316e1e937720e.thYPF2z3eMW5QvSe5SnvYtn35l6UCvUtsyx9EBLeqxk
+    products-notebooks-notebook-widget-trust-controls--gate--dark:
+        hash: v1.k794b7964.c80e0972d000da940edf44cc7fe7e903a6029acc0ee5d39e1225ffea5e1c94fe.cCblqVHP947F9S2v0Uh5SLPcgujTHDQMm1dn9OEDPko
+    products-notebooks-notebook-widget-trust-controls--gate--light:
+        hash: v1.k794b7964.32ddaa39dd02c5549ec517ab12d668070e6e4c39d8450373d7da2adac3e9772b.DkHk-zttngHspmfETCOJfSEMMILcHEc2E_lS6wRvsEA
+    products-notebooks-notebook-widget-trust-controls--missing-build-hash--dark:
+        hash: v1.k794b7964.d33dd675affd6ffda6ae38206e0f36c694caf6f34183f800d94873283d3f5a5c.tbCjqh8J1EPf-EVgWiuUzp8oMzYA66SoBTagzv7nH2Y
+    products-notebooks-notebook-widget-trust-controls--missing-build-hash--light:
+        hash: v1.k794b7964.c827e5d6322186539a4952870f0a385ed61f88e275422d8bdb7b9c949aaeb804.2lSXmHjaDJVYJCYrVAYRWDj3O5CJlPk0JweO5NPpYIc
+    products-notebooks-notebook-widget-trust-controls--toolbar--dark:
+        hash: v1.k794b7964.3e39cf4a72bb69eb18f2aba914e5b513b4e48a159eb628ec0142c9fac2f9937d.XqQxJ3tz9cgnECs5Xz-VrmxynkPUunFC6YslZaJWbuw
+    products-notebooks-notebook-widget-trust-controls--toolbar--light:
+        hash: v1.k794b7964.fab133e4eaa3f601e4917e00e0b15f8b5f9d8407b2bfe8a91502890617d0438c.O2AACD_EntjxMM-Ut77UcbecsSAESSEJdT3SWuLaXoo
     products-posthog-ai-composer--default--dark:
         hash: v1.k794b7964.4ccf5eb666de2b3315dc3f142ded80b445748d58ce8ae2d7d154272d7b194b3b.E61uR16UwC5qC1XkQquxMh1z3bonN6IYLdYDyzcorTA
     products-posthog-ai-composer--default--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5281,17 +5281,17 @@ snapshots:
     products-mcp-analytics-routingbar--all-variants--light:
         hash: v1.k794b7964.7f57dacddb48fbad29a8614127d42d54425501b1f7755423d84316e1e937720e.thYPF2z3eMW5QvSe5SnvYtn35l6UCvUtsyx9EBLeqxk
     products-notebooks-notebook-widget-trust-controls--gate--dark:
-        hash: v1.k794b7964.c80e0972d000da940edf44cc7fe7e903a6029acc0ee5d39e1225ffea5e1c94fe.cCblqVHP947F9S2v0Uh5SLPcgujTHDQMm1dn9OEDPko
+        hash: v1.k794b7964.a51e3886b9b210b87ad0165be8e11217f7e6690c4c6fb3f055d91eb743297986.rTe9aGKWZkly97EDDu4Ml4H1iZL-bHzlkuJ4hhxLZGI
     products-notebooks-notebook-widget-trust-controls--gate--light:
-        hash: v1.k794b7964.32ddaa39dd02c5549ec517ab12d668070e6e4c39d8450373d7da2adac3e9772b.DkHk-zttngHspmfETCOJfSEMMILcHEc2E_lS6wRvsEA
+        hash: v1.k794b7964.dba4c5816812fb18955fac3ef7e21d4e2f09ea489f3fd98610e7e2c08cd7b720.v_U6astxnykhOLozpJLNTYhnKqZ2UKlo63c2XV2dIg0
     products-notebooks-notebook-widget-trust-controls--missing-build-hash--dark:
-        hash: v1.k794b7964.d33dd675affd6ffda6ae38206e0f36c694caf6f34183f800d94873283d3f5a5c.tbCjqh8J1EPf-EVgWiuUzp8oMzYA66SoBTagzv7nH2Y
+        hash: v1.k794b7964.710a8f35d2bb0ff64962fa14422f9b19afedf525ecf888fa1a31d109866edc65.xPoRXj8l2nIWGfk_DEjMPUR3kIAoBAxMcW9uBlGeyGY
     products-notebooks-notebook-widget-trust-controls--missing-build-hash--light:
-        hash: v1.k794b7964.c827e5d6322186539a4952870f0a385ed61f88e275422d8bdb7b9c949aaeb804.2lSXmHjaDJVYJCYrVAYRWDj3O5CJlPk0JweO5NPpYIc
+        hash: v1.k794b7964.0e2cc5104d4beb9dc308c92f194195156bd5fb48f6d8a1a278cce43e1313af67.eFnIkptK__hsvjhmXeAKmQxJBT1C3NZ6XXlRPLjHRA4
     products-notebooks-notebook-widget-trust-controls--toolbar--dark:
-        hash: v1.k794b7964.3e39cf4a72bb69eb18f2aba914e5b513b4e48a159eb628ec0142c9fac2f9937d.XqQxJ3tz9cgnECs5Xz-VrmxynkPUunFC6YslZaJWbuw
+        hash: v1.k794b7964.a7394acbef2f45ccce1f0a9ad5d4dc09fa14cb337ffdc0b19642aef2728c65a3.VxLUiUKH_TDO-qiJRfaJ0r-HgJ7M2MAGbUDTd1kR32k
     products-notebooks-notebook-widget-trust-controls--toolbar--light:
-        hash: v1.k794b7964.fab133e4eaa3f601e4917e00e0b15f8b5f9d8407b2bfe8a91502890617d0438c.O2AACD_EntjxMM-Ut77UcbecsSAESSEJdT3SWuLaXoo
+        hash: v1.k794b7964.54adb15f34d6024fc6e441a77a81146a3eb7a31dfb689071b012df26ab133ab4.PjdDZ6fn1152SwEb7DfcTzJsZwNDQ25XzVL3EgjOiio
     products-posthog-ai-composer--default--dark:
         hash: v1.k794b7964.4ccf5eb666de2b3315dc3f142ded80b445748d58ce8ae2d7d154272d7b194b3b.E61uR16UwC5qC1XkQquxMh1z3bonN6IYLdYDyzcorTA
     products-posthog-ai-composer--default--light:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3921,9 +3921,19 @@ importers:
       kea-router:
         specifier: 'catalog:'
         version: 3.4.1(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))
+      posthog-js:
+        specifier: 'catalog:'
+        version: 1.422.5(@types/react@18.3.27)(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^14.3.1
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      kea-test-utils:
+        specifier: 'catalog:'
+        version: 0.2.4(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))
 
   products/notifications:
     dependencies:

--- a/products/mcp_analytics/frontend/timeBuckets.test.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.test.ts
@@ -12,6 +12,14 @@ import {
 } from './timeBuckets'
 
 describe('timeBuckets', () => {
+    beforeEach(() => {
+        jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
     describe('normalizeBucket', () => {
         // Guards the flat-zero-sparkline bug: however the query serializes the bucket, its
         // wall-clock digits must survive verbatim, even when the browser sits in a different

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/NotebookWidgetTrustControls.stories.tsx
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/NotebookWidgetTrustControls.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { NotebookWidgetTrustControls, type NotebookWidgetTrustControlsProps } from './NotebookWidgetTrustControls'
+
+type Story = StoryObj<NotebookWidgetTrustControlsProps>
+
+const meta: Meta<NotebookWidgetTrustControlsProps> = {
+    title: 'Products/Notebooks/Notebook widget trust controls',
+    component: NotebookWidgetTrustControls,
+    args: {
+        buildHash: 'a'.repeat(64),
+        securityReview: {
+            severity: 'high',
+            summary: 'The widget may send notebook data to another window.',
+            findings: [
+                {
+                    severity: 'high',
+                    title: 'Notebook data may leave the preview',
+                    details: 'The source sends rows to the parent window without using the approved bridge.',
+                },
+            ],
+            model: 'claude-haiku-4-5',
+            review_version: '1',
+            reviewed_at: '2026-08-31T10:00:00Z',
+        },
+        onRun: () => undefined,
+        onViewSource: () => undefined,
+    },
+}
+
+export default meta
+
+export const Gate: Story = {
+    args: { variant: 'gate' },
+}
+
+export const Toolbar: Story = {
+    args: {
+        variant: 'toolbar',
+        securityReview: {
+            severity: 'none',
+            summary: 'No security issues found.',
+            findings: [],
+            model: 'claude-haiku-4-5',
+            review_version: '1',
+            reviewed_at: '2026-08-31T10:00:00Z',
+        },
+    },
+}
+
+export const MissingBuildHash: Story = {
+    args: { buildHash: null, securityReview: null, variant: 'gate' },
+}

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/NotebookWidgetTrustControls.tsx
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/NotebookWidgetTrustControls.tsx
@@ -1,0 +1,115 @@
+import { LemonButton, LemonTag, type LemonTagType } from '@posthog/lemon-ui'
+
+import type { WidgetSecurityReviewApi } from 'products/notebooks/frontend/generated/api.schemas'
+
+export type NotebookWidgetTrustControlsProps = {
+    buildHash: string | null
+    securityReview: WidgetSecurityReviewApi | null
+    variant: 'gate' | 'toolbar'
+    onRun: () => void
+    onViewSource: () => void
+}
+
+const SEVERITY_LABELS: Record<WidgetSecurityReviewApi['severity'], string> = {
+    none: 'No issues found',
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    critical: 'Critical',
+}
+
+function severityTagType(severity: WidgetSecurityReviewApi['severity']): LemonTagType {
+    if (severity === 'none') {
+        return 'success'
+    }
+    if (severity === 'high' || severity === 'critical') {
+        return 'danger'
+    }
+    return 'warning'
+}
+
+export function NotebookWidgetTrustControls({
+    buildHash,
+    securityReview,
+    variant,
+    onRun,
+    onViewSource,
+}: NotebookWidgetTrustControlsProps): JSX.Element {
+    const shortBuildHash = buildHash ? buildHash.slice(0, 12) : null
+    const reviewTag = securityReview ? (
+        <LemonTag type={severityTagType(securityReview.severity)}>
+            Security review: {SEVERITY_LABELS[securityReview.severity]}
+        </LemonTag>
+    ) : (
+        <LemonTag type="muted">Not reviewed</LemonTag>
+    )
+
+    if (variant === 'toolbar') {
+        return (
+            <div className="flex flex-wrap items-center justify-between gap-2 border-b px-2 py-1.5">
+                <div className="flex flex-wrap items-center gap-2">
+                    <LemonButton size="xsmall" onClick={onViewSource} data-attr="notebook-widget-view-source">
+                        View source
+                    </LemonButton>
+                    {reviewTag}
+                    {shortBuildHash ? (
+                        <span className="font-mono text-xs text-muted">Build {shortBuildHash}</span>
+                    ) : null}
+                </div>
+            </div>
+        )
+    }
+
+    const hasFindings = securityReview !== null && securityReview.severity !== 'none'
+    return (
+        <div className="h-full min-h-48 overflow-auto p-4">
+            <div className="mx-auto flex min-h-full max-w-2xl flex-col justify-center gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                    <div className="text-base font-semibold">
+                        {hasFindings
+                            ? 'Security review found potential issues'
+                            : 'This widget has not been security reviewed'}
+                    </div>
+                    {reviewTag}
+                </div>
+                <div className="text-secondary">
+                    {hasFindings
+                        ? securityReview.summary
+                        : 'This version was generated before automated reviews were available. View its source before deciding whether to run it.'}
+                </div>
+                {hasFindings ? (
+                    <ul className="m-0 flex list-disc flex-col gap-2 pl-5 text-left">
+                        {securityReview.findings.map((finding, index) => (
+                            <li key={`${finding.severity}-${finding.title}-${index}`}>
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <span className="font-semibold">{finding.title}</span>
+                                    <LemonTag type={severityTagType(finding.severity)} size="small">
+                                        {SEVERITY_LABELS[finding.severity]}
+                                    </LemonTag>
+                                </div>
+                                <div className="text-secondary">{finding.details}</div>
+                            </li>
+                        ))}
+                    </ul>
+                ) : null}
+                {shortBuildHash ? (
+                    <div className="font-mono text-xs text-muted">Build {shortBuildHash}</div>
+                ) : (
+                    <div className="text-warning">
+                        This preview has no verifiable build hash. Regenerate it before running it.
+                    </div>
+                )}
+                <div className="flex flex-wrap gap-2">
+                    {buildHash ? (
+                        <LemonButton type="primary" onClick={onRun} data-attr="notebook-widget-run">
+                            {hasFindings ? 'Run widget anyway' : 'Run widget'}
+                        </LemonButton>
+                    ) : null}
+                    <LemonButton onClick={onViewSource} data-attr="notebook-widget-view-source">
+                        View source
+                    </LemonButton>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/NotebookWidgetTrustControls.tsx
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/NotebookWidgetTrustControls.tsx
@@ -96,7 +96,7 @@ export function NotebookWidgetTrustControls({
                     <div className="font-mono text-xs text-muted">Build {shortBuildHash}</div>
                 ) : (
                     <div className="text-warning">
-                        This preview has no verifiable build hash. Regenerate it before running it.
+                        This widget version can't be verified. Regenerate the widget before running it.
                     </div>
                 )}
                 <div className="flex flex-wrap gap-2">

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/WidgetArtifactFrame.test.tsx
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/WidgetArtifactFrame.test.tsx
@@ -1,0 +1,229 @@
+import '@testing-library/jest-dom'
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { initKeaTests } from '~/test/init'
+
+import type { WidgetFrameApi } from 'products/notebooks/frontend/generated/api.schemas'
+
+import { NOTEBOOK_FRAME_KEY_PREFIX } from './widgetArtifactBridge'
+import { WidgetArtifactFrame } from './WidgetArtifactFrame'
+
+class TestMessagePort {
+    close = jest.fn()
+    postMessage = jest.fn()
+    addEventListener = jest.fn()
+    start = jest.fn()
+}
+
+const nativeMessageChannel = globalThis.MessageChannel
+
+function sendNotebookPort(iframe: HTMLIFrameElement, port: TestMessagePort): void {
+    window.dispatchEvent(
+        new MessageEvent('message', {
+            data: { channel: 'posthog-canvas', type: 'notebook-connect' },
+            source: iframe.contentWindow,
+            ports: [port as unknown as MessagePort],
+        })
+    )
+}
+
+describe('WidgetArtifactFrame', () => {
+    beforeEach(() => {
+        initKeaTests()
+        jest.useFakeTimers()
+        jest.spyOn(HTMLIFrameElement.prototype, 'contentWindow', 'get').mockReturnValue(window)
+    })
+
+    afterEach(() => {
+        cleanup()
+        jest.runOnlyPendingTimers()
+        jest.useRealTimers()
+        jest.restoreAllMocks()
+        Object.defineProperty(globalThis, 'MessageChannel', {
+            configurable: true,
+            value: nativeMessageChannel,
+            writable: true,
+        })
+    })
+
+    it('accepts the trusted bootstrap port once and closes it on unmount', () => {
+        const port = new TestMessagePort()
+        const { unmount } = render(
+            <WidgetArtifactFrame
+                artifactUrl="https://example.com/globe.html"
+                allowedFrames={[]}
+                onReadFrame={jest.fn()}
+            />
+        )
+        const iframe = screen.getByTitle('Widget') as HTMLIFrameElement
+        expect(iframe).toHaveAttribute('src', 'https://example.com/globe.html#theme=light')
+        expect(iframe).not.toHaveAttribute('srcdoc')
+        sendNotebookPort(iframe, port)
+
+        expect(port.start).toHaveBeenCalledTimes(1)
+        unmount()
+        expect(port.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('pins concurrent pages for one dataframe to the first resolved run', async () => {
+        const firstFrame: WidgetFrameApi = {
+            name: 'pandas_df',
+            runId: '00000000-0000-0000-0000-000000000001',
+            columns: [],
+            rows: [],
+            totalRowCount: 200,
+            includedRowCount: 100,
+            offset: 0,
+            nextOffset: 100,
+            truncated: true,
+        }
+        let resolveFirstFrame: (frame: WidgetFrameApi) => void = () => undefined
+        const pendingFirstFrame = new Promise<WidgetFrameApi>((resolve) => {
+            resolveFirstFrame = resolve
+        })
+        const onReadFrame = jest
+            .fn()
+            .mockImplementationOnce(() => pendingFirstFrame)
+            .mockResolvedValue({ ...firstFrame, offset: 100, nextOffset: null, truncated: false })
+        const port = new TestMessagePort()
+        render(
+            <WidgetArtifactFrame
+                artifactUrl="https://example.com/globe.html"
+                allowedFrames={['pandas_df']}
+                onReadFrame={onReadFrame}
+            />
+        )
+        sendNotebookPort(screen.getByTitle('Widget') as HTMLIFrameElement, port)
+        const route = port.addEventListener.mock.calls[0][1] as (event: { data: unknown }) => Promise<void>
+
+        const firstRequest = route({
+            data: {
+                channel: 'posthog-canvas',
+                type: 'data-request',
+                id: 'first',
+                method: 'stateGet',
+                payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:100` },
+            },
+        })
+        const secondRequest = route({
+            data: {
+                channel: 'posthog-canvas',
+                type: 'data-request',
+                id: 'second',
+                method: 'stateGet',
+                payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:100:100` },
+            },
+        })
+        await Promise.resolve()
+        await Promise.resolve()
+        expect(onReadFrame).toHaveBeenCalledTimes(1)
+
+        resolveFirstFrame(firstFrame)
+        await Promise.all([firstRequest, secondRequest])
+
+        expect(onReadFrame).toHaveBeenNthCalledWith(2, 'pandas_df', 100, 100, firstFrame.runId, expect.any(AbortSignal))
+    })
+
+    it('deduplicates repeated pages within one artifact load', async () => {
+        const onReadFrame = jest.fn().mockResolvedValue({
+            name: 'pandas_df',
+            runId: '00000000-0000-0000-0000-000000000001',
+            columns: [],
+            rows: [],
+            totalRowCount: 0,
+            includedRowCount: 0,
+            offset: 0,
+            nextOffset: null,
+            truncated: false,
+        } satisfies WidgetFrameApi)
+        const port = new TestMessagePort()
+        render(
+            <WidgetArtifactFrame
+                artifactUrl="https://example.com/globe.html"
+                allowedFrames={['pandas_df']}
+                onReadFrame={onReadFrame}
+            />
+        )
+        sendNotebookPort(screen.getByTitle('Widget') as HTMLIFrameElement, port)
+        const route = port.addEventListener.mock.calls[0][1] as (event: { data: unknown }) => Promise<void>
+        const request = (id: string): Promise<void> =>
+            route({
+                data: {
+                    channel: 'posthog-canvas',
+                    type: 'data-request',
+                    id,
+                    method: 'stateGet',
+                    payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:100` },
+                },
+            })
+
+        await Promise.all([request('first'), request('second')])
+        await request('third')
+
+        expect(onReadFrame).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reconnect after the artifact navigates', () => {
+        const onArtifactUnavailable = jest.fn()
+        const initialPort = new TestMessagePort()
+        const navigatedPort = new TestMessagePort()
+        render(
+            <WidgetArtifactFrame
+                artifactUrl="https://example.com/globe.html"
+                allowedFrames={[]}
+                onReadFrame={jest.fn()}
+                onArtifactUnavailable={onArtifactUnavailable}
+            />
+        )
+        const iframe = screen.getByTitle('Widget') as HTMLIFrameElement
+        sendNotebookPort(iframe, initialPort)
+        fireEvent.load(iframe)
+        fireEvent.load(iframe)
+        sendNotebookPort(iframe, navigatedPort)
+
+        expect(initialPort.close).toHaveBeenCalledTimes(1)
+        expect(navigatedPort.start).not.toHaveBeenCalled()
+        expect(onArtifactUnavailable).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not give a parent-created bridge to artifacts without the trusted bootstrap', () => {
+        const messageChannel = jest.fn()
+        Object.defineProperty(globalThis, 'MessageChannel', {
+            configurable: true,
+            value: messageChannel,
+            writable: true,
+        })
+        const postMessage = jest.spyOn(window, 'postMessage').mockImplementation()
+        render(
+            <WidgetArtifactFrame
+                artifactUrl="https://example.com/globe.html"
+                allowedFrames={[]}
+                onReadFrame={jest.fn()}
+            />
+        )
+
+        fireEvent.load(screen.getByTitle('Widget'))
+
+        expect(messageChannel).not.toHaveBeenCalled()
+        expect(postMessage).not.toHaveBeenCalled()
+    })
+
+    it('reports an unavailable artifact when the trusted runtime does not render in time', () => {
+        const onArtifactUnavailable = jest.fn()
+        const port = new TestMessagePort()
+        render(
+            <WidgetArtifactFrame
+                artifactUrl="https://example.com/globe.html"
+                allowedFrames={[]}
+                onReadFrame={jest.fn()}
+                onArtifactUnavailable={onArtifactUnavailable}
+            />
+        )
+        const iframe = screen.getByTitle('Widget') as HTMLIFrameElement
+        sendNotebookPort(iframe, port)
+
+        act(() => jest.advanceTimersByTime(20_000))
+        expect(onArtifactUnavailable).toHaveBeenCalledTimes(1)
+    })
+})

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/WidgetArtifactFrame.test.tsx
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/WidgetArtifactFrame.test.tsx
@@ -13,6 +13,7 @@ class TestMessagePort {
     close = jest.fn()
     postMessage = jest.fn()
     addEventListener = jest.fn()
+    removeEventListener = jest.fn()
     start = jest.fn()
 }
 
@@ -125,8 +126,8 @@ describe('WidgetArtifactFrame', () => {
         expect(onReadFrame).toHaveBeenNthCalledWith(2, 'pandas_df', 100, 100, firstFrame.runId, expect.any(AbortSignal))
     })
 
-    it('deduplicates repeated pages within one artifact load', async () => {
-        const onReadFrame = jest.fn().mockResolvedValue({
+    it('deduplicates only in-flight requests for the same page', async () => {
+        const resolvedFrame = {
             name: 'pandas_df',
             runId: '00000000-0000-0000-0000-000000000001',
             columns: [],
@@ -136,7 +137,12 @@ describe('WidgetArtifactFrame', () => {
             offset: 0,
             nextOffset: null,
             truncated: false,
-        } satisfies WidgetFrameApi)
+        } satisfies WidgetFrameApi
+        let resolveFrame: (frame: WidgetFrameApi) => void = () => undefined
+        const pendingFrame = new Promise<WidgetFrameApi>((resolve) => {
+            resolveFrame = resolve
+        })
+        const onReadFrame = jest.fn().mockReturnValueOnce(pendingFrame).mockResolvedValue(resolvedFrame)
         const port = new TestMessagePort()
         render(
             <WidgetArtifactFrame
@@ -158,10 +164,56 @@ describe('WidgetArtifactFrame', () => {
                 },
             })
 
-        await Promise.all([request('first'), request('second')])
+        const firstRequest = request('first')
+        const secondRequest = request('second')
+        await Promise.resolve()
+        await Promise.resolve()
+        expect(onReadFrame).toHaveBeenCalledTimes(1)
+
+        resolveFrame(resolvedFrame)
+        await Promise.all([firstRequest, secondRequest])
         await request('third')
 
-        expect(onReadFrame).toHaveBeenCalledTimes(1)
+        expect(onReadFrame).toHaveBeenCalledTimes(2)
+    })
+
+    it('aborts active frame reads when unmounted', async () => {
+        let requestSignal: AbortSignal | undefined
+        const onReadFrame = jest.fn(
+            (_name: string, _offset: number, _limit: number, _runId: string | undefined, signal: AbortSignal) => {
+                requestSignal = signal
+                return new Promise<WidgetFrameApi>((_, reject) => {
+                    signal.addEventListener('abort', () => reject(new Error('Request aborted')))
+                })
+            }
+        )
+        const port = new TestMessagePort()
+        const { unmount } = render(
+            <WidgetArtifactFrame
+                artifactUrl="https://example.com/globe.html"
+                allowedFrames={['pandas_df']}
+                onReadFrame={onReadFrame}
+            />
+        )
+        sendNotebookPort(screen.getByTitle('Widget') as HTMLIFrameElement, port)
+        const route = port.addEventListener.mock.calls[0][1] as (event: { data: unknown }) => Promise<void>
+        const routing = route({
+            data: {
+                channel: 'posthog-canvas',
+                type: 'data-request',
+                id: 'first',
+                method: 'stateGet',
+                payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:100` },
+            },
+        })
+        await Promise.resolve()
+        await Promise.resolve()
+
+        unmount()
+        await routing
+
+        expect(requestSignal?.aborted).toBe(true)
+        expect(port.removeEventListener).toHaveBeenCalledTimes(1)
     })
 
     it('does not reconnect after the artifact navigates', () => {

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/WidgetArtifactFrame.tsx
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/WidgetArtifactFrame.tsx
@@ -1,0 +1,201 @@
+import { useValues } from 'kea'
+import { useEffect, useRef } from 'react'
+
+import { themeLogic } from 'lib/logic/themeLogic'
+
+import type { WidgetFrameApi } from 'products/notebooks/frontend/generated/api.schemas'
+
+import { createWidgetHostMessageRouter, readWidgetFrame } from './widgetArtifactBridge'
+
+export type WidgetArtifactFrameProps = {
+    artifactUrl: string
+    title?: string
+    allowedFrames: string[]
+    onReadFrame: (
+        name: string,
+        offset: number,
+        limit: number,
+        runId: string | undefined,
+        signal: AbortSignal
+    ) => Promise<WidgetFrameApi>
+    onArtifactUnavailable?: () => void
+    onError?: (message?: string) => void
+    onRendered?: () => void
+}
+
+export function WidgetArtifactFrame({
+    artifactUrl,
+    title,
+    allowedFrames,
+    onReadFrame,
+    onArtifactUnavailable,
+    onError,
+    onRendered,
+}: WidgetArtifactFrameProps): JSX.Element {
+    const { isDarkModeOn } = useValues(themeLogic)
+    const theme = isDarkModeOn ? 'dark' : 'light'
+    const iframeRef = useRef<HTMLIFrameElement>(null)
+    const artifactPortRef = useRef<MessagePort | null>(null)
+    const renderTimeoutRef = useRef<number | null>(null)
+    const hasLoadedRef = useRef(false)
+    const initialTheme = useRef(theme).current
+    const latest = useRef({ allowedFrames, onArtifactUnavailable, onError, onReadFrame, onRendered, theme })
+    latest.current = { allowedFrames, onArtifactUnavailable, onError, onReadFrame, onRendered, theme }
+
+    const themedArtifactUrl = new URL(artifactUrl)
+    themedArtifactUrl.hash = `theme=${initialTheme}`
+    const themedArtifactHref = themedArtifactUrl.href
+
+    const clearConnection = (): void => {
+        artifactPortRef.current?.close()
+        artifactPortRef.current = null
+        if (renderTimeoutRef.current !== null) {
+            window.clearTimeout(renderTimeoutRef.current)
+            renderTimeoutRef.current = null
+        }
+    }
+
+    const connect = (port: MessagePort): void => {
+        if (renderTimeoutRef.current !== null) {
+            window.clearTimeout(renderTimeoutRef.current)
+        }
+        artifactPortRef.current = port
+        const runIds = new Map<string, string>()
+        const initialRunIds = new Map<string, Promise<string>>()
+        const pageRequests = new Map<string, Promise<WidgetFrameApi>>()
+        const route = createWidgetHostMessageRouter(
+            (message) => port.postMessage(message),
+            () => ({
+                onDataRequest: async (_method, payload, signal) =>
+                    await readWidgetFrame(
+                        latest.current.allowedFrames,
+                        async (name, offset, limit, requestSignal) => {
+                            let runId = runIds.get(name)
+                            const pageKey = (): string => `${name}:${runId ?? 'initial'}:${offset}:${limit}`
+                            const cachedPage = pageRequests.get(pageKey())
+                            if (cachedPage) {
+                                return await cachedPage
+                            }
+                            const loadPage = async (): Promise<WidgetFrameApi> => {
+                                if (!runId) {
+                                    const pendingRunId = initialRunIds.get(name)
+                                    if (pendingRunId) {
+                                        runId = await pendingRunId
+                                    } else {
+                                        const firstFrame = latest.current.onReadFrame(
+                                            name,
+                                            offset,
+                                            limit,
+                                            undefined,
+                                            requestSignal
+                                        )
+                                        const firstRunId = firstFrame.then((frame) => frame.runId)
+                                        initialRunIds.set(name, firstRunId)
+                                        try {
+                                            const frame = await firstFrame
+                                            runIds.set(name, frame.runId)
+                                            return frame
+                                        } finally {
+                                            initialRunIds.delete(name)
+                                        }
+                                    }
+                                }
+                                const frame = await latest.current.onReadFrame(
+                                    name,
+                                    offset,
+                                    limit,
+                                    runId,
+                                    requestSignal
+                                )
+                                runIds.set(name, frame.runId)
+                                return frame
+                            }
+                            const request = loadPage()
+                            const initialPageKey = pageKey()
+                            pageRequests.set(initialPageKey, request)
+                            try {
+                                const frame = await request
+                                pageRequests.set(`${name}:${frame.runId}:${offset}:${limit}`, Promise.resolve(frame))
+                                return frame
+                            } catch (error) {
+                                pageRequests.delete(initialPageKey)
+                                throw error
+                            }
+                        },
+                        payload,
+                        signal
+                    ),
+                onError: (message) => latest.current.onError?.(message),
+                onRendered: () => {
+                    if (renderTimeoutRef.current !== null) {
+                        window.clearTimeout(renderTimeoutRef.current)
+                        renderTimeoutRef.current = null
+                    }
+                    latest.current.onRendered?.()
+                },
+            })
+        )
+        port.addEventListener('message', (event) => void route(event.data))
+        port.start()
+        port.postMessage({ channel: 'posthog-canvas', type: 'set-theme', theme: latest.current.theme })
+        renderTimeoutRef.current = window.setTimeout(() => latest.current.onArtifactUnavailable?.(), 20_000)
+    }
+
+    useEffect(() => {
+        clearConnection()
+        hasLoadedRef.current = false
+        const iframe = iframeRef.current
+        if (!iframe?.contentWindow) {
+            latest.current.onArtifactUnavailable?.()
+            return
+        }
+        const expectedWindow = iframe.contentWindow
+        const receiveNotebookPort = (event: MessageEvent): void => {
+            if (
+                artifactPortRef.current ||
+                event.source !== expectedWindow ||
+                event.data?.channel !== 'posthog-canvas' ||
+                event.data?.type !== 'notebook-connect' ||
+                !event.ports[0]
+            ) {
+                return
+            }
+            // The trusted runtime is injected before generated application code. Accepting only its first port
+            // prevents a document loaded by a later self-navigation from acquiring the notebook data bridge.
+            window.removeEventListener('message', receiveNotebookPort)
+            connect(event.ports[0])
+        }
+        window.addEventListener('message', receiveNotebookPort)
+        iframe.src = themedArtifactHref
+        renderTimeoutRef.current = window.setTimeout(() => latest.current.onArtifactUnavailable?.(), 20_000)
+        return () => {
+            window.removeEventListener('message', receiveNotebookPort)
+            clearConnection()
+        }
+    }, [themedArtifactHref])
+
+    useEffect(() => {
+        artifactPortRef.current?.postMessage({ channel: 'posthog-canvas', type: 'set-theme', theme })
+    }, [theme])
+
+    return (
+        <iframe
+            ref={iframeRef}
+            title={title || 'Widget'}
+            sandbox="allow-scripts"
+            referrerPolicy="no-referrer"
+            className={`w-full h-full border-0 bg-primary ${
+                theme === 'dark' ? '[color-scheme:dark]' : '[color-scheme:light]'
+            }`}
+            onLoad={() => {
+                if (hasLoadedRef.current) {
+                    clearConnection()
+                    latest.current.onArtifactUnavailable?.()
+                    return
+                }
+                hasLoadedRef.current = true
+            }}
+            onError={() => onArtifactUnavailable?.()}
+        />
+    )
+}

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/WidgetArtifactFrame.tsx
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/WidgetArtifactFrame.tsx
@@ -36,6 +36,7 @@ export function WidgetArtifactFrame({
     const theme = isDarkModeOn ? 'dark' : 'light'
     const iframeRef = useRef<HTMLIFrameElement>(null)
     const artifactPortRef = useRef<MessagePort | null>(null)
+    const connectionDisposeRef = useRef<(() => void) | null>(null)
     const renderTimeoutRef = useRef<number | null>(null)
     const hasLoadedRef = useRef(false)
     const initialTheme = useRef(theme).current
@@ -47,7 +48,8 @@ export function WidgetArtifactFrame({
     const themedArtifactHref = themedArtifactUrl.href
 
     const clearConnection = (): void => {
-        artifactPortRef.current?.close()
+        connectionDisposeRef.current?.()
+        connectionDisposeRef.current = null
         artifactPortRef.current = null
         if (renderTimeoutRef.current !== null) {
             window.clearTimeout(renderTimeoutRef.current)
@@ -61,9 +63,9 @@ export function WidgetArtifactFrame({
         }
         artifactPortRef.current = port
         const runIds = new Map<string, string>()
-        const initialRunIds = new Map<string, Promise<string>>()
+        const initialFrames = new Map<string, Promise<WidgetFrameApi>>()
         const pageRequests = new Map<string, Promise<WidgetFrameApi>>()
-        const route = createWidgetHostMessageRouter(
+        const router = createWidgetHostMessageRouter(
             (message) => port.postMessage(message),
             () => ({
                 onDataRequest: async (_method, payload, signal) =>
@@ -78,9 +80,9 @@ export function WidgetArtifactFrame({
                             }
                             const loadPage = async (): Promise<WidgetFrameApi> => {
                                 if (!runId) {
-                                    const pendingRunId = initialRunIds.get(name)
-                                    if (pendingRunId) {
-                                        runId = await pendingRunId
+                                    const pendingInitialFrame = initialFrames.get(name)
+                                    if (pendingInitialFrame) {
+                                        runId = (await pendingInitialFrame).runId
                                     } else {
                                         const firstFrame = latest.current.onReadFrame(
                                             name,
@@ -89,14 +91,13 @@ export function WidgetArtifactFrame({
                                             undefined,
                                             requestSignal
                                         )
-                                        const firstRunId = firstFrame.then((frame) => frame.runId)
-                                        initialRunIds.set(name, firstRunId)
+                                        initialFrames.set(name, firstFrame)
                                         try {
                                             const frame = await firstFrame
                                             runIds.set(name, frame.runId)
                                             return frame
                                         } finally {
-                                            initialRunIds.delete(name)
+                                            initialFrames.delete(name)
                                         }
                                     }
                                 }
@@ -114,12 +115,9 @@ export function WidgetArtifactFrame({
                             const initialPageKey = pageKey()
                             pageRequests.set(initialPageKey, request)
                             try {
-                                const frame = await request
-                                pageRequests.set(`${name}:${frame.runId}:${offset}:${limit}`, Promise.resolve(frame))
-                                return frame
-                            } catch (error) {
+                                return await request
+                            } finally {
                                 pageRequests.delete(initialPageKey)
-                                throw error
                             }
                         },
                         payload,
@@ -133,9 +131,21 @@ export function WidgetArtifactFrame({
                     }
                     latest.current.onRendered?.()
                 },
-            })
+            }),
+            () => {
+                if (artifactPortRef.current === port) {
+                    clearConnection()
+                    latest.current.onArtifactUnavailable?.()
+                }
+            }
         )
-        port.addEventListener('message', (event) => void route(event.data))
+        const receiveArtifactMessage = (event: MessageEvent): Promise<void> => router.route(event.data)
+        port.addEventListener('message', receiveArtifactMessage)
+        connectionDisposeRef.current = () => {
+            port.removeEventListener('message', receiveArtifactMessage)
+            router.dispose()
+            port.close()
+        }
         port.start()
         port.postMessage({ channel: 'posthog-canvas', type: 'set-theme', theme: latest.current.theme })
         renderTimeoutRef.current = window.setTimeout(() => latest.current.onArtifactUnavailable?.(), 20_000)

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/notebookWidgetTrustLogic.test.ts
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/notebookWidgetTrustLogic.test.ts
@@ -1,0 +1,48 @@
+import { initKeaTests } from '~/test/init'
+
+import { getNotebookWidgetTrust, type NotebookWidgetTrust, notebookWidgetTrustLogic } from './notebookWidgetTrustLogic'
+
+const BUILD_HASH = 'a'.repeat(64)
+
+describe('notebookWidgetTrustLogic', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        initKeaTests()
+        notebookWidgetTrustLogic.mount()
+    })
+
+    afterEach(() => {
+        notebookWidgetTrustLogic.unmount()
+    })
+
+    function trustFor({
+        userId = 12,
+        buildHash = BUILD_HASH,
+    }: {
+        userId?: number | null
+        buildHash?: string | null
+    } = {}): NotebookWidgetTrust {
+        return getNotebookWidgetTrust({
+            trustByUser: notebookWidgetTrustLogic.values.trustByUser,
+            sessionBuildHashes: notebookWidgetTrustLogic.values.sessionBuildHashes,
+            userId,
+            buildHash,
+        })
+    }
+
+    it('trusts only the exact immutable build for the current user', () => {
+        notebookWidgetTrustLogic.actions.trustBuild(12, BUILD_HASH)
+
+        expect(trustFor().buildTrusted).toBe(true)
+        expect(trustFor({ buildHash: 'b'.repeat(64) }).buildTrusted).toBe(false)
+        expect(trustFor({ userId: 13 }).buildTrusted).toBe(false)
+        expect(trustFor({ buildHash: 'not-a-build-hash' }).buildTrusted).toBe(false)
+    })
+
+    it('keeps anonymous approval in the current session only', () => {
+        notebookWidgetTrustLogic.actions.trustBuild(null, BUILD_HASH)
+
+        expect(trustFor({ userId: null }).buildTrusted).toBe(true)
+        expect(notebookWidgetTrustLogic.values.trustByUser).toEqual({})
+    })
+})

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/notebookWidgetTrustLogic.ts
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/notebookWidgetTrustLogic.ts
@@ -1,0 +1,103 @@
+import { LogicWrapper, MakeLogicType, actions, kea, path, reducers } from 'kea'
+
+// This records viewer consent, not a source-validation verdict. The full rationale lives in
+// docs/internal/generated-notebook-widgets.md#generated-code-trust-model.
+
+const MAX_TRUSTED_BUILD_HASHES = 500
+const BUILD_HASH_PATTERN = /^[a-f0-9]{64}$/
+
+type WidgetTrustScopes = {
+    buildHashes: string[]
+}
+
+type WidgetTrustByUser = Record<string, WidgetTrustScopes>
+
+export type NotebookWidgetTrust = {
+    buildTrusted: boolean
+}
+
+interface notebookWidgetTrustLogicValues {
+    sessionBuildHashes: string[]
+    trustByUser: WidgetTrustByUser
+}
+
+interface notebookWidgetTrustLogicActions {
+    trustBuild: (userId: number | null, buildHash: string) => { userId: number | null; buildHash: string }
+}
+
+type notebookWidgetTrustLogicType = MakeLogicType<notebookWidgetTrustLogicValues, notebookWidgetTrustLogicActions>
+
+const EMPTY_TRUST_SCOPES: WidgetTrustScopes = {
+    buildHashes: [],
+}
+
+function scopesForUser(trustByUser: WidgetTrustByUser, userId: number): WidgetTrustScopes {
+    const scopes = trustByUser[String(userId)]
+    return scopes && Array.isArray(scopes.buildHashes) ? scopes : EMPTY_TRUST_SCOPES
+}
+
+function setMembership<T>(values: T[], value: T, included: boolean, maxLength?: number): T[] {
+    const withoutValue = values.filter((candidate) => candidate !== value)
+    if (!included) {
+        return withoutValue
+    }
+    const next = [...withoutValue, value]
+    return maxLength ? next.slice(-maxLength) : next
+}
+
+export function getNotebookWidgetTrust({
+    trustByUser,
+    sessionBuildHashes,
+    userId,
+    buildHash,
+}: {
+    trustByUser: WidgetTrustByUser
+    sessionBuildHashes: string[]
+    userId: number | null
+    buildHash: string | null
+}): NotebookWidgetTrust {
+    const validBuildHash = buildHash !== null && BUILD_HASH_PATTERN.test(buildHash)
+    const scopes = userId === null ? EMPTY_TRUST_SCOPES : scopesForUser(trustByUser, userId)
+    return {
+        buildTrusted:
+            validBuildHash && (sessionBuildHashes.includes(buildHash) || scopes.buildHashes.includes(buildHash)),
+    }
+}
+
+export const notebookWidgetTrustLogic: LogicWrapper<notebookWidgetTrustLogicType> = kea<notebookWidgetTrustLogicType>([
+    path(['products', 'notebooks', 'notebookWidgetTrustLogic']),
+    actions({
+        trustBuild: (userId: number | null, buildHash: string) => ({ userId, buildHash }),
+    }),
+    reducers({
+        sessionBuildHashes: [
+            [] as string[],
+            {
+                trustBuild: (state, { userId, buildHash }) =>
+                    userId === null && BUILD_HASH_PATTERN.test(buildHash)
+                        ? setMembership(state, buildHash, true, MAX_TRUSTED_BUILD_HASHES)
+                        : state,
+            },
+        ],
+        trustByUser: [
+            {} as WidgetTrustByUser,
+            { persist: true },
+            {
+                trustBuild: (state, { userId, buildHash }) => {
+                    if (userId === null || !BUILD_HASH_PATTERN.test(buildHash)) {
+                        return state
+                    }
+                    const userKey = String(userId)
+                    const scopes = scopesForUser(state, userId)
+                    return {
+                        ...state,
+                        [userKey]: {
+                            ...scopes,
+                            buildHashes: setMembership(scopes.buildHashes, buildHash, true, MAX_TRUSTED_BUILD_HASHES),
+                        },
+                    }
+                },
+            },
+        ],
+    }),
+])

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/widgetArtifactBridge.test.ts
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/widgetArtifactBridge.test.ts
@@ -1,0 +1,181 @@
+import type { WidgetFrameApi } from 'products/notebooks/frontend/generated/api.schemas'
+
+import { NOTEBOOK_FRAME_KEY_PREFIX, createWidgetHostMessageRouter, readWidgetFrame } from './widgetArtifactBridge'
+
+const frame: WidgetFrameApi = {
+    name: 'pandas_df',
+    runId: '00000000-0000-0000-0000-000000000001',
+    columns: [{ name: 'lat', type: 'float64' }],
+    rows: [[51.5]],
+    totalRowCount: 1,
+    includedRowCount: 1,
+    offset: 0,
+    nextOffset: null,
+    truncated: false,
+}
+
+describe('widgetArtifactBridge', () => {
+    it('serves bounded pages for dataframes allowed by the widget version', async () => {
+        const loadFrame = jest.fn().mockResolvedValue(frame)
+        const signal = new AbortController().signal
+
+        await expect(
+            readWidgetFrame(
+                ['pandas_df'],
+                loadFrame,
+                {
+                    key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:10:250`,
+                },
+                signal
+            )
+        ).resolves.toBe(frame)
+        expect(loadFrame).toHaveBeenCalledWith('pandas_df', 10, 250, signal)
+        await expect(
+            readWidgetFrame(
+                ['pandas_df'],
+                loadFrame,
+                {
+                    key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:5000`,
+                },
+                signal
+            )
+        ).resolves.toBe(frame)
+        expect(loadFrame).toHaveBeenLastCalledWith('pandas_df', 0, 500, signal)
+        await expect(
+            readWidgetFrame(
+                ['pandas_df'],
+                loadFrame,
+                {
+                    key: `${NOTEBOOK_FRAME_KEY_PREFIX}private_df:0:100`,
+                },
+                signal
+            )
+        ).rejects.toThrow('not available')
+    })
+
+    it('rejects invalid page sizes', async () => {
+        const signal = new AbortController().signal
+        await expect(
+            readWidgetFrame(
+                ['pandas_df'],
+                jest.fn(),
+                {
+                    key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:0`,
+                },
+                signal
+            )
+        ).rejects.toThrow('page is invalid')
+    })
+
+    it('rejects Canvas methods other than the frame shim', async () => {
+        const responses: Record<string, unknown>[] = []
+        const route = createWidgetHostMessageRouter(
+            (message) => responses.push(message),
+            () => ({ onDataRequest: jest.fn() })
+        )
+
+        await route({ channel: 'posthog-canvas', type: 'data-request', id: '1', method: 'query', payload: {} })
+
+        expect(responses[0]).toMatchObject({ id: '1', ok: false })
+    })
+
+    it('passes a bounded runtime error to the host', async () => {
+        const onError = jest.fn()
+        const route = createWidgetHostMessageRouter(jest.fn(), () => ({ onDataRequest: jest.fn(), onError }))
+
+        await route({ channel: 'posthog-canvas', type: 'error', message: 'x'.repeat(1_000) })
+
+        expect(onError).toHaveBeenCalledWith('x'.repeat(500))
+    })
+
+    it('caps the total work one artifact can request', async () => {
+        const responses: Record<string, unknown>[] = []
+        const onDataRequest = jest.fn().mockResolvedValue(frame)
+        const route = createWidgetHostMessageRouter(
+            (message) => responses.push(message),
+            () => ({ onDataRequest })
+        )
+
+        for (let index = 0; index < 201; index++) {
+            await route({
+                channel: 'posthog-canvas',
+                type: 'data-request',
+                id: String(index),
+                method: 'stateGet',
+                payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:100` },
+            })
+        }
+
+        expect(onDataRequest).toHaveBeenCalledTimes(200)
+        expect(responses.at(-1)).toMatchObject({
+            id: '200',
+            ok: false,
+            error: 'Widget data request exceeds runtime limits',
+        })
+    })
+
+    it('bounds requests that never finish', async () => {
+        jest.useFakeTimers()
+        const responses: Record<string, unknown>[] = []
+        const route = createWidgetHostMessageRouter(
+            (message) => responses.push(message),
+            () => ({
+                onDataRequest: (_method, _payload, signal) =>
+                    new Promise((_, reject) => {
+                        signal.addEventListener('abort', () => reject(new Error('Request aborted')))
+                    }),
+            })
+        )
+
+        const routing = route({
+            channel: 'posthog-canvas',
+            type: 'data-request',
+            id: '1',
+            method: 'stateGet',
+            payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:100` },
+        })
+        await jest.advanceTimersByTimeAsync(30_000)
+        await routing
+
+        expect(responses[0]).toMatchObject({ id: '1', ok: false, error: 'Widget data request timed out' })
+        jest.useRealTimers()
+    })
+
+    it('releases request capacity when an aborted callback never settles', async () => {
+        jest.useFakeTimers()
+        const responses: Record<string, unknown>[] = []
+        let requestCount = 0
+        const route = createWidgetHostMessageRouter(
+            (message) => responses.push(message),
+            () => ({
+                onDataRequest: () => {
+                    requestCount += 1
+                    return requestCount <= 8 ? new Promise(() => undefined) : Promise.resolve(frame)
+                },
+            })
+        )
+        const stalled = Array.from({ length: 8 }, (_, index) =>
+            route({
+                channel: 'posthog-canvas',
+                type: 'data-request',
+                id: `stalled-${index}`,
+                method: 'stateGet',
+                payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:100` },
+            })
+        )
+
+        await jest.advanceTimersByTimeAsync(30_000)
+        await Promise.all(stalled)
+        await route({
+            channel: 'posthog-canvas',
+            type: 'data-request',
+            id: 'next',
+            method: 'stateGet',
+            payload: {},
+        })
+
+        expect(responses).toHaveLength(9)
+        expect(responses.at(-1)).toEqual(expect.objectContaining({ id: 'next', ok: true, result: frame }))
+        jest.useRealTimers()
+    })
+})

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/widgetArtifactBridge.test.ts
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/widgetArtifactBridge.test.ts
@@ -69,7 +69,7 @@ describe('widgetArtifactBridge', () => {
 
     it('rejects Canvas methods other than the frame shim', async () => {
         const responses: Record<string, unknown>[] = []
-        const route = createWidgetHostMessageRouter(
+        const { route } = createWidgetHostMessageRouter(
             (message) => responses.push(message),
             () => ({ onDataRequest: jest.fn() })
         )
@@ -81,7 +81,7 @@ describe('widgetArtifactBridge', () => {
 
     it('passes a bounded runtime error to the host', async () => {
         const onError = jest.fn()
-        const route = createWidgetHostMessageRouter(jest.fn(), () => ({ onDataRequest: jest.fn(), onError }))
+        const { route } = createWidgetHostMessageRouter(jest.fn(), () => ({ onDataRequest: jest.fn(), onError }))
 
         await route({ channel: 'posthog-canvas', type: 'error', message: 'x'.repeat(1_000) })
 
@@ -91,9 +91,11 @@ describe('widgetArtifactBridge', () => {
     it('caps the total work one artifact can request', async () => {
         const responses: Record<string, unknown>[] = []
         const onDataRequest = jest.fn().mockResolvedValue(frame)
-        const route = createWidgetHostMessageRouter(
+        const onExhausted = jest.fn()
+        const { route } = createWidgetHostMessageRouter(
             (message) => responses.push(message),
-            () => ({ onDataRequest })
+            () => ({ onDataRequest }),
+            onExhausted
         )
 
         for (let index = 0; index < 201; index++) {
@@ -107,17 +109,39 @@ describe('widgetArtifactBridge', () => {
         }
 
         expect(onDataRequest).toHaveBeenCalledTimes(200)
-        expect(responses.at(-1)).toMatchObject({
-            id: '200',
-            ok: false,
-            error: 'Widget data request exceeds runtime limits',
-        })
+        expect(responses).toHaveLength(200)
+        expect(onExhausted).toHaveBeenCalledTimes(1)
+    })
+
+    it('counts rejected requests toward the artifact limit', async () => {
+        const responses: Record<string, unknown>[] = []
+        const onDataRequest = jest.fn()
+        const onExhausted = jest.fn()
+        const { route } = createWidgetHostMessageRouter(
+            (message) => responses.push(message),
+            () => ({ onDataRequest }),
+            onExhausted
+        )
+
+        for (let index = 0; index < 201; index++) {
+            await route({
+                channel: 'posthog-canvas',
+                type: 'data-request',
+                id: String(index),
+                method: 'query',
+                payload: {},
+            })
+        }
+
+        expect(onDataRequest).not.toHaveBeenCalled()
+        expect(responses).toHaveLength(200)
+        expect(onExhausted).toHaveBeenCalledTimes(1)
     })
 
     it('bounds requests that never finish', async () => {
         jest.useFakeTimers()
         const responses: Record<string, unknown>[] = []
-        const route = createWidgetHostMessageRouter(
+        const { route } = createWidgetHostMessageRouter(
             (message) => responses.push(message),
             () => ({
                 onDataRequest: (_method, _payload, signal) =>
@@ -145,7 +169,7 @@ describe('widgetArtifactBridge', () => {
         jest.useFakeTimers()
         const responses: Record<string, unknown>[] = []
         let requestCount = 0
-        const route = createWidgetHostMessageRouter(
+        const { route } = createWidgetHostMessageRouter(
             (message) => responses.push(message),
             () => ({
                 onDataRequest: () => {
@@ -171,11 +195,34 @@ describe('widgetArtifactBridge', () => {
             type: 'data-request',
             id: 'next',
             method: 'stateGet',
-            payload: {},
+            payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:100` },
         })
 
         expect(responses).toHaveLength(9)
         expect(responses.at(-1)).toEqual(expect.objectContaining({ id: 'next', ok: true, result: frame }))
         jest.useRealTimers()
+    })
+
+    it('aborts active requests when disposed', async () => {
+        let requestSignal: AbortSignal | undefined
+        const { route, dispose } = createWidgetHostMessageRouter(jest.fn(), () => ({
+            onDataRequest: (_method, _payload, signal) => {
+                requestSignal = signal
+                return new Promise(() => undefined)
+            },
+        }))
+        const routing = route({
+            channel: 'posthog-canvas',
+            type: 'data-request',
+            id: '1',
+            method: 'stateGet',
+            payload: { key: `${NOTEBOOK_FRAME_KEY_PREFIX}pandas_df:0:100` },
+        })
+        await Promise.resolve()
+
+        dispose()
+        await routing
+
+        expect(requestSignal?.aborted).toBe(true)
     })
 })

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/widgetArtifactBridge.ts
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/widgetArtifactBridge.ts
@@ -4,8 +4,10 @@ const CANVAS_CHANNEL = 'posthog-canvas'
 export const NOTEBOOK_FRAME_KEY_PREFIX = '__posthog_notebook_frame__:'
 const MAX_CONCURRENT_REQUESTS = 8
 const MAX_TOTAL_REQUESTS = 200
+const MAX_TOTAL_MESSAGES = MAX_TOTAL_REQUESTS + 16
 const MAX_TOTAL_RESPONSE_BYTES = 32 * 1024 * 1024
-const MAX_REQUEST_BYTES = 8 * 1024
+const MAX_REQUEST_KEY_LENGTH = 8 * 1024
+const MAX_MESSAGE_ID_LENGTH = 128
 const MAX_FRAME_PAGE_ROWS = 500
 const REQUEST_TIMEOUT_MS = 30_000
 
@@ -48,15 +50,61 @@ export type WidgetHostCallbacks = {
     onRendered?: () => void
 }
 
+export type WidgetHostMessageRouter = {
+    route: (message: unknown) => Promise<void>
+    dispose: () => void
+}
+
 export function createWidgetHostMessageRouter(
     post: (message: Record<string, unknown>) => void,
-    callbacks: () => WidgetHostCallbacks
-): (message: unknown) => Promise<void> {
+    callbacks: () => WidgetHostCallbacks,
+    onExhausted?: () => void
+): WidgetHostMessageRouter {
     let activeRequests = 0
     let totalRequests = 0
+    let totalMessages = 0
     let totalResponseBytes = 0
+    let disposed = false
+    const activeControllers = new Set<AbortController>()
+    const activeCancellations = new Set<() => void>()
+    const activeTimeouts = new Set<ReturnType<typeof setTimeout>>()
 
-    return async (raw: unknown): Promise<void> => {
+    const dispose = (): void => {
+        if (disposed) {
+            return
+        }
+        disposed = true
+        for (const controller of activeControllers) {
+            controller.abort()
+        }
+        activeControllers.clear()
+        for (const cancel of activeCancellations) {
+            cancel()
+        }
+        activeCancellations.clear()
+        for (const timeoutId of activeTimeouts) {
+            clearTimeout(timeoutId)
+        }
+        activeTimeouts.clear()
+    }
+
+    const exhaust = (): void => {
+        if (disposed) {
+            return
+        }
+        dispose()
+        onExhausted?.()
+    }
+
+    const route = async (raw: unknown): Promise<void> => {
+        if (disposed) {
+            return
+        }
+        totalMessages += 1
+        if (totalMessages > MAX_TOTAL_MESSAGES) {
+            exhaust()
+            return
+        }
         if (typeof raw !== 'object' || raw === null) {
             return
         }
@@ -72,7 +120,19 @@ export function createWidgetHostMessageRouter(
             callbacks().onRendered?.()
             return
         }
-        if (message.type !== 'data-request' || typeof message.id !== 'string' || typeof message.method !== 'string') {
+        if (message.type === 'data-request') {
+            totalRequests += 1
+            if (totalRequests > MAX_TOTAL_REQUESTS) {
+                exhaust()
+                return
+            }
+        }
+        if (
+            message.type !== 'data-request' ||
+            typeof message.id !== 'string' ||
+            message.id.length > MAX_MESSAGE_ID_LENGTH ||
+            typeof message.method !== 'string'
+        ) {
             return
         }
         if (message.method !== 'stateGet') {
@@ -86,16 +146,16 @@ export function createWidgetHostMessageRouter(
             return
         }
 
-        let requestBytes = Number.POSITIVE_INFINITY
-        try {
-            requestBytes = JSON.stringify(message.payload).length
-        } catch {
-            requestBytes = Number.POSITIVE_INFINITY
-        }
+        const requestKey =
+            typeof message.payload === 'object' &&
+            message.payload !== null &&
+            typeof (message.payload as { key?: unknown }).key === 'string'
+                ? (message.payload as { key: string }).key
+                : null
         if (
             activeRequests >= MAX_CONCURRENT_REQUESTS ||
-            totalRequests >= MAX_TOTAL_REQUESTS ||
-            requestBytes > MAX_REQUEST_BYTES
+            requestKey === null ||
+            requestKey.length > MAX_REQUEST_KEY_LENGTH
         ) {
             post({
                 channel: CANVAS_CHANNEL,
@@ -108,8 +168,13 @@ export function createWidgetHostMessageRouter(
         }
 
         activeRequests += 1
-        totalRequests += 1
         const controller = new AbortController()
+        activeControllers.add(controller)
+        let cancelRequest = (): void => undefined
+        const cancellation = new Promise<never>((_, reject) => {
+            cancelRequest = () => reject(new Error('Widget data request canceled'))
+        })
+        activeCancellations.add(cancelRequest)
         let timeoutId: ReturnType<typeof setTimeout> | undefined
         const request = Promise.resolve().then(() =>
             callbacks().onDataRequest('stateGet', message.payload, controller.signal)
@@ -117,20 +182,31 @@ export function createWidgetHostMessageRouter(
         try {
             const result = await Promise.race([
                 request,
+                cancellation,
                 new Promise<never>((_, reject) => {
-                    timeoutId = setTimeout(() => {
+                    const timer = setTimeout(() => {
+                        activeTimeouts.delete(timer)
                         controller.abort()
                         reject(new Error('Widget data request timed out'))
                     }, REQUEST_TIMEOUT_MS)
+                    timeoutId = timer
+                    activeTimeouts.add(timer)
                 }),
             ])
-            const responseBytes = JSON.stringify(result).length
+            if (disposed) {
+                return
+            }
+            const responseBytes = new TextEncoder().encode(JSON.stringify(result)).byteLength
             if (totalResponseBytes + responseBytes > MAX_TOTAL_RESPONSE_BYTES) {
-                throw new Error('Widget data response exceeds runtime limits')
+                exhaust()
+                return
             }
             totalResponseBytes += responseBytes
             post({ channel: CANVAS_CHANNEL, type: 'data-response', id: message.id, ok: true, result })
         } catch (error) {
+            if (disposed) {
+                return
+            }
             post({
                 channel: CANVAS_CHANNEL,
                 type: 'data-response',
@@ -141,9 +217,14 @@ export function createWidgetHostMessageRouter(
         } finally {
             if (timeoutId !== undefined) {
                 clearTimeout(timeoutId)
+                activeTimeouts.delete(timeoutId)
             }
+            activeControllers.delete(controller)
+            activeCancellations.delete(cancelRequest)
             activeRequests -= 1
             void request.catch(() => undefined)
         }
     }
+
+    return { route, dispose }
 }

--- a/products/notebooks/frontend/NotebookNodeGeneratedWidget/widgetArtifactBridge.ts
+++ b/products/notebooks/frontend/NotebookNodeGeneratedWidget/widgetArtifactBridge.ts
@@ -1,0 +1,149 @@
+import type { WidgetFrameApi } from 'products/notebooks/frontend/generated/api.schemas'
+
+const CANVAS_CHANNEL = 'posthog-canvas'
+export const NOTEBOOK_FRAME_KEY_PREFIX = '__posthog_notebook_frame__:'
+const MAX_CONCURRENT_REQUESTS = 8
+const MAX_TOTAL_REQUESTS = 200
+const MAX_TOTAL_RESPONSE_BYTES = 32 * 1024 * 1024
+const MAX_REQUEST_BYTES = 8 * 1024
+const MAX_FRAME_PAGE_ROWS = 500
+const REQUEST_TIMEOUT_MS = 30_000
+
+type ArtifactMessage = {
+    channel?: unknown
+    type?: unknown
+    id?: unknown
+    method?: unknown
+    payload?: unknown
+    message?: unknown
+}
+
+export async function readWidgetFrame(
+    allowedFrames: string[],
+    loadFrame: (name: string, offset: number, limit: number, signal: AbortSignal) => Promise<WidgetFrameApi>,
+    payload: unknown,
+    signal: AbortSignal
+): Promise<WidgetFrameApi> {
+    const key =
+        typeof payload === 'object' && payload !== null && typeof (payload as { key?: unknown }).key === 'string'
+            ? (payload as { key: string }).key
+            : ''
+    const encodedRequest = key.startsWith(NOTEBOOK_FRAME_KEY_PREFIX) ? key.slice(NOTEBOOK_FRAME_KEY_PREFIX.length) : ''
+    const [encodedName = '', rawOffset = '0', rawLimit = '100'] = encodedRequest.split(':')
+    const name = decodeURIComponent(encodedName)
+    const offset = Number(rawOffset)
+    const limit = Number(rawLimit)
+    if (!name || !allowedFrames.includes(name)) {
+        throw new Error('This dataframe is not available to the widget')
+    }
+    if (!Number.isSafeInteger(offset) || offset < 0 || !Number.isSafeInteger(limit) || limit < 1) {
+        throw new Error('The dataframe page is invalid')
+    }
+    return await loadFrame(name, offset, Math.min(limit, MAX_FRAME_PAGE_ROWS), signal)
+}
+
+export type WidgetHostCallbacks = {
+    onDataRequest: (method: string, payload: unknown, signal: AbortSignal) => Promise<unknown> | unknown
+    onError?: (message?: string) => void
+    onRendered?: () => void
+}
+
+export function createWidgetHostMessageRouter(
+    post: (message: Record<string, unknown>) => void,
+    callbacks: () => WidgetHostCallbacks
+): (message: unknown) => Promise<void> {
+    let activeRequests = 0
+    let totalRequests = 0
+    let totalResponseBytes = 0
+
+    return async (raw: unknown): Promise<void> => {
+        if (typeof raw !== 'object' || raw === null) {
+            return
+        }
+        const message = raw as ArtifactMessage
+        if (message.channel !== CANVAS_CHANNEL) {
+            return
+        }
+        if (message.type === 'error') {
+            callbacks().onError?.(typeof message.message === 'string' ? message.message.slice(0, 500) : undefined)
+            return
+        }
+        if (message.type === 'rendered') {
+            callbacks().onRendered?.()
+            return
+        }
+        if (message.type !== 'data-request' || typeof message.id !== 'string' || typeof message.method !== 'string') {
+            return
+        }
+        if (message.method !== 'stateGet') {
+            post({
+                channel: CANVAS_CHANNEL,
+                type: 'data-response',
+                id: message.id,
+                ok: false,
+                error: 'This Canvas method is not available in notebook widgets',
+            })
+            return
+        }
+
+        let requestBytes = Number.POSITIVE_INFINITY
+        try {
+            requestBytes = JSON.stringify(message.payload).length
+        } catch {
+            requestBytes = Number.POSITIVE_INFINITY
+        }
+        if (
+            activeRequests >= MAX_CONCURRENT_REQUESTS ||
+            totalRequests >= MAX_TOTAL_REQUESTS ||
+            requestBytes > MAX_REQUEST_BYTES
+        ) {
+            post({
+                channel: CANVAS_CHANNEL,
+                type: 'data-response',
+                id: message.id,
+                ok: false,
+                error: 'Widget data request exceeds runtime limits',
+            })
+            return
+        }
+
+        activeRequests += 1
+        totalRequests += 1
+        const controller = new AbortController()
+        let timeoutId: ReturnType<typeof setTimeout> | undefined
+        const request = Promise.resolve().then(() =>
+            callbacks().onDataRequest('stateGet', message.payload, controller.signal)
+        )
+        try {
+            const result = await Promise.race([
+                request,
+                new Promise<never>((_, reject) => {
+                    timeoutId = setTimeout(() => {
+                        controller.abort()
+                        reject(new Error('Widget data request timed out'))
+                    }, REQUEST_TIMEOUT_MS)
+                }),
+            ])
+            const responseBytes = JSON.stringify(result).length
+            if (totalResponseBytes + responseBytes > MAX_TOTAL_RESPONSE_BYTES) {
+                throw new Error('Widget data response exceeds runtime limits')
+            }
+            totalResponseBytes += responseBytes
+            post({ channel: CANVAS_CHANNEL, type: 'data-response', id: message.id, ok: true, result })
+        } catch (error) {
+            post({
+                channel: CANVAS_CHANNEL,
+                type: 'data-response',
+                id: message.id,
+                ok: false,
+                error: error instanceof Error ? error.message : 'Widget data request failed',
+            })
+        } finally {
+            if (timeoutId !== undefined) {
+                clearTimeout(timeoutId)
+            }
+            activeRequests -= 1
+            void request.catch(() => undefined)
+        }
+    }
+}

--- a/products/notebooks/package.json
+++ b/products/notebooks/package.json
@@ -6,7 +6,12 @@
     "dependencies": {
         "kea": "catalog:",
         "kea-loaders": "catalog:",
-        "kea-router": "catalog:"
+        "kea-router": "catalog:",
+        "posthog-js": "catalog:"
+    },
+    "devDependencies": {
+        "@testing-library/react": "^14.3.1",
+        "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
         "@posthog/icons": "catalog:",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,9 @@
             "@posthog/llm-normalizer/*": ["./packages/llm-normalizer/src/*"],
             "@posthog/quill-charts": ["./packages/quill/packages/charts/src/index.ts"],
             "@posthog/quill-charts/*": ["./packages/quill/packages/charts/src/*"],
-            // @tiptap/* is installed under frontend/node_modules only, which product files
-            // (products/*/frontend) can't reach by walking up from their own directory.
+            // These packages are installed under frontend/node_modules only, which product
+            // files (products/*/frontend) can't reach by walking up from their own directory.
+            "@storybook/react": ["./frontend/node_modules/@storybook/react/dist/index.d.ts"],
             "@tiptap/*": ["./frontend/node_modules/@tiptap/*"],
             // Needed to access the subpath since torph didn't set up types properly
             "torph/react": ["./frontend/node_modules/torph/dist/react/index"],


### PR DESCRIPTION
## Problem

Notebook viewers still cannot mount generated artifacts after [#91533](https://github.com/PostHog/posthog/pull/91533); the browser lacks a trust gate and bounded data bridge.

Generated JavaScript remains untrusted even after automated review, so execution needs a separate browser boundary.

## Changes

- A clean security review lets the exact generated build mount automatically.
- Findings or missing reviews stop before execution and offer source inspection or exact-build consent.
- Consent binds to the PostHog user and build hash, so changed artifacts require a new decision.
- A sandboxed cross-origin iframe receives only declared dataframe frames through a permission-checked bridge.
- Request budgets, row limits, timeouts, and navigation interception limit runtime impact.

> [!WARNING]
> Automated review is advisory. The iframe, bridge, server authorization, and exact-build consent remain independent controls.

**Before**

```mermaid
flowchart LR
    Artifact[(Generated artifact)] --> Missing[No notebook browser runtime]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Artifact,Missing phGray;
```

**After**

```mermaid
flowchart LR
    Artifact[(Exact artifact)] --> Gate[Review and consent gate]
    Gate -->|clean| Frame[Sandboxed iframe]
    Gate -->|findings| Choice[View source or run anyway]
    Choice --> Frame
    Frame --> Bridge[Bounded frame bridge]
    Bridge --> API[Permission-checked API]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Gate,Frame,Bridge phBlue;
    class API phRed;
    class Choice phYellow;
    class Artifact phGray;
```

No product screenshot applies because the notebook does not register these runtime components until the next layer.

## How did you test this code?

- Local tests cover iframe handshakes, bridge quotas, concurrent requests, trust persistence, build changes, and navigation interception.
- The frontend TypeScript check completed locally.
- Not checked: a manual browser pass because this layer has no notebook route.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The final stack layer documents the complete generated-code trust model.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used the repository shell, Flox, and GitHub CLI.
- Skills: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-kea-logics`, `/writing-code-comments`, `/stacking-prs`, and `/writing-pr-descriptions`.
- This layer keeps browser execution reviewable without the notebook presentation and generation controls.