### PR TITLE
fix(tasks): clear merged reports from pull requests

### DIFF
--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -31,6 +31,7 @@ from products.tasks.backend.webhooks import (
     _bounded_attribution_lookup,
     _installation_team_ids,
     _task_run_scope_team_ids,
+    _transition_signal_reports_for_pr,
     find_task_run,
 )
 
@@ -1111,11 +1112,11 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
             task_id=str(self.task.id),
         )
 
-    def _post_pr_webhook(self, action: str, merged: bool):
+    def _post_pr_webhook(self, action: str, merged: bool, pr_url: str = "https://github.com/posthog/posthog/pull/42"):
         payload = {
             "action": action,
             "pull_request": {
-                "html_url": "https://github.com/posthog/posthog/pull/42",
+                "html_url": pr_url,
                 "merged": merged,
             },
         }
@@ -1169,6 +1170,10 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.assertEqual(response.status_code, 200)
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, expected_status)
+        if merged:
+            self.task_run.refresh_from_db()
+            assert self.task_run.output is not None
+            self.assertIs(self.task_run.output.get("pr_merged"), True)
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     @patch("products.tasks.backend.models.posthoganalytics.capture")
@@ -1183,6 +1188,181 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         self.assertEqual(response.status_code, 200)
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, SignalReport.Status.READY)
+
+    @parameterized.expand(
+        [
+            ("merged", True, SignalReport.Status.RESOLVED),
+            ("closed", False, SignalReport.Status.SUPPRESSED),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_event_transitions_report_when_pr_is_bound_to_another_task(
+        self, _name, merged, expected_status, _mock_capture, mock_get_secret
+    ):
+        mock_get_secret.return_value = self.webhook_secret
+        pr_url = "https://github.com/posthog/posthog/pull/42"
+        self.task_run.state = {}
+        self.task_run.save(update_fields=["state"])
+        review_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Review task",
+            description="Review the implementation",
+            origin_product=Task.OriginProduct.REVIEW_HOG,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=review_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"verified_pr_urls": [pr_url]},
+            output={"pr_url": pr_url},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=merged)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, expected_status)
+        if merged:
+            self.task_run.refresh_from_db()
+            assert self.task_run.output is not None
+            self.assertIs(self.task_run.output.get("pr_merged"), True)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_event_does_not_transition_report_for_older_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/99"},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.READY)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_implementation_pr_takes_priority_over_newer_discussion_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        discussion_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Discuss report",
+            description="Discuss the signal report",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            repository="posthog/posthog",
+        )
+        TaskRun.objects.create(
+            task=discussion_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/99"},
+        )
+        append_task_run_artefact(
+            team_id=self.team.id,
+            report_id=str(self.report.id),
+            product="signals",
+            type="discussion",
+            task_id=str(discussion_task.id),
+        )
+
+        response = self._post_pr_webhook(
+            action="closed", merged=False, pr_url="https://github.com/posthog/posthog/pull/99"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.READY)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_merge_attests_the_run_the_badge_reads(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self.task_run.status = TaskRun.Status.IN_PROGRESS
+        self.task_run.save(update_fields=["status"])
+        newest_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            output={"pr_url": "https://github.com/posthog/posthog/pull/42"},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        newest_run.refresh_from_db()
+        assert newest_run.output is not None
+        self.assertIs(newest_run.output.get("pr_merged"), True)
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_merge_does_not_attest_a_run_that_only_read_the_pr(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        research_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"ai_stage": "research"},
+            output={"pr_url": "https://github.com/posthog/posthog/pull/42"},
+        )
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        research_run.refresh_from_db()
+        assert research_run.output is not None
+        self.assertIsNone(research_run.output.get("pr_merged"))
+
+    @patch("products.tasks.backend.webhooks._signal_reports_for_pr_runs", return_value=[])
+    def test_observer_runs_are_excluded_before_report_lookup(self, mock_signal_reports):
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"ai_stage": "research"},
+            output={"pr_url": "https://github.com/posthog/posthog/pull/42"},
+        )
+
+        _transition_signal_reports_for_pr(
+            "https://github.com/posthog/posthog/pull/42",
+            SignalReport.Status.RESOLVED,
+            "github_pr_webhook_signal_report_resolved",
+            [self.team.id],
+            record_merge=True,
+        )
+
+        mock_signal_reports.assert_called_once()
+        self.assertEqual(mock_signal_reports.call_args.args[1], [self.task_run])
+
+    @parameterized.expand(
+        [
+            ("trailing_slash", "https://github.com/posthog/posthog/pull/42/"),
+            ("www_host", "https://www.github.com/posthog/posthog/pull/42"),
+            ("www_host_trailing_slash", "https://www.github.com/posthog/posthog/pull/42/"),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_url_variants_match_the_webhook_pr(self, _name, stored_pr_url, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        self.task_run.output = {"pr_url": stored_pr_url}
+        self.task_run.save(update_fields=["output"])
+
+        response = self._post_pr_webhook(action="closed", merged=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.report.refresh_from_db()
+        self.task_run.refresh_from_db()
+        self.assertEqual(self.report.status, SignalReport.Status.RESOLVED)
+        assert self.task_run.output is not None
+        self.assertIs(self.task_run.output.get("pr_merged"), True)
 
 
 class TestExternalPRWebhook(TestCase):
@@ -1505,6 +1685,68 @@ class TestFindTaskRun(TestCase):
         )
         result = find_task_run(branch="feature/my-branch", repository="posthog/posthog")
         self.assertEqual(result, task_run)
+
+    @parameterized.expand([("branch", False), ("signed_head_branch", True)])
+    def test_branch_fallback_prefers_newest_run_even_when_it_is_terminal(self, _name, signed_head_branch):
+        branch_fields = (
+            {
+                "branch": "master",
+                "output": {"head_branches": [{"repository": "posthog/posthog", "branch": "feature/shared-branch"}]},
+            }
+            if signed_head_branch
+            else {"branch": "feature/shared-branch"}
+        )
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            **branch_fields,
+        )
+        review_task = Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Review task",
+            description="Review the implementation",
+            origin_product=Task.OriginProduct.REVIEW_HOG,
+            repository="posthog/posthog",
+        )
+        newest_run = TaskRun.objects.create(
+            task=review_task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            **branch_fields,
+        )
+
+        result = find_task_run(branch="feature/shared-branch", repository="posthog/posthog")
+
+        self.assertEqual(result, newest_run)
+
+    @parameterized.expand([("branch", False), ("signed_head_branch", True)])
+    def test_branch_fallback_prefers_newest_run_with_same_status_rank(self, _name, signed_head_branch):
+        branch_fields = (
+            {
+                "branch": "master",
+                "output": {"head_branches": [{"repository": "posthog/posthog", "branch": "feature/shared-branch"}]},
+            }
+            if signed_head_branch
+            else {"branch": "feature/shared-branch"}
+        )
+        TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.IN_PROGRESS,
+            **branch_fields,
+        )
+        newest_run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.QUEUED,
+            **branch_fields,
+        )
+
+        result = find_task_run(branch="feature/shared-branch", repository="posthog/posthog")
+
+        self.assertEqual(result, newest_run)
 
     def test_finds_by_signed_commit_head_branch(self):
         task_run = TaskRun.objects.create(

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1341,6 +1341,18 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
         mock_signal_reports.assert_called_once()
         self.assertEqual(mock_signal_reports.call_args.args[1], [self.task_run])
 
+    @patch("products.tasks.backend.webhooks._signal_reports_for_pr_runs")
+    def test_report_transition_fails_closed_without_a_team_scope(self, mock_signal_reports):
+        _transition_signal_reports_for_pr(
+            "https://github.com/posthog/posthog/pull/42",
+            SignalReport.Status.RESOLVED,
+            "github_pr_webhook_signal_report_resolved",
+            [],
+            record_merge=True,
+        )
+
+        mock_signal_reports.assert_not_called()
+
     @parameterized.expand(
         [
             ("trailing_slash", "https://github.com/posthog/posthog/pull/42/"),

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -302,7 +302,7 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
             pr_url,
             SignalReport.Status.RESOLVED,
             "github_pr_webhook_signal_report_resolved",
-            scoped_team_ids or ([task_run.team_id] if task_run else None),
+            scoped_team_ids or ([task_run.team_id] if task_run else []),
             record_merge=True,
         )
 
@@ -314,7 +314,7 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
             pr_url,
             SignalReport.Status.SUPPRESSED,
             "github_pr_webhook_signal_report_archived",
-            scoped_team_ids or ([task_run.team_id] if task_run else None),
+            scoped_team_ids or ([task_run.team_id] if task_run else []),
         )
 
     return HttpResponse(status=200)
@@ -972,7 +972,7 @@ def _transition_signal_reports_for_pr(
     pr_url: str,
     target_status: SignalReport.Status,
     success_log_event: str,
-    team_ids: list[int] | None,
+    team_ids: list[int],
     *,
     record_merge: bool = False,
 ) -> None:
@@ -986,11 +986,15 @@ def _transition_signal_reports_for_pr(
     # Observer-only runs can record a PR while inspecting in-flight work, but they did not create
     # it and cannot lead to a report whose surfaced implementation PR matches this webhook. Drop
     # them before materializing candidates so popular PRs do not fan out through report lookup.
+    if not team_ids:
+        logger.warning("github_pr_webhook_signal_report_transition_unscoped", pr_url=pr_url)
+        return
+
     run_candidates = TaskRun.objects.filter(
-        pr_bearing_task_run_filter(), output__pr_url__in=_pr_url_lookup_values(pr_url)
+        pr_bearing_task_run_filter(),
+        output__pr_url__in=_pr_url_lookup_values(pr_url),
+        team_id__in=team_ids,
     )
-    if team_ids:
-        run_candidates = run_candidates.filter(team_id__in=team_ids)
     reports = _signal_reports_for_pr_runs(pr_url, list(run_candidates))
 
     if record_merge and reports:

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -15,6 +15,7 @@ import posthoganalytics
 from social_django.models import UserSocialAuth
 
 from posthog.event_usage import groups
+from posthog.models.github_integration_base import GitHubIntegrationBase
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.integration import Integration
 from posthog.models.organization import OrganizationMembership
@@ -22,6 +23,10 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.models.user_integration import UserIntegration
 
+from products.signals.backend.implementation_pr import (
+    fetch_implementation_pr_state_for_reports,
+    pr_bearing_task_run_filter,
+)
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
 from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
 from products.tasks.backend.constants import PR_LOOP_ENABLED_STATE_KEY
@@ -113,6 +118,7 @@ def find_task_run(
                 branch=branch,
                 state__wizard_head_branch__isnull=True,
             )
+            .order_by("-created_at", "-id")
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
@@ -129,6 +135,7 @@ def find_task_run(
                 output__head_branches__contains=[head_branch],
                 state__wizard_head_branch__isnull=True,
             )
+            .order_by("-created_at", "-id")
             .select_related(*TASK_RUN_SELECT_RELATED)
             .first()
         )
@@ -236,9 +243,8 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
 
     branch = pull_request.get("head", {}).get("ref")
     repository_full_name = (payload.get("repository") or {}).get("full_name")
-    task_run = find_task_run(
-        pr_url=pr_url, branch=branch, repository=repository_full_name, team_ids=_task_run_scope_team_ids(payload)
-    )
+    scoped_team_ids = _task_run_scope_team_ids(payload)
+    task_run = find_task_run(pr_url=pr_url, branch=branch, repository=repository_full_name, team_ids=scoped_team_ids)
     claimed_pr_urls = (
         read_pr_urls(task_run.output if isinstance(task_run.output, dict) else {}) if task_run is not None else []
     )
@@ -286,27 +292,29 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         event_uuid = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{pr_url}:{analytics_event}"))
         _capture_pr_event(payload, task_run, analytics_event, event_uuid)
 
-    if task_run and action == "closed" and merged:
+    if action == "closed" and merged:
         # Only trust the merge for the run that actually claims this PR URL. The pr_url backstop
         # above already covers branch-matched internal PRs, so requiring equality here keeps a
         # same-branch webhook for a different PR from marking this run's PR as merged.
-        if pr_url in claimed_pr_urls:
+        if task_run and pr_url in claimed_pr_urls:
             _record_run_pr_merged(task_run)
-        # Ungated on the pr_url match above: unlike the run-bookkeeping calls, this keys off
-        # task_id (reports_for_task_filter), not output.pr_url, so the same-branch trust rule
-        # doesn't apply — a merged PR resolves its report.
-        _transition_signal_reports_for_task(
-            task_run.task_id, pr_url, SignalReport.Status.RESOLVED, "github_pr_webhook_signal_report_resolved"
+        _transition_signal_reports_for_pr(
+            pr_url,
+            SignalReport.Status.RESOLVED,
+            "github_pr_webhook_signal_report_resolved",
+            scoped_team_ids or ([task_run.team_id] if task_run else None),
+            record_merge=True,
         )
 
-    if task_run and action == "closed" and not merged:
+    if action == "closed" and not merged:
         # Same trust rule as the merge branch: only the run that claims this PR URL.
-        if pr_url in claimed_pr_urls:
+        if task_run and pr_url in claimed_pr_urls:
             _cancel_wizard_run_on_close(task_run)
-        # Ungated for the same reason as the merge branch's resolve call: a closed-unmerged PR
-        # archives (suppresses) its report so it leaves the inbox instead of lingering.
-        _transition_signal_reports_for_task(
-            task_run.task_id, pr_url, SignalReport.Status.SUPPRESSED, "github_pr_webhook_signal_report_archived"
+        _transition_signal_reports_for_pr(
+            pr_url,
+            SignalReport.Status.SUPPRESSED,
+            "github_pr_webhook_signal_report_archived",
+            scoped_team_ids or ([task_run.team_id] if task_run else None),
         )
 
     return HttpResponse(status=200)
@@ -909,18 +917,39 @@ def _resolve_external_team(payload: dict) -> Team | None:
     return Team.objects.filter(pk=team_ids[0]).first()
 
 
-def _transition_signal_reports_for_task(
-    task_id: uuid.UUID, pr_url: str, target_status: SignalReport.Status, success_log_event: str
-) -> None:
-    """Transition signal reports linked to a task's PR to ``target_status``.
+def _pull_request_identity(pr_url: str) -> tuple[str, int] | None:
+    parsed = GitHubIntegrationBase.parse_pull_request_url(pr_url)
+    if parsed is None:
+        return None
+    return parsed.repository.lower(), parsed.number
 
-    Covers both PR outcomes: a merged PR resolves its reports, a closed-unmerged PR archives
-    (suppresses) them so they leave the inbox instead of lingering as if work were still pending.
-    Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
-    5xx responses and we've already acknowledged the PR event.
+
+def _pr_url_lookup_values(pr_url: str) -> list[str]:
+    """The ``output.pr_url`` strings that can stand for ``pr_url``.
+
+    ``output.pr_url`` is caller-supplied: the agent server PATCHes it onto the run, so it can hold
+    a valid but noncanonical form of the URL GitHub sends as ``html_url``. The variants are
+    enumerated rather than matched with a prefix or a normalizing scan so the lookup stays on the
+    partial index ``task_run_output_pr_url_idx``. A prefix match cannot use that index, and this
+    lookup runs on every closed-PR delivery, including the many for PRs no run ever opened.
     """
-    reports = (
-        SignalReport.objects.filter(SignalReport.reports_for_task_filter(task_id))
+    parsed = GitHubIntegrationBase.parse_pull_request_url(pr_url)
+    if parsed is None:
+        return [pr_url]
+    values = {pr_url}
+    for host in ("github.com", "www.github.com"):
+        for repository in (parsed.repository, parsed.repository.lower()):
+            base = f"https://{host}/{repository}/pull/{parsed.number}"
+            values.update((base, f"{base}/"))
+    return sorted(values)
+
+
+def _signal_reports_for_pr_runs(pr_url: str, runs: list[TaskRun]) -> list[SignalReport]:
+    if not runs:
+        return []
+
+    reports = list(
+        SignalReport.objects.filter(SignalReport.reports_for_task_ids_filter({run.task_id for run in runs}))
         .exclude(
             status__in=[
                 SignalReport.Status.RESOLVED,
@@ -930,6 +959,59 @@ def _transition_signal_reports_for_task(
         )
         .distinct()
     )
+    pr_identity = _pull_request_identity(pr_url)
+    surfaced_prs = fetch_implementation_pr_state_for_reports([str(report.id) for report in reports])
+    return [
+        report
+        for report in reports
+        if (surfaced_pr := surfaced_prs.get(str(report.id))) and _pull_request_identity(surfaced_pr.url) == pr_identity
+    ]
+
+
+def _transition_signal_reports_for_pr(
+    pr_url: str,
+    target_status: SignalReport.Status,
+    success_log_event: str,
+    team_ids: list[int] | None,
+    *,
+    record_merge: bool = False,
+) -> None:
+    """Transition signal reports whose surfaced implementation PR matches ``pr_url``.
+
+    Covers both PR outcomes: a merged PR resolves its reports, a closed-unmerged PR archives
+    (suppresses) them so they leave the inbox instead of lingering as if work were still pending.
+    Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
+    5xx responses and we've already acknowledged the PR event.
+    """
+    # Observer-only runs can record a PR while inspecting in-flight work, but they did not create
+    # it and cannot lead to a report whose surfaced implementation PR matches this webhook. Drop
+    # them before materializing candidates so popular PRs do not fan out through report lookup.
+    run_candidates = TaskRun.objects.filter(
+        pr_bearing_task_run_filter(), output__pr_url__in=_pr_url_lookup_values(pr_url)
+    )
+    if team_ids:
+        run_candidates = run_candidates.filter(team_id__in=team_ids)
+    reports = _signal_reports_for_pr_runs(pr_url, list(run_candidates))
+
+    if record_merge and reports:
+        # The inbox badge reads pr_merged off the run the report's surfaced PR came from, so the
+        # attestation has to land there and not only on the run the webhook bound to.
+        # Research, repo-selection and scout runs are excluded because a PR URL on one of them is a
+        # PR the agent read while checking for in-flight work, not one it opened.
+        # Newest run per task, matching get_latest_pr_url_by_task and get_merged_pr_task_ids
+        # run-for-run. Those two decide which run the badge reads, so any other ordering here can
+        # attest one run while the badge reads another, which is the bug this block exists to fix.
+        report_task_runs = SignalReport.associated_task_runs_for_reports(
+            report_ids=[str(report.id) for report in reports]
+        )
+        associated_task_ids = {run.task_id for runs in report_task_runs.values() for run in runs}
+        surfaced_runs = (
+            run_candidates.filter(pr_bearing_task_run_filter(), task_id__in=associated_task_ids)
+            .order_by("task_id", "-created_at", "-id")
+            .distinct("task_id")
+        )
+        for run in surfaced_runs:
+            _record_run_pr_merged(run)
 
     for report in reports:
         try:
@@ -946,6 +1028,5 @@ def _transition_signal_reports_for_task(
         logger.info(
             success_log_event,
             report_id=str(report.id),
-            task_id=str(task_id),
             pr_url=pr_url,
         )


### PR DESCRIPTION
## Problem

A merged implementation PR can remain in the Inbox Pull requests tab with an Open badge.

The webhook can bind the PR to a different run on the same branch, so the report never transitions.

Closes #88140
Supersedes #88195 with verified history on current master.

## Changes

- The Inbox removes a report when its surfaced implementation PR closes. A merge resolves it; an unmerged close suppresses it.
- The surfaced run records the merge, so its Open badge clears.
- Observer-only runs leave the candidate set before report lookup, which avoids unnecessary webhook fan-out.
- Fixed URL variants preserve the indexed PR lookup.

**Before**

```mermaid
flowchart LR
    Hook[GitHub closed webhook] --> Run[Attributed run]
    Run --> Report[Linked report]
    Report --> Stale[Report stays ready]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Hook phRed;
    class Run,Report phBlue;
    class Stale phYellow;
```

**After**

```mermaid
flowchart LR
    Hook[GitHub closed webhook] --> Candidates[PR-bearing runs]
    Candidates --> Surface[Surfaced implementation PR]
    Surface --> Outcome[Resolve or suppress report]
    Surface --> Merge[Record merge on surfaced run]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Hook phRed;
    class Candidates,Surface phBlue;
    class Outcome,Merge phYellow;
```

No screenshot: the card leaves the tab because its status changes.

## How did you test this code?

- Added regressions for cross-run attribution, surfaced-run merge state, URL variants, implementation priority, and observer-run filtering.
- `ruff check` and `ruff format --check` passed for both changed files.
- `hogli ci:preflight --strict` passed on current master.
- Not completed locally: the database-backed test body because the fresh schema bootstrap did not finish. CI will run it.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This changes internal webhook bookkeeping.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop rebuilt #88195 as one verified commit and addressed the remaining observer-run review finding.

Skills invoked: `/investigating-ci-failures` and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*