### PR TITLE
fix(devex): stop preflight claiming OpenAPI drift it never measured

### DIFF
--- a/hogli.yaml
+++ b/hogli.yaml
@@ -569,7 +569,9 @@ build:
             - build:openapi-cli-agent-scopes
             - build:openapi-scene-tool-context
             - build:openapi-exec-docs
-        description: Generate OpenAPI schema and TypeScript types from the backend
+        description: 'Generate OpenAPI schema and TypeScript types from the backend.
+            Needs the dev stack running (Postgres and ClickHouse): Django starts
+            before the schema is generated. Start it with hogli up -d'
     build:grammar:
         cmd: pnpm grammar:build
         description: Generate HogQL grammar definitions (C++)

--- a/tools/hogli-commands/hogli_commands/ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/ci_preflight.py
@@ -70,6 +70,16 @@ class DiffCheck:
     workspace_scoped: bool = False
     matched: list[str] = field(default_factory=list)
 
+    @property
+    def measures(self) -> bool:
+        """Whether this check runs something, or only advises.
+
+        A check that runs nothing has found nothing, so it must not be reported
+        as a finding whatever shape it takes: a nudge (``advice``) and a
+        guidance-only check (``verify is None``) are both unmeasured.
+        """
+        return self.advice is None and self.verify is not None
+
 
 # Ordered cheapest-first. Grounded in failure classes seen in `hogli ci:insights`:
 # broken lockfile blocking all CI, OpenAPI drift, formatting/lint/type checking,
@@ -185,10 +195,14 @@ DIFF_CHECKS: list[DiffCheck] = [
     ),
     DiffCheck(
         key="openapi",
-        label="OpenAPI types out of date (frontend/MCP drift)",
+        # Measuring real drift means regenerating and diffing, which needs the dev stack.
+        # This check only knows that the diff touches files the generated types are built
+        # from, so the label names that trigger instead of asserting the types are stale.
+        # A branch keeps those source edits in its diff after a regen, so a label that
+        # claims staleness can never be cleared by running the fix.
+        label="OpenAPI sources changed (generated types may need a regen)",
         # From build.py so preflight and build:openapi can't drift on which diffs need a regen.
         triggers=list(BUILD_TRIGGERS["build:openapi"]),
-        # Drift detection regenerates then diffs — needs the DB. Guidance-only here.
         verify=None,
         fix=["hogli", "build:openapi"],
         requires=("stack",),
@@ -341,7 +355,10 @@ def _run_diff_check(chk: DiffCheck, do_fix: bool) -> tuple[Status, str]:
         # Guidance-only (no runnable local check, or its fix needs an absent capability):
         # advise regardless, so the hint still shows on a bare checkout — even with --fix.
         # Ownership framing lives once in the advisory footer, not per check.
-        return "advisory", f"run `{' '.join(chk.fix or [])}` and commit before pushing"
+        # Phrased as a condition the reader can check, because nothing here measured
+        # whether the fix is needed: an unconditional "run this and commit" reads as a
+        # finding, and sends anyone who already ran it looking for a diff that isn't there.
+        return "advisory", f"if you have not run `{' '.join(chk.fix or [])}` since changing them, run it and commit"
     elif unmet:
         return "skipped", f"needs {', '.join(unmet)}"
     else:
@@ -647,7 +664,7 @@ def ci_preflight(do_fix: bool, strict: bool, against: str | None, as_json: bool)
         failures += status == "fail"
         # Nudges say "consider this", not "this is drift" — counting them would cry wolf in
         # the footer on every matching push and cost the detected advisories their weight.
-        advisories += status == "advisory" and chk.advice is None
+        advisories += status == "advisory" and chk.measures
         results.append({"check": chk.key, "status": status, "files": len(chk.matched), "detail": detail})
         if not as_json:
             click.secho(f"   {_ICON[status]} [{chk.key}] {chk.label}", fg=_COLOR[status])

--- a/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_ci_preflight.py
@@ -83,7 +83,26 @@ class TestStrictAndFixContracts:
     ) -> None:
         result = runner.invoke(cli, ["ci:preflight", "--fix"])
         assert result.exit_code == 0
