### PR TITLE
fix(mcp): handle redis errors in context-mill background refresh lock acquire

### DIFF
--- a/services/mcp/src/hono/cache/ContextMillResourceCache.ts
+++ b/services/mcp/src/hono/cache/ContextMillResourceCache.ts
@@ -150,12 +150,14 @@ export class ContextMillResourceCache extends SharedBlobCache {
 
     private async refreshInBackground(): Promise<void> {
         const token = randomUUID()
-        if (!(await this.acquireLock(token))) {
-            contextMillCacheEventsTotal.inc({ event: 'lock_contended' })
-            return
-        }
-        contextMillCacheEventsTotal.inc({ event: 'lock_acquired' })
+        let acquired = false
         try {
+            acquired = await this.acquireLock(token)
+            if (!acquired) {
+                contextMillCacheEventsTotal.inc({ event: 'lock_contended' })
+                return
+            }
+            contextMillCacheEventsTotal.inc({ event: 'lock_acquired' })
             const bytes = await this.loadBlob()
             await this.writeCache(bytes)
             contextMillCacheEventsTotal.inc({ event: 'background_success' })
@@ -163,7 +165,9 @@ export class ContextMillResourceCache extends SharedBlobCache {
             contextMillCacheEventsTotal.inc({ event: 'background_error' })
             console.error(`[ContextMillResourceCache:${this.lockKey}] background refresh failed:`, err)
         } finally {
-            await this.releaseLock(token)
+            if (acquired) {
+                await this.releaseLock(token)
+            }
         }
     }
 

--- a/services/mcp/tests/hono/context-mill-resource-cache.test.ts
+++ b/services/mcp/tests/hono/context-mill-resource-cache.test.ts
@@ -319,6 +319,36 @@ describe('ContextMillResourceCache', () => {
         }
     })
 
+    it('degrades to background_error when the lock acquire fails, without an unhandled rejection', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const unhandled = vi.fn()
+        process.on('unhandledRejection', unhandled)
+        try {
+            const cache = new TestContextMillResourceCache(redis, async () => [makeEntry('a')], {
+                freshSeconds: 0,
+                waitIntervalMs: 5,
+                waitTimeoutMs: 100,
+            })
+            await cache.loadOrRefresh()
+            cache.setLoader(async () => [makeEntry('b')])
+            redis.set = vi.fn(async () => {
+                throw new Error('Command timed out')
+            })
+
+            const stale = await cache.loadOrRefresh()
+            expect(stale.result).toBe('stale_hit')
+
+            await new Promise((r) => setTimeout(r, 30))
+
+            expect(mockCacheEventsInc).toHaveBeenCalledWith({ event: 'background_error' })
+            expect(redis._store.has(MANIFEST_LOCK_KEY)).toBe(false)
+            expect(unhandled).not.toHaveBeenCalled()
+        } finally {
+            process.off('unhandledRejection', unhandled)
+            consoleError.mockRestore()
+        }
+    })
+
     it('falls back to a direct load when the writer never publishes', async () => {
         redis._store.set(MANIFEST_LOCK_KEY, 'someone-else')
         const entries = [makeEntry('fallback')]


### PR DESCRIPTION
## Problem

A transient Valkey/Redis command timeout could kill an `mcp-server` pod instead of degrading. The context-mill cache's stale-hit path fires `refreshInBackground()` with `void` (fire-and-forget), and the writer-lock `SET NX` was awaited **outside** the function's try/catch — so a `Command timed out` rejection had no handler, and Node's default `unhandledRejection` behavior terminated the process.

## Changes

- Moved the lock acquire inside `refreshInBackground()`'s try/catch, so a Redis error now degrades to the existing `background_error` metric + log line instead of an unhandled rejection.
- The lock is only released when it was actually acquired — a timed-out acquire can no longer `DEL` another writer's lock key in the `finally`.
