### PR TITLE
feat(review_hog): add opt-in overengineering & paranoia perspective

### DIFF
--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -8,8 +8,9 @@ GitHub, splits it into logically reviewable **chunks**, picks which perspectives
 (**perspective selection**, a cheap one-shot), runs the selected **perspective reviews in parallel** on each
 chunk inside **sandbox agents**, then combines → scope-cleans → deduplicates → validates the findings, renders
 a markdown report, and posts inline review comments back to the PR. Each review **perspective** (Logic &
-Correctness, Contracts & Security, Performance & Reliability) is a DB-synced **LLMA skill** the sandbox agent
-pulls over MCP — the same canonical-skill pattern the Signals scouts use.
+Correctness, Contracts & Security, Performance & Reliability, plus the opt-in Overengineering & Paranoia —
+canonical for every team but disabled until a user switches it on) is a DB-synced **LLMA skill** the sandbox
+agent pulls over MCP — the same canonical-skill pattern the Signals scouts use.
 
 The repo-access LLM steps (perspective review, blind-spot check, validation) run inside **sandbox agents**
 spawned through the shared `products/tasks` infrastructure (`Task`/`TaskRun` → Temporal
@@ -270,15 +271,19 @@ pr_metadata.head_branch` is threaded (as explicit kwargs, alongside `team_id` / 
    same Sonnet 5 @ xhigh via the `CHUNKING_*` constants (identical prompt — the sandbox only adds repo
    access the agent may not use). Returns the
    `ChunksList`; persists a `chunk_set` row (and resumes from it on a re-run of the same head).
-5. **Parallel perspective review** — `review_chunks` runs **three independent specialist perspectives
-   concurrently** per chunk (one sandbox activity per `(perspective × chunk)`, bounded by the child workflow's `asyncio.Semaphore`),
-   each with **no cross-perspective context** — overlap is left to dedup (7):
+5. **Parallel perspective review** — `review_chunks` runs the acting user's **enabled specialist
+   perspectives concurrently** per chunk (one sandbox activity per `(perspective × chunk)`, bounded by the child workflow's `asyncio.Semaphore`),
+   each with **no cross-perspective context** — overlap is left to dedup (7). The default-enabled three:
    - **Logic & Correctness** (`PerspectiveType.LOGIC_CORRECTNESS`)
    - **Contracts & Security** (`PerspectiveType.CONTRACTS_SECURITY`)
    - **Performance & Reliability** (`PerspectiveType.PERFORMANCE_RELIABILITY`)
 
-   The three perspectives come from the ordered `PERSPECTIVES` registry (`reviewer/skill_loader.py`);
-   `load_perspectives_for_run(team_id)` pins each one's current `LLMSkill` version for the run. Delivery is
+   The canonical perspectives come from `reviewer/skill_loader.py`: the ordered `PERSPECTIVES` registry
+   (auto-seeds enabled on a user's first run) plus `OPT_IN_CANONICAL_PERSPECTIVE_SKILL_NAMES`
+   (currently **Overengineering & Paranoia**, which hunts complexity the PR adds that its job doesn't
+   need — synced for every team but never auto-enabled; a user switches it on from the Code review
+   scene like a custom). `load_perspectives_for_run(team_id)` pins each enabled one's current
+   `LLMSkill` version for the run. Delivery is
    **pull** — the prompt instructs the sandbox agent to `skill-get(review-hog-perspective-…, version=N)` over
    MCP and apply that perspective's focus, rather than splicing the focus text into the prompt. Each
    perspective×chunk is one sandbox call validating `IssuesReview` (step name `issues-review-p{pass}-c{chunk}`);
@@ -507,7 +512,7 @@ content". Most begin with `{{ CLAUDE_CODE_CONTEXT | safe }}` (the `@path#L…` r
   `<your_review_perspective>` block instructs the agent to `skill-get(PERSPECTIVE_SKILL_NAME, version=N)` over
   MCP and apply that perspective's focus (pull delivery). → `IssuesReview`. The perspective focuses themselves
   live as **DB-synced LLMA skills** at
-  `products/review_hog/skills/review-hog-perspective-{logic-correctness,contracts-security,performance-reliability}/SKILL.md`.
+  `products/review_hog/skills/review-hog-perspective-{logic-correctness,contracts-security,performance-reliability,overengineering-paranoia}/SKILL.md`.
 - `issue_deduplicator/prompt.jinja` — mark duplicates (same file + overlapping lines + similar root cause)
   and issues matching prior review comments; keep the single most comprehensive representative. →
   `IssueDeduplication`.

--- a/products/review_hog/DECISIONS.md
+++ b/products/review_hog/DECISIONS.md
@@ -198,6 +198,31 @@ read `FINAL_REPORT.md` there first (config glossary + coverage matrix + ranking)
    rate drops materially (toward ≤50%) on frozen-PR evals with the valid-finding set intact (item 5's
    coverage matrix as the guard); kill if valid findings drop with the noise.
 
+### ✅ BUILT 2026-08-31 — opt-in canonical perspective: Overengineering & Paranoia (shipped to everyone, enabled by no one)
+
+The first canonical perspective that does not auto-enable: `review-hog-perspective-overengineering-paranoia`
+hunts complexity the PR itself introduces (premature abstraction, speculative options, guards for impossible
+states, unreachable fallbacks, dead weight) and always proposes a removal, never an addition. Two decisions:
+
+- **A third seeding class.** Canonicals used to mean "visible to everyone AND auto-enabled"; customs mean
+  "author-only AND off until toggled". This lens wants the cross: every team gets it, nobody runs it
+  uninvited (its findings are opinionated, and the default wave's cost/precision balance is tuned around
+  three lenses). `skill_loader.py` splits the sets — `PERSPECTIVES` stays the auto-enable seed,
+  `OPT_IN_CANONICAL_PERSPECTIVE_SKILL_NAMES` joins it in `CANONICAL_PERSPECTIVE_SKILL_NAMES` (the
+  visibility set) but never gets a seeded config row, so a missing row reads as disabled exactly like a
+  custom. No `PerspectiveType` member: skill_name has been the identity since the customizable-perspectives
+  decision.
+- **The validator needed a keep-bucket, not just the lens (grilled 2026-08-31).** The canonical validation
+  criteria's keep list was a closed set of behavioral harms; a grounded "delete this machinery the PR added"
+  finding matched none of them (removal changes no behavior), so the lens's output would have been judged
+  invalid wholesale. Added one tight keep-bullet — needless complexity the PR itself introduces, kept only
+  with evidence (call sites counted, types checked, or the existing utility named) and a safe removal — and
+  made the overengineering drop-bullet's direction explicit (it drops asks to _add_ machinery). The initial
+  "different cases, no conflict" read was half right: the drop list wasn't the blocker, the keep list was.
+
+Downstream needed nothing: selection, the blind-spot prompt, dedup, `perspective_stats`, and the scene all
+key off skill name + description. `progress.py`'s cold-user estimate now counts the default-enabled set.
+
 ### ✅ DECIDED 2026-08-21 — label trigger moves onto the GitHub App webhook (additive handler, no second inlet)
 
 - **What.** The `reviewhog` label add reaches ReviewHog as a `pull_request` handler registered in core's

--- a/products/review_hog/backend/api/perspectives.py
+++ b/products/review_hog/backend/api/perspectives.py
@@ -52,7 +52,8 @@ class ReviewPerspectiveConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericVie
     perspectives run on the requesting user's PR reviews. Visibility is per-user: the menu shows
     the canonicals plus the customs the requesting user authored — a teammate's custom is neither
     listed nor enableable (`visible_skill_names`). `list` joins that menu with the user's enable
-    state (the 3 canonicals auto-seed enabled on first read); `partial_update` toggles one by skill
+    state (the default canonicals auto-seed enabled on first read; opt-in canonicals stay off until
+    toggled); `partial_update` toggles one by skill
     name (upserting the config row, so a freshly authored custom perspective is enabled by the same
     call). At least one perspective must stay enabled.
     """
@@ -77,8 +78,9 @@ class ReviewPerspectiveConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericVie
         description=(
             "List the `review-hog-perspective-*` skills visible to the requesting user — the "
             "canonical perspectives plus the customs they authored — joined with their enable "
-            "state. The 3 canonical perspectives are auto-seeded enabled on the first read; a "
-            "custom perspective the user has not switched on shows as disabled."
+            "state. The default canonical perspectives are auto-seeded enabled on the first read; "
+            "opt-in canonicals and custom perspectives the user has not switched on show as "
+            "disabled."
         ),
     )
     def list(self, request: Request, **kwargs) -> Response:

--- a/products/review_hog/backend/reviewer/progress.py
+++ b/products/review_hog/backend/reviewer/progress.py
@@ -34,7 +34,7 @@ from products.review_hog.backend.reviewer.constants import BLIND_SPOT_PASS_NUMBE
 from products.review_hog.backend.reviewer.models.github_meta import PRMetadata
 from products.review_hog.backend.reviewer.models.perspective_selection import ChunkPerspectiveSelection
 from products.review_hog.backend.reviewer.skill_loader import (
-    CANONICAL_PERSPECTIVE_SKILL_NAMES,
+    DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES,
     REVIEW_HOG_PERSPECTIVE_PREFIX,
 )
 
@@ -358,8 +358,8 @@ def _expected_reads(team_id: int, report: ReviewReport, turn: TurnStats) -> int 
         .filter(user_id=report.acting_user_id, enabled=True, skill_name__startswith=REVIEW_HOG_PERSPECTIVE_PREFIX)
         .count()
     )
-    # No configs yet means the run will seed and use the canonical set.
-    perspectives = enabled or len(CANONICAL_PERSPECTIVE_SKILL_NAMES)
+    # No configs yet means the run will seed and use the default-enabled canonical set.
+    perspectives = enabled or len(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
     return chunk_count * (perspectives + 1)
 
 

--- a/products/review_hog/backend/reviewer/skill_loader.py
+++ b/products/review_hog/backend/reviewer/skill_loader.py
@@ -25,16 +25,30 @@ logger = logging.getLogger(__name__)
 # this prefix is a perspective. Canonical and custom are identical except canonicals auto-seed enabled.
 REVIEW_HOG_PERSPECTIVE_PREFIX = "review-hog-perspective-"
 
-# Canonical perspectives that auto-seed. `PerspectiveType` is just this seed list now — NOT an identity
-# (skill_name is, stamped at review time), so a custom perspective without an enum member is first-class.
+# Canonical perspectives that auto-seed ENABLED on a user's first run. `PerspectiveType` is just this
+# seed list now — NOT an identity (skill_name is, stamped at review time), so a custom perspective
+# without an enum member is first-class.
 PERSPECTIVES: tuple[tuple[PerspectiveType, str], ...] = (
     (PerspectiveType.LOGIC_CORRECTNESS, f"{REVIEW_HOG_PERSPECTIVE_PREFIX}logic-correctness"),
     (PerspectiveType.CONTRACTS_SECURITY, f"{REVIEW_HOG_PERSPECTIVE_PREFIX}contracts-security"),
     (PerspectiveType.PERFORMANCE_RELIABILITY, f"{REVIEW_HOG_PERSPECTIVE_PREFIX}performance-reliability"),
 )
 
-# The canonical perspective skill names — the set `register_missing_perspective_configs` auto-enables.
-CANONICAL_PERSPECTIVE_SKILL_NAMES: tuple[str, ...] = tuple(name for _, name in PERSPECTIVES)
+# Canonical perspectives that ship to every team but never auto-enable — a user switches them on from
+# the Code review scene, like a custom. Kept out of `PERSPECTIVES` so the config seed cannot enable
+# them; the on-disk skill still syncs for every team because discovery is directory-driven.
+OPT_IN_CANONICAL_PERSPECTIVE_SKILL_NAMES: tuple[str, ...] = (
+    f"{REVIEW_HOG_PERSPECTIVE_PREFIX}overengineering-paranoia",
+)
+
+# The subset `register_missing_perspective_configs` auto-enables on a user's first run.
+DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES: tuple[str, ...] = tuple(name for _, name in PERSPECTIVES)
+
+# Every canonical perspective skill name — the everyone-visible set (`visible_skill_names`).
+CANONICAL_PERSPECTIVE_SKILL_NAMES: tuple[str, ...] = (
+    *DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES,
+    *OPT_IN_CANONICAL_PERSPECTIVE_SKILL_NAMES,
+)
 
 
 class NoEnabledPerspectivesError(LookupError):
@@ -82,9 +96,9 @@ class LoadedPerspective:
 
 
 def _register_missing_configs(team_id: int, user_id: int, skill_names: tuple[str, ...]) -> None:
-    """Seed an enabled `ReviewSkillConfig` for each canonical skill this user lacks.
+    """Seed an enabled `ReviewSkillConfig` for each given canonical skill this user lacks.
 
-    The one allowed canonical/custom difference: the canonicals auto-enable on a user's first run
+    The one allowed canonical/custom difference: these canonicals auto-enable on a user's first run
     ("auto-added on the start"); customs are switched on explicitly via the config API. Idempotent
     (`get_or_create` on the `(team, user, skill_name)` unique key), and a row the user disabled is
     left untouched — seeding never re-enables. `team_id` / `user_id` stay in the create kwargs: the
@@ -99,14 +113,20 @@ def _register_missing_configs(team_id: int, user_id: int, skill_names: tuple[str
 
 
 def register_missing_perspective_configs(team_id: int, user_id: int) -> None:
-    """Seed an enabled `ReviewSkillConfig` for each canonical perspective this user lacks."""
-    _register_missing_configs(team_id, user_id, CANONICAL_PERSPECTIVE_SKILL_NAMES)
+    """Seed an enabled `ReviewSkillConfig` for each default canonical perspective this user lacks.
+
+    Opt-in canonicals get no config row here: with no row they read as disabled everywhere (the
+    config API and the loader both default a missing row to off), which is exactly the
+    disabled-until-switched-on behavior customs have.
+    """
+    _register_missing_configs(team_id, user_id, DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
 
 
 def load_perspectives_for_run(team_id: int, acting_user_id: int) -> list[LoadedPerspective]:
     """Resolve the acting user's enabled perspectives, each pinned to its current latest version.
 
-    Seeds the canonical configs first (so a cold user gets the 3 canonicals), then reads the user's
+    Seeds the default canonical configs first (so a cold user gets those enabled; opt-in canonicals
+    stay off until the user switches them on), then reads the user's
     enabled set and resolves each name to its live `LLMSkill` (latest, non-deleted). `pass_number`
     is the 1-based slot in the full enabled set sorted by name — NOT an index over the live subset,
     so a dead skill leaves a hole instead of shifting the others. That keeps each surviving

--- a/products/review_hog/backend/reviewer/skill_loader.py
+++ b/products/review_hog/backend/reviewer/skill_loader.py
@@ -22,7 +22,9 @@ from products.skills.backend.models.skills import LLMSkill
 logger = logging.getLogger(__name__)
 
 # Naming contract for review perspectives (mirrors `SIGNALS_SCOUT_SKILL_PREFIX`): any team skill with
-# this prefix is a perspective. Canonical and custom are identical except canonicals auto-seed enabled.
+# this prefix is a perspective. Canonical and custom are identical in shape; only default-enabled
+# canonicals auto-seed enabled, while opt-in canonicals and customs stay off until a user switches
+# them on.
 REVIEW_HOG_PERSPECTIVE_PREFIX = "review-hog-perspective-"
 
 # Canonical perspectives that auto-seed ENABLED on a user's first run. `PerspectiveType` is just this

--- a/products/review_hog/backend/tests/test_perspective_config_api.py
+++ b/products/review_hog/backend/tests/test_perspective_config_api.py
@@ -8,6 +8,8 @@ from products.review_hog.backend.models import ReviewSkillConfig
 from products.review_hog.backend.reviewer.lazy_seed import sync_canonical_perspectives
 from products.review_hog.backend.reviewer.skill_loader import (
     CANONICAL_PERSPECTIVE_SKILL_NAMES,
+    DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES,
+    OPT_IN_CANONICAL_PERSPECTIVE_SKILL_NAMES,
     REVIEW_HOG_PERSPECTIVE_PREFIX,
     REVIEW_HOG_VALIDATION_SKILL_NAME,
     register_missing_perspective_configs,
@@ -15,6 +17,7 @@ from products.review_hog.backend.reviewer.skill_loader import (
 from products.skills.backend.models.skills import LLMSkill
 
 _CUSTOM = f"{REVIEW_HOG_PERSPECTIVE_PREFIX}custom-x"
+_OPT_IN = OPT_IN_CANONICAL_PERSPECTIVE_SKILL_NAMES[0]
 
 
 class TestReviewPerspectiveConfigAPI(APIBaseTest):
@@ -35,15 +38,17 @@ class TestReviewPerspectiveConfigAPI(APIBaseTest):
         )
 
     def test_list_shows_canonicals_enabled_and_custom_disabled(self) -> None:
-        # The menu surfaces every perspective skill with this user's enable state — canonicals seed on,
-        # a custom not yet switched on shows off — so the future UI can render the full toggle list.
+        # The menu surfaces every perspective skill with this user's enable state — default canonicals
+        # seed on, an opt-in canonical or a custom not yet switched on shows off — so the future UI
+        # can render the full toggle list.
         self._author_custom()
 
         res = self.client.get(f"{self.base}/")
 
         assert res.status_code == 200
         by_name = {item["skill_name"]: item["enabled"] for item in res.json()}
-        assert all(by_name[name] is True for name in CANONICAL_PERSPECTIVE_SKILL_NAMES)
+        assert all(by_name[name] is True for name in DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
+        assert by_name[_OPT_IN] is False
         assert by_name[_CUSTOM] is False
 
     def test_enabling_a_custom_perspective_upserts_the_config(self) -> None:
@@ -58,31 +63,41 @@ class TestReviewPerspectiveConfigAPI(APIBaseTest):
         config = ReviewSkillConfig.objects.for_team(self.team.id).get(user_id=self.user.id, skill_name=_CUSTOM)
         assert config.enabled is True
 
+    def test_enabling_an_opt_in_canonical_upserts_the_config(self) -> None:
+        # An opt-in canonical is seeded with no author, so unlike a custom its visibility rides only
+        # on the canonical name set — if the name fell out of it, this PATCH would 404 for everyone.
+        res = self.client.patch(f"{self.base}/{_OPT_IN}/", {"enabled": True}, format="json")
+
+        assert res.status_code == 200
+        assert res.json()["enabled"] is True
+        config = ReviewSkillConfig.objects.for_team(self.team.id).get(user_id=self.user.id, skill_name=_OPT_IN)
+        assert config.enabled is True
+
     def test_cannot_disable_the_last_enabled_perspective(self) -> None:
         # The min-1 floor: a user must always keep ≥1 perspective on, or their reviews would run empty.
         register_missing_perspective_configs(self.team.id, self.user.id)
-        names = sorted(CANONICAL_PERSPECTIVE_SKILL_NAMES)
-        for name in names[:2]:
+        names = sorted(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
+        for name in names[:-1]:
             assert self.client.patch(f"{self.base}/{name}/", {"enabled": False}, format="json").status_code == 200
 
-        res = self.client.patch(f"{self.base}/{names[2]}/", {"enabled": False}, format="json")
+        res = self.client.patch(f"{self.base}/{names[-1]}/", {"enabled": False}, format="json")
 
         assert res.status_code == 400
-        last = ReviewSkillConfig.objects.for_team(self.team.id).get(user_id=self.user.id, skill_name=names[2])
+        last = ReviewSkillConfig.objects.for_team(self.team.id).get(user_id=self.user.id, skill_name=names[-1])
         assert last.enabled is True
 
     def test_an_enabled_validator_does_not_satisfy_the_perspective_floor(self) -> None:
         # The min-1 floor counts only perspectives: an enabled validator in the shared table must not
         # let a user disable their last perspective.
         register_missing_perspective_configs(self.team.id, self.user.id)
-        names = sorted(CANONICAL_PERSPECTIVE_SKILL_NAMES)
-        for name in names[:2]:
+        names = sorted(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
+        for name in names[:-1]:
             assert self.client.patch(f"{self.base}/{name}/", {"enabled": False}, format="json").status_code == 200
         ReviewSkillConfig.objects.for_team(self.team.id).create(
             team_id=self.team.id, user_id=self.user.id, skill_name=REVIEW_HOG_VALIDATION_SKILL_NAME, enabled=True
         )
 
-        res = self.client.patch(f"{self.base}/{names[2]}/", {"enabled": False}, format="json")
+        res = self.client.patch(f"{self.base}/{names[-1]}/", {"enabled": False}, format="json")
 
         assert res.status_code == 400
 

--- a/products/review_hog/backend/tests/test_perspectives.py
+++ b/products/review_hog/backend/tests/test_perspectives.py
@@ -14,7 +14,8 @@ from products.review_hog.backend.reviewer.lazy_seed import (
 )
 from products.review_hog.backend.reviewer.skill_loader import (
     CANONICAL_PERSPECTIVE_SKILL_NAMES,
-    PERSPECTIVES,
+    DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES,
+    OPT_IN_CANONICAL_PERSPECTIVE_SKILL_NAMES,
     REVIEW_HOG_PERSPECTIVE_PREFIX,
     REVIEW_HOG_VALIDATION_SKILL_NAME,
     NoEnabledPerspectivesError,
@@ -26,6 +27,7 @@ from products.skills.backend.models.skills import LLMSkill
 
 _LOGIC = f"{REVIEW_HOG_PERSPECTIVE_PREFIX}logic-correctness"
 _CUSTOM = f"{REVIEW_HOG_PERSPECTIVE_PREFIX}custom-x"
+_OPT_IN = OPT_IN_CANONICAL_PERSPECTIVE_SKILL_NAMES[0]
 
 
 def _author_perspective_skill(team, name: str, created_by: User | None = None) -> LLMSkill:
@@ -34,10 +36,11 @@ def _author_perspective_skill(team, name: str, created_by: User | None = None) -
     )
 
 
-def test_discover_finds_the_three_canonical_perspectives() -> None:
-    # The on-disk SKILL.md set must parse and match the registry names exactly.
+def test_discover_finds_the_canonical_perspectives() -> None:
+    # The on-disk SKILL.md set must parse and match the registry names exactly — the default-enabled
+    # ones and the opt-in ones alike.
     discovered = {s.name for s in discover_canonical_perspectives()}
-    assert discovered == {name for _, name in PERSPECTIVES}
+    assert discovered == set(CANONICAL_PERSPECTIVE_SKILL_NAMES)
 
 
 def _changed_canonical(name: str) -> CanonicalSkill:
@@ -55,9 +58,9 @@ class TestSyncCanonicalPerspectives(BaseTest):
     def test_creates_a_seeded_row_per_perspective(self) -> None:
         result = sync_canonical_perspectives(self.team)
 
-        assert set(result.created_skill_names) == {name for _, name in PERSPECTIVES}
+        assert set(result.created_skill_names) == set(CANONICAL_PERSPECTIVE_SKILL_NAMES)
         rows = LLMSkill.objects.filter(team=self.team, deleted=False, is_latest=True)
-        assert rows.count() == len(PERSPECTIVES)
+        assert rows.count() == len(CANONICAL_PERSPECTIVE_SKILL_NAMES)
         row = rows.get(name=_LOGIC)
         assert row.version == 1
         assert row.category == REVIEW_HOG_SKILL_CATEGORY
@@ -144,15 +147,16 @@ class TestSyncCanonicalPerspectives(BaseTest):
 
 
 class TestRegisterMissingPerspectiveConfigs(BaseTest):
-    def test_seeds_only_canonicals_enabled_and_is_idempotent(self) -> None:
-        # Seeding enables the 3 canonicals for the user and must NOT auto-create a config for a custom
-        # perspective (customs are user-enabled only). Re-running must not duplicate rows.
+    def test_seeds_only_default_canonicals_enabled_and_is_idempotent(self) -> None:
+        # Seeding enables the default canonicals for the user and must NOT auto-create a config for a
+        # custom perspective or an opt-in canonical (both are user-enabled only). Re-running must not
+        # duplicate rows.
         _author_perspective_skill(self.team, _CUSTOM)
         register_missing_perspective_configs(self.team.id, self.user.id)
         register_missing_perspective_configs(self.team.id, self.user.id)
 
         rows = ReviewSkillConfig.objects.for_team(self.team.id).filter(user_id=self.user.id)
-        assert {r.skill_name for r in rows} == set(CANONICAL_PERSPECTIVE_SKILL_NAMES)
+        assert {r.skill_name for r in rows} == set(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
         assert all(r.enabled for r in rows)
 
     def test_does_not_re_enable_a_disabled_canonical(self) -> None:
@@ -169,14 +173,15 @@ class TestRegisterMissingPerspectiveConfigs(BaseTest):
 
 
 class TestLoadPerspectivesForRun(BaseTest):
-    def test_cold_user_gets_the_canonicals_pinned(self) -> None:
-        # A user who never toggled anything: seeding enables the 3 canonicals, the loader resolves them
-        # sorted, pass_number a contiguous per-run index, version pinned to the synced latest.
+    def test_cold_user_gets_the_default_canonicals_pinned(self) -> None:
+        # A user who never toggled anything: seeding enables the default canonicals (never the opt-in
+        # ones), the loader resolves them sorted, pass_number a contiguous per-run index, version
+        # pinned to the synced latest.
         sync_canonical_perspectives(self.team)
 
         loaded = load_perspectives_for_run(self.team.id, self.user.id)
 
-        assert [lp.skill_name for lp in loaded] == sorted(CANONICAL_PERSPECTIVE_SKILL_NAMES)
+        assert [lp.skill_name for lp in loaded] == sorted(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
         assert [lp.pass_number for lp in loaded] == [1, 2, 3]
         assert all(lp.version == 1 for lp in loaded)
 
@@ -202,7 +207,7 @@ class TestLoadPerspectivesForRun(BaseTest):
 
         loaded = load_perspectives_for_run(self.team.id, self.user.id)
 
-        assert [lp.skill_name for lp in loaded] == sorted(set(CANONICAL_PERSPECTIVE_SKILL_NAMES) - {_LOGIC})
+        assert [lp.skill_name for lp in loaded] == sorted(set(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES) - {_LOGIC})
         assert [lp.pass_number for lp in loaded] == [1, 2]
 
     def test_includes_an_enabled_custom_perspective(self) -> None:
@@ -232,7 +237,7 @@ class TestLoadPerspectivesForRun(BaseTest):
         loaded = load_perspectives_for_run(self.team.id, self.user.id)
 
         assert REVIEW_HOG_VALIDATION_SKILL_NAME not in {lp.skill_name for lp in loaded}
-        assert [lp.skill_name for lp in loaded] == sorted(CANONICAL_PERSPECTIVE_SKILL_NAMES)
+        assert [lp.skill_name for lp in loaded] == sorted(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
 
     def test_raises_when_user_has_zero_enabled(self) -> None:
         sync_canonical_perspectives(self.team)
@@ -260,7 +265,7 @@ class TestLoadPerspectivesForRun(BaseTest):
 
         loaded = load_perspectives_for_run(self.team.id, self.user.id)
 
-        assert [lp.skill_name for lp in loaded] == sorted(CANONICAL_PERSPECTIVE_SKILL_NAMES)
+        assert [lp.skill_name for lp in loaded] == sorted(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
         assert [lp.pass_number for lp in loaded] == [1, 3, 4]
 
     def test_skips_an_enabled_perspective_authored_by_another_user(self) -> None:
@@ -278,8 +283,21 @@ class TestLoadPerspectivesForRun(BaseTest):
 
         loaded = load_perspectives_for_run(self.team.id, self.user.id)
 
-        assert [lp.skill_name for lp in loaded] == sorted(CANONICAL_PERSPECTIVE_SKILL_NAMES)
+        assert [lp.skill_name for lp in loaded] == sorted(DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES)
         assert [lp.pass_number for lp in loaded] == [1, 3, 4]
+
+    def test_includes_the_opt_in_canonical_once_enabled(self) -> None:
+        # An opt-in canonical is seeded with no author, so if its name fell out of the canonical
+        # visibility set the loader would skip it as a foreign custom — enabling it must run it.
+        sync_canonical_perspectives(self.team)
+        register_missing_perspective_configs(self.team.id, self.user.id)
+        ReviewSkillConfig.objects.for_team(self.team.id).create(
+            team_id=self.team.id, user_id=self.user.id, skill_name=_OPT_IN, enabled=True
+        )
+
+        loaded = load_perspectives_for_run(self.team.id, self.user.id)
+
+        assert [lp.skill_name for lp in loaded] == sorted([*DEFAULT_ENABLED_PERSPECTIVE_SKILL_NAMES, _OPT_IN])
 
     def test_enablement_is_per_user(self) -> None:
         # Disabling a perspective for one user must not affect another user's run — enablement is per-USER.

--- a/products/review_hog/backend/tests/test_reviews_api.py
+++ b/products/review_hog/backend/tests/test_reviews_api.py
@@ -440,8 +440,9 @@ class TestRecentReviewsAPI(APIBaseTest):
             head_sha="sha1",
             results={(1, 1): _issues_review(1), (2, 1): _issues_review(0)},
         )
-        # No persisted plan (a fallback run): the dense estimate — 2 chunks × (3 canonical
-        # perspectives + the blind-spot sweep) = 8 expected reads.
+        # No persisted plan (a fallback run): the dense estimate — 2 chunks × (3 default-enabled
+        # canonical perspectives + the blind-spot sweep) = 8 expected reads. Opt-in canonicals
+        # never seed, so they don't inflate the cold-user estimate.
         assert self.client.get(self.url).json()["results"][0]["progress"] == {
             "review_stage": "reviewing",
             "done": 2,

--- a/products/review_hog/frontend/generated/api.ts
+++ b/products/review_hog/frontend/generated/api.ts
@@ -90,7 +90,7 @@ export const getReviewHogPerspectivesListUrl = (projectId: string) => {
 }
 
 /**
- * List the `review-hog-perspective-*` skills visible to the requesting user — the canonical perspectives plus the customs they authored — joined with their enable state. The 3 canonical perspectives are auto-seeded enabled on the first read; a custom perspective the user has not switched on shows as disabled.
+ * List the `review-hog-perspective-*` skills visible to the requesting user — the canonical perspectives plus the customs they authored — joined with their enable state. The default canonical perspectives are auto-seeded enabled on the first read; opt-in canonicals and custom perspectives the user has not switched on show as disabled.
  * @summary List review perspectives and their enablement
  */
 export const reviewHogPerspectivesList = async (

--- a/products/review_hog/skills/review-hog-perspective-overengineering-paranoia/SKILL.md
+++ b/products/review_hog/skills/review-hog-perspective-overengineering-paranoia/SKILL.md
@@ -63,7 +63,7 @@ this perspective always makes the change smaller or simpler.
 
 ## Investigation commands
 
-- Count a symbol's callers: `rg "\bthe_symbol\b" -l` (only the defining file → nothing uses it)
+- Count a symbol's callers: `rg -n "\bthe_symbol\b"` (list every match with its line, then count the call sites apart from the definition — a helper called only inside its own file still has callers, so `-l` returning one path does not mean it is unused)
 - Find single-implementation abstractions: `rg "class \w+\((ABC|Protocol)\)" --type py -A 3`, then count subclasses / implementors of each
 - Check whether an option is ever set: `rg "option_name\s*[=:]"` across callers and config
 - Find broad exception handling: `rg "except Exception|except:|catch \(" -B 3 -A 5`

--- a/products/review_hog/skills/review-hog-perspective-overengineering-paranoia/SKILL.md
+++ b/products/review_hog/skills/review-hog-perspective-overengineering-paranoia/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: review-hog-perspective-overengineering-paranoia
+description: >
+  The Overengineering & Paranoia review perspective for PostHog Review. Flags needless complexity a
+  PR introduces: premature abstraction, speculative generality, defensive guards against states that
+  cannot occur, redundant fallbacks, and dead weight. Proposes concrete, safe simplifications;
+  reports excess-complexity issues only.
+metadata:
+  owner_team: review_hog
+  perspective: overengineering_paranoia
+---
+
+# Review perspective: Overengineering & Paranoia
+
+You are reviewing a PR chunk through the **Overengineering & Paranoia** perspective: did the change
+build more than its job needs? Concentrate on complexity this PR introduces — abstraction nothing
+uses twice, options nothing sets, guards for states that cannot occur, fallbacks that cannot be
+reached — and propose the concrete simplification.
+
+This is one of several independent perspectives reviewing the same chunk in parallel — correctness,
+security, and performance are covered elsewhere. Stay in your lane, and report every
+excess-complexity issue you find without worrying about what another perspective might also report
+(overlap is resolved later by a separate deduplication step).
+
+The direction of this lens is removal. Where other perspectives ask "what is missing?", you ask
+"what is here that the job doesn't need?". Never suggest adding machinery — a valid finding from
+this perspective always makes the change smaller or simpler.
+
+## Primary investigation areas
+
+1. **Premature abstraction**
+   - Interfaces, base classes, or protocols with exactly one implementation
+   - Factories, registries, or dispatch tables with a single entry
+   - Wrapper layers that only forward arguments to the layer below
+   - Helpers or components extracted for a single caller, with no second caller in the PR
+   - Count call sites across the repo before flagging — one caller is the evidence
+
+2. **Speculative generality**
+   - Options, parameters, settings, or props that no caller sets and no code reads
+   - Branches for modes, types, or inputs that no call site can produce
+   - Configurability ("pass it in", "make it pluggable") for a value that only ever has one value
+   - Hooks, events, or extension points with no consumer
+
+3. **Defensive paranoia**
+   - Guards against `None` / empty / invalid states that upstream types, validation, schema
+     constraints, or framework guarantees already rule out — verify by reading the call sites
+     and types, don't assume
+   - Re-validation of data already validated at the boundary where it entered
+   - Broad try / except (or catch) wrapping code that cannot raise, or re-raising without adding
+     handling, context, or cleanup
+   - Retries, locks, or timeouts around local, deterministic, single-threaded operations
+
+4. **Redundant and unreachable paths**
+   - Fallback and default branches no input can reach
+   - Duplicate sources of truth kept "in sync" where one derived value would do
+   - Caching or memoization of cheap computations
+   - Feature flags or kill switches guarding code with no rollout risk
+
+5. **Dead weight**
+   - Code the PR adds that nothing calls: functions, parameters, fields, enum members, constants
+   - Reimplementations of what the codebase, framework, or standard library already provides —
+     search for the existing utility before flagging
+
+## Investigation commands
+
+- Count a symbol's callers: `rg "\bthe_symbol\b" -l` (only the defining file → nothing uses it)
+- Find single-implementation abstractions: `rg "class \w+\((ABC|Protocol)\)" --type py -A 3`, then count subclasses / implementors of each
+- Check whether an option is ever set: `rg "option_name\s*[=:]"` across callers and config
+- Find broad exception handling: `rg "except Exception|except:|catch \(" -B 3 -A 5`
+- Check what upstream already guarantees: read the caller's types, serializer / schema validation, and DB constraints before judging a guard redundant
+- Look for the existing utility: `rg "def similar_name|useSimilarHook"` in shared modules before accepting a reimplementation
+
+## Where to focus
+
+Concentrate primary attention on:
+
+- New modules, classes, and helpers the PR introduces
+- New parameters, options, settings, and props
+- Error-handling blocks the PR adds
+- Branching added for inputs or modes the PR itself never produces
+- Utility code that shadows existing shared helpers
+
+Detect issues only in non-test files. Flag only complexity this PR introduces or expands —
+pre-existing complexity in touched files is context, not a finding.
+
+## What to leave to other perspectives
+
+- MISSING error handling, retries, or recovery → Performance & Reliability (you flag the excess; they flag the lack)
+- Actual bugs the added complexity causes or hides → Logic & Correctness
+- Input validation and authorization at trust boundaries → Contracts & Security. Never flag
+  validation of external input, authz / permission checks, tenant scoping, or security hardening
+  as paranoia — defense-in-depth at a trust boundary is deliberate.
+- Code style, naming, or formatting → not a PostHog Review concern
+
+## Key questions
+
+- What does this PR add that its stated job does not need?
+- Who else calls this? If the answer is "nobody yet", the abstraction is premature.
+- Can the guarded state actually occur, given the call sites, types, and validation in place?
+- Does the codebase already provide this?
+- What would the simplest version of this change look like?
+
+## What a valid finding looks like
+
+An Overengineering & Paranoia finding names three things:
+
+- **The mechanism** the PR introduces (the abstraction, the option, the guard, the fallback), with
+  file and lines
+- **The evidence it is not needed** — the counted call sites, the type or validation that rules the
+  state out, or the existing utility it duplicates
+- **The concrete simplification** — what to delete or inline, and why that is safe
+
+"This could be simpler" without all three is taste, not a finding — don't report it. You are done
+when every mechanism the chunk adds is either flagged with that evidence or cleared as pulling its
+weight.
+
+### Severity guide
+
+- **Must fix**: the added machinery actively harms — a defensive catch-all that swallows real
+  errors, a duplicate source of truth that will drift, an abstraction that makes the surrounding
+  code misleading or wrong
+- **Should fix**: real bloat with a safe removal — an option nothing reads, a
+  single-implementation interface, a cluster of guards for impossible states
+- **Consider**: marginal simplifications — a small redundant check, a helper that could be inlined

--- a/products/review_hog/skills/review-hog-validation-criteria/SKILL.md
+++ b/products/review_hog/skills/review-hog-validation-criteria/SKILL.md
@@ -3,7 +3,8 @@ name: review-hog-validation-criteria
 description: >
   The validation criteria for PostHog Review, the bar for deciding whether a flagged PR issue is worth
   keeping. Keeps real, user-affecting correctness / security / data-loss / contract / performance
-  problems; drops overengineering, speculation, paranoia, never-gonna-happen edge cases, and style.
+  problems, plus needless complexity the PR itself introduces; drops overengineering, speculation,
+  paranoia, never-gonna-happen edge cases, and style.
 metadata:
   owner_team: review_hog
   skill_type: validation_criteria
@@ -22,7 +23,9 @@ findings is worth far more than a long list padded with maybes.
 
 ## Keep an issue (`is_valid = true`) when it is a real problem that plausibly affects users or the codebase
 
-Keep it if the flagged code, as written and as actually reached, would cause one of:
+Keep it if the flagged code, as written and as actually reached, matches one of the following. Every
+bullet except the last names a behavioral harm the code would cause; the needless-complexity bullet
+is behavior-neutral and carries its own bar in its own text.
 
 - **Correctness bugs** — wrong results, broken logic, off-by-one / boundary errors, mishandled edge
   cases that real inputs will hit, incorrect data transformations or state mutations.
@@ -46,9 +49,12 @@ Keep it if the flagged code, as written and as actually reached, would cause one
   **delete** machinery the PR added is a real maintainability problem, even though removing it
   changes no behavior.
 
-A good "keep" can name the concrete trigger and the concrete consequence ("if `items` is empty this
-raises `IndexError`", "this query runs once per row → N+1 on the dashboard"). If you can't name both,
-be skeptical.
+For a finding that claims a behavioral harm, a good "keep" can name the concrete trigger and the
+concrete consequence ("if `items` is empty this raises `IndexError`", "this query runs once per row →
+N+1 on the dashboard"); if you can't name both, be skeptical. The needless-complexity keep is the
+exception: it changes no behavior, so it has no runtime trigger or consequence to name. Its complete
+bar is the one in its own bullet — the concrete mechanism, the evidence it is unneeded, and a safe
+removal — nothing more.
 
 ## Drop an issue (`is_valid = false`) when it is noise
 

--- a/products/review_hog/skills/review-hog-validation-criteria/SKILL.md
+++ b/products/review_hog/skills/review-hog-validation-criteria/SKILL.md
@@ -37,6 +37,14 @@ Keep it if the flagged code, as written and as actually reached, would cause one
   quadratic behavior.
 - **Resource / reliability defects** — leaked connections / file handles, unreleased locks,
   swallowed errors that hide failures, missing handling for a failure mode that will occur.
+- **Needless complexity the PR itself introduces** — dead code, an option or parameter nothing
+  reads, an abstraction with a single implementation, a defensive guard for a state upstream types
+  or validation already rule out, an unreachable fallback. Keep it only when the finding names the
+  concrete mechanism, the evidence it is unneeded (call sites counted, types checked, or the
+  existing utility it duplicates), and a removal that is safe. This is the inverse of the
+  overengineering drop below: that bullet drops asks to **add** machinery; a grounded ask to
+  **delete** machinery the PR added is a real maintainability problem, even though removing it
+  changes no behavior.
 
 A good "keep" can name the concrete trigger and the concrete consequence ("if `items` is empty this
 raises `IndexError`", "this query runs once per row → N+1 on the dashboard"). If you can't name both,
@@ -46,8 +54,9 @@ be skeptical.
 
 Drop it if it is any of:
 
-- **Overengineering** — "extract this", "add an abstraction/interface", "make it configurable",
-  "future-proof for a case that isn't in scope".
+- **Overengineering** — asks to add machinery: "extract this", "add an abstraction/interface",
+  "make it configurable", "future-proof for a case that isn't in scope". (An evidence-backed ask to
+  _remove_ machinery the PR added falls under the needless-complexity keep above, not here.)
 - **Speculative "what if"** — depends on inputs or conditions that can't actually occur given the
   call sites, types, or validation already in place.
 - **Defensive-coding paranoia** — guarding against `None`/errors that upstream types or invariants

--- a/products/review_hog/skills/review-hog-validation-criteria/SKILL.md
+++ b/products/review_hog/skills/review-hog-validation-criteria/SKILL.md
@@ -59,14 +59,19 @@ Drop it if it is any of:
   _remove_ machinery the PR added falls under the needless-complexity keep above, not here.)
 - **Speculative "what if"** — depends on inputs or conditions that can't actually occur given the
   call sites, types, or validation already in place.
-- **Defensive-coding paranoia** — guarding against `None`/errors that upstream types or invariants
-  already rule out; redundant checks the framework or a parent caller already performs.
+- **Defensive-coding paranoia** — asks to add a guard against `None`/errors that upstream types or
+  invariants already rule out, or a redundant check the framework or a parent caller already
+  performs. (An evidence-backed ask to _remove_ such a guard the PR added falls under the
+  needless-complexity keep above, not here.)
 - **Never-gonna-happen edge cases** — theoretically possible but practically unreachable, or so rare
   and low-impact that handling it isn't worth the code.
 - **Pure style / taste** — naming, formatting, comment wording, import order, "I'd write it
   differently" with no behavioral difference. (Formatting is not a PostHog Review concern.)
 - **Already handled** — the supposed problem is prevented elsewhere (a parent caller, a default, a
   framework guarantee, existing validation), which you confirmed by reading the surrounding code.
+  (This covers a finding whose problem upstream already prevents. A needless-complexity finding that
+  _cites_ that upstream guarantee as the evidence a guard the PR added is redundant routes to the
+  keep above instead.)
 - **Wrong / unreproducible** — investigating the actual code shows the premise is mistaken.
 
 ## How to decide


### PR DESCRIPTION
## Problem

PostHog Review's three default perspectives all hunt for what a PR lacks (bugs, security holes, missing error handling); nothing flags what a PR over-builds. Agent-written PRs in particular land with complexity bloat — premature abstractions, speculative options, guards for impossible states — and no lens calls it out.

## Changes

- Users get a fourth canonical perspective on the Code review scene, **Overengineering & Paranoia**: it flags needless complexity the PR itself introduces and always proposes a removal, never an addition.
- It ships to every team but stays **disabled until a user switches it on** — the first opt-in canonical. `skill_loader.py` now splits the everyone-visible canonical set from the auto-seeded default-enabled subset; an opt-in canonical gets no config row, so it reads as disabled exactly like a custom.
- The canonical validation criteria gain one keep-bullet for evidence-backed "delete this machinery the PR added" findings. Without it the keep list was a closed set of behavioral harms, so the validator would have judged every finding of the new lens invalid (removing complexity changes no behavior).
- The cold-user progress estimate now counts only default-enabled canonicals, so the fourth skill does not inflate the expected-reads total.
- Mechanical: regenerated `frontend/generated/api.ts` (endpoint description), ARCHITECTURE.md / DECISIONS.md sync. Everything downstream (selection, blind-spot prompt, dedup, stats, scene UI) keys off skill name + description and needed no changes.

## How did you test this code?

- Ran `products/review_hog/backend/tests/test_perspectives.py` and `test_perspective_config_api.py` locally (all passed), plus the dense-estimate progress test in `test_reviews_api.py`.
- New test `test_includes_the_opt_in_canonical_once_enabled`: the opt-in canonical is seeded with no author, so if its name fell out of the canonical visibility set the loader would silently skip it as a foreign custom — no existing test covered that path.
- New test `test_enabling_an_opt_in_canonical_upserts_the_config`: same regression on the API path, where it would surface as a 404 for every user.
- Extended `test_list_shows_canonicals_enabled_and_custom_disabled` to lock in that the opt-in canonical lists as disabled while defaults list as enabled.
- Not run: a live end-to-end review with the perspective enabled; the skill body's finding quality needs a dogfood run to tune.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

ARCHITECTURE.md and DECISIONS.md updated in this PR; no `docs/` pages cover Review perspectives yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (PostHog Desktop task) from a short spec: a default "Overengineering & Paranoia" perspective, disabled by default, available to everyone.
- Skills invoked: `review-hog-authoring` (perspective body shape), `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/improving-drf-endpoints`, `/writing-pr-descriptions`.
- Key decision settled with the driver mid-session: the validation-criteria keep-bullet. The initial read was that the validator's overengineering drop-bullet (asks to add machinery) and the new lens (asks to remove machinery) were disjoint; the real blocker was the keep list having no bucket for behavior-neutral maintainability findings.
- Public artifact: everything in this PR is written fresh from the repo's own conventions; no session material beyond the spec above informed the content.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
