### PR TITLE
chore: send verification email to users without an organization

### DIFF
--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -595,7 +595,7 @@ def send_email_verification(
     posthoganalytics.capture(
         distinct_id=str(user.distinct_id),
         event="verification email sent",
-        groups={"organization": str(user.current_organization.id)},  # type: ignore
+        groups={"organization": str(user.current_organization.id)} if user.current_organization else None,
     )
 
 
@@ -629,7 +629,7 @@ def send_email_verification_code(user_id: int, code: str, target_email: str | No
         capture(
             distinct_id=str(user.distinct_id),
             event="verification code sent",
-            groups={"organization": str(user.current_organization.id)},  # type: ignore
+            groups={"organization": str(user.current_organization.id)} if user.current_organization else None,
         )
 
 
@@ -656,7 +656,7 @@ def send_code_based_verification(user_id: int, code: str) -> None:
     posthoganalytics.capture(
         distinct_id=str(user.distinct_id),
         event="login verification code sent",
-        groups={"organization": str(user.current_organization.id)},  # type: ignore
+        groups={"organization": str(user.current_organization.id)} if user.current_organization else None,
     )
 
 


### PR DESCRIPTION
## Problem

A user without a current organization who triggers a verification email gets two of them. The code email sends, then the "sent" analytics capture crashes on `user.current_organization.id`, `send_code` treats that as a send failure, and the fallback link email goes out too.

Follow-up to #86493. Two occurrences since the rollout ([error tracking](https://us.posthog.com/project/2/error_tracking/01a047e6-6430-74f2-ac0b-a97c0f3b4f94)), both on an email change via `PATCH /api/users/@me/`. The login code flow has the [same crash](https://us.posthog.com/project/2/error_tracking/019f5be9-c79d-74a0-ad21-b8d490513109) with ~120 occurrences since July.

## Changes

- Guard the `groups={"organization": ...}` argument in the three capture calls in `posthog/tasks/email.py` (`send_email_verification`, `send_email_verification_code`, `send_code_based_verification`): pass `None` when the user has no organization.
- This removes the only trigger of the link-email fallback seen in production, and the duplicate email with it.

## How did you test this code?

Not run locally (worktree). The change only affects the analytics capture argument; CI covers the email tasks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed.