-        assert "run `hogli build:openapi` and commit before pushing" in result.output
+        assert "if you have not run `hogli build:openapi` since changing them, run it and commit" in result.output
+        # Nothing regenerated here, so the advisory must not claim the types are stale.
+        # A branch keeps its source edits in the diff after a regen, so a staleness claim
+        # can never be cleared by running the fix.
+        assert "out of date" not in result.output
+
+    @patch("hogli_commands.ci_preflight._emit_telemetry")
+    @patch("hogli_commands.ci_preflight._staleness", return_value=("pass", "even with master", {}))
+    @patch("hogli_commands.ci_preflight._fetch_master")
+    @patch("hogli_commands.ci_preflight.changed_files", return_value=["posthog/api/does_not_exist.py"])
+    def test_guidance_only_check_is_not_counted_as_an_advisory(
+        self, mock_changed: MagicMock, mock_fetch: MagicMock, mock_stale: MagicMock, mock_emit: MagicMock
+    ) -> None:
+        result = runner.invoke(cli, ["ci:preflight", "--json"])
+        summary = json.loads(result.output)
+        assert "openapi" in summary["triggered"]
+        # A check that runs nothing has found nothing. Counting it puts an advisory on
+        # every push that touches an API file, which spends the weight the footer needs
+        # for the checks that did measure something.
+        assert summary["advisories"] == 0
 
     @patch("hogli_commands.ci_preflight._emit_telemetry")
     @patch("hogli_commands.ci_preflight._staleness", return_value=("pass", "even with master", {}))


### PR DESCRIPTION
## Problem

Anyone who edits a backend API file is told their OpenAPI types are out of date, and running the suggested command never clears it.

- The `openapi` preflight check has no local verify step. Measuring real drift means regenerating and diffing, which needs the dev stack.
- The check only knows that the diff touches files the generated types are built from.
- It claimed more than that. The label asserted the types were out of date.
- The count beside the label is the number of changed source files. It reads as a count of stale generated files.
- The footer then called it an unpushed CI failure to resolve before pushing.
- Regenerating and committing leaves the source edits in the diff, so the advisory fires again for the life of the branch.
- Reports through `hogli devex:feedback` describe the same loop: run `hogli build:openapi`, watch git stay clean, push anyway.

## Changes

Before and after, for a diff that touches one API file:

```text
-  ⚠ [openapi] OpenAPI types out of date (frontend/MCP drift)
-       1 file(s) · run `hogli build:openapi` and commit before pushing
-
-  1 advisory(ies) are unpushed CI failures — resolve before pushing,
-  including drift you didn't introduce. You own the branch state you push.
+  → [openapi] OpenAPI sources changed (generated types may need a regen)
+       1 file(s) · if you have not run `hogli build:openapi` since changing them, run it and commit
```

- The advisory names its trigger instead of asserting the types are stale.
- The message states a condition the reader can check instead of an order they cannot clear.
- An unmeasured check no longer counts toward the advisory total, so the "unpushed CI failures" footer no longer fires for this check alone.
- `hogli build:openapi --help` now states that the command needs the dev stack running.
- The wording change applies to any guidance-only check, not just this one. Today `openapi` is the only one.
- Mechanical: a `DiffCheck.measures` property replaces the compound condition that decides whether a check found anything.

The dev stack requirement is real and stays. This PR makes it visible rather than removing it.

## How did you test this code?

- Updated `test_fix_without_stack_still_advises_openapi` for the new wording, and made it assert the advisory does not claim staleness. It previously locked in the sentence this PR removes.
- Added `test_guidance_only_check_is_not_counted_as_an_advisory`. It guards the footer accounting, which is the part that read as a CI failure. No existing test covered the advisory count.
- Ran the `test_ci_preflight.py` suite and `hogli ci:preflight` locally.
- Not run: `hogli build:openapi` itself, because this environment has no dev stack. The description change was checked by rendering `hogli build:openapi --help`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, directed by @webjunkie. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/simplify`, `/writing-pr-descriptions`.

The work started from a review of feedback sent through `hogli devex:feedback`, which grouped the OpenAPI complaints into four distinct problems. Two were already fixed on master. This PR takes the one that is fully diagnosed.

Two decisions worth a reviewer's attention:

- An earlier draft swallowed the `OperationalError` that `resolve_self_capture_team` raises when Postgres is unreachable, so that `django.setup()` would survive without a database. That was dropped: `build:openapi-schema` genuinely needs Postgres, and it declares that in its `services:` block. Hiding the connection error would move the failure rather than fix it.
- A `prechecks:` entry looked like the right way to fail fast with a readable message. It is not wired for this command: `_run_prechecks` runs only for `BinScriptCommand` (`command_types.py:260`), while `build:openapi` is composite and `build:openapi-schema` is direct. A declared precheck on either would be ignored silently. Wiring that is a larger change and stays out of this PR.

The deeper fix is to make the check measure real drift without a database, by having `build:openapi` write a stamp of its input hashes for preflight to compare. That is a bigger change and is not attempted here.
