### PR TITLE
fix(auth): let legacy accounts complete an email change with a code

### DIFF
--- a/posthog/api/email_verification.py
+++ b/posthog/api/email_verification.py
@@ -84,8 +84,10 @@ class EmailVerificationCodeVerifier:
             # Signup verification always proves the account address. Only a verified user's
             # email change targets the staged address; an unverified user's staged change must
             # not let a code sent to the unverified new address verify the account.
+            # is_email_verified None marks an account from before verification existed. The login
+            # flow trusts those accounts as verified, so the email change flow does too.
             target: str | None = target_email
-            if target is None and user.is_email_verified:
+            if target is None and user.is_email_verified is not False:
                 target = user.pending_email
             issued_at = int(time.time())
             code = code_based_verification_token_generator.make_code(user, issued_at)
@@ -133,7 +135,9 @@ class EmailVerificationCodeVerifier:
             return False
         issued_at, target = state
         # A code verifies only the address it was issued for. Signup codes store '' as the target.
-        expected_target = (user.pending_email or "") if user.is_email_verified else ""
+        # None counts as verified here, like in send_code, or a legacy account's change code
+        # (bound to the staged address) could never match and the change could never complete.
+        expected_target = (user.pending_email or "") if user.is_email_verified is not False else ""
         if target != expected_target:
             return False
         return code_based_verification_token_generator.check_code(user, code, issued_at)

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -3276,8 +3276,9 @@ class TestEmailVerificationCodeAPI(APIBaseTest):
         html_message = mail.outbox[0].alternatives[0][0]  # type: ignore
         assert f"https://my.posthog.net/verify_email/{self.user.uuid}/" in html_message
 
-    def test_email_change_code_goes_to_the_pending_address_and_completes_the_swap(self):
-        self.user.is_email_verified = True
+    @parameterized.expand([("verified", True), ("legacy_never_verified", None)])
+    def test_email_change_code_goes_to_the_pending_address_and_completes_the_swap(self, _name, is_email_verified):
+        self.user.is_email_verified = is_email_verified
         self.user.pending_email = "new-address@posthog.com"
         self.user.save()
 
@@ -3309,6 +3310,8 @@ class TestEmailVerificationCodeAPI(APIBaseTest):
     def test_unverified_user_with_staged_change_verifies_only_the_account_address(self):
         # A signup code for an unverified user must go to the account address and prove that one,
         # even if a change to another address is staged: the staged address is itself unproven.
+        # False means an unverified signup; None (a legacy account) is trusted as verified.
+        self.user.is_email_verified = False
         self.user.pending_email = "staged@posthog.com"
         self.user.save()
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -1301,8 +1301,9 @@ class UserViewSet(
 
         # The swap needs a credential issued for the staged address. A token always is (its hash
         # includes pending_email). A code is only for a verified user; an unverified user's code
-        # proves the account address, so their staged change stays pending.
-        if user.pending_email and (token or user.is_email_verified):
+        # proves the account address, so their staged change stays pending. A legacy account
+        # (is_email_verified None) counts as verified, like in the login flow and in the verifier.
+        if user.pending_email and (token or user.is_email_verified is not False):
             old_email = user.email
             with transaction.atomic():
                 user.email = user.pending_email


### PR DESCRIPTION
## Problem

- An account from before email verification (`is_email_verified` is `NULL`) cannot complete an email change. The code sent to the new address is always rejected as invalid.
- The verifier binds the code to the new address, but treats a `NULL` account as unverified and expects a code for the account address. The two never match. The swap is also gated on `is_email_verified`.
- The rest of the app trusts `NULL` accounts as verified: only `False` blocks login. This flow missed that convention.
- Today the link fallback can rescue these users. #90177 removes the link flow, so this must be fixed first.

## Changes

- A legacy account now completes an email change like a verified one: the code goes to the new address, and entering it applies the change.
- Three checks change from truthiness to `is not False`: the send target in `send_code`, the expected target in `check_code`, and the swap gate in `verify_email`.
- Unverified signups (`False`) are unchanged: their code still proves the account address only.

## How did you test this code?

- Added an `is_email_verified=None` case to the email-change swap test. It fails without the fix.
- Pinned `False` in the unverified-signup test, so it keeps guarding that invariant and not the legacy default.
- Ran `TestEmailVerificationCodeAPI` (19 passed) and the email-change/verify selection of `test_user.py` (27 passed). Not run: mypy repo-wide (CI covers it).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5). Found while reviewing #90177; the bug predates it (#86493). Kept separate so the fix can deploy before the cleanup. A `NULL` to `True` backfill was rejected: it would record a verification that never happened.
