### PR TITLE
feat(agent): instruct sessions to follow repo rules and comment style

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/session/instructions.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/instructions.test.ts
@@ -22,6 +22,7 @@ describe("buildAppendedInstructions", () => {
     "# Plan Mode",
     "# MCP Tool Access",
     "# Data Handling",
+    "# Repository Conventions",
     "# Shell Efficiency",
   ])("always appends %s", (heading) => {
     expect(buildAppendedInstructions({ spokenNarration: false })).toContain(

--- a/products/desktop/packages/agent/src/adapters/claude/session/instructions.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/instructions.ts
@@ -40,6 +40,17 @@ const DATA_HANDLING = `
 Material you were given as task context — customer conversations, support tickets, logs, internal threads — stays out of code, test data, comments, commit messages, and pull request text. Rewriting it, summarizing it, or swapping out names and domains does not clear it.
 `;
 
+const REPOSITORY_CONVENTIONS = `
+# Repository Conventions
+
+Repositories carry their own coding conventions. Before your first edit, discover and read the ones this harness does not load for you:
+
+- \`AGENTS.md\` at the repo root, when there is no \`CLAUDE.md\` (\`CLAUDE.md\` itself is loaded for you automatically).
+- Cursor rule files: \`.cursor/rules/*.mdc\` and the legacy \`.cursorrules\`. These are never loaded automatically. A rule's frontmatter tells you its scope: \`alwaysApply: true\` rules apply to every change, \`globs\` scope a rule to matching files.
+
+Follow those conventions, and match the style of the surrounding code even where no rule states it. Comment density matters most: do not add comments that narrate the change or restate what the code plainly does. Keep only comments a rule or the existing code style would call for.
+`;
+
 const SHELL_EFFICIENCY = `
 # Shell Efficiency
 
@@ -77,6 +88,7 @@ const BASE_INSTRUCTIONS =
   PLAN_MODE +
   MCP_TOOLS +
   DATA_HANDLING +
+  REPOSITORY_CONVENTIONS +
   SHELL_EFFICIENCY;
 
 /** Shell-word shaped, so nothing else in the variable reaches the prompt. */

--- a/products/desktop/packages/agent/src/adapters/claude/session/instructions.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/instructions.ts
@@ -45,8 +45,8 @@ const REPOSITORY_CONVENTIONS = `
 
 Repositories carry their own coding conventions. Before your first edit, discover and read the ones this harness does not load for you:
 
-- \`AGENTS.md\` at the repo root, when there is no \`CLAUDE.md\` (\`CLAUDE.md\` itself is loaded for you automatically).
-- Cursor rule files: \`.cursor/rules/*.mdc\` and the legacy \`.cursorrules\`. These are never loaded automatically. A rule's frontmatter tells you its scope: \`alwaysApply: true\` rules apply to every change, \`globs\` scope a rule to matching files.
+- \`AGENTS.md\` files: at the repo root and in any directory whose files you edit. \`CLAUDE.md\` is loaded for you automatically; when an \`AGENTS.md\` merely mirrors it you can move on, but when it carries its own content, follow that too.
+- Cursor rule files: \`.cursor/rules/*.mdc\` (the repo root's, and any nested \`.cursor/rules/\` near the files you edit) and the legacy \`.cursorrules\`. These are never loaded automatically. A rule's frontmatter tells you its scope: \`alwaysApply: true\` rules apply to every change, \`globs\` scope a rule to matching files.
 
 Follow those conventions, and match the style of the surrounding code even where no rule states it. Comment density matters most: do not add comments that narrate the change or restate what the code plainly does. Keep only comments a rule or the existing code style would call for.
 `;


### PR DESCRIPTION
## Problem

- PRs from the coding agent ignore conventions a repo keeps in Cursor rules or `AGENTS.md`, and add comments that just narrate the change ([support ticket 64146](https://us.posthog.com/project/2/support/tickets/64146?status=%5B%22new%22,%22open%22,%22on_hold%22%5D&assignee=%5B%22role:019d8ba4-c52d-0000-ed2e-50d41e87e4f7%22%5D)).
- The Claude harness loads `CLAUDE.md` automatically, but nothing points the agent at `AGENTS.md`, `.cursor/rules/*.mdc`, or `.cursorrules`, and nothing asks it to match the repo's comment style.

## Changes

- Every Claude adapter session (desktop and cloud) now carries a "Repository Conventions" instruction block: read the repo's convention files before the first edit, follow them, and match the surrounding code's comment density instead of narrating the change.
- The block explains Cursor rule scoping (`alwaysApply`, `globs`) so the agent applies each rule where it belongs.

Nothing user-visible changes in the app UI; the change is prompt content.

## How did you test this code?

- Extended the always-appended-headings case in `instructions.test.ts`, guarding against the block being dropped from the assembled prompt.
- Not run: an end-to-end cloud task; the sandbox image needs a published `@posthog/agent` first.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session driven by @VojtechBartos. An earlier iteration of this branch read and injected the rule files deterministically at session start; it was replaced with this instruction-only version to keep the agent's judgment in the loop and avoid owning a parser for Cursor's rule format.
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/simplify`.
- Verified locally: vitest for the touched package, `turbo typecheck --filter=@posthog/agent`, Biome, `hogli ci:preflight` (pre-push hook).
