### PR TITLE
fix: mark a notification read when it is archived

### DIFF
--- a/products/notifications/backend/presentation/views.py
+++ b/products/notifications/backend/presentation/views.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import cast
+from uuid import UUID
 
+from django.db import transaction
 from django.db.models import Exists, OuterRef, QuerySet, Subquery
 from django.shortcuts import get_object_or_404
 from django.utils.dateparse import parse_datetime
@@ -356,6 +358,21 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             invalidate_unread_count(user.id, self.team.organization_id)
         return Response({"updated": len(eligible_ids)})
 
+    def _archive_events(self, user: User, event_ids: list[UUID]) -> None:
+        # Archiving takes a notification out of the unread count, so the read state has to follow.
+        # Read and archive are independent tables, so without this an archived notification keeps
+        # `read: false` and the archived list shows it as unread.
+        with transaction.atomic():
+            NotificationArchiveState.objects.bulk_create(
+                [NotificationArchiveState(notification_event_id=eid, user=user) for eid in event_ids],
+                ignore_conflicts=True,
+            )
+            NotificationReadState.objects.bulk_create(
+                [NotificationReadState(notification_event_id=eid, user=user) for eid in event_ids],
+                ignore_conflicts=True,
+            )
+        invalidate_unread_count(user.id, self.team.organization_id)
+
     @extend_schema(request=None)
     @action(methods=["POST"], detail=True, url_path="archive")
     def archive(self, request: Request, **kwargs) -> Response:
@@ -364,8 +381,7 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
 
         user = self._get_user()
         event = self._get_recipient_event_or_404()
-        NotificationArchiveState.objects.get_or_create(notification_event=event, user=user)
-        invalidate_unread_count(user.id, self.team.organization_id)
+        self._archive_events(user, [event.id])
         return Response({"status": "ok"})
 
     @validated_request(request_serializer=BulkNotificationIdsRequestSerializer)
@@ -387,9 +403,7 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             ).values_list("id", flat=True)
         )
         if eligible_ids:
-            archive_states = [NotificationArchiveState(notification_event_id=eid, user=user) for eid in eligible_ids]
-            NotificationArchiveState.objects.bulk_create(archive_states, ignore_conflicts=True)
-            invalidate_unread_count(user.id, self.team.organization_id)
+            self._archive_events(user, eligible_ids)
         return Response({"updated": len(eligible_ids)})
 
     @extend_schema(request=None)
@@ -402,7 +416,5 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
         queryset = self._get_base_queryset().filter(archived=False)
         event_ids = list(queryset.values_list("id", flat=True))
         if event_ids:
-            archive_states = [NotificationArchiveState(notification_event_id=eid, user=user) for eid in event_ids]
-            NotificationArchiveState.objects.bulk_create(archive_states, ignore_conflicts=True)
-            invalidate_unread_count(user.id, self.team.organization_id)
+            self._archive_events(user, event_ids)
         return Response({"updated": len(event_ids)})

--- a/products/notifications/backend/presentation/views.py
+++ b/products/notifications/backend/presentation/views.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from datetime import datetime
 from typing import cast
 from uuid import UUID
@@ -358,7 +359,9 @@ class NotificationsViewSet(TeamAndOrgViewSetMixin, GenericViewSet):
             invalidate_unread_count(user.id, self.team.organization_id)
         return Response({"updated": len(eligible_ids)})
 
-    def _archive_events(self, user: User, event_ids: list[UUID]) -> None:
+    # `Sequence`, not `list`: the viewset defines a `list` action, which shadows the builtin
+    # when this annotation is evaluated in the class body.
+    def _archive_events(self, user: User, event_ids: Sequence[UUID]) -> None:
         # Archiving takes a notification out of the unread count, so the read state has to follow.
         # Read and archive are independent tables, so without this an archived notification keeps
         # `read: false` and the archived list shows it as unread.

--- a/products/notifications/backend/tests/test_api.py
+++ b/products/notifications/backend/tests/test_api.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from django.core.cache import cache
 from django.utils import timezone
 
+from parameterized import parameterized
 from rest_framework.test import APIClient
 
 from posthog.models import Organization, Team, User
