### PR TITLE
fix(dashboards): stop an empty filter override reading as an active one

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
+++ b/frontend/src/scenes/dashboard/DashboardOverridesBanner.tsx
@@ -9,10 +9,10 @@ import { DashboardMode } from '~/types'
 import { dashboardLogic } from './dashboardLogic'
 
 export const DashboardOverridesBanner = (): JSX.Element | null => {
-    const { dashboardMode, urlFilters, cancellingPreview } = useValues(dashboardLogic)
+    const { dashboardMode, hasUrlFilters, cancellingPreview } = useValues(dashboardLogic)
     const { setDashboardMode } = useActions(dashboardLogic)
 
-    if (dashboardMode === DashboardMode.Edit || Object.keys(urlFilters).length === 0) {
+    if (dashboardMode === DashboardMode.Edit || !hasUrlFilters) {
         return null
     }
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1165,6 +1165,46 @@ describe('dashboardLogic', () => {
             })
         })
 
+        describe('url filter overrides', () => {
+            const PROPERTY_OVERRIDE = [{ key: '$browser', value: 'Chrome', type: 'event' }]
+
+            const openWithUrlFilters = async (urlFilters: Record<string, any>): Promise<void> => {
+                logic.unmount()
+                router.actions.push('/dashboard/5', {
+                    [dashboardUtils.SEARCH_PARAM_FILTERS_KEY]: JSON.stringify(urlFilters),
+                })
+                logic = dashboardLogic({ id: 5 })
+                logic.mount()
+                await expectLogic(logic).toFinishAllListeners()
+            }
+
+            // The overrides banner renders off hasUrlFilters. An override that constrains nothing still
+            // has keys, so testing for key presence announces overrides on a dashboard that is showing
+            // exactly its saved state.
+            const activeOverrideCases: [string, Record<string, any>, boolean][] = [
+                ['a date override is active', { date_from: '-7d', date_to: null }, true],
+                ['a property override is active', { properties: PROPERTY_OVERRIDE }, true],
+                ['properties cleared to empty is not active', { properties: [] }, false],
+            ]
+
+            it.each(activeOverrideCases)('%s', async (_name, urlFilters, expected) => {
+                await openWithUrlFilters(urlFilters)
+
+                expect(logic.values.hasUrlFilters).toBe(expected)
+            })
+
+            it('drops the url param when the last filter is cleared', async () => {
+                await openWithUrlFilters({ properties: PROPERTY_OVERRIDE })
+                expect(router.values.searchParams[dashboardUtils.SEARCH_PARAM_FILTERS_KEY]).not.toBeUndefined()
+
+                await expectLogic(logic, () => {
+                    logic.actions.setProperties([])
+                }).toFinishAllListeners()
+
+                expect(router.values.searchParams[dashboardUtils.SEARCH_PARAM_FILTERS_KEY]).toBeUndefined()
+            })
+        })
+
         describe('hasUnsavedLayoutChanges selector', () => {
             const moveFirstTile = (): void => {
                 const firstTile = logic.values.dashboard!.tiles[0]

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -133,6 +133,7 @@ import {
     mergeBreakdownColorConfigs,
 } from './dashboardBreakdownColors'
 import { AUTO_REFRESH_INITIAL_INTERVAL_SECONDS } from './dashboardConstants'
+import { isDashboardFilterEmpty } from './dashboardFilterEmpty'
 import {
     BREAKPOINT_COLUMN_COUNTS,
     DASHBOARD_MIN_REFRESH_INTERVAL_MINUTES,
@@ -153,6 +154,7 @@ import {
     parseURLFilters,
     parseURLVariables,
     runWithLimit,
+    searchParamsWithUrlFilters,
     shouldSharedDashboardAutoForceForStaleTime,
     shouldSnapshotUrlAtEditModeEntry,
 } from './dashboardUtils'
@@ -2543,10 +2545,10 @@ export const dashboardLogic = kea<dashboardLogicType>([
             (intermittentFilters: DashboardFilter) =>
                 Object.values(intermittentFilters).some((filter) => filter !== undefined),
         ],
-        hasUrlFilters: [
-            (s) => [s.urlFilters],
-            (urlFilters: DashboardFilter) => Object.values(urlFilters).some((filter) => filter !== undefined),
-        ],
+        // An override that constrains nothing still has keys — clearing the last property filter leaves
+        // `{"properties":[]}` in the URL. Counting keys reads that as an active override, so the dashboard
+        // announces overrides while showing exactly its saved state.
+        hasUrlFilters: [(s) => [s.urlFilters], (urlFilters: DashboardFilter) => !isDashboardFilterEmpty(urlFilters)],
         showApplyFiltersBanner: [
             (s) => [s.canAutoPreview, s.hasIntermittentFilters],
             (canAutoPreview: boolean, hasIntermittentFilters: boolean) => !canAutoPreview && hasIntermittentFilters,
@@ -4774,13 +4776,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
             const urlFilters = parseURLFilters(currentLocation.searchParams)
             const newUrlFilters: DashboardFilter = combineDashboardFilters(urlFilters, values.intermittentFilters)
 
-            const newSearchParams = {
-                ...currentLocation.searchParams,
-            }
-
             return [
                 currentLocation.pathname,
-                { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
                 currentLocation.hashParams,
             ]
         },
@@ -4797,13 +4795,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 properties,
             }
 
-            const newSearchParams = {
-                ...currentLocation.searchParams,
-            }
-
             return [
                 currentLocation.pathname,
-                { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
                 currentLocation.hashParams,
             ]
         },
@@ -4822,13 +4816,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 explicitDate: explicit_date ?? values.intermittentFilters.explicitDate,
             }
 
-            const newSearchParams = {
-                ...currentLocation.searchParams,
-            }
-
             return [
                 currentLocation.pathname,
-                { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
                 currentLocation.hashParams,
             ]
         },
@@ -4845,13 +4835,9 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 breakdown_filter,
             }
 
-            const newSearchParams = {
-                ...currentLocation.searchParams,
-            }
-
             return [
                 currentLocation.pathname,
-                { ...newSearchParams, ...encodeURLFilters(newUrlFilters) },
+                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
                 currentLocation.hashParams,
             ]
         },
@@ -4870,7 +4856,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                { ...currentLocation.searchParams, ...encodeURLFilters(newUrlFilters) },
+                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
                 currentLocation.hashParams,
             ]
         },
