### PR TITLE
fix(signals): stop inbox evidence badges spilling past the card

### DIFF
--- a/products/signals/frontend/inbox/components/signalCards/SignalCardShell.tsx
+++ b/products/signals/frontend/inbox/components/signalCards/SignalCardShell.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { createContext, useContext } from 'react'
 
 import { IconChevronDown, IconChevronRight } from '@posthog/icons'
@@ -55,7 +56,10 @@ export function SignalCardHeader({
 
     return (
         <div
-            className={disclosure && !disclosure.expanded ? 'flex items-center gap-2' : 'flex items-center gap-2 mb-2'}
+            className={clsx(
+                'flex flex-wrap items-center gap-x-2 gap-y-1',
+                (!disclosure || disclosure.expanded) && 'mb-2'
+            )}
         >
             {Icon ? (
                 <span className="inline-flex shrink-0 items-center" aria-hidden>
@@ -75,19 +79,20 @@ export function SignalCardHeader({
                 {' · '}
                 <TZLabel time={signal.timestamp} />
             </span>
-            {label && <span className="text-xs font-medium text-primary flex-1 truncate">{label}</span>}
-            <span className="flex-1" />
-            {rightSlot}
-            {disclosure ? (
-                <LemonButton
-                    type="tertiary"
-                    size="xsmall"
-                    icon={disclosure.expanded ? <IconChevronDown /> : <IconChevronRight />}
-                    aria-label={disclosure.expanded ? 'Collapse signal details' : 'Expand signal details'}
-                    onClick={() => disclosure.onChange(!disclosure.expanded)}
-                    className="shrink-0"
-                />
-            ) : null}
+            {label && <span className="text-xs font-medium text-primary flex-1 min-w-0 truncate">{label}</span>}
+            {/* Badges and the chevron stay together, and drop to their own line before they can spill past the card. */}
+            <div className="flex items-center gap-2 ml-auto shrink-0">
+                {rightSlot}
+                {disclosure ? (
+                    <LemonButton
+                        type="tertiary"
+                        size="xsmall"
+                        icon={disclosure.expanded ? <IconChevronDown /> : <IconChevronRight />}
+                        aria-label={disclosure.expanded ? 'Collapse signal details' : 'Expand signal details'}
+                        onClick={() => disclosure.onChange(!disclosure.expanded)}
+                    />
+                ) : null}
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

In the Inbox evidence rail, a replay-vision finding's "Bug" and "90% confidence" badges hang outside the card, over the panel next to it. The scanner name that should sit in the same row is squeezed to zero width and disappears.

The header row is a single non-wrapping flex row. The source line is `whitespace-nowrap` and the badge cluster is `shrink-0`, so neither gives when the rail is narrow. The rail is 375px in a 1280px window, well under what that row needs.

## Changes

- Badges now drop to their own line, right-aligned, instead of crossing the card border.
- The scanner name is readable again. A `flex-1` spacer span used to take half the leftover width from the `flex-1` label; removing it gives the label the full remainder.
- The header row wraps, the badges and the expand chevron move into one group at the end of it, and the label gets `min-w-0` so it truncates rather than pushing the row wider.

Layout only. No copy, data, or behavior changes.

![before](https://raw.githubusercontent.com/PostHog/pr-assets/44a40328b2a71d4ca351e418ef56ab77edaafea7/2026/08/68c6a012-220b-4dff-a247-cc9ac2d1b6e3.png)

![after](https://raw.githubusercontent.com/PostHog/pr-assets/44a40328b2a71d4ca351e418ef56ab77edaafea7/2026/08/a3e9d243-016d-4696-94a2-6df4bcb549a4.png)

## How did you test this code?

Rendered `Scenes-App/Inbox/Signal cards` in Storybook and measured, for every card, the gap between the rightmost badge's right edge and the card's right edge.

| Rail width | Before | After |
| --- | --- | --- |
| 416px (story default) | +54px past the edge | 13px inside |
| 375px (the real rail) | not measured | 13px inside |
| 320px | not measured | 13px inside |
| 240px | not measured | 13px inside |

Also rendered `Scenes-App/Inbox/Detail` to confirm cards carrying a single badge still fit on one line and look unchanged.

Ran the existing `signalCards` Jest suite. No new test: this is a layout regression that jsdom cannot measure, and the affected stories are already covered by visual regression snapshots, which this change will move.

Not run: `tsgo --noEmit`, which the sandbox kills for memory. CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported from Slack with a screenshot of the overflow. Written by the PostHog Slack app (Claude Code). Skills invoked: `/writing-pr-descriptions`.

Two fixes were considered. Truncating the source line keeps one line but loses the timestamp, which is the more useful of the two. Wrapping the badges keeps everything readable and costs one line only when the rail is too narrow, so it won.

No customer data or session material is in this diff. The screenshots come from Storybook fixtures already in the repo.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788173223899129)*
