### PR TITLE
fix(clickhouse): repair multinode schema drift

### DIFF
--- a/posthog/clickhouse/hcl/golden/dev/batch_exports.hcl
+++ b/posthog/clickhouse/hcl/golden/dev/batch_exports.hcl
@@ -351,7 +351,7 @@ database "posthog" {
   table "sharded_events_recent" {
     order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
     partition_by = "toStartOfDay(inserted_at)"
-    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    ttl          = "toDate(inserted_at) + toIntervalDay(9)"
     settings = {
       index_granularity     = "8192"
       parts_to_delay_insert = "800"

--- a/posthog/clickhouse/hcl/golden/local-multi/data.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/data.hcl
@@ -6056,7 +6056,7 @@ database "posthog" {
   table "sharded_events_recent" {
     order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
     partition_by = "toStartOfDay(inserted_at)"
-    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    ttl          = "toDate(inserted_at) + toIntervalDay(9)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"

--- a/posthog/clickhouse/hcl/golden/local-multi/logs.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/logs.hcl
@@ -523,6 +523,12 @@ database "posthog" {
       type  = "UInt64"
       codec = "DoubleDelta, ZSTD(1)"
     }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
+    }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"
       remote_database = "posthog"
@@ -669,6 +675,12 @@ database "posthog" {
     column "_record_count" {
       type  = "UInt64"
       codec = "DoubleDelta, ZSTD(1)"
+    }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
     }
     index "idx_severity_text_set" {
       expr        = "severity_text"

--- a/posthog/clickhouse/hcl/golden/local-single/all.hcl
+++ b/posthog/clickhouse/hcl/golden/local-single/all.hcl
@@ -4931,6 +4931,12 @@ database "posthog" {
       type  = "UInt64"
       codec = "DoubleDelta, ZSTD(1)"
     }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
+    }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"
       remote_database = "posthog"
@@ -5077,6 +5083,12 @@ database "posthog" {
     column "_record_count" {
       type  = "UInt64"
       codec = "DoubleDelta, ZSTD(1)"
+    }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
     }
     index "idx_severity_text_set" {
       expr        = "severity_text"
@@ -10352,7 +10364,7 @@ SQL
   table "sharded_events_recent" {
     order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
     partition_by = "toStartOfDay(inserted_at)"
-    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    ttl          = "toDate(inserted_at) + toIntervalDay(9)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"

--- a/posthog/clickhouse/hcl/golden/prod-eu/batch_exports.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-eu/batch_exports.hcl
@@ -351,7 +351,7 @@ database "posthog" {
   table "sharded_events_recent" {
     order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
     partition_by = "toStartOfDay(inserted_at)"
-    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    ttl          = "toDate(inserted_at) + toIntervalDay(9)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"

--- a/posthog/clickhouse/hcl/golden/prod-us/batch_exports.hcl
+++ b/posthog/clickhouse/hcl/golden/prod-us/batch_exports.hcl
@@ -351,7 +351,7 @@ database "posthog" {
   table "sharded_events_recent" {
     order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
     partition_by = "toStartOfDay(inserted_at)"
-    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    ttl          = "toDate(inserted_at) + toIntervalDay(9)"
     settings = {
       index_granularity     = "8192"
       parts_to_delay_insert = "800"

--- a/posthog/clickhouse/hcl/roles/batch_exports/prod-us/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/batch_exports/prod-us/tables.hcl
@@ -3,7 +3,7 @@ database "posthog" {
     override = true
     order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
     partition_by = "toStartOfDay(inserted_at)"
-    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    ttl          = "toDate(inserted_at) + toIntervalDay(9)"
     settings = {
       index_granularity     = "8192"
       parts_to_delay_insert = "800"

--- a/posthog/clickhouse/hcl/roles/coshared/batch_exports_data/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/coshared/batch_exports_data/tables.hcl
@@ -6,7 +6,7 @@ database "posthog" {
   table "sharded_events_recent" {
     order_by     = ["team_id", "toStartOfHour(inserted_at)", "event", "cityHash64(distinct_id)", "cityHash64(uuid)"]
     partition_by = "toStartOfDay(inserted_at)"
-    ttl          = "toDateTime(inserted_at) + toIntervalDay(7)"
+    ttl          = "toDate(inserted_at) + toIntervalDay(9)"
     settings = {
       index_granularity   = "8192"
       ttl_only_drop_parts = "1"

--- a/posthog/clickhouse/hcl/roles/logs/local/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/logs/local/tables.hcl
@@ -196,6 +196,12 @@ database "posthog" {
       type  = "UInt64"
       codec = "DoubleDelta, ZSTD(1)"
     }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
+    }
     engine "distributed" {
       cluster_name    = "posthog_single_shard"
       remote_database = "posthog"
@@ -341,6 +347,12 @@ database "posthog" {
     column "_record_count" {
       type  = "UInt64"
       codec = "DoubleDelta, ZSTD(1)"
+    }
+    column "pattern" {
+      type = "String"
+    }
+    column "pattern_version" {
+      type = "UInt8"
     }
     index "idx_severity_text_set" {
       expr        = "severity_text"

--- a/posthog/clickhouse/hcl/sql/dev/batch_exports.sql
+++ b/posthog/clickhouse/hcl/sql/dev/batch_exports.sql
@@ -122,7 +122,7 @@ CREATE TABLE posthog.sharded_events_recent (
   _timestamp DateTime,
   _offset UInt64,
   inserted_at DateTime64(6, 'UTC') DEFAULT now64()
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDateTime(inserted_at) + toIntervalDay(7) SETTINGS index_granularity = 8192, parts_to_delay_insert = 800, parts_to_throw_insert = 1500, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDate(inserted_at) + toIntervalDay(9) SETTINGS index_granularity = 8192, parts_to_delay_insert = 800, parts_to_throw_insert = 1500, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.writable_query_log_archive (
   hostname LowCardinality(String),
   user LowCardinality(String),

--- a/posthog/clickhouse/hcl/sql/local-multi/data.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/data.sql
@@ -1172,7 +1172,7 @@ CREATE TABLE posthog.sharded_events_recent (
   _timestamp DateTime,
   _offset UInt64,
   inserted_at DateTime64(6, 'UTC') DEFAULT now64()
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDateTime(inserted_at) + toIntervalDay(7) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDate(inserted_at) + toIntervalDay(9) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.sharded_experiment_exposures_preaggregated (
   team_id Int64,
   job_id UUID,

--- a/posthog/clickhouse/hcl/sql/local-multi/logs.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/logs.sql
@@ -136,6 +136,8 @@ CREATE TABLE posthog.logs32 (
   _bytes_uncompressed UInt64 CODEC(DoubleDelta, ZSTD(1)),
   _bytes_compressed UInt64 CODEC(DoubleDelta, ZSTD(1)),
   _record_count UInt64 CODEC(DoubleDelta, ZSTD(1)),
+  pattern String,
+  pattern_version UInt8,
   INDEX idx_severity_text_set severity_text TYPE set(10) GRANULARITY 1,
   INDEX idx_attributes_str_keys mapKeys(attributes_map_str) TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX idx_attributes_str_values mapValues(attributes_map_str) TYPE bloom_filter(0.001) GRANULARITY 1,
@@ -1222,7 +1224,9 @@ CREATE TABLE posthog.logs (
   _offset UInt64 CODEC(DoubleDelta, ZSTD(1)),
   _bytes_uncompressed UInt64 CODEC(DoubleDelta, ZSTD(1)),
   _bytes_compressed UInt64 CODEC(DoubleDelta, ZSTD(1)),
-  _record_count UInt64 CODEC(DoubleDelta, ZSTD(1))
+  _record_count UInt64 CODEC(DoubleDelta, ZSTD(1)),
+  pattern String,
+  pattern_version UInt8
 ) ENGINE = Distributed('posthog_single_shard', 'posthog', 'logs32');
 CREATE TABLE posthog.metric_samples (
   team_id Int32,

--- a/posthog/clickhouse/hcl/sql/local-single/all.sql
+++ b/posthog/clickhouse/hcl/sql/local-single/all.sql
@@ -973,6 +973,8 @@ CREATE TABLE posthog.logs32 (
   _bytes_uncompressed UInt64 CODEC(DoubleDelta, ZSTD(1)),
   _bytes_compressed UInt64 CODEC(DoubleDelta, ZSTD(1)),
   _record_count UInt64 CODEC(DoubleDelta, ZSTD(1)),
+  pattern String,
+  pattern_version UInt8,
   INDEX idx_severity_text_set severity_text TYPE set(10) GRANULARITY 1,
   INDEX idx_attributes_str_keys mapKeys(attributes_map_str) TYPE bloom_filter(0.01) GRANULARITY 1,
   INDEX idx_attributes_str_values mapValues(attributes_map_str) TYPE bloom_filter(0.001) GRANULARITY 1,
@@ -1895,7 +1897,7 @@ CREATE TABLE posthog.sharded_events_recent (
   _timestamp DateTime,
   _offset UInt64,
   inserted_at DateTime64(6, 'UTC') DEFAULT now64()
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDateTime(inserted_at) + toIntervalDay(7) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDate(inserted_at) + toIntervalDay(9) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.sharded_experiment_exposures_preaggregated (
   team_id Int64,
   job_id UUID,
@@ -6145,7 +6147,9 @@ CREATE TABLE posthog.logs (
   _offset UInt64 CODEC(DoubleDelta, ZSTD(1)),
   _bytes_uncompressed UInt64 CODEC(DoubleDelta, ZSTD(1)),
   _bytes_compressed UInt64 CODEC(DoubleDelta, ZSTD(1)),
-  _record_count UInt64 CODEC(DoubleDelta, ZSTD(1))
+  _record_count UInt64 CODEC(DoubleDelta, ZSTD(1)),
+  pattern String,
+  pattern_version UInt8
 ) ENGINE = Distributed('posthog_single_shard', 'posthog', 'logs32');
 CREATE TABLE posthog.marketing_conversions_preaggregated (
   team_id Int64,

--- a/posthog/clickhouse/hcl/sql/prod-eu/batch_exports.sql
+++ b/posthog/clickhouse/hcl/sql/prod-eu/batch_exports.sql
@@ -123,7 +123,7 @@ CREATE TABLE posthog.sharded_events_recent (
   _timestamp DateTime,
   _offset UInt64,
   inserted_at DateTime64(6, 'UTC') DEFAULT now64()
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDateTime(inserted_at) + toIntervalDay(7) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDate(inserted_at) + toIntervalDay(9) SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.writable_query_log_archive (
   hostname LowCardinality(String),
   user LowCardinality(String),

--- a/posthog/clickhouse/hcl/sql/prod-us/batch_exports.sql
+++ b/posthog/clickhouse/hcl/sql/prod-us/batch_exports.sql
@@ -122,7 +122,7 @@ CREATE TABLE posthog.sharded_events_recent (
   _timestamp DateTime,
   _offset UInt64,
   inserted_at DateTime64(6, 'UTC') DEFAULT now64()
-) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDateTime(inserted_at) + toIntervalDay(7) SETTINGS index_granularity = 8192, parts_to_delay_insert = 800, parts_to_throw_insert = 1500, ttl_only_drop_parts = 1;
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/batch_exports/{shard}/posthog.sharded_events_recent', '{replica}', _timestamp) ORDER BY (team_id, toStartOfHour(inserted_at), event, cityHash64(distinct_id), cityHash64(uuid)) PARTITION BY toStartOfDay(inserted_at) TTL toDate(inserted_at) + toIntervalDay(9) SETTINGS index_granularity = 8192, parts_to_delay_insert = 800, parts_to_throw_insert = 1500, ttl_only_drop_parts = 1;
 CREATE TABLE posthog.writable_query_log_archive (
   hostname LowCardinality(String),
   user LowCardinality(String),


### PR DESCRIPTION
## Problem

Engineers cannot validate ClickHouse migrations because the multinode smoke test finds unrelated schema drift already present on `master`.

The [failing `master` run](https://github.com/PostHog/posthog/actions/runs/33386787125) completed all migrations, then failed while comparing the live topology with HCL.

The smoke test starts an empty per-role topology, replays every ClickHouse migration, dumps each node, and compares the result with committed HCL goldens.

### Root cause analysis

Two independent changes updated executable schema builders without updating every declarative HCL definition that represents those tables.

#### Local logs tables

1. [#90725](https://github.com/PostHog/posthog/pull/90725) added `pattern` and `pattern_version` to `LOGS32_TABLE_SQL` for local and test schemas.
2. Historical migration `0211_logs32` calls that builder at runtime, so a fresh replay now creates `logs32` with both columns.
3. Historical migration `0214_logs` creates the local `logs` table from `logs32`, so the distributed table also exposes both columns.
4. The local HCL definitions for the legacy `logs32` and `logs` names still omitted both columns.
5. Migration `0304_logs34_pattern_columns` targets the deployed-cloud names `logs34` and `logs_distributed`, so it does not define these local tables.

The replayed local schema therefore contained both columns, while local HCL still described tables without them.

#### Recent-events TTL

1. [#91030](https://github.com/PostHog/posthog/pull/91030) changed `SHARDED_EVENTS_RECENT_TABLE_SQL` from seven days to nine days.
2. That change also replaced `toDateTime(inserted_at)` with `toDate(inserted_at)` to match both production regions.
3. Historical migration `0206_events_recent_sharded` calls the current builder at runtime, so a fresh replay now creates the nine-day TTL.
4. The batch-export HCL definitions still declared the old seven-day expression.
5. Production already used the nine-day expression before #91030, so the HCL was stale rather than the deployed table.

The replayed schema therefore used `toDate(inserted_at) + 9 days`, while HCL still expected `toDateTime(inserted_at) + 7 days`.

> [!NOTE]
> This drift is unrelated to Error Tracking. It blocked [#91499](https://github.com/PostHog/posthog/pull/91499) only because that PR triggers the full migration convergence check.

## Changes

- Local logs HCL now declares `pattern` and `pattern_version` on both `logs32` and `logs`.
- Both recent-events HCL definitions now match the production and replayed nine-day TTL.
- Generated HCL goldens and SQL now describe the corrected source definitions.
- This PR adds no migration and executes no DDL.

A numbered migration would add deployment risk without changing the fresh replay or deployed-cloud schemas, which already have the intended definitions.

Already-created local tables remain outside this repair. Schema reconciliation can derive any local correction from the updated HCL.

Nothing user-visible changes. This base layer restores schema convergence before the Error Tracking migration stack.

## How did you test this code?

- `posthog/clickhouse/hcl/check.sh` validates every source HCL composition, generated golden, and generated SQL file.
- `hogli test posthog/clickhouse/test/test_migrations.py` validates migration discovery after restoring `0309` as this layer's migration maximum.
- The [multinode migration smoke test passes](https://github.com/PostHog/posthog/actions/runs/33390773735) with the HCL-only repair and no numbered migration.

No manual testing was performed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change. This PR repairs internal ClickHouse schema declarations.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi investigated the smoke failure, traced both drift sources through migration replay, and authored the repair with repository and GitHub tools.

Review removed the initial numbered migration. The final HCL-only repair avoids an unnecessary deployment step.

Skills: `/clickhouse-migrations`, `/debugging-ci-failures`, `/writing-tests`, `/writing-code-comments`, `/running-ci-preflight`, `/stacking-prs`, and `/writing-pr-descriptions`.

