### PR TITLE
fix(aio): distinguish zero from unknown in trace header sums

### DIFF
--- a/posthog/hogql_queries/ai/test/__snapshots__/test_trace_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_trace_query_runner.ambr
@@ -431,24 +431,7 @@
             JSONExtractRaw(__ai_events_fallback.properties, '$ai_output_state') AS output_state,
             JSONExtractRaw(__ai_events_fallback.properties, '$ai_tools') AS tools
      FROM events AS __ai_events_fallback
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS __ai_events_fallback__override ON equals(__ai_events_fallback.distinct_id, __ai_events_fallback__override.distinct_id)
-     LEFT JOIN
-       (SELECT person.id AS id,
-               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'bar'), ''), 'null'), '^"|"$', '') AS properties___bar
-        FROM person
-        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                      (SELECT person.id AS id, max(person.version) AS version
-                                                       FROM person
-                                                       WHERE equals(person.team_id, 99999)
-                                                       GROUP BY person.id
-                                                       HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS __ai_events_fallback__person ON equals(if(not(empty(__ai_events_fallback__override.distinct_id)), __ai_events_fallback__override.person_id, __ai_events_fallback.person_id), __ai_events_fallback__person.id)
-     WHERE and(equals(__ai_events_fallback.team_id, 99999), in(__ai_events_fallback.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(__ai_events_fallback.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(__ai_events_fallback.timestamp, assumeNotNull(toDateTime('2024-12-08 00:10:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(__ai_events_fallback.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(__ai_events_fallback__person.properties___bar, 'foo'), 0)))
+     WHERE and(equals(__ai_events_fallback.team_id, 99999), in(__ai_events_fallback.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(__ai_events_fallback.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(__ai_events_fallback.timestamp, assumeNotNull(toDateTime('2024-12-08 00:10:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(__ai_events_fallback.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(__ai_events_fallback.person_properties, 'bar'), ''), 'null'), '^"|"$', ''), 'foo'), 0)))
      LIMIT 1 BY __ai_events_fallback.uuid) AS deduped
   GROUP BY deduped.trace_id
   LIMIT 1 SETTINGS readonly=2,

--- a/posthog/hogql_queries/ai/test/__snapshots__/test_trace_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_trace_query_runner.ambr
@@ -8,11 +8,11 @@
          ifNull(nullIf(argMinIf(deduped.distinct_id, deduped.timestamp, equals(deduped.event, '$ai_trace')), ''), argMin(deduped.distinct_id, deduped.timestamp)) AS first_distinct_id,
          round(if(and(equals(countIf(and(ifNull(greater(deduped.latency, 0), 0), notEquals(deduped.event, '$ai_generation'))), 0), greater(countIf(and(ifNull(greater(deduped.latency, 0), 0), equals(deduped.event, '$ai_generation'))), 0)), sumIf(deduped.latency, and(equals(deduped.event, '$ai_generation'), ifNull(greater(deduped.latency, 0), 0))), sumIf(deduped.latency, or(isNull(deduped.parent_id), ifNull(equals(deduped.parent_id, deduped.trace_id), isNull(deduped.parent_id)
                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(deduped.trace_id))))), 2) AS total_latency,
-         nullIf(sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         if(greater(countIf(and(isNotNull(deduped.input_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS input_tokens,
+         if(greater(countIf(and(isNotNull(deduped.output_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS output_tokens,
+         if(greater(countIf(and(isNotNull(deduped.input_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS input_cost,
+         if(greater(countIf(and(isNotNull(deduped.output_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS output_cost,
+         if(greater(countIf(and(isNotNull(deduped.total_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS total_cost,
          arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(deduped.uuid, deduped.event, deduped.timestamp, deduped.properties, deduped.input, deduped.output, deduped.output_choices, deduped.input_state, deduped.output_state, deduped.tools), notEquals(deduped.event, '$ai_trace')))) AS events,
          argMinIf(deduped.input_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS input_state,
          argMinIf(deduped.output_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS output_state,
@@ -67,11 +67,11 @@
          ifNull(nullIf(argMinIf(deduped.distinct_id, deduped.timestamp, equals(deduped.event, '$ai_trace')), ''), argMin(deduped.distinct_id, deduped.timestamp)) AS first_distinct_id,
          round(if(and(equals(countIf(and(ifNull(greater(deduped.latency, 0), 0), notEquals(deduped.event, '$ai_generation'))), 0), greater(countIf(and(ifNull(greater(deduped.latency, 0), 0), equals(deduped.event, '$ai_generation'))), 0)), sumIf(deduped.latency, and(equals(deduped.event, '$ai_generation'), ifNull(greater(deduped.latency, 0), 0))), sumIf(deduped.latency, or(isNull(deduped.parent_id), ifNull(equals(deduped.parent_id, deduped.trace_id), isNull(deduped.parent_id)
                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(deduped.trace_id))))), 2) AS total_latency,
-         nullIf(sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         if(greater(countIf(and(isNotNull(deduped.input_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS input_tokens,
+         if(greater(countIf(and(isNotNull(deduped.output_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS output_tokens,
+         if(greater(countIf(and(isNotNull(deduped.input_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS input_cost,
+         if(greater(countIf(and(isNotNull(deduped.output_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS output_cost,
+         if(greater(countIf(and(isNotNull(deduped.total_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS total_cost,
          arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(deduped.uuid, deduped.event, deduped.timestamp, deduped.properties, deduped.input, deduped.output, deduped.output_choices, deduped.input_state, deduped.output_state, deduped.tools), notEquals(deduped.event, '$ai_trace')))) AS events,
          argMinIf(deduped.input_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS input_state,
          argMinIf(deduped.output_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS output_state,
@@ -126,11 +126,11 @@
          ifNull(nullIf(argMinIf(deduped.distinct_id, deduped.timestamp, equals(deduped.event, '$ai_trace')), ''), argMin(deduped.distinct_id, deduped.timestamp)) AS first_distinct_id,
          round(if(and(equals(countIf(and(ifNull(greater(deduped.latency, 0), 0), notEquals(deduped.event, '$ai_generation'))), 0), greater(countIf(and(ifNull(greater(deduped.latency, 0), 0), equals(deduped.event, '$ai_generation'))), 0)), sumIf(deduped.latency, and(equals(deduped.event, '$ai_generation'), ifNull(greater(deduped.latency, 0), 0))), sumIf(deduped.latency, or(isNull(deduped.parent_id), ifNull(equals(deduped.parent_id, deduped.trace_id), isNull(deduped.parent_id)
                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(deduped.trace_id))))), 2) AS total_latency,
-         nullIf(sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         if(greater(countIf(and(isNotNull(deduped.input_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS input_tokens,
+         if(greater(countIf(and(isNotNull(deduped.output_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS output_tokens,
+         if(greater(countIf(and(isNotNull(deduped.input_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS input_cost,
+         if(greater(countIf(and(isNotNull(deduped.output_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS output_cost,
+         if(greater(countIf(and(isNotNull(deduped.total_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS total_cost,
          arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(deduped.uuid, deduped.event, deduped.timestamp, deduped.properties, deduped.input, deduped.output, deduped.output_choices, deduped.input_state, deduped.output_state, deduped.tools), notEquals(deduped.event, '$ai_trace')))) AS events,
          argMinIf(deduped.input_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS input_state,
          argMinIf(deduped.output_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS output_state,
@@ -185,11 +185,11 @@
          ifNull(nullIf(argMinIf(deduped.distinct_id, deduped.timestamp, equals(deduped.event, '$ai_trace')), ''), argMin(deduped.distinct_id, deduped.timestamp)) AS first_distinct_id,
          round(if(and(equals(countIf(and(ifNull(greater(deduped.latency, 0), 0), notEquals(deduped.event, '$ai_generation'))), 0), greater(countIf(and(ifNull(greater(deduped.latency, 0), 0), equals(deduped.event, '$ai_generation'))), 0)), sumIf(deduped.latency, and(equals(deduped.event, '$ai_generation'), ifNull(greater(deduped.latency, 0), 0))), sumIf(deduped.latency, or(isNull(deduped.parent_id), ifNull(equals(deduped.parent_id, deduped.trace_id), isNull(deduped.parent_id)
                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(deduped.trace_id))))), 2) AS total_latency,
-         nullIf(sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         if(greater(countIf(and(isNotNull(deduped.input_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS input_tokens,
+         if(greater(countIf(and(isNotNull(deduped.output_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS output_tokens,
+         if(greater(countIf(and(isNotNull(deduped.input_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS input_cost,
+         if(greater(countIf(and(isNotNull(deduped.output_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS output_cost,
+         if(greater(countIf(and(isNotNull(deduped.total_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS total_cost,
          arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(deduped.uuid, deduped.event, deduped.timestamp, deduped.properties, deduped.input, deduped.output, deduped.output_choices, deduped.input_state, deduped.output_state, deduped.tools), notEquals(deduped.event, '$ai_trace')))) AS events,
          argMinIf(deduped.input_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS input_state,
          argMinIf(deduped.output_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS output_state,
@@ -244,11 +244,11 @@
          ifNull(nullIf(argMinIf(deduped.distinct_id, deduped.timestamp, equals(deduped.event, '$ai_trace')), ''), argMin(deduped.distinct_id, deduped.timestamp)) AS first_distinct_id,
          round(if(and(equals(countIf(and(ifNull(greater(deduped.latency, 0), 0), notEquals(deduped.event, '$ai_generation'))), 0), greater(countIf(and(ifNull(greater(deduped.latency, 0), 0), equals(deduped.event, '$ai_generation'))), 0)), sumIf(deduped.latency, and(equals(deduped.event, '$ai_generation'), ifNull(greater(deduped.latency, 0), 0))), sumIf(deduped.latency, or(isNull(deduped.parent_id), ifNull(equals(deduped.parent_id, deduped.trace_id), isNull(deduped.parent_id)
                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(deduped.trace_id))))), 2) AS total_latency,
-         nullIf(sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         if(greater(countIf(and(isNotNull(deduped.input_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS input_tokens,
+         if(greater(countIf(and(isNotNull(deduped.output_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS output_tokens,
+         if(greater(countIf(and(isNotNull(deduped.input_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS input_cost,
+         if(greater(countIf(and(isNotNull(deduped.output_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS output_cost,
+         if(greater(countIf(and(isNotNull(deduped.total_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS total_cost,
          arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(deduped.uuid, deduped.event, deduped.timestamp, deduped.properties, deduped.input, deduped.output, deduped.output_choices, deduped.input_state, deduped.output_state, deduped.tools), notEquals(deduped.event, '$ai_trace')))) AS events,
          argMinIf(deduped.input_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS input_state,
          argMinIf(deduped.output_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS output_state,
@@ -321,11 +321,11 @@
          ifNull(nullIf(argMinIf(deduped.distinct_id, deduped.timestamp, equals(deduped.event, '$ai_trace')), ''), argMin(deduped.distinct_id, deduped.timestamp)) AS first_distinct_id,
          round(if(and(equals(countIf(and(ifNull(greater(deduped.latency, 0), 0), notEquals(deduped.event, '$ai_generation'))), 0), greater(countIf(and(ifNull(greater(deduped.latency, 0), 0), equals(deduped.event, '$ai_generation'))), 0)), sumIf(deduped.latency, and(equals(deduped.event, '$ai_generation'), ifNull(greater(deduped.latency, 0), 0))), sumIf(deduped.latency, or(isNull(deduped.parent_id), ifNull(equals(deduped.parent_id, deduped.trace_id), isNull(deduped.parent_id)
                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(deduped.trace_id))))), 2) AS total_latency,
-         nullIf(sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         if(greater(countIf(and(isNotNull(deduped.input_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS input_tokens,
+         if(greater(countIf(and(isNotNull(deduped.output_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS output_tokens,
+         if(greater(countIf(and(isNotNull(deduped.input_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS input_cost,
+         if(greater(countIf(and(isNotNull(deduped.output_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS output_cost,
+         if(greater(countIf(and(isNotNull(deduped.total_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS total_cost,
          arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(deduped.uuid, deduped.event, deduped.timestamp, deduped.properties, deduped.input, deduped.output, deduped.output_choices, deduped.input_state, deduped.output_state, deduped.tools), notEquals(deduped.event, '$ai_trace')))) AS events,
          argMinIf(deduped.input_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS input_state,
          argMinIf(deduped.output_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS output_state,
@@ -398,11 +398,11 @@
          ifNull(nullIf(argMinIf(deduped.distinct_id, deduped.timestamp, equals(deduped.event, '$ai_trace')), ''), argMin(deduped.distinct_id, deduped.timestamp)) AS first_distinct_id,
          round(if(and(equals(countIf(and(ifNull(greater(deduped.latency, 0), 0), notEquals(deduped.event, '$ai_generation'))), 0), greater(countIf(and(ifNull(greater(deduped.latency, 0), 0), equals(deduped.event, '$ai_generation'))), 0)), sumIf(deduped.latency, and(equals(deduped.event, '$ai_generation'), ifNull(greater(deduped.latency, 0), 0))), sumIf(deduped.latency, or(isNull(deduped.parent_id), ifNull(equals(deduped.parent_id, deduped.trace_id), isNull(deduped.parent_id)
                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(deduped.trace_id))))), 2) AS total_latency,
-         nullIf(sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         if(greater(countIf(and(isNotNull(deduped.input_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.input_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS input_tokens,
+         if(greater(countIf(and(isNotNull(deduped.output_tokens), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), sumIf(deduped.output_tokens, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), NULL) AS output_tokens,
+         if(greater(countIf(and(isNotNull(deduped.input_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.input_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS input_cost,
+         if(greater(countIf(and(isNotNull(deduped.output_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.output_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS output_cost,
+         if(greater(countIf(and(isNotNull(deduped.total_cost_usd), in(deduped.event, tuple('$ai_generation', '$ai_embedding')))), 0), round(sumIf(deduped.total_cost_usd, in(deduped.event, tuple('$ai_generation', '$ai_embedding'))), 10), NULL) AS total_cost,
          arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(deduped.uuid, deduped.event, deduped.timestamp, deduped.properties, deduped.input, deduped.output, deduped.output_choices, deduped.input_state, deduped.output_state, deduped.tools), notEquals(deduped.event, '$ai_trace')))) AS events,
          argMinIf(deduped.input_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS input_state,
          argMinIf(deduped.output_state, deduped.timestamp, equals(deduped.event, '$ai_trace')) AS output_state,
@@ -431,7 +431,24 @@
             JSONExtractRaw(__ai_events_fallback.properties, '$ai_output_state') AS output_state,
             JSONExtractRaw(__ai_events_fallback.properties, '$ai_tools') AS tools
      FROM events AS __ai_events_fallback
-     WHERE and(equals(__ai_events_fallback.team_id, 99999), in(__ai_events_fallback.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(__ai_events_fallback.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(__ai_events_fallback.timestamp, assumeNotNull(toDateTime('2024-12-08 00:10:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(__ai_events_fallback.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(__ai_events_fallback.person_properties, 'bar'), ''), 'null'), '^"|"$', ''), 'foo'), 0)))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS __ai_events_fallback__override ON equals(__ai_events_fallback.distinct_id, __ai_events_fallback__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'bar'), ''), 'null'), '^"|"$', '') AS properties___bar
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS __ai_events_fallback__person ON equals(if(not(empty(__ai_events_fallback__override.distinct_id)), __ai_events_fallback__override.person_id, __ai_events_fallback.person_id), __ai_events_fallback__person.id)
+     WHERE and(equals(__ai_events_fallback.team_id, 99999), in(__ai_events_fallback.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(__ai_events_fallback.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(__ai_events_fallback.timestamp, assumeNotNull(toDateTime('2024-12-08 00:10:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(__ai_events_fallback.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(__ai_events_fallback__person.properties___bar, 'foo'), 0)))
      LIMIT 1 BY __ai_events_fallback.uuid) AS deduped
   GROUP BY deduped.trace_id
   LIMIT 1 SETTINGS readonly=2,

--- a/posthog/hogql_queries/ai/test/test_trace_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_trace_query_runner.py
@@ -966,6 +966,57 @@ class TestTraceQueryRunner(ClickhouseTestMixin, BaseTest):
         self.assertEqual(trace.totalLatency, 3.9)
         self.assertEqual(trace.events[0].properties.get("$ai_input"), [{"role": "user", "content": "Foo"}])
 
+    def test_sums_distinguish_reported_zero_from_no_report(self):
+        zero_trace_id = str(uuid.uuid4())
+        unpriced_trace_id = str(uuid.uuid4())
+        timestamp = datetime(2024, 12, 1, 0, 0, tzinfo=UTC)
+        _create_ai_generation_event(
+            distinct_id="person1",
+            trace_id=zero_trace_id,
+            team=self.team,
+            timestamp=timestamp,
+            properties={
+                "$ai_input_tokens": 0,
+                "$ai_output_tokens": 0,
+                "$ai_input_cost_usd": 0,
+                "$ai_output_cost_usd": 0,
+                "$ai_total_cost_usd": 0,
+            },
+        )
+        # A generation whose provider never reported usage carries no token or
+        # cost properties at all.
+        _create_event(
+            event="$ai_generation",
+            distinct_id="person1",
+            team=self.team,
+            timestamp=timestamp,
+            properties={
+                "$ai_trace_id": unpriced_trace_id,
+                "$ai_latency": 1,
+                "$ai_input": [{"role": "user", "content": "Foo"}],
+                "$ai_output_choices": [{"role": "assistant", "content": "Bar"}],
+            },
+        )
+
+        date_range = DateRange(date_from="2024-12-01T00:00:00Z", date_to="2024-12-01T00:10:00Z")
+        zero_trace = (
+            TraceQueryRunner(team=self.team, query=TraceQuery(traceId=zero_trace_id, dateRange=date_range))
+            .calculate()
+            .results[0]
+        )
+        unpriced_trace = (
+            TraceQueryRunner(team=self.team, query=TraceQuery(traceId=unpriced_trace_id, dateRange=date_range))
+            .calculate()
+            .results[0]
+        )
+
+        self.assertEqual(zero_trace.totalCost, 0)
+        self.assertEqual(zero_trace.inputCost, 0)
+        self.assertEqual(zero_trace.inputTokens, 0)
+        self.assertIsNone(unpriced_trace.totalCost)
+        self.assertIsNone(unpriced_trace.inputCost)
+        self.assertIsNone(unpriced_trace.inputTokens)
+
     def test_trace_name_from_trace_event(self):
         """Test that trace_name comes from $ai_trace events when they exist."""
         _create_person(distinct_ids=["person1"], team=self.team)

--- a/posthog/hogql_queries/ai/test/test_traces_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_traces_query_runner.py
@@ -385,7 +385,7 @@ class TestTracesQueryRunner(ClickhouseTestMixin, BaseTest):
 
         unpriced_trace = traces["trace_unpriced"]
         self.assertIsNone(unpriced_trace.totalCost)
-        self.assertIsNone(unpriced_trace.requestCost)
+        self.assertIsNone(unpriced_trace.inputCost)
         self.assertIsNone(unpriced_trace.inputTokens)
 
     @freeze_time("2025-01-16T00:00:00Z")

--- a/posthog/hogql_queries/ai/test/test_traces_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_traces_query_runner.py
@@ -347,6 +347,48 @@ class TestTracesQueryRunner(ClickhouseTestMixin, BaseTest):
     # test_trace_id_filter removed - TracesQuery no longer supports traceId parameter
 
     @freeze_time("2025-01-16T00:00:00Z")
+    def test_sums_distinguish_reported_zero_from_no_report(self):
+        _create_person(distinct_ids=["person1"], team=self.team)
+        _create_ai_generation_event(
+            distinct_id="person1",
+            trace_id="trace_zero",
+            team=self.team,
+            timestamp=datetime(2025, 1, 15, 0),
+            properties={
+                "$ai_input_tokens": 0,
+                "$ai_output_tokens": 0,
+                "$ai_input_cost_usd": 0,
+                "$ai_output_cost_usd": 0,
+                "$ai_total_cost_usd": 0,
+            },
+        )
+        # A generation whose provider never reported usage carries no token or
+        # cost properties at all.
+        _create_event(
+            event="$ai_generation",
+            distinct_id="person1",
+            team=self.team,
+            timestamp=datetime(2025, 1, 15, 1),
+            properties={
+                "$ai_trace_id": "trace_unpriced",
+                "$ai_latency": 1,
+            },
+        )
+
+        response = TracesQueryRunner(team=self.team, query=TracesQuery()).calculate()
+        traces = {trace.id: trace for trace in response.results}
+
+        zero_trace = traces["trace_zero"]
+        self.assertEqual(zero_trace.totalCost, 0)
+        self.assertEqual(zero_trace.inputCost, 0)
+        self.assertEqual(zero_trace.inputTokens, 0)
+
+        unpriced_trace = traces["trace_unpriced"]
+        self.assertIsNone(unpriced_trace.totalCost)
+        self.assertIsNone(unpriced_trace.requestCost)
+        self.assertIsNone(unpriced_trace.inputTokens)
+
+    @freeze_time("2025-01-16T00:00:00Z")
     def test_stored_sentiment_evaluations_are_mapped_to_trace_and_generation(self):
         event_uuid = uuid.uuid4()
         generation_id = "generation-id-1"

--- a/posthog/hogql_queries/ai/trace_query_runner.py
+++ b/posthog/hogql_queries/ai/trace_query_runner.py
@@ -151,27 +151,43 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
                              )
                     END, 2
                 ) AS total_latency,
-                nullIf(sumIf(deduped.input_tokens,
-                      deduped.event IN ('$ai_generation', '$ai_embedding')
-                ), 0) AS input_tokens,
-                nullIf(sumIf(deduped.output_tokens,
-                      deduped.event IN ('$ai_generation', '$ai_embedding')
-                ), 0) AS output_tokens,
-                nullIf(round(
-                    sumIf(deduped.input_cost_usd,
-                          deduped.event IN ('$ai_generation', '$ai_embedding')
-                    ), 10
-                ), 0) AS input_cost,
-                nullIf(round(
-                    sumIf(deduped.output_cost_usd,
-                          deduped.event IN ('$ai_generation', '$ai_embedding')
-                    ), 10
-                ), 0) AS output_cost,
-                nullIf(round(
-                    sumIf(deduped.total_cost_usd,
-                          deduped.event IN ('$ai_generation', '$ai_embedding')
-                    ), 10
-                ), 0) AS total_cost,
+                -- NULL means no event carried the field, 0 is a reported zero.
+                -- nullIf(sum, 0) would collapse a real zero into NULL.
+                if(countIf(isNotNull(deduped.input_tokens)
+                           AND deduped.event IN ('$ai_generation', '$ai_embedding')) > 0,
+                   sumIf(deduped.input_tokens,
+                         deduped.event IN ('$ai_generation', '$ai_embedding')
+                   ),
+                   NULL
+                ) AS input_tokens,
+                if(countIf(isNotNull(deduped.output_tokens)
+                           AND deduped.event IN ('$ai_generation', '$ai_embedding')) > 0,
+                   sumIf(deduped.output_tokens,
+                         deduped.event IN ('$ai_generation', '$ai_embedding')
+                   ),
+                   NULL
+                ) AS output_tokens,
+                if(countIf(isNotNull(deduped.input_cost_usd)
+                           AND deduped.event IN ('$ai_generation', '$ai_embedding')) > 0,
+                   round(sumIf(deduped.input_cost_usd,
+                               deduped.event IN ('$ai_generation', '$ai_embedding')
+                   ), 10),
+                   NULL
+                ) AS input_cost,
+                if(countIf(isNotNull(deduped.output_cost_usd)
+                           AND deduped.event IN ('$ai_generation', '$ai_embedding')) > 0,
+                   round(sumIf(deduped.output_cost_usd,
+                               deduped.event IN ('$ai_generation', '$ai_embedding')
+                   ), 10),
+                   NULL
+                ) AS output_cost,
+                if(countIf(isNotNull(deduped.total_cost_usd)
+                           AND deduped.event IN ('$ai_generation', '$ai_embedding')) > 0,
+                   round(sumIf(deduped.total_cost_usd,
+                               deduped.event IN ('$ai_generation', '$ai_embedding')
+                   ), 10),
+                   NULL
+                ) AS total_cost,
                 arrayDistinct(
                     arraySort(
                         x -> x.3,

--- a/products/ai_observability/frontend/traceExportUtils.test.ts
+++ b/products/ai_observability/frontend/traceExportUtils.test.ts
@@ -316,6 +316,34 @@ describe('traceExportUtils', () => {
             expect(result.events[0].metrics).toBeUndefined()
         })
 
+        it('should keep a genuine zero cost at both the trace and event level', () => {
+            const zeroCostTrace: LLMTrace = { ...mockTrace, totalCost: 0 }
+            const zeroCostEvent: LLMTraceEvent = {
+                id: 'event-zero',
+                event: '$ai_generation',
+                properties: {
+                    $ai_model: 'claude-3',
+                    $ai_latency: 120,
+                    $ai_total_cost_usd: 0,
+                },
+                createdAt: '2024-01-01T12:00:06Z',
+            }
+            const tree: EnrichedTraceTreeNode[] = [
+                {
+                    event: zeroCostEvent,
+                    displayTotalCost: 0,
+                    displayLatency: 120,
+                    displayUsage: null,
+                    attachedFeedback: [],
+                },
+            ]
+            const result = buildMinimalTraceJSON(zeroCostTrace, tree)
+
+            // Falsy zero used to drop these keys entirely.
+            expect(result.total_cost).toBe(0)
+            expect(result.events[0].metrics).toEqual({ latency: 120, cost: 0 })
+        })
+
         it('should handle generation with output_choices instead of output', () => {
             const choicesEvent: LLMTraceEvent = {
                 id: 'event-6',

--- a/products/ai_observability/frontend/traceExportUtils.ts
+++ b/products/ai_observability/frontend/traceExportUtils.ts
@@ -120,7 +120,9 @@ function buildEventExport(event: LLMTraceEvent, children?: EnrichedTraceTreeNode
             output: event.properties.$ai_output_tokens || 0,
         }
     }
-    if (event.properties.$ai_total_cost_usd) {
+    // `!= null` keeps a genuine $0 cost, which ingestion now reports for a
+    // generation that priced to zero, rather than dropping it as falsy.
+    if (event.properties.$ai_total_cost_usd != null) {
         metrics.cost = event.properties.$ai_total_cost_usd
     }
 
@@ -152,8 +154,9 @@ export function buildMinimalTraceJSON(trace: LLMTrace, tree: EnrichedTraceTreeNo
         result.name = trace.traceName
     }
 
-    // Add total cost if available
-    if (trace.totalCost) {
+    // Add total cost if reported. `!= null` keeps a genuine $0, which the trace
+    // header now shows, so the export agrees with it.
+    if (trace.totalCost != null) {
         result.total_cost = trace.totalCost
     }
 


### PR DESCRIPTION
## Problem

A trace that genuinely cost $0.00 hides its cost on the single-trace header. The runner wraps every sum in `nullIf(sum, 0)`, which collapses a reported zero into null, so the header cannot tell a free trace from one whose cost was never reported.

Follow-up to #90211, which drew this distinction for generation rows and spans. Proposed in [this review comment](https://github.com/PostHog/posthog/pull/90211#discussion_r3893211498).

While building this, the matching change to the traces list runner turned out to be unnecessary: its bare `sumIf` runs over `Nullable(Float64)` on both storage paths, so it already returns null when no event carried the field. The `$0.00` rows on the list come from events ingested before #90211, which carry a stored `0` that no query change can rewrite. That runner is untouched, and the already-correct behavior is pinned by a test instead.

## Changes

- A trace that genuinely cost $0.00 now shows `$0.00` on the single-trace header, instead of nothing.
- A trace whose events never carried a cost or token field still shows nothing, now by an explicit count guard rather than by `nullIf` accident: null when no event carried the field, the real sum, including zero, when one did. Applies to all five summed fields.
- The trace JSON export now keeps a genuine `$0.00`, at the trace total and each event, instead of dropping it as a falsy value. The header already showed `$0.00`; the export now agrees.
- Tests only on the traces list runner: a regression lock that unpriced traces return null sums. It passes today through `Nullable` aggregation semantics, so a column-type or extraction change could silently flip it to `$0.00` without this test.

> [!NOTE]
> Events ingested before #90211 carry a stored `0` for unknown costs and keep rendering `$0.00` everywhere. This change affects reads only; nothing is rewritten.

## How did you test this code?

- One test per runner, each covering both directions with two fixture traces: one asserting explicit zeros, one carrying no cost or token properties at all.
- Revert-proven where the behavior changes: with the runner change stashed, the single-trace test fails on `None != 0`. The list-runner test passes with and without its (dropped) SQL change, which is what showed that change was churn and led to reverting it.
- A frontend case pins the export keeping a `$0.00` at both levels, and fails on the old falsy guard (verified by reverting). The corrected list-runner assertion now pins `inputCost` is null for an unpriced trace, where before it read a field that was null for both fixtures.
- Both full runner suites pass locally against the dev stack, plus the `traceExportUtils` jest suite. SQL snapshots regenerated for the changed runner only.
- `ruff check`, `ruff format`, and `oxfmt` pass; `hogli ci:preflight` run before pushing.
- Not run: `hogli review` — the command does not exist on this master checkout, so the Greptile pass happens server-side on the PR.

## Automatic notifications

- [ ] Publish to changelog?

Covered by the changelog entry on #90211: this completes "no cost shown when the cost was never known, $0.00 when it was genuinely zero" for the trace header.

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, directed by a PostHog engineer, from a review comment on #90211 proposing the two trace runners agree on null-vs-zero. Investigation narrowed the fix to one runner: the literal suggestion there, dropping the `nullIf`, turns out to be nearly right — `Nullable` aggregation makes the bare sum null-correct — but the explicit count guard keeps that correctness independent of column nullability, which the list-runner test showed is load-bearing.

Kept out of #90211 deliberately: that PR was approved with no Python files in its diff, and this product's agent guide requires runner changes to ship with their tests as one reviewed unit.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*



