### PR TITLE
feat(kafka-consumer): add the shared consumer crate's domain core

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2903,6 +2903,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-kafka-consumer"
+version = "0.1.0"
+dependencies = [
+ "rdkafka",
+]
+
+[[package]]
 name = "common-liveness"
 version = "0.1.0"
 
@@ -6156,6 +6163,7 @@ dependencies = [
  "chrono",
  "common-alloc",
  "common-continuous-profiling",
+ "common-kafka-consumer",
  "dashmap 6.1.0",
  "envconfig",
  "futures",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2906,6 +2906,7 @@ dependencies = [
 name = "common-kafka-consumer"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "rdkafka",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "common/dns",
   "common/health",
   "common/kafka",
+  "common/kafka-consumer",
   "common/liveness",
   "common/lifecycle",
   "common/limiters",

--- a/rust/common/kafka-consumer/Cargo.toml
+++ b/rust/common/kafka-consumer/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "common-kafka-consumer"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rdkafka = { workspace = true }

--- a/rust/common/kafka-consumer/Cargo.toml
+++ b/rust/common/kafka-consumer/Cargo.toml
@@ -9,3 +9,6 @@ workspace = true
 
 [dependencies]
 rdkafka = { workspace = true }
+
+[dev-dependencies]
+proptest = "1"

--- a/rust/common/kafka-consumer/README.md
+++ b/rust/common/kafka-consumer/README.md
@@ -7,3 +7,14 @@ The design is the domain side of the driver-model doc in `rust/ingestion-consume
 ## Modules
 
 - `config`: `ConsumerConfigBuilder`, the rdkafka `ClientConfig` builder with PostHog consumer defaults.
+- `types`: `Partition`, `Offset`, `AssignmentEpoch`, `Advance`, `DrainHarvest`.
+- `charge`: `Charge` (events + bytes, one value, two axes) and `Budget`, the `B` gate: charged at poll, refunded at commit or at a drain's end.
+- `ledger`: `OffsetLedger`, a dense ring per partition; completion in any order, only the frontier — the highest contiguous completed offset — is ordered.
+- `accumulator`: `Group` (one routing key's messages from one poll; null key owes no order), `Accumulator`, and the demux.
+- `partition`: `PartitionDriver`, one partition's ledger plus its stall deadline.
+- `manager`: `PartitionManager`, assignment lifecycle over the drivers; stragglers die by epoch.
+- `commit`: `CommitManager`, the commit policy whole — batched interval issues, immediate final commit on a drain's end.
+
+The invariants (doc §4): only a ledger's frontier is ever committed; an offset goes done only when a completion names it; `B` = polled minus committed, exactly (`tests/exactness.rs` pins this over random schedules); a revoked partition's final commit issues before it is handed back.
+
+Still to come (plan stages 2+): the consumer loop itself (event pump, rdkafka context, pause/resume poll gate, bounded drain wiring, commit monitor), stats export, and the commit sentinel.

--- a/rust/common/kafka-consumer/README.md
+++ b/rust/common/kafka-consumer/README.md
@@ -1,0 +1,9 @@
+# common-kafka-consumer
+
+Kafka consumption core for stateful services: poll, demux to groups, budget-gated admission, contiguous-frontier commits, bounded drain on revoke, per-partition stall watchdog, and commit verification.
+
+The design is the domain side of the driver-model doc in `rust/ingestion-consumer/docs/driver-model.md` (§3.1-§3.7). That doc's §8 is the vocabulary authority for names in this crate.
+
+## Modules
+
+- `config`: `ConsumerConfigBuilder`, the rdkafka `ClientConfig` builder with PostHog consumer defaults.

--- a/rust/common/kafka-consumer/src/accumulator.rs
+++ b/rust/common/kafka-consumer/src/accumulator.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use crate::charge::Charge;
+use crate::types::{AssignmentEpoch, Offset, Partition};
+
+/// One polled message, as the partition driver sees it: Kafka metadata plus
+/// the application's raw payload. The loop never decodes `inner`.
+#[derive(Debug)]
+pub struct PolledMessage<M> {
+    pub offset: Offset,
+    /// The routing key: the message's Kafka partition key, opaque bytes.
+    /// `None` owes no order at all — one free group per message.
+    pub key: Option<Vec<u8>>,
+    pub charge: Charge,
+    pub inner: M,
+}
+
+/// One routing key's messages from one poll — or one keyless message. The
+/// per-key unit that crosses the seam and comes back as a completion.
+#[derive(Debug)]
+pub struct Group<M> {
+    /// The affinity hint: the partition the group came from.
+    pub partition: Partition,
+    pub epoch: AssignmentEpoch,
+    /// The group's offsets, ascending; any subset of the partition's ring.
+    pub offsets: Vec<Offset>,
+    pub charge: Charge,
+    pub key: Option<Vec<u8>>,
+    pub messages: Vec<M>,
+}
+
+/// One poll's demuxed groups, in offset order per key. Obtained from the
+/// factory, lent down the demux under `&mut`, released to the transport side
+/// whole, by value.
+#[derive(Debug)]
+pub struct Accumulator<M> {
+    groups: Vec<Group<M>>,
+}
+
+impl<M> Default for Accumulator<M> {
+    fn default() -> Accumulator<M> {
+        Accumulator { groups: Vec::new() }
+    }
+}
+
+impl<M> Accumulator<M> {
+    pub fn is_empty(&self) -> bool {
+        self.groups.is_empty()
+    }
+
+    pub fn groups(&self) -> &[Group<M>] {
+        &self.groups
+    }
+
+    pub fn into_groups(self) -> Vec<Group<M>> {
+        self.groups
+    }
+
+    /// Demux one partition's slice of a poll into groups, preserving offset
+    /// order within each key. Keys group in first-seen order; a null-key
+    /// message becomes its own free group.
+    pub(crate) fn push_demuxed(
+        &mut self,
+        partition: Partition,
+        epoch: AssignmentEpoch,
+        msgs: Vec<PolledMessage<M>>,
+    ) {
+        let mut by_key: HashMap<Vec<u8>, usize> = HashMap::new();
+        for msg in msgs {
+            let index = match &msg.key {
+                None => {
+                    self.groups.push(Group {
+                        partition,
+                        epoch,
+                        offsets: Vec::with_capacity(1),
+                        charge: Charge::ZERO,
+                        key: None,
+                        messages: Vec::with_capacity(1),
+                    });
+                    self.groups.len() - 1
+                }
+                Some(key) => *by_key.entry(key.clone()).or_insert_with(|| {
+                    self.groups.push(Group {
+                        partition,
+                        epoch,
+                        offsets: Vec::new(),
+                        charge: Charge::ZERO,
+                        key: msg.key.clone(),
+                        messages: Vec::new(),
+                    });
+                    self.groups.len() - 1
+                }),
+            };
+            let group = &mut self.groups[index];
+            group.offsets.push(msg.offset);
+            group.charge += msg.charge;
+            group.messages.push(msg.inner);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(offset: i64, key: Option<&str>) -> PolledMessage<i64> {
+        PolledMessage {
+            offset: Offset(offset),
+            key: key.map(|k| k.as_bytes().to_vec()),
+            charge: Charge {
+                events: 1,
+                bytes: 1,
+            },
+            inner: offset,
+        }
+    }
+
+    #[test]
+    fn keys_group_in_offset_order_and_null_keys_stay_free() {
+        let mut acc = Accumulator::default();
+        acc.push_demuxed(
+            Partition(0),
+            AssignmentEpoch(1),
+            vec![
+                msg(0, Some("a")),
+                msg(1, None),
+                msg(2, Some("b")),
+                msg(3, Some("a")),
+                msg(4, None),
+            ],
+        );
+
+        let groups = acc.groups();
+        assert_eq!(groups.len(), 4);
+        assert_eq!(groups[0].key.as_deref(), Some(b"a".as_slice()));
+        assert_eq!(groups[0].offsets, vec![Offset(0), Offset(3)]);
+        assert_eq!(groups[1].key, None);
+        assert_eq!(groups[1].offsets, vec![Offset(1)]);
+        assert_eq!(groups[2].key.as_deref(), Some(b"b".as_slice()));
+        assert_eq!(
+            groups[3].key, None,
+            "each null-key message is its own group"
+        );
+        assert_eq!(groups[3].offsets, vec![Offset(4)]);
+    }
+}

--- a/rust/common/kafka-consumer/src/charge.rs
+++ b/rust/common/kafka-consumer/src/charge.rs
@@ -1,0 +1,118 @@
+use std::iter::Sum;
+use std::ops::{Add, AddAssign, SubAssign};
+
+/// A message's cost against the budget: one value, two axes, because the
+/// budget caps both (whichever binds). Component-wise monoid, nothing more.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Charge {
+    pub events: u64,
+    pub bytes: u64,
+}
+
+impl Charge {
+    pub const ZERO: Charge = Charge {
+        events: 0,
+        bytes: 0,
+    };
+
+    pub fn is_zero(&self) -> bool {
+        *self == Charge::ZERO
+    }
+}
+
+impl Add for Charge {
+    type Output = Charge;
+
+    fn add(self, rhs: Charge) -> Charge {
+        Charge {
+            events: self.events + rhs.events,
+            bytes: self.bytes + rhs.bytes,
+        }
+    }
+}
+
+impl AddAssign for Charge {
+    fn add_assign(&mut self, rhs: Charge) {
+        self.events += rhs.events;
+        self.bytes += rhs.bytes;
+    }
+}
+
+impl SubAssign for Charge {
+    fn sub_assign(&mut self, rhs: Charge) {
+        self.events -= rhs.events;
+        self.bytes -= rhs.bytes;
+    }
+}
+
+impl Sum for Charge {
+    fn sum<I: Iterator<Item = Charge>>(iter: I) -> Charge {
+        iter.fold(Charge::ZERO, |acc, c| acc + c)
+    }
+}
+
+/// The `B` accounting: charged at poll, refunded at commit and at a drain's
+/// end. `used` is Σ charged − Σ refunded, exactly; only `under_cap` reads the
+/// axes.
+#[derive(Debug)]
+pub struct Budget {
+    used: Charge,
+    cap: Charge,
+}
+
+impl Budget {
+    pub fn new(cap: Charge) -> Budget {
+        Budget {
+            used: Charge::ZERO,
+            cap,
+        }
+    }
+
+    pub fn charge(&mut self, c: Charge) {
+        self.used += c;
+    }
+
+    pub fn refund(&mut self, c: Charge) {
+        self.used -= c;
+    }
+
+    pub fn under_cap(&self) -> bool {
+        self.used.events < self.cap.events && self.used.bytes < self.cap.bytes
+    }
+
+    pub fn used(&self) -> Charge {
+        self.used
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn either_axis_closes_the_gate() {
+        let mut budget = Budget::new(Charge {
+            events: 10,
+            bytes: 100,
+        });
+        assert!(budget.under_cap());
+
+        budget.charge(Charge {
+            events: 10,
+            bytes: 1,
+        });
+        assert!(!budget.under_cap());
+
+        budget.refund(Charge {
+            events: 1,
+            bytes: 0,
+        });
+        assert!(budget.under_cap());
+
+        budget.charge(Charge {
+            events: 0,
+            bytes: 99,
+        });
+        assert!(!budget.under_cap());
+    }
+}

--- a/rust/common/kafka-consumer/src/commit.rs
+++ b/rust/common/kafka-consumer/src/commit.rs
@@ -1,0 +1,240 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::charge::Charge;
+use crate::types::{Advance, DrainHarvest, Offset, Partition};
+
+/// The injected commit issue: the caller commits `(partition, next offset)`
+/// pairs, async and fire-and-forget, and never blocks the loop.
+pub type IssueCommit<'a> = dyn FnMut(&[(Partition, Offset)]) + 'a;
+
+/// The whole commit policy behind three calls: `progress` on every frontier
+/// advance, `tick` from the loop's housekeeping tick, and `finish_revoke` for
+/// a drain's end. When and how to issue — delay, batching — is this
+/// component's algorithm and appears nowhere else. Budget refunds return from
+/// whichever call issues, keeping `B` = polled minus committed exact.
+#[derive(Debug)]
+pub struct CommitManager {
+    /// Latest unissued frontier plus the charge tally behind it.
+    pending: HashMap<Partition, PendingAdvance>,
+    last_issue: Option<Instant>,
+    interval: Duration,
+}
+
+#[derive(Debug)]
+struct PendingAdvance {
+    frontier: Offset,
+    charge: Charge,
+}
+
+impl CommitManager {
+    pub fn new(interval: Duration) -> CommitManager {
+        CommitManager {
+            pending: HashMap::new(),
+            last_issue: None,
+            interval,
+        }
+    }
+
+    /// Called on every completion that moved a frontier; whether to issue now
+    /// is this component's decision, nobody else's.
+    pub fn progress(
+        &mut self,
+        advances: Vec<Advance>,
+        now: Instant,
+        issue: &mut IssueCommit<'_>,
+    ) -> Charge {
+        for a in advances {
+            let entry = self.pending.entry(a.partition).or_insert(PendingAdvance {
+                frontier: a.frontier,
+                charge: Charge::ZERO,
+            });
+            entry.frontier = entry.frontier.max(a.frontier);
+            entry.charge += a.charge;
+        }
+        self.maybe_issue(now, issue)
+    }
+
+    /// The clock: issue if the delay is up.
+    pub fn tick(&mut self, now: Instant, issue: &mut IssueCommit<'_>) -> Charge {
+        self.maybe_issue(now, issue)
+    }
+
+    /// The drain's end: issue the partition's final frontier NOW — the
+    /// rebalance is waiting. Every completed span was already reported via
+    /// `progress`, so the refund is the held tally plus the never-completed
+    /// charge — nothing counts twice.
+    pub fn finish_revoke(
+        &mut self,
+        harvest: DrainHarvest,
+        now: Instant,
+        issue: &mut IssueCommit<'_>,
+    ) -> Charge {
+        let held = self.pending.remove(&harvest.partition);
+        if let Some(frontier) = harvest.frontier {
+            self.issue(&[(harvest.partition, frontier.next())], now, issue);
+        }
+        held.map_or(Charge::ZERO, |h| h.charge) + harvest.dropped
+    }
+
+    /// The algorithm — today: at most one batched issue per interval.
+    fn maybe_issue(&mut self, now: Instant, issue: &mut IssueCommit<'_>) -> Charge {
+        if self
+            .last_issue
+            .is_some_and(|last| now.duration_since(last) < self.interval)
+        {
+            return Charge::ZERO;
+        }
+        if self.pending.is_empty() {
+            return Charge::ZERO;
+        }
+        let batch: Vec<(Partition, Offset)> = self
+            .pending
+            .iter()
+            .map(|(p, a)| (*p, a.frontier.next()))
+            .collect();
+        let refund = self.pending.drain().map(|(_, a)| a.charge).sum();
+        self.issue(&batch, now, issue);
+        refund
+    }
+
+    fn issue(&mut self, batch: &[(Partition, Offset)], now: Instant, issue: &mut IssueCommit<'_>) {
+        issue(batch);
+        self.last_issue = Some(now);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const INTERVAL: Duration = Duration::from_secs(5);
+
+    fn advance(p: i32, frontier: i64, events: u64) -> Advance {
+        Advance {
+            partition: Partition(p),
+            frontier: Offset(frontier),
+            charge: Charge { events, bytes: 0 },
+        }
+    }
+
+    #[test]
+    fn at_most_one_batched_issue_per_interval() {
+        let now = Instant::now();
+        let mut commits = CommitManager::new(INTERVAL);
+        let mut issued: Vec<Vec<(Partition, Offset)>> = vec![];
+
+        // The first advance issues immediately (nothing issued yet).
+        let refund = commits.progress(vec![advance(0, 3, 4)], now, &mut |b| {
+            issued.push(b.to_vec())
+        });
+        assert_eq!(issued, vec![vec![(Partition(0), Offset(4))]]);
+        assert_eq!(
+            refund,
+            Charge {
+                events: 4,
+                bytes: 0
+            }
+        );
+
+        // More advances inside the interval accumulate instead of issuing.
+        let refund = commits.progress(
+            vec![advance(0, 7, 4), advance(1, 1, 2)],
+            now + Duration::from_secs(1),
+            &mut |b| issued.push(b.to_vec()),
+        );
+        assert_eq!(issued.len(), 1);
+        assert_eq!(refund, Charge::ZERO);
+
+        // The tick past the interval issues both frontiers, one batch.
+        let refund = commits.tick(now + INTERVAL, &mut |b| issued.push(b.to_vec()));
+        assert_eq!(
+            refund,
+            Charge {
+                events: 6,
+                bytes: 0
+            }
+        );
+        let mut batch = issued[1].clone();
+        batch.sort();
+        assert_eq!(
+            batch,
+            vec![(Partition(0), Offset(8)), (Partition(1), Offset(2))]
+        );
+
+        // Nothing pending: the next tick stays quiet.
+        assert_eq!(
+            commits.tick(now + INTERVAL * 2, &mut |b| issued.push(b.to_vec())),
+            Charge::ZERO
+        );
+        assert_eq!(issued.len(), 2);
+    }
+
+    #[test]
+    fn finish_revoke_issues_immediately_and_refunds_exactly_once() {
+        let now = Instant::now();
+        let mut commits = CommitManager::new(INTERVAL);
+        let mut issued: Vec<Vec<(Partition, Offset)>> = vec![];
+
+        commits.progress(vec![advance(0, 2, 3)], now, &mut |b| {
+            issued.push(b.to_vec())
+        });
+        // A second advance is still held when the drain ends.
+        commits.progress(
+            vec![advance(0, 5, 3)],
+            now + Duration::from_secs(1),
+            &mut |b| issued.push(b.to_vec()),
+        );
+
+        let refund = commits.finish_revoke(
+            DrainHarvest {
+                partition: Partition(0),
+                frontier: Some(Offset(5)),
+                dropped: Charge {
+                    events: 2,
+                    bytes: 0,
+                },
+            },
+            now + Duration::from_secs(2),
+            &mut |b| issued.push(b.to_vec()),
+        );
+        // Held tally (3) plus never-completed charge (2); the first issue's 3
+        // was already refunded, so nothing counts twice.
+        assert_eq!(
+            refund,
+            Charge {
+                events: 5,
+                bytes: 0
+            }
+        );
+        assert_eq!(issued.last().unwrap(), &vec![(Partition(0), Offset(6))]);
+    }
+
+    #[test]
+    fn finish_revoke_with_no_frontier_commits_nothing() {
+        let now = Instant::now();
+        let mut commits = CommitManager::new(INTERVAL);
+        let mut issued = 0usize;
+
+        let refund = commits.finish_revoke(
+            DrainHarvest {
+                partition: Partition(0),
+                frontier: None,
+                dropped: Charge {
+                    events: 7,
+                    bytes: 0,
+                },
+            },
+            now,
+            &mut |_| issued += 1,
+        );
+        assert_eq!(issued, 0, "nothing ever completed, nothing to commit");
+        assert_eq!(
+            refund,
+            Charge {
+                events: 7,
+                bytes: 0
+            }
+        );
+    }
+}

--- a/rust/common/kafka-consumer/src/config.rs
+++ b/rust/common/kafka-consumer/src/config.rs
@@ -243,6 +243,33 @@ mod tests {
     use super::*;
 
     #[test]
+    fn batch_consumer_defaults_are_stable() {
+        let config = ConsumerConfigBuilder::for_batch_consumer("kafka:9092", "g").build();
+
+        let mut entries: Vec<(String, String)> = config
+            .config_map()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        entries.sort();
+
+        assert_eq!(
+            entries,
+            [
+                ("enable.auto.commit", "false"),
+                ("enable.auto.offset.store", "false"),
+                ("group.id", "g"),
+                ("heartbeat.interval.ms", "5000"),
+                ("max.poll.interval.ms", "300000"),
+                ("metadata.broker.list", "kafka:9092"),
+                ("session.timeout.ms", "60000"),
+                ("socket.timeout.ms", "10000"),
+            ]
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+        );
+    }
+
+    #[test]
     fn strips_classic_keys_under_consumer_protocol() {
         let config = ConsumerConfigBuilder::for_batch_consumer("kafka:9092", "g")
             .with_sticky_partition_assignment(Some("pod-1"), true)

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -1,0 +1,185 @@
+use std::collections::VecDeque;
+
+use crate::charge::Charge;
+use crate::types::Offset;
+
+#[derive(Debug)]
+struct Slot {
+    done: bool,
+    charge: Charge,
+}
+
+/// A partition's offset accounting: a dense ring over one contiguous offset
+/// range. Polls deliver offsets in order, so appending keeps the ring dense;
+/// completion arrives in any order and only the frontier — the highest
+/// contiguous completed offset — is ordered.
+#[derive(Debug, Default)]
+pub struct OffsetLedger {
+    /// The offset of `slots[0]`; `None` until the first delivery.
+    base: Option<i64>,
+    /// Highest contiguous completed offset; `None` until the first advance.
+    frontier: Option<i64>,
+    slots: VecDeque<Slot>,
+}
+
+impl OffsetLedger {
+    pub fn new() -> OffsetLedger {
+        OffsetLedger::default()
+    }
+
+    /// Record one poll's offsets, in offset order. An offset gap (transaction
+    /// control records) gets pre-done zero-charge filler so the frontier walks
+    /// over it and the index math stays honest. Returns the poll's debit.
+    pub fn add_pending(&mut self, msgs: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
+        let mut total = Charge::ZERO;
+        for (offset, charge) in msgs {
+            let base = *self.base.get_or_insert(offset.0);
+            let next = base + self.slots.len() as i64;
+            assert!(
+                offset.0 >= next,
+                "poll delivered offset {} below the ring's end {next}",
+                offset.0
+            );
+            for _ in next..offset.0 {
+                self.slots.push_back(Slot {
+                    done: true,
+                    charge: Charge::ZERO,
+                });
+            }
+            self.slots.push_back(Slot {
+                done: false,
+                charge,
+            });
+            total += charge;
+        }
+        total
+    }
+
+    /// Mark a group's offsets done — any subset of the ring, in any order
+    /// across requests — then pop the done prefix in the same call. Returns
+    /// the new frontier and the charge of exactly the span it walked over, or
+    /// `None` when the front is still in flight and nothing advanced.
+    pub fn complete(&mut self, offsets: &[Offset]) -> Option<(Offset, Charge)> {
+        let base = self.base.expect("completion before any delivery");
+        for o in offsets {
+            let index = usize::try_from(o.0 - base).expect("completion below the frontier");
+            let slot = &mut self.slots[index];
+            assert!(!slot.done, "offset {o} completed twice");
+            slot.done = true;
+        }
+
+        let mut charge = Charge::ZERO;
+        while self.slots.front().is_some_and(|s| s.done) {
+            charge += self.slots.pop_front().expect("front checked").charge;
+            let base = self.base.as_mut().expect("base set above");
+            self.frontier = Some(*base);
+            *base += 1;
+        }
+        // Zero-charge filler is only ever popped together with a real slot
+        // (it is pre-done, so the frontier never rests just below it), so a
+        // zero charge means nothing advanced.
+        (!charge.is_zero()).then(|| (Offset(self.frontier.expect("advanced")), charge))
+    }
+
+    /// Highest contiguous completed offset; `None` until the first advance.
+    pub fn frontier(&self) -> Option<Offset> {
+        self.frontier.map(Offset)
+    }
+
+    pub fn has_pending(&self) -> bool {
+        !self.slots.is_empty()
+    }
+
+    /// Everything the frontier never walked over — including done work
+    /// stranded above a gap, which was never refunded and replays like the
+    /// rest.
+    pub fn pending_charge(&self) -> Charge {
+        self.slots.iter().map(|s| s.charge).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(n: u64) -> Charge {
+        Charge {
+            events: n,
+            bytes: n * 10,
+        }
+    }
+
+    fn deliver(ledger: &mut OffsetLedger, offsets: impl IntoIterator<Item = i64>) -> Charge {
+        ledger.add_pending(offsets.into_iter().map(|o| (Offset(o), ev(1))))
+    }
+
+    #[test]
+    fn out_of_order_completion_holds_the_frontier_until_the_gap_fills() {
+        let mut ledger = OffsetLedger::new();
+        deliver(&mut ledger, 0..=6);
+
+        // A later request's offsets settle first: done above the gap, no advance.
+        assert_eq!(ledger.complete(&[Offset(4), Offset(5), Offset(6)]), None);
+        assert_eq!(ledger.frontier(), None);
+
+        // The earlier work lands: one advance walks over all of it.
+        let (frontier, charge) = ledger
+            .complete(&[Offset(0), Offset(1), Offset(2), Offset(3)])
+            .expect("the gap filled");
+        assert_eq!(frontier, Offset(6));
+        assert_eq!(charge, ev(7));
+        assert!(!ledger.has_pending());
+    }
+
+    #[test]
+    fn offset_gaps_get_pre_done_zero_charge_filler() {
+        let mut ledger = OffsetLedger::new();
+        // Transaction control records at offsets 2 and 3 are never delivered.
+        let charged = deliver(&mut ledger, [0, 1, 4]);
+        assert_eq!(charged, ev(3));
+
+        let (frontier, charge) = ledger.complete(&[Offset(0), Offset(1)]).expect("advance");
+        assert_eq!(frontier, Offset(3), "the frontier walks over the filler");
+        assert_eq!(charge, ev(2), "filler carries no charge");
+
+        let (frontier, charge) = ledger.complete(&[Offset(4)]).expect("advance");
+        assert_eq!(frontier, Offset(4));
+        assert_eq!(charge, ev(1));
+    }
+
+    #[test]
+    fn refund_is_exactly_the_span_the_frontier_walked_over() {
+        let mut ledger = OffsetLedger::new();
+        deliver(&mut ledger, 0..=3);
+
+        let (_, first) = ledger.complete(&[Offset(0)]).expect("advance");
+        assert_eq!(ledger.complete(&[Offset(2)]), None, "no advance, no refund");
+        let (_, second) = ledger.complete(&[Offset(1)]).expect("advance");
+        let (_, third) = ledger.complete(&[Offset(3)]).expect("advance");
+        assert_eq!(first + second + third, ev(4), "every charge refunded once");
+    }
+
+    #[test]
+    fn pending_charge_includes_done_work_stranded_above_a_gap() {
+        let mut ledger = OffsetLedger::new();
+        deliver(&mut ledger, 0..=2);
+
+        assert_eq!(ledger.complete(&[Offset(1), Offset(2)]), None);
+        // Offsets 1 and 2 are done but the frontier never walked over them:
+        // they were never refunded and replay like the rest on a drain.
+        assert_eq!(ledger.pending_charge(), ev(3));
+    }
+
+    #[test]
+    fn later_polls_append_to_the_same_ring() {
+        let mut ledger = OffsetLedger::new();
+        deliver(&mut ledger, 0..=1);
+        deliver(&mut ledger, 2..=3);
+
+        let (frontier, charge) = ledger
+            .complete(&[Offset(0), Offset(1), Offset(2), Offset(3)])
+            .expect("advance");
+        assert_eq!(frontier, Offset(3));
+        assert_eq!(charge, ev(4));
+    }
+}

--- a/rust/common/kafka-consumer/src/lib.rs
+++ b/rust/common/kafka-consumer/src/lib.rs
@@ -1,0 +1,7 @@
+//! Kafka consumption core for stateful services.
+//!
+//! The vocabulary follows `rust/ingestion-consumer/docs/driver-model.md` §8:
+//! the top-level component is the consumer loop, a driver is the single owner
+//! of one unit's state, and a group is one routing key's messages from one poll.
+
+pub mod config;

--- a/rust/common/kafka-consumer/src/lib.rs
+++ b/rust/common/kafka-consumer/src/lib.rs
@@ -1,7 +1,15 @@
 //! Kafka consumption core for stateful services.
 //!
-//! The vocabulary follows `rust/ingestion-consumer/docs/driver-model.md` §8:
-//! the top-level component is the consumer loop, a driver is the single owner
-//! of one unit's state, and a group is one routing key's messages from one poll.
+//! The design is the domain side of `rust/ingestion-consumer/docs/driver-model.md`
+//! (§3.1-§3.7), whose §8 is the vocabulary authority: the top-level component
+//! is the consumer loop, a driver is the single owner of one unit's state, and
+//! a group is one routing key's messages from one poll.
 
+pub mod accumulator;
+pub mod charge;
+pub mod commit;
 pub mod config;
+pub mod ledger;
+pub mod manager;
+pub mod partition;
+pub mod types;

--- a/rust/common/kafka-consumer/src/manager.rs
+++ b/rust/common/kafka-consumer/src/manager.rs
@@ -1,0 +1,206 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use crate::accumulator::{Accumulator, Group, PolledMessage};
+use crate::charge::Charge;
+use crate::partition::PartitionDriver;
+use crate::types::{Advance, AssignmentEpoch, DrainHarvest, Partition};
+
+/// The domain side's root: assignment lifecycle plus the offset ledgers. Owns
+/// every partition driver; nothing transport-shaped, no per-key state, and no
+/// clock of its own.
+#[derive(Debug)]
+pub struct PartitionManager {
+    partitions: HashMap<Partition, PartitionDriver>,
+    stall_timeout: Duration,
+}
+
+impl PartitionManager {
+    pub fn new(stall_timeout: Duration) -> PartitionManager {
+        PartitionManager {
+            partitions: HashMap::new(),
+            stall_timeout,
+        }
+    }
+
+    pub fn assign(&mut self, p: Partition, epoch: AssignmentEpoch, now: Instant) {
+        let previous = self
+            .partitions
+            .insert(p, PartitionDriver::new(p, epoch, now, self.stall_timeout));
+        assert!(
+            previous.is_none(),
+            "partition {p} assigned while already assigned"
+        );
+    }
+
+    /// Drain begun: the driver stays — its ledger must absorb the completions
+    /// still in flight.
+    pub fn revoking(&mut self, p: Partition) {
+        if let Some(driver) = self.partitions.get_mut(&p) {
+            driver.begin_revoke();
+        }
+    }
+
+    /// The drain's end: remove the driver and take its last word.
+    pub fn drained(&mut self, p: Partition) -> DrainHarvest {
+        let driver = self
+            .partitions
+            .remove(&p)
+            .expect("Drained for an unassigned partition");
+        let (frontier, dropped) = driver.drained();
+        DrainHarvest {
+            partition: p,
+            frontier,
+            dropped,
+        }
+    }
+
+    /// One poll, demuxed to its partitions; returns the poll's debit for `B`.
+    /// Messages must arrive grouped per partition in offset order, as rdkafka
+    /// delivers them.
+    pub fn accept<M>(
+        &mut self,
+        polled: Vec<(Partition, Vec<PolledMessage<M>>)>,
+        acc: &mut Accumulator<M>,
+    ) -> Charge {
+        let mut charge = Charge::ZERO;
+        for (p, msgs) in polled {
+            let driver = self
+                .partitions
+                .get_mut(&p)
+                .expect("poll delivered a message for an unassigned partition");
+            charge += driver.accept(msgs, acc);
+        }
+        charge
+    }
+
+    /// One ACKed request's groups, distributed to their ledgers. Stragglers
+    /// from before a reassignment die here by epoch; mid-drain completions
+    /// land.
+    pub fn complete<M>(&mut self, completed: Vec<Group<M>>, now: Instant) -> Vec<Advance> {
+        completed
+            .into_iter()
+            .filter_map(|g| {
+                let driver = self.partitions.get_mut(&g.partition)?;
+                if g.epoch != driver.epoch() {
+                    return None;
+                }
+                driver.complete(&g.offsets, now)
+            })
+            .collect()
+    }
+
+    /// Driven by the loop's housekeeping tick; returns the stalled partitions.
+    pub fn stalled(&self, now: Instant) -> Vec<Partition> {
+        self.partitions
+            .iter()
+            .filter(|(_, d)| d.is_stalled(now))
+            .map(|(p, _)| *p)
+            .collect()
+    }
+
+    pub fn is_assigned(&self, p: Partition) -> bool {
+        self.partitions.contains_key(&p)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Offset;
+
+    fn msg(offset: i64, key: &str) -> PolledMessage<()> {
+        PolledMessage {
+            offset: Offset(offset),
+            key: Some(key.as_bytes().to_vec()),
+            charge: Charge {
+                events: 1,
+                bytes: 1,
+            },
+            inner: (),
+        }
+    }
+
+    fn poll(
+        manager: &mut PartitionManager,
+        p: Partition,
+        msgs: Vec<PolledMessage<()>>,
+    ) -> Vec<Group<()>> {
+        let mut acc = Accumulator::default();
+        manager.accept(vec![(p, msgs)], &mut acc);
+        acc.into_groups()
+    }
+
+    #[test]
+    fn completions_with_a_dead_epoch_drop() {
+        let now = Instant::now();
+        let mut manager = PartitionManager::new(Duration::from_secs(60));
+        manager.assign(Partition(0), AssignmentEpoch(1), now);
+        let groups = poll(&mut manager, Partition(0), vec![msg(0, "a")]);
+
+        // The partition is revoked, drained, and reassigned under a new epoch
+        // while the group is still out.
+        manager.revoking(Partition(0));
+        manager.drained(Partition(0));
+        manager.assign(Partition(0), AssignmentEpoch(2), now);
+
+        // The straggler dies by epoch: no advance, no ledger touch.
+        assert_eq!(manager.complete(groups, now), vec![]);
+    }
+
+    #[test]
+    fn drained_returns_the_final_frontier_and_the_dropped_charge() {
+        let now = Instant::now();
+        let mut manager = PartitionManager::new(Duration::from_secs(60));
+        manager.assign(Partition(0), AssignmentEpoch(1), now);
+        let mut groups = poll(
+            &mut manager,
+            Partition(0),
+            vec![msg(0, "a"), msg(1, "b"), msg(2, "c")],
+        );
+
+        // Only "a" lands before the drain.
+        let first = groups.remove(0);
+        let advances = manager.complete(vec![first], now);
+        assert_eq!(advances.len(), 1);
+        assert_eq!(advances[0].frontier, Offset(0));
+
+        manager.revoking(Partition(0));
+        let harvest = manager.drained(Partition(0));
+        assert_eq!(harvest.frontier, Some(Offset(0)));
+        assert_eq!(
+            harvest.dropped,
+            Charge {
+                events: 2,
+                bytes: 2
+            }
+        );
+        assert!(!manager.is_assigned(Partition(0)));
+    }
+
+    #[test]
+    fn stall_check_fires_only_on_pending_work_and_stands_down_mid_drain() {
+        let now = Instant::now();
+        let stall = Duration::from_secs(60);
+        let mut manager = PartitionManager::new(stall);
+        manager.assign(Partition(0), AssignmentEpoch(1), now);
+        manager.assign(Partition(1), AssignmentEpoch(1), now);
+        let groups = poll(&mut manager, Partition(0), vec![msg(0, "a")]);
+        poll(&mut manager, Partition(1), vec![msg(0, "x")]);
+
+        let later = now + stall + Duration::from_secs(1);
+        assert_eq!(
+            manager.stalled(later).len(),
+            2,
+            "pending work past the deadline stalls"
+        );
+
+        // Progress on partition 0 resets its deadline; partition 1 stays stalled.
+        manager.complete(groups, later);
+        assert_eq!(manager.stalled(later), vec![Partition(1)]);
+
+        // A draining partition stands down.
+        manager.revoking(Partition(1));
+        assert_eq!(manager.stalled(later), vec![]);
+    }
+}

--- a/rust/common/kafka-consumer/src/partition.rs
+++ b/rust/common/kafka-consumer/src/partition.rs
@@ -1,0 +1,85 @@
+use std::time::{Duration, Instant};
+
+use crate::accumulator::{Accumulator, PolledMessage};
+use crate::charge::Charge;
+use crate::ledger::OffsetLedger;
+use crate::types::{Advance, AssignmentEpoch, Offset, Partition};
+
+/// The single owner of one partition's domain state: the offset ledger and
+/// the stall deadline. Methods are synchronous and never block; the loop's
+/// housekeeping tick drives the stall check.
+#[derive(Debug)]
+pub struct PartitionDriver {
+    partition: Partition,
+    epoch: AssignmentEpoch,
+    ledger: OffsetLedger,
+    stall_deadline: Instant,
+    stall_timeout: Duration,
+    /// Drain in progress: completions still land; the stall check stands down.
+    revoking: bool,
+}
+
+impl PartitionDriver {
+    pub fn new(
+        partition: Partition,
+        epoch: AssignmentEpoch,
+        now: Instant,
+        stall_timeout: Duration,
+    ) -> PartitionDriver {
+        PartitionDriver {
+            partition,
+            epoch,
+            ledger: OffsetLedger::new(),
+            stall_deadline: now + stall_timeout,
+            stall_timeout,
+            revoking: false,
+        }
+    }
+
+    pub fn epoch(&self) -> AssignmentEpoch {
+        self.epoch
+    }
+
+    pub fn revoking(&self) -> bool {
+        self.revoking
+    }
+
+    pub fn begin_revoke(&mut self) {
+        self.revoking = true;
+    }
+
+    /// One poll's messages for this partition, in offset order: record them
+    /// in the ledger and push the demuxed groups into the lent accumulator.
+    /// Returns the poll's debit for the budget.
+    pub fn accept<M>(&mut self, msgs: Vec<PolledMessage<M>>, acc: &mut Accumulator<M>) -> Charge {
+        let charge = self
+            .ledger
+            .add_pending(msgs.iter().map(|m| (m.offset, m.charge)));
+        acc.push_demuxed(self.partition, self.epoch, msgs);
+        charge
+    }
+
+    /// One ACKed group — the record of what landed. `None` when the frontier
+    /// did not move.
+    pub fn complete(&mut self, offsets: &[Offset], now: Instant) -> Option<Advance> {
+        let (frontier, charge) = self.ledger.complete(offsets)?;
+        self.stall_deadline = now + self.stall_timeout;
+        Some(Advance {
+            partition: self.partition,
+            frontier,
+            charge,
+        })
+    }
+
+    /// Consumed at the drain's end: the final frontier to commit, and the
+    /// charge the frontier never walked over.
+    pub fn drained(self) -> (Option<Offset>, Charge) {
+        (self.ledger.frontier(), self.ledger.pending_charge())
+    }
+
+    /// A frontier stuck for the timeout while work is pending. The caller
+    /// decides what failing the process looks like; replay is bounded by `B`.
+    pub fn is_stalled(&self, now: Instant) -> bool {
+        !self.revoking && self.ledger.has_pending() && now > self.stall_deadline
+    }
+}

--- a/rust/common/kafka-consumer/src/types.rs
+++ b/rust/common/kafka-consumer/src/types.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+
+use crate::charge::Charge;
+
+/// A partition index on the loop's single topic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Partition(pub i32);
+
+impl fmt::Display for Partition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A Kafka message offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Offset(pub i64);
+
+impl Offset {
+    /// The next offset after this one — what Kafka expects in a commit.
+    pub fn next(self) -> Offset {
+        Offset(self.0 + 1)
+    }
+}
+
+impl fmt::Display for Offset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A pod-local counter bumped on every partition assignment. Groups are
+/// stamped with their driver's epoch; a completion whose epoch does not match
+/// the current driver's is a straggler from before a reassignment and is
+/// dropped — the replay it represents is legal duplication, never loss.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AssignmentEpoch(pub u64);
+
+/// One frontier movement: the partition, its new frontier, and the charge of
+/// the span the frontier walked over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Advance {
+    pub partition: Partition,
+    pub frontier: Offset,
+    pub charge: Charge,
+}
+
+/// A drain's last word: the final frontier to commit (if anything ever
+/// completed) and the charge the frontier never walked over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DrainHarvest {
+    pub partition: Partition,
+    pub frontier: Option<Offset>,
+    pub dropped: Charge,
+}

--- a/rust/common/kafka-consumer/tests/exactness.rs
+++ b/rust/common/kafka-consumer/tests/exactness.rs
@@ -1,0 +1,129 @@
+//! The §8.2 accounting invariant: every message's charge is debited once at
+//! poll and refunded exactly once — at the commit that covers it, or as a
+//! drain's `dropped` — so after any schedule ends with every partition
+//! drained, the budget returns to zero.
+
+use std::time::{Duration, Instant};
+
+use proptest::prelude::*;
+
+use common_kafka_consumer::accumulator::{Accumulator, Group, PolledMessage};
+use common_kafka_consumer::charge::{Budget, Charge};
+use common_kafka_consumer::commit::CommitManager;
+use common_kafka_consumer::manager::PartitionManager;
+use common_kafka_consumer::types::{AssignmentEpoch, Offset, Partition};
+
+const PARTITIONS: i32 = 3;
+const COMMIT_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone)]
+enum Op {
+    /// Deliver `count` messages to the partition, skipping an offset first
+    /// when `gap` (a transaction control record).
+    Poll {
+        partition: i32,
+        count: u8,
+        gap: bool,
+    },
+    /// Complete the outstanding group at `index % outstanding.len()`.
+    Complete { index: u8 },
+    /// Advance time and give the commit manager its clock.
+    Tick,
+    /// Revoke the partition, drain it, and reassign it under a new epoch.
+    RevokeAndReassign { partition: i32 },
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        4 => (0..PARTITIONS, 1u8..8, any::<bool>())
+            .prop_map(|(partition, count, gap)| Op::Poll { partition, count, gap }),
+        4 => any::<u8>().prop_map(|index| Op::Complete { index }),
+        1 => Just(Op::Tick),
+        1 => (0..PARTITIONS).prop_map(|partition| Op::RevokeAndReassign { partition }),
+    ]
+}
+
+proptest! {
+    #[test]
+    fn budget_returns_to_zero_after_any_schedule(ops in prop::collection::vec(op_strategy(), 1..80)) {
+        let mut now = Instant::now();
+        let mut manager = PartitionManager::new(Duration::from_secs(3600));
+        let mut commits = CommitManager::new(COMMIT_INTERVAL);
+        let mut budget = Budget::new(Charge { events: u64::MAX, bytes: u64::MAX });
+
+        let mut epoch = 0u64;
+        let mut next_offset = vec![0i64; PARTITIONS as usize];
+        let mut outstanding: Vec<Group<u8>> = Vec::new();
+        let mut issue = |_: &[(Partition, Offset)]| {};
+
+        for p in 0..PARTITIONS {
+            manager.assign(Partition(p), AssignmentEpoch(epoch), now);
+        }
+
+        for op in ops {
+            now += Duration::from_secs(1);
+            match op {
+                Op::Poll { partition, count, gap } => {
+                    let offset = &mut next_offset[partition as usize];
+                    if gap {
+                        *offset += 1;
+                    }
+                    let msgs: Vec<PolledMessage<u8>> = (0..count)
+                        .map(|i| {
+                            let o = *offset + i as i64;
+                            PolledMessage {
+                                offset: Offset(o),
+                                // A few keys so groups span multiple offsets;
+                                // key 0 is null (a free group per message).
+                                key: (o % 4 != 0).then(|| vec![(o % 4) as u8]),
+                                charge: Charge { events: 1, bytes: 1 + (o as u64 % 7) },
+                                inner: 0,
+                            }
+                        })
+                        .collect();
+                    *offset += count as i64;
+                    let mut acc = Accumulator::default();
+                    budget.charge(manager.accept(vec![(Partition(partition), msgs)], &mut acc));
+                    outstanding.extend(acc.into_groups());
+                }
+                Op::Complete { index } => {
+                    if outstanding.is_empty() {
+                        continue;
+                    }
+                    let group = outstanding.remove(index as usize % outstanding.len());
+                    let advances = manager.complete(vec![group], now);
+                    budget.refund(commits.progress(advances, now, &mut issue));
+                }
+                Op::Tick => {
+                    now += COMMIT_INTERVAL;
+                    budget.refund(commits.tick(now, &mut issue));
+                }
+                Op::RevokeAndReassign { partition } => {
+                    let p = Partition(partition);
+                    manager.revoking(p);
+                    budget.refund(commits.finish_revoke(manager.drained(p), now, &mut issue));
+                    epoch += 1;
+                    manager.assign(p, AssignmentEpoch(epoch), now);
+                    // Offsets replay from the frontier in reality; delivering
+                    // fresh offsets instead keeps the model simple and still
+                    // exercises the accounting (a replay is just a poll).
+                }
+            }
+        }
+
+        // Straggler completions from before any reassignment die by epoch.
+        for group in outstanding.drain(..) {
+            let advances = manager.complete(vec![group], now);
+            budget.refund(commits.progress(advances, now, &mut issue));
+        }
+        // Drain everything: whatever the frontiers never walked over comes
+        // back as `dropped`.
+        for p in 0..PARTITIONS {
+            let p = Partition(p);
+            manager.revoking(p);
+            budget.refund(commits.finish_revoke(manager.drained(p), now, &mut issue));
+        }
+
+        prop_assert_eq!(budget.used(), Charge::ZERO);
+    }
+}

--- a/rust/ingestion-consumer/Cargo.toml
+++ b/rust/ingestion-consumer/Cargo.toml
@@ -9,6 +9,7 @@ axum = { workspace = true }
 chrono = { workspace = true }
 common-alloc = { path = "../common/alloc" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
+common-kafka-consumer = { path = "../common/kafka-consumer" }
 dashmap = { workspace = true }
 envconfig = { workspace = true }
 futures = { workspace = true }

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -4,8 +4,8 @@ use rdkafka::ClientConfig;
 use tracing::info;
 
 use crate::discovery::DiscoveryMode;
-use crate::kafka_config::ConsumerConfigBuilder;
 use crate::routing::RoutingStrategy;
+use common_kafka_consumer::config::ConsumerConfigBuilder;
 
 /// Configuration for the ingestion consumer.
 ///

--- a/rust/ingestion-consumer/src/lib.rs
+++ b/rust/ingestion-consumer/src/lib.rs
@@ -5,7 +5,6 @@ pub mod debug_recorder;
 pub mod discovery;
 pub mod dispatcher;
 pub mod grpc_transport;
-pub mod kafka_config;
 pub mod kafka_stats;
 pub mod order_sentinel;
 pub mod readiness;


### PR DESCRIPTION
## Problem

- Every stateful Kafka consumer under `rust/` hand-rolls its poll loop, offset tracking, and commit path. The ingestion consumer and the deduplicator carry two copies, and the cohort stream processor bypasses `common/kafka` because it cannot commit per partition.
- In the ingestion consumer, commit contiguity is emergent (oldest-first completion plus an all-accepted check) and verified after the fact by a sentinel, not constructed.
- This is the first layer of a shared Kafka consumption core, `rust/common/kafka-consumer`: the domain side of the driver-model redesign in #89277 (sections 3.1 to 3.7). Nothing adopts it yet; running services do not change.

## Changes

- Adds the `common-kafka-consumer` crate with the pure domain core and no Kafka client: offset ledger, charge and budget, per-key demux into groups, partition drivers with stall deadlines, the partition manager, and the commit manager.
- The ledger constructs contiguity. Completions arrive in any order; only the highest contiguous completed offset (the frontier) ever reaches the commit path. Offset gaps get zero-charge filler, so a gap never blocks the frontier.
- The budget is exact by construction. Each message's charge is debited at poll and refunded once: at the commit that covers it, or as a drain's dropped charge.
- Completions that carry a stale assignment epoch drop. A straggler after a reassignment replays and never touches the new ledger.
- Mechanical: `ingestion-consumer/src/kafka_config.rs` moves into the crate as `config.rs` unchanged, and the ingestion consumer imports it from there.

## How did you test this code?

- Unit tests per component, each named for the invariant it pins: an out-of-order completion holds the frontier, gap filler, the refund equals the span the frontier walked, `finish_revoke` refunds held plus dropped exactly once, dead-epoch completions drop, demux keeps per-key offset order and a null key is one group per message.
- `tests/exactness.rs`: a proptest over random accept, complete, and commit schedules asserting `B` = polled minus committed.
- `config.rs` keeps the moved builder's tests and adds a fixture that pins the batch-consumer defaults.
- Not run: no service adopts the crate yet, so no e2e path exercises it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The crate's README carries the seam and the invariants.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Claude Fable 5), directed by the assignee. Skills invoked: `/writing-pr-descriptions`, `/stacking-prs`.
- Decisions across the session: the crate is named after the doc's vocabulary (the top component is the consumer loop; "driver" is reserved for a unit's state owner); the loop never decodes payloads; demux is by routing key only.
- Layer 1 of a stack. #91683 adds the loop that owns the rdkafka client.
