### PR TITLE
feat(kafka-consumer): add the consumer loop over rdkafka

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2906,8 +2906,15 @@ dependencies = [
 name = "common-kafka-consumer"
 version = "0.1.0"
 dependencies = [
+ "futures",
+ "metrics",
  "proptest",
  "rdkafka",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/common/kafka-consumer/Cargo.toml
+++ b/rust/common/kafka-consumer/Cargo.toml
@@ -8,7 +8,14 @@ publish = false
 workspace = true
 
 [dependencies]
+futures = { workspace = true }
+metrics = { workspace = true }
 rdkafka = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 proptest = "1"
+tracing-subscriber = { workspace = true }

--- a/rust/common/kafka-consumer/README.md
+++ b/rust/common/kafka-consumer/README.md
@@ -4,17 +4,49 @@ Kafka consumption core for stateful services: poll, demux to groups, budget-gate
 
 The design is the domain side of the driver-model doc in `rust/ingestion-consumer/docs/driver-model.md` (§3.1-§3.7). That doc's §8 is the vocabulary authority for names in this crate.
 
+## The seam
+
+The loop owns the left side. The application (the transport side) owns the right and talks only through the two channels.
+
+```text
+                 Feed { Batch(Accumulator) | Revoked { partition, epoch } }
+consumer loop ─────────────────────────────────────────────────────────►  transport side
+              ◄─────────────────────────────────────────────────────────
+                 Completion { Completed(Vec<GroupCompletion>) | Drained { partition, epoch } }
+```
+
+Rules the transport side must keep:
+
+- A `Group` comes back as one `GroupCompletion` (`Group::completion`), slim: partition, epoch, done offsets, no messages. Only when its work is done; a partial acceptance narrows the offsets to the accepted prefix. Failures never cross the seam: keep the group and retry; its offsets stay pending.
+- One assignment epoch per process: `ConsumerLoop::epoch_counter` is the counter the transport stamps on requests, so worker-side sentinels rebaseline on the same rebalances the groups see.
+- `Revoked` is in-band: drop the partition's queued groups (never sent, the next owner re-reads them), let in-flight work settle, then send `Drained` with the same epoch behind the last completion. Groups for that partition that arrive after the marker are dropped too.
+- Shutdown is a `Revoked` for every partition; nothing else changes.
+
 ## Modules
 
 - `config`: `ConsumerConfigBuilder`, the rdkafka `ClientConfig` builder with PostHog consumer defaults.
-- `types`: `Partition`, `Offset`, `AssignmentEpoch`, `Advance`, `DrainHarvest`.
-- `charge`: `Charge` (events + bytes, one value, two axes) and `Budget`, the `B` gate: charged at poll, refunded at commit or at a drain's end.
+- `consumer_loop`: `ConsumerLoop`, the event pump: a biased select over shutdown, the housekeeping tick, rebalance events, completions, and the poll. `ConsumerLoopConfig` carries every knob with defaults.
+- `context`: the rdkafka `ConsumerContext`: `incremental_assign` in the callback, revokes forwarded to the loop, the hand-back deferred to the drain's end; `closing` makes the close-time revoke answer inline.
+- `types`: `Partition`, `Offset`, `AssignmentEpoch`, `Advance`, `DrainHarvest`, `RawMessage`.
+- `charge`: `Charge` (events + bytes, one value, two axes) and `Budget`, the `B` gate with two watermarks: closes at `cap`, reopens at `low`.
 - `ledger`: `OffsetLedger`, a dense ring per partition; completion in any order, only the frontier — the highest contiguous completed offset — is ordered.
 - `accumulator`: `Group` (one routing key's messages from one poll; null key owes no order), `Accumulator`, and the demux.
 - `partition`: `PartitionDriver`, one partition's ledger plus its stall deadline.
 - `manager`: `PartitionManager`, assignment lifecycle over the drivers; stragglers die by epoch.
-- `commit`: `CommitManager`, the commit policy whole — batched interval issues, immediate final commit on a drain's end.
+- `commit`: `CommitManager`, the commit policy whole — batched interval issues, immediate final commit on a drain's end, `abandon` for a lost assignment.
+- `sentinel`: `CommitSentinel`, the cheap assert that issues only move forward, and the broker-side confirmation the commit monitor feeds.
+- `stats`: librdkafka statistics export, unlabeled series.
+- `events`: `Observer`, the loop-side event points (`alive` for liveness, assign/revoke/drain/commit/stall/gate).
+- `metrics`: every metric name, pinned by a fixture test; every labeled series carries `group`.
 
-The invariants (doc §4): only a ledger's frontier is ever committed; an offset goes done only when a completion names it; `B` = polled minus committed, exactly (`tests/exactness.rs` pins this over random schedules); a revoked partition's final commit issues before it is handed back.
+## Invariants (doc §4)
 
-Still to come (plan stages 2+): the consumer loop itself (event pump, rdkafka context, pause/resume poll gate, bounded drain wiring, commit monitor), stats export, and the commit sentinel.
+Only a ledger's frontier is ever committed; an offset goes done only when a completion names it; `B` = polled minus committed, exactly (`tests/exactness.rs` pins this over random schedules); a revoked partition's final commit issues before it is handed back (`tests/mock_cluster.rs`).
+
+## Facts about rdkafka the loop is built around
+
+- The rebalance callback runs inside `poll`, on the task that awaits `recv()`: the loop's own. It never waits there; the hand-back (`incremental_unassign`) comes from the loop after the drain, which librdkafka allows outside the callback.
+- While a revoke waits for that call, librdkafka pauses every assigned partition. The drain window is a pod-wide fetch pause; keep it short.
+- Dropping the consumer revokes the whole assignment through the same callback and polls until closed; the `closing` flag answers that one inline, or the drop spins forever.
+- `pause` purges the fetch queue and `resume` refetches it, hence the gate's two watermarks.
+- The poll arm is never disabled: a paused consumer still serves callbacks and keeps `max.poll.interval.ms` alive; an unpolled one does neither.

--- a/rust/common/kafka-consumer/src/accumulator.rs
+++ b/rust/common/kafka-consumer/src/accumulator.rs
@@ -29,6 +29,31 @@ pub struct Group<M> {
     pub messages: Vec<M>,
 }
 
+impl<M> Group<M> {
+    /// The completion for this whole group: what the transport side sends
+    /// back when the group's work is done. A partial acceptance narrows
+    /// `offsets` to the accepted prefix and keeps the rest for redelivery.
+    pub fn completion(&self) -> GroupCompletion {
+        GroupCompletion {
+            partition: self.partition,
+            epoch: self.epoch,
+            offsets: self.offsets.clone(),
+        }
+    }
+}
+
+/// One ACKed group, slim: the ledger needs the offsets, the epoch check needs
+/// the epoch, and nothing needs the messages back. Failures never cross the
+/// seam; a group that failed is retried by the transport side and completed
+/// once its work is done.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GroupCompletion {
+    pub partition: Partition,
+    pub epoch: AssignmentEpoch,
+    /// Done offsets, ascending; any subset of the group's offsets.
+    pub offsets: Vec<Offset>,
+}
+
 /// One poll's demuxed groups, in offset order per key. Obtained from the
 /// factory, lent down the demux under `&mut`, released to the transport side
 /// whole, by value.

--- a/rust/common/kafka-consumer/src/charge.rs
+++ b/rust/common/kafka-consumer/src/charge.rs
@@ -52,36 +52,78 @@ impl Sum for Charge {
 }
 
 /// The `B` accounting: charged at poll, refunded at commit and at a drain's
-/// end. `used` is Σ charged − Σ refunded, exactly; only `under_cap` reads the
+/// end. `used` is Σ charged − Σ refunded, exactly; only the gate reads the
 /// axes.
+///
+/// The gate has two watermarks. It closes when `used` reaches `cap` on either
+/// axis and reopens only when `used` is back at or under `low` on both. The
+/// poll gate is rdkafka pause/resume, and a pause purges the fetch queue that
+/// a resume then refetches, so a gate that flipped on every refund across a
+/// single threshold would refetch on every crossing.
 #[derive(Debug)]
 pub struct Budget {
     used: Charge,
     cap: Charge,
+    low: Charge,
+    closed: bool,
 }
 
 impl Budget {
+    /// Default low watermark: 80% of the cap on each axis.
+    pub const DEFAULT_LOW_RATIO: f64 = 0.8;
+
     pub fn new(cap: Charge) -> Budget {
+        Budget::with_low_ratio(cap, Budget::DEFAULT_LOW_RATIO)
+    }
+
+    pub fn with_low_ratio(cap: Charge, ratio: f64) -> Budget {
+        let ratio = ratio.clamp(0.0, 1.0);
+        Budget::with_low(
+            cap,
+            Charge {
+                events: (cap.events as f64 * ratio) as u64,
+                bytes: (cap.bytes as f64 * ratio) as u64,
+            },
+        )
+    }
+
+    pub fn with_low(cap: Charge, low: Charge) -> Budget {
         Budget {
             used: Charge::ZERO,
             cap,
+            low: Charge {
+                events: low.events.min(cap.events),
+                bytes: low.bytes.min(cap.bytes),
+            },
+            closed: false,
         }
     }
 
     pub fn charge(&mut self, c: Charge) {
         self.used += c;
+        if self.used.events >= self.cap.events || self.used.bytes >= self.cap.bytes {
+            self.closed = true;
+        }
     }
 
     pub fn refund(&mut self, c: Charge) {
         self.used -= c;
+        if self.used.events <= self.low.events && self.used.bytes <= self.low.bytes {
+            self.closed = false;
+        }
     }
 
-    pub fn under_cap(&self) -> bool {
-        self.used.events < self.cap.events && self.used.bytes < self.cap.bytes
+    /// Whether the loop may poll.
+    pub fn gate_open(&self) -> bool {
+        !self.closed
     }
 
     pub fn used(&self) -> Charge {
         self.used
+    }
+
+    pub fn cap(&self) -> Charge {
+        self.cap
     }
 }
 
@@ -89,30 +131,53 @@ impl Budget {
 mod tests {
     use super::*;
 
+    fn charge(events: u64, bytes: u64) -> Charge {
+        Charge { events, bytes }
+    }
+
     #[test]
     fn either_axis_closes_the_gate() {
-        let mut budget = Budget::new(Charge {
-            events: 10,
-            bytes: 100,
-        });
-        assert!(budget.under_cap());
+        let mut budget = Budget::with_low(charge(10, 100), charge(10, 100));
+        assert!(budget.gate_open());
 
-        budget.charge(Charge {
-            events: 10,
-            bytes: 1,
-        });
-        assert!(!budget.under_cap());
+        budget.charge(charge(10, 1));
+        assert!(!budget.gate_open());
 
-        budget.refund(Charge {
-            events: 1,
-            bytes: 0,
-        });
-        assert!(budget.under_cap());
+        budget.refund(charge(1, 0));
+        assert!(budget.gate_open());
 
-        budget.charge(Charge {
-            events: 0,
-            bytes: 99,
-        });
-        assert!(!budget.under_cap());
+        budget.charge(charge(0, 99));
+        assert!(!budget.gate_open());
+    }
+
+    #[test]
+    fn a_refund_between_low_and_cap_keeps_the_gate_closed() {
+        let mut budget = Budget::with_low(charge(10, 100), charge(8, 80));
+        budget.charge(charge(10, 50));
+        assert!(!budget.gate_open());
+
+        budget.refund(charge(1, 0));
+        assert!(!budget.gate_open(), "9 events is above low (8)");
+
+        budget.refund(charge(1, 0));
+        assert!(budget.gate_open(), "8 events is at low on both axes");
+    }
+
+    #[test]
+    fn reopening_needs_both_axes_at_or_under_low() {
+        let mut budget = Budget::with_low(charge(10, 100), charge(8, 80));
+        budget.charge(charge(10, 100));
+        budget.refund(charge(5, 0));
+        assert!(!budget.gate_open(), "bytes still at cap");
+        budget.refund(charge(0, 20));
+        assert!(budget.gate_open());
+    }
+
+    #[test]
+    fn low_ratio_derives_the_watermark_per_axis() {
+        let budget = Budget::with_low_ratio(charge(100, 1000), 0.5);
+        assert_eq!(budget.low, charge(50, 500));
+        let clamped = Budget::with_low_ratio(charge(100, 1000), 7.0);
+        assert_eq!(clamped.low, charge(100, 1000));
     }
 }

--- a/rust/common/kafka-consumer/src/commit.rs
+++ b/rust/common/kafka-consumer/src/commit.rs
@@ -17,6 +17,9 @@ pub type IssueCommit<'a> = dyn FnMut(&[(Partition, Offset)]) + 'a;
 pub struct CommitManager {
     /// Latest unissued frontier plus the charge tally behind it.
     pending: HashMap<Partition, PendingAdvance>,
+    /// The offset last issued per partition, so a drain's final issue can
+    /// skip what `progress` already committed.
+    issued: HashMap<Partition, Offset>,
     last_issue: Option<Instant>,
     interval: Duration,
 }
@@ -31,6 +34,7 @@ impl CommitManager {
     pub fn new(interval: Duration) -> CommitManager {
         CommitManager {
             pending: HashMap::new(),
+            issued: HashMap::new(),
             last_issue: None,
             interval,
         }
@@ -71,9 +75,24 @@ impl CommitManager {
         issue: &mut IssueCommit<'_>,
     ) -> Charge {
         let held = self.pending.remove(&harvest.partition);
+        let already_issued = self.issued.remove(&harvest.partition);
         if let Some(frontier) = harvest.frontier {
-            self.issue(&[(harvest.partition, frontier.next())], now, issue);
+            if already_issued != Some(frontier.next()) {
+                self.issue(&[(harvest.partition, frontier.next())], now, issue);
+            }
         }
+        // The driver is gone; its last issue must not outlive it.
+        self.issued.remove(&harvest.partition);
+        held.map_or(Charge::ZERO, |h| h.charge) + harvest.dropped
+    }
+
+    /// A drain that ends without a commit: the assignment was lost, so the
+    /// broker would reject the partition's final offset. Returns the held
+    /// tally plus the never-completed charge, exactly as `finish_revoke`
+    /// would, and issues nothing.
+    pub fn abandon(&mut self, harvest: DrainHarvest) -> Charge {
+        let held = self.pending.remove(&harvest.partition);
+        self.issued.remove(&harvest.partition);
         held.map_or(Charge::ZERO, |h| h.charge) + harvest.dropped
     }
 
@@ -100,6 +119,9 @@ impl CommitManager {
 
     fn issue(&mut self, batch: &[(Partition, Offset)], now: Instant, issue: &mut IssueCommit<'_>) {
         issue(batch);
+        for (p, o) in batch {
+            self.issued.insert(*p, *o);
+        }
         self.last_issue = Some(now);
     }
 }
@@ -116,6 +138,44 @@ mod tests {
             frontier: Offset(frontier),
             charge: Charge { events, bytes: 0 },
         }
+    }
+
+    #[test]
+    fn a_drain_does_not_reissue_a_frontier_progress_already_committed() {
+        let now = Instant::now();
+        let mut commits = CommitManager::new(INTERVAL);
+        let mut issued: Vec<Vec<(Partition, Offset)>> = vec![];
+        commits.progress(vec![advance(0, 5, 6)], now, &mut |b| {
+            issued.push(b.to_vec())
+        });
+        assert_eq!(issued.len(), 1);
+
+        let refund = commits.finish_revoke(
+            DrainHarvest {
+                partition: Partition(0),
+                frontier: Some(Offset(5)),
+                dropped: Charge {
+                    events: 2,
+                    bytes: 0,
+                },
+            },
+            now,
+            &mut |b| issued.push(b.to_vec()),
+        );
+        assert_eq!(issued.len(), 1, "the frontier was already issued");
+        assert_eq!(
+            refund,
+            Charge {
+                events: 2,
+                bytes: 0
+            }
+        );
+
+        // A later incarnation of the partition baselines afresh.
+        commits.progress(vec![advance(0, 5, 1)], now + INTERVAL, &mut |b| {
+            issued.push(b.to_vec())
+        });
+        assert_eq!(issued.len(), 2);
     }
 
     #[test]

--- a/rust/common/kafka-consumer/src/consumer_loop.rs
+++ b/rust/common/kafka-consumer/src/consumer_loop.rs
@@ -1,0 +1,953 @@
+//! The consumer loop: the event pump (doc §3.1).
+//!
+//! One task owns every domain struct by value. Its single await point is a
+//! biased select whose order is the starvation proof: an arm can only starve
+//! the arms below it, so shutdown, the housekeeping tick, and the rare
+//! rebalance events sit on top, completions above the poll (drain before
+//! taking new work), and the poll last.
+//!
+//! The poll arm is never disabled. Backpressure is rdkafka pause/resume on
+//! the assignment: a paused consumer still serves rebalance callbacks and
+//! keeps `max.poll.interval.ms` alive, an unpolled one does neither.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures::FutureExt;
+use metrics::{counter, gauge, histogram, Counter, Gauge, Histogram};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::error::KafkaError;
+use rdkafka::message::{BorrowedMessage, Headers, Message};
+use rdkafka::types::RDKafkaErrorCode;
+use rdkafka::{ClientConfig, TopicPartitionList};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use crate::accumulator::{Accumulator, GroupCompletion, PolledMessage};
+use crate::charge::{Budget, Charge};
+use crate::commit::CommitManager;
+use crate::context::{LoopContext, RebalanceEvent};
+use crate::events::Observer;
+use crate::manager::PartitionManager;
+use crate::metrics as names;
+use crate::sentinel::CommitSentinel;
+use crate::stats;
+use crate::types::{AssignmentEpoch, Offset, Partition, RawMessage};
+
+/// Everything the loop needs to build, with the defaults an adopter can
+/// override field by field.
+pub struct ConsumerLoopConfig {
+    /// The built rdkafka client config, `group.id` included.
+    pub client: ClientConfig,
+    pub topic: String,
+    /// The `B` cap: uncommitted events and bytes at which polling pauses.
+    pub budget: Charge,
+    /// The gate reopens at this fraction of the cap on both axes.
+    pub budget_low_ratio: f64,
+    /// A partition whose frontier does not move for this long while work is
+    /// pending fails the loop.
+    pub stall_timeout: Duration,
+    /// At most one batched commit issue per interval.
+    pub commit_interval: Duration,
+    /// The housekeeping tick: the commit clock and the stall checks.
+    pub tick_interval: Duration,
+    /// Messages per poll, at most.
+    pub poll_max_messages: usize,
+    /// Charge bytes per poll, at most; `0` turns the bound off.
+    pub poll_max_bytes: usize,
+    /// Completion channel depth; keep it at or above the transport's pool
+    /// size so completions never block a worker.
+    pub completion_capacity: usize,
+    /// Bound on the synchronous final commit at shutdown.
+    pub shutdown_commit_timeout: Duration,
+    /// How often the commit monitor fetches the broker's committed offsets.
+    pub commit_monitor_interval: Duration,
+}
+
+impl ConsumerLoopConfig {
+    pub fn new(client: ClientConfig, topic: impl Into<String>) -> ConsumerLoopConfig {
+        ConsumerLoopConfig {
+            client,
+            topic: topic.into(),
+            budget: Charge {
+                events: 200_000,
+                bytes: 512 << 20,
+            },
+            budget_low_ratio: Budget::DEFAULT_LOW_RATIO,
+            stall_timeout: Duration::from_secs(120),
+            commit_interval: Duration::from_secs(5),
+            tick_interval: Duration::from_secs(1),
+            poll_max_messages: 500,
+            poll_max_bytes: 0,
+            completion_capacity: 64,
+            shutdown_commit_timeout: Duration::from_secs(10),
+            commit_monitor_interval: Duration::from_secs(30),
+        }
+    }
+}
+
+/// What the loop sends down to the transport side.
+#[derive(Debug)]
+pub enum Feed {
+    /// One poll's demuxed groups.
+    Batch(Accumulator<RawMessage>),
+    /// A drain has begun: drop the partition's queued work, settle what is
+    /// in flight, then answer with `Completion::Drained` behind the last
+    /// completion. Groups for the partition that arrive after this marker
+    /// are never sent either.
+    Revoked {
+        partition: Partition,
+        epoch: AssignmentEpoch,
+    },
+}
+
+/// What the transport side sends back up.
+#[derive(Debug)]
+pub enum Completion {
+    /// One ACKed request's groups, slim. Failures never cross the seam.
+    Completed(Vec<GroupCompletion>),
+    /// The drain's end for the `Revoked` marker carrying this epoch.
+    Drained {
+        partition: Partition,
+        epoch: AssignmentEpoch,
+    },
+}
+
+/// The transport side's ends of the two channels.
+pub struct TransportHandle {
+    pub feed: mpsc::UnboundedReceiver<Feed>,
+    pub completions: mpsc::Sender<Completion>,
+}
+
+/// Why `run` returned. Every variant but `Stopped` means the process should
+/// exit and replay from the last commit.
+#[derive(Debug, thiserror::Error)]
+pub enum ConsumerLoopError {
+    #[error("kafka client error: {0}")]
+    Kafka(#[from] KafkaError),
+    #[error("fatal kafka client error ({code:?}): {reason}")]
+    Fatal {
+        code: RDKafkaErrorCode,
+        reason: String,
+    },
+    #[error("partitions stalled: {0:?}")]
+    Stalled(Vec<Partition>),
+    #[error("the transport side closed its end of the seam")]
+    TransportGone,
+    #[error("a poll delivered partition {0}, which is not assigned")]
+    UnassignedPartition(Partition),
+}
+
+/// A broker-driven revoke being drained: hand the whole set back once the
+/// last partition in it drains.
+struct HandBack {
+    all: Vec<Partition>,
+    remaining: HashSet<Partition>,
+    since: Instant,
+}
+
+struct Meters {
+    polls: Counter,
+    messages_polled: Counter,
+    bytes_polled: Counter,
+    budget_used_events: Gauge,
+    budget_used_bytes: Gauge,
+    gate_closed: Gauge,
+    gate_to_closed: Counter,
+    gate_to_open: Counter,
+    commits_issued: Counter,
+    assigned_partitions: Gauge,
+    rebalance_assign: Counter,
+    rebalance_revoke: Counter,
+    rebalance_lost: Counter,
+    rebalance_error: Counter,
+    drain_duration: Histogram,
+    stalls: Counter,
+    errors: Counter,
+}
+
+impl Meters {
+    fn new(group: &str) -> Meters {
+        let g = |name: &'static str| gauge!(name, names::GROUP_LABEL => group.to_string());
+        let c = |name: &'static str| counter!(name, names::GROUP_LABEL => group.to_string());
+        Meters {
+            polls: c(names::POLLS_TOTAL),
+            messages_polled: c(names::MESSAGES_POLLED_TOTAL),
+            bytes_polled: c(names::BYTES_POLLED_TOTAL),
+            budget_used_events: g(names::BUDGET_USED_EVENTS),
+            budget_used_bytes: g(names::BUDGET_USED_BYTES),
+            gate_closed: g(names::POLL_GATE_CLOSED),
+            gate_to_closed: counter!(names::POLL_GATE_TRANSITIONS_TOTAL, names::GROUP_LABEL => group.to_string(), "to" => "closed"),
+            gate_to_open: counter!(names::POLL_GATE_TRANSITIONS_TOTAL, names::GROUP_LABEL => group.to_string(), "to" => "open"),
+            commits_issued: c(names::COMMITS_ISSUED_TOTAL),
+            assigned_partitions: g(names::ASSIGNED_PARTITIONS),
+            rebalance_assign: counter!(names::REBALANCES_TOTAL, names::GROUP_LABEL => group.to_string(), "event" => "assign"),
+            rebalance_revoke: counter!(names::REBALANCES_TOTAL, names::GROUP_LABEL => group.to_string(), "event" => "revoke"),
+            rebalance_lost: counter!(names::REBALANCES_TOTAL, names::GROUP_LABEL => group.to_string(), "event" => "lost"),
+            rebalance_error: counter!(names::REBALANCES_TOTAL, names::GROUP_LABEL => group.to_string(), "event" => "error"),
+            drain_duration: histogram!(names::DRAIN_DURATION_SECONDS, names::GROUP_LABEL => group.to_string()),
+            stalls: c(names::STALLS_TOTAL),
+            errors: c(names::ERRORS_TOTAL),
+        }
+    }
+}
+
+/// The event pump. Owns the domain side and the seam's loop-side ends.
+pub struct ConsumerLoop<O: Observer> {
+    consumer: Arc<StreamConsumer<LoopContext>>,
+    topic: String,
+    group: String,
+    partitions: PartitionManager,
+    budget: Budget,
+    commits: CommitManager,
+    sentinel: Arc<CommitSentinel>,
+    rebalances: mpsc::UnboundedReceiver<RebalanceEvent>,
+    closing: Arc<AtomicBool>,
+    epoch: Arc<AtomicU64>,
+    feed: mpsc::UnboundedSender<Feed>,
+    completions: mpsc::Receiver<Completion>,
+    observer: O,
+    meters: Meters,
+    poll_max_messages: usize,
+    poll_max_bytes: usize,
+    tick_interval: Duration,
+    shutdown_commit_timeout: Duration,
+    commit_monitor_interval: Duration,
+    /// The assignment is paused (the gate is closed).
+    paused: bool,
+    shutting_down: bool,
+    hand_back: Option<HandBack>,
+}
+
+impl<O: Observer> ConsumerLoop<O> {
+    /// Create the rdkafka client and the seam's channels. Nothing is polled
+    /// or subscribed until `run`.
+    pub fn build(
+        config: ConsumerLoopConfig,
+        observer: O,
+    ) -> Result<(ConsumerLoop<O>, TransportHandle), ConsumerLoopError> {
+        let group = config
+            .client
+            .get("group.id")
+            .unwrap_or_default()
+            .to_string();
+        let (rebalance_tx, rebalance_rx) = mpsc::unbounded_channel();
+        let closing = Arc::new(AtomicBool::new(false));
+        let epoch = Arc::new(AtomicU64::new(0));
+        let context = LoopContext::new(rebalance_tx, Arc::clone(&closing), Arc::clone(&epoch));
+        let consumer: StreamConsumer<LoopContext> = config.client.create_with_context(context)?;
+        stats::export_limits(
+            &config.client,
+            config.poll_max_messages,
+            config.poll_max_bytes,
+        );
+
+        let (feed_tx, feed_rx) = mpsc::unbounded_channel();
+        let (completion_tx, completion_rx) = mpsc::channel(config.completion_capacity.max(1));
+
+        let consumer_loop = ConsumerLoop {
+            consumer: Arc::new(consumer),
+            topic: config.topic,
+            meters: Meters::new(&group),
+            sentinel: Arc::new(CommitSentinel::new(group.clone())),
+            group,
+            partitions: PartitionManager::new(config.stall_timeout),
+            budget: Budget::with_low_ratio(config.budget, config.budget_low_ratio),
+            commits: CommitManager::new(config.commit_interval),
+            rebalances: rebalance_rx,
+            closing,
+            epoch,
+            feed: feed_tx,
+            completions: completion_rx,
+            observer,
+            poll_max_messages: config.poll_max_messages.max(1),
+            poll_max_bytes: config.poll_max_bytes,
+            tick_interval: config.tick_interval,
+            shutdown_commit_timeout: config.shutdown_commit_timeout,
+            commit_monitor_interval: config.commit_monitor_interval,
+            paused: false,
+            shutting_down: false,
+            hand_back: None,
+        };
+        Ok((
+            consumer_loop,
+            TransportHandle {
+                feed: feed_rx,
+                completions: completion_tx,
+            },
+        ))
+    }
+
+    pub fn sentinel(&self) -> Arc<CommitSentinel> {
+        Arc::clone(&self.sentinel)
+    }
+
+    /// The assignment epoch counter, bumped on every assignment. Share it
+    /// with the transport side so requests carry the same epoch the groups
+    /// do; there must be one counter per process, not one per component.
+    pub fn epoch_counter(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.epoch)
+    }
+
+    /// Subscribe and pump until `shutdown` fires and the assignment has
+    /// drained, or until a fatal condition. Start this only once the
+    /// transport side can route: stall deadlines start at assignment.
+    pub async fn run(mut self, shutdown: CancellationToken) -> Result<(), ConsumerLoopError> {
+        self.consumer.subscribe(&[&self.topic])?;
+        self.observer.started(&self.group, &self.topic);
+        info!(group = %self.group, topic = %self.topic, "Consumer loop starting");
+
+        let monitor = AbortOnDrop(tokio::spawn(commit_monitor(
+            Arc::clone(&self.consumer),
+            Arc::clone(&self.sentinel),
+            self.topic.clone(),
+            self.group.clone(),
+            self.commit_monitor_interval,
+        )));
+
+        let mut tick = tokio::time::interval(self.tick_interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        let result = loop {
+            self.observer.alive();
+            if self.shutting_down && self.partitions.is_empty() {
+                break Ok(());
+            }
+            let step = tokio::select! {
+                biased;
+                _ = shutdown.cancelled(), if !self.shutting_down => {
+                    self.begin_shutdown();
+                    Ok(())
+                }
+                _ = tick.tick() => self.on_tick(),
+                event = self.rebalances.recv() => match event {
+                    Some(event) => self.on_rebalance(event),
+                    // The context holds the sender for as long as the
+                    // consumer lives, and the consumer lives in `self`.
+                    None => Ok(()),
+                },
+                completion = self.completions.recv() => match completion {
+                    Some(completion) => self.on_completion(completion),
+                    None => Err(ConsumerLoopError::TransportGone),
+                },
+                polled = recv_owned(&self.consumer, &self.topic) => self.on_polled(polled),
+            };
+            if let Err(err) = step {
+                break Err(err);
+            }
+        };
+
+        drop(monitor);
+        match result {
+            Ok(()) => {
+                info!(group = %self.group, "Consumer loop drained; committing and leaving");
+                self.close().await;
+                Ok(())
+            }
+            Err(err) => {
+                self.closing.store(true, Ordering::SeqCst);
+                let consumer = Arc::clone(&self.consumer);
+                drop(self);
+                drop(tokio::task::spawn_blocking(move || drop(consumer)).await);
+                Err(err)
+            }
+        }
+    }
+
+    // ---- arms ----
+
+    fn begin_shutdown(&mut self) {
+        self.shutting_down = true;
+        // From here every broker revoke is answered inline (see `context`).
+        self.closing.store(true, Ordering::SeqCst);
+        let assigned = self.partitions.assigned();
+        info!(
+            partitions = assigned.len(),
+            "Shutdown: draining the assignment"
+        );
+        self.pause_all();
+        for p in assigned {
+            if self.partitions.is_revoking(p) {
+                continue;
+            }
+            self.begin_drain(p);
+        }
+    }
+
+    fn on_tick(&mut self) -> Result<(), ConsumerLoopError> {
+        let now = Instant::now();
+        let refund = {
+            let mut issue = issuer(
+                &self.consumer,
+                &self.sentinel,
+                &self.topic,
+                &self.meters,
+                &self.observer,
+            );
+            self.commits.tick(now, &mut issue)
+        };
+        self.budget.refund(refund);
+        self.apply_gate();
+
+        // Keep librdkafka's `max.poll.interval.ms` clock moving while the
+        // assignment is paused and nothing wakes the poll arm.
+        if let Some(polled) = recv_owned(&self.consumer, &self.topic).now_or_never() {
+            self.on_polled(polled)?;
+        }
+
+        let stalled = self.partitions.stalled(now);
+        if !stalled.is_empty() {
+            self.meters.stalls.increment(1);
+            self.observer.stalled(&stalled);
+            return Err(ConsumerLoopError::Stalled(stalled));
+        }
+        Ok(())
+    }
+
+    fn on_rebalance(&mut self, event: RebalanceEvent) -> Result<(), ConsumerLoopError> {
+        match event {
+            RebalanceEvent::Assigned { partitions, epoch } => self.on_assigned(partitions, epoch),
+            RebalanceEvent::Revoked {
+                partitions,
+                lost,
+                handed_back,
+            } => self.on_revoked(partitions, lost, handed_back),
+            RebalanceEvent::Error(err) => {
+                warn!(error = %err, "Rebalance error; abandoning the assignment");
+                self.meters.rebalance_error.increment(1);
+                let all = self.partitions.assigned();
+                self.abandon(&all);
+                self.hand_back = None;
+            }
+        }
+        self.meters
+            .assigned_partitions
+            .set(self.partitions.len() as f64);
+        Ok(())
+    }
+
+    fn on_assigned(&mut self, partitions: Vec<Partition>, epoch: AssignmentEpoch) {
+        let now = Instant::now();
+        self.meters.rebalance_assign.increment(1);
+        let mut fresh = Vec::with_capacity(partitions.len());
+        for p in partitions {
+            if self.partitions.is_assigned(p) {
+                warn!(
+                    partition = p.0,
+                    "Assigned a partition already held; ignoring"
+                );
+                continue;
+            }
+            self.partitions.assign(p, epoch, now);
+            fresh.push(p);
+        }
+        info!(partitions = ?fresh, epoch = epoch.0, "Partitions assigned");
+        if self.paused || self.shutting_down {
+            // Assignment resets rdkafka's pause flags: keep the gate honest.
+            self.pause(&fresh);
+        }
+        if self.shutting_down {
+            for p in fresh.iter().copied() {
+                self.begin_drain(p);
+            }
+        }
+        self.observer.assigned(&fresh, epoch);
+    }
+
+    fn on_revoked(&mut self, partitions: Vec<Partition>, lost: bool, handed_back: bool) {
+        if lost {
+            self.meters.rebalance_lost.increment(1);
+        } else {
+            self.meters.rebalance_revoke.increment(1);
+        }
+        info!(partitions = ?partitions, lost, handed_back, "Partitions revoked");
+        self.sentinel.forget(partitions.iter().copied());
+        self.observer.revoked(&partitions, lost);
+
+        if handed_back {
+            // Already gone at the broker (lost) or answered inline (closing):
+            // no final commit is possible, so drop the drivers now.
+            self.abandon(&partitions);
+            if lost {
+                self.hand_back = None;
+            }
+            return;
+        }
+
+        let now = Instant::now();
+        let hand_back = self.hand_back.get_or_insert_with(|| HandBack {
+            all: Vec::new(),
+            remaining: HashSet::new(),
+            since: now,
+        });
+        for p in partitions.iter().copied() {
+            hand_back.all.push(p);
+            hand_back.remaining.insert(p);
+        }
+        for p in partitions {
+            if self.partitions.is_assigned(p) && !self.partitions.is_revoking(p) {
+                self.begin_drain(p);
+            } else if !self.partitions.is_assigned(p) {
+                // Nothing to drain: count it as already drained.
+                self.hand_back.as_mut().map(|h| h.remaining.remove(&p));
+            }
+        }
+        self.maybe_hand_back();
+    }
+
+    fn on_completion(&mut self, completion: Completion) -> Result<(), ConsumerLoopError> {
+        let now = Instant::now();
+        match completion {
+            Completion::Completed(groups) => {
+                let advances = self.partitions.complete(groups, now);
+                let refund = {
+                    let mut issue = issuer(
+                        &self.consumer,
+                        &self.sentinel,
+                        &self.topic,
+                        &self.meters,
+                        &self.observer,
+                    );
+                    self.commits.progress(advances, now, &mut issue)
+                };
+                self.budget.refund(refund);
+            }
+            Completion::Drained { partition, epoch } => {
+                if self.partitions.epoch(partition) != Some(epoch) {
+                    info!(
+                        partition = partition.0,
+                        epoch = epoch.0,
+                        "Drained marker for a partition no longer held at that epoch; ignoring"
+                    );
+                    return Ok(());
+                }
+                let harvest = self.partitions.drained(partition);
+                let refund = {
+                    let mut issue = issuer(
+                        &self.consumer,
+                        &self.sentinel,
+                        &self.topic,
+                        &self.meters,
+                        &self.observer,
+                    );
+                    self.commits.finish_revoke(harvest, now, &mut issue)
+                };
+                self.budget.refund(refund);
+                self.observer.drained(&harvest, true);
+                if let Some(hand_back) = &mut self.hand_back {
+                    hand_back.remaining.remove(&partition);
+                }
+                self.maybe_hand_back();
+                self.meters
+                    .assigned_partitions
+                    .set(self.partitions.len() as f64);
+            }
+        }
+        self.apply_gate();
+        Ok(())
+    }
+
+    fn on_polled(
+        &mut self,
+        first: Result<Option<Polled>, KafkaError>,
+    ) -> Result<(), ConsumerLoopError> {
+        let mut poll = PollBatch::default();
+        match first {
+            Ok(Some(polled)) => poll.push(polled),
+            Ok(None) => {}
+            Err(err) => return self.on_recv_error(err),
+        }
+        // Drain what is ready now, bounded; no linger, the transport paces.
+        while poll.count < self.poll_max_messages
+            && (self.poll_max_bytes == 0 || poll.bytes < self.poll_max_bytes)
+        {
+            match recv_owned(&self.consumer, &self.topic).now_or_never() {
+                Some(Ok(Some(polled))) => poll.push(polled),
+                Some(Ok(None)) => continue,
+                Some(Err(err)) => {
+                    self.on_recv_error(err)?;
+                    break;
+                }
+                None => break,
+            }
+        }
+        let count = poll.count;
+        let batch = poll.batch;
+
+        // The callback may have fired during collection. Assignments apply
+        // now (their messages may be in this poll); revokes apply after this
+        // batch is released, so the marker rides behind it.
+        let mut deferred = Vec::new();
+        while let Ok(event) = self.rebalances.try_recv() {
+            match event {
+                RebalanceEvent::Assigned { partitions, epoch } => {
+                    self.on_assigned(partitions, epoch)
+                }
+                other => deferred.push(other),
+            }
+        }
+
+        if count > 0 {
+            for (p, _) in &batch {
+                if !self.partitions.is_assigned(*p) {
+                    return Err(ConsumerLoopError::UnassignedPartition(*p));
+                }
+            }
+            let mut acc = Accumulator::default();
+            let charge = self.partitions.accept(batch, &mut acc);
+            self.budget.charge(charge);
+            self.meters.polls.increment(1);
+            self.meters.messages_polled.increment(charge.events);
+            self.meters.bytes_polled.increment(charge.bytes);
+            self.observer.poll_accepted(count, charge);
+            if self.feed.send(Feed::Batch(acc)).is_err() {
+                return Err(ConsumerLoopError::TransportGone);
+            }
+            self.apply_gate();
+        }
+
+        for event in deferred {
+            self.on_rebalance(event)?;
+        }
+        Ok(())
+    }
+
+    fn on_recv_error(&mut self, err: KafkaError) -> Result<(), ConsumerLoopError> {
+        if let KafkaError::PartitionEOF(_) = err {
+            return Ok(());
+        }
+        if let KafkaError::MessageConsumptionFatal(code) = err {
+            let reason = self
+                .consumer
+                .client()
+                .fatal_error()
+                .map(|(_, reason)| reason)
+                .unwrap_or_default();
+            return Err(ConsumerLoopError::Fatal { code, reason });
+        }
+        // A fatal client error (such as UnreleasedInstanceId from a
+        // static-membership collision) permanently disables the consumer;
+        // exit so the process restarts instead of re-polling a dead client.
+        if let Some((code, reason)) = self.consumer.client().fatal_error() {
+            return Err(ConsumerLoopError::Fatal { code, reason });
+        }
+        warn!(error = %err, "Kafka recv error");
+        self.meters.errors.increment(1);
+        Ok(())
+    }
+
+    // ---- helpers ----
+
+    /// Mark the partition revoking and send the in-band marker.
+    fn begin_drain(&mut self, p: Partition) {
+        let Some(epoch) = self.partitions.epoch(p) else {
+            return;
+        };
+        self.partitions.revoking(p);
+        drop(self.feed.send(Feed::Revoked {
+            partition: p,
+            epoch,
+        }));
+    }
+
+    /// Drop the drivers without a final commit and refund everything they
+    /// held. The marker still goes down so the transport clears its queues;
+    /// the `Drained` it answers with dies by epoch.
+    fn abandon(&mut self, partitions: &[Partition]) {
+        for p in partitions.iter().copied() {
+            if !self.partitions.is_assigned(p) {
+                continue;
+            }
+            if !self.partitions.is_revoking(p) {
+                self.begin_drain(p);
+            }
+            let harvest = self.partitions.drained(p);
+            let refund = self.commits.abandon(harvest);
+            self.budget.refund(refund);
+            self.observer.drained(&harvest, false);
+        }
+        self.apply_gate();
+    }
+
+    /// Hand the revoke set back once every partition in it has drained.
+    fn maybe_hand_back(&mut self) {
+        let Some(hand_back) = &self.hand_back else {
+            return;
+        };
+        if !hand_back.remaining.is_empty() {
+            return;
+        }
+        let hand_back = self.hand_back.take().expect("checked above");
+        let tpl = self.tpl(hand_back.all.iter().copied());
+        if let Err(err) = self.consumer.incremental_unassign(&tpl) {
+            warn!(error = %err, partitions = ?hand_back.all, "incremental_unassign failed");
+        }
+        let elapsed = hand_back.since.elapsed();
+        self.meters.drain_duration.record(elapsed.as_secs_f64());
+        info!(partitions = ?hand_back.all, elapsed = ?elapsed, "Partitions handed back");
+    }
+
+    fn apply_gate(&mut self) {
+        let used = self.budget.used();
+        self.meters.budget_used_events.set(used.events as f64);
+        self.meters.budget_used_bytes.set(used.bytes as f64);
+        if self.shutting_down {
+            return;
+        }
+        let open = self.budget.gate_open();
+        if open && self.paused {
+            self.resume_all();
+            self.meters.gate_to_open.increment(1);
+            self.observer.gate_closed(false, used);
+        } else if !open && !self.paused {
+            self.pause_all();
+            self.meters.gate_to_closed.increment(1);
+            self.observer.gate_closed(true, used);
+        }
+    }
+
+    fn pause_all(&mut self) {
+        let assigned = self.partitions.assigned();
+        self.pause(&assigned);
+        self.paused = true;
+        self.meters.gate_closed.set(1.0);
+    }
+
+    fn pause(&self, partitions: &[Partition]) {
+        if partitions.is_empty() {
+            return;
+        }
+        if let Err(err) = self.consumer.pause(&self.tpl(partitions.iter().copied())) {
+            warn!(error = %err, "pause failed");
+        }
+    }
+
+    fn resume_all(&mut self) {
+        let assigned = self.partitions.assigned();
+        if !assigned.is_empty() {
+            if let Err(err) = self.consumer.resume(&self.tpl(assigned.into_iter())) {
+                warn!(error = %err, "resume failed");
+            }
+        }
+        self.paused = false;
+        self.meters.gate_closed.set(0.0);
+    }
+
+    fn tpl(&self, partitions: impl Iterator<Item = Partition>) -> TopicPartitionList {
+        let mut tpl = TopicPartitionList::new();
+        for p in partitions {
+            tpl.add_partition(&self.topic, p.0);
+        }
+        tpl
+    }
+
+    /// The end of a clean shutdown: re-submit every attempted offset
+    /// synchronously so the commits are known to have landed, then close.
+    async fn close(self) {
+        let attempted = self.sentinel.attempted();
+        let consumer = Arc::clone(&self.consumer);
+        let topic = self.topic.clone();
+        let timeout = self.shutdown_commit_timeout;
+        if !attempted.is_empty() {
+            let final_commit = tokio::task::spawn_blocking(move || {
+                let mut tpl = TopicPartitionList::new();
+                for (p, o) in &attempted {
+                    drop(tpl.add_partition_offset(&topic, p.0, rdkafka::Offset::Offset(o.0)));
+                }
+                consumer.commit(&tpl, CommitMode::Sync)
+            });
+            match tokio::time::timeout(timeout, final_commit).await {
+                Ok(Ok(Ok(()))) => info!("Final commit landed"),
+                Ok(Ok(Err(err))) => warn!(error = %err, "Final commit failed"),
+                Ok(Err(err)) => warn!(error = %err, "Final commit task failed"),
+                Err(_) => warn!("Final commit timed out"),
+            }
+        }
+        let consumer = Arc::clone(&self.consumer);
+        drop(self);
+        // rdkafka's Drop runs consumer_close and polls until it completes.
+        drop(tokio::task::spawn_blocking(move || drop(consumer)).await);
+    }
+}
+
+impl<O: Observer> Drop for ConsumerLoop<O> {
+    /// A cancelled `run` drops the consumer without reaching `close`; the
+    /// close-time revoke must still be answered inline or the drop spins.
+    fn drop(&mut self) {
+        self.closing.store(true, Ordering::SeqCst);
+    }
+}
+
+/// One polled message in the loop's own terms.
+struct Polled {
+    partition: Partition,
+    message: PolledMessage<RawMessage>,
+}
+
+/// One poll under collection: messages grouped per partition in delivery
+/// order, as the manager's `accept` wants them.
+#[derive(Default)]
+struct PollBatch {
+    batch: Vec<(Partition, Vec<PolledMessage<RawMessage>>)>,
+    index: HashMap<Partition, usize>,
+    count: usize,
+    bytes: usize,
+}
+
+impl PollBatch {
+    fn push(&mut self, polled: Polled) {
+        self.count += 1;
+        self.bytes += polled.message.charge.bytes as usize;
+        let slot = *self.index.entry(polled.partition).or_insert_with(|| {
+            self.batch.push((polled.partition, Vec::new()));
+            self.batch.len() - 1
+        });
+        self.batch[slot].1.push(polled.message);
+    }
+}
+
+/// Await one message and hand it over owned, so the arm's output borrows
+/// nothing from the consumer. `Ok(None)` is a message on another topic.
+async fn recv_owned(
+    consumer: &StreamConsumer<LoopContext>,
+    topic: &str,
+) -> Result<Option<Polled>, KafkaError> {
+    let message = consumer.recv().await?;
+    Ok(owned(&message, topic))
+}
+
+fn owned(message: &BorrowedMessage<'_>, topic: &str) -> Option<Polled> {
+    if message.topic() != topic {
+        warn!(
+            topic = message.topic(),
+            "Message on an unsubscribed topic; ignoring"
+        );
+        return None;
+    }
+    let key = message.key().map(<[u8]>::to_vec);
+    let payload = message.payload().map(<[u8]>::to_vec).unwrap_or_default();
+    let mut headers = Vec::new();
+    let mut header_bytes = 0usize;
+    if let Some(borrowed) = message.headers() {
+        headers.reserve(borrowed.count());
+        for i in 0..borrowed.count() {
+            let header = borrowed.get(i);
+            let value = header.value.map(<[u8]>::to_vec).unwrap_or_default();
+            header_bytes += header.key.len() + value.len();
+            headers.push((header.key.to_string(), value));
+        }
+    }
+    let bytes = payload.len() + key.as_ref().map_or(0, Vec::len) + header_bytes;
+    let partition = Partition(message.partition());
+    let offset = Offset(message.offset());
+    Some(Polled {
+        partition,
+        message: PolledMessage {
+            offset,
+            key,
+            charge: Charge {
+                events: 1,
+                bytes: bytes as u64,
+            },
+            inner: RawMessage {
+                partition,
+                offset,
+                timestamp_ms: message.timestamp().to_millis(),
+                payload,
+                headers,
+            },
+        },
+    })
+}
+
+/// The injected commit issue: async, fire-and-forget, never blocks the loop.
+fn issuer<'a, O: Observer>(
+    consumer: &'a StreamConsumer<LoopContext>,
+    sentinel: &'a CommitSentinel,
+    topic: &'a str,
+    meters: &'a Meters,
+    observer: &'a O,
+) -> impl FnMut(&[(Partition, Offset)]) + 'a {
+    move |batch: &[(Partition, Offset)]| {
+        let mut tpl = TopicPartitionList::new();
+        for (p, o) in batch {
+            drop(tpl.add_partition_offset(topic, p.0, rdkafka::Offset::Offset(o.0)));
+        }
+        sentinel.check_issue(batch);
+        match consumer.commit(&tpl, CommitMode::Async) {
+            Ok(()) => meters.commits_issued.increment(1),
+            Err(err) => {
+                warn!(error = %err, "Commit issue failed");
+                meters.errors.increment(1);
+            }
+        }
+        observer.committed(batch);
+    }
+}
+
+/// Periodically fetch the broker's committed offsets for the current
+/// assignment (an OffsetFetch round trip) and feed them to the sentinel.
+async fn commit_monitor(
+    consumer: Arc<StreamConsumer<LoopContext>>,
+    sentinel: Arc<CommitSentinel>,
+    topic: String,
+    group: String,
+    interval: Duration,
+) {
+    loop {
+        tokio::time::sleep(interval).await;
+        let fetch_consumer = Arc::clone(&consumer);
+        // assignment() and committed_offsets() block on librdkafka.
+        let fetched = tokio::task::spawn_blocking(move || {
+            let assignment = fetch_consumer.assignment()?;
+            if assignment.count() == 0 {
+                return Ok(None);
+            }
+            fetch_consumer
+                .committed_offsets(assignment, Duration::from_secs(5))
+                .map(Some)
+        })
+        .await;
+        match fetched {
+            Ok(Ok(Some(committed))) => {
+                let observed: Vec<(Partition, Offset)> = committed
+                    .elements()
+                    .iter()
+                    .filter(|e| e.topic() == topic)
+                    .filter_map(|e| match e.offset() {
+                        rdkafka::Offset::Offset(offset) => {
+                            Some((Partition(e.partition()), Offset(offset)))
+                        }
+                        // Invalid = no offset stored for the partition yet.
+                        _ => None,
+                    })
+                    .collect();
+                sentinel.observe_broker_committed(observed);
+            }
+            Ok(Ok(None)) => {}
+            Ok(Err(err)) => {
+                counter!(names::COMMIT_MONITOR_ERRORS_TOTAL, names::GROUP_LABEL => group.clone())
+                    .increment(1);
+                warn!(error = %err, "Commit monitor failed to fetch committed offsets");
+            }
+            Err(err) => {
+                counter!(names::COMMIT_MONITOR_ERRORS_TOTAL, names::GROUP_LABEL => group.clone())
+                    .increment(1);
+                warn!(error = %err, "Commit monitor task join error");
+            }
+        }
+    }
+}
+
+/// Aborts the wrapped task when dropped.
+struct AbortOnDrop(JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}

--- a/rust/common/kafka-consumer/src/context.rs
+++ b/rust/common/kafka-consumer/src/context.rs
@@ -1,0 +1,134 @@
+//! The rdkafka consumer context: turns rebalance callbacks into events on the
+//! loop's channel, and exports librdkafka statistics.
+//!
+//! rdkafka runs the rebalance callback synchronously inside `poll`, on the
+//! task that awaits `recv()` — the consumer loop's own task. So the callback
+//! never waits: on assign it applies the assignment at once (there is nothing
+//! to wait for) and reports it; on revoke it only reports, and the loop hands
+//! the partitions back with `incremental_unassign` once their drain ends.
+//!
+//! One exception: while `closing` is set, a revoke is answered inline.
+//! Closing the consumer revokes the whole assignment through this same
+//! callback and rdkafka's `Drop` polls until the close completes, so a
+//! deferred answer there would spin forever.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
+use rdkafka::error::KafkaError;
+use rdkafka::types::RDKafkaRespErr;
+use rdkafka::{ClientContext, Statistics, TopicPartitionList};
+use tokio::sync::mpsc;
+use tracing::warn;
+
+use crate::stats;
+use crate::types::{AssignmentEpoch, Partition};
+
+/// What the callback tells the loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RebalanceEvent {
+    /// Partitions added to the assignment, already applied to rdkafka.
+    Assigned {
+        partitions: Vec<Partition>,
+        epoch: AssignmentEpoch,
+    },
+    /// Partitions leaving the assignment. `handed_back` is true when the
+    /// callback already called `incremental_unassign` (closing, or the
+    /// assignment was lost); otherwise the loop must, after the drain.
+    Revoked {
+        partitions: Vec<Partition>,
+        lost: bool,
+        handed_back: bool,
+    },
+    /// librdkafka reported a rebalance failure; the assignment was cleared.
+    Error(KafkaError),
+}
+
+pub struct LoopContext {
+    events: mpsc::UnboundedSender<RebalanceEvent>,
+    /// The process's one assignment epoch counter, shared with the transport
+    /// side through `ConsumerLoop::epoch_counter`.
+    epoch: Arc<AtomicU64>,
+    closing: Arc<AtomicBool>,
+}
+
+impl LoopContext {
+    pub fn new(
+        events: mpsc::UnboundedSender<RebalanceEvent>,
+        closing: Arc<AtomicBool>,
+        epoch: Arc<AtomicU64>,
+    ) -> LoopContext {
+        LoopContext {
+            events,
+            epoch,
+            closing,
+        }
+    }
+
+    fn send(&self, event: RebalanceEvent) {
+        // The receiver is the loop; if it is gone the process is exiting.
+        drop(self.events.send(event));
+    }
+}
+
+impl ClientContext for LoopContext {
+    /// Fired on a librdkafka thread every `statistics.interval.ms`; disabled
+    /// when that is 0.
+    fn stats(&self, statistics: Statistics) {
+        stats::export(&statistics);
+    }
+}
+
+impl ConsumerContext for LoopContext {
+    fn rebalance(
+        &self,
+        base: &BaseConsumer<Self>,
+        err: RDKafkaRespErr,
+        tpl: &mut TopicPartitionList,
+    ) {
+        let partitions: Vec<Partition> = tpl
+            .elements()
+            .iter()
+            .map(|e| Partition(e.partition()))
+            .collect();
+        match err {
+            RDKafkaRespErr::RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS => {
+                if let Err(err) = base.incremental_assign(tpl) {
+                    warn!(error = %err, "incremental_assign failed");
+                }
+                if partitions.is_empty() {
+                    return;
+                }
+                let epoch = AssignmentEpoch(self.epoch.fetch_add(1, Ordering::Relaxed) + 1);
+                self.send(RebalanceEvent::Assigned { partitions, epoch });
+            }
+            RDKafkaRespErr::RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS => {
+                let lost = base.assignment_lost();
+                let inline = lost || self.closing.load(Ordering::SeqCst);
+                if inline {
+                    if let Err(err) = base.incremental_unassign(tpl) {
+                        warn!(error = %err, "incremental_unassign failed");
+                    }
+                }
+                if partitions.is_empty() {
+                    return;
+                }
+                self.send(RebalanceEvent::Revoked {
+                    partitions,
+                    lost,
+                    handed_back: inline,
+                });
+            }
+            other => {
+                let code = other.into();
+                warn!(error = ?code, "rebalance error; clearing the assignment");
+                // librdkafka requires assign(NULL) here to synchronize state.
+                if let Err(err) = base.unassign() {
+                    warn!(error = %err, "unassign after rebalance error failed");
+                }
+                self.send(RebalanceEvent::Error(KafkaError::Rebalance(code)));
+            }
+        }
+    }
+}

--- a/rust/common/kafka-consumer/src/events.rs
+++ b/rust/common/kafka-consumer/src/events.rs
@@ -1,0 +1,46 @@
+//! The loop's observer: the event points an adopter can subscribe to (a debug
+//! recorder, a liveness heartbeat) without the crate depending on it.
+
+use crate::charge::Charge;
+use crate::types::{AssignmentEpoch, DrainHarvest, Offset, Partition};
+
+/// Loop-side event points. Every method has a no-op default; implement the
+/// ones you need. All are called from the consumer loop's task and must not
+/// block.
+#[allow(unused_variables)]
+pub trait Observer: Send + 'static {
+    /// Called once per loop iteration, whichever arm ran. Wire this to the
+    /// process's liveness heartbeat.
+    fn alive(&self) {}
+
+    /// The loop subscribed and is polling.
+    fn started(&self, group_id: &str, topic: &str) {}
+
+    /// One poll accepted: `messages` demuxed, `charge` debited from `B`.
+    fn poll_accepted(&self, messages: usize, charge: Charge) {}
+
+    fn assigned(&self, partitions: &[Partition], epoch: AssignmentEpoch) {}
+
+    /// A drain has begun for these partitions. `lost` means the broker
+    /// already fenced them: no final commit will be issued.
+    fn revoked(&self, partitions: &[Partition], lost: bool) {}
+
+    /// A partition's drain ended and its final commit issued (or was
+    /// abandoned, when `committed` is false).
+    fn drained(&self, harvest: &DrainHarvest, committed: bool) {}
+
+    /// A commit issued for these `(partition, next offset)` pairs.
+    fn committed(&self, offsets: &[(Partition, Offset)]) {}
+
+    /// The stall watchdog fired; the loop is about to exit.
+    fn stalled(&self, partitions: &[Partition]) {}
+
+    /// The poll gate closed (`true`) or reopened (`false`).
+    fn gate_closed(&self, closed: bool, used: Charge) {}
+}
+
+/// The observer that observes nothing.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopObserver;
+
+impl Observer for NoopObserver {}

--- a/rust/common/kafka-consumer/src/lib.rs
+++ b/rust/common/kafka-consumer/src/lib.rs
@@ -9,7 +9,21 @@ pub mod accumulator;
 pub mod charge;
 pub mod commit;
 pub mod config;
+pub mod consumer_loop;
+pub mod context;
+pub mod events;
 pub mod ledger;
 pub mod manager;
+pub mod metrics;
 pub mod partition;
+pub mod sentinel;
+pub mod stats;
 pub mod types;
+
+pub use accumulator::{Accumulator, Group, GroupCompletion};
+pub use charge::{Budget, Charge};
+pub use consumer_loop::{
+    Completion, ConsumerLoop, ConsumerLoopConfig, ConsumerLoopError, Feed, TransportHandle,
+};
+pub use events::{NoopObserver, Observer};
+pub use types::{AssignmentEpoch, Offset, Partition, RawMessage};

--- a/rust/common/kafka-consumer/src/manager.rs
+++ b/rust/common/kafka-consumer/src/manager.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use crate::accumulator::{Accumulator, Group, PolledMessage};
+use crate::accumulator::{Accumulator, GroupCompletion, PolledMessage};
 use crate::charge::Charge;
 use crate::partition::PartitionDriver;
 use crate::types::{Advance, AssignmentEpoch, DrainHarvest, Partition};
@@ -77,15 +77,15 @@ impl PartitionManager {
     /// One ACKed request's groups, distributed to their ledgers. Stragglers
     /// from before a reassignment die here by epoch; mid-drain completions
     /// land.
-    pub fn complete<M>(&mut self, completed: Vec<Group<M>>, now: Instant) -> Vec<Advance> {
+    pub fn complete(&mut self, completed: Vec<GroupCompletion>, now: Instant) -> Vec<Advance> {
         completed
             .into_iter()
-            .filter_map(|g| {
-                let driver = self.partitions.get_mut(&g.partition)?;
-                if g.epoch != driver.epoch() {
+            .filter_map(|c| {
+                let driver = self.partitions.get_mut(&c.partition)?;
+                if c.epoch != driver.epoch() {
                     return None;
                 }
-                driver.complete(&g.offsets, now)
+                driver.complete(&c.offsets, now)
             })
             .collect()
     }
@@ -102,11 +102,35 @@ impl PartitionManager {
     pub fn is_assigned(&self, p: Partition) -> bool {
         self.partitions.contains_key(&p)
     }
+
+    pub fn is_revoking(&self, p: Partition) -> bool {
+        self.partitions.get(&p).is_some_and(|d| d.revoking())
+    }
+
+    pub fn epoch(&self, p: Partition) -> Option<AssignmentEpoch> {
+        self.partitions.get(&p).map(|d| d.epoch())
+    }
+
+    /// Every assigned partition, drains included, in ascending order.
+    pub fn assigned(&self) -> Vec<Partition> {
+        let mut assigned: Vec<Partition> = self.partitions.keys().copied().collect();
+        assigned.sort();
+        assigned
+    }
+
+    pub fn len(&self) -> usize {
+        self.partitions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.partitions.is_empty()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::accumulator::Group;
     use crate::types::Offset;
 
     fn msg(offset: i64, key: &str) -> PolledMessage<()> {
@@ -119,6 +143,10 @@ mod tests {
             },
             inner: (),
         }
+    }
+
+    fn completions(groups: &[Group<()>]) -> Vec<GroupCompletion> {
+        groups.iter().map(Group::completion).collect()
     }
 
     fn poll(
@@ -145,7 +173,7 @@ mod tests {
         manager.assign(Partition(0), AssignmentEpoch(2), now);
 
         // The straggler dies by epoch: no advance, no ledger touch.
-        assert_eq!(manager.complete(groups, now), vec![]);
+        assert_eq!(manager.complete(completions(&groups), now), vec![]);
     }
 
     #[test]
@@ -161,7 +189,7 @@ mod tests {
 
         // Only "a" lands before the drain.
         let first = groups.remove(0);
-        let advances = manager.complete(vec![first], now);
+        let advances = manager.complete(vec![first.completion()], now);
         assert_eq!(advances.len(), 1);
         assert_eq!(advances[0].frontier, Offset(0));
 
@@ -196,7 +224,7 @@ mod tests {
         );
 
         // Progress on partition 0 resets its deadline; partition 1 stays stalled.
-        manager.complete(groups, later);
+        manager.complete(completions(&groups), later);
         assert_eq!(manager.stalled(later), vec![Partition(1)]);
 
         // A draining partition stands down.

--- a/rust/common/kafka-consumer/src/metrics.rs
+++ b/rust/common/kafka-consumer/src/metrics.rs
@@ -1,0 +1,136 @@
+//! Every metric name this crate emits, in one place, pinned by a fixture
+//! test so a new or renamed series is a reviewed diff. Every series carries
+//! the `group` label (the consumer group id) so adopters stay distinguishable
+//! on one dashboard; the librdkafka statistics series in `stats` are the
+//! exception and stay unlabeled, see that module's docs.
+
+/// Polls that accepted at least one message.
+pub const POLLS_TOTAL: &str = "kafka_consumer_polls_total";
+/// Messages accepted from polls.
+pub const MESSAGES_POLLED_TOTAL: &str = "kafka_consumer_messages_polled_total";
+/// Charge bytes accepted from polls (payload + key + headers).
+pub const BYTES_POLLED_TOTAL: &str = "kafka_consumer_bytes_polled_total";
+/// Uncommitted events currently charged against the budget.
+pub const BUDGET_USED_EVENTS: &str = "kafka_consumer_budget_used_events";
+/// Uncommitted bytes currently charged against the budget.
+pub const BUDGET_USED_BYTES: &str = "kafka_consumer_budget_used_bytes";
+/// 1 while the poll gate is closed (assignment paused), else 0.
+pub const POLL_GATE_CLOSED: &str = "kafka_consumer_poll_gate_closed";
+/// Gate transitions, labeled `to=closed|open`.
+pub const POLL_GATE_TRANSITIONS_TOTAL: &str = "kafka_consumer_poll_gate_transitions_total";
+/// Commit requests issued (one per batched issue, not per partition).
+pub const COMMITS_ISSUED_TOTAL: &str = "kafka_consumer_commits_issued_total";
+/// Partitions currently assigned, drains included.
+pub const ASSIGNED_PARTITIONS: &str = "kafka_consumer_assigned_partitions";
+/// Rebalance events, labeled `event=assign|revoke|lost|error`.
+pub const REBALANCES_TOTAL: &str = "kafka_consumer_rebalances_total";
+/// Seconds from a revoke to its hand-back; fetching is paused pod-wide for
+/// this long.
+pub const DRAIN_DURATION_SECONDS: &str = "kafka_consumer_drain_duration_seconds";
+/// Stall watchdog firings (the loop exits after one).
+pub const STALLS_TOTAL: &str = "kafka_consumer_stalls_total";
+/// Non-fatal errors from `recv`.
+pub const ERRORS_TOTAL: &str = "kafka_consumer_errors_total";
+/// Commits the sentinel checked.
+pub const COMMITS_CHECKED_TOTAL: &str = "kafka_consumer_commits_checked_total";
+/// Sentinel violations, labeled `kind=backwards|repeat`.
+pub const COMMIT_VIOLATIONS_TOTAL: &str = "kafka_consumer_commit_violations_total";
+/// The offset last submitted for commit, per partition.
+pub const COMMITTED_OFFSET: &str = "kafka_consumer_committed_offset";
+/// The group's committed offset as the broker reports it, per partition.
+pub const BROKER_COMMITTED_OFFSET: &str = "kafka_consumer_broker_committed_offset";
+/// Attempted minus broker-confirmed, per partition.
+pub const COMMIT_CONFIRMATION_LAG: &str = "kafka_consumer_commit_confirmation_lag";
+/// Unix time of the last verified commit progress.
+pub const LAST_SUCCESSFUL_COMMIT_TIMESTAMP_SECONDS: &str =
+    "kafka_consumer_last_successful_commit_timestamp_seconds";
+/// Commit monitor fetch failures.
+pub const COMMIT_MONITOR_ERRORS_TOTAL: &str = "kafka_consumer_commit_monitor_errors_total";
+
+/// The label every labeled series carries.
+pub const GROUP_LABEL: &str = "group";
+
+pub const ALL: &[&str] = &[
+    POLLS_TOTAL,
+    MESSAGES_POLLED_TOTAL,
+    BYTES_POLLED_TOTAL,
+    BUDGET_USED_EVENTS,
+    BUDGET_USED_BYTES,
+    POLL_GATE_CLOSED,
+    POLL_GATE_TRANSITIONS_TOTAL,
+    COMMITS_ISSUED_TOTAL,
+    ASSIGNED_PARTITIONS,
+    REBALANCES_TOTAL,
+    DRAIN_DURATION_SECONDS,
+    STALLS_TOTAL,
+    ERRORS_TOTAL,
+    COMMITS_CHECKED_TOTAL,
+    COMMIT_VIOLATIONS_TOTAL,
+    COMMITTED_OFFSET,
+    BROKER_COMMITTED_OFFSET,
+    COMMIT_CONFIRMATION_LAG,
+    LAST_SUCCESSFUL_COMMIT_TIMESTAMP_SECONDS,
+    COMMIT_MONITOR_ERRORS_TOTAL,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The fixture: change this list only with a dashboard change in hand.
+    const FIXTURE: &str = "\
+kafka_consumer_polls_total
+kafka_consumer_messages_polled_total
+kafka_consumer_bytes_polled_total
+kafka_consumer_budget_used_events
+kafka_consumer_budget_used_bytes
+kafka_consumer_poll_gate_closed
+kafka_consumer_poll_gate_transitions_total
+kafka_consumer_commits_issued_total
+kafka_consumer_assigned_partitions
+kafka_consumer_rebalances_total
+kafka_consumer_drain_duration_seconds
+kafka_consumer_stalls_total
+kafka_consumer_errors_total
+kafka_consumer_commits_checked_total
+kafka_consumer_commit_violations_total
+kafka_consumer_committed_offset
+kafka_consumer_broker_committed_offset
+kafka_consumer_commit_confirmation_lag
+kafka_consumer_last_successful_commit_timestamp_seconds
+kafka_consumer_commit_monitor_errors_total
+";
+
+    /// The unlabeled librdkafka statistics series, see `stats`.
+    const STATS_FIXTURE: &str = "\
+kafka_consumer_fetchq_messages
+kafka_consumer_fetchq_bytes
+kafka_consumer_replyq_ops
+kafka_consumer_broker_rtt_max_seconds
+kafka_consumer_broker_outbuf_requests
+kafka_consumer_broker_waitresp_requests
+kafka_consumer_rebalance_total
+kafka_consumer_fetchq_bytes_limit
+kafka_consumer_fetchq_messages_limit
+kafka_consumer_poll_messages_limit
+kafka_consumer_poll_bytes_limit
+";
+
+    #[test]
+    fn metric_names_match_the_fixture() {
+        let expected: Vec<&str> = FIXTURE.lines().collect();
+        assert_eq!(ALL, expected.as_slice());
+        let expected: Vec<&str> = STATS_FIXTURE.lines().collect();
+        assert_eq!(crate::stats::NAMES, expected.as_slice());
+    }
+
+    #[test]
+    fn every_name_carries_the_crate_prefix() {
+        for name in ALL.iter().chain(crate::stats::NAMES) {
+            assert!(
+                name.starts_with("kafka_consumer_"),
+                "{name} is outside the crate's prefix"
+            );
+        }
+    }
+}

--- a/rust/common/kafka-consumer/src/sentinel.rs
+++ b/rust/common/kafka-consumer/src/sentinel.rs
@@ -1,0 +1,304 @@
+//! The commit sentinel: a cheap assert that issued commits only ever move a
+//! partition forward, plus out-of-band verification that they land.
+//!
+//! Contiguity is constructed by the ledger, so the sentinel no longer has to
+//! detect gaps; it checks monotonicity per partition and compares what this
+//! process attempted with what the broker reports as the group's committed
+//! offset. The comparison is out of band because commits use
+//! `CommitMode::Async` and librdkafka silently drops the result of manual
+//! async commits (no conf-level `offset_commit_cb` is ever registered by
+//! rust-rdkafka, so `ConsumerContext::commit_callback` never fires for them).
+//! The loop's commit monitor task fetches the broker's committed offsets and
+//! feeds them to [`CommitSentinel::observe_broker_committed`].
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use metrics::{counter, gauge};
+use tracing::warn;
+
+use crate::metrics as names;
+use crate::types::{Offset, Partition};
+
+/// How an issue violated monotonicity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommitViolationKind {
+    /// The issued offset is below the previous issue: the commit moves the
+    /// partition backwards.
+    Backwards,
+    /// The issued offset equals the previous issue: the commit manager
+    /// issued without an advance.
+    Repeat,
+}
+
+impl CommitViolationKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            CommitViolationKind::Backwards => "backwards",
+            CommitViolationKind::Repeat => "repeat",
+        }
+    }
+}
+
+/// One detected violation, returned for tests and logged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CommitViolation {
+    pub kind: CommitViolationKind,
+    pub partition: Partition,
+    /// The offset previously issued for the partition.
+    pub previous: Offset,
+    pub issued: Offset,
+}
+
+/// Per-partition commit tracking: what this process asked Kafka to commit
+/// (attempted) and what the broker has confirmed as the group's committed
+/// offset (observed by the commit monitor via OffsetFetch).
+#[derive(Default, Clone, Copy)]
+struct PartitionCommits {
+    attempted: Option<Offset>,
+    confirmed: Option<Offset>,
+}
+
+pub struct CommitSentinel {
+    partitions: Mutex<HashMap<Partition, PartitionCommits>>,
+    /// Kill switch. When off, checks no-op and no state accumulates.
+    enabled: AtomicBool,
+    group: String,
+}
+
+impl CommitSentinel {
+    pub fn new(group: impl Into<String>) -> CommitSentinel {
+        CommitSentinel {
+            partitions: Mutex::new(HashMap::new()),
+            enabled: AtomicBool::new(true),
+            group: group.into(),
+        }
+    }
+
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Check one issued batch of `(partition, next offset)` pairs against the
+    /// previous issue per partition, then record it as attempted. The first
+    /// issue after a partition is (re)assigned baselines and is never a
+    /// violation.
+    pub fn check_issue(&self, batch: &[(Partition, Offset)]) -> Vec<CommitViolation> {
+        if !self.enabled.load(Ordering::Relaxed) {
+            return Vec::new();
+        }
+        let mut partitions = self.partitions.lock().unwrap();
+        let mut violations = Vec::new();
+
+        for (partition, issued) in batch {
+            counter!(names::COMMITS_CHECKED_TOTAL, names::GROUP_LABEL => self.group.clone())
+                .increment(1);
+            let state = partitions.entry(*partition).or_default();
+            if let Some(previous) = state.attempted {
+                let kind = if *issued < previous {
+                    Some(CommitViolationKind::Backwards)
+                } else if *issued == previous {
+                    Some(CommitViolationKind::Repeat)
+                } else {
+                    None
+                };
+                if let Some(kind) = kind {
+                    counter!(
+                        names::COMMIT_VIOLATIONS_TOTAL,
+                        names::GROUP_LABEL => self.group.clone(),
+                        "kind" => kind.as_str(),
+                    )
+                    .increment(1);
+                    warn!(
+                        kind = kind.as_str(),
+                        partition = partition.0,
+                        previous = previous.0,
+                        issued = issued.0,
+                        "Commit order violation"
+                    );
+                    violations.push(CommitViolation {
+                        kind,
+                        partition: *partition,
+                        previous,
+                        issued: *issued,
+                    });
+                }
+            }
+            state.attempted = Some(*issued);
+            gauge!(
+                names::COMMITTED_OFFSET,
+                names::GROUP_LABEL => self.group.clone(),
+                "partition" => partition.to_string(),
+            )
+            .set(issued.0 as f64);
+        }
+
+        violations
+    }
+
+    /// Feed broker-confirmed committed offsets (from an OffsetFetch of the
+    /// group's assigned partitions) and compare against what this process
+    /// attempted. Returns true when commits verifiably progressed since the
+    /// last observation — the broker offset advanced, or everything attempted
+    /// is confirmed — and stamps the last-successful-commit gauge.
+    pub fn observe_broker_committed(
+        &self,
+        observed: impl IntoIterator<Item = (Partition, Offset)>,
+    ) -> bool {
+        if !self.enabled.load(Ordering::Relaxed) {
+            return false;
+        }
+        let mut partitions = self.partitions.lock().unwrap();
+        let mut advanced = false;
+
+        for (partition, committed) in observed {
+            gauge!(
+                names::BROKER_COMMITTED_OFFSET,
+                names::GROUP_LABEL => self.group.clone(),
+                "partition" => partition.to_string(),
+            )
+            .set(committed.0 as f64);
+
+            let state = partitions.entry(partition).or_default();
+            if let Some(attempted) = state.attempted {
+                gauge!(
+                    names::COMMIT_CONFIRMATION_LAG,
+                    names::GROUP_LABEL => self.group.clone(),
+                    "partition" => partition.to_string(),
+                )
+                .set((attempted.0 - committed.0).max(0) as f64);
+            }
+            // Only an increase over a *previous* observation counts as
+            // progress — the first poll baselines (the broker may be reporting
+            // a prior incarnation's commits, which say nothing about ours).
+            if state.confirmed.is_some_and(|prev| committed > prev) {
+                advanced = true;
+            }
+            state.confirmed = Some(committed);
+        }
+
+        let all_confirmed = {
+            let attempted_any = partitions.values().any(|s| s.attempted.is_some());
+            attempted_any
+                && partitions.values().all(|s| match s.attempted {
+                    Some(attempted) => s.confirmed.is_some_and(|c| c >= attempted),
+                    None => true,
+                })
+        };
+
+        let progressed = advanced || all_confirmed;
+        if progressed {
+            gauge!(
+                names::LAST_SUCCESSFUL_COMMIT_TIMESTAMP_SECONDS,
+                names::GROUP_LABEL => self.group.clone(),
+            )
+            .set(
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs_f64(),
+            );
+        }
+        progressed
+    }
+
+    /// Drop the baselines for revoked partitions so the next issue after a
+    /// re-assignment baselines instead of reporting a false violation
+    /// (another group member may have committed in between).
+    pub fn forget(&self, revoked: impl IntoIterator<Item = Partition>) {
+        let mut partitions = self.partitions.lock().unwrap();
+        for partition in revoked {
+            partitions.remove(&partition);
+        }
+    }
+
+    /// Every partition's last attempted offset: what a final synchronous
+    /// commit at shutdown re-submits.
+    pub fn attempted(&self) -> Vec<(Partition, Offset)> {
+        let partitions = self.partitions.lock().unwrap();
+        let mut attempted: Vec<(Partition, Offset)> = partitions
+            .iter()
+            .filter_map(|(p, s)| s.attempted.map(|o| (*p, o)))
+            .collect();
+        attempted.sort();
+        attempted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn issue(p: i32, o: i64) -> (Partition, Offset) {
+        (Partition(p), Offset(o))
+    }
+
+    #[test]
+    fn monotone_issues_pass_and_the_first_issue_baselines() {
+        let sentinel = CommitSentinel::new("g");
+        assert!(sentinel.check_issue(&[issue(0, 100)]).is_empty());
+        assert!(sentinel
+            .check_issue(&[issue(0, 150), issue(1, 7)])
+            .is_empty());
+    }
+
+    #[test]
+    fn backwards_and_repeat_issues_are_violations() {
+        let sentinel = CommitSentinel::new("g");
+        sentinel.check_issue(&[issue(0, 100)]);
+        let violations = sentinel.check_issue(&[issue(0, 100)]);
+        assert_eq!(violations[0].kind, CommitViolationKind::Repeat);
+        let violations = sentinel.check_issue(&[issue(0, 90)]);
+        assert_eq!(
+            violations,
+            vec![CommitViolation {
+                kind: CommitViolationKind::Backwards,
+                partition: Partition(0),
+                previous: Offset(100),
+                issued: Offset(90),
+            }]
+        );
+    }
+
+    #[test]
+    fn forgetting_a_partition_rebaselines_it() {
+        let sentinel = CommitSentinel::new("g");
+        sentinel.check_issue(&[issue(0, 100)]);
+        sentinel.forget([Partition(0)]);
+        assert!(sentinel.check_issue(&[issue(0, 5)]).is_empty());
+    }
+
+    #[test]
+    fn broker_observation_reports_progress_only_after_a_baseline() {
+        let sentinel = CommitSentinel::new("g");
+        sentinel.check_issue(&[issue(0, 100)]);
+        assert!(
+            !sentinel.observe_broker_committed([issue(0, 50)]),
+            "first observation baselines"
+        );
+        assert!(sentinel.observe_broker_committed([issue(0, 80)]));
+        assert!(
+            sentinel.observe_broker_committed([issue(0, 100)]),
+            "everything attempted is confirmed"
+        );
+    }
+
+    #[test]
+    fn attempted_lists_every_partition_for_the_final_commit() {
+        let sentinel = CommitSentinel::new("g");
+        sentinel.check_issue(&[issue(3, 30), issue(1, 10)]);
+        sentinel.check_issue(&[issue(1, 12)]);
+        assert_eq!(sentinel.attempted(), vec![issue(1, 12), issue(3, 30)]);
+    }
+
+    #[test]
+    fn disabled_sentinel_checks_nothing() {
+        let sentinel = CommitSentinel::new("g");
+        sentinel.set_enabled(false);
+        sentinel.check_issue(&[issue(0, 100)]);
+        assert!(sentinel.check_issue(&[issue(0, 1)]).is_empty());
+        assert!(sentinel.attempted().is_empty());
+    }
+}

--- a/rust/common/kafka-consumer/src/stats.rs
+++ b/rust/common/kafka-consumer/src/stats.rs
@@ -1,0 +1,251 @@
+//! Export librdkafka's internal statistics as Prometheus gauges.
+//!
+//! librdkafka buffers fetched messages in its own queue ahead of the
+//! application, sized by `queued.max.messages.kbytes` / `queued.min.messages`.
+//! Under a backlog that queue fills to its cap and dominates the process's
+//! heap, but nothing in the loop's own metrics shows it — the poll and budget
+//! metrics only describe messages the loop has already taken delivery of.
+//! These gauges make that queue, and the broker connections feeding it, visible.
+//!
+//! [`export`] is called from the consumer context's `stats` callback, which
+//! librdkafka fires on its own thread every `statistics.interval.ms`. It walks
+//! the assigned partitions and connected brokers once and emits gauges — no
+//! allocation, and nothing on the per-message path.
+//!
+//! # Every series here is unlabeled, and every one is written every tick
+//!
+//! The `metrics` facade cannot unregister a series, so a gauge labeled by
+//! partition or broker keeps reporting its last value forever once that
+//! partition moves to another pod or that broker leaves the cluster.
+//! Dashboards and alerts then describe an assignment that no longer exists.
+//! Aggregating to one pod-level scalar per statistic removes the failure mode
+//! by construction rather than relying on eviction: there is no key that can go
+//! away, and a value that stops being true is overwritten on the next tick.
+//!
+//! This is also why nothing here is skipped conditionally. A gauge that is only
+//! written when a value is available is a stale gauge the moment it stops being
+//! available, so each one below is written on every invocation, including when
+//! the underlying value is absent.
+//!
+//! # Per-partition queue depths are not additive
+//!
+//! librdkafka's queue accessors follow queue forwarding, and the high-level
+//! consumer forwards every partition queue into one shared queue. A statistic
+//! that looks per-partition can therefore be the same shared total repeated
+//! once per assigned partition. Aggregate those with a maximum, not a sum — see
+//! [`fetch_queue`].
+
+use metrics::gauge;
+use rdkafka::{ClientConfig, Statistics};
+
+/// Messages sitting in librdkafka's shared fetch queue. See [`fetch_queue`] for
+/// why this is a max across partitions rather than a sum.
+const FETCHQ_MESSAGES: &str = "kafka_consumer_fetchq_messages";
+
+/// Bytes sitting in librdkafka's shared fetch queue — the memory the client
+/// holds on the consumer's behalf, bounded by `queued.max.messages.kbytes`.
+/// Same max-not-sum rule as [`FETCHQ_MESSAGES`].
+const FETCHQ_BYTES: &str = "kafka_consumer_fetchq_bytes";
+
+/// Operations waiting for the application to poll.
+///
+/// Read from the client's main reply queue, which the high-level consumer
+/// forwards into the same shared queue the partition fetch queues feed, so this
+/// tracks [`FETCHQ_MESSAGES`] rather than counting a separate backlog.
+const REPLYQ_OPS: &str = "kafka_consumer_replyq_ops";
+
+/// Slowest average request round-trip time across the connected brokers, over
+/// the last statistics interval. `0` means no broker reported any request in
+/// the interval, not a zero-latency cluster.
+const BROKER_RTT_MAX_SECONDS: &str = "kafka_consumer_broker_rtt_max_seconds";
+
+/// Requests awaiting transmission, summed over all brokers.
+const BROKER_OUTBUF_REQUESTS: &str = "kafka_consumer_broker_outbuf_requests";
+
+/// Requests sent and awaiting a response, summed over all brokers.
+const BROKER_WAITRESP_REQUESTS: &str = "kafka_consumer_broker_waitresp_requests";
+
+/// Rebalances this client has taken part in since it started. A gauge holding a
+/// monotonic total: librdkafka reports the running count, not a delta, so read
+/// it with `changes()` or `delta()` rather than `rate()`. Reads `0` until the
+/// client joins its consumer group.
+const REBALANCE_TOTAL: &str = "kafka_consumer_rebalance_total";
+
+/// Cap on [`FETCHQ_BYTES`], from the resolved `queued.max.messages.kbytes`.
+/// A config mirror, set once at startup.
+const FETCHQ_BYTES_LIMIT: &str = "kafka_consumer_fetchq_bytes_limit";
+
+/// Cap on [`FETCHQ_MESSAGES`], from the resolved `queued.min.messages`.
+/// A config mirror, set once at startup.
+const FETCHQ_MESSAGES_LIMIT: &str = "kafka_consumer_fetchq_messages_limit";
+
+/// Cap on messages per poll. A config mirror, set once at startup.
+const POLL_MESSAGES_LIMIT: &str = "kafka_consumer_poll_messages_limit";
+
+/// Cap on charge bytes per poll. A config mirror, set once at startup. `0`
+/// means the byte bound is off, so a dashboard can tell "unset" from a cap.
+const POLL_BYTES_LIMIT: &str = "kafka_consumer_poll_bytes_limit";
+
+/// The unlabeled series this module writes; pinned with the crate's other
+/// names by the fixture test in `metrics`.
+pub const NAMES: &[&str] = &[
+    FETCHQ_MESSAGES,
+    FETCHQ_BYTES,
+    REPLYQ_OPS,
+    BROKER_RTT_MAX_SECONDS,
+    BROKER_OUTBUF_REQUESTS,
+    BROKER_WAITRESP_REQUESTS,
+    REBALANCE_TOTAL,
+    FETCHQ_BYTES_LIMIT,
+    FETCHQ_MESSAGES_LIMIT,
+    POLL_MESSAGES_LIMIT,
+    POLL_BYTES_LIMIT,
+];
+
+/// librdkafka's own default for `queued.max.messages.kbytes`.
+const DEFAULT_QUEUED_MAX_MESSAGES_KBYTES: f64 = 102_400.0;
+
+/// librdkafka's own default for `queued.min.messages`.
+const DEFAULT_QUEUED_MIN_MESSAGES: f64 = 100_000.0;
+
+/// Export the gauges described in the module docs from one statistics snapshot.
+pub fn export(stats: &Statistics) {
+    gauge!(REPLYQ_OPS).set(stats.replyq as f64);
+
+    let fetchq = fetch_queue(stats);
+    gauge!(FETCHQ_MESSAGES).set(fetchq.messages as f64);
+    gauge!(FETCHQ_BYTES).set(fetchq.bytes as f64);
+
+    let mut outbuf_requests: i64 = 0;
+    let mut waitresp_requests: i64 = 0;
+    let mut rtt_max_micros: i64 = 0;
+    for broker in stats.brokers.values() {
+        outbuf_requests += broker.outbuf_cnt;
+        waitresp_requests += broker.waitresp_cnt;
+        // A broker with no request in the interval has no window at all, so it
+        // contributes nothing to the max rather than a misleading zero.
+        if let Some(rtt) = &broker.rtt {
+            rtt_max_micros = rtt_max_micros.max(rtt.avg);
+        }
+    }
+    gauge!(BROKER_OUTBUF_REQUESTS).set(outbuf_requests as f64);
+    gauge!(BROKER_WAITRESP_REQUESTS).set(waitresp_requests as f64);
+    gauge!(BROKER_RTT_MAX_SECONDS).set(rtt_max_micros as f64 / 1_000_000.0);
+
+    // Written even before the group is joined, so the series never goes stale.
+    let rebalance_count = stats.cgrp.as_ref().map_or(0, |cgrp| cgrp.rebalance_cnt);
+    gauge!(REBALANCE_TOTAL).set(rebalance_count as f64);
+}
+
+/// Depth of the one queue librdkafka holds fetched messages in.
+struct FetchQueue {
+    messages: i64,
+    bytes: u64,
+}
+
+/// Read the shared fetch queue's depth from a statistics snapshot.
+///
+/// Takes the maximum across partitions, never the sum. librdkafka fills each
+/// partition's `fetchq_cnt` and `fetchq_size` from that partition's queue
+/// handle, and those accessors follow queue forwarding. The high-level consumer
+/// forwards every partition queue into a single shared queue, so each assigned
+/// partition reports the whole shared queue rather than a disjoint slice of it.
+/// Summing therefore multiplies the real depth by the assigned partition count,
+/// and can report more memory than the process has. A partition that is not
+/// forwarding yet reports its own empty queue, which the maximum ignores.
+fn fetch_queue(stats: &Statistics) -> FetchQueue {
+    let mut messages = 0i64;
+    let mut bytes = 0u64;
+    for topic in stats.topics.values() {
+        for partition in topic.partitions.values() {
+            messages = messages.max(partition.fetchq_cnt);
+            bytes = bytes.max(partition.fetchq_size);
+        }
+    }
+    FetchQueue { messages, bytes }
+}
+
+/// Publish the configured caps that bound the live gauges above.
+///
+/// Config mirrors, set once at startup because none of them change while the
+/// process runs. They exist so a dashboard can compute utilization against the
+/// cap per deployment, rather than hardcoding limits that differ per lane.
+///
+/// The librdkafka caps come from the built [`ClientConfig`], not from the typed
+/// settings that seeded it. A generic passthrough can override any property, so
+/// only the built config states what the client actually runs with.
+pub fn export_limits(
+    client_config: &ClientConfig,
+    poll_max_messages: usize,
+    poll_max_bytes: usize,
+) {
+    let queued_max_kbytes = property(
+        client_config,
+        "queued.max.messages.kbytes",
+        DEFAULT_QUEUED_MAX_MESSAGES_KBYTES,
+    );
+    gauge!(FETCHQ_BYTES_LIMIT).set(queued_max_kbytes * 1024.0);
+    gauge!(FETCHQ_MESSAGES_LIMIT).set(property(
+        client_config,
+        "queued.min.messages",
+        DEFAULT_QUEUED_MIN_MESSAGES,
+    ));
+    gauge!(POLL_MESSAGES_LIMIT).set(poll_max_messages as f64);
+    gauge!(POLL_BYTES_LIMIT).set(poll_max_bytes as f64);
+}
+
+/// Read a numeric librdkafka property from the built config, falling back to
+/// librdkafka's own default when the key is unset. A value librdkafka would
+/// reject also falls back here, and fails the client creation that follows.
+fn property(client_config: &ClientConfig, key: &str, default: f64) -> f64 {
+    client_config
+        .get(key)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rdkafka::statistics::{Partition, Topic};
+
+    use super::*;
+
+    fn partition(id: i32, fetchq_cnt: i64, fetchq_size: u64) -> Partition {
+        Partition {
+            partition: id,
+            fetchq_cnt,
+            fetchq_size,
+            ..Default::default()
+        }
+    }
+
+    fn statistics(partitions: Vec<Partition>) -> Statistics {
+        let partitions = partitions.into_iter().map(|p| (p.partition, p)).collect();
+        Statistics {
+            topics: HashMap::from([(
+                "t".to_string(),
+                Topic {
+                    partitions,
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        }
+    }
+
+    /// Every forwarding partition reports the whole shared queue, so the depth
+    /// is one partition's figure — not the total across them.
+    #[test]
+    fn fetch_queue_does_not_multiply_shared_queue_by_partition_count() {
+        let mut partitions: Vec<Partition> = (0..6).map(|id| partition(id, 100, 1_000)).collect();
+        // Assigned but not fetching yet: reports its own still-empty queue.
+        partitions.push(partition(6, 0, 0));
+
+        let fetchq = fetch_queue(&statistics(partitions));
+
+        assert_eq!(fetchq.messages, 100);
+        assert_eq!(fetchq.bytes, 1_000);
+    }
+}

--- a/rust/common/kafka-consumer/src/types.rs
+++ b/rust/common/kafka-consumer/src/types.rs
@@ -53,3 +53,18 @@ pub struct DrainHarvest {
     pub frontier: Option<Offset>,
     pub dropped: Charge,
 }
+
+/// One polled message as it crosses the seam: Kafka metadata plus the raw
+/// payload. The loop never decodes it; a non-UTF-8 payload travels as is.
+/// The routing key lives on the group, not repeated here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawMessage {
+    pub partition: Partition,
+    pub offset: Offset,
+    /// Kafka message timestamp in milliseconds, when the broker set one.
+    pub timestamp_ms: Option<i64>,
+    pub payload: Vec<u8>,
+    /// Header keys and values in wire order; a header with no value is
+    /// carried as an empty value.
+    pub headers: Vec<(String, Vec<u8>)>,
+}

--- a/rust/common/kafka-consumer/tests/exactness.rs
+++ b/rust/common/kafka-consumer/tests/exactness.rs
@@ -91,7 +91,7 @@ proptest! {
                         continue;
                     }
                     let group = outstanding.remove(index as usize % outstanding.len());
-                    let advances = manager.complete(vec![group], now);
+                    let advances = manager.complete(vec![group.completion()], now);
                     budget.refund(commits.progress(advances, now, &mut issue));
                 }
                 Op::Tick => {
@@ -113,7 +113,7 @@ proptest! {
 
         // Straggler completions from before any reassignment die by epoch.
         for group in outstanding.drain(..) {
-            let advances = manager.complete(vec![group], now);
+            let advances = manager.complete(vec![group.completion()], now);
             budget.refund(commits.progress(advances, now, &mut issue));
         }
         // Drain everything: whatever the frontiers never walked over comes

--- a/rust/common/kafka-consumer/tests/mock_cluster.rs
+++ b/rust/common/kafka-consumer/tests/mock_cluster.rs
@@ -1,0 +1,640 @@
+//! End-to-end against rdkafka's `MockCluster`. The test plays the transport
+//! side: it reads the feed and sends completions, so every seam rule is
+//! exercised from outside the crate.
+//!
+//! The mock coordinator delays the first join by 3 s and every later round by
+//! `session.timeout.ms` minus one second; a session timeout below that first
+//! delay expires while the member waits for its JoinGroup response, so the
+//! consumers here use 4 s: the floor, and 3 s rounds.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use common_kafka_consumer::config::ConsumerConfigBuilder;
+use common_kafka_consumer::consumer_loop::{
+    Completion, ConsumerLoop, ConsumerLoopConfig, ConsumerLoopError, Feed, TransportHandle,
+};
+use common_kafka_consumer::events::Observer;
+use common_kafka_consumer::types::{AssignmentEpoch, DrainHarvest, Offset, Partition, RawMessage};
+use common_kafka_consumer::{Charge, Group, GroupCompletion};
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use rdkafka::mocking::MockCluster;
+use rdkafka::producer::{DefaultProducerContext, FutureProducer, FutureRecord};
+use rdkafka::{ClientConfig, TopicPartitionList};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+const TOPIC: &str = "t";
+const GROUP: &str = "loop-tests";
+const WAIT: Duration = Duration::from_secs(15);
+
+type Cluster = MockCluster<'static, DefaultProducerContext>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Ev {
+    Assigned(Vec<Partition>),
+    Revoked(Vec<Partition>, bool),
+    Drained(Partition, bool),
+    Committed(Vec<(Partition, Offset)>),
+    Gate(bool),
+    Stalled(Vec<Partition>),
+}
+
+#[derive(Clone, Default)]
+struct Recorder(Arc<Mutex<Vec<Ev>>>);
+
+impl Recorder {
+    fn events(&self) -> Vec<Ev> {
+        self.0.lock().unwrap().clone()
+    }
+
+    async fn wait_for(&self, what: &str, pred: impl Fn(&Ev) -> bool) -> Ev {
+        let deadline = Instant::now() + WAIT;
+        loop {
+            if let Some(ev) = self.events().into_iter().find(|e| pred(e)) {
+                return ev;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {what}; events: {:?}",
+                self.events()
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
+    fn committed(&self, p: Partition) -> Option<Offset> {
+        self.events().iter().rev().find_map(|e| match e {
+            Ev::Committed(batch) => batch.iter().find(|(q, _)| *q == p).map(|(_, o)| *o),
+            _ => None,
+        })
+    }
+}
+
+impl Observer for Recorder {
+    fn assigned(&self, partitions: &[Partition], _epoch: AssignmentEpoch) {
+        self.0
+            .lock()
+            .unwrap()
+            .push(Ev::Assigned(partitions.to_vec()));
+    }
+    fn revoked(&self, partitions: &[Partition], lost: bool) {
+        self.0
+            .lock()
+            .unwrap()
+            .push(Ev::Revoked(partitions.to_vec(), lost));
+    }
+    fn drained(&self, harvest: &DrainHarvest, committed: bool) {
+        self.0
+            .lock()
+            .unwrap()
+            .push(Ev::Drained(harvest.partition, committed));
+    }
+    fn committed(&self, offsets: &[(Partition, Offset)]) {
+        self.0.lock().unwrap().push(Ev::Committed(offsets.to_vec()));
+    }
+    fn gate_closed(&self, closed: bool, _used: Charge) {
+        self.0.lock().unwrap().push(Ev::Gate(closed));
+    }
+    fn stalled(&self, partitions: &[Partition]) {
+        self.0
+            .lock()
+            .unwrap()
+            .push(Ev::Stalled(partitions.to_vec()));
+    }
+}
+
+/// Leaked on purpose: the loop tasks close their consumers during the test
+/// runtime's teardown, after the test body's locals are gone, and a close
+/// against a dropped cluster never completes.
+fn cluster(partitions: i32) -> &'static Cluster {
+    let cluster = MockCluster::new(1).expect("mock cluster");
+    cluster
+        .create_topic(TOPIC, partitions, 1)
+        .expect("create topic");
+    Box::leak(Box::new(cluster))
+}
+
+fn client_config(cluster: &Cluster, client_id: &str) -> ClientConfig {
+    let mut config = ConsumerConfigBuilder::for_batch_consumer(&cluster.bootstrap_servers(), GROUP)
+        .with_sticky_partition_assignment(Some(client_id), false)
+        .with_session_timeout_ms(4000)
+        .with_heartbeat_interval_ms(1000)
+        .with_fetch_wait_max_ms(50)
+        .build();
+    config.set("auto.offset.reset", "earliest");
+    config
+}
+
+fn loop_config(cluster: &Cluster, client_id: &str) -> ConsumerLoopConfig {
+    let mut config = ConsumerLoopConfig::new(client_config(cluster, client_id), TOPIC);
+    config.tick_interval = Duration::from_millis(50);
+    config.commit_interval = Duration::from_millis(100);
+    config.commit_monitor_interval = Duration::from_millis(200);
+    config.stall_timeout = Duration::from_secs(60);
+    config
+}
+
+struct Running {
+    handle: TransportHandle,
+    recorder: Recorder,
+    shutdown: CancellationToken,
+    task: JoinHandle<Result<(), ConsumerLoopError>>,
+}
+
+fn start(config: ConsumerLoopConfig) -> Running {
+    drop(
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_test_writer()
+            .try_init(),
+    );
+    let recorder = Recorder::default();
+    let (consumer_loop, handle) = ConsumerLoop::build(config, recorder.clone()).expect("build");
+    let shutdown = CancellationToken::new();
+    let task = tokio::spawn(consumer_loop.run(shutdown.clone()));
+    Running {
+        handle,
+        recorder,
+        shutdown,
+        task,
+    }
+}
+
+fn producer(cluster: &Cluster) -> FutureProducer {
+    ClientConfig::new()
+        .set("bootstrap.servers", cluster.bootstrap_servers())
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("producer")
+}
+
+async fn produce(producer: &FutureProducer, partition: i32, key: &str, payload: &str) {
+    producer
+        .send(
+            FutureRecord::to(TOPIC)
+                .partition(partition)
+                .key(key)
+                .payload(payload),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("produce");
+}
+
+/// Whole-group completions for the transport side to send back.
+fn completions(groups: &[Group<RawMessage>]) -> Vec<GroupCompletion> {
+    groups.iter().map(Group::completion).collect()
+}
+
+/// The next feed item, or a timeout failure.
+async fn next(feed: &mut mpsc::UnboundedReceiver<Feed>, what: &str) -> Feed {
+    tokio::time::timeout(WAIT, feed.recv())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+        .expect("feed closed")
+}
+
+/// Read batches until `n` messages have arrived; returns their groups.
+async fn groups_until(
+    feed: &mut mpsc::UnboundedReceiver<Feed>,
+    n: usize,
+) -> Vec<Group<RawMessage>> {
+    let mut groups = Vec::new();
+    let mut seen = 0;
+    while seen < n {
+        match next(feed, &format!("{n} messages ({seen} so far)")).await {
+            Feed::Batch(acc) => {
+                for g in acc.into_groups() {
+                    seen += g.messages.len();
+                    groups.push(g);
+                }
+            }
+            Feed::Revoked { .. } => panic!("unexpected revoke while collecting"),
+        }
+    }
+    groups
+}
+
+/// What the broker holds as the group's committed offset.
+fn broker_committed(cluster: &Cluster, partition: i32) -> Option<i64> {
+    let consumer: BaseConsumer = ClientConfig::new()
+        .set("bootstrap.servers", cluster.bootstrap_servers())
+        .set("group.id", GROUP)
+        .create()
+        .expect("probe consumer");
+    let mut tpl = TopicPartitionList::new();
+    tpl.add_partition(TOPIC, partition);
+    let committed = consumer
+        .committed_offsets(tpl, Duration::from_secs(5))
+        .expect("committed_offsets");
+    match committed.elements()[0].offset() {
+        rdkafka::Offset::Offset(o) => Some(o),
+        _ => None,
+    }
+}
+
+async fn wait_for_broker_committed(cluster: &Cluster, partition: i32, expected: i64) {
+    let deadline = Instant::now() + WAIT;
+    loop {
+        let committed = broker_committed(cluster, partition);
+        if committed == Some(expected) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "broker committed offset for p{partition} is {committed:?}, expected {expected}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn p(i: i32) -> Partition {
+    Partition(i)
+}
+
+// ---- tests ----
+
+#[tokio::test]
+async fn commits_land_at_the_frontier_only() {
+    let cluster = cluster(1);
+    let producer = producer(cluster);
+    for i in 0..6 {
+        produce(&producer, 0, &format!("k{}", i / 2), &format!("m{i}")).await;
+    }
+    let mut running = start(loop_config(cluster, "a"));
+    let groups = groups_until(&mut running.handle.feed, 6).await;
+
+    // Complete the last key first: nothing may commit past the gap.
+    let (last, rest): (Vec<Group<RawMessage>>, Vec<Group<RawMessage>>) = groups
+        .into_iter()
+        .partition(|g| g.offsets.contains(&Offset(5)));
+    running
+        .handle
+        .completions
+        .send(Completion::Completed(completions(&last)))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        running.recorder.committed(p(0)),
+        None,
+        "committed past a gap"
+    );
+
+    running
+        .handle
+        .completions
+        .send(Completion::Completed(completions(&rest)))
+        .await
+        .unwrap();
+    running
+        .recorder
+        .wait_for(
+            "commit at 6",
+            |e| matches!(e, Ev::Committed(b) if b.contains(&(p(0), Offset(6)))),
+        )
+        .await;
+    wait_for_broker_committed(cluster, 0, 6).await;
+
+    running.shutdown.cancel();
+    answer_shutdown(&mut running).await;
+    running.task.await.unwrap().expect("clean stop");
+}
+
+#[tokio::test]
+async fn revoke_drains_commits_then_hands_back_and_the_new_owner_resumes_after_the_commit() {
+    let cluster = cluster(2);
+    let producer = producer(cluster);
+    for i in 0..4 {
+        produce(&producer, 0, "k", &format!("p0-{i}")).await;
+        produce(&producer, 1, "k", &format!("p1-{i}")).await;
+    }
+    let mut a = start(loop_config(cluster, "a"));
+    a.recorder
+        .wait_for(
+            "A owns both",
+            |e| matches!(e, Ev::Assigned(ps) if ps.len() == 2),
+        )
+        .await;
+    let held = groups_until(&mut a.handle.feed, 8).await;
+
+    let mut b = start(loop_config(cluster, "b"));
+    let revoked = a
+        .recorder
+        .wait_for(
+            "A revoked one",
+            |e| matches!(e, Ev::Revoked(ps, false) if ps.len() == 1),
+        )
+        .await;
+    let Ev::Revoked(moved, _) = revoked else {
+        unreachable!()
+    };
+    let moved = moved[0];
+    match next(&mut a.handle.feed, "revoke marker").await {
+        Feed::Revoked { partition, epoch } => {
+            assert_eq!(partition, moved);
+            // B must not own the partition while A still holds it.
+            assert!(!b
+                .recorder
+                .events()
+                .iter()
+                .any(|e| matches!(e, Ev::Assigned(_))));
+            // Settle the in-flight work, then answer the marker.
+            let (for_moved, others): (Vec<_>, Vec<_>) =
+                held.into_iter().partition(|g| g.partition == moved);
+            a.handle
+                .completions
+                .send(Completion::Completed(completions(&for_moved)))
+                .await
+                .unwrap();
+            a.handle
+                .completions
+                .send(Completion::Drained { partition, epoch })
+                .await
+                .unwrap();
+            drop(others);
+        }
+        Feed::Batch(_) => panic!("expected the revoke marker"),
+    }
+    a.recorder
+        .wait_for("A drained with commit", |e| *e == Ev::Drained(moved, true))
+        .await;
+    assert_eq!(a.recorder.committed(moved), Some(Offset(4)));
+
+    b.recorder
+        .wait_for("B owns the moved partition", |e| {
+            *e == Ev::Assigned(vec![moved])
+        })
+        .await;
+    // B starts after A's final commit: no replay of the drained work.
+    produce(&producer, moved.0, "k", "after").await;
+    let groups = groups_until(&mut b.handle.feed, 1).await;
+    assert_eq!(groups[0].offsets, vec![Offset(4)]);
+
+    a.shutdown.cancel();
+    b.shutdown.cancel();
+    // The drains at shutdown: answer every marker.
+    for running in [&mut a, &mut b] {
+        answer_shutdown(running).await;
+    }
+    a.task.await.unwrap().expect("A stops");
+    b.task.await.unwrap().expect("B stops");
+}
+
+/// Play a transport that drops everything at shutdown: answer each revoke
+/// marker with `Drained` and ignore batches.
+async fn answer_shutdown(running: &mut Running) {
+    loop {
+        match tokio::time::timeout(Duration::from_secs(5), running.handle.feed.recv()).await {
+            Ok(Some(Feed::Revoked { partition, epoch })) => {
+                running
+                    .handle
+                    .completions
+                    .send(Completion::Drained { partition, epoch })
+                    .await
+                    .unwrap();
+            }
+            Ok(Some(Feed::Batch(_))) => {}
+            Ok(None) | Err(_) => return,
+        }
+    }
+}
+
+#[tokio::test]
+async fn the_gate_closes_at_cap_and_reopens_at_low() {
+    let cluster = cluster(1);
+    let producer = producer(cluster);
+    for i in 0..10 {
+        produce(&producer, 0, &format!("k{i}"), "m").await;
+    }
+    let mut config = loop_config(cluster, "a");
+    config.budget = Charge {
+        events: 4,
+        bytes: u64::MAX,
+    };
+    config.budget_low_ratio = 0.5;
+    config.poll_max_messages = 2;
+    let mut running = start(config);
+
+    let held = groups_until(&mut running.handle.feed, 4).await;
+    running
+        .recorder
+        .wait_for("gate closed", |e| *e == Ev::Gate(true))
+        .await;
+    // Nothing more arrives while closed.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(500), running.handle.feed.recv())
+            .await
+            .is_err(),
+        "polled past the cap"
+    );
+
+    // One refund leaves used=3, above low=2: still closed.
+    let mut held = held.into_iter();
+    running
+        .handle
+        .completions
+        .send(Completion::Completed(vec![held
+            .next()
+            .unwrap()
+            .completion()]))
+        .await
+        .unwrap();
+    running
+        .recorder
+        .wait_for("first commit", |e| matches!(e, Ev::Committed(_)))
+        .await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(400), running.handle.feed.recv())
+            .await
+            .is_err(),
+        "reopened above low"
+    );
+
+    running
+        .handle
+        .completions
+        .send(Completion::Completed(vec![held
+            .next()
+            .unwrap()
+            .completion()]))
+        .await
+        .unwrap();
+    running
+        .recorder
+        .wait_for("gate reopened", |e| *e == Ev::Gate(false))
+        .await;
+    let more = groups_until(&mut running.handle.feed, 2).await;
+    assert_eq!(more.len(), 2);
+
+    running.shutdown.cancel();
+    answer_shutdown(&mut running).await;
+    running.task.await.unwrap().expect("clean stop");
+}
+
+#[tokio::test]
+async fn the_stall_watchdog_fires_only_without_progress() {
+    let cluster = cluster(1);
+    let producer = producer(cluster);
+    for i in 0..4 {
+        produce(&producer, 0, &format!("k{i}"), "m").await;
+    }
+    let mut config = loop_config(cluster, "a");
+    config.stall_timeout = Duration::from_millis(600);
+    let mut running = start(config);
+    let mut held = groups_until(&mut running.handle.feed, 4).await.into_iter();
+
+    // Progress inside the window resets the deadline.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    running
+        .handle
+        .completions
+        .send(Completion::Completed(vec![held
+            .next()
+            .unwrap()
+            .completion()]))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert!(
+        !running.task.is_finished(),
+        "stalled despite progress 400 ms ago"
+    );
+
+    // Then nothing lands for a full window: the loop fails.
+    let result = tokio::time::timeout(Duration::from_secs(3), running.task)
+        .await
+        .expect("loop exits on stall")
+        .unwrap();
+    assert!(matches!(result, Err(ConsumerLoopError::Stalled(ps)) if ps == vec![p(0)]));
+    assert!(running.recorder.events().contains(&Ev::Stalled(vec![p(0)])));
+}
+
+#[tokio::test]
+async fn a_completion_after_teardown_dies_by_epoch() {
+    let cluster = cluster(2);
+    let producer = producer(cluster);
+    for i in 0..3 {
+        produce(&producer, 0, "k", &format!("p0-{i}")).await;
+        produce(&producer, 1, "k", &format!("p1-{i}")).await;
+    }
+    let mut a = start(loop_config(cluster, "a"));
+    let held = groups_until(&mut a.handle.feed, 6).await;
+
+    let mut b = start(loop_config(cluster, "b"));
+    let moved = match next(&mut a.handle.feed, "revoke marker").await {
+        Feed::Revoked { partition, epoch } => {
+            // Drop the work instead of settling it: hand back at once.
+            a.handle
+                .completions
+                .send(Completion::Drained { partition, epoch })
+                .await
+                .unwrap();
+            partition
+        }
+        Feed::Batch(_) => panic!("expected the revoke marker"),
+    };
+    a.recorder
+        .wait_for("A drained", |e| *e == Ev::Drained(moved, true))
+        .await;
+    assert_eq!(
+        a.recorder.committed(moved),
+        None,
+        "nothing completed, nothing to commit"
+    );
+
+    // The straggler: completions for the torn-down partition.
+    let (stale, live): (Vec<_>, Vec<_>) = held.into_iter().partition(|g| g.partition == moved);
+    a.handle
+        .completions
+        .send(Completion::Completed(completions(&stale)))
+        .await
+        .unwrap();
+    // The loop is unharmed: the retained partition still commits.
+    a.handle
+        .completions
+        .send(Completion::Completed(completions(&live)))
+        .await
+        .unwrap();
+    let retained = p(1 - moved.0);
+    a.recorder
+        .wait_for(
+            "retained commits",
+            |e| matches!(e, Ev::Committed(b) if b.contains(&(retained, Offset(3)))),
+        )
+        .await;
+    assert_eq!(a.recorder.committed(moved), None, "the straggler committed");
+
+    b.recorder
+        .wait_for("B owns the moved partition", |e| {
+            *e == Ev::Assigned(vec![moved])
+        })
+        .await;
+    // B replays the dropped work from the start.
+    let groups = groups_until(&mut b.handle.feed, 3).await;
+    let offsets: Vec<Offset> = groups.iter().flat_map(|g| g.offsets.clone()).collect();
+    assert_eq!(offsets, vec![Offset(0), Offset(1), Offset(2)]);
+
+    a.shutdown.cancel();
+    b.shutdown.cancel();
+    answer_shutdown(&mut a).await;
+    answer_shutdown(&mut b).await;
+    a.task.await.unwrap().expect("A stops");
+    b.task.await.unwrap().expect("B stops");
+}
+
+#[tokio::test]
+async fn shutdown_drains_commits_and_leaves() {
+    let cluster = cluster(2);
+    let producer = producer(cluster);
+    for i in 0..3 {
+        produce(&producer, 0, "k", &format!("p0-{i}")).await;
+        produce(&producer, 1, "k", &format!("p1-{i}")).await;
+    }
+    let mut running = start(loop_config(cluster, "a"));
+    let held = groups_until(&mut running.handle.feed, 6).await;
+
+    running.shutdown.cancel();
+    // Both markers arrive; settle the in-flight work behind each.
+    let mut markers = Vec::new();
+    for _ in 0..2 {
+        match next(&mut running.handle.feed, "shutdown marker").await {
+            Feed::Revoked { partition, epoch } => markers.push((partition, epoch)),
+            Feed::Batch(_) => panic!("polled during shutdown"),
+        }
+    }
+    assert!(!running.task.is_finished(), "left before the drain");
+    running
+        .handle
+        .completions
+        .send(Completion::Completed(completions(&held)))
+        .await
+        .unwrap();
+    for (partition, epoch) in markers {
+        running
+            .handle
+            .completions
+            .send(Completion::Drained { partition, epoch })
+            .await
+            .unwrap();
+    }
+    tokio::time::timeout(WAIT, running.task)
+        .await
+        .expect("loop stops")
+        .unwrap()
+        .expect("clean stop");
+
+    assert_eq!(broker_committed(cluster, 0), Some(3));
+    assert_eq!(broker_committed(cluster, 1), Some(3));
+
+    // The next member of the group starts where the commit left off.
+    produce(&producer, 0, "k", "after").await;
+    let mut next_owner = start(loop_config(cluster, "b"));
+    let groups = groups_until(&mut next_owner.handle.feed, 1).await;
+    assert_eq!(groups[0].offsets, vec![Offset(3)]);
+    next_owner.shutdown.cancel();
+    answer_shutdown(&mut next_owner).await;
+    next_owner.task.await.unwrap().expect("clean stop");
+}


### PR DESCRIPTION
## Problem

- Layer 2 of the stack on #91682, which added the domain core with no Kafka client. This layer adds the loop that owns the rdkafka client, so a service can consume a topic through the crate: poll, demux, hand groups to a transport side, commit frontiers, drain on revoke.
- Handing a revoked partition back only after its in-flight work settles has a deadlock shape in rdkafka: the rebalance callback runs inside `poll`, on the task that awaits `recv()`, so a callback that waits for the drain waits on itself. No consumer under `rust/` handles this today; a revocation replays in-flight work on the new owner.

## Changes

- A service gets a bounded drain on rebalance. The callback only reports the revoke, the transport side settles in-flight work and answers `Drained`, and the loop issues the final commit and hands the whole revoke set back with `incremental_unassign`. The next owner starts after that commit.
- Backpressure is exact and bounded. Polling pauses when uncommitted work reaches the budget cap and resumes at a low watermark (0.8 times the cap). Two watermarks, because a pause purges rdkafka's fetch queue and a resume refetches it.
- Shutdown drains every partition through the same path, then re-submits the attempted offsets synchronously before leaving the group.
- A stalled partition (frontier unmoved for `stall_timeout` while work is pending) or a fatal client error returns `Err` from `run`. The adopter exits the process and replays at most `B`.

> [!NOTE]
> Closing the consumer revokes the whole assignment through the same callback, and rdkafka's `Drop` polls until the close completes. A deferred answer there spins forever, so a `closing` flag answers the close-time revoke inline. While any revoke waits for the hand-back, librdkafka pauses every assigned partition: the drain window is a pod-wide fetch pause, bounded by the transport's request timeout.

- The seam to the transport side is two channels: `Feed { Batch(Accumulator) | Revoked }` down and `Completion { Completed(Vec<GroupCompletion>) | Drained }` up. Completions are slim (partition, epoch, done offsets) and never carry messages. One assignment epoch counter is exposed for the transport to stamp requests with.
- Mechanical: the commit sentinel is ported as a monotonicity assert with broker-side confirmation (contiguity is now constructed); librdkafka stats export moves from the ingestion consumer; an observer trait carries liveness and debug events; metric names sit under `kafka_consumer_*` with a `group` label and a fixture test pins them.
- Nothing adopts the loop yet; running services do not change.

## How did you test this code?

- `tests/mock_cluster.rs` against rdkafka's `MockCluster`, with the test playing the transport side. Each test names the regression it catches: an out-of-order completion commits nothing past the gap; revoke, drained, final commit, hand-back happen in that order and the new owner reads from the committed offset; the gate closes at the cap and reopens only at the low watermark; the stall watchdog fires only without progress; a completion after teardown dies by epoch; shutdown commits and the next member starts where it left off.
- Unit tests for the watermarks, the drain's no-reissue rule, the sentinel, and the metric fixture.
- A local harness (not in this PR) compared the loop with today's `collect_batch` path on Kafka at localhost, 100k messages of 1 KiB, release profile. Today's full pipe: 55k msg/s and 33 allocations per message. The new loop with a null transport: 850k msg/s and 12 allocations per message. The old figure includes a localhost gRPC hop with gzip, so read it as an upper bound. The allocation delta is loop-side: today's path copies the key, the payload, and each header into a `String` per message.
- The MockCluster suite runs serially (`--test-threads=1`, about 38 s); a rebalance round costs 3 s in the mock.
- Not run: no e2e path in `ingestion-consumer` exercises the crate yet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The crate's README carries the seam rules and the rdkafka facts the loop rests on.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Claude Fable 5), directed by the assignee. Skills invoked: `/writing-pr-descriptions`, `/stacking-prs`.
- A throwaway spike against `MockCluster` settled the hand-back design: `incremental_unassign` from the loop task after the drain works (librdkafka allows it outside the callback), and it surfaced the close-time hang and the pod-wide fetch pause described above.
- The seam was reconciled with the driver-model implementation plan in #91468: slim completions and one epoch counter per process. That plan rolls the redesign out cycle by cycle inside `ingestion-consumer`; this stack builds the domain side as a crate and switches once. Which rollout lands is an open question on #91468.
