### PR TITLE
fix(cdp): release cyclotron v2 jobs when a consume batch throws

### DIFF
--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.test.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.test.ts
@@ -216,6 +216,96 @@ describe('CyclotronJobQueuePostgresV2', () => {
         })
     })
 
+    describe('startAsConsumer', () => {
+        function createConsumerQueue(): {
+            queue: CyclotronJobQueuePostgresV2
+            deliverBatch: (jobs: any[]) => Promise<unknown>
+        } {
+            const { queue } = createQueue()
+            let onBatch: ((jobs: any[]) => Promise<void>) | undefined
+            ;(queue as any).createWorker = () => ({
+                connect: (cb: (jobs: any[]) => Promise<void>) => {
+                    onBatch = cb
+                    return Promise.resolve()
+                },
+                disconnect: () => Promise.resolve(),
+            })
+
+            return {
+                queue,
+                // Drives one poll the way CyclotronV2Worker's consumer loop does.
+                deliverBatch: (jobs: any[]) => onBatch!(jobs),
+            }
+        }
+
+        it('releases the batch when consuming throws, instead of orphaning it', async () => {
+            const { queue, deliverBatch } = createConsumerQueue()
+            const consumeBatch = jest
+                .fn()
+                .mockRejectedValue(new Error('ConnectError: [unavailable] connect ECONNREFUSED'))
+
+            await queue.startAsConsumer('hog', consumeBatch)
+
+            const jobs = [createDequeuedJob(), createDequeuedJob(), createDequeuedJob()]
+            await expect(deliverBatch(jobs)).rejects.toThrow('ECONNREFUSED')
+
+            expect(consumeBatch).toHaveBeenCalledTimes(1)
+            expect((queue as any).pendingJobs.size).toBe(0)
+            for (const job of jobs) {
+                expect(job.reschedule).toHaveBeenCalledTimes(1)
+                expect(job.fail).not.toHaveBeenCalled()
+                expect(job.ack).not.toHaveBeenCalled()
+            }
+        })
+
+        it('does not accumulate pending jobs across repeated failing polls', async () => {
+            const { queue, deliverBatch } = createConsumerQueue()
+            const consumeBatch = jest.fn().mockRejectedValue(new Error('personhog down'))
+
+            await queue.startAsConsumer('hog', consumeBatch)
+
+            for (let poll = 0; poll < 5; poll++) {
+                await expect(deliverBatch([createDequeuedJob(), createDequeuedJob()])).rejects.toThrow('personhog down')
+            }
+
+            expect((queue as any).pendingJobs.size).toBe(0)
+        })
+
+        it('still drops the batch from pending when releasing it also fails', async () => {
+            const { queue, deliverBatch } = createConsumerQueue()
+            await queue.startAsConsumer('hog', jest.fn().mockRejectedValue(new Error('personhog down')))
+
+            const job = createDequeuedJob({
+                reschedule: jest.fn().mockRejectedValue(new Error('postgres down too')),
+            })
+            await expect(deliverBatch([job])).rejects.toThrow('personhog down')
+
+            expect((queue as any).pendingJobs.size).toBe(0)
+        })
+
+        it('keeps the batch pending while consuming succeeds, so results can ack it', async () => {
+            const { queue, deliverBatch } = createConsumerQueue()
+            const job = createDequeuedJob()
+
+            await queue.startAsConsumer('hog', (invocations) => {
+                expect(invocations).toHaveLength(1)
+                expect((queue as any).pendingJobs.has(job.id)).toBe(true)
+                return Promise.resolve({ backgroundTask: Promise.resolve() })
+            })
+
+            await deliverBatch([job])
+
+            expect((queue as any).pendingJobs.has(job.id)).toBe(true)
+
+            await queue.queueInvocationResults([
+                createResult({ invocation: { ...baseInvocation, id: job.id }, finished: true }),
+            ])
+
+            expect(job.ack).toHaveBeenCalledTimes(1)
+            expect((queue as any).pendingJobs.size).toBe(0)
+        })
+    })
+
     describe('queueInvocationResults', () => {
         it('should call ack on finished jobs', async () => {
             const { queue } = createQueue()

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
@@ -111,10 +111,45 @@ export class CyclotronJobQueuePostgresV2 implements JobQueue {
                 maxBatchSize: this.consumerBatchSize,
             })
 
-            await consumeBatch(invocations)
-
-            pendingJobsGauge.set(this.pendingJobs.size)
+            try {
+                await consumeBatch(invocations)
+            } catch (err) {
+                // The batch never produced results, so nothing will ack/fail/reschedule
+                // these jobs. Release them here or they stay in `pendingJobs` for the
+                // life of the process and only a restart reclaims the memory.
+                await this.releasePendingBatch(jobs)
+                throw err
+            } finally {
+                pendingJobsGauge.set(this.pendingJobs.size)
+            }
         })
+    }
+
+    /**
+     * Hands a batch back to Postgres after processing threw. `reschedule()` with no
+     * options returns the row to `available` and zeroes `janitor_touch_count`, so a
+     * dependency outage costs a retry rather than the job's poison budget.
+     *
+     * Release failures are swallowed: the janitor's stall sweep reclaims the row
+     * anyway, and losing the map entry is what actually matters here.
+     */
+    private async releasePendingBatch(jobs: CyclotronV2DequeuedJob[]): Promise<void> {
+        await Promise.all(
+            jobs.map(async (job) => {
+                // A partially-successful batch may already have disposed of some jobs.
+                if (!this.pendingJobs.delete(job.id)) {
+                    return
+                }
+                try {
+                    await job.reschedule()
+                } catch (err) {
+                    logger.warn('Failed to release V2 job after batch error', {
+                        id: job.id,
+                        error: String(err),
+                    })
+                }
+            })
+        )
     }
 
     public async stopConsumer(): Promise<void> {


### PR DESCRIPTION
## Problem

A Cyclotron V2 worker that throws while processing a batch holds those jobs in memory for the life of the process, so on-call gets a pending-jobs alert that only a restart clears.

- `startAsConsumer` adds every dequeued job to the in-memory `pendingJobs` map before it calls `consumeBatch`.
- Entries leave that map only through `queueInvocationResults`, `dequeueInvocations` or `releaseInvocations`.
- A batch that throws reaches none of them, so its entries stay. The consumer loop logs, sleeps, dequeues the next batch and leaks that one too.
- The jobs themselves are safe. The janitor reclaims the Postgres rows after the stall timeout and they run again. Only the map entries are stranded.

This affects the Postgres-backed workers. The Kafka backend does not keep this map.

## Changes

- A worker that hits a dependency error now returns to a normal pending count on its own, instead of holding a false count until someone restarts it.
- `startAsConsumer` wraps `consumeBatch`, and releases the batch back to Postgres when it throws.
- The release calls `reschedule()` with no options, which returns the row to `available` and zeroes `janitor_touch_count`. An outage costs a retry rather than the job's poison budget.
- The release skips jobs a partially-successful batch already disposed of, and drops the map entry even when the release itself fails. The janitor's stall sweep is the backstop for the row.

> [!NOTE]
> This closes one of two orphan paths. `ConsumeBatchFn` returns `{ backgroundTask }`, and `queueInvocationResults` runs inside it. The Postgres V2 backend discards that promise, so a rejection there orphans entries with no log and no release. The Kafka backend hands it to the consumer framework instead. Closing that gap needs a decision about how this backend should track background tasks, so it is deliberately out of scope here.

## How did you test this code?

Four cases added to `job-queue-postgres-v2.test.ts`, which already covers the map but not the consumer callback. They catch a regression no existing test did: a throwing `consumeBatch` stranding its batch in `pendingJobs`. On the pre-fix code the first two fail with 3 and 10 stranded entries.

Reproduced against a real worker on the local dev stack, before the fix: `cdp-cyclotron-worker-hogflow` in `postgres-v2` mode, real local Cyclotron Postgres, 274 real hogflow jobs, and the local person service stopped so the person fetch failed for real.

<details>
<summary>Local run, pre-fix</summary>

```
t+10s  pending=0    available=0    running=274
t+20s  pending=274  available=125  running=149
t+30s  pending=274  available=274  running=0
```

95 × `ConnectError: [unavailable] connect ECONNREFUSED`. `pending == available` means every job was counted twice, once in the queue and once in memory. After the dependency recovered, pending sat at 271 and fell to 256 over 100 seconds while `running` stayed 0.
</details>

Not verified: the fix under the same local outage. On the second run the seeded jobs had advanced to steps that make no person lookup, so no batch threw and the throw path never executed. The fix rests on the unit tests alone.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) while investigating a pending-jobs alert. The root cause came from reading the queue and worker sources against worker logs; the local reproduction came afterwards and confirmed it.

Skills invoked: `/writing-tests`, `/posthog-local-e2e-qa`, `/writing-pr-descriptions`.

The first draft released the batch in a `finally`, which would have covered both orphan paths at once. Reading `processBatch` ruled that out: it returns `backgroundTask` un-awaited, so a `finally` would race the background disposal and double-handle the job. The fix is narrowed to the throw path, and the note in Changes records the rest.

No customer data, logs, or session material appear in this PR. The test fixtures are written from the code's own types.
