### PR TITLE
fix(slack_app): stop hiding the web task link from unlinked readers

### DIFF
--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -276,10 +276,11 @@ class TaskItem:
     """One row on the Tasks card."""
 
     title: str
-    # Both task links are `None` for a viewer without PostHog Code access, matching the
-    # reply footer: a task page they can't open is as much a dead end as the desktop app.
-    # Stated at every construction rather than defaulted, so a row can't lose its links
-    # by omission and render as plain text.
+    # The desktop link is `None` for a viewer without PostHog Desktop access, matching
+    # the reply footer. The web link is always present: the task page enforces access
+    # itself, so at worst it asks the viewer to sign in. Stated at every construction
+    # rather than defaulted, so a row can't lose its links by omission and render as
+    # plain text.
     posthog_url: str | None
     desktop_url: str | None
     status: str | None  # TaskRun.Status value or None when there's no run yet
@@ -2008,10 +2009,11 @@ def _resolve_tasks_state(
     mapping_by_task = {str(m["task_id"]): m for m in mappings}
 
     site_url = (settings.SITE_URL or "").rstrip("/")
-    # Both task links answer to the reader, the same check the reply footer's links use.
-    # The desktop one goes through the `/code/task` web bridge, which opens the app when
-    # installed and offers a download when not, so it rides alongside the web one.
-    can_open_code_links = viewer_has_code_access(integration, slack_user_id)
+    # Only the desktop link answers to the viewer, the same check the reply footer's
+    # desktop link uses. It goes through the `/code/task` web bridge, which opens the app
+    # when installed and offers a download when not. The web link is always shown — the
+    # task page enforces access itself.
+    can_open_desktop_links = viewer_has_code_access(integration, slack_user_id)
     now = django_timezone.now()
     all_items: list[TaskItem] = []
     repos_seen: list[str] = []
@@ -2022,10 +2024,8 @@ def _resolve_tasks_state(
             continue
         run = runs_by_task.get(str(t.id))
         mapping: Mapping[str, Any] = mapping_by_task.get(str(t.id), {})
-        posthog_url = desktop_url = None
-        if can_open_code_links:
-            posthog_url = f"{site_url}/project/{t.team_id}/tasks/{t.id}"
-            desktop_url = f"{site_url}/code/task/{t.id}"
+        posthog_url = f"{site_url}/project/{t.team_id}/tasks/{t.id}"
+        desktop_url = f"{site_url}/code/task/{t.id}" if can_open_desktop_links else None
         all_items.append(
             TaskItem(
                 title=t.title,

--- a/products/slack_app/backend/services/slack_messages.py
+++ b/products/slack_app/backend/services/slack_messages.py
@@ -501,8 +501,9 @@ def load_run_footer(run_id: str | UUID | None) -> RunFooter:
     Never raises: the footer is the last thing added to an answer that is already
     written, so failing to describe the run must not cost the reader the answer.
 
-    Describes the run in full, links included. Whether the reader may open them is
-    ``viewer_has_code_access``'s question, asked where the reader is known.
+    Describes the run in full, links included. Whether the reader gets the desktop link
+    is ``viewer_has_code_access``'s question, asked where the reader is known; the web
+    link is for everyone, since the task page enforces access itself.
     """
     # Deferred so the tasks product stays off this module's import path, matching
     # `model_catalogue`.

--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -176,29 +176,32 @@ class SlackThreadHandler:
         return bool(self._footer_flag)
 
     def viewer_can_open_code_links(self) -> bool:
-        """Whether this reply's reader can open a PostHog Code link. Memoized: the cards
-        ask for their buttons and the footer asks again for its own links."""
+        """Whether this reply's reader passes the PostHog Desktop access check. Memoized:
+        the cards ask for their buttons and the footer asks again for its desktop link."""
         if self._code_access is None:
             self._code_access = viewer_has_code_access(self._get_integration(), self.actor_slack_user_id)
         return bool(self._code_access)
 
     def reader_footer(self) -> RunFooter:
-        """`run_footer` as this reply's reader may see it, links withheld where they can't
-        open them.
+        """`run_footer` with the desktop link withheld where this reply's reader can't
+        open it.
 
-        The one place that answers this, so a card's buttons and the footer's links can't
-        disagree about the same reader. A footer carrying no links asks nothing, which
-        keeps a plain answer off the identity lookup behind the access check.
+        The web task link is never withheld: the task page enforces access itself, so at
+        worst it asks the reader to sign in. The one place that answers this, so a card's
+        buttons and the footer's links can't disagree about the same reader. A footer
+        carrying no desktop link asks nothing, which keeps a plain answer off the
+        identity lookup behind the access check.
         """
-        if not (self.run_footer.task_url or self.run_footer.desktop_url):
+        if not self.run_footer.desktop_url:
             return self.run_footer
         if self.viewer_can_open_code_links():
             return self.run_footer
-        return replace(self.run_footer, task_url=None, desktop_url=None)
+        return replace(self.run_footer, desktop_url=None)
 
     def reader_task_url(self) -> str | None:
-        """The task page this reply's reader may open, or `None` where they may not."""
-        return self.reader_footer().task_url
+        """The task page behind this reply, or `None` when the run has no task. Shown to
+        every reader; the page enforces access itself."""
+        return self.run_footer.task_url
 
     def _footer_block(self, include_task_url: bool = True) -> dict[str, Any] | None:
         """This handler's footer, or `None` when the workspace isn't in the rollout.

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -781,11 +781,11 @@ class TestTasksCard:
         assert "<https://app/project/1/tasks/abc|View on web>" in sub
         assert "<https://us.posthog.com/code/task/abc|View on desktop>" in sub
 
-    def test_both_task_links_are_withheld_from_a_viewer_without_code_access(self):
-        # A task page is as much a dead end for them as the desktop app, so the pair goes
-        # together — the same rule the reply footer's links follow.
+    def test_only_the_desktop_link_is_withheld_from_a_viewer_without_desktop_access(self):
+        # The task page enforces access itself, so the web link stays even when the
+        # desktop one is withheld — the same rule the reply footer's links follow.
         state = TasksState(
-            items=(self._item(posthog_url=None, desktop_url=None),),
+            items=(self._item(desktop_url=None),),
             has_any_tasks=True,
             page=0,
             total_pages=1,
@@ -794,7 +794,7 @@ class TestTasksCard:
         view = render_home_view(**self._kwargs(tasks_state=state))
         _, sub = self._task_items(view, expected_count=1)[0]
 
-        assert "View on web" not in sub
+        assert "View on web" in sub
         assert "View on desktop" not in sub
 
     def test_title_is_plain_text_when_neither_thread_nor_task_link_is_available(self):

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -385,8 +385,8 @@ class TestReplyFooterGate(SimpleTestCase):
         _mock_flag,
         _mock_home,
     ) -> None:
-        # Whether this reader can open a task page changes which segments render, never
-        # whether the line appears: the model and the way to change it are theirs either way.
+        # Desktop access changes only the desktop segment: the web link works for anyone
+        # with a PostHog login, and the model and the way to change it are theirs either way.
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
         mock_get_integration.return_value = Integration(config={"app_id": "A1"}, integration_id="T1")
@@ -402,7 +402,7 @@ class TestReplyFooterGate(SimpleTestCase):
         line = mock_client.chat_postMessage.call_args.kwargs["blocks"][-1]["elements"][0]["text"]
         assert "*Claude Opus 5*" in line
         assert "|Configure>" in line
-        assert ("View on web" in line) is code_access
+        assert "View on web" in line
         assert ("View on desktop" in line) is code_access
 
     @parameterized.expand([("off", False, False), ("on", True, True)])

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -35,7 +35,7 @@ class TestPostSlackUpdate(TestCase):
         self._footer_patcher.start()
         self.addCleanup(self._footer_patcher.stop)
         # The gate is patched on the class so it answers without a Slack identity lookup;
-        # the deny-path test flips it to prove the url really hangs off this answer.
+        # the deny-path test flips it to prove the web url does not hang off this answer.
         self._access_patcher = patch.object(SlackThreadHandler, "viewer_can_open_code_links", return_value=True)
         self._access_patcher.start()
         self.addCleanup(self._access_patcher.stop)
@@ -577,7 +577,7 @@ class TestPostSlackUpdate(TestCase):
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch("products.tasks.backend.models.TaskRun")
-    def test_user_without_posthog_code_access_omits_task_url(
+    def test_user_without_posthog_code_access_still_gets_task_url(
         self,
         mock_task_run_class,
         _mock_update_reaction,
@@ -587,9 +587,9 @@ class TestPostSlackUpdate(TestCase):
         mock_post_progress,
         mock_post_completion,
     ):
-        # When the task creator is not a PostHog Desktop user, every handler call
-        # (including the progress handler) receives ``task_url=None`` so the
-        # web buttons are skipped.
+        # The web task link is never withheld — the task page enforces access
+        # itself — so every handler call (including the progress handler)
+        # receives the task url even when the reader fails the access check.
         self._access_patcher.stop()
         deny_patcher = patch.object(SlackThreadHandler, "viewer_can_open_code_links", return_value=False)
         deny_patcher.start()
@@ -629,13 +629,13 @@ class TestPostSlackUpdate(TestCase):
             handler_mock.assert_called_once()
             # ``task_url`` is the second positional argument on ``post_pr_opened``
             # and the trailing positional argument on every other handler — the
-            # contract is "no access ⇒ this argument is ``None``".
+            # contract is "no access ⇒ the web link still flows through".
             task_url_arg = (
                 handler_mock.call_args.args[1]
                 if handler_mock is mock_post_pr_opened
                 else handler_mock.call_args.args[-1]
             )
-            assert task_url_arg is None
+            assert task_url_arg == "http://localhost:8000/project/1/tasks/10?runId=run-1"
 
         mock_post_pr_opened.reset_mock()
         cleaned_with_pr = self._make_mock_run(
@@ -653,7 +653,7 @@ class TestPostSlackUpdate(TestCase):
         )
         mock_post_pr_opened.assert_called_once()
         # task_url is the second positional argument on post_pr_opened.
-        assert mock_post_pr_opened.call_args.args[1] is None
+        assert mock_post_pr_opened.call_args.args[1] == "http://localhost:8000/project/1/tasks/10?runId=run-1"
 
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")


### PR DESCRIPTION
## Problem

- A Slack reader without a linked PostHog identity, or in an org denied Desktop access, gets a model-only reply footer: both task links are withheld.
- The web task page enforces access itself, so withholding its link only costs readers a working link. Since Desktop access became default-allow, "not linked" is the main reason links disappear.

## Changes

- Reply footers, App Home task rows, and task-run update cards now always show "View on web"; the page asks the reader to sign in if needed.
- "View on desktop" stays behind the per-reader access check, unchanged.
- No screenshots: Slack surfaces only, and nothing renders differently apart from which links appear.

## How did you test this code?

- Updated the thread-footer and App Home tests to lock in the new rule (web always, desktop gated); the "both links withheld" state can no longer be produced, so its test now asserts the web link survives a desktop denial.
- Ran the slack_app thread, App Home, and run-footer test files locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session; skills invoked: /writing-tests, /writing-pr-descriptions.
- Session scope: analysis of the footer gating first, then this change on request; the access check itself (`viewer_has_code_access`) is untouched and still fail-closed for the desktop link.