@@ -4889,7 +4875,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             return [
                 currentLocation.pathname,
-                { ...currentLocation.searchParams, ...encodeURLFilters(newUrlFilters) },
+                searchParamsWithUrlFilters(currentLocation.searchParams, newUrlFilters),
                 currentLocation.hashParams,
             ]
         },

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -32,6 +32,7 @@ import {
 } from '~/types'
 
 import { SHARED_DASHBOARD_AUTO_FORCE_IF_STALE_MINUTES } from './dashboardConstants'
+import { isDashboardFilterEmpty } from './dashboardFilterEmpty'
 
 export function getInsightQueryError(insight: QueryBasedInsightModel): ApiError | null {
     const queryStatus = insight.query_status
@@ -453,6 +454,23 @@ export const encodeURLFilters = (filters: DashboardFilter): Record<string, strin
     }
 
     return encodedFilters
+}
+
+/**
+ * Search params for a dashboard filter change. A filter that constrains nothing drops the param instead
+ * of writing an empty one, so clearing the last filter doesn't leave the dashboard looking overridden on
+ * its next load. Spreading the encoded filter can't do this — it never removes a key already in the URL.
+ */
+export function searchParamsWithUrlFilters(
+    searchParams: Record<string, any>,
+    filters: DashboardFilter
+): Record<string, any> {
+    const nextSearchParams = { ...searchParams }
+    if (isDashboardFilterEmpty(filters)) {
+        delete nextSearchParams[SEARCH_PARAM_FILTERS_KEY]
+        return nextSearchParams
+    }
+    return { ...nextSearchParams, ...encodeURLFilters(filters) }
 }
 
 export function combineDashboardFilters(...filters: DashboardFilter[]): DashboardFilter {


### PR DESCRIPTION
## Problem

A dashboard tells you it is filtered when it is not. Clear the last dashboard filter, reload, and the blue **"You are viewing this dashboard with filter overrides"** banner is back — on a dashboard showing exactly its saved state. There is no Save button to reconcile it either, because that only appears in edit mode, so there is no way to tell which state the dashboard is in or to get out of it.

Clearing the last filter leaves `query_filters={"properties":[]}` in the URL. The banner tested for key presence, and an empty list is still a key.

Reported through in-app support.

## Changes

- The overrides banner stays hidden when the URL override constrains nothing, so a dashboard in its saved state stops claiming otherwise. It asks whether the filter means anything, using the existing `isDashboardFilterEmpty` helper that the insight side already uses for this same question.
- Clearing the last filter removes `query_filters` from the URL instead of leaving an empty one behind. Spreading the encoded filter over the existing search params could never remove a key already there, which is why the stale param survived.
- Mechanical: `hasUrlFilters` had no consumers. The banner now reads it instead of computing its own answer, so one selector holds the definition.

No screenshot: this sandbox has no dev stack, so the before and after could not be captured. The visible difference is the banner's presence on the reload described above.

> [!NOTE]
> One case stays unhandled. On a dashboard that has *saved* property filters, clearing them is a real override — the data changes — but it now reads as empty, so the banner won't flag it and the param is dropped, meaning the cleared view no longer survives a reload. Telling that apart needs the override compared against the persisted filters rather than tested for emptiness, which is a larger change than this one.

## How did you test this code?

Three cases in `dashboardLogic.test.ts`: two parameterized selector cases covering an active override versus an emptied one, and one asserting the URL param is dropped when the last filter is cleared.

Both new assertions were confirmed to fail on `master` before the fix, with the exact reported symptoms — `hasUrlFilters` returning `true` for `{"properties":[]}`, and the URL holding `{"properties":[]}`. The two control cases (a real date override, a real property override) pass on `master` too, so the tests fail for the intended reason rather than from broken setup.

Full `scenes/dashboard` suite passes (447). Typecheck reports the same error count with and without this diff — all pre-existing, from an unbuilt nested workspace.

Not run: the app itself. No manual click-through.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Left unassigned deliberately: a person directed this work, but this session had no verified GitHub handle for them, and guessing one assigns a stranger. The requester should assign themselves.

Written by Claude Code (PostHog Desktop). Skills: `/writing-tests` and `/writing-pr-descriptions` were both unresolvable in this session, so the repo's own guidance was read directly instead — `.agents/skills/writing-tests/SKILL.md` for the value gate and `.github/pull_request_template.md` plus `CLAUDE.md` for this body.

Found while investigating a different reported symptom. The first candidate fix — [#91478](https://github.com/PostHog/posthog/pull/91478), which stops URL overrides riding into an unrelated save — turned out to address a real but separate defect that the report did not describe. This PR is the one that matches the reported behavior. The two are independent and this branch is cut from `master`, not stacked on that one.

The naive version of this fix was rejected mid-session: dropping the param unconditionally, or treating any empty filter as no override, silently breaks the saved-property case now recorded in the Note above. That case is left explicit rather than papered over.

`/simplify` was not run; the diff is 4 files and under 50 net lines.
