### PR TITLE
feat(desktop): mobile pick a cloud environment or image

### DIFF
--- a/products/desktop/apps/mobile/src/app/task/index.tsx
+++ b/products/desktop/apps/mobile/src/app/task/index.tsx
@@ -55,6 +55,8 @@ import {
   pickPhotoFromLibrary,
 } from "@/features/tasks/composer/attachments/pickers";
 import type { PendingAttachment } from "@/features/tasks/composer/attachments/types";
+import { CloudTargetControl } from "@/features/tasks/composer/CloudTargetControl";
+import { cloudTargetIds } from "@/features/tasks/composer/cloudTargets";
 import { DotBackground } from "@/features/tasks/composer/DotBackground";
 import {
   type ContextWindow,
@@ -64,6 +66,7 @@ import {
   getModelConfigOption,
 } from "@/features/tasks/composer/options";
 import { RepositoryPickerInline } from "@/features/tasks/composer/RepositoryPickerInline";
+import { useCloudTargetSelection } from "@/features/tasks/composer/useCloudTargetSelection";
 import { useCloudTaskConfigOptions } from "@/features/tasks/hooks/useCloudTaskConfigOptions";
 import { useUserIntegrations } from "@/features/tasks/hooks/useUserIntegrations";
 import { useWarmTask } from "@/features/tasks/hooks/useWarmTask";
@@ -209,6 +212,13 @@ export default function NewTaskScreen() {
   const [fastMode, setFastMode] = useState<boolean>(
     () => usePreferencesStore.getState().lastUsedFastMode,
   );
+  const {
+    cloudTarget,
+    setCloudTarget,
+    options: cloudTargetOptions,
+    favoriteKey: cloudTargetFavoriteKey,
+    toggleFavorite: toggleCloudTargetFavorite,
+  } = useCloudTargetSelection();
 
   useEffect(() => {
     if (!hasLiveConfig) return;
@@ -382,6 +392,7 @@ export default function NewTaskScreen() {
           contextWindow,
           fastMode,
         }),
+        ...cloudTargetIds(cloudTarget),
         autoPublish: usePreferencesStore.getState().autoPublishCloudRuns,
         rtkEnabled: usePreferencesStore.getState().rtkEnabledCloud,
         ...(signalReport
@@ -410,6 +421,7 @@ export default function NewTaskScreen() {
     reasoning,
     contextWindow,
     fastMode,
+    cloudTarget,
     router,
     selection,
     signalReport,
@@ -614,6 +626,15 @@ export default function NewTaskScreen() {
                         paddingRight: 16,
                       }}
                     >
+                      {cloudTargetOptions.length > 1 ? (
+                        <CloudTargetControl
+                          cloudTarget={cloudTarget}
+                          onCloudTargetChange={setCloudTarget}
+                          options={cloudTargetOptions}
+                          favoriteKey={cloudTargetFavoriteKey}
+                          onToggleFavorite={toggleCloudTargetFavorite}
+                        />
+                      ) : null}
                       <AgentConfigControls
                         adapter={adapter}
                         mode={mode}

--- a/products/desktop/apps/mobile/src/features/preferences/stores/preferencesStore.ts
+++ b/products/desktop/apps/mobile/src/features/preferences/stores/preferencesStore.ts
@@ -95,6 +95,9 @@ interface PreferencesState {
 
   rtkEnabledCloud: boolean;
   setRtkEnabledCloud: (enabled: boolean) => void;
+
+  favoriteCloudTargetKey: string | null;
+  setFavoriteCloudTargetKey: (key: string | null) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -155,6 +158,9 @@ export const usePreferencesStore = create<PreferencesState>()(
 
       rtkEnabledCloud: true,
       setRtkEnabledCloud: (enabled) => set({ rtkEnabledCloud: enabled }),
+
+      favoriteCloudTargetKey: null,
+      setFavoriteCloudTargetKey: (key) => set({ favoriteCloudTargetKey: key }),
     }),
     {
       name: "posthog-preferences",
@@ -191,6 +197,7 @@ export const usePreferencesStore = create<PreferencesState>()(
         lastUsedFastMode: state.lastUsedFastMode,
         autoPublishCloudRuns: state.autoPublishCloudRuns,
         rtkEnabledCloud: state.rtkEnabledCloud,
+        favoriteCloudTargetKey: state.favoriteCloudTargetKey,
       }),
     },
   ),

--- a/products/desktop/apps/mobile/src/features/tasks/composer/CloudTargetControl.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/CloudTargetControl.tsx
@@ -1,0 +1,68 @@
+import { Cloud } from "phosphor-react-native";
+import { useState } from "react";
+import { useThemeColors } from "@/lib/theme";
+import {
+  type CloudTarget,
+  type CloudTargetOption,
+  cloudTargetFromKey,
+  cloudTargetKey,
+} from "./cloudTargets";
+import { Pill } from "./Pill";
+import { SelectSheet } from "./SelectSheet";
+
+interface CloudTargetControlProps {
+  cloudTarget: CloudTarget;
+  onCloudTargetChange: (target: CloudTarget) => void;
+  options: CloudTargetOption[];
+  favoriteKey: string | null;
+  onToggleFavorite: (target: CloudTarget) => void;
+  disabled?: boolean;
+}
+
+export function CloudTargetControl({
+  cloudTarget,
+  onCloudTargetChange,
+  options,
+  favoriteKey,
+  onToggleFavorite,
+  disabled,
+}: CloudTargetControlProps) {
+  const themeColors = useThemeColors();
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  const currentKey = cloudTargetKey(cloudTarget);
+  const currentName =
+    options.find((option) => option.key === currentKey)?.name ?? "Default";
+
+  return (
+    <>
+      <Pill
+        icon={<Cloud size={14} color={themeColors.gray[11]} />}
+        label={currentName}
+        onPress={() => setSheetOpen(true)}
+        disabled={disabled}
+      />
+
+      <SelectSheet
+        open={sheetOpen}
+        title="Cloud sandbox"
+        value={currentKey}
+        favoriteValue={favoriteKey}
+        onChange={(next) => {
+          const target = cloudTargetFromKey(next);
+          if (target) onCloudTargetChange(target);
+        }}
+        onToggleFavorite={(next) => {
+          const target = cloudTargetFromKey(next);
+          if (target) onToggleFavorite(target);
+        }}
+        onClose={() => setSheetOpen(false)}
+        options={options.map((option) => ({
+          value: option.key,
+          label: option.name,
+          description: option.description,
+        }))}
+      />
+    </>
+  );
+}

--- a/products/desktop/apps/mobile/src/features/tasks/composer/SelectSheet.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/SelectSheet.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@components/text";
-import { Check } from "phosphor-react-native";
+import { Check, Star } from "phosphor-react-native";
 import type { ReactNode } from "react";
 import { Pressable, ScrollView, View } from "react-native";
 import { SheetContainer } from "@/components/SheetContainer";
@@ -20,6 +20,10 @@ interface SelectSheetProps<T extends string> {
   value: T;
   onChange: (value: T) => void;
   onClose: () => void;
+  /** When set, each row shows a star. The value matching `favoriteValue` is
+   *  filled; tapping any star calls `onToggleFavorite` and does not select. */
+  favoriteValue?: T | null;
+  onToggleFavorite?: (value: T) => void;
 }
 
 export function SelectSheet<T extends string>({
@@ -29,8 +33,11 @@ export function SelectSheet<T extends string>({
   value,
   onChange,
   onClose,
+  favoriteValue,
+  onToggleFavorite,
 }: SelectSheetProps<T>) {
   const themeColors = useThemeColors();
+  const showFavorites = !!onToggleFavorite;
 
   return (
     <SheetContainer open={open} onClose={onClose}>
@@ -41,6 +48,7 @@ export function SelectSheet<T extends string>({
       <ScrollView className="max-h-96">
         {options.map((option) => {
           const selected = option.value === value;
+          const isFavorite = showFavorites && option.value === favoriteValue;
           return (
             <Pressable
               key={option.value}
@@ -71,6 +79,28 @@ export function SelectSheet<T extends string>({
               </View>
               {selected ? (
                 <Check size={16} color={themeColors.accent[9]} weight="bold" />
+              ) : null}
+              {showFavorites ? (
+                <Pressable
+                  hitSlop={10}
+                  onPress={() => onToggleFavorite?.(option.value)}
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    isFavorite
+                      ? `Stop using ${option.label} by default`
+                      : `Use ${option.label} by default`
+                  }
+                  accessibilityState={{ selected: isFavorite }}
+                  className="active:opacity-60"
+                >
+                  <Star
+                    size={16}
+                    color={
+                      isFavorite ? themeColors.gray[12] : themeColors.gray[10]
+                    }
+                    weight={isFavorite ? "fill" : "regular"}
+                  />
+                </Pressable>
               ) : null}
             </Pressable>
           );

--- a/products/desktop/apps/mobile/src/features/tasks/composer/cloudTargets.test.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/cloudTargets.test.ts
@@ -1,0 +1,172 @@
+import type {
+  SandboxCustomImage,
+  SandboxEnvironment,
+} from "@posthog/shared/domain-types";
+import { describe, expect, it } from "vitest";
+import {
+  buildCloudTargetOptions,
+  type CloudTarget,
+  cloudTargetFromKey,
+  cloudTargetIds,
+  cloudTargetKey,
+  moveFavoriteFirst,
+  resolveCloudTarget,
+} from "./cloudTargets";
+
+const env = (overrides: Partial<SandboxEnvironment>): SandboxEnvironment =>
+  ({
+    id: "env-1",
+    name: "Internal APIs",
+    network_access_level: "custom",
+    allowed_domains: ["github.com"],
+    custom_image_id: null,
+    ...overrides,
+  }) as SandboxEnvironment;
+
+const image = (overrides: Partial<SandboxCustomImage>): SandboxCustomImage =>
+  ({
+    id: "image-1",
+    name: "posthog stack",
+    status: "ready",
+    version: 279,
+    ...overrides,
+  }) as SandboxCustomImage;
+
+describe("cloudTargets", () => {
+  it("offers an image that no environment starts from", () => {
+    const options = buildCloudTargetOptions({
+      environments: [env({})],
+      images: [image({})],
+      imagesEnabled: true,
+    });
+
+    expect(options.map((option) => option.key)).toEqual([
+      "default",
+      "environment:env-1",
+      "image:image-1",
+    ]);
+  });
+
+  it.each([
+    [
+      "attached to an environment",
+      {
+        environments: [env({ custom_image_id: "image-1" })],
+        images: [image({})],
+        imagesEnabled: true,
+      },
+    ],
+    [
+      "not ready",
+      {
+        environments: [env({})],
+        images: [image({ status: "building" })],
+        imagesEnabled: true,
+      },
+    ],
+    [
+      "images are off",
+      {
+        environments: [env({})],
+        images: [image({})],
+        imagesEnabled: false,
+      },
+    ],
+  ])("hides an image that is %s", (_case, input) => {
+    const options = buildCloudTargetOptions(input);
+
+    expect(options.some((option) => option.key === "image:image-1")).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    [{ kind: "default" }, {}],
+    [{ kind: "environment", id: "env-1" }, { sandboxEnvironmentId: "env-1" }],
+    [{ kind: "image", id: "image-1" }, { customImageId: "image-1" }],
+  ] as [CloudTarget, ReturnType<typeof cloudTargetIds>][])(
+    "sends %o as %o",
+    (target, ids) => {
+      expect(cloudTargetIds(target)).toEqual(ids);
+      expect(cloudTargetFromKey(cloudTargetKey(target))).toEqual(target);
+    },
+  );
+
+  it("describes environments by network access level", () => {
+    const options = buildCloudTargetOptions({
+      environments: [
+        env({ id: "env-full", network_access_level: "full" }),
+        env({ id: "env-trusted", network_access_level: "trusted" }),
+        env({
+          id: "env-one",
+          network_access_level: "custom",
+          allowed_domains: ["github.com"],
+        }),
+        env({
+          id: "env-many",
+          network_access_level: "custom",
+          allowed_domains: ["github.com", "npm.org"],
+        }),
+      ],
+      images: [],
+      imagesEnabled: false,
+    });
+
+    expect(
+      options
+        .filter((o) => o.key.startsWith("environment:"))
+        .map((o) => ({
+          key: o.key,
+          description: o.description,
+        })),
+    ).toEqual([
+      { key: "environment:env-full", description: "Full network access" },
+      { key: "environment:env-trusted", description: "Trusted sources only" },
+      { key: "environment:env-one", description: "1 allowed domain" },
+      { key: "environment:env-many", description: "2 allowed domains" },
+    ]);
+  });
+
+  it("describes an image by version", () => {
+    const options = buildCloudTargetOptions({
+      environments: [],
+      images: [image({ version: 42 })],
+      imagesEnabled: true,
+    });
+
+    expect(options.find((o) => o.key === "image:image-1")?.description).toBe(
+      "Image v42, full network access",
+    );
+  });
+
+  it("returns null when decoding an unknown key", () => {
+    expect(cloudTargetFromKey(null)).toBeNull();
+    expect(cloudTargetFromKey("")).toBeNull();
+    expect(cloudTargetFromKey("environment")).toBeNull();
+    expect(cloudTargetFromKey("unknown:1")).toBeNull();
+  });
+
+  it("puts the favorite first", () => {
+    const options = buildCloudTargetOptions({
+      environments: [env({})],
+      images: [image({})],
+      imagesEnabled: true,
+    });
+
+    expect(
+      moveFavoriteFirst(options, "image:image-1").map((option) => option.key),
+    ).toEqual(["image:image-1", "default", "environment:env-1"]);
+  });
+
+  it("falls back to the default when the favorite is gone", () => {
+    const options = buildCloudTargetOptions({
+      environments: [],
+      images: [],
+      imagesEnabled: true,
+    });
+
+    expect(
+      resolveCloudTarget({ kind: "image", id: "image-1" }, options),
+    ).toEqual({ kind: "default" });
+  });
+});

--- a/products/desktop/apps/mobile/src/features/tasks/composer/cloudTargets.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/cloudTargets.ts
@@ -1,0 +1,111 @@
+import type {
+  SandboxCustomImage,
+  SandboxEnvironment,
+} from "@posthog/shared/domain-types";
+
+export type CloudTarget =
+  | { kind: "default" }
+  | { kind: "environment"; id: string }
+  | { kind: "image"; id: string };
+
+export const DEFAULT_CLOUD_TARGET: CloudTarget = { kind: "default" };
+
+export interface CloudTargetOption {
+  key: string;
+  target: CloudTarget;
+  name: string;
+  description: string;
+}
+
+export function cloudTargetKey(target: CloudTarget): string {
+  return target.kind === "default" ? "default" : `${target.kind}:${target.id}`;
+}
+
+export function cloudTargetFromKey(key: string | null): CloudTarget | null {
+  if (!key) return null;
+  if (key === "default") return DEFAULT_CLOUD_TARGET;
+  const [kind, id] = key.split(":");
+  if (!id) return null;
+  if (kind === "environment") return { kind: "environment", id };
+  if (kind === "image") return { kind: "image", id };
+  return null;
+}
+
+export function cloudTargetIds(target: CloudTarget): {
+  sandboxEnvironmentId?: string;
+  customImageId?: string;
+} {
+  if (target.kind === "environment") return { sandboxEnvironmentId: target.id };
+  if (target.kind === "image") return { customImageId: target.id };
+  return {};
+}
+
+function environmentDescription(environment: SandboxEnvironment): string {
+  if (environment.network_access_level === "full") return "Full network access";
+  if (environment.network_access_level === "trusted") {
+    return "Trusted sources only";
+  }
+  const count = environment.allowed_domains.length;
+  return `${count} allowed domain${count === 1 ? "" : "s"}`;
+}
+
+export function buildCloudTargetOptions({
+  environments,
+  images,
+  imagesEnabled,
+}: {
+  environments: readonly SandboxEnvironment[];
+  images: readonly SandboxCustomImage[];
+  imagesEnabled: boolean;
+}): CloudTargetOption[] {
+  const attachedImageIds = new Set(
+    environments.flatMap((environment) =>
+      environment.custom_image_id ? [environment.custom_image_id] : [],
+    ),
+  );
+  const standaloneImages = imagesEnabled
+    ? images.filter(
+        (image) => image.status === "ready" && !attachedImageIds.has(image.id),
+      )
+    : [];
+
+  return [
+    {
+      key: "default",
+      target: DEFAULT_CLOUD_TARGET,
+      name: "Default",
+      description: "Full network access",
+    },
+    ...environments.map((environment) => ({
+      key: cloudTargetKey({ kind: "environment", id: environment.id }),
+      target: { kind: "environment" as const, id: environment.id },
+      name: environment.name,
+      description: environmentDescription(environment),
+    })),
+    ...standaloneImages.map((image) => ({
+      key: cloudTargetKey({ kind: "image", id: image.id }),
+      target: { kind: "image" as const, id: image.id },
+      name: image.name,
+      description: `Image v${image.version}, full network access`,
+    })),
+  ];
+}
+
+export function resolveCloudTarget(
+  favorite: CloudTarget | null,
+  options: readonly CloudTargetOption[],
+): CloudTarget {
+  if (!favorite) return DEFAULT_CLOUD_TARGET;
+  return options.some((option) => option.key === cloudTargetKey(favorite))
+    ? favorite
+    : DEFAULT_CLOUD_TARGET;
+}
+
+export function moveFavoriteFirst(
+  options: readonly CloudTargetOption[],
+  favoriteKey: string | null,
+): CloudTargetOption[] {
+  const favorite = options.find((option) => option.key === favoriteKey);
+  if (!favorite) return [...options];
+  return [favorite, ...options.filter((option) => option !== favorite)];
+}

--- a/products/desktop/apps/mobile/src/features/tasks/composer/useCloudTargetSelection.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/useCloudTargetSelection.ts
@@ -1,0 +1,107 @@
+import { SandboxCustomImagesDisabledError } from "@posthog/api-client/posthog-client";
+import { useQuery } from "@tanstack/react-query";
+import { useFeatureFlag } from "posthog-react-native";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAuthStore } from "@/features/auth";
+import { usePreferencesStore } from "@/features/preferences/stores/preferencesStore";
+import { sandboxKeys } from "@/features/tasks/hooks/useCustomImageName";
+import { getPostHogApiClient } from "@/lib/posthogApiClient";
+import {
+  buildCloudTargetOptions,
+  type CloudTarget,
+  type CloudTargetOption,
+  cloudTargetFromKey,
+  cloudTargetKey,
+  DEFAULT_CLOUD_TARGET,
+  moveFavoriteFirst,
+  resolveCloudTarget,
+} from "./cloudTargets";
+
+const CUSTOM_IMAGES_FEATURE_FLAG = "tasks-modal-vm-sandbox";
+
+export interface UseCloudTargetSelectionResult {
+  cloudTarget: CloudTarget;
+  setCloudTarget: (target: CloudTarget) => void;
+  options: CloudTargetOption[];
+  favoriteKey: string | null;
+  toggleFavorite: (target: CloudTarget) => void;
+  isLoaded: boolean;
+}
+
+export function useCloudTargetSelection(): UseCloudTargetSelectionResult {
+  const { projectId, oauthAccessToken } = useAuthStore();
+  const canQuery = !!projectId && !!oauthAccessToken;
+  const imagesFlagEnabled = !!useFeatureFlag(CUSTOM_IMAGES_FEATURE_FLAG);
+
+  const environmentsQuery = useQuery({
+    queryKey: sandboxKeys.environments(),
+    queryFn: () => getPostHogApiClient().listSandboxEnvironments(),
+    enabled: canQuery,
+    staleTime: 60_000,
+    retry: 0,
+  });
+
+  const imagesQuery = useQuery({
+    queryKey: sandboxKeys.customImages(),
+    queryFn: () => getPostHogApiClient().listSandboxCustomImages(),
+    enabled: canQuery && imagesFlagEnabled,
+    staleTime: 60_000,
+    retry: (failureCount, error) =>
+      !(error instanceof SandboxCustomImagesDisabledError) && failureCount < 2,
+  });
+
+  const favoriteKey = usePreferencesStore((s) => s.favoriteCloudTargetKey);
+  const setFavoriteKey = usePreferencesStore(
+    (s) => s.setFavoriteCloudTargetKey,
+  );
+
+  const imagesEnabled = imagesFlagEnabled && imagesQuery.data !== undefined;
+  const options = useMemo(
+    () =>
+      moveFavoriteFirst(
+        buildCloudTargetOptions({
+          environments: environmentsQuery.data ?? [],
+          images: imagesQuery.data ?? [],
+          imagesEnabled,
+        }),
+        favoriteKey,
+      ),
+    [environmentsQuery.data, imagesQuery.data, imagesEnabled, favoriteKey],
+  );
+
+  const isLoaded = !environmentsQuery.isLoading && !imagesQuery.isLoading;
+
+  const [cloudTarget, setCloudTargetState] =
+    useState<CloudTarget>(DEFAULT_CLOUD_TARGET);
+  const didResolveRef = useRef(false);
+
+  useEffect(() => {
+    if (didResolveRef.current || !isLoaded) return;
+    didResolveRef.current = true;
+    setCloudTargetState(
+      resolveCloudTarget(cloudTargetFromKey(favoriteKey), options),
+    );
+  }, [isLoaded, favoriteKey, options]);
+
+  const setCloudTarget = useCallback((target: CloudTarget) => {
+    didResolveRef.current = true;
+    setCloudTargetState(target);
+  }, []);
+
+  const toggleFavorite = useCallback(
+    (target: CloudTarget) => {
+      const key = cloudTargetKey(target);
+      setFavoriteKey(favoriteKey === key ? null : key);
+    },
+    [favoriteKey, setFavoriteKey],
+  );
+
+  return {
+    cloudTarget,
+    setCloudTarget,
+    options,
+    favoriteKey,
+    toggleFavorite,
+    isLoaded,
+  };
+}


### PR DESCRIPTION
## Problem

Port of #91224. On the desktop app, a person creating a cloud task can pick which sandbox it runs in and star a default. The mobile composer had no such control — every cloud task ran in the default sandbox, even when the person had saved environments or standalone custom images ready to use.

## Changes

- New cloud-sandbox pill on the mobile new-task composer, next to the agent config pill. Only shows when the account has an environment or a standalone ready custom image, so accounts with nothing to pick see no extra chrome.
- The picker sheet lists the default sandbox first, then every saved sandbox environment, then any standalone ready custom images. An image is standalone only when its status is ready and no environment references it. Custom images appear only when the custom-images feature flag is on.
- Each row has a star. Starring a target persists it as the favorite in mobile preferences, moves it to the top of the sheet, and pre-selects it the next time the composer opens. Starring an already-starred target clears the favorite. Falls back to the default when the favorite no longer matches any option.
- The selected environment or image id flows into `runTaskInCloud` via the existing `sandboxEnvironmentId` / `customImageId` fields on the mobile API layer.
- New portable module `composer/cloudTargets.ts` holds the option-building, key encoding, ordering, and resolution logic — mirrors the desktop `packages/ui/src/features/task-detail/cloudTargets.ts` shape so the rules stay identical across hosts. Unit tests cover option building, image visibility gating, key roundtripping, favorite ordering, and fallback resolution.
- `SelectSheet` gains an optional `favoriteValue` + `onToggleFavorite` pair, so the same sheet renders a star column when a caller opts in.

## How did you test this code?

- `pnpm --filter @posthog/mobile test` — 68 files, 623 tests passing, including the new `cloudTargets.test.ts` (12 cases).
- `pnpm --filter @posthog/mobile lint`, `pnpm --filter @posthog/mobile format`.
- `node scripts/check-mobile-types.mjs` — no new type errors; baseline unchanged at 44.
- No manual device testing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Ported the desktop PR to mobile: kept the portable logic module identical to the desktop one so the rules (favorite ordering, image standalone-ness, environment descriptions, fallback resolution) stay in lockstep across hosts, then wired it through mobile's existing composer patterns (Pill + SelectSheet, preferences store, \`runTaskInCloud\` call). Extended \`SelectSheet\` instead of forking a sibling sheet: the star column is opt-in via two extra props, so every existing caller stays untouched.

Skills invoked: \`/writing-pr-descriptions\`, \`/simplify\` (pruned two low-value tests that didn't catch anything the remaining cases missed).

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*