### PR TITLE
feat(desktop): mobile profile picture in settings

### DIFF
--- a/products/desktop/apps/mobile/src/app/settings/index.tsx
+++ b/products/desktop/apps/mobile/src/app/settings/index.tsx
@@ -5,9 +5,15 @@ import {
 } from "@posthog/shared/domain-types";
 import { router } from "expo-router";
 import { ArrowSquareOut, CaretRight, SpeakerHigh } from "phosphor-react-native";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Linking, Pressable, ScrollView, Switch, View } from "react-native";
 import { useAuthStore, useProjectsQuery, useUserQuery } from "@/features/auth";
+import {
+  GRAVATAR_MANAGE_URL,
+  mapProbeResultToStatus,
+} from "@/features/auth/gravatar";
+import { useGravatarUrl } from "@/features/auth/useGravatarUrl";
+import { useImageProbe } from "@/features/auth/useImageProbe";
 import { useDismissedReportsStore } from "@/features/inbox/stores/dismissedReportsStore";
 import { usePushTokenStore } from "@/features/notifications/stores/pushTokenStore";
 import {
@@ -21,6 +27,7 @@ import {
 import { DailyReportLimitRow } from "@/features/settings/components/DailyReportLimitRow";
 import { DebugInfoSection } from "@/features/settings/components/DebugInfoSection";
 import { FloatingSettingsHeader } from "@/features/settings/components/FloatingSettingsHeader";
+import { ProfilePictureRow } from "@/features/settings/components/ProfilePictureRow";
 import { SettingsRow } from "@/features/settings/components/SettingsRow";
 import { SettingsSection } from "@/features/settings/components/SettingsSection";
 import { SelectSheet } from "@/features/tasks/composer/SelectSheet";
@@ -213,6 +220,20 @@ export default function SettingsScreen() {
     (s) => s.dismissedIds.length + s.acceptedIds.length,
   );
   const clearDismissed = useDismissedReportsStore((s) => s.clearDismissed);
+
+  const [refreshedAt, setRefreshedAt] = useState<number | null>(null);
+  const gravatarUrl = useGravatarUrl(userData?.email);
+  const candidateUrl =
+    gravatarUrl && refreshedAt
+      ? `${gravatarUrl}&_=${refreshedAt}`
+      : gravatarUrl;
+  const probe = useImageProbe(candidateUrl);
+  const handleRefreshGravatar = useCallback(() => {
+    setRefreshedAt(Date.now());
+  }, []);
+  const handleOpenGravatar = useCallback(() => {
+    Linking.openURL(GRAVATAR_MANAGE_URL).catch(() => {});
+  }, []);
 
   const [themeSheetOpen, setThemeSheetOpen] = useState(false);
   const [fontSizeSheetOpen, setFontSizeSheetOpen] = useState(false);
@@ -548,6 +569,16 @@ export default function SettingsScreen() {
 
         {/* Profile */}
         <SettingsSection title="Profile">
+          {userData ? (
+            <ProfilePictureRow
+              user={userData}
+              imageUrl={probe.url}
+              status={mapProbeResultToStatus(probe.result)}
+              checking={probe.loading || !candidateUrl}
+              onRefresh={handleRefreshGravatar}
+              onOpenGravatar={handleOpenGravatar}
+            />
+          ) : null}
           <SettingsRow
             label="First name"
             rightSlot={

--- a/products/desktop/apps/mobile/src/features/auth/gravatar.test.ts
+++ b/products/desktop/apps/mobile/src/features/auth/gravatar.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("expo-crypto", async () => {
+  const { createHash } = await import("node:crypto");
+  return {
+    CryptoDigestAlgorithm: { SHA256: "SHA-256" },
+    digestStringAsync: vi.fn(async (_algorithm: string, data: string) =>
+      createHash("sha256").update(data).digest("hex"),
+    ),
+  };
+});
+
+import {
+  buildGravatarUrl,
+  mapProbeResultToStatus,
+  profilePictureDescription,
+} from "./gravatar";
+
+describe("buildGravatarUrl", () => {
+  it.each([
+    {
+      name: "hashes the email and asks for the default size with d=404",
+      email: "user@example.com",
+      size: undefined,
+      expected:
+        "https://www.gravatar.com/avatar/b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514?s=144&d=404",
+    },
+    {
+      name: "lowercases and trims the email before hashing",
+      email: "  TEST@Example.com ",
+      size: undefined,
+      expected:
+        "https://www.gravatar.com/avatar/973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b?s=144&d=404",
+    },
+    {
+      name: "requests the size the caller asks for",
+      email: "user@example.com",
+      size: 96,
+      expected:
+        "https://www.gravatar.com/avatar/b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514?s=96&d=404",
+    },
+  ])("$name", async ({ email, size, expected }) => {
+    expect(await buildGravatarUrl(email, size)).toBe(expected);
+  });
+
+  it.each([
+    { label: "null email", email: null },
+    { label: "undefined email", email: undefined },
+    { label: "empty string", email: "" },
+    { label: "whitespace only", email: "   " },
+  ])("returns undefined for a $label", async ({ email }) => {
+    expect(await buildGravatarUrl(email)).toBeUndefined();
+  });
+});
+
+describe("mapProbeResultToStatus", () => {
+  it.each([
+    { result: "loaded", status: "found" },
+    { result: "failed", status: "missing" },
+    { result: "unknown", status: "unknown" },
+  ] as const)("maps $result to $status", ({ result, status }) => {
+    expect(mapProbeResultToStatus(result)).toBe(status);
+  });
+});
+
+describe("profilePictureDescription", () => {
+  it("names Gravatar and the email in every state", () => {
+    expect(profilePictureDescription("unknown", "sam@example.com")).toBe(
+      "Checking Gravatar for sam@example.com",
+    );
+    expect(profilePictureDescription("found", "sam@example.com")).toContain(
+      "Comes from Gravatar, matched to sam@example.com",
+    );
+    expect(profilePictureDescription("missing", "sam@example.com")).toContain(
+      "Add one on Gravatar for sam@example.com",
+    );
+  });
+});

--- a/products/desktop/apps/mobile/src/features/auth/gravatar.ts
+++ b/products/desktop/apps/mobile/src/features/auth/gravatar.ts
@@ -1,0 +1,50 @@
+import * as Crypto from "expo-crypto";
+
+export type ImageProbeResult = "unknown" | "loaded" | "failed";
+export type ProfilePictureStatus = "unknown" | "found" | "missing";
+
+export const DEFAULT_GRAVATAR_SIZE = 144;
+export const GRAVATAR_MANAGE_URL = "https://gravatar.com/profile/avatars";
+
+export async function buildGravatarUrl(
+  email: string | null | undefined,
+  size: number = DEFAULT_GRAVATAR_SIZE,
+): Promise<string | undefined> {
+  if (!email) return undefined;
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) return undefined;
+  const hash = await Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    normalized,
+  );
+  // `d=404` makes Gravatar return 404 rather than a default silhouette, so a
+  // missing picture falls back to initials.
+  return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=404`;
+}
+
+export function mapProbeResultToStatus(
+  result: ImageProbeResult,
+): ProfilePictureStatus {
+  switch (result) {
+    case "loaded":
+      return "found";
+    case "failed":
+      return "missing";
+    case "unknown":
+      return "unknown";
+  }
+}
+
+export function profilePictureDescription(
+  status: ProfilePictureStatus,
+  email: string,
+): string {
+  switch (status) {
+    case "unknown":
+      return `Checking Gravatar for ${email}`;
+    case "found":
+      return `Comes from Gravatar, matched to ${email}. Change it there, then refresh to see it here.`;
+    case "missing":
+      return `No picture yet. Add one on Gravatar for ${email} and it shows here and anywhere teammates see you.`;
+  }
+}

--- a/products/desktop/apps/mobile/src/features/auth/useGravatarUrl.ts
+++ b/products/desktop/apps/mobile/src/features/auth/useGravatarUrl.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { buildGravatarUrl } from "./gravatar";
+
+export function useGravatarUrl(
+  email: string | null | undefined,
+  size?: number,
+): string | undefined {
+  const [url, setUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!email) {
+      setUrl(undefined);
+      return;
+    }
+    let cancelled = false;
+    setUrl(undefined);
+    buildGravatarUrl(email, size)
+      .then((next) => {
+        if (!cancelled) setUrl(next);
+      })
+      .catch(() => {
+        if (!cancelled) setUrl(undefined);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [email, size]);
+
+  return url;
+}

--- a/products/desktop/apps/mobile/src/features/auth/useImageProbe.ts
+++ b/products/desktop/apps/mobile/src/features/auth/useImageProbe.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { Image } from "react-native";
+import type { ImageProbeResult } from "./gravatar";
+
+export interface ImageProbe {
+  result: ImageProbeResult;
+  url: string | undefined;
+  loading: boolean;
+}
+
+const INITIAL_PROBE: ImageProbe = {
+  result: "unknown",
+  url: undefined,
+  loading: false,
+};
+
+export function useImageProbe(url: string | undefined): ImageProbe {
+  const [probe, setProbe] = useState<ImageProbe>(INITIAL_PROBE);
+
+  useEffect(() => {
+    if (!url) {
+      setProbe(INITIAL_PROBE);
+      return;
+    }
+    let cancelled = false;
+    setProbe((previous) => ({ ...previous, loading: true }));
+    Image.prefetch(url)
+      .then((ok) => {
+        if (cancelled) return;
+        if (ok) {
+          setProbe({ result: "loaded", url, loading: false });
+        } else {
+          setProbe({ result: "failed", url: undefined, loading: false });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setProbe({ result: "failed", url: undefined, loading: false });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return probe;
+}

--- a/products/desktop/apps/mobile/src/features/settings/components/ProfilePictureRow.tsx
+++ b/products/desktop/apps/mobile/src/features/settings/components/ProfilePictureRow.tsx
@@ -1,0 +1,99 @@
+import { Text } from "@components/text";
+import { avatarColor } from "@posthog/core/auth/avatarColor";
+import {
+  getUserInitials,
+  type UserLike,
+} from "@posthog/core/auth/userInitials";
+import { ArrowSquareOut, ArrowsClockwise } from "phosphor-react-native";
+import { Image, Pressable, View } from "react-native";
+import {
+  type ProfilePictureStatus,
+  profilePictureDescription,
+} from "@/features/auth/gravatar";
+import { useThemeColors } from "@/lib/theme";
+
+interface ProfilePictureRowProps {
+  user: UserLike & { uuid?: string | null };
+  imageUrl: string | undefined;
+  status: ProfilePictureStatus;
+  checking: boolean;
+  onRefresh: () => void;
+  onOpenGravatar: () => void;
+}
+
+export function ProfilePictureRow({
+  user,
+  imageUrl,
+  status,
+  checking,
+  onRefresh,
+  onOpenGravatar,
+}: ProfilePictureRowProps) {
+  const themeColors = useThemeColors();
+  const email = user.email ?? "your email";
+  const color = avatarColor(user.uuid ?? user.email ?? "user");
+  const gravatarActionLabel =
+    status === "found" ? "Change on Gravatar" : "Add on Gravatar";
+
+  return (
+    <View className="gap-3 border-gray-5 border-b px-4 py-3">
+      <View className="flex-row items-center gap-3">
+        <View
+          className={`h-14 w-14 items-center justify-center overflow-hidden rounded-xl ${
+            status === "missing" ? "border border-gray-7 border-dashed" : ""
+          }`}
+          style={{ backgroundColor: color.bg }}
+        >
+          <Text
+            className="font-medium text-[18px]"
+            style={{ color: color.text }}
+          >
+            {getUserInitials(user)}
+          </Text>
+          {imageUrl ? (
+            <Image
+              source={{ uri: imageUrl }}
+              accessibilityIgnoresInvertColors
+              className="absolute inset-0 h-full w-full"
+            />
+          ) : null}
+        </View>
+
+        <View className="min-w-0 flex-1">
+          <Text className="font-medium text-[15px] text-gray-12">
+            Profile picture
+          </Text>
+          <Text className="mt-0.5 text-[12px] text-gray-10 leading-snug">
+            {profilePictureDescription(status, email)}
+          </Text>
+        </View>
+      </View>
+
+      <View className="flex-row gap-2">
+        <Pressable
+          onPress={onRefresh}
+          disabled={checking}
+          hitSlop={6}
+          accessibilityLabel="Check Gravatar again"
+          className={`flex-row items-center gap-1.5 rounded-md border border-gray-6 bg-gray-3 px-3 py-1.5 active:opacity-60 ${
+            checking ? "opacity-50" : ""
+          }`}
+        >
+          <ArrowsClockwise size={14} color={themeColors.gray[12]} />
+          <Text className="font-medium text-[13px] text-gray-12">Refresh</Text>
+        </Pressable>
+        <Pressable
+          onPress={onOpenGravatar}
+          hitSlop={6}
+          accessibilityLabel={`${gravatarActionLabel} (opens gravatar.com)`}
+          className="flex-row items-center gap-1.5 rounded-md border border-gray-6 bg-gray-3 px-3 py-1.5 active:opacity-60"
+        >
+          <Text className="font-medium text-[13px] text-gray-12">
+            {gravatarActionLabel}
+          </Text>
+          <ArrowSquareOut size={14} color={themeColors.gray[11]} />
+        </Pressable>
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## Problem

Mobile settings shows no avatar anywhere, so a person cannot see or update how they appear to teammates from the phone. Desktop just gained a Gravatar-backed profile picture in general settings (#91323); mobile should offer the same affordance.

Port of #91323.

## Changes

- Profile section in mobile settings now shows the Gravatar picture when Gravatar has one, and the person's initials on a colored tile with a dashed outline when it does not.
- The row describes what a person is looking at (checking, matched to Gravatar, or no picture yet), a refresh button re-checks Gravatar, and a second button opens `gravatar.com/profile/avatars`.
- Mechanical: pure Gravatar URL building, status mapping, and copy live in `features/auth/gravatar.ts` with unit tests; the RN-only image probe uses React Native's `Image.prefetch` to reach the `unknown`/`loaded`/`failed` states the desktop `useImageProbe` gets from `new Image()`.

## How did you test this code?

- Automated: `pnpm --filter @posthog/mobile test` (622 passed), `node scripts/check-mobile-types.mjs` (no new baselined type errors), `pnpm --filter @posthog/mobile lint`.
- Not tested: no manual run of the app on device or simulator.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Port of #91323 into `apps/mobile`, kept mobile-only (no changes to `apps/code`, `apps/web`, or `packages/*`).
- `expo-crypto` was already a dependency, so the SHA-256 hash uses it rather than pulling in a new package. `Image.prefetch` (from `react-native`) drives the probe state machine.
- `avatarColor` and `getUserInitials` come from `@posthog/core/auth/*`, already reused in `HandoffTaskSheet`; nothing was duplicated locally.
- Skills invoked while shaping this PR: `/simplify`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*