### PR TITLE
fix(error-tracking): stop weekly digest failing under clickhouse load

### DIFF
--- a/products/error_tracking/backend/temporal/weekly_digest/activities.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/activities.py
@@ -352,5 +352,15 @@ def _send_org_digest(inputs: SendOrgDigestInputs, attempt: int) -> SendOrgDigest
 @activity.defn
 def send_org_digest_activity(inputs: SendOrgDigestInputs) -> SendOrgDigestResult:
     close_old_connections()
+    attempt = activity.info().attempt
     with HeartbeaterSync(logger=logger):
-        return _send_org_digest(inputs, attempt=activity.info().attempt)
+        try:
+            return _send_org_digest(inputs, attempt=attempt)
+        except Exception:
+            # Every other failure log sits inside the per-team build loop, so a failure before it
+            # (the org-wide exception count query, or any Postgres read) names no org anywhere.
+            # Temporal's own activity-failure log carries the activity id but not the inputs, which
+            # leaves those orgs unidentifiable after the fact. This one event names the org for
+            # every failure path: filter it on attempt == max_attempts for the orgs a run gave up on.
+            logger.exception("et_weekly_digest.org_failed", org_id=inputs.org_id, attempt=attempt)
+            raise

--- a/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
@@ -137,6 +137,11 @@ class TestLoadPageOrgs(SimpleTestCase):
 
 
 # send_digest_to_workflow refuses to send outside Cloud, so the send path needs cloud mode.
+# The fallback and final-attempt branches are defined relative to max_attempts, so the cases
+# below have to move with it rather than hardcode the attempt numbers of one particular budget.
+_MAX_ATTEMPTS = SendOrgDigestInputs(org_id="").max_attempts
+
+
 @override_settings(CLOUD_DEPLOYMENT="US")
 class TestSendOrgDigest(ClickhouseTestMixin, APIBaseTest):
     @classmethod
@@ -404,7 +409,7 @@ class TestSendOrgDigest(ClickhouseTestMixin, APIBaseTest):
             # Final attempt (attempt == max_attempts): fall back to delivering the healthy teams rather
             # than starving the recipient of a digest entirely. The activity still raises for visibility.
             with pytest.raises(ApplicationError, match="team builds") as exc_info:
-                self._run(attempt=6)
+                self._run(attempt=_MAX_ATTEMPTS)
 
         assert mock_post.call_count == 1
         sections = mock_post.call_args.kwargs["json"]["digest"]["project_sections"]
