### PR TITLE
fix(devex): stop an empty JUnit freezing every product's test timings

### DIFF
--- a/.github/scripts/optimize_test_durations.py
+++ b/.github/scripts/optimize_test_durations.py
@@ -129,6 +129,16 @@ class JUnitShard:
     # An XML of this shard (any attempt) did not parse, so call_times is incomplete.
     unreadable: bool = False
 
+    @property
+    def recorded_nothing(self) -> bool:
+        """Every XML parsed and none held a testcase: this shard ran no tests.
+
+        A product with no tests still uploads a JUnit declaring `tests="0"`, so a shard
+        holding only such products reads zero. That is a clock reading of zero rather
+        than a missing clock, which is why it is not `unreadable`.
+        """
+        return not self.unreadable and not self.call_times
+
     @classmethod
     def load_all(cls, junit_dir: Path, segment: str | None = None) -> list["JUnitShard"]:
         """Load JUnit XMLs and extract per-test call times from each shard.
@@ -948,7 +958,10 @@ def main():
         # The check is only as good as its clock. A missing, partial, or
         # truncated JUnit set would pass vacuously and let an unchecked slice
         # through, so a strict run needs one readable JUnit per timing shard.
-        unreadable = [shard.name for shard in junit_shards or [] if shard.unreadable or not shard.call_times]
+        # A shard that parsed and ran no tests counts as read: it reports zero
+        # rather than hiding a number, and refusing it discarded the slice for
+        # every product because one product had no tests yet.
+        unreadable = [shard.name for shard in junit_shards or [] if shard.unreadable]
         if not junit_shards:
             logger.error("--fail-on-drift needs JUnit artifacts and none loaded")
             sys.exit(1)
@@ -971,8 +984,10 @@ def main():
             logger.info("  map/clock %s: %.2f", name, ratio)
         # A shard with no ratio shares no keys with the map, or only zero times.
         # Neither is a pass: it means the clock and the map do not describe the
-        # same tests, which is exactly what strict mode is there to catch.
-        unrated = [shard.name for shard in junit_shards if shard.name not in ratios]
+        # same tests, which is exactly what strict mode is there to catch. A shard
+        # that ran no tests is the exception: there is nothing to compare, so its
+        # absence from the ratios says nothing about the map.
+        unrated = [shard.name for shard in junit_shards if shard.name not in ratios and not shard.recorded_nothing]
         if unrated and args.fail_on_drift:
             logger.error("Map/clock ratio missing for %d shards (no overlapping tests): %s", len(unrated), unrated)
             sys.exit(1)

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -535,7 +535,9 @@ def test_fail_on_drift_refuses_an_incomplete_junit_set(tmp_path: Path, monkeypat
     assert not out.exists()
 
 
-def test_fail_on_drift_accepts_a_shard_whose_junit_ran_no_tests(tmp_path: Path, monkeypatch) -> None:
+def test_fail_on_drift_accepts_a_shard_whose_junit_ran_no_tests(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # A product with no tests yet uploads a valid JUnit declaring tests="0". Reading that
     # as a missing clock made the strict run exit, and the workflow then kept the previous
     # products slice — freezing the timings of every product in the run, not just the empty

--- a/.github/scripts/test_optimize_test_durations.py
+++ b/.github/scripts/test_optimize_test_durations.py
@@ -33,6 +33,11 @@ _MIN_JUNIT_XML = b"""<?xml version="1.0"?>
 <testsuite name="pytest"><testcase classname="posthog.test_foo.TestThing" name="test_one" time="0.5"/></testsuite>
 """
 
+# What pytest writes for a product that has no tests yet: valid, parseable, and empty.
+_NO_TESTS_JUNIT_XML = b"""<?xml version="1.0"?>
+<testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="0" skipped="0" tests="0" time="0.479"/></testsuites>
+"""
+
 
 class TestPickOutlier:
     def test_all_same_returns_value(self):
@@ -528,6 +533,48 @@ def test_fail_on_drift_refuses_an_incomplete_junit_set(tmp_path: Path, monkeypat
     with pytest.raises(SystemExit):
         main()
     assert not out.exists()
+
+
+def test_fail_on_drift_accepts_a_shard_whose_junit_ran_no_tests(tmp_path: Path, monkeypatch) -> None:
+    # A product with no tests yet uploads a valid JUnit declaring tests="0". Reading that
+    # as a missing clock made the strict run exit, and the workflow then kept the previous
+    # products slice — freezing the timings of every product in the run, not just the empty
+    # one. The slice must be written, and keep the shard's entries.
+    artifacts = tmp_path / "timing_artifacts"
+    timings = {
+        "1": {"posthog/test_foo.py::TestThing::test_one": 0.5},
+        "2": {"posthog/test_bar.py::TestOther::test_two": 1.0},
+    }
+    for shard, entries in timings.items():
+        shard_dir = artifacts / f"timing_data-Core-{shard}"
+        shard_dir.mkdir(parents=True)
+        (shard_dir / ".test_durations").write_text(json.dumps(entries))
+    junit_dir = tmp_path / "junit_artifacts"
+    for shard, xml in (("1", _MIN_JUNIT_XML), ("2", _NO_TESTS_JUNIT_XML)):
+        (junit_dir / f"junit-results-backend-core-{shard}").mkdir(parents=True)
+        (junit_dir / f"junit-results-backend-core-{shard}" / "junit.xml").write_bytes(xml)
+    out = tmp_path / "core_durations"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "optimize_test_durations.py",
+            str(artifacts),
+            str(out),
+            "--segment",
+            "Core",
+            "--junit-dir",
+            str(junit_dir),
+            "--fail-on-drift",
+        ],
+    )
+
+    main()
+
+    assert json.loads(out.read_text()) == {
+        "posthog/test_foo.py::TestThing::test_one": 0.5,
+        "posthog/test_bar.py::TestOther::test_two": 1.0,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

CI has been sizing product test jobs from stale timings since 2026-08-29. The timing workflow discards the fresh numbers on every run and republishes the previous ones, so sharding decisions across every product run on data that no longer describes the suites.

- A product with no tests still uploads a JUnit, and pytest writes it declaring `tests="0"`.
- The strict `--fail-on-drift` guard counts a shard holding only such products as unreadable, and exits.
- `ci-backend-update-test-timing.yml` catches that exit, keeps the previous products slice, and still reports success.
- So one test-free product freezes the recorded timings of every product in the run, not just its own.

The [12:04Z run](https://github.com/PostHog/posthog/actions/runs/33389785014) computed a complete slice — 99,762 tests, 40 of 40 shards covered — then threw it away over `product-junit-results-39`, a 337-byte JUnit for the `autoresearch` skeleton.

## Changes

- Product timings refresh again. A shard whose JUnit parsed and holds no call times now reads as a clock reporting zero rather than a missing clock.
- The map/clock ratio check skips such a shard. A shard that ran nothing has nothing to compare against, so its absence from the ratios is not evidence of drift.
- A genuinely unreadable JUnit still fails the guard, including one truncated attempt on top of a good one.

Nothing a user sees changes. The second file is one test.

> [!NOTE]
> This fixes the current cause, not every way the slice can freeze. The runs before 2026-08-31 failed through a different guard — `needs the same shard set on both sides: 40 timing shards, 39 JUnit shards` — where the test-free product uploaded no JUnit at all. That guard is untouched here, because a missing artifact and a shard that ran nothing are not distinguishable from the script's side. Making the product JUnit upload unconditional is the workflow-side fix, and belongs in its own change.

## How did you test this code?

Replayed the failing run's own artifacts through the script locally: all 40 `timing_data-Products-*` and all 40 `product-junit-results-*` from [run 33387028971](https://github.com/PostHog/posthog/actions/runs/33387028971), same arguments the workflow uses.

| | PA keys | PA seconds | funnels keys |
| --- | --- | --- | --- |
| slice this PR produces | 1088 | 301 | 512 |
| slice production published | 559 | 127 | 0 |
| that run's own PA shard artifact | 1088 | 301 | 512 |
| that run's own PA JUnit | 1088 | 305 | 525 |

Exit 0, 99,762 tests written — the same count the failing run computed before discarding it — and every one of the 39 rated shards at ratio 1.00, so no other guard was masking this one.

The new test catches a re-conflation of "parsed, zero testcases" with "unreadable". Reverting the guard line fails it with the production error text:

<details>
<summary>the test against the unfixed guard</summary>

```
E               SystemExit: 1
error  --fail-on-drift needs a readable JUnit artifact for every timing shard;
       unreadable: ['junit-results-backend-core-2']
FAILED test_fail_on_drift_accepts_a_shard_whose_junit_ran_no_tests
```

</details>

It could not be a case on the neighbouring `test_fail_on_drift_refuses_an_incomplete_junit_set`, which asserts the inverse outcome.

Not checked: no CI job runs this workflow on a pull request, so the fix is verified by local replay against real artifacts rather than by a green timing run. The first scheduled run after merge is the real confirmation.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus) in a PostHog Desktop cloud task. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Found while checking whether a shard split had appeared after moving the funnels query runners into product analytics ([#90749](https://github.com/PostHog/posthog/pull/90749)). It had not, and the reason turned out to have nothing to do with that move: the funnels durations were recorded correctly by CI and dropped by this merge.

Two things were ruled out before landing on the guard. The move itself was cleared by finding the funnels durations present in the product's own shard artifact and absent from the published map. Drift was cleared by computing every Products shard ratio from the real artifacts, which came back at 1.00 — Temporal and Dagster drift badly in the same run, so the shared warning text pointed the wrong way.

The narrower fix of deleting the `not shard.call_times` clause was rejected in favour of naming the state, because the clause also guards the truncated-JUnit case and the distinction is the whole point.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