@@ -525,6 +526,43 @@ class TestNotificationsAPI(BaseTest):
         assert resp.json()["updated"] == 3
         for ev in (self.event, a1, a2):
             assert NotificationArchiveState.objects.filter(notification_event=ev, user=self.user).exists()
+
+    @parameterized.expand(
+        [
+            ("detail", "{base}/{id}/archive/", None),
+            ("bulk", "{base}/archive_bulk/", "notification_ids"),
+            ("all", "{base}/archive_all/", None),
+        ]
+    )
+    def test_archive_marks_notification_read(self, _name, path_template, ids_field):
+        event = self._create_notification()
+        base = f"/api/environments/{self.team.id}/notifications"
+        path = path_template.format(base=base, id=event.id)
+        payload = {ids_field: [str(event.id)]} if ids_field else None
+
+        resp = self.client.post(path, payload, format="json") if payload else self.client.post(path)
+
+        assert resp.status_code == 200
+        assert NotificationReadState.objects.filter(notification_event=event, user=self.user).exists()
+
+    def test_archived_notification_serializes_as_read(self):
+        event = self._create_notification()
+        self.client.post(f"/api/environments/{self.team.id}/notifications/{event.id}/archive/")
+
+        resp = self.client.get(f"/api/environments/{self.team.id}/notifications/?archived=true")
+
+        row = next(r for r in resp.json()["results"] if r["id"] == str(event.id))
+        assert row["read"] is True
+        assert row["read_at"] is not None
+
+    def test_archive_does_not_mark_read_for_another_user(self):
+        other_user = User.objects.create_and_join(self.organization, "archiveread@test.com", "password")
+        event = self._create_notification()
+        NotificationEvent.objects.filter(pk=event.pk).update(resolved_user_ids=[self.user.id, other_user.id])
+
+        self.client.post(f"/api/environments/{self.team.id}/notifications/{event.id}/archive/")
+
+        assert not NotificationReadState.objects.filter(notification_event=event, user=other_user).exists()
 
     def test_archive_is_per_user(self):
         other_user = User.objects.create_and_join(self.organization, "archiveother@test.com", "password")


### PR DESCRIPTION
## Problem

A notification archived while unread stays unread, so the archived tab shows it with the unread highlight and an unread toggle forever.

- Read state and archive state are two independent tables, `NotificationReadState` and `NotificationArchiveState`.
- The archive endpoints write only the archive state, unlike `mark_read_bulk`.
- The badge count is not affected, because `unread_count` filters on `read=False, archived=False`.
- So the payload keeps `read: false` and `read_at: null` for anything archived before it was read.

## Changes

- Archiving a notification now marks it read, so the archived tab no longer shows unread styling on items nobody read.
- All three endpoints get this: `archive`, `archive_bulk` and `archive_all`.
- The two writes share one `_archive_events` helper and run in one transaction, so the states cannot diverge.
- No frontend change. The archived list refetches from the server whenever the tab opens, so it picks up the new read state on its own.
- Nothing looks different outside the archived tab.

> [!NOTE]
> Notifications archived before this ships keep `read: false`. This PR adds no backfill, so the archived tab still shows those as unread.

## How did you test this code?

Automated tests only.

- `test_archive_marks_notification_read` covers all three endpoints. Nothing asserted that archiving touches read state, so a regression on any one of them was invisible.
- `test_archived_notification_serializes_as_read` asserts the API response, not just the row. It catches the read annotation on the archived list breaking independently of the write.
- `test_archive_does_not_mark_read_for_another_user` pins that archiving stays per-user, matching `test_archive_is_per_user` for archive state.
- Ran `ruff check` and `ruff format` over `products/notifications/backend/`.
- Not run: the pytest suite. This work happened in a git worktree, where running the stack or the suites is not allowed, so CI is the first run of these tests.
- Not run: `hogli build:openapi`. Preflight flags it as advisory because `views.py` changed, but no serializer or endpoint signature changed here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

- The gap surfaced while reviewing #89987, which adds a `notification clicked` event. That event carries `was_unread`, and the reviewer asked whether archived notifications already report `was_unread: false`. They do not, which is what this PR fixes.
- The two PRs stay separate on purpose. 
- A backfill migration for already-archived rows was considered and left out to keep the change small. 