@@ -414,9 +419,9 @@ class TestSendOrgDigest(ClickhouseTestMixin, APIBaseTest):
 
     @parameterized.expand(
         [
-            ("before_last_two_attempts_no_fallback", 4, 0),
-            ("second_to_last_attempt_falls_back", 5, 1),
-            ("final_attempt_falls_back", 6, 1),
+            ("before_last_two_attempts_no_fallback", _MAX_ATTEMPTS - 2, 0),
+            ("second_to_last_attempt_falls_back", _MAX_ATTEMPTS - 1, 1),
+            ("final_attempt_falls_back", _MAX_ATTEMPTS, 1),
         ]
     )
     def test_broken_test_account_filter_falls_back_to_unfiltered_on_last_two_attempts(
@@ -741,17 +746,59 @@ class TestErrorTrackingWeeklyDigestWorkflow:
         assert result == WeeklyDigestResult(orgs=5, orgs_failed=0, sent=5)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("page_size", [0, -5])
-    async def test_non_positive_page_size_fails_the_run(self, page_size):
-        # 0 used to raise ZeroDivisionError from the page arithmetic, which Temporal retries
-        # as a workflow task forever rather than failing; a negative value produced an empty
-        # page range and reported a successful run that sent nothing.
+    @pytest.mark.parametrize("field", ["page_size", "max_concurrent_pages"])
+    @pytest.mark.parametrize("value", [0, -5])
+    async def test_non_positive_fan_out_input_fails_the_run(self, field, value):
+        # Both values shape the fan-out, and neither fails loudly on its own. 0 page_size raises
+        # ZeroDivisionError from the page arithmetic and 0 max_concurrent_pages waits on a
+        # semaphore permit that never arrives, and Temporal retries both as a workflow task
+        # forever rather than failing. A negative page_size yields an empty page range and
+        # reports a successful run that sent nothing.
         @activity.defn(name="send_org_digest_activity")
         async def _send(inputs: SendOrgDigestInputs) -> SendOrgDigestResult:
-            raise AssertionError("should not fan out for an invalid page_size")
+            raise AssertionError(f"should not fan out for an invalid {field}")
 
         with pytest.raises(Exception) as exc_info:
-            await self._execute(WeeklyDigestInputs(page_size=page_size), [*_storage_stubs(["org-a"]), _send])
+            await self._execute(WeeklyDigestInputs(**{field: value}), [*_storage_stubs(["org-a"]), _send])
 
         cause = exc_info.value.__cause__
-        assert cause is not None and "page_size" in str(cause)
+        assert cause is not None and field in str(cause)
+
+    @pytest.mark.asyncio
+    async def test_caps_how_many_page_children_run_at_once(self):
+        # Each page holds up to max_concurrent org activities open, so the run's peak ClickHouse
+        # concurrency is the product of the two caps. Without the page cap that product includes
+        # the page count, which means peak load climbs every time the org list grows, and the
+        # offline cluster's concurrent-query limit is shared with every other product.
+        org_ids = sorted(f"org-{i:03d}" for i in range(60))
+        active_pages: Counter[int] = Counter()
+        max_active_pages = 0
+        state_lock = asyncio.Lock()
+
+        @activity.defn(name="send_org_digest_activity")
+        async def _send(inputs: SendOrgDigestInputs) -> SendOrgDigestResult:
+            nonlocal max_active_pages
+            page = int(inputs.org_id.removeprefix("org-")) // 10 + 1
+            async with state_lock:
+                active_pages[page] += 1
+                max_active_pages = max(max_active_pages, len(active_pages))
+            try:
+                await asyncio.sleep(0.01)
+            finally:
+                async with state_lock:
+                    active_pages[page] -= 1
+                    if not active_pages[page]:
+                        del active_pages[page]
+            return SendOrgDigestResult(sent=1, teams_built=1)
+
+        result = await self._execute(
+            WeeklyDigestInputs(page_size=10, max_concurrent_pages=2, max_concurrent=5),
+            [*_storage_stubs(org_ids), _send],
+            max_concurrent_activities=len(org_ids),
+        )
+
+        assert result == WeeklyDigestResult(orgs=60, orgs_failed=0, sent=60)
+        assert max_active_pages <= 2, (
+            f"parent ran {max_active_pages} page children at once but max_concurrent_pages=2, "
+            f"so the page semaphore guard is missing"
+        )

--- a/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
@@ -746,59 +746,17 @@ class TestErrorTrackingWeeklyDigestWorkflow:
         assert result == WeeklyDigestResult(orgs=5, orgs_failed=0, sent=5)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("field", ["page_size", "max_concurrent_pages"])
-    @pytest.mark.parametrize("value", [0, -5])
-    async def test_non_positive_fan_out_input_fails_the_run(self, field, value):
-        # Both values shape the fan-out, and neither fails loudly on its own. 0 page_size raises
-        # ZeroDivisionError from the page arithmetic and 0 max_concurrent_pages waits on a
-        # semaphore permit that never arrives, and Temporal retries both as a workflow task
-        # forever rather than failing. A negative page_size yields an empty page range and
-        # reports a successful run that sent nothing.
+    @pytest.mark.parametrize("page_size", [0, -5])
+    async def test_non_positive_page_size_fails_the_run(self, page_size):
+        # 0 used to raise ZeroDivisionError from the page arithmetic, which Temporal retries
+        # as a workflow task forever rather than failing; a negative value produced an empty
+        # page range and reported a successful run that sent nothing.
         @activity.defn(name="send_org_digest_activity")
         async def _send(inputs: SendOrgDigestInputs) -> SendOrgDigestResult:
-            raise AssertionError(f"should not fan out for an invalid {field}")
+            raise AssertionError("should not fan out for an invalid page_size")
 
         with pytest.raises(Exception) as exc_info:
-            await self._execute(WeeklyDigestInputs(**{field: value}), [*_storage_stubs(["org-a"]), _send])
+            await self._execute(WeeklyDigestInputs(page_size=page_size), [*_storage_stubs(["org-a"]), _send])
 
         cause = exc_info.value.__cause__
-        assert cause is not None and field in str(cause)
-
-    @pytest.mark.asyncio
-    async def test_caps_how_many_page_children_run_at_once(self):
-        # Each page holds up to max_concurrent org activities open, so the run's peak ClickHouse
-        # concurrency is the product of the two caps. Without the page cap that product includes
-        # the page count, which means peak load climbs every time the org list grows, and the
-        # offline cluster's concurrent-query limit is shared with every other product.
-        org_ids = sorted(f"org-{i:03d}" for i in range(60))
-        active_pages: Counter[int] = Counter()
-        max_active_pages = 0
-        state_lock = asyncio.Lock()
-
-        @activity.defn(name="send_org_digest_activity")
-        async def _send(inputs: SendOrgDigestInputs) -> SendOrgDigestResult:
-            nonlocal max_active_pages
-            page = int(inputs.org_id.removeprefix("org-")) // 10 + 1
-            async with state_lock:
-                active_pages[page] += 1
-                max_active_pages = max(max_active_pages, len(active_pages))
-            try:
-                await asyncio.sleep(0.01)
-            finally:
-                async with state_lock:
-                    active_pages[page] -= 1
-                    if not active_pages[page]:
-                        del active_pages[page]
-            return SendOrgDigestResult(sent=1, teams_built=1)
-
-        result = await self._execute(
-            WeeklyDigestInputs(page_size=10, max_concurrent_pages=2, max_concurrent=5),
-            [*_storage_stubs(org_ids), _send],
-            max_concurrent_activities=len(org_ids),
-        )
-
-        assert result == WeeklyDigestResult(orgs=60, orgs_failed=0, sent=60)
-        assert max_active_pages <= 2, (
-            f"parent ran {max_active_pages} page children at once but max_concurrent_pages=2, "
-            f"so the page semaphore guard is missing"
-        )
+        assert cause is not None and "page_size" in str(cause)

--- a/products/error_tracking/backend/temporal/weekly_digest/types.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/types.py
@@ -12,10 +12,16 @@ class WeeklyDigestInputs:
     org_ids: list[str] | None = None
     # How many per-org activities run at once within each page (bounds ClickHouse load
     # and webhook rate per page).
-    max_concurrent: int = 10
-    # Total executions per org activity: initial run + 5 retries. The final attempt sends
+    max_concurrent: int = 8
+    # How many page children run at once. Without this the parent starts every page at once,
+    # so the run's peak ClickHouse concurrency is max_concurrent * ceil(total_orgs / page_size)
+    # and grows with the org count. Together the two caps hold the whole run to
+    # max_concurrent_pages * max_concurrent org activities in flight, whatever the org count.
+    max_concurrent_pages: int = 20
+    # Total executions per org activity: initial run + 7 retries. The final attempt sends
     # partial digests instead of deferring recipients whose teams failed to build.
-    max_attempts: int = 6
+    # See SEND_ORG_* in workflow.py for the retry pacing this count is chosen against.
+    max_attempts: int = 8
     # Orgs handled per page child workflow. Bounds each page's history and the size of
     # the org-id slice its load activity returns (~40KB per 1000 orgs).
     page_size: int = 1000
@@ -55,8 +61,8 @@ class WeeklyDigestPageInputs:
     page_number: int
     page_size: int
     dry_run: bool = True
-    max_concurrent: int = 10
-    max_attempts: int = 6
+    max_concurrent: int = 8
+    max_attempts: int = 8
 
 
 @dataclasses.dataclass(frozen=True)
@@ -64,9 +70,9 @@ class SendOrgDigestInputs:
     org_id: str
     # Fail-safe default, matching WeeklyDigestInputs: the workflow always passes it explicitly.
     dry_run: bool = True
-    # Must equal the activity's RetryPolicy.maximum_attempts — an activity cannot read its own
-    # retry policy, and final-attempt detection (attempt >= max_attempts) depends on it.
-    max_attempts: int = 6
+    # Must equal the activity's RetryPolicy.maximum_attempts, because an activity cannot read
+    # its own retry policy and final-attempt detection (attempt >= max_attempts) depends on it.
+    max_attempts: int = 8
 
 
 @dataclasses.dataclass(frozen=True)

--- a/products/error_tracking/backend/temporal/weekly_digest/types.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/types.py
@@ -10,14 +10,11 @@ class WeeklyDigestInputs:
     # targeted manual runs.
     dry_run: bool = True
     org_ids: list[str] | None = None
-    # How many per-org activities run at once within each page (bounds ClickHouse load
-    # and webhook rate per page).
-    max_concurrent: int = 8
-    # How many page children run at once. Without this the parent starts every page at once,
-    # so the run's peak ClickHouse concurrency is max_concurrent * ceil(total_orgs / page_size)
-    # and grows with the org count. Together the two caps hold the whole run to
-    # max_concurrent_pages * max_concurrent org activities in flight, whatever the org count.
-    max_concurrent_pages: int = 20
+    # How many per-org activities run at once within each page. Every page runs at once, so
+    # this is the only cap on the run's ClickHouse demand: peak concurrency is this value
+    # times ceil(total_orgs / page_size). The offline cluster has a global concurrent-query
+    # limit shared with every other product, so the value has to leave room for them.
+    max_concurrent: int = 5
     # Total executions per org activity: initial run + 7 retries. The final attempt sends
     # partial digests instead of deferring recipients whose teams failed to build.
     # See SEND_ORG_* in workflow.py for the retry pacing this count is chosen against.
@@ -61,7 +58,7 @@ class WeeklyDigestPageInputs:
     page_number: int
     page_size: int
     dry_run: bool = True
-    max_concurrent: int = 8
+    max_concurrent: int = 5
     max_attempts: int = 8
 
 

--- a/products/error_tracking/backend/temporal/weekly_digest/workflow.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/workflow.py
@@ -140,14 +140,13 @@ class ErrorTrackingWeeklyDigestPageWorkflow(PostHogWorkflow):
 
 @workflow.defn(name=WORKFLOW_NAME)
 class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
-    """Discovers orgs once, stores the list in object storage, and fans the pages out as
-    child workflows, ``max_concurrent_pages`` at a time.
+    """Discovers orgs once, stores the list in object storage, and fans every page out as
+    a child workflow immediately.
 
     Only a storage key and a count ride through workflow history, so history and payload
-    sizes stay flat regardless of org count. The page cap is what holds the run's peak
-    ClickHouse load flat too: the offline cluster has a global concurrent-query limit that
-    this run shares with every other product, and an uncapped fan-out raises the digest's
-    demand for it every time the org count grows.
+    sizes stay flat regardless of org count. All children start at once, so the run's peak
+    ClickHouse demand is ``max_concurrent`` per page times the page count, and it grows with
+    the org count. The worker fleet's activity-slot capacity is the outer bound.
     """
 
     inputs_cls = WeeklyDigestInputs
@@ -164,15 +163,6 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
         # range and reports a successful run that sent nothing.
         if inputs.page_size < 1:
             raise ApplicationError(f"page_size must be at least 1, got {inputs.page_size}", non_retryable=True)
-
-        # Same reasoning, for the value the page semaphore is built from. Zero makes every page
-        # wait on a permit that never arrives, so the run hangs until the workflow timeout instead
-        # of failing; a negative value raises ValueError inside the workflow, which Temporal retries
-        # as a workflow task forever.
-        if inputs.max_concurrent_pages < 1:
-            raise ApplicationError(
-                f"max_concurrent_pages must be at least 1, got {inputs.max_concurrent_pages}", non_retryable=True
-            )
 
         info = workflow.info()
         # run_id-scoped so a re-run of the same workflow id can never read a stale list.
@@ -191,28 +181,23 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
             for page_number in range(1, page_count + 1)
         ]
 
-        # Releases as soon as a page finishes, so the next page starts immediately instead of
-        # waiting for a whole wave of pages to drain.
-        page_semaphore = asyncio.Semaphore(inputs.max_concurrent_pages)
-
         async def run_page(page_number: int) -> WeeklyDigestResult:
-            async with page_semaphore:
-                return await workflow.execute_child_workflow(
-                    ErrorTrackingWeeklyDigestPageWorkflow.run,
-                    WeeklyDigestPageInputs(
-                        storage_key=storage_key,
-                        page_number=page_number,
-                        page_size=inputs.page_size,
-                        dry_run=inputs.dry_run,
-                        max_concurrent=inputs.max_concurrent,
-                        max_attempts=inputs.max_attempts,
-                    ),
-                    id=f"{info.workflow_id}-page-{page_number}",
-                    # Explicitly the default: terminating the parent must stop all page
-                    # children too, so killing the parent is a reliable stop-everything
-                    # switch and no abandoned child keeps sending digests.
-                    parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
-                )
+            return await workflow.execute_child_workflow(
+                ErrorTrackingWeeklyDigestPageWorkflow.run,
+                WeeklyDigestPageInputs(
+                    storage_key=storage_key,
+                    page_number=page_number,
+                    page_size=inputs.page_size,
+                    dry_run=inputs.dry_run,
+                    max_concurrent=inputs.max_concurrent,
+                    max_attempts=inputs.max_attempts,
+                ),
+                id=f"{info.workflow_id}-page-{page_number}",
+                # Explicitly the default: terminating the parent must stop all page
+                # children too, so killing the parent is a reliable stop-everything
+                # switch and no abandoned child keeps sending digests.
+                parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
+            )
 
         results = await asyncio.gather(
             *(run_page(page_number) for page_number in range(1, page_count + 1)), return_exceptions=True

--- a/products/error_tracking/backend/temporal/weekly_digest/workflow.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/workflow.py
@@ -43,8 +43,13 @@ CLEANUP_TIMEOUT = timedelta(minutes=1)
 
 SEND_ORG_START_TO_CLOSE_TIMEOUT = timedelta(minutes=30)
 SEND_ORG_HEARTBEAT_TIMEOUT = timedelta(minutes=5)
-SEND_ORG_INITIAL_RETRY_INTERVAL = timedelta(seconds=1)
-SEND_ORG_MAXIMUM_RETRY_INTERVAL = timedelta(seconds=30)
+# The retry budget must outlast a ClickHouse capacity incident, because every attempt made during
+# one fails the same way and a budget that fits inside the incident guarantees the org fails.
+# These values give 5s, 20s, 80s, 320s, then 600s per retry, so the default 8 attempts spread
+# across about 37 minutes.
+SEND_ORG_INITIAL_RETRY_INTERVAL = timedelta(seconds=5)
+SEND_ORG_BACKOFF_COEFFICIENT = 4.0
+SEND_ORG_MAXIMUM_RETRY_INTERVAL = timedelta(minutes=10)
 
 
 def _sent_from_error(error: BaseException) -> int:
@@ -81,11 +86,11 @@ async def _send_orgs(org_ids: list[str], dry_run: bool, max_concurrent: int, max
                 start_to_close_timeout=SEND_ORG_START_TO_CLOSE_TIMEOUT,
                 heartbeat_timeout=SEND_ORG_HEARTBEAT_TIMEOUT,
                 retry_policy=common.RetryPolicy(
-                    # Must match SendOrgDigestInputs.max_attempts — final-attempt detection
+                    # Must match SendOrgDigestInputs.max_attempts, because final-attempt detection
                     # inside the activity depends on the two agreeing.
                     maximum_attempts=max_attempts,
                     initial_interval=SEND_ORG_INITIAL_RETRY_INTERVAL,
-                    backoff_coefficient=2.0,
+                    backoff_coefficient=SEND_ORG_BACKOFF_COEFFICIENT,
                     maximum_interval=SEND_ORG_MAXIMUM_RETRY_INTERVAL,
                 ),
             )
@@ -135,12 +140,14 @@ class ErrorTrackingWeeklyDigestPageWorkflow(PostHogWorkflow):
 
 @workflow.defn(name=WORKFLOW_NAME)
 class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
-    """Discovers orgs once, stores the list in object storage, and fans every page out as
-    a child workflow immediately.
+    """Discovers orgs once, stores the list in object storage, and fans the pages out as
+    child workflows, ``max_concurrent_pages`` at a time.
 
     Only a storage key and a count ride through workflow history, so history and payload
-    sizes stay flat regardless of org count. All children start at once, so the worker
-    fleet's activity-slot capacity is the intended global throttle.
+    sizes stay flat regardless of org count. The page cap is what holds the run's peak
+    ClickHouse load flat too: the offline cluster has a global concurrent-query limit that
+    this run shares with every other product, and an uncapped fan-out raises the digest's
+    demand for it every time the org count grows.
     """
 
     inputs_cls = WeeklyDigestInputs
@@ -157,6 +164,15 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
         # range and reports a successful run that sent nothing.
         if inputs.page_size < 1:
             raise ApplicationError(f"page_size must be at least 1, got {inputs.page_size}", non_retryable=True)
+
+        # Same reasoning, for the value the page semaphore is built from. Zero makes every page
+        # wait on a permit that never arrives, so the run hangs until the workflow timeout instead
+        # of failing; a negative value raises ValueError inside the workflow, which Temporal retries
+        # as a workflow task forever.
+        if inputs.max_concurrent_pages < 1:
+            raise ApplicationError(
+                f"max_concurrent_pages must be at least 1, got {inputs.max_concurrent_pages}", non_retryable=True
+            )
 
         info = workflow.info()
         # run_id-scoped so a re-run of the same workflow id can never read a stale list.
@@ -175,23 +191,28 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
             for page_number in range(1, page_count + 1)
         ]
 
+        # Releases as soon as a page finishes, so the next page starts immediately instead of
+        # waiting for a whole wave of pages to drain.
+        page_semaphore = asyncio.Semaphore(inputs.max_concurrent_pages)
+
         async def run_page(page_number: int) -> WeeklyDigestResult:
-            return await workflow.execute_child_workflow(
-                ErrorTrackingWeeklyDigestPageWorkflow.run,
-                WeeklyDigestPageInputs(
-                    storage_key=storage_key,
-                    page_number=page_number,
-                    page_size=inputs.page_size,
-                    dry_run=inputs.dry_run,
-                    max_concurrent=inputs.max_concurrent,
-                    max_attempts=inputs.max_attempts,
-                ),
-                id=f"{info.workflow_id}-page-{page_number}",
-                # Explicitly the default: terminating the parent must stop all page
-                # children too, so killing the parent is a reliable stop-everything
-                # switch and no abandoned child keeps sending digests.
-                parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
-            )
+            async with page_semaphore:
+                return await workflow.execute_child_workflow(
+                    ErrorTrackingWeeklyDigestPageWorkflow.run,
+                    WeeklyDigestPageInputs(
+                        storage_key=storage_key,
+                        page_number=page_number,
+                        page_size=inputs.page_size,
+                        dry_run=inputs.dry_run,
+                        max_concurrent=inputs.max_concurrent,
+                        max_attempts=inputs.max_attempts,
+                    ),
+                    id=f"{info.workflow_id}-page-{page_number}",
+                    # Explicitly the default: terminating the parent must stop all page
+                    # children too, so killing the parent is a reliable stop-everything
+                    # switch and no abandoned child keeps sending digests.
+                    parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
+                )
 
         results = await asyncio.gather(
             *(run_page(page_number) for page_number in range(1, page_count + 1)), return_exceptions=True


### PR DESCRIPTION
## Problem

Some organizations get no error tracking weekly digest when the offline ClickHouse cluster sits at its concurrent-query limit, and the scheduled run then fails.

- The digest queries run on the offline cluster, which every product shares. At capacity that cluster rejects new queries with ClickHouse code 202, which surfaces as `ClickHouseAtCapacity`.
- The per-org activity used 6 attempts, a 1 second initial interval, and a 30 second ceiling.
- That budget spent itself in about 31 seconds, so an org that started during a capacity event exhausted every attempt inside it.
- An org that failed before the per-team build loop left no log line naming it. Temporal's activity failure log carries the activity id, not the inputs.

## Changes

- An org whose queries are rejected now keeps its digest, because the retry budget spreads across about 37 minutes. Intervals go 5s, 20s, 80s, 320s, then 600s, over 8 attempts.
- The digest asks for less of the cluster at once. `max_concurrent` drops from 10 to 5, which halves the org activities each page child runs in parallel.
- Every activity failure now logs `et_weekly_digest.org_failed` with `org_id` and `attempt`. Filter on `attempt == max_attempts` for the orgs a run gave up on.
- Nothing a person sees changes. The digest email is unchanged.

The parent still starts every page child at once, so the run's peak demand stays `max_concurrent` times the page count and still grows with the org count. Lowering `max_concurrent` buys headroom now; it does not make peak load independent of the org list.

The slower pacing has one cost. A team whose test account filters are permanently broken reaches the unfiltered fallback on the last two attempts, which now arrive later. A weekly digest tolerates that delay. The alternative keeps a retry budget that cannot outlast a capacity event.

## How did you test this code?

- The activity tests now derive their attempt numbers from the default `max_attempts`, so the fallback and final-attempt cases move with the retry budget instead of asserting against one particular budget.
- No new test. The two changed defaults are configuration, and the existing fan-out test already pins that a page child honors `max_concurrent`.
- Not covered: the `et_weekly_digest.org_failed` log line. A test for it would assert on a mocked logger call, which locks in the activity's internals.
- Not done: any manual run. The digest workflow was not run against a real org.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by the assignee. The work started from a production digest run that failed, which was traced through Grafana Loki and ClickHouse `system.query_log`. Every failing org in that run hit `ClickHouseAtCapacity` on its final attempt, which set the fixes here.

Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`, `/query-clickhouse-via-metabase`.

One decision worth a reviewer's attention. Raising the retry ceiling alone changes nothing: with a coefficient of 2.0 over 6 attempts the intervals never reach a 30 second ceiling, so the budget stays at about 31 seconds. The coefficient and the attempt count had to move with it.

An earlier revision of this PR also capped how many page children ran at once, which would have held peak load flat as the org count grows. The assignee chose to keep `max_concurrent` as the single lever, so that cap and its test came back out.

No customer data, org identifiers, or internal infrastructure names appear in this PR. The org ids and cluster names from the investigation stayed out of the code, the tests, and this description.
