### PR TITLE
chore(ci): record filter-key flips in the paths-filter shadow

### DIFF
--- a/.depot/actions/paths-filter/README.md
+++ b/.depot/actions/paths-filter/README.md
@@ -81,6 +81,10 @@ Without the variable the action does no extra work. Set it in one workflow that 
 every pull request; that keeps the merge-ref fetch off the critical path of the other
 gating jobs. This is temporary, and goes away with the decision it exists to inform.
 
+The event carries the differing paths and, in `selection_changed` and `keys_lost`, which
+filter keys answer differently on the two lists. The keys are what gate a job, so they are
+what the decision reads; the paths are there to explain a flip.
+
 ## Rebuilding after source changes
 
 The action runs the committed `dist/index.js` bundle. After editing anything under `src/`,

--- a/.depot/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.depot/actions/paths-filter/__tests__/shadow.test.ts
@@ -1,8 +1,8 @@
 import {PullRequest} from '@octokit/webhooks-types'
 
-import {ChangeStatus} from '../src/file'
+import {ChangeStatus, File} from '../src/file'
 import {Filter} from '../src/filter'
-import {compareWithMergeCommit} from '../src/shadow'
+import {ShadowInput, compareWithMergeCommit} from '../src/shadow'
 
 const cp = jest.requireMock('child_process') as {execFile: jest.Mock}
 
@@ -30,6 +30,19 @@ frontend:
   - 'frontend/**'
 `)
 
+// The action matches the API list once in `run()` and hands the result to the shadow, so
+// a test builds the same pairing here.
+function input(withFilter: Filter, apiFiles: File[]): ShadowInput {
+  return {
+    filter: withFilter,
+    apiFiles,
+    apiResults: withFilter.match(apiFiles),
+    apiRows: apiFiles.length,
+    apiTruncated: false,
+    pr: pullRequest
+  }
+}
+
 function stubGit(...stdouts: string[]): void {
   for (const stdout of stdouts) {
     cp.execFile.mockImplementationOnce((...args: ExecFileArgs) => args[3](null, stdout, ''))
@@ -48,15 +61,12 @@ describe('shadow merge-commit comparison', () => {
     cp.execFile.mockReset()
   })
 
-  // A git call that forgets the scratch dir runs against the job workspace, where a
-  // --depth or --filter fetch drops the schema cache of every later step in the job.
+  // A git call against the job workspace drops the schema cache of every later step.
   test('never runs git against the job workspace', async () => {
     stubGit('', '', HEAD, 'M\0posthog/a.py\0')
 
     const result = await compareWithMergeCommit(
-      filter,
-      [{filename: 'posthog/a.py', status: ChangeStatus.Modified}],
-      pullRequest
+      input(filter, [{filename: 'posthog/a.py', status: ChangeStatus.Modified}])
     )
 
     expect(result.verdict).toBe('match')
@@ -66,46 +76,39 @@ describe('shadow merge-commit comparison', () => {
     }
   })
 
-  // Losing this guard scores a merge ref from an earlier push as this pull request's
-  // changes, which fills the measurement with mismatches that mean nothing.
+  // Without this guard an earlier push's merge ref reads as this pull request's changes.
   test('refuses a stale merge ref instead of comparing against it', async () => {
     stubGit('', '', OTHER_SHA)
 
     const result = await compareWithMergeCommit(
-      filter,
-      [{filename: 'posthog/a.py', status: ChangeStatus.Modified}],
-      pullRequest
+      input(filter, [{filename: 'posthog/a.py', status: ChangeStatus.Modified}])
     )
 
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toBe('stale-merge-ref')
   })
 
-  // Losing --no-renames reports one path where the API path reports two, so every
-  // rename reads as a mismatch.
+  // Without --no-renames every rename reads as a mismatch.
   test('matches a rename that the API reported as two entries', async () => {
     stubGit('', '', HEAD, 'D\0posthog/old.py\0A\0posthog/new.py\0')
 
     const result = await compareWithMergeCommit(
-      filter,
-      [
+      input(filter, [
         {filename: 'posthog/new.py', status: ChangeStatus.Added},
         {filename: 'posthog/old.py', status: ChangeStatus.Deleted}
-      ],
-      pullRequest
+      ])
     )
 
     expect(result.verdict).toBe('match')
     expect(cp.execFile.mock.calls.map(c => c[1])).toContainEqual(expect.arrayContaining(['--no-renames']))
   })
 
-  // An exec with no handle on the child leaves the fetch running after the budget gives
-  // up, and the action's process stays open until git exits.
+  // Without a handle on the child, an abandoned fetch holds the action open until git exits.
   test('stops git when the budget expires', async () => {
     cp.execFile.mockImplementation(() => undefined)
     jest.useFakeTimers()
 
-    const pending = compareWithMergeCommit(filter, [], pullRequest)
+    const pending = compareWithMergeCommit(input(filter, []))
     await jest.advanceTimersByTimeAsync(PAST_ANY_BUDGET_MS)
     const result = await pending
 
@@ -116,9 +119,7 @@ describe('shadow merge-commit comparison', () => {
     jest.useRealTimers()
   })
 
-  // A differing file list is only worth acting on where it flips a key, because the key
-  // is what gates a job. Comparing the lists instead of the keys reports every dropped
-  // path as consequential, which is the reading this field exists to replace.
+  // Comparing the file lists instead of the keys reports every dropped path as consequential.
   test.each([
     ['the dropped path is the only one holding a key', 'M\0frontend/b.ts\0', ['backend']],
     ['a surviving path holds the same key', 'M\0posthog/b.py\0M\0frontend/b.ts\0', []]
@@ -126,13 +127,11 @@ describe('shadow merge-commit comparison', () => {
     stubGit('', '', HEAD, diff)
 
     const result = await compareWithMergeCommit(
-      filter,
-      [
+      input(filter, [
         {filename: 'posthog/a.py', status: ChangeStatus.Modified},
         {filename: 'posthog/b.py', status: ChangeStatus.Modified},
         {filename: 'frontend/b.ts', status: ChangeStatus.Modified}
-      ],
-      pullRequest
+      ])
     )
 
     expect(result.verdict).toBe('mismatch')
@@ -140,9 +139,7 @@ describe('shadow merge-commit comparison', () => {
     expect(result.keysGained).toEqual([])
   })
 
-  // --name-status emits a status field and a path field per entry. Reading them in the
-  // wrong order turns every path into a status letter, and a rule scoped to a status
-  // then answers on the wrong file.
+  // Reading the -z fields in the wrong order turns every path into a status letter.
   test('carries each file status through to a status-scoped rule', async () => {
     const scoped = new Filter(`
 added_only:
@@ -151,12 +148,10 @@ added_only:
     stubGit('', '', HEAD, 'A\0posthog/new.py\0D\0posthog/gone.py\0')
 
     const result = await compareWithMergeCommit(
-      scoped,
-      [
+      input(scoped, [
         {filename: 'posthog/new.py', status: ChangeStatus.Added},
         {filename: 'posthog/gone.py', status: ChangeStatus.Deleted}
-      ],
-      pullRequest
+      ])
     )
 
     expect(result.verdict).toBe('match')

--- a/.depot/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.depot/actions/paths-filter/__tests__/shadow.test.ts
@@ -1,6 +1,7 @@
 import {PullRequest} from '@octokit/webhooks-types'
 
 import {ChangeStatus} from '../src/file'
+import {Filter} from '../src/filter'
 import {compareWithMergeCommit} from '../src/shadow'
 
 const cp = jest.requireMock('child_process') as {execFile: jest.Mock}
@@ -21,6 +22,13 @@ type ExecFileArgs = [
 ]
 
 const pullRequest = {number: 42, head: {sha: HEAD}} as PullRequest
+
+const filter = new Filter(`
+backend:
+  - 'posthog/**'
+frontend:
+  - 'frontend/**'
+`)
 
 function stubGit(...stdouts: string[]): void {
   for (const stdout of stdouts) {
@@ -43,9 +51,13 @@ describe('shadow merge-commit comparison', () => {
   // A git call that forgets the scratch dir runs against the job workspace, where a
   // --depth or --filter fetch drops the schema cache of every later step in the job.
   test('never runs git against the job workspace', async () => {
-    stubGit('', '', HEAD, 'a.ts\0')
+    stubGit('', '', HEAD, 'M\0posthog/a.py\0')
 
-    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
+    const result = await compareWithMergeCommit(
+      filter,
+      [{filename: 'posthog/a.py', status: ChangeStatus.Modified}],
+      pullRequest
+    )
 
     expect(result.verdict).toBe('match')
     expect(argvOf(0)).toContain(GIT_DIR)
@@ -59,7 +71,11 @@ describe('shadow merge-commit comparison', () => {
   test('refuses a stale merge ref instead of comparing against it', async () => {
     stubGit('', '', OTHER_SHA)
 
-    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
+    const result = await compareWithMergeCommit(
+      filter,
+      [{filename: 'posthog/a.py', status: ChangeStatus.Modified}],
+      pullRequest
+    )
 
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toBe('stale-merge-ref')
@@ -68,12 +84,13 @@ describe('shadow merge-commit comparison', () => {
   // Losing --no-renames reports one path where the API path reports two, so every
   // rename reads as a mismatch.
   test('matches a rename that the API reported as two entries', async () => {
-    stubGit('', '', HEAD, 'old.ts\0new.ts\0')
+    stubGit('', '', HEAD, 'D\0posthog/old.py\0A\0posthog/new.py\0')
 
     const result = await compareWithMergeCommit(
+      filter,
       [
-        {filename: 'new.ts', status: ChangeStatus.Added},
-        {filename: 'old.ts', status: ChangeStatus.Deleted}
+        {filename: 'posthog/new.py', status: ChangeStatus.Added},
+        {filename: 'posthog/old.py', status: ChangeStatus.Deleted}
       ],
       pullRequest
     )
@@ -88,7 +105,7 @@ describe('shadow merge-commit comparison', () => {
     cp.execFile.mockImplementation(() => undefined)
     jest.useFakeTimers()
 
-    const pending = compareWithMergeCommit([], pullRequest)
+    const pending = compareWithMergeCommit(filter, [], pullRequest)
     await jest.advanceTimersByTimeAsync(PAST_ANY_BUDGET_MS)
     const result = await pending
 
@@ -97,5 +114,53 @@ describe('shadow merge-commit comparison', () => {
     const [, , options] = cp.execFile.mock.calls[0] as ExecFileArgs
     expect(options.signal.aborted).toBe(true)
     jest.useRealTimers()
+  })
+
+  // A differing file list is only worth acting on where it flips a key, because the key
+  // is what gates a job. Comparing the lists instead of the keys reports every dropped
+  // path as consequential, which is the reading this field exists to replace.
+  test.each([
+    ['the dropped path is the only one holding a key', 'M\0frontend/b.ts\0', ['backend']],
+    ['a surviving path holds the same key', 'M\0posthog/b.py\0M\0frontend/b.ts\0', []]
+  ])('reports keys lost when %s', async (_case, diff, keysLost) => {
+    stubGit('', '', HEAD, diff)
+
+    const result = await compareWithMergeCommit(
+      filter,
+      [
+        {filename: 'posthog/a.py', status: ChangeStatus.Modified},
+        {filename: 'posthog/b.py', status: ChangeStatus.Modified},
+        {filename: 'frontend/b.ts', status: ChangeStatus.Modified}
+      ],
+      pullRequest
+    )
+
+    expect(result.verdict).toBe('mismatch')
+    expect(result.keysLost).toEqual(keysLost)
+    expect(result.keysGained).toEqual([])
+  })
+
+  // --name-status emits a status field and a path field per entry. Reading them in the
+  // wrong order turns every path into a status letter, and a rule scoped to a status
+  // then answers on the wrong file.
+  test('carries each file status through to a status-scoped rule', async () => {
+    const scoped = new Filter(`
+added_only:
+  - added: 'posthog/**'
+`)
+    stubGit('', '', HEAD, 'A\0posthog/new.py\0D\0posthog/gone.py\0')
+
+    const result = await compareWithMergeCommit(
+      scoped,
+      [
+        {filename: 'posthog/new.py', status: ChangeStatus.Added},
+        {filename: 'posthog/gone.py', status: ChangeStatus.Deleted}
+      ],
+      pullRequest
+    )
+
+    expect(result.verdict).toBe('match')
+    expect(result.keysLost).toEqual([])
+    expect(result.keysGained).toEqual([])
   })
 })

--- a/.depot/actions/paths-filter/dist/index.js
+++ b/.depot/actions/paths-filter/dist/index.js
@@ -42708,7 +42708,7 @@ async function run() {
             return;
         }
         const filter = new filter_1.Filter(filtersYaml);
-        const files = await getChangedFiles(token, base, ref, initialFetchDepth);
+        const files = await getChangedFiles(filter, token, base, ref, initialFetchDepth);
         core.info(`Detected ${files.length} changed files`);
         const results = filter.match(files);
         exportResults(results, listFiles);
@@ -42729,7 +42729,7 @@ function getConfigFileContent(configPath) {
     }
     return fs.readFileSync(configPath, { encoding: 'utf8' });
 }
-async function getChangedFiles(token, base, ref, initialFetchDepth) {
+async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
     var _a, _b;
     // if base is 'HEAD' only local uncommitted changes will be detected
     // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
@@ -42754,8 +42754,8 @@ async function getChangedFiles(token, base, ref, initialFetchDepth) {
             }
             const pr = github.context.payload.pull_request;
             if (token) {
-                const apiFiles = await getChangedFilesFromApi(token, pr);
-                await shadow.report(apiFiles, pr);
+                const { files: apiFiles, rows } = await getChangedFilesFromApi(token, pr);
+                await shadow.report(filter, apiFiles, rows, pr);
                 return apiFiles;
             }
             if (github.context.eventName === 'pull_request_target') {
@@ -42821,12 +42821,16 @@ async function getChangedFilesFromGit(base, head, initialFetchDepth) {
     return await git.getChangesSinceMergeBase(base, head, initialFetchDepth);
 }
 // Uses github REST api to get list of files changed in PR
+// `rows` counts what the API returned rather than what `files` holds, because a renamed
+// row expands into two entries below. The API caps the response at 3,000 rows and says
+// nothing when it does, so the row count is the only tell that the list is partial.
 async function getChangedFilesFromApi(token, pullRequest) {
     core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
     try {
         const client = github.getOctokit(token);
         const per_page = 100;
         const files = [];
+        let rows = 0;
         core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`);
         for await (const response of client.paginate.iterator(client.rest.pulls.listFiles.endpoint.merge({
             owner: github.context.repo.owner,
@@ -42839,6 +42843,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
             }
             core.info(`Received ${response.data.length} items`);
             for (const row of response.data) {
+                rows++;
                 core.info(`[${row.status}] ${row.filename}`);
                 // There's no obvious use-case for detection of renames
                 // Therefore we treat it as if rename detection in git diff was turned off.
@@ -42864,7 +42869,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
                 }
             }
         }
-        return files;
+        return { files, rows };
     }
     finally {
         core.endGroup();
@@ -42976,6 +42981,7 @@ const child_process_1 = __nccwpck_require__(5317);
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const core = __importStar(__nccwpck_require__(7484));
+const file_1 = __nccwpck_require__(3765);
 // Compares the API's changed-file list against the same list derived locally from
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
@@ -43061,6 +43067,29 @@ function originUrl() {
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
+// git reports a type change as T, which is a content change like any other to a filter.
+// R and C are unreachable under --no-renames and are mapped so a future caller without
+// that flag still gets a status rather than the fallback.
+const STATUS_OF = {
+    A: file_1.ChangeStatus.Added,
+    C: file_1.ChangeStatus.Copied,
+    D: file_1.ChangeStatus.Deleted,
+    M: file_1.ChangeStatus.Modified,
+    R: file_1.ChangeStatus.Renamed,
+    T: file_1.ChangeStatus.Modified,
+    U: file_1.ChangeStatus.Unmerged
+};
+// -z --name-status emits a status field and a path field per entry, each NUL-terminated.
+// A status carries a similarity score for R and C, which --no-renames rules out, so the
+// first character is the whole status here.
+function parseNameStatus(out) {
+    const fields = out.split('\0').filter(Boolean);
+    const files = [];
+    for (let i = 0; i + 1 < fields.length; i += 2) {
+        files.push({ filename: fields[i + 1], status: STATUS_OF[fields[i][0]] || file_1.ChangeStatus.Modified });
+    }
+    return files;
+}
 async function localChangedFiles(pr, signal) {
     const gitDir = await scratchRepo(signal);
     const fetched = await git(gitDir, [
@@ -43088,12 +43117,14 @@ async function localChangedFiles(pr, signal) {
     }
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
     // the API path builds by hand from `previous_filename`. -z because git quotes a
-    // path holding a newline or a non-ASCII byte in the default format.
-    const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
+    // path holding a newline or a non-ASCII byte in the default format. --name-status
+    // because a filter rule can scope itself to a change status, so a comparison that
+    // guessed one would answer a different question than the filter asks.
+    const diff = await git(gitDir, ['diff', '--no-renames', '--name-status', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
     if (diff.code !== 0) {
         throw new Unavailable('diff-failed', firstLine(diff.err));
     }
-    return diff.out.split('\0').filter(Boolean);
+    return parseNameStatus(diff.out);
 }
 // A queue branch can differ by thousands of paths, which is neither readable in a log
 // line nor worth carrying as an event property. The count answers how far apart the two
@@ -43112,9 +43143,20 @@ function difference(from, against) {
     }
     return { count, sample };
 }
-function compare(api, local) {
+// A filter key gates a job on whether any changed file matched it, so the key's answer
+// is `length > 0` and nothing finer. `exportResults` reads it the same way.
+function firedKeys(filter, files) {
+    return new Set(Object.entries(filter.match(files))
+        .filter(([, matched]) => matched.length > 0)
+        .map(([key]) => key));
+}
+function compare(filter, apiFiles, gitFiles) {
+    const api = new Set(apiFiles.map(f => f.filename));
+    const local = new Set(gitFiles.map(f => f.filename));
     const onlyInApi = difference(api, local);
     const onlyInGit = difference(local, api);
+    const apiKeys = firedKeys(filter, apiFiles);
+    const gitKeys = firedKeys(filter, gitFiles);
     return {
         verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
         reason: null,
@@ -43122,7 +43164,9 @@ function compare(api, local) {
         apiCount: api.size,
         gitCount: local.size,
         onlyInApi,
-        onlyInGit
+        onlyInGit,
+        keysLost: [...apiKeys].filter(k => !gitKeys.has(k)).sort(),
+        keysGained: [...gitKeys].filter(k => !apiKeys.has(k)).sort()
     };
 }
 async function budgeted(work, ms) {
@@ -43136,27 +43180,28 @@ async function budgeted(work, ms) {
     });
     return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer));
 }
-async function compareWithMergeCommit(apiFiles, pr) {
-    const api = new Set(apiFiles.map(f => f.filename));
+async function compareWithMergeCommit(filter, apiFiles, pr) {
     try {
         const gitFiles = await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS);
-        return compare(api, new Set(gitFiles));
+        return compare(filter, apiFiles, gitFiles);
     }
     catch (error) {
         return {
             verdict: 'unavailable',
             reason: error instanceof Unavailable ? error.reason : 'unknown',
             detail: error instanceof Unavailable ? error.detail : messageOf(error),
-            apiCount: api.size,
+            apiCount: new Set(apiFiles.map(f => f.filename)).size,
             gitCount: null,
             onlyInApi: { count: 0, sample: [] },
-            onlyInGit: { count: 0, sample: [] }
+            onlyInGit: { count: 0, sample: [] },
+            keysLost: [],
+            keysGained: []
         };
     }
 }
 // Without this the only record of a divergence is a log line in one job of one run,
 // which is unreadable at the volume that makes the comparison worth running.
-async function capture(apiKey, result, pr, durationMs) {
+async function capture(apiKey, result, pr, apiRows, durationMs) {
     var _a;
     const repo = process.env.GITHUB_REPOSITORY || null;
     const properties = {
@@ -43170,11 +43215,17 @@ async function capture(apiKey, result, pr, durationMs) {
         only_in_api_count: result.onlyInApi.count,
         only_in_git: result.onlyInGit.sample,
         only_in_git_count: result.onlyInGit.count,
-        // pulls/{n}/files truncates silently, so record both sides of the tell: what the
-        // API returned, and what the pull request payload says it should have been. The
-        // count has to come from the payload, because `api_count` counts a rename twice:
-        // the API path expands each renamed row into an add plus a delete.
-        api_truncated: pr.changed_files >= API_FILE_CAP,
+        selection_changed: result.keysLost.length > 0 || result.keysGained.length > 0,
+        keys_lost: result.keysLost,
+        keys_gained: result.keysGained,
+        // pulls/{n}/files truncates silently at the cap, and the cap counts API rows, so
+        // the tell is how many rows came back. `api_count` cannot stand in: the API path
+        // expands each renamed row into an add plus a delete.
+        api_rows: apiRows,
+        api_truncated: apiRows >= API_FILE_CAP,
+        // Kept beside `api_rows` rather than used as the tell, because the payload's count
+        // is computed when the event fires and reads stale on a pull request whose base
+        // moved. The two disagreeing is itself worth seeing.
         pr_changed_files: pr.changed_files,
         pr_number: pr.number,
         head_sha: pr.head.sha,
@@ -43212,7 +43263,8 @@ function summarize(result) {
     }
     if (result.verdict === 'mismatch') {
         return (`MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
-            `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)}`);
+            `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)} ` +
+            `keysLost=${JSON.stringify(result.keysLost)} keysGained=${JSON.stringify(result.keysGained)}`);
     }
     return `match (${result.apiCount} files)`;
 }
@@ -43223,7 +43275,7 @@ function summarize(result) {
 // detects changes runs this action, so a comparison whose result cannot be recorded
 // is a merge-ref fetch on the critical path of a gate job in exchange for a log line
 // nobody reads. Fork pull requests get no secrets, so they take this path too.
-async function report(apiFiles, pr) {
+async function report(filter, apiFiles, apiRows, pr) {
     const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
     if (!apiKey) {
         return;
@@ -43231,12 +43283,12 @@ async function report(apiFiles, pr) {
     try {
         core.startGroup('Shadow: merge-commit change detection');
         const startedAt = Date.now();
-        const result = await compareWithMergeCommit(apiFiles, pr);
+        const result = await compareWithMergeCommit(filter, apiFiles, pr);
         const durationMs = Date.now() - startedAt;
         // core.info even for a mismatch: a warning becomes an annotation on the run summary
         // and the checks page, which reads as a problem with the pull request.
         core.info(`shadow: ${summarize(result)} in ${durationMs}ms`);
-        await capture(apiKey, result, pr, durationMs).catch(error => {
+        await capture(apiKey, result, pr, apiRows, durationMs).catch(error => {
             core.info(`shadow: capture skipped (${messageOf(error)})`);
         });
     }

--- a/.depot/actions/paths-filter/dist/index.js
+++ b/.depot/actions/paths-filter/dist/index.js
@@ -42189,6 +42189,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Filter = void 0;
+exports.firedKeys = firedKeys;
 const jsyaml = __importStar(__nccwpck_require__(4281));
 const picomatch_1 = __importDefault(__nccwpck_require__(4006));
 // Minimatch options used in all matchers
@@ -42202,6 +42203,11 @@ function isNegatedPattern(pattern) {
 }
 function positivePattern(pattern) {
     return isNegatedPattern(pattern) ? pattern.slice(1) : pattern;
+}
+// A key gates a job on whether any file matched it, so its answer is `length > 0` and
+// nothing finer. Both the action's outputs and the shadow comparison read it through here.
+function firedKeys(results) {
+    return new Set(Object.keys(results).filter(key => results[key].length > 0));
 }
 class Filter {
     // Creates instance of Filter and load rules from YAML if it's provided
@@ -42708,10 +42714,13 @@ async function run() {
             return;
         }
         const filter = new filter_1.Filter(filtersYaml);
-        const files = await getChangedFiles(filter, token, base, ref, initialFetchDepth);
+        const { files, api } = await getChangedFiles(token, base, ref, initialFetchDepth);
         core.info(`Detected ${files.length} changed files`);
         const results = filter.match(files);
         exportResults(results, listFiles);
+        if (api) {
+            await shadow.report({ filter, apiFiles: files, apiResults: results, ...api });
+        }
     }
     catch (error) {
         core.setFailed(getErrorMessage(error));
@@ -42729,7 +42738,7 @@ function getConfigFileContent(configPath) {
     }
     return fs.readFileSync(configPath, { encoding: 'utf8' });
 }
-async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
+async function getChangedFiles(token, base, ref, initialFetchDepth) {
     var _a, _b;
     // if base is 'HEAD' only local uncommitted changes will be detected
     // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
@@ -42737,7 +42746,7 @@ async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
         if (ref) {
             core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
         }
-        return await git.getChangesOnHead();
+        return { files: await git.getChangesOnHead() };
     }
     switch (github.context.eventName) {
         // To keep backward compatibility, commits in GitHub pull request event
@@ -42754,9 +42763,8 @@ async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
             }
             const pr = github.context.payload.pull_request;
             if (token) {
-                const { files: apiFiles, rows } = await getChangedFilesFromApi(token, pr);
-                await shadow.report(filter, apiFiles, rows, pr);
-                return apiFiles;
+                const { files, apiRows, apiTruncated } = await getChangedFilesFromApi(token, pr);
+                return { files, api: { apiRows, apiTruncated, pr } };
             }
             if (github.context.eventName === 'pull_request_target') {
                 // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
@@ -42768,10 +42776,10 @@ async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
             const baseSha = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.base.sha;
             const defaultBranch = (_b = github.context.payload.repository) === null || _b === void 0 ? void 0 : _b.default_branch;
             const currentRef = await git.getCurrentRef();
-            return await git.getChanges(base || baseSha || defaultBranch, currentRef);
+            return { files: await git.getChanges(base || baseSha || defaultBranch, currentRef) };
         }
     }
-    return getChangedFilesFromGit(base, ref, initialFetchDepth);
+    return { files: await getChangedFilesFromGit(base, ref, initialFetchDepth) };
 }
 async function getChangedFilesFromGit(base, head, initialFetchDepth) {
     var _a;
@@ -42820,17 +42828,17 @@ async function getChangedFilesFromGit(base, head, initialFetchDepth) {
     core.info(`Changes will be detected between ${base} and ${head}`);
     return await git.getChangesSinceMergeBase(base, head, initialFetchDepth);
 }
+// The API truncates at this many rows and says nothing when it does.
+const API_FILE_CAP = 3000;
 // Uses github REST api to get list of files changed in PR
-// `rows` counts what the API returned rather than what `files` holds, because a renamed
-// row expands into two entries below. The API caps the response at 3,000 rows and says
-// nothing when it does, so the row count is the only tell that the list is partial.
+// Truncation is judged on API rows, not on `files`, which expands a rename into two.
 async function getChangedFilesFromApi(token, pullRequest) {
     core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
     try {
         const client = github.getOctokit(token);
         const per_page = 100;
         const files = [];
-        let rows = 0;
+        let apiRows = 0;
         core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`);
         for await (const response of client.paginate.iterator(client.rest.pulls.listFiles.endpoint.merge({
             owner: github.context.repo.owner,
@@ -42843,7 +42851,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
             }
             core.info(`Received ${response.data.length} items`);
             for (const row of response.data) {
-                rows++;
+                apiRows++;
                 core.info(`[${row.status}] ${row.filename}`);
                 // There's no obvious use-case for detection of renames
                 // Therefore we treat it as if rename detection in git diff was turned off.
@@ -42869,7 +42877,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
                 }
             }
         }
-        return { files, rows };
+        return { files, apiRows, apiTruncated: apiRows >= API_FILE_CAP };
     }
     finally {
         core.endGroup();
@@ -42877,12 +42885,11 @@ async function getChangedFilesFromApi(token, pullRequest) {
 }
 function exportResults(results, format) {
     core.info('Results:');
-    const changes = [];
+    const fired = (0, filter_1.firedKeys)(results);
     for (const [key, files] of Object.entries(results)) {
-        const value = files.length > 0;
+        const value = fired.has(key);
         core.startGroup(`Filter ${key} = ${value}`);
-        if (files.length > 0) {
-            changes.push(key);
+        if (value) {
             core.info('Matching files:');
             for (const file of files) {
                 core.info(`${file.filename} [${file.status}]`);
@@ -42900,7 +42907,7 @@ function exportResults(results, format) {
         core.endGroup();
     }
     if (results['changes'] === undefined) {
-        const changesJson = JSON.stringify(changes);
+        const changesJson = JSON.stringify([...fired]);
         core.info(`Changes output set to ${changesJson}`);
         core.setOutput('changes', changesJson);
     }
@@ -42981,36 +42988,24 @@ const child_process_1 = __nccwpck_require__(5317);
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const core = __importStar(__nccwpck_require__(7484));
-const file_1 = __nccwpck_require__(3765);
-// Compares the API's changed-file list against the same list derived locally from
-// the pull request's merge commit, and reports disagreement without acting on it.
-// The API result stays authoritative, so a wrong local answer can only produce a
-// log line. Removing the API call later is only safe once this has run quiet
-// across the shapes no offline sample can reach: very large diffs, and ones GitHub
-// has not finished computing a merge ref for.
-//
-// Detecting changes from `base.sha..HEAD` instead reports every commit the branch
-// picked up when the base was merged into it as the pull request's own work, which
-// is wrong by thousands of files on a branch that has taken master in. The merge
-// commit's first parent is the base GitHub actually merged against, so
-// `HEAD^1..HEAD` is the pull request's own changes and matches the API.
+const filter_1 = __nccwpck_require__(9037);
+const git_1 = __nccwpck_require__(1243);
+// Compares the API's changed-file list against the same list derived from the pull
+// request's merge commit, and reports disagreement without acting on it. The API
+// result stays authoritative, so a wrong local answer can only produce a log line.
 const MERGE_REF_FETCH_DEPTH = 2;
 const POSTHOG_HOST = 'https://us.i.posthog.com';
 const EVENT_NAME = 'paths_filter_shadow_compared';
 // A change-detection job is on the critical path of every workflow, so the comparison
-// and the capture that follows it share one wall-clock budget, and give up rather than
-// holding the job to its timeout-minutes. The git-level low-speed settings cover a
-// stalled transfer; the budget covers everything else.
+// and its capture share one wall-clock budget rather than holding the job to its
+// timeout-minutes.
 const BUDGET_MS = 20000;
 const CAPTURE_FLOOR_MS = 500;
 const LIST_CAP = 50;
-// A queue branch carries the cumulative batch diff, so the path list can be far larger
-// than a human pull request's. execFile's 1 MB default would fail those as a diff error,
-// which drops the population the comparison most needs to measure.
+// A queue branch carries the cumulative batch diff, which execFile's 1 MB default would
+// fail as a diff error.
 const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024;
 const DETAIL_CAP = 200;
-// The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
-const API_FILE_CAP = 3000;
 class Unavailable extends Error {
     constructor(reason, detail) {
         super(`${reason}: ${detail}`);
@@ -43018,20 +43013,15 @@ class Unavailable extends Error {
         this.detail = detail;
     }
 }
-// Every git call that reads or writes history names the scratch repository. `--depth`
-// and `--filter` rewrite `.git/shallow` and the promisor config of whatever repository
-// they run in, and steps later in the same job read history from the workspace checkout:
-// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>` after
-// this action returns, and an empty merge base there silently drops their schema cache.
+// `--depth` and `--filter` rewrite `.git/shallow` and the promisor config of whatever
+// repository they run in, so every call names the scratch repository. ci-dagster and
+// ci-e2e-playwright read history from the workspace checkout after this action returns.
 async function git(gitDir, args, signal) {
     return run(['--git-dir', gitDir, ...args], signal);
 }
-// The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
-// on the child process, so a fetch the budget gave up on keeps running and holds the
-// action's process open until it finishes, past the budget it was supposed to obey.
-//
-// stdout is returned raw. A caller that reads a path list must not trim it, because a
-// tracked path can begin with a space, and that path sorts first in the -z output.
+// execFile rather than `@actions/exec`, which gives no handle on the child process, so a
+// fetch the budget gave up on would hold the action open until it finished. stdout is
+// returned raw because a tracked path can begin with a space.
 async function run(args, signal) {
     return new Promise(resolve => {
         (0, child_process_1.execFile)('git', args, { signal, maxBuffer: MAX_GIT_OUTPUT_BYTES }, (error, stdout, stderr) => {
@@ -43045,6 +43035,9 @@ function firstLine(stderr) {
 function messageOf(error) {
     return error instanceof Error ? error.message : String(error);
 }
+function missing(from, against) {
+    return [...from].filter(key => !against.has(key)).sort();
+}
 async function scratchRepo(signal) {
     const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
     const init = await run(['init', '--bare', '--quiet', gitDir], signal);
@@ -43053,9 +43046,8 @@ async function scratchRepo(signal) {
     }
     return gitDir;
 }
-// The workspace remote carries no credentials of its own: actions/checkout keeps the
-// token in an http.extraheader the scratch repository does not inherit. A private
-// remote therefore reports unavailable rather than comparing against a partial fetch.
+// actions/checkout keeps the token in an http.extraheader the scratch repository does not
+// inherit, so a private remote reports unavailable rather than comparing a partial fetch.
 function originUrl() {
     const server = process.env.GITHUB_SERVER_URL;
     const repo = process.env.GITHUB_REPOSITORY;
@@ -43063,32 +43055,6 @@ function originUrl() {
         throw new Unavailable('no-origin-url', 'GITHUB_SERVER_URL or GITHUB_REPOSITORY is unset');
     }
     return `${server}/${repo}`;
-}
-// The merge ref is not guaranteed to be present or current: GitHub recomputes it
-// asynchronously after a push. Requiring the second parent to equal the head SHA
-// rejects a stale ref rather than reading it as this pull request's changes.
-// git reports a type change as T, which is a content change like any other to a filter.
-// R and C are unreachable under --no-renames and are mapped so a future caller without
-// that flag still gets a status rather than the fallback.
-const STATUS_OF = {
-    A: file_1.ChangeStatus.Added,
-    C: file_1.ChangeStatus.Copied,
-    D: file_1.ChangeStatus.Deleted,
-    M: file_1.ChangeStatus.Modified,
-    R: file_1.ChangeStatus.Renamed,
-    T: file_1.ChangeStatus.Modified,
-    U: file_1.ChangeStatus.Unmerged
-};
-// -z --name-status emits a status field and a path field per entry, each NUL-terminated.
-// A status carries a similarity score for R and C, which --no-renames rules out, so the
-// first character is the whole status here.
-function parseNameStatus(out) {
-    const fields = out.split('\0').filter(Boolean);
-    const files = [];
-    for (let i = 0; i + 1 < fields.length; i += 2) {
-        files.push({ filename: fields[i + 1], status: STATUS_OF[fields[i][0]] || file_1.ChangeStatus.Modified });
-    }
-    return files;
 }
 async function localChangedFiles(pr, signal) {
     const gitDir = await scratchRepo(signal);
@@ -43111,24 +43077,21 @@ async function localChangedFiles(pr, signal) {
     if (head.code !== 0) {
         throw new Unavailable('no-second-parent', firstLine(head.err));
     }
+    // GitHub recomputes the merge ref asynchronously after a push, so a ref whose second
+    // parent is not the head SHA describes an earlier push.
     const headSha = head.out.trim();
     if (headSha !== pr.head.sha) {
         throw new Unavailable('stale-merge-ref', `^2=${headSha.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)}`);
     }
-    // --no-renames so a rename arrives as a delete plus an add, which is the shape
-    // the API path builds by hand from `previous_filename`. -z because git quotes a
-    // path holding a newline or a non-ASCII byte in the default format. --name-status
-    // because a filter rule can scope itself to a change status, so a comparison that
-    // guessed one would answer a different question than the filter asks.
+    // The same flags the action's own git path uses, so the comparison measures what
+    // dropping the API call would select. --no-renames matches the add-plus-delete shape
+    // the API path builds from `previous_filename`.
     const diff = await git(gitDir, ['diff', '--no-renames', '--name-status', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
     if (diff.code !== 0) {
         throw new Unavailable('diff-failed', firstLine(diff.err));
     }
-    return parseNameStatus(diff.out);
+    return (0, git_1.parseGitDiffOutput)(diff.out);
 }
-// A queue branch can differ by thousands of paths, which is neither readable in a log
-// line nor worth carrying as an event property. The count answers how far apart the two
-// answers are, and the sample answers what kind of path is involved.
 function difference(from, against) {
     const sample = [];
     let count = 0;
@@ -43143,20 +43106,12 @@ function difference(from, against) {
     }
     return { count, sample };
 }
-// A filter key gates a job on whether any changed file matched it, so the key's answer
-// is `length > 0` and nothing finer. `exportResults` reads it the same way.
-function firedKeys(filter, files) {
-    return new Set(Object.entries(filter.match(files))
-        .filter(([, matched]) => matched.length > 0)
-        .map(([key]) => key));
-}
-function compare(filter, apiFiles, gitFiles) {
-    const api = new Set(apiFiles.map(f => f.filename));
+function compare(input, api, gitFiles) {
     const local = new Set(gitFiles.map(f => f.filename));
     const onlyInApi = difference(api, local);
     const onlyInGit = difference(local, api);
-    const apiKeys = firedKeys(filter, apiFiles);
-    const gitKeys = firedKeys(filter, gitFiles);
+    const apiKeys = (0, filter_1.firedKeys)(input.apiResults);
+    const gitKeys = (0, filter_1.firedKeys)(input.filter.match(gitFiles));
     return {
         verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
         reason: null,
@@ -43165,8 +43120,8 @@ function compare(filter, apiFiles, gitFiles) {
         gitCount: local.size,
         onlyInApi,
         onlyInGit,
-        keysLost: [...apiKeys].filter(k => !gitKeys.has(k)).sort(),
-        keysGained: [...gitKeys].filter(k => !apiKeys.has(k)).sort()
+        keysLost: missing(apiKeys, gitKeys),
+        keysGained: missing(gitKeys, apiKeys)
     };
 }
 async function budgeted(work, ms) {
@@ -43180,17 +43135,18 @@ async function budgeted(work, ms) {
     });
     return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer));
 }
-async function compareWithMergeCommit(filter, apiFiles, pr) {
+async function compareWithMergeCommit(input) {
+    const api = new Set(input.apiFiles.map(f => f.filename));
     try {
-        const gitFiles = await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS);
-        return compare(filter, apiFiles, gitFiles);
+        const gitFiles = await budgeted(async (signal) => localChangedFiles(input.pr, signal), BUDGET_MS);
+        return compare(input, api, gitFiles);
     }
     catch (error) {
         return {
             verdict: 'unavailable',
             reason: error instanceof Unavailable ? error.reason : 'unknown',
             detail: error instanceof Unavailable ? error.detail : messageOf(error),
-            apiCount: new Set(apiFiles.map(f => f.filename)).size,
+            apiCount: api.size,
             gitCount: null,
             onlyInApi: { count: 0, sample: [] },
             onlyInGit: { count: 0, sample: [] },
@@ -43199,11 +43155,10 @@ async function compareWithMergeCommit(filter, apiFiles, pr) {
         };
     }
 }
-// Without this the only record of a divergence is a log line in one job of one run,
-// which is unreadable at the volume that makes the comparison worth running.
-async function capture(apiKey, result, pr, apiRows, durationMs) {
+async function capture(apiKey, input, result, durationMs) {
     var _a;
     const repo = process.env.GITHUB_REPOSITORY || null;
+    const pr = input.pr;
     const properties = {
         repo,
         verdict: result.verdict,
@@ -43218,21 +43173,15 @@ async function capture(apiKey, result, pr, apiRows, durationMs) {
         selection_changed: result.keysLost.length > 0 || result.keysGained.length > 0,
         keys_lost: result.keysLost,
         keys_gained: result.keysGained,
-        // pulls/{n}/files truncates silently at the cap, and the cap counts API rows, so
-        // the tell is how many rows came back. `api_count` cannot stand in: the API path
-        // expands each renamed row into an add plus a delete.
-        api_rows: apiRows,
-        api_truncated: apiRows >= API_FILE_CAP,
-        // Kept beside `api_rows` rather than used as the tell, because the payload's count
-        // is computed when the event fires and reads stale on a pull request whose base
-        // moved. The two disagreeing is itself worth seeing.
+        // `pr_changed_files` reads stale on a pull request whose base moved, so it is
+        // recorded beside the API's own row count rather than used as the truncation tell.
+        api_rows: input.apiRows,
+        api_truncated: input.apiTruncated,
         pr_changed_files: pr.changed_files,
         pr_number: pr.number,
         head_sha: pr.head.sha,
         head_ref: pr.head.ref,
         base_ref: pr.base.ref,
-        // Queue branches carry the cumulative batch diff and page far more than a human
-        // pull request, so they are the population worth reading separately.
         branch_class: pr.head.ref.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
         is_fork: ((_a = pr.head.repo) === null || _a === void 0 ? void 0 : _a.full_name) !== repo,
         duration_ms: durationMs,
@@ -43250,7 +43199,6 @@ async function capture(apiKey, result, pr, apiRows, durationMs) {
             distinct_id: repo || 'paths-filter-shadow',
             properties
         }),
-        // Whatever the comparison did not spend, so the step's ceiling stays the budget.
         signal: AbortSignal.timeout(Math.max(CAPTURE_FLOOR_MS, BUDGET_MS - durationMs))
     });
     if (!res.ok) {
@@ -43268,14 +43216,10 @@ function summarize(result) {
     }
     return `match (${result.apiCount} files)`;
 }
-// Never throws: the filter's real answer is already computed by the time this runs,
-// so nothing here is worth failing a CI job over.
-//
-// The token gates the comparison itself, not just the capture. Every workflow that
-// detects changes runs this action, so a comparison whose result cannot be recorded
-// is a merge-ref fetch on the critical path of a gate job in exchange for a log line
-// nobody reads. Fork pull requests get no secrets, so they take this path too.
-async function report(filter, apiFiles, apiRows, pr) {
+// Never throws: the filter's real answer is already computed by the time this runs. The
+// token gates the comparison itself, so a run that cannot record its result does not pay
+// for a merge-ref fetch. Fork pull requests get no secrets and take that path too.
+async function report(input) {
     const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
     if (!apiKey) {
         return;
@@ -43283,12 +43227,12 @@ async function report(filter, apiFiles, apiRows, pr) {
     try {
         core.startGroup('Shadow: merge-commit change detection');
         const startedAt = Date.now();
-        const result = await compareWithMergeCommit(filter, apiFiles, pr);
+        const result = await compareWithMergeCommit(input);
         const durationMs = Date.now() - startedAt;
-        // core.info even for a mismatch: a warning becomes an annotation on the run summary
-        // and the checks page, which reads as a problem with the pull request.
+        // core.info even for a mismatch, because a warning becomes an annotation on the
+        // checks page and reads as a problem with the pull request.
         core.info(`shadow: ${summarize(result)} in ${durationMs}ms`);
-        await capture(apiKey, result, pr, apiRows, durationMs).catch(error => {
+        await capture(apiKey, input, result, durationMs).catch(error => {
             core.info(`shadow: capture skipped (${messageOf(error)})`);
         });
     }

--- a/.depot/actions/paths-filter/src/filter.ts
+++ b/.depot/actions/paths-filter/src/filter.ts
@@ -38,6 +38,12 @@ export interface FilterResults {
   [key: string]: File[]
 }
 
+// A key gates a job on whether any file matched it, so its answer is `length > 0` and
+// nothing finer. Both the action's outputs and the shadow comparison read it through here.
+export function firedKeys(results: FilterResults): Set<string> {
+  return new Set(Object.keys(results).filter(key => results[key].length > 0))
+}
+
 export class Filter {
   rules: {[key: string]: FilterRuleItem[]} = {}
 

--- a/.depot/actions/paths-filter/src/main.ts
+++ b/.depot/actions/paths-filter/src/main.ts
@@ -4,7 +4,7 @@ import * as github from '@actions/github'
 import {GetResponseDataTypeFromEndpointMethod} from '@octokit/types'
 import {PullRequest, PushEvent} from '@octokit/webhooks-types'
 
-import {Filter, FilterResults} from './filter'
+import {Filter, FilterResults, firedKeys} from './filter'
 import {File, ChangeStatus} from './file'
 import * as git from './git'
 import * as shadow from './shadow'
@@ -34,10 +34,13 @@ async function run(): Promise<void> {
     }
 
     const filter = new Filter(filtersYaml)
-    const files = await getChangedFiles(filter, token, base, ref, initialFetchDepth)
+    const {files, api} = await getChangedFiles(token, base, ref, initialFetchDepth)
     core.info(`Detected ${files.length} changed files`)
     const results = filter.match(files)
     exportResults(results, listFiles)
+    if (api) {
+      await shadow.report({filter, apiFiles: files, apiResults: results, ...api})
+    }
   } catch (error) {
     core.setFailed(getErrorMessage(error))
   }
@@ -59,20 +62,27 @@ function getConfigFileContent(configPath: string): string {
   return fs.readFileSync(configPath, {encoding: 'utf8'})
 }
 
+// `api` is present only when the list came from the pull request files API, and carries
+// what the shadow comparison needs to describe that call. The shadow runs from `run()`,
+// which already holds the filter and its results, so detection stays free of it.
+interface ChangedFiles {
+  files: File[]
+  api?: {apiRows: number; apiTruncated: boolean; pr: PullRequest}
+}
+
 async function getChangedFiles(
-  filter: Filter,
   token: string,
   base: string,
   ref: string,
   initialFetchDepth: number
-): Promise<File[]> {
+): Promise<ChangedFiles> {
   // if base is 'HEAD' only local uncommitted changes will be detected
   // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
   if (base === git.HEAD) {
     if (ref) {
       core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`)
     }
-    return await git.getChangesOnHead()
+    return {files: await git.getChangesOnHead()}
   }
 
   switch (github.context.eventName) {
@@ -90,9 +100,8 @@ async function getChangedFiles(
       }
       const pr = github.context.payload.pull_request as PullRequest
       if (token) {
-        const {files: apiFiles, rows} = await getChangedFilesFromApi(token, pr)
-        await shadow.report(filter, apiFiles, rows, pr)
-        return apiFiles
+        const {files, apiRows, apiTruncated} = await getChangedFilesFromApi(token, pr)
+        return {files, api: {apiRows, apiTruncated, pr}}
       }
       if (github.context.eventName === 'pull_request_target') {
         // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
@@ -104,11 +113,11 @@ async function getChangedFiles(
       const baseSha = github.context.payload.pull_request?.base.sha
       const defaultBranch = github.context.payload.repository?.default_branch
       const currentRef = await git.getCurrentRef()
-      return await git.getChanges(base || baseSha || defaultBranch, currentRef)
+      return {files: await git.getChanges(base || baseSha || defaultBranch, currentRef)}
     }
   }
 
-  return getChangedFilesFromGit(base, ref, initialFetchDepth)
+  return {files: await getChangedFilesFromGit(base, ref, initialFetchDepth)}
 }
 
 async function getChangedFilesFromGit(base: string, head: string, initialFetchDepth: number): Promise<File[]> {
@@ -173,17 +182,21 @@ async function getChangedFilesFromGit(base: string, head: string, initialFetchDe
   return await git.getChangesSinceMergeBase(base, head, initialFetchDepth)
 }
 
+// The API truncates at this many rows and says nothing when it does.
+const API_FILE_CAP = 3000
+
 // Uses github REST api to get list of files changed in PR
-// `rows` counts what the API returned rather than what `files` holds, because a renamed
-// row expands into two entries below. The API caps the response at 3,000 rows and says
-// nothing when it does, so the row count is the only tell that the list is partial.
-async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): Promise<{files: File[]; rows: number}> {
+// Truncation is judged on API rows, not on `files`, which expands a rename into two.
+async function getChangedFilesFromApi(
+  token: string,
+  pullRequest: PullRequest
+): Promise<{files: File[]; apiRows: number; apiTruncated: boolean}> {
   core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`)
   try {
     const client = github.getOctokit(token)
     const per_page = 100
     const files: File[] = []
-    let rows = 0
+    let apiRows = 0
 
     core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`)
     for await (const response of client.paginate.iterator(
@@ -200,7 +213,7 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       core.info(`Received ${response.data.length} items`)
 
       for (const row of response.data as GetResponseDataTypeFromEndpointMethod<typeof client.rest.pulls.listFiles>) {
-        rows++
+        apiRows++
         core.info(`[${row.status}] ${row.filename}`)
         // There's no obvious use-case for detection of renames
         // Therefore we treat it as if rename detection in git diff was turned off.
@@ -226,7 +239,7 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       }
     }
 
-    return {files, rows}
+    return {files, apiRows, apiTruncated: apiRows >= API_FILE_CAP}
   } finally {
     core.endGroup()
   }
@@ -234,12 +247,11 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
 
 function exportResults(results: FilterResults, format: ExportFormat): void {
   core.info('Results:')
-  const changes = []
+  const fired = firedKeys(results)
   for (const [key, files] of Object.entries(results)) {
-    const value = files.length > 0
+    const value = fired.has(key)
     core.startGroup(`Filter ${key} = ${value}`)
-    if (files.length > 0) {
-      changes.push(key)
+    if (value) {
       core.info('Matching files:')
       for (const file of files) {
         core.info(`${file.filename} [${file.status}]`)
@@ -258,7 +270,7 @@ function exportResults(results: FilterResults, format: ExportFormat): void {
   }
 
   if (results['changes'] === undefined) {
-    const changesJson = JSON.stringify(changes)
+    const changesJson = JSON.stringify([...fired])
     core.info(`Changes output set to ${changesJson}`)
     core.setOutput('changes', changesJson)
   } else {

--- a/.depot/actions/paths-filter/src/main.ts
+++ b/.depot/actions/paths-filter/src/main.ts
@@ -34,7 +34,7 @@ async function run(): Promise<void> {
     }
 
     const filter = new Filter(filtersYaml)
-    const files = await getChangedFiles(token, base, ref, initialFetchDepth)
+    const files = await getChangedFiles(filter, token, base, ref, initialFetchDepth)
     core.info(`Detected ${files.length} changed files`)
     const results = filter.match(files)
     exportResults(results, listFiles)
@@ -59,7 +59,13 @@ function getConfigFileContent(configPath: string): string {
   return fs.readFileSync(configPath, {encoding: 'utf8'})
 }
 
-async function getChangedFiles(token: string, base: string, ref: string, initialFetchDepth: number): Promise<File[]> {
+async function getChangedFiles(
+  filter: Filter,
+  token: string,
+  base: string,
+  ref: string,
+  initialFetchDepth: number
+): Promise<File[]> {
   // if base is 'HEAD' only local uncommitted changes will be detected
   // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
   if (base === git.HEAD) {
@@ -84,8 +90,8 @@ async function getChangedFiles(token: string, base: string, ref: string, initial
       }
       const pr = github.context.payload.pull_request as PullRequest
       if (token) {
-        const apiFiles = await getChangedFilesFromApi(token, pr)
-        await shadow.report(apiFiles, pr)
+        const {files: apiFiles, rows} = await getChangedFilesFromApi(token, pr)
+        await shadow.report(filter, apiFiles, rows, pr)
         return apiFiles
       }
       if (github.context.eventName === 'pull_request_target') {
@@ -168,12 +174,16 @@ async function getChangedFilesFromGit(base: string, head: string, initialFetchDe
 }
 
 // Uses github REST api to get list of files changed in PR
-async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): Promise<File[]> {
+// `rows` counts what the API returned rather than what `files` holds, because a renamed
+// row expands into two entries below. The API caps the response at 3,000 rows and says
+// nothing when it does, so the row count is the only tell that the list is partial.
+async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): Promise<{files: File[]; rows: number}> {
   core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`)
   try {
     const client = github.getOctokit(token)
     const per_page = 100
     const files: File[] = []
+    let rows = 0
 
     core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`)
     for await (const response of client.paginate.iterator(
@@ -190,6 +200,7 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       core.info(`Received ${response.data.length} items`)
 
       for (const row of response.data as GetResponseDataTypeFromEndpointMethod<typeof client.rest.pulls.listFiles>) {
+        rows++
         core.info(`[${row.status}] ${row.filename}`)
         // There's no obvious use-case for detection of renames
         // Therefore we treat it as if rename detection in git diff was turned off.
@@ -215,7 +226,7 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       }
     }
 
-    return files
+    return {files, rows}
   } finally {
     core.endGroup()
   }

--- a/.depot/actions/paths-filter/src/shadow.ts
+++ b/.depot/actions/paths-filter/src/shadow.ts
@@ -5,7 +5,8 @@ import * as path from 'path'
 import * as core from '@actions/core'
 import {PullRequest} from '@octokit/webhooks-types'
 
-import {File} from './file'
+import {File, ChangeStatus} from './file'
+import {Filter} from './filter'
 
 // Compares the API's changed-file list against the same list derived locally from
 // the pull request's merge commit, and reports disagreement without acting on it.
@@ -74,6 +75,10 @@ interface ShadowResult {
   gitCount: number | null
   onlyInApi: Difference
   onlyInGit: Difference
+  // Which filter keys answer differently on the two file lists. A differing file list
+  // only matters where it flips a key, because the key is what gates a job.
+  keysLost: string[]
+  keysGained: string[]
 }
 
 interface GitResult {
@@ -137,7 +142,32 @@ function originUrl(): string {
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
-async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<string[]> {
+// git reports a type change as T, which is a content change like any other to a filter.
+// R and C are unreachable under --no-renames and are mapped so a future caller without
+// that flag still gets a status rather than the fallback.
+const STATUS_OF: {[letter: string]: ChangeStatus} = {
+  A: ChangeStatus.Added,
+  C: ChangeStatus.Copied,
+  D: ChangeStatus.Deleted,
+  M: ChangeStatus.Modified,
+  R: ChangeStatus.Renamed,
+  T: ChangeStatus.Modified,
+  U: ChangeStatus.Unmerged
+}
+
+// -z --name-status emits a status field and a path field per entry, each NUL-terminated.
+// A status carries a similarity score for R and C, which --no-renames rules out, so the
+// first character is the whole status here.
+function parseNameStatus(out: string): File[] {
+  const fields = out.split('\0').filter(Boolean)
+  const files: File[] = []
+  for (let i = 0; i + 1 < fields.length; i += 2) {
+    files.push({filename: fields[i + 1], status: STATUS_OF[fields[i][0]] || ChangeStatus.Modified})
+  }
+  return files
+}
+
+async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<File[]> {
   const gitDir = await scratchRepo(signal)
 
   const fetched = await git(
@@ -171,12 +201,14 @@ async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<
 
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
   // the API path builds by hand from `previous_filename`. -z because git quotes a
-  // path holding a newline or a non-ASCII byte in the default format.
-  const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
+  // path holding a newline or a non-ASCII byte in the default format. --name-status
+  // because a filter rule can scope itself to a change status, so a comparison that
+  // guessed one would answer a different question than the filter asks.
+  const diff = await git(gitDir, ['diff', '--no-renames', '--name-status', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
   if (diff.code !== 0) {
     throw new Unavailable('diff-failed', firstLine(diff.err))
   }
-  return diff.out.split('\0').filter(Boolean)
+  return parseNameStatus(diff.out)
 }
 
 // A queue branch can differ by thousands of paths, which is neither readable in a log
@@ -197,9 +229,23 @@ function difference(from: Set<string>, against: Set<string>): Difference {
   return {count, sample}
 }
 
-function compare(api: Set<string>, local: Set<string>): ShadowResult {
+// A filter key gates a job on whether any changed file matched it, so the key's answer
+// is `length > 0` and nothing finer. `exportResults` reads it the same way.
+function firedKeys(filter: Filter, files: File[]): Set<string> {
+  return new Set(
+    Object.entries(filter.match(files))
+      .filter(([, matched]) => matched.length > 0)
+      .map(([key]) => key)
+  )
+}
+
+function compare(filter: Filter, apiFiles: File[], gitFiles: File[]): ShadowResult {
+  const api = new Set(apiFiles.map(f => f.filename))
+  const local = new Set(gitFiles.map(f => f.filename))
   const onlyInApi = difference(api, local)
   const onlyInGit = difference(local, api)
+  const apiKeys = firedKeys(filter, apiFiles)
+  const gitKeys = firedKeys(filter, gitFiles)
   return {
     verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
     reason: null,
@@ -207,7 +253,9 @@ function compare(api: Set<string>, local: Set<string>): ShadowResult {
     apiCount: api.size,
     gitCount: local.size,
     onlyInApi,
-    onlyInGit
+    onlyInGit,
+    keysLost: [...apiKeys].filter(k => !gitKeys.has(k)).sort(),
+    keysGained: [...gitKeys].filter(k => !apiKeys.has(k)).sort()
   }
 }
 
@@ -223,27 +271,34 @@ async function budgeted<T>(work: (signal: AbortSignal) => Promise<T>, ms: number
   return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer))
 }
 
-export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
-  const api = new Set(apiFiles.map(f => f.filename))
+export async function compareWithMergeCommit(filter: Filter, apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
   try {
     const gitFiles = await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS)
-    return compare(api, new Set(gitFiles))
+    return compare(filter, apiFiles, gitFiles)
   } catch (error) {
     return {
       verdict: 'unavailable',
       reason: error instanceof Unavailable ? error.reason : 'unknown',
       detail: error instanceof Unavailable ? error.detail : messageOf(error),
-      apiCount: api.size,
+      apiCount: new Set(apiFiles.map(f => f.filename)).size,
       gitCount: null,
       onlyInApi: {count: 0, sample: []},
-      onlyInGit: {count: 0, sample: []}
+      onlyInGit: {count: 0, sample: []},
+      keysLost: [],
+      keysGained: []
     }
   }
 }
 
 // Without this the only record of a divergence is a log line in one job of one run,
 // which is unreadable at the volume that makes the comparison worth running.
-async function capture(apiKey: string, result: ShadowResult, pr: PullRequest, durationMs: number): Promise<void> {
+async function capture(
+  apiKey: string,
+  result: ShadowResult,
+  pr: PullRequest,
+  apiRows: number,
+  durationMs: number
+): Promise<void> {
   const repo = process.env.GITHUB_REPOSITORY || null
   const properties = {
     repo,
@@ -256,11 +311,17 @@ async function capture(apiKey: string, result: ShadowResult, pr: PullRequest, du
     only_in_api_count: result.onlyInApi.count,
     only_in_git: result.onlyInGit.sample,
     only_in_git_count: result.onlyInGit.count,
-    // pulls/{n}/files truncates silently, so record both sides of the tell: what the
-    // API returned, and what the pull request payload says it should have been. The
-    // count has to come from the payload, because `api_count` counts a rename twice:
-    // the API path expands each renamed row into an add plus a delete.
-    api_truncated: pr.changed_files >= API_FILE_CAP,
+    selection_changed: result.keysLost.length > 0 || result.keysGained.length > 0,
+    keys_lost: result.keysLost,
+    keys_gained: result.keysGained,
+    // pulls/{n}/files truncates silently at the cap, and the cap counts API rows, so
+    // the tell is how many rows came back. `api_count` cannot stand in: the API path
+    // expands each renamed row into an add plus a delete.
+    api_rows: apiRows,
+    api_truncated: apiRows >= API_FILE_CAP,
+    // Kept beside `api_rows` rather than used as the tell, because the payload's count
+    // is computed when the event fires and reads stale on a pull request whose base
+    // moved. The two disagreeing is itself worth seeing.
     pr_changed_files: pr.changed_files,
     pr_number: pr.number,
     head_sha: pr.head.sha,
@@ -300,7 +361,8 @@ function summarize(result: ShadowResult): string {
   if (result.verdict === 'mismatch') {
     return (
       `MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
-      `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)}`
+      `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)} ` +
+      `keysLost=${JSON.stringify(result.keysLost)} keysGained=${JSON.stringify(result.keysGained)}`
     )
   }
   return `match (${result.apiCount} files)`
@@ -313,7 +375,7 @@ function summarize(result: ShadowResult): string {
 // detects changes runs this action, so a comparison whose result cannot be recorded
 // is a merge-ref fetch on the critical path of a gate job in exchange for a log line
 // nobody reads. Fork pull requests get no secrets, so they take this path too.
-export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
+export async function report(filter: Filter, apiFiles: File[], apiRows: number, pr: PullRequest): Promise<void> {
   const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
   if (!apiKey) {
     return
@@ -321,14 +383,14 @@ export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
   try {
     core.startGroup('Shadow: merge-commit change detection')
     const startedAt = Date.now()
-    const result = await compareWithMergeCommit(apiFiles, pr)
+    const result = await compareWithMergeCommit(filter, apiFiles, pr)
     const durationMs = Date.now() - startedAt
 
     // core.info even for a mismatch: a warning becomes an annotation on the run summary
     // and the checks page, which reads as a problem with the pull request.
     core.info(`shadow: ${summarize(result)} in ${durationMs}ms`)
 
-    await capture(apiKey, result, pr, durationMs).catch(error => {
+    await capture(apiKey, result, pr, apiRows, durationMs).catch(error => {
       core.info(`shadow: capture skipped (${messageOf(error)})`)
     })
   } catch (error) {

--- a/.depot/actions/paths-filter/src/shadow.ts
+++ b/.depot/actions/paths-filter/src/shadow.ts
@@ -5,47 +5,34 @@ import * as path from 'path'
 import * as core from '@actions/core'
 import {PullRequest} from '@octokit/webhooks-types'
 
-import {File, ChangeStatus} from './file'
-import {Filter} from './filter'
+import {File} from './file'
+import {Filter, FilterResults, firedKeys} from './filter'
+import {parseGitDiffOutput} from './git'
 
-// Compares the API's changed-file list against the same list derived locally from
-// the pull request's merge commit, and reports disagreement without acting on it.
-// The API result stays authoritative, so a wrong local answer can only produce a
-// log line. Removing the API call later is only safe once this has run quiet
-// across the shapes no offline sample can reach: very large diffs, and ones GitHub
-// has not finished computing a merge ref for.
-//
-// Detecting changes from `base.sha..HEAD` instead reports every commit the branch
-// picked up when the base was merged into it as the pull request's own work, which
-// is wrong by thousands of files on a branch that has taken master in. The merge
-// commit's first parent is the base GitHub actually merged against, so
-// `HEAD^1..HEAD` is the pull request's own changes and matches the API.
+// Compares the API's changed-file list against the same list derived from the pull
+// request's merge commit, and reports disagreement without acting on it. The API
+// result stays authoritative, so a wrong local answer can only produce a log line.
 
 const MERGE_REF_FETCH_DEPTH = 2
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 const EVENT_NAME = 'paths_filter_shadow_compared'
 
 // A change-detection job is on the critical path of every workflow, so the comparison
-// and the capture that follows it share one wall-clock budget, and give up rather than
-// holding the job to its timeout-minutes. The git-level low-speed settings cover a
-// stalled transfer; the budget covers everything else.
+// and its capture share one wall-clock budget rather than holding the job to its
+// timeout-minutes.
 const BUDGET_MS = 20000
 const CAPTURE_FLOOR_MS = 500
 const LIST_CAP = 50
 
-// A queue branch carries the cumulative batch diff, so the path list can be far larger
-// than a human pull request's. execFile's 1 MB default would fail those as a diff error,
-// which drops the population the comparison most needs to measure.
+// A queue branch carries the cumulative batch diff, which execFile's 1 MB default would
+// fail as a diff error.
 const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024
 const DETAIL_CAP = 200
 
-// The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
-const API_FILE_CAP = 3000
-
 type Verdict = 'match' | 'mismatch' | 'unavailable'
 
-// A closed set, because this is the field the comparison is grouped by once the events
-// land. Git's own words go in `detail`, which is free text and unbounded.
+// Closed, because this is the field the events are grouped by. Git's own words go in
+// `detail`, which is unbounded.
 type Reason =
   | 'no-scratch-repo'
   | 'no-origin-url'
@@ -75,10 +62,17 @@ interface ShadowResult {
   gitCount: number | null
   onlyInApi: Difference
   onlyInGit: Difference
-  // Which filter keys answer differently on the two file lists. A differing file list
-  // only matters where it flips a key, because the key is what gates a job.
   keysLost: string[]
   keysGained: string[]
+}
+
+export interface ShadowInput {
+  filter: Filter
+  apiFiles: File[]
+  apiResults: FilterResults
+  apiRows: number
+  apiTruncated: boolean
+  pr: PullRequest
 }
 
 interface GitResult {
@@ -87,21 +81,16 @@ interface GitResult {
   err: string
 }
 
-// Every git call that reads or writes history names the scratch repository. `--depth`
-// and `--filter` rewrite `.git/shallow` and the promisor config of whatever repository
-// they run in, and steps later in the same job read history from the workspace checkout:
-// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>` after
-// this action returns, and an empty merge base there silently drops their schema cache.
+// `--depth` and `--filter` rewrite `.git/shallow` and the promisor config of whatever
+// repository they run in, so every call names the scratch repository. ci-dagster and
+// ci-e2e-playwright read history from the workspace checkout after this action returns.
 async function git(gitDir: string, args: string[], signal: AbortSignal): Promise<GitResult> {
   return run(['--git-dir', gitDir, ...args], signal)
 }
 
-// The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
-// on the child process, so a fetch the budget gave up on keeps running and holds the
-// action's process open until it finishes, past the budget it was supposed to obey.
-//
-// stdout is returned raw. A caller that reads a path list must not trim it, because a
-// tracked path can begin with a space, and that path sorts first in the -z output.
+// execFile rather than `@actions/exec`, which gives no handle on the child process, so a
+// fetch the budget gave up on would hold the action open until it finished. stdout is
+// returned raw because a tracked path can begin with a space.
 async function run(args: string[], signal: AbortSignal): Promise<GitResult> {
   return new Promise(resolve => {
     execFile('git', args, {signal, maxBuffer: MAX_GIT_OUTPUT_BYTES}, (error, stdout, stderr) => {
@@ -118,6 +107,10 @@ function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function missing(from: Set<string>, against: Set<string>): string[] {
+  return [...from].filter(key => !against.has(key)).sort()
+}
+
 async function scratchRepo(signal: AbortSignal): Promise<string> {
   const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
   const init = await run(['init', '--bare', '--quiet', gitDir], signal)
@@ -127,9 +120,8 @@ async function scratchRepo(signal: AbortSignal): Promise<string> {
   return gitDir
 }
 
-// The workspace remote carries no credentials of its own: actions/checkout keeps the
-// token in an http.extraheader the scratch repository does not inherit. A private
-// remote therefore reports unavailable rather than comparing against a partial fetch.
+// actions/checkout keeps the token in an http.extraheader the scratch repository does not
+// inherit, so a private remote reports unavailable rather than comparing a partial fetch.
 function originUrl(): string {
   const server = process.env.GITHUB_SERVER_URL
   const repo = process.env.GITHUB_REPOSITORY
@@ -137,34 +129,6 @@ function originUrl(): string {
     throw new Unavailable('no-origin-url', 'GITHUB_SERVER_URL or GITHUB_REPOSITORY is unset')
   }
   return `${server}/${repo}`
-}
-
-// The merge ref is not guaranteed to be present or current: GitHub recomputes it
-// asynchronously after a push. Requiring the second parent to equal the head SHA
-// rejects a stale ref rather than reading it as this pull request's changes.
-// git reports a type change as T, which is a content change like any other to a filter.
-// R and C are unreachable under --no-renames and are mapped so a future caller without
-// that flag still gets a status rather than the fallback.
-const STATUS_OF: {[letter: string]: ChangeStatus} = {
-  A: ChangeStatus.Added,
-  C: ChangeStatus.Copied,
-  D: ChangeStatus.Deleted,
-  M: ChangeStatus.Modified,
-  R: ChangeStatus.Renamed,
-  T: ChangeStatus.Modified,
-  U: ChangeStatus.Unmerged
-}
-
-// -z --name-status emits a status field and a path field per entry, each NUL-terminated.
-// A status carries a similarity score for R and C, which --no-renames rules out, so the
-// first character is the whole status here.
-function parseNameStatus(out: string): File[] {
-  const fields = out.split('\0').filter(Boolean)
-  const files: File[] = []
-  for (let i = 0; i + 1 < fields.length; i += 2) {
-    files.push({filename: fields[i + 1], status: STATUS_OF[fields[i][0]] || ChangeStatus.Modified})
-  }
-  return files
 }
 
 async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<File[]> {
@@ -194,26 +158,23 @@ async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<
   if (head.code !== 0) {
     throw new Unavailable('no-second-parent', firstLine(head.err))
   }
+  // GitHub recomputes the merge ref asynchronously after a push, so a ref whose second
+  // parent is not the head SHA describes an earlier push.
   const headSha = head.out.trim()
   if (headSha !== pr.head.sha) {
     throw new Unavailable('stale-merge-ref', `^2=${headSha.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)}`)
   }
 
-  // --no-renames so a rename arrives as a delete plus an add, which is the shape
-  // the API path builds by hand from `previous_filename`. -z because git quotes a
-  // path holding a newline or a non-ASCII byte in the default format. --name-status
-  // because a filter rule can scope itself to a change status, so a comparison that
-  // guessed one would answer a different question than the filter asks.
+  // The same flags the action's own git path uses, so the comparison measures what
+  // dropping the API call would select. --no-renames matches the add-plus-delete shape
+  // the API path builds from `previous_filename`.
   const diff = await git(gitDir, ['diff', '--no-renames', '--name-status', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
   if (diff.code !== 0) {
     throw new Unavailable('diff-failed', firstLine(diff.err))
   }
-  return parseNameStatus(diff.out)
+  return parseGitDiffOutput(diff.out)
 }
 
-// A queue branch can differ by thousands of paths, which is neither readable in a log
-// line nor worth carrying as an event property. The count answers how far apart the two
-// answers are, and the sample answers what kind of path is involved.
 function difference(from: Set<string>, against: Set<string>): Difference {
   const sample: string[] = []
   let count = 0
@@ -229,23 +190,12 @@ function difference(from: Set<string>, against: Set<string>): Difference {
   return {count, sample}
 }
 
-// A filter key gates a job on whether any changed file matched it, so the key's answer
-// is `length > 0` and nothing finer. `exportResults` reads it the same way.
-function firedKeys(filter: Filter, files: File[]): Set<string> {
-  return new Set(
-    Object.entries(filter.match(files))
-      .filter(([, matched]) => matched.length > 0)
-      .map(([key]) => key)
-  )
-}
-
-function compare(filter: Filter, apiFiles: File[], gitFiles: File[]): ShadowResult {
-  const api = new Set(apiFiles.map(f => f.filename))
+function compare(input: ShadowInput, api: Set<string>, gitFiles: File[]): ShadowResult {
   const local = new Set(gitFiles.map(f => f.filename))
   const onlyInApi = difference(api, local)
   const onlyInGit = difference(local, api)
-  const apiKeys = firedKeys(filter, apiFiles)
-  const gitKeys = firedKeys(filter, gitFiles)
+  const apiKeys = firedKeys(input.apiResults)
+  const gitKeys = firedKeys(input.filter.match(gitFiles))
   return {
     verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
     reason: null,
@@ -254,8 +204,8 @@ function compare(filter: Filter, apiFiles: File[], gitFiles: File[]): ShadowResu
     gitCount: local.size,
     onlyInApi,
     onlyInGit,
-    keysLost: [...apiKeys].filter(k => !gitKeys.has(k)).sort(),
-    keysGained: [...gitKeys].filter(k => !apiKeys.has(k)).sort()
+    keysLost: missing(apiKeys, gitKeys),
+    keysGained: missing(gitKeys, apiKeys)
   }
 }
 
@@ -271,16 +221,17 @@ async function budgeted<T>(work: (signal: AbortSignal) => Promise<T>, ms: number
   return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer))
 }
 
-export async function compareWithMergeCommit(filter: Filter, apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
+export async function compareWithMergeCommit(input: ShadowInput): Promise<ShadowResult> {
+  const api = new Set(input.apiFiles.map(f => f.filename))
   try {
-    const gitFiles = await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS)
-    return compare(filter, apiFiles, gitFiles)
+    const gitFiles = await budgeted(async signal => localChangedFiles(input.pr, signal), BUDGET_MS)
+    return compare(input, api, gitFiles)
   } catch (error) {
     return {
       verdict: 'unavailable',
       reason: error instanceof Unavailable ? error.reason : 'unknown',
       detail: error instanceof Unavailable ? error.detail : messageOf(error),
-      apiCount: new Set(apiFiles.map(f => f.filename)).size,
+      apiCount: api.size,
       gitCount: null,
       onlyInApi: {count: 0, sample: []},
       onlyInGit: {count: 0, sample: []},
@@ -290,16 +241,9 @@ export async function compareWithMergeCommit(filter: Filter, apiFiles: File[], p
   }
 }
 
-// Without this the only record of a divergence is a log line in one job of one run,
-// which is unreadable at the volume that makes the comparison worth running.
-async function capture(
-  apiKey: string,
-  result: ShadowResult,
-  pr: PullRequest,
-  apiRows: number,
-  durationMs: number
-): Promise<void> {
+async function capture(apiKey: string, input: ShadowInput, result: ShadowResult, durationMs: number): Promise<void> {
   const repo = process.env.GITHUB_REPOSITORY || null
+  const pr = input.pr
   const properties = {
     repo,
     verdict: result.verdict,
@@ -314,21 +258,15 @@ async function capture(
     selection_changed: result.keysLost.length > 0 || result.keysGained.length > 0,
     keys_lost: result.keysLost,
     keys_gained: result.keysGained,
-    // pulls/{n}/files truncates silently at the cap, and the cap counts API rows, so
-    // the tell is how many rows came back. `api_count` cannot stand in: the API path
-    // expands each renamed row into an add plus a delete.
-    api_rows: apiRows,
-    api_truncated: apiRows >= API_FILE_CAP,
-    // Kept beside `api_rows` rather than used as the tell, because the payload's count
-    // is computed when the event fires and reads stale on a pull request whose base
-    // moved. The two disagreeing is itself worth seeing.
+    // `pr_changed_files` reads stale on a pull request whose base moved, so it is
+    // recorded beside the API's own row count rather than used as the truncation tell.
+    api_rows: input.apiRows,
+    api_truncated: input.apiTruncated,
     pr_changed_files: pr.changed_files,
     pr_number: pr.number,
     head_sha: pr.head.sha,
     head_ref: pr.head.ref,
     base_ref: pr.base.ref,
-    // Queue branches carry the cumulative batch diff and page far more than a human
-    // pull request, so they are the population worth reading separately.
     branch_class: pr.head.ref.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
     is_fork: pr.head.repo?.full_name !== repo,
     duration_ms: durationMs,
@@ -346,7 +284,6 @@ async function capture(
       distinct_id: repo || 'paths-filter-shadow',
       properties
     }),
-    // Whatever the comparison did not spend, so the step's ceiling stays the budget.
     signal: AbortSignal.timeout(Math.max(CAPTURE_FLOOR_MS, BUDGET_MS - durationMs))
   })
   if (!res.ok) {
@@ -368,14 +305,10 @@ function summarize(result: ShadowResult): string {
   return `match (${result.apiCount} files)`
 }
 
-// Never throws: the filter's real answer is already computed by the time this runs,
-// so nothing here is worth failing a CI job over.
-//
-// The token gates the comparison itself, not just the capture. Every workflow that
-// detects changes runs this action, so a comparison whose result cannot be recorded
-// is a merge-ref fetch on the critical path of a gate job in exchange for a log line
-// nobody reads. Fork pull requests get no secrets, so they take this path too.
-export async function report(filter: Filter, apiFiles: File[], apiRows: number, pr: PullRequest): Promise<void> {
+// Never throws: the filter's real answer is already computed by the time this runs. The
+// token gates the comparison itself, so a run that cannot record its result does not pay
+// for a merge-ref fetch. Fork pull requests get no secrets and take that path too.
+export async function report(input: ShadowInput): Promise<void> {
   const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
   if (!apiKey) {
     return
@@ -383,14 +316,14 @@ export async function report(filter: Filter, apiFiles: File[], apiRows: number, 
   try {
     core.startGroup('Shadow: merge-commit change detection')
     const startedAt = Date.now()
-    const result = await compareWithMergeCommit(filter, apiFiles, pr)
+    const result = await compareWithMergeCommit(input)
     const durationMs = Date.now() - startedAt
 
-    // core.info even for a mismatch: a warning becomes an annotation on the run summary
-    // and the checks page, which reads as a problem with the pull request.
+    // core.info even for a mismatch, because a warning becomes an annotation on the
+    // checks page and reads as a problem with the pull request.
     core.info(`shadow: ${summarize(result)} in ${durationMs}ms`)
 
-    await capture(apiKey, result, pr, apiRows, durationMs).catch(error => {
+    await capture(apiKey, input, result, durationMs).catch(error => {
       core.info(`shadow: capture skipped (${messageOf(error)})`)
     })
   } catch (error) {

--- a/.github/actions/paths-filter/README.md
+++ b/.github/actions/paths-filter/README.md
@@ -81,6 +81,10 @@ Without the variable the action does no extra work. Set it in one workflow that 
 every pull request; that keeps the merge-ref fetch off the critical path of the other
 gating jobs. This is temporary, and goes away with the decision it exists to inform.
 
+The event carries the differing paths and, in `selection_changed` and `keys_lost`, which
+filter keys answer differently on the two lists. The keys are what gate a job, so they are
+what the decision reads; the paths are there to explain a flip.
+
 ## Rebuilding after source changes
 
 The action runs the committed `dist/index.js` bundle. After editing anything under `src/`,

--- a/.github/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.github/actions/paths-filter/__tests__/shadow.test.ts
@@ -1,8 +1,8 @@
 import {PullRequest} from '@octokit/webhooks-types'
 
-import {ChangeStatus} from '../src/file'
+import {ChangeStatus, File} from '../src/file'
 import {Filter} from '../src/filter'
-import {compareWithMergeCommit} from '../src/shadow'
+import {ShadowInput, compareWithMergeCommit} from '../src/shadow'
 
 const cp = jest.requireMock('child_process') as {execFile: jest.Mock}
 
@@ -30,6 +30,19 @@ frontend:
   - 'frontend/**'
 `)
 
+// The action matches the API list once in `run()` and hands the result to the shadow, so
+// a test builds the same pairing here.
+function input(withFilter: Filter, apiFiles: File[]): ShadowInput {
+  return {
+    filter: withFilter,
+    apiFiles,
+    apiResults: withFilter.match(apiFiles),
+    apiRows: apiFiles.length,
+    apiTruncated: false,
+    pr: pullRequest
+  }
+}
+
 function stubGit(...stdouts: string[]): void {
   for (const stdout of stdouts) {
     cp.execFile.mockImplementationOnce((...args: ExecFileArgs) => args[3](null, stdout, ''))
@@ -48,15 +61,12 @@ describe('shadow merge-commit comparison', () => {
     cp.execFile.mockReset()
   })
 
-  // A git call that forgets the scratch dir runs against the job workspace, where a
-  // --depth or --filter fetch drops the schema cache of every later step in the job.
+  // A git call against the job workspace drops the schema cache of every later step.
   test('never runs git against the job workspace', async () => {
     stubGit('', '', HEAD, 'M\0posthog/a.py\0')
 
     const result = await compareWithMergeCommit(
-      filter,
-      [{filename: 'posthog/a.py', status: ChangeStatus.Modified}],
-      pullRequest
+      input(filter, [{filename: 'posthog/a.py', status: ChangeStatus.Modified}])
     )
 
     expect(result.verdict).toBe('match')
@@ -66,46 +76,39 @@ describe('shadow merge-commit comparison', () => {
     }
   })
 
-  // Losing this guard scores a merge ref from an earlier push as this pull request's
-  // changes, which fills the measurement with mismatches that mean nothing.
+  // Without this guard an earlier push's merge ref reads as this pull request's changes.
   test('refuses a stale merge ref instead of comparing against it', async () => {
     stubGit('', '', OTHER_SHA)
 
     const result = await compareWithMergeCommit(
-      filter,
-      [{filename: 'posthog/a.py', status: ChangeStatus.Modified}],
-      pullRequest
+      input(filter, [{filename: 'posthog/a.py', status: ChangeStatus.Modified}])
     )
 
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toBe('stale-merge-ref')
   })
 
-  // Losing --no-renames reports one path where the API path reports two, so every
-  // rename reads as a mismatch.
+  // Without --no-renames every rename reads as a mismatch.
   test('matches a rename that the API reported as two entries', async () => {
     stubGit('', '', HEAD, 'D\0posthog/old.py\0A\0posthog/new.py\0')
 
     const result = await compareWithMergeCommit(
-      filter,
-      [
+      input(filter, [
         {filename: 'posthog/new.py', status: ChangeStatus.Added},
         {filename: 'posthog/old.py', status: ChangeStatus.Deleted}
-      ],
-      pullRequest
+      ])
     )
 
     expect(result.verdict).toBe('match')
     expect(cp.execFile.mock.calls.map(c => c[1])).toContainEqual(expect.arrayContaining(['--no-renames']))
   })
 
-  // An exec with no handle on the child leaves the fetch running after the budget gives
-  // up, and the action's process stays open until git exits.
+  // Without a handle on the child, an abandoned fetch holds the action open until git exits.
   test('stops git when the budget expires', async () => {
     cp.execFile.mockImplementation(() => undefined)
     jest.useFakeTimers()
 
-    const pending = compareWithMergeCommit(filter, [], pullRequest)
+    const pending = compareWithMergeCommit(input(filter, []))
     await jest.advanceTimersByTimeAsync(PAST_ANY_BUDGET_MS)
     const result = await pending
 
@@ -116,9 +119,7 @@ describe('shadow merge-commit comparison', () => {
     jest.useRealTimers()
   })
 
-  // A differing file list is only worth acting on where it flips a key, because the key
-  // is what gates a job. Comparing the lists instead of the keys reports every dropped
-  // path as consequential, which is the reading this field exists to replace.
+  // Comparing the file lists instead of the keys reports every dropped path as consequential.
   test.each([
     ['the dropped path is the only one holding a key', 'M\0frontend/b.ts\0', ['backend']],
     ['a surviving path holds the same key', 'M\0posthog/b.py\0M\0frontend/b.ts\0', []]
@@ -126,13 +127,11 @@ describe('shadow merge-commit comparison', () => {
     stubGit('', '', HEAD, diff)
 
     const result = await compareWithMergeCommit(
-      filter,
-      [
+      input(filter, [
         {filename: 'posthog/a.py', status: ChangeStatus.Modified},
         {filename: 'posthog/b.py', status: ChangeStatus.Modified},
         {filename: 'frontend/b.ts', status: ChangeStatus.Modified}
-      ],
-      pullRequest
+      ])
     )
 
     expect(result.verdict).toBe('mismatch')
@@ -140,9 +139,7 @@ describe('shadow merge-commit comparison', () => {
     expect(result.keysGained).toEqual([])
   })
 
-  // --name-status emits a status field and a path field per entry. Reading them in the
-  // wrong order turns every path into a status letter, and a rule scoped to a status
-  // then answers on the wrong file.
+  // Reading the -z fields in the wrong order turns every path into a status letter.
   test('carries each file status through to a status-scoped rule', async () => {
     const scoped = new Filter(`
 added_only:
@@ -151,12 +148,10 @@ added_only:
     stubGit('', '', HEAD, 'A\0posthog/new.py\0D\0posthog/gone.py\0')
 
     const result = await compareWithMergeCommit(
-      scoped,
-      [
+      input(scoped, [
         {filename: 'posthog/new.py', status: ChangeStatus.Added},
         {filename: 'posthog/gone.py', status: ChangeStatus.Deleted}
-      ],
-      pullRequest
+      ])
     )
 
     expect(result.verdict).toBe('match')

--- a/.github/actions/paths-filter/__tests__/shadow.test.ts
+++ b/.github/actions/paths-filter/__tests__/shadow.test.ts
@@ -1,6 +1,7 @@
 import {PullRequest} from '@octokit/webhooks-types'
 
 import {ChangeStatus} from '../src/file'
+import {Filter} from '../src/filter'
 import {compareWithMergeCommit} from '../src/shadow'
 
 const cp = jest.requireMock('child_process') as {execFile: jest.Mock}
@@ -21,6 +22,13 @@ type ExecFileArgs = [
 ]
 
 const pullRequest = {number: 42, head: {sha: HEAD}} as PullRequest
+
+const filter = new Filter(`
+backend:
+  - 'posthog/**'
+frontend:
+  - 'frontend/**'
+`)
 
 function stubGit(...stdouts: string[]): void {
   for (const stdout of stdouts) {
@@ -43,9 +51,13 @@ describe('shadow merge-commit comparison', () => {
   // A git call that forgets the scratch dir runs against the job workspace, where a
   // --depth or --filter fetch drops the schema cache of every later step in the job.
   test('never runs git against the job workspace', async () => {
-    stubGit('', '', HEAD, 'a.ts\0')
+    stubGit('', '', HEAD, 'M\0posthog/a.py\0')
 
-    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
+    const result = await compareWithMergeCommit(
+      filter,
+      [{filename: 'posthog/a.py', status: ChangeStatus.Modified}],
+      pullRequest
+    )
 
     expect(result.verdict).toBe('match')
     expect(argvOf(0)).toContain(GIT_DIR)
@@ -59,7 +71,11 @@ describe('shadow merge-commit comparison', () => {
   test('refuses a stale merge ref instead of comparing against it', async () => {
     stubGit('', '', OTHER_SHA)
 
-    const result = await compareWithMergeCommit([{filename: 'a.ts', status: ChangeStatus.Modified}], pullRequest)
+    const result = await compareWithMergeCommit(
+      filter,
+      [{filename: 'posthog/a.py', status: ChangeStatus.Modified}],
+      pullRequest
+    )
 
     expect(result.verdict).toBe('unavailable')
     expect(result.reason).toBe('stale-merge-ref')
@@ -68,12 +84,13 @@ describe('shadow merge-commit comparison', () => {
   // Losing --no-renames reports one path where the API path reports two, so every
   // rename reads as a mismatch.
   test('matches a rename that the API reported as two entries', async () => {
-    stubGit('', '', HEAD, 'old.ts\0new.ts\0')
+    stubGit('', '', HEAD, 'D\0posthog/old.py\0A\0posthog/new.py\0')
 
     const result = await compareWithMergeCommit(
+      filter,
       [
-        {filename: 'new.ts', status: ChangeStatus.Added},
-        {filename: 'old.ts', status: ChangeStatus.Deleted}
+        {filename: 'posthog/new.py', status: ChangeStatus.Added},
+        {filename: 'posthog/old.py', status: ChangeStatus.Deleted}
       ],
       pullRequest
     )
@@ -88,7 +105,7 @@ describe('shadow merge-commit comparison', () => {
     cp.execFile.mockImplementation(() => undefined)
     jest.useFakeTimers()
 
-    const pending = compareWithMergeCommit([], pullRequest)
+    const pending = compareWithMergeCommit(filter, [], pullRequest)
     await jest.advanceTimersByTimeAsync(PAST_ANY_BUDGET_MS)
     const result = await pending
 
@@ -97,5 +114,53 @@ describe('shadow merge-commit comparison', () => {
     const [, , options] = cp.execFile.mock.calls[0] as ExecFileArgs
     expect(options.signal.aborted).toBe(true)
     jest.useRealTimers()
+  })
+
+  // A differing file list is only worth acting on where it flips a key, because the key
+  // is what gates a job. Comparing the lists instead of the keys reports every dropped
+  // path as consequential, which is the reading this field exists to replace.
+  test.each([
+    ['the dropped path is the only one holding a key', 'M\0frontend/b.ts\0', ['backend']],
+    ['a surviving path holds the same key', 'M\0posthog/b.py\0M\0frontend/b.ts\0', []]
+  ])('reports keys lost when %s', async (_case, diff, keysLost) => {
+    stubGit('', '', HEAD, diff)
+
+    const result = await compareWithMergeCommit(
+      filter,
+      [
+        {filename: 'posthog/a.py', status: ChangeStatus.Modified},
+        {filename: 'posthog/b.py', status: ChangeStatus.Modified},
+        {filename: 'frontend/b.ts', status: ChangeStatus.Modified}
+      ],
+      pullRequest
+    )
+
+    expect(result.verdict).toBe('mismatch')
+    expect(result.keysLost).toEqual(keysLost)
+    expect(result.keysGained).toEqual([])
+  })
+
+  // --name-status emits a status field and a path field per entry. Reading them in the
+  // wrong order turns every path into a status letter, and a rule scoped to a status
+  // then answers on the wrong file.
+  test('carries each file status through to a status-scoped rule', async () => {
+    const scoped = new Filter(`
+added_only:
+  - added: 'posthog/**'
+`)
+    stubGit('', '', HEAD, 'A\0posthog/new.py\0D\0posthog/gone.py\0')
+
+    const result = await compareWithMergeCommit(
+      scoped,
+      [
+        {filename: 'posthog/new.py', status: ChangeStatus.Added},
+        {filename: 'posthog/gone.py', status: ChangeStatus.Deleted}
+      ],
+      pullRequest
+    )
+
+    expect(result.verdict).toBe('match')
+    expect(result.keysLost).toEqual([])
+    expect(result.keysGained).toEqual([])
   })
 })

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -42708,7 +42708,7 @@ async function run() {
             return;
         }
         const filter = new filter_1.Filter(filtersYaml);
-        const files = await getChangedFiles(token, base, ref, initialFetchDepth);
+        const files = await getChangedFiles(filter, token, base, ref, initialFetchDepth);
         core.info(`Detected ${files.length} changed files`);
         const results = filter.match(files);
         exportResults(results, listFiles);
@@ -42729,7 +42729,7 @@ function getConfigFileContent(configPath) {
     }
     return fs.readFileSync(configPath, { encoding: 'utf8' });
 }
-async function getChangedFiles(token, base, ref, initialFetchDepth) {
+async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
     var _a, _b;
     // if base is 'HEAD' only local uncommitted changes will be detected
     // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
@@ -42754,8 +42754,8 @@ async function getChangedFiles(token, base, ref, initialFetchDepth) {
             }
             const pr = github.context.payload.pull_request;
             if (token) {
-                const apiFiles = await getChangedFilesFromApi(token, pr);
-                await shadow.report(apiFiles, pr);
+                const { files: apiFiles, rows } = await getChangedFilesFromApi(token, pr);
+                await shadow.report(filter, apiFiles, rows, pr);
                 return apiFiles;
             }
             if (github.context.eventName === 'pull_request_target') {
@@ -42821,12 +42821,16 @@ async function getChangedFilesFromGit(base, head, initialFetchDepth) {
     return await git.getChangesSinceMergeBase(base, head, initialFetchDepth);
 }
 // Uses github REST api to get list of files changed in PR
+// `rows` counts what the API returned rather than what `files` holds, because a renamed
+// row expands into two entries below. The API caps the response at 3,000 rows and says
+// nothing when it does, so the row count is the only tell that the list is partial.
 async function getChangedFilesFromApi(token, pullRequest) {
     core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
     try {
         const client = github.getOctokit(token);
         const per_page = 100;
         const files = [];
+        let rows = 0;
         core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`);
         for await (const response of client.paginate.iterator(client.rest.pulls.listFiles.endpoint.merge({
             owner: github.context.repo.owner,
@@ -42839,6 +42843,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
             }
             core.info(`Received ${response.data.length} items`);
             for (const row of response.data) {
+                rows++;
                 core.info(`[${row.status}] ${row.filename}`);
                 // There's no obvious use-case for detection of renames
                 // Therefore we treat it as if rename detection in git diff was turned off.
@@ -42864,7 +42869,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
                 }
             }
         }
-        return files;
+        return { files, rows };
     }
     finally {
         core.endGroup();
@@ -42976,6 +42981,7 @@ const child_process_1 = __nccwpck_require__(5317);
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const core = __importStar(__nccwpck_require__(7484));
+const file_1 = __nccwpck_require__(3765);
 // Compares the API's changed-file list against the same list derived locally from
 // the pull request's merge commit, and reports disagreement without acting on it.
 // The API result stays authoritative, so a wrong local answer can only produce a
@@ -43061,6 +43067,29 @@ function originUrl() {
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
+// git reports a type change as T, which is a content change like any other to a filter.
+// R and C are unreachable under --no-renames and are mapped so a future caller without
+// that flag still gets a status rather than the fallback.
+const STATUS_OF = {
+    A: file_1.ChangeStatus.Added,
+    C: file_1.ChangeStatus.Copied,
+    D: file_1.ChangeStatus.Deleted,
+    M: file_1.ChangeStatus.Modified,
+    R: file_1.ChangeStatus.Renamed,
+    T: file_1.ChangeStatus.Modified,
+    U: file_1.ChangeStatus.Unmerged
+};
+// -z --name-status emits a status field and a path field per entry, each NUL-terminated.
+// A status carries a similarity score for R and C, which --no-renames rules out, so the
+// first character is the whole status here.
+function parseNameStatus(out) {
+    const fields = out.split('\0').filter(Boolean);
+    const files = [];
+    for (let i = 0; i + 1 < fields.length; i += 2) {
+        files.push({ filename: fields[i + 1], status: STATUS_OF[fields[i][0]] || file_1.ChangeStatus.Modified });
+    }
+    return files;
+}
 async function localChangedFiles(pr, signal) {
     const gitDir = await scratchRepo(signal);
     const fetched = await git(gitDir, [
@@ -43088,12 +43117,14 @@ async function localChangedFiles(pr, signal) {
     }
     // --no-renames so a rename arrives as a delete plus an add, which is the shape
     // the API path builds by hand from `previous_filename`. -z because git quotes a
-    // path holding a newline or a non-ASCII byte in the default format.
-    const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
+    // path holding a newline or a non-ASCII byte in the default format. --name-status
+    // because a filter rule can scope itself to a change status, so a comparison that
+    // guessed one would answer a different question than the filter asks.
+    const diff = await git(gitDir, ['diff', '--no-renames', '--name-status', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
     if (diff.code !== 0) {
         throw new Unavailable('diff-failed', firstLine(diff.err));
     }
-    return diff.out.split('\0').filter(Boolean);
+    return parseNameStatus(diff.out);
 }
 // A queue branch can differ by thousands of paths, which is neither readable in a log
 // line nor worth carrying as an event property. The count answers how far apart the two
@@ -43112,9 +43143,20 @@ function difference(from, against) {
     }
     return { count, sample };
 }
-function compare(api, local) {
+// A filter key gates a job on whether any changed file matched it, so the key's answer
+// is `length > 0` and nothing finer. `exportResults` reads it the same way.
+function firedKeys(filter, files) {
+    return new Set(Object.entries(filter.match(files))
+        .filter(([, matched]) => matched.length > 0)
+        .map(([key]) => key));
+}
+function compare(filter, apiFiles, gitFiles) {
+    const api = new Set(apiFiles.map(f => f.filename));
+    const local = new Set(gitFiles.map(f => f.filename));
     const onlyInApi = difference(api, local);
     const onlyInGit = difference(local, api);
+    const apiKeys = firedKeys(filter, apiFiles);
+    const gitKeys = firedKeys(filter, gitFiles);
     return {
         verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
         reason: null,
@@ -43122,7 +43164,9 @@ function compare(api, local) {
         apiCount: api.size,
         gitCount: local.size,
         onlyInApi,
-        onlyInGit
+        onlyInGit,
+        keysLost: [...apiKeys].filter(k => !gitKeys.has(k)).sort(),
+        keysGained: [...gitKeys].filter(k => !apiKeys.has(k)).sort()
     };
 }
 async function budgeted(work, ms) {
@@ -43136,27 +43180,28 @@ async function budgeted(work, ms) {
     });
     return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer));
 }
-async function compareWithMergeCommit(apiFiles, pr) {
-    const api = new Set(apiFiles.map(f => f.filename));
+async function compareWithMergeCommit(filter, apiFiles, pr) {
     try {
         const gitFiles = await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS);
-        return compare(api, new Set(gitFiles));
+        return compare(filter, apiFiles, gitFiles);
     }
     catch (error) {
         return {
             verdict: 'unavailable',
             reason: error instanceof Unavailable ? error.reason : 'unknown',
             detail: error instanceof Unavailable ? error.detail : messageOf(error),
-            apiCount: api.size,
+            apiCount: new Set(apiFiles.map(f => f.filename)).size,
             gitCount: null,
             onlyInApi: { count: 0, sample: [] },
-            onlyInGit: { count: 0, sample: [] }
+            onlyInGit: { count: 0, sample: [] },
+            keysLost: [],
+            keysGained: []
         };
     }
 }
 // Without this the only record of a divergence is a log line in one job of one run,
 // which is unreadable at the volume that makes the comparison worth running.
-async function capture(apiKey, result, pr, durationMs) {
+async function capture(apiKey, result, pr, apiRows, durationMs) {
     var _a;
     const repo = process.env.GITHUB_REPOSITORY || null;
     const properties = {
@@ -43170,11 +43215,17 @@ async function capture(apiKey, result, pr, durationMs) {
         only_in_api_count: result.onlyInApi.count,
         only_in_git: result.onlyInGit.sample,
         only_in_git_count: result.onlyInGit.count,
-        // pulls/{n}/files truncates silently, so record both sides of the tell: what the
-        // API returned, and what the pull request payload says it should have been. The
-        // count has to come from the payload, because `api_count` counts a rename twice:
-        // the API path expands each renamed row into an add plus a delete.
-        api_truncated: pr.changed_files >= API_FILE_CAP,
+        selection_changed: result.keysLost.length > 0 || result.keysGained.length > 0,
+        keys_lost: result.keysLost,
+        keys_gained: result.keysGained,
+        // pulls/{n}/files truncates silently at the cap, and the cap counts API rows, so
+        // the tell is how many rows came back. `api_count` cannot stand in: the API path
+        // expands each renamed row into an add plus a delete.
+        api_rows: apiRows,
+        api_truncated: apiRows >= API_FILE_CAP,
+        // Kept beside `api_rows` rather than used as the tell, because the payload's count
+        // is computed when the event fires and reads stale on a pull request whose base
+        // moved. The two disagreeing is itself worth seeing.
         pr_changed_files: pr.changed_files,
         pr_number: pr.number,
         head_sha: pr.head.sha,
@@ -43212,7 +43263,8 @@ function summarize(result) {
     }
     if (result.verdict === 'mismatch') {
         return (`MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
-            `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)}`);
+            `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)} ` +
+            `keysLost=${JSON.stringify(result.keysLost)} keysGained=${JSON.stringify(result.keysGained)}`);
     }
     return `match (${result.apiCount} files)`;
 }
@@ -43223,7 +43275,7 @@ function summarize(result) {
 // detects changes runs this action, so a comparison whose result cannot be recorded
 // is a merge-ref fetch on the critical path of a gate job in exchange for a log line
 // nobody reads. Fork pull requests get no secrets, so they take this path too.
-async function report(apiFiles, pr) {
+async function report(filter, apiFiles, apiRows, pr) {
     const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
     if (!apiKey) {
         return;
@@ -43231,12 +43283,12 @@ async function report(apiFiles, pr) {
     try {
         core.startGroup('Shadow: merge-commit change detection');
         const startedAt = Date.now();
-        const result = await compareWithMergeCommit(apiFiles, pr);
+        const result = await compareWithMergeCommit(filter, apiFiles, pr);
         const durationMs = Date.now() - startedAt;
         // core.info even for a mismatch: a warning becomes an annotation on the run summary
         // and the checks page, which reads as a problem with the pull request.
         core.info(`shadow: ${summarize(result)} in ${durationMs}ms`);
-        await capture(apiKey, result, pr, durationMs).catch(error => {
+        await capture(apiKey, result, pr, apiRows, durationMs).catch(error => {
             core.info(`shadow: capture skipped (${messageOf(error)})`);
         });
     }

--- a/.github/actions/paths-filter/dist/index.js
+++ b/.github/actions/paths-filter/dist/index.js
@@ -42189,6 +42189,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Filter = void 0;
+exports.firedKeys = firedKeys;
 const jsyaml = __importStar(__nccwpck_require__(4281));
 const picomatch_1 = __importDefault(__nccwpck_require__(4006));
 // Minimatch options used in all matchers
@@ -42202,6 +42203,11 @@ function isNegatedPattern(pattern) {
 }
 function positivePattern(pattern) {
     return isNegatedPattern(pattern) ? pattern.slice(1) : pattern;
+}
+// A key gates a job on whether any file matched it, so its answer is `length > 0` and
+// nothing finer. Both the action's outputs and the shadow comparison read it through here.
+function firedKeys(results) {
+    return new Set(Object.keys(results).filter(key => results[key].length > 0));
 }
 class Filter {
     // Creates instance of Filter and load rules from YAML if it's provided
@@ -42708,10 +42714,13 @@ async function run() {
             return;
         }
         const filter = new filter_1.Filter(filtersYaml);
-        const files = await getChangedFiles(filter, token, base, ref, initialFetchDepth);
+        const { files, api } = await getChangedFiles(token, base, ref, initialFetchDepth);
         core.info(`Detected ${files.length} changed files`);
         const results = filter.match(files);
         exportResults(results, listFiles);
+        if (api) {
+            await shadow.report({ filter, apiFiles: files, apiResults: results, ...api });
+        }
     }
     catch (error) {
         core.setFailed(getErrorMessage(error));
@@ -42729,7 +42738,7 @@ function getConfigFileContent(configPath) {
     }
     return fs.readFileSync(configPath, { encoding: 'utf8' });
 }
-async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
+async function getChangedFiles(token, base, ref, initialFetchDepth) {
     var _a, _b;
     // if base is 'HEAD' only local uncommitted changes will be detected
     // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
@@ -42737,7 +42746,7 @@ async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
         if (ref) {
             core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`);
         }
-        return await git.getChangesOnHead();
+        return { files: await git.getChangesOnHead() };
     }
     switch (github.context.eventName) {
         // To keep backward compatibility, commits in GitHub pull request event
@@ -42754,9 +42763,8 @@ async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
             }
             const pr = github.context.payload.pull_request;
             if (token) {
-                const { files: apiFiles, rows } = await getChangedFilesFromApi(token, pr);
-                await shadow.report(filter, apiFiles, rows, pr);
-                return apiFiles;
+                const { files, apiRows, apiTruncated } = await getChangedFilesFromApi(token, pr);
+                return { files, api: { apiRows, apiTruncated, pr } };
             }
             if (github.context.eventName === 'pull_request_target') {
                 // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
@@ -42768,10 +42776,10 @@ async function getChangedFiles(filter, token, base, ref, initialFetchDepth) {
             const baseSha = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.base.sha;
             const defaultBranch = (_b = github.context.payload.repository) === null || _b === void 0 ? void 0 : _b.default_branch;
             const currentRef = await git.getCurrentRef();
-            return await git.getChanges(base || baseSha || defaultBranch, currentRef);
+            return { files: await git.getChanges(base || baseSha || defaultBranch, currentRef) };
         }
     }
-    return getChangedFilesFromGit(base, ref, initialFetchDepth);
+    return { files: await getChangedFilesFromGit(base, ref, initialFetchDepth) };
 }
 async function getChangedFilesFromGit(base, head, initialFetchDepth) {
     var _a;
@@ -42820,17 +42828,17 @@ async function getChangedFilesFromGit(base, head, initialFetchDepth) {
     core.info(`Changes will be detected between ${base} and ${head}`);
     return await git.getChangesSinceMergeBase(base, head, initialFetchDepth);
 }
+// The API truncates at this many rows and says nothing when it does.
+const API_FILE_CAP = 3000;
 // Uses github REST api to get list of files changed in PR
-// `rows` counts what the API returned rather than what `files` holds, because a renamed
-// row expands into two entries below. The API caps the response at 3,000 rows and says
-// nothing when it does, so the row count is the only tell that the list is partial.
+// Truncation is judged on API rows, not on `files`, which expands a rename into two.
 async function getChangedFilesFromApi(token, pullRequest) {
     core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
     try {
         const client = github.getOctokit(token);
         const per_page = 100;
         const files = [];
-        let rows = 0;
+        let apiRows = 0;
         core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`);
         for await (const response of client.paginate.iterator(client.rest.pulls.listFiles.endpoint.merge({
             owner: github.context.repo.owner,
@@ -42843,7 +42851,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
             }
             core.info(`Received ${response.data.length} items`);
             for (const row of response.data) {
-                rows++;
+                apiRows++;
                 core.info(`[${row.status}] ${row.filename}`);
                 // There's no obvious use-case for detection of renames
                 // Therefore we treat it as if rename detection in git diff was turned off.
@@ -42869,7 +42877,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
                 }
             }
         }
-        return { files, rows };
+        return { files, apiRows, apiTruncated: apiRows >= API_FILE_CAP };
     }
     finally {
         core.endGroup();
@@ -42877,12 +42885,11 @@ async function getChangedFilesFromApi(token, pullRequest) {
 }
 function exportResults(results, format) {
     core.info('Results:');
-    const changes = [];
+    const fired = (0, filter_1.firedKeys)(results);
     for (const [key, files] of Object.entries(results)) {
-        const value = files.length > 0;
+        const value = fired.has(key);
         core.startGroup(`Filter ${key} = ${value}`);
-        if (files.length > 0) {
-            changes.push(key);
+        if (value) {
             core.info('Matching files:');
             for (const file of files) {
                 core.info(`${file.filename} [${file.status}]`);
@@ -42900,7 +42907,7 @@ function exportResults(results, format) {
         core.endGroup();
     }
     if (results['changes'] === undefined) {
-        const changesJson = JSON.stringify(changes);
+        const changesJson = JSON.stringify([...fired]);
         core.info(`Changes output set to ${changesJson}`);
         core.setOutput('changes', changesJson);
     }
@@ -42981,36 +42988,24 @@ const child_process_1 = __nccwpck_require__(5317);
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const core = __importStar(__nccwpck_require__(7484));
-const file_1 = __nccwpck_require__(3765);
-// Compares the API's changed-file list against the same list derived locally from
-// the pull request's merge commit, and reports disagreement without acting on it.
-// The API result stays authoritative, so a wrong local answer can only produce a
-// log line. Removing the API call later is only safe once this has run quiet
-// across the shapes no offline sample can reach: very large diffs, and ones GitHub
-// has not finished computing a merge ref for.
-//
-// Detecting changes from `base.sha..HEAD` instead reports every commit the branch
-// picked up when the base was merged into it as the pull request's own work, which
-// is wrong by thousands of files on a branch that has taken master in. The merge
-// commit's first parent is the base GitHub actually merged against, so
-// `HEAD^1..HEAD` is the pull request's own changes and matches the API.
+const filter_1 = __nccwpck_require__(9037);
+const git_1 = __nccwpck_require__(1243);
+// Compares the API's changed-file list against the same list derived from the pull
+// request's merge commit, and reports disagreement without acting on it. The API
+// result stays authoritative, so a wrong local answer can only produce a log line.
 const MERGE_REF_FETCH_DEPTH = 2;
 const POSTHOG_HOST = 'https://us.i.posthog.com';
 const EVENT_NAME = 'paths_filter_shadow_compared';
 // A change-detection job is on the critical path of every workflow, so the comparison
-// and the capture that follows it share one wall-clock budget, and give up rather than
-// holding the job to its timeout-minutes. The git-level low-speed settings cover a
-// stalled transfer; the budget covers everything else.
+// and its capture share one wall-clock budget rather than holding the job to its
+// timeout-minutes.
 const BUDGET_MS = 20000;
 const CAPTURE_FLOOR_MS = 500;
 const LIST_CAP = 50;
-// A queue branch carries the cumulative batch diff, so the path list can be far larger
-// than a human pull request's. execFile's 1 MB default would fail those as a diff error,
-// which drops the population the comparison most needs to measure.
+// A queue branch carries the cumulative batch diff, which execFile's 1 MB default would
+// fail as a diff error.
 const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024;
 const DETAIL_CAP = 200;
-// The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
-const API_FILE_CAP = 3000;
 class Unavailable extends Error {
     constructor(reason, detail) {
         super(`${reason}: ${detail}`);
@@ -43018,20 +43013,15 @@ class Unavailable extends Error {
         this.detail = detail;
     }
 }
-// Every git call that reads or writes history names the scratch repository. `--depth`
-// and `--filter` rewrite `.git/shallow` and the promisor config of whatever repository
-// they run in, and steps later in the same job read history from the workspace checkout:
-// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>` after
-// this action returns, and an empty merge base there silently drops their schema cache.
+// `--depth` and `--filter` rewrite `.git/shallow` and the promisor config of whatever
+// repository they run in, so every call names the scratch repository. ci-dagster and
+// ci-e2e-playwright read history from the workspace checkout after this action returns.
 async function git(gitDir, args, signal) {
     return run(['--git-dir', gitDir, ...args], signal);
 }
-// The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
-// on the child process, so a fetch the budget gave up on keeps running and holds the
-// action's process open until it finishes, past the budget it was supposed to obey.
-//
-// stdout is returned raw. A caller that reads a path list must not trim it, because a
-// tracked path can begin with a space, and that path sorts first in the -z output.
+// execFile rather than `@actions/exec`, which gives no handle on the child process, so a
+// fetch the budget gave up on would hold the action open until it finished. stdout is
+// returned raw because a tracked path can begin with a space.
 async function run(args, signal) {
     return new Promise(resolve => {
         (0, child_process_1.execFile)('git', args, { signal, maxBuffer: MAX_GIT_OUTPUT_BYTES }, (error, stdout, stderr) => {
@@ -43045,6 +43035,9 @@ function firstLine(stderr) {
 function messageOf(error) {
     return error instanceof Error ? error.message : String(error);
 }
+function missing(from, against) {
+    return [...from].filter(key => !against.has(key)).sort();
+}
 async function scratchRepo(signal) {
     const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git');
     const init = await run(['init', '--bare', '--quiet', gitDir], signal);
@@ -43053,9 +43046,8 @@ async function scratchRepo(signal) {
     }
     return gitDir;
 }
-// The workspace remote carries no credentials of its own: actions/checkout keeps the
-// token in an http.extraheader the scratch repository does not inherit. A private
-// remote therefore reports unavailable rather than comparing against a partial fetch.
+// actions/checkout keeps the token in an http.extraheader the scratch repository does not
+// inherit, so a private remote reports unavailable rather than comparing a partial fetch.
 function originUrl() {
     const server = process.env.GITHUB_SERVER_URL;
     const repo = process.env.GITHUB_REPOSITORY;
@@ -43063,32 +43055,6 @@ function originUrl() {
         throw new Unavailable('no-origin-url', 'GITHUB_SERVER_URL or GITHUB_REPOSITORY is unset');
     }
     return `${server}/${repo}`;
-}
-// The merge ref is not guaranteed to be present or current: GitHub recomputes it
-// asynchronously after a push. Requiring the second parent to equal the head SHA
-// rejects a stale ref rather than reading it as this pull request's changes.
-// git reports a type change as T, which is a content change like any other to a filter.
-// R and C are unreachable under --no-renames and are mapped so a future caller without
-// that flag still gets a status rather than the fallback.
-const STATUS_OF = {
-    A: file_1.ChangeStatus.Added,
-    C: file_1.ChangeStatus.Copied,
-    D: file_1.ChangeStatus.Deleted,
-    M: file_1.ChangeStatus.Modified,
-    R: file_1.ChangeStatus.Renamed,
-    T: file_1.ChangeStatus.Modified,
-    U: file_1.ChangeStatus.Unmerged
-};
-// -z --name-status emits a status field and a path field per entry, each NUL-terminated.
-// A status carries a similarity score for R and C, which --no-renames rules out, so the
-// first character is the whole status here.
-function parseNameStatus(out) {
-    const fields = out.split('\0').filter(Boolean);
-    const files = [];
-    for (let i = 0; i + 1 < fields.length; i += 2) {
-        files.push({ filename: fields[i + 1], status: STATUS_OF[fields[i][0]] || file_1.ChangeStatus.Modified });
-    }
-    return files;
 }
 async function localChangedFiles(pr, signal) {
     const gitDir = await scratchRepo(signal);
@@ -43111,24 +43077,21 @@ async function localChangedFiles(pr, signal) {
     if (head.code !== 0) {
         throw new Unavailable('no-second-parent', firstLine(head.err));
     }
+    // GitHub recomputes the merge ref asynchronously after a push, so a ref whose second
+    // parent is not the head SHA describes an earlier push.
     const headSha = head.out.trim();
     if (headSha !== pr.head.sha) {
         throw new Unavailable('stale-merge-ref', `^2=${headSha.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)}`);
     }
-    // --no-renames so a rename arrives as a delete plus an add, which is the shape
-    // the API path builds by hand from `previous_filename`. -z because git quotes a
-    // path holding a newline or a non-ASCII byte in the default format. --name-status
-    // because a filter rule can scope itself to a change status, so a comparison that
-    // guessed one would answer a different question than the filter asks.
+    // The same flags the action's own git path uses, so the comparison measures what
+    // dropping the API call would select. --no-renames matches the add-plus-delete shape
+    // the API path builds from `previous_filename`.
     const diff = await git(gitDir, ['diff', '--no-renames', '--name-status', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal);
     if (diff.code !== 0) {
         throw new Unavailable('diff-failed', firstLine(diff.err));
     }
-    return parseNameStatus(diff.out);
+    return (0, git_1.parseGitDiffOutput)(diff.out);
 }
-// A queue branch can differ by thousands of paths, which is neither readable in a log
-// line nor worth carrying as an event property. The count answers how far apart the two
-// answers are, and the sample answers what kind of path is involved.
 function difference(from, against) {
     const sample = [];
     let count = 0;
@@ -43143,20 +43106,12 @@ function difference(from, against) {
     }
     return { count, sample };
 }
-// A filter key gates a job on whether any changed file matched it, so the key's answer
-// is `length > 0` and nothing finer. `exportResults` reads it the same way.
-function firedKeys(filter, files) {
-    return new Set(Object.entries(filter.match(files))
-        .filter(([, matched]) => matched.length > 0)
-        .map(([key]) => key));
-}
-function compare(filter, apiFiles, gitFiles) {
-    const api = new Set(apiFiles.map(f => f.filename));
+function compare(input, api, gitFiles) {
     const local = new Set(gitFiles.map(f => f.filename));
     const onlyInApi = difference(api, local);
     const onlyInGit = difference(local, api);
-    const apiKeys = firedKeys(filter, apiFiles);
-    const gitKeys = firedKeys(filter, gitFiles);
+    const apiKeys = (0, filter_1.firedKeys)(input.apiResults);
+    const gitKeys = (0, filter_1.firedKeys)(input.filter.match(gitFiles));
     return {
         verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
         reason: null,
@@ -43165,8 +43120,8 @@ function compare(filter, apiFiles, gitFiles) {
         gitCount: local.size,
         onlyInApi,
         onlyInGit,
-        keysLost: [...apiKeys].filter(k => !gitKeys.has(k)).sort(),
-        keysGained: [...gitKeys].filter(k => !apiKeys.has(k)).sort()
+        keysLost: missing(apiKeys, gitKeys),
+        keysGained: missing(gitKeys, apiKeys)
     };
 }
 async function budgeted(work, ms) {
@@ -43180,17 +43135,18 @@ async function budgeted(work, ms) {
     });
     return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer));
 }
-async function compareWithMergeCommit(filter, apiFiles, pr) {
+async function compareWithMergeCommit(input) {
+    const api = new Set(input.apiFiles.map(f => f.filename));
     try {
-        const gitFiles = await budgeted(async (signal) => localChangedFiles(pr, signal), BUDGET_MS);
-        return compare(filter, apiFiles, gitFiles);
+        const gitFiles = await budgeted(async (signal) => localChangedFiles(input.pr, signal), BUDGET_MS);
+        return compare(input, api, gitFiles);
     }
     catch (error) {
         return {
             verdict: 'unavailable',
             reason: error instanceof Unavailable ? error.reason : 'unknown',
             detail: error instanceof Unavailable ? error.detail : messageOf(error),
-            apiCount: new Set(apiFiles.map(f => f.filename)).size,
+            apiCount: api.size,
             gitCount: null,
             onlyInApi: { count: 0, sample: [] },
             onlyInGit: { count: 0, sample: [] },
@@ -43199,11 +43155,10 @@ async function compareWithMergeCommit(filter, apiFiles, pr) {
         };
     }
 }
-// Without this the only record of a divergence is a log line in one job of one run,
-// which is unreadable at the volume that makes the comparison worth running.
-async function capture(apiKey, result, pr, apiRows, durationMs) {
+async function capture(apiKey, input, result, durationMs) {
     var _a;
     const repo = process.env.GITHUB_REPOSITORY || null;
+    const pr = input.pr;
     const properties = {
         repo,
         verdict: result.verdict,
@@ -43218,21 +43173,15 @@ async function capture(apiKey, result, pr, apiRows, durationMs) {
         selection_changed: result.keysLost.length > 0 || result.keysGained.length > 0,
         keys_lost: result.keysLost,
         keys_gained: result.keysGained,
-        // pulls/{n}/files truncates silently at the cap, and the cap counts API rows, so
-        // the tell is how many rows came back. `api_count` cannot stand in: the API path
-        // expands each renamed row into an add plus a delete.
-        api_rows: apiRows,
-        api_truncated: apiRows >= API_FILE_CAP,
-        // Kept beside `api_rows` rather than used as the tell, because the payload's count
-        // is computed when the event fires and reads stale on a pull request whose base
-        // moved. The two disagreeing is itself worth seeing.
+        // `pr_changed_files` reads stale on a pull request whose base moved, so it is
+        // recorded beside the API's own row count rather than used as the truncation tell.
+        api_rows: input.apiRows,
+        api_truncated: input.apiTruncated,
         pr_changed_files: pr.changed_files,
         pr_number: pr.number,
         head_sha: pr.head.sha,
         head_ref: pr.head.ref,
         base_ref: pr.base.ref,
-        // Queue branches carry the cumulative batch diff and page far more than a human
-        // pull request, so they are the population worth reading separately.
         branch_class: pr.head.ref.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
         is_fork: ((_a = pr.head.repo) === null || _a === void 0 ? void 0 : _a.full_name) !== repo,
         duration_ms: durationMs,
@@ -43250,7 +43199,6 @@ async function capture(apiKey, result, pr, apiRows, durationMs) {
             distinct_id: repo || 'paths-filter-shadow',
             properties
         }),
-        // Whatever the comparison did not spend, so the step's ceiling stays the budget.
         signal: AbortSignal.timeout(Math.max(CAPTURE_FLOOR_MS, BUDGET_MS - durationMs))
     });
     if (!res.ok) {
@@ -43268,14 +43216,10 @@ function summarize(result) {
     }
     return `match (${result.apiCount} files)`;
 }
-// Never throws: the filter's real answer is already computed by the time this runs,
-// so nothing here is worth failing a CI job over.
-//
-// The token gates the comparison itself, not just the capture. Every workflow that
-// detects changes runs this action, so a comparison whose result cannot be recorded
-// is a merge-ref fetch on the critical path of a gate job in exchange for a log line
-// nobody reads. Fork pull requests get no secrets, so they take this path too.
-async function report(filter, apiFiles, apiRows, pr) {
+// Never throws: the filter's real answer is already computed by the time this runs. The
+// token gates the comparison itself, so a run that cannot record its result does not pay
+// for a merge-ref fetch. Fork pull requests get no secrets and take that path too.
+async function report(input) {
     const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN;
     if (!apiKey) {
         return;
@@ -43283,12 +43227,12 @@ async function report(filter, apiFiles, apiRows, pr) {
     try {
         core.startGroup('Shadow: merge-commit change detection');
         const startedAt = Date.now();
-        const result = await compareWithMergeCommit(filter, apiFiles, pr);
+        const result = await compareWithMergeCommit(input);
         const durationMs = Date.now() - startedAt;
-        // core.info even for a mismatch: a warning becomes an annotation on the run summary
-        // and the checks page, which reads as a problem with the pull request.
+        // core.info even for a mismatch, because a warning becomes an annotation on the
+        // checks page and reads as a problem with the pull request.
         core.info(`shadow: ${summarize(result)} in ${durationMs}ms`);
-        await capture(apiKey, result, pr, apiRows, durationMs).catch(error => {
+        await capture(apiKey, input, result, durationMs).catch(error => {
             core.info(`shadow: capture skipped (${messageOf(error)})`);
         });
     }

--- a/.github/actions/paths-filter/src/filter.ts
+++ b/.github/actions/paths-filter/src/filter.ts
@@ -38,6 +38,12 @@ export interface FilterResults {
   [key: string]: File[]
 }
 
+// A key gates a job on whether any file matched it, so its answer is `length > 0` and
+// nothing finer. Both the action's outputs and the shadow comparison read it through here.
+export function firedKeys(results: FilterResults): Set<string> {
+  return new Set(Object.keys(results).filter(key => results[key].length > 0))
+}
+
 export class Filter {
   rules: {[key: string]: FilterRuleItem[]} = {}
 

--- a/.github/actions/paths-filter/src/main.ts
+++ b/.github/actions/paths-filter/src/main.ts
@@ -4,7 +4,7 @@ import * as github from '@actions/github'
 import {GetResponseDataTypeFromEndpointMethod} from '@octokit/types'
 import {PullRequest, PushEvent} from '@octokit/webhooks-types'
 
-import {Filter, FilterResults} from './filter'
+import {Filter, FilterResults, firedKeys} from './filter'
 import {File, ChangeStatus} from './file'
 import * as git from './git'
 import * as shadow from './shadow'
@@ -34,10 +34,13 @@ async function run(): Promise<void> {
     }
 
     const filter = new Filter(filtersYaml)
-    const files = await getChangedFiles(filter, token, base, ref, initialFetchDepth)
+    const {files, api} = await getChangedFiles(token, base, ref, initialFetchDepth)
     core.info(`Detected ${files.length} changed files`)
     const results = filter.match(files)
     exportResults(results, listFiles)
+    if (api) {
+      await shadow.report({filter, apiFiles: files, apiResults: results, ...api})
+    }
   } catch (error) {
     core.setFailed(getErrorMessage(error))
   }
@@ -59,20 +62,27 @@ function getConfigFileContent(configPath: string): string {
   return fs.readFileSync(configPath, {encoding: 'utf8'})
 }
 
+// `api` is present only when the list came from the pull request files API, and carries
+// what the shadow comparison needs to describe that call. The shadow runs from `run()`,
+// which already holds the filter and its results, so detection stays free of it.
+interface ChangedFiles {
+  files: File[]
+  api?: {apiRows: number; apiTruncated: boolean; pr: PullRequest}
+}
+
 async function getChangedFiles(
-  filter: Filter,
   token: string,
   base: string,
   ref: string,
   initialFetchDepth: number
-): Promise<File[]> {
+): Promise<ChangedFiles> {
   // if base is 'HEAD' only local uncommitted changes will be detected
   // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
   if (base === git.HEAD) {
     if (ref) {
       core.warning(`'ref' input parameter is ignored when 'base' is set to HEAD`)
     }
-    return await git.getChangesOnHead()
+    return {files: await git.getChangesOnHead()}
   }
 
   switch (github.context.eventName) {
@@ -90,9 +100,8 @@ async function getChangedFiles(
       }
       const pr = github.context.payload.pull_request as PullRequest
       if (token) {
-        const {files: apiFiles, rows} = await getChangedFilesFromApi(token, pr)
-        await shadow.report(filter, apiFiles, rows, pr)
-        return apiFiles
+        const {files, apiRows, apiTruncated} = await getChangedFilesFromApi(token, pr)
+        return {files, api: {apiRows, apiTruncated, pr}}
       }
       if (github.context.eventName === 'pull_request_target') {
         // pull_request_target is executed in context of base branch and GITHUB_SHA points to last commit in base branch
@@ -104,11 +113,11 @@ async function getChangedFiles(
       const baseSha = github.context.payload.pull_request?.base.sha
       const defaultBranch = github.context.payload.repository?.default_branch
       const currentRef = await git.getCurrentRef()
-      return await git.getChanges(base || baseSha || defaultBranch, currentRef)
+      return {files: await git.getChanges(base || baseSha || defaultBranch, currentRef)}
     }
   }
 
-  return getChangedFilesFromGit(base, ref, initialFetchDepth)
+  return {files: await getChangedFilesFromGit(base, ref, initialFetchDepth)}
 }
 
 async function getChangedFilesFromGit(base: string, head: string, initialFetchDepth: number): Promise<File[]> {
@@ -173,17 +182,21 @@ async function getChangedFilesFromGit(base: string, head: string, initialFetchDe
   return await git.getChangesSinceMergeBase(base, head, initialFetchDepth)
 }
 
+// The API truncates at this many rows and says nothing when it does.
+const API_FILE_CAP = 3000
+
 // Uses github REST api to get list of files changed in PR
-// `rows` counts what the API returned rather than what `files` holds, because a renamed
-// row expands into two entries below. The API caps the response at 3,000 rows and says
-// nothing when it does, so the row count is the only tell that the list is partial.
-async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): Promise<{files: File[]; rows: number}> {
+// Truncation is judged on API rows, not on `files`, which expands a rename into two.
+async function getChangedFilesFromApi(
+  token: string,
+  pullRequest: PullRequest
+): Promise<{files: File[]; apiRows: number; apiTruncated: boolean}> {
   core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`)
   try {
     const client = github.getOctokit(token)
     const per_page = 100
     const files: File[] = []
-    let rows = 0
+    let apiRows = 0
 
     core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`)
     for await (const response of client.paginate.iterator(
@@ -200,7 +213,7 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       core.info(`Received ${response.data.length} items`)
 
       for (const row of response.data as GetResponseDataTypeFromEndpointMethod<typeof client.rest.pulls.listFiles>) {
-        rows++
+        apiRows++
         core.info(`[${row.status}] ${row.filename}`)
         // There's no obvious use-case for detection of renames
         // Therefore we treat it as if rename detection in git diff was turned off.
@@ -226,7 +239,7 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       }
     }
 
-    return {files, rows}
+    return {files, apiRows, apiTruncated: apiRows >= API_FILE_CAP}
   } finally {
     core.endGroup()
   }
@@ -234,12 +247,11 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
 
 function exportResults(results: FilterResults, format: ExportFormat): void {
   core.info('Results:')
-  const changes = []
+  const fired = firedKeys(results)
   for (const [key, files] of Object.entries(results)) {
-    const value = files.length > 0
+    const value = fired.has(key)
     core.startGroup(`Filter ${key} = ${value}`)
-    if (files.length > 0) {
-      changes.push(key)
+    if (value) {
       core.info('Matching files:')
       for (const file of files) {
         core.info(`${file.filename} [${file.status}]`)
@@ -258,7 +270,7 @@ function exportResults(results: FilterResults, format: ExportFormat): void {
   }
 
   if (results['changes'] === undefined) {
-    const changesJson = JSON.stringify(changes)
+    const changesJson = JSON.stringify([...fired])
     core.info(`Changes output set to ${changesJson}`)
     core.setOutput('changes', changesJson)
   } else {

--- a/.github/actions/paths-filter/src/main.ts
+++ b/.github/actions/paths-filter/src/main.ts
@@ -34,7 +34,7 @@ async function run(): Promise<void> {
     }
 
     const filter = new Filter(filtersYaml)
-    const files = await getChangedFiles(token, base, ref, initialFetchDepth)
+    const files = await getChangedFiles(filter, token, base, ref, initialFetchDepth)
     core.info(`Detected ${files.length} changed files`)
     const results = filter.match(files)
     exportResults(results, listFiles)
@@ -59,7 +59,13 @@ function getConfigFileContent(configPath: string): string {
   return fs.readFileSync(configPath, {encoding: 'utf8'})
 }
 
-async function getChangedFiles(token: string, base: string, ref: string, initialFetchDepth: number): Promise<File[]> {
+async function getChangedFiles(
+  filter: Filter,
+  token: string,
+  base: string,
+  ref: string,
+  initialFetchDepth: number
+): Promise<File[]> {
   // if base is 'HEAD' only local uncommitted changes will be detected
   // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
   if (base === git.HEAD) {
@@ -84,8 +90,8 @@ async function getChangedFiles(token: string, base: string, ref: string, initial
       }
       const pr = github.context.payload.pull_request as PullRequest
       if (token) {
-        const apiFiles = await getChangedFilesFromApi(token, pr)
-        await shadow.report(apiFiles, pr)
+        const {files: apiFiles, rows} = await getChangedFilesFromApi(token, pr)
+        await shadow.report(filter, apiFiles, rows, pr)
         return apiFiles
       }
       if (github.context.eventName === 'pull_request_target') {
@@ -168,12 +174,16 @@ async function getChangedFilesFromGit(base: string, head: string, initialFetchDe
 }
 
 // Uses github REST api to get list of files changed in PR
-async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): Promise<File[]> {
+// `rows` counts what the API returned rather than what `files` holds, because a renamed
+// row expands into two entries below. The API caps the response at 3,000 rows and says
+// nothing when it does, so the row count is the only tell that the list is partial.
+async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): Promise<{files: File[]; rows: number}> {
   core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`)
   try {
     const client = github.getOctokit(token)
     const per_page = 100
     const files: File[] = []
+    let rows = 0
 
     core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, per_page: ${per_page})`)
     for await (const response of client.paginate.iterator(
@@ -190,6 +200,7 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       core.info(`Received ${response.data.length} items`)
 
       for (const row of response.data as GetResponseDataTypeFromEndpointMethod<typeof client.rest.pulls.listFiles>) {
+        rows++
         core.info(`[${row.status}] ${row.filename}`)
         // There's no obvious use-case for detection of renames
         // Therefore we treat it as if rename detection in git diff was turned off.
@@ -215,7 +226,7 @@ async function getChangedFilesFromApi(token: string, pullRequest: PullRequest): 
       }
     }
 
-    return files
+    return {files, rows}
   } finally {
     core.endGroup()
   }

--- a/.github/actions/paths-filter/src/shadow.ts
+++ b/.github/actions/paths-filter/src/shadow.ts
@@ -5,7 +5,8 @@ import * as path from 'path'
 import * as core from '@actions/core'
 import {PullRequest} from '@octokit/webhooks-types'
 
-import {File} from './file'
+import {File, ChangeStatus} from './file'
+import {Filter} from './filter'
 
 // Compares the API's changed-file list against the same list derived locally from
 // the pull request's merge commit, and reports disagreement without acting on it.
@@ -74,6 +75,10 @@ interface ShadowResult {
   gitCount: number | null
   onlyInApi: Difference
   onlyInGit: Difference
+  // Which filter keys answer differently on the two file lists. A differing file list
+  // only matters where it flips a key, because the key is what gates a job.
+  keysLost: string[]
+  keysGained: string[]
 }
 
 interface GitResult {
@@ -137,7 +142,32 @@ function originUrl(): string {
 // The merge ref is not guaranteed to be present or current: GitHub recomputes it
 // asynchronously after a push. Requiring the second parent to equal the head SHA
 // rejects a stale ref rather than reading it as this pull request's changes.
-async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<string[]> {
+// git reports a type change as T, which is a content change like any other to a filter.
+// R and C are unreachable under --no-renames and are mapped so a future caller without
+// that flag still gets a status rather than the fallback.
+const STATUS_OF: {[letter: string]: ChangeStatus} = {
+  A: ChangeStatus.Added,
+  C: ChangeStatus.Copied,
+  D: ChangeStatus.Deleted,
+  M: ChangeStatus.Modified,
+  R: ChangeStatus.Renamed,
+  T: ChangeStatus.Modified,
+  U: ChangeStatus.Unmerged
+}
+
+// -z --name-status emits a status field and a path field per entry, each NUL-terminated.
+// A status carries a similarity score for R and C, which --no-renames rules out, so the
+// first character is the whole status here.
+function parseNameStatus(out: string): File[] {
+  const fields = out.split('\0').filter(Boolean)
+  const files: File[] = []
+  for (let i = 0; i + 1 < fields.length; i += 2) {
+    files.push({filename: fields[i + 1], status: STATUS_OF[fields[i][0]] || ChangeStatus.Modified})
+  }
+  return files
+}
+
+async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<File[]> {
   const gitDir = await scratchRepo(signal)
 
   const fetched = await git(
@@ -171,12 +201,14 @@ async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<
 
   // --no-renames so a rename arrives as a delete plus an add, which is the shape
   // the API path builds by hand from `previous_filename`. -z because git quotes a
-  // path holding a newline or a non-ASCII byte in the default format.
-  const diff = await git(gitDir, ['diff', '--no-renames', '--name-only', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
+  // path holding a newline or a non-ASCII byte in the default format. --name-status
+  // because a filter rule can scope itself to a change status, so a comparison that
+  // guessed one would answer a different question than the filter asks.
+  const diff = await git(gitDir, ['diff', '--no-renames', '--name-status', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
   if (diff.code !== 0) {
     throw new Unavailable('diff-failed', firstLine(diff.err))
   }
-  return diff.out.split('\0').filter(Boolean)
+  return parseNameStatus(diff.out)
 }
 
 // A queue branch can differ by thousands of paths, which is neither readable in a log
@@ -197,9 +229,23 @@ function difference(from: Set<string>, against: Set<string>): Difference {
   return {count, sample}
 }
 
-function compare(api: Set<string>, local: Set<string>): ShadowResult {
+// A filter key gates a job on whether any changed file matched it, so the key's answer
+// is `length > 0` and nothing finer. `exportResults` reads it the same way.
+function firedKeys(filter: Filter, files: File[]): Set<string> {
+  return new Set(
+    Object.entries(filter.match(files))
+      .filter(([, matched]) => matched.length > 0)
+      .map(([key]) => key)
+  )
+}
+
+function compare(filter: Filter, apiFiles: File[], gitFiles: File[]): ShadowResult {
+  const api = new Set(apiFiles.map(f => f.filename))
+  const local = new Set(gitFiles.map(f => f.filename))
   const onlyInApi = difference(api, local)
   const onlyInGit = difference(local, api)
+  const apiKeys = firedKeys(filter, apiFiles)
+  const gitKeys = firedKeys(filter, gitFiles)
   return {
     verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
     reason: null,
@@ -207,7 +253,9 @@ function compare(api: Set<string>, local: Set<string>): ShadowResult {
     apiCount: api.size,
     gitCount: local.size,
     onlyInApi,
-    onlyInGit
+    onlyInGit,
+    keysLost: [...apiKeys].filter(k => !gitKeys.has(k)).sort(),
+    keysGained: [...gitKeys].filter(k => !apiKeys.has(k)).sort()
   }
 }
 
@@ -223,27 +271,34 @@ async function budgeted<T>(work: (signal: AbortSignal) => Promise<T>, ms: number
   return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer))
 }
 
-export async function compareWithMergeCommit(apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
-  const api = new Set(apiFiles.map(f => f.filename))
+export async function compareWithMergeCommit(filter: Filter, apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
   try {
     const gitFiles = await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS)
-    return compare(api, new Set(gitFiles))
+    return compare(filter, apiFiles, gitFiles)
   } catch (error) {
     return {
       verdict: 'unavailable',
       reason: error instanceof Unavailable ? error.reason : 'unknown',
       detail: error instanceof Unavailable ? error.detail : messageOf(error),
-      apiCount: api.size,
+      apiCount: new Set(apiFiles.map(f => f.filename)).size,
       gitCount: null,
       onlyInApi: {count: 0, sample: []},
-      onlyInGit: {count: 0, sample: []}
+      onlyInGit: {count: 0, sample: []},
+      keysLost: [],
+      keysGained: []
     }
   }
 }
 
 // Without this the only record of a divergence is a log line in one job of one run,
 // which is unreadable at the volume that makes the comparison worth running.
-async function capture(apiKey: string, result: ShadowResult, pr: PullRequest, durationMs: number): Promise<void> {
+async function capture(
+  apiKey: string,
+  result: ShadowResult,
+  pr: PullRequest,
+  apiRows: number,
+  durationMs: number
+): Promise<void> {
   const repo = process.env.GITHUB_REPOSITORY || null
   const properties = {
     repo,
@@ -256,11 +311,17 @@ async function capture(apiKey: string, result: ShadowResult, pr: PullRequest, du
     only_in_api_count: result.onlyInApi.count,
     only_in_git: result.onlyInGit.sample,
     only_in_git_count: result.onlyInGit.count,
-    // pulls/{n}/files truncates silently, so record both sides of the tell: what the
-    // API returned, and what the pull request payload says it should have been. The
-    // count has to come from the payload, because `api_count` counts a rename twice:
-    // the API path expands each renamed row into an add plus a delete.
-    api_truncated: pr.changed_files >= API_FILE_CAP,
+    selection_changed: result.keysLost.length > 0 || result.keysGained.length > 0,
+    keys_lost: result.keysLost,
+    keys_gained: result.keysGained,
+    // pulls/{n}/files truncates silently at the cap, and the cap counts API rows, so
+    // the tell is how many rows came back. `api_count` cannot stand in: the API path
+    // expands each renamed row into an add plus a delete.
+    api_rows: apiRows,
+    api_truncated: apiRows >= API_FILE_CAP,
+    // Kept beside `api_rows` rather than used as the tell, because the payload's count
+    // is computed when the event fires and reads stale on a pull request whose base
+    // moved. The two disagreeing is itself worth seeing.
     pr_changed_files: pr.changed_files,
     pr_number: pr.number,
     head_sha: pr.head.sha,
@@ -300,7 +361,8 @@ function summarize(result: ShadowResult): string {
   if (result.verdict === 'mismatch') {
     return (
       `MISMATCH api=${result.apiCount} git=${result.gitCount} ` +
-      `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)}`
+      `onlyInApi=${JSON.stringify(result.onlyInApi.sample)} onlyInGit=${JSON.stringify(result.onlyInGit.sample)} ` +
+      `keysLost=${JSON.stringify(result.keysLost)} keysGained=${JSON.stringify(result.keysGained)}`
     )
   }
   return `match (${result.apiCount} files)`
@@ -313,7 +375,7 @@ function summarize(result: ShadowResult): string {
 // detects changes runs this action, so a comparison whose result cannot be recorded
 // is a merge-ref fetch on the critical path of a gate job in exchange for a log line
 // nobody reads. Fork pull requests get no secrets, so they take this path too.
-export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
+export async function report(filter: Filter, apiFiles: File[], apiRows: number, pr: PullRequest): Promise<void> {
   const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
   if (!apiKey) {
     return
@@ -321,14 +383,14 @@ export async function report(apiFiles: File[], pr: PullRequest): Promise<void> {
   try {
     core.startGroup('Shadow: merge-commit change detection')
     const startedAt = Date.now()
-    const result = await compareWithMergeCommit(apiFiles, pr)
+    const result = await compareWithMergeCommit(filter, apiFiles, pr)
     const durationMs = Date.now() - startedAt
 
     // core.info even for a mismatch: a warning becomes an annotation on the run summary
     // and the checks page, which reads as a problem with the pull request.
     core.info(`shadow: ${summarize(result)} in ${durationMs}ms`)
 
-    await capture(apiKey, result, pr, durationMs).catch(error => {
+    await capture(apiKey, result, pr, apiRows, durationMs).catch(error => {
       core.info(`shadow: capture skipped (${messageOf(error)})`)
     })
   } catch (error) {

--- a/.github/actions/paths-filter/src/shadow.ts
+++ b/.github/actions/paths-filter/src/shadow.ts
@@ -5,47 +5,34 @@ import * as path from 'path'
 import * as core from '@actions/core'
 import {PullRequest} from '@octokit/webhooks-types'
 
-import {File, ChangeStatus} from './file'
-import {Filter} from './filter'
+import {File} from './file'
+import {Filter, FilterResults, firedKeys} from './filter'
+import {parseGitDiffOutput} from './git'
 
-// Compares the API's changed-file list against the same list derived locally from
-// the pull request's merge commit, and reports disagreement without acting on it.
-// The API result stays authoritative, so a wrong local answer can only produce a
-// log line. Removing the API call later is only safe once this has run quiet
-// across the shapes no offline sample can reach: very large diffs, and ones GitHub
-// has not finished computing a merge ref for.
-//
-// Detecting changes from `base.sha..HEAD` instead reports every commit the branch
-// picked up when the base was merged into it as the pull request's own work, which
-// is wrong by thousands of files on a branch that has taken master in. The merge
-// commit's first parent is the base GitHub actually merged against, so
-// `HEAD^1..HEAD` is the pull request's own changes and matches the API.
+// Compares the API's changed-file list against the same list derived from the pull
+// request's merge commit, and reports disagreement without acting on it. The API
+// result stays authoritative, so a wrong local answer can only produce a log line.
 
 const MERGE_REF_FETCH_DEPTH = 2
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 const EVENT_NAME = 'paths_filter_shadow_compared'
 
 // A change-detection job is on the critical path of every workflow, so the comparison
-// and the capture that follows it share one wall-clock budget, and give up rather than
-// holding the job to its timeout-minutes. The git-level low-speed settings cover a
-// stalled transfer; the budget covers everything else.
+// and its capture share one wall-clock budget rather than holding the job to its
+// timeout-minutes.
 const BUDGET_MS = 20000
 const CAPTURE_FLOOR_MS = 500
 const LIST_CAP = 50
 
-// A queue branch carries the cumulative batch diff, so the path list can be far larger
-// than a human pull request's. execFile's 1 MB default would fail those as a diff error,
-// which drops the population the comparison most needs to measure.
+// A queue branch carries the cumulative batch diff, which execFile's 1 MB default would
+// fail as a diff error.
 const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024
 const DETAIL_CAP = 200
 
-// The API caps pulls/{n}/files at this many entries and says nothing when it truncates.
-const API_FILE_CAP = 3000
-
 type Verdict = 'match' | 'mismatch' | 'unavailable'
 
-// A closed set, because this is the field the comparison is grouped by once the events
-// land. Git's own words go in `detail`, which is free text and unbounded.
+// Closed, because this is the field the events are grouped by. Git's own words go in
+// `detail`, which is unbounded.
 type Reason =
   | 'no-scratch-repo'
   | 'no-origin-url'
@@ -75,10 +62,17 @@ interface ShadowResult {
   gitCount: number | null
   onlyInApi: Difference
   onlyInGit: Difference
-  // Which filter keys answer differently on the two file lists. A differing file list
-  // only matters where it flips a key, because the key is what gates a job.
   keysLost: string[]
   keysGained: string[]
+}
+
+export interface ShadowInput {
+  filter: Filter
+  apiFiles: File[]
+  apiResults: FilterResults
+  apiRows: number
+  apiTruncated: boolean
+  pr: PullRequest
 }
 
 interface GitResult {
@@ -87,21 +81,16 @@ interface GitResult {
   err: string
 }
 
-// Every git call that reads or writes history names the scratch repository. `--depth`
-// and `--filter` rewrite `.git/shallow` and the promisor config of whatever repository
-// they run in, and steps later in the same job read history from the workspace checkout:
-// ci-dagster and ci-e2e-playwright resolve `git merge-base HEAD^2 origin/<base>` after
-// this action returns, and an empty merge base there silently drops their schema cache.
+// `--depth` and `--filter` rewrite `.git/shallow` and the promisor config of whatever
+// repository they run in, so every call names the scratch repository. ci-dagster and
+// ci-e2e-playwright read history from the workspace checkout after this action returns.
 async function git(gitDir: string, args: string[], signal: AbortSignal): Promise<GitResult> {
   return run(['--git-dir', gitDir, ...args], signal)
 }
 
-// The signal is what makes the wall-clock budget real. `@actions/exec` gives no handle
-// on the child process, so a fetch the budget gave up on keeps running and holds the
-// action's process open until it finishes, past the budget it was supposed to obey.
-//
-// stdout is returned raw. A caller that reads a path list must not trim it, because a
-// tracked path can begin with a space, and that path sorts first in the -z output.
+// execFile rather than `@actions/exec`, which gives no handle on the child process, so a
+// fetch the budget gave up on would hold the action open until it finished. stdout is
+// returned raw because a tracked path can begin with a space.
 async function run(args: string[], signal: AbortSignal): Promise<GitResult> {
   return new Promise(resolve => {
     execFile('git', args, {signal, maxBuffer: MAX_GIT_OUTPUT_BYTES}, (error, stdout, stderr) => {
@@ -118,6 +107,10 @@ function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function missing(from: Set<string>, against: Set<string>): string[] {
+  return [...from].filter(key => !against.has(key)).sort()
+}
+
 async function scratchRepo(signal: AbortSignal): Promise<string> {
   const gitDir = path.join(process.env.RUNNER_TEMP || os.tmpdir(), 'paths-filter-shadow.git')
   const init = await run(['init', '--bare', '--quiet', gitDir], signal)
@@ -127,9 +120,8 @@ async function scratchRepo(signal: AbortSignal): Promise<string> {
   return gitDir
 }
 
-// The workspace remote carries no credentials of its own: actions/checkout keeps the
-// token in an http.extraheader the scratch repository does not inherit. A private
-// remote therefore reports unavailable rather than comparing against a partial fetch.
+// actions/checkout keeps the token in an http.extraheader the scratch repository does not
+// inherit, so a private remote reports unavailable rather than comparing a partial fetch.
 function originUrl(): string {
   const server = process.env.GITHUB_SERVER_URL
   const repo = process.env.GITHUB_REPOSITORY
@@ -137,34 +129,6 @@ function originUrl(): string {
     throw new Unavailable('no-origin-url', 'GITHUB_SERVER_URL or GITHUB_REPOSITORY is unset')
   }
   return `${server}/${repo}`
-}
-
-// The merge ref is not guaranteed to be present or current: GitHub recomputes it
-// asynchronously after a push. Requiring the second parent to equal the head SHA
-// rejects a stale ref rather than reading it as this pull request's changes.
-// git reports a type change as T, which is a content change like any other to a filter.
-// R and C are unreachable under --no-renames and are mapped so a future caller without
-// that flag still gets a status rather than the fallback.
-const STATUS_OF: {[letter: string]: ChangeStatus} = {
-  A: ChangeStatus.Added,
-  C: ChangeStatus.Copied,
-  D: ChangeStatus.Deleted,
-  M: ChangeStatus.Modified,
-  R: ChangeStatus.Renamed,
-  T: ChangeStatus.Modified,
-  U: ChangeStatus.Unmerged
-}
-
-// -z --name-status emits a status field and a path field per entry, each NUL-terminated.
-// A status carries a similarity score for R and C, which --no-renames rules out, so the
-// first character is the whole status here.
-function parseNameStatus(out: string): File[] {
-  const fields = out.split('\0').filter(Boolean)
-  const files: File[] = []
-  for (let i = 0; i + 1 < fields.length; i += 2) {
-    files.push({filename: fields[i + 1], status: STATUS_OF[fields[i][0]] || ChangeStatus.Modified})
-  }
-  return files
 }
 
 async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<File[]> {
@@ -194,26 +158,23 @@ async function localChangedFiles(pr: PullRequest, signal: AbortSignal): Promise<
   if (head.code !== 0) {
     throw new Unavailable('no-second-parent', firstLine(head.err))
   }
+  // GitHub recomputes the merge ref asynchronously after a push, so a ref whose second
+  // parent is not the head SHA describes an earlier push.
   const headSha = head.out.trim()
   if (headSha !== pr.head.sha) {
     throw new Unavailable('stale-merge-ref', `^2=${headSha.slice(0, 8)}, head=${pr.head.sha.slice(0, 8)}`)
   }
 
-  // --no-renames so a rename arrives as a delete plus an add, which is the shape
-  // the API path builds by hand from `previous_filename`. -z because git quotes a
-  // path holding a newline or a non-ASCII byte in the default format. --name-status
-  // because a filter rule can scope itself to a change status, so a comparison that
-  // guessed one would answer a different question than the filter asks.
+  // The same flags the action's own git path uses, so the comparison measures what
+  // dropping the API call would select. --no-renames matches the add-plus-delete shape
+  // the API path builds from `previous_filename`.
   const diff = await git(gitDir, ['diff', '--no-renames', '--name-status', '-z', 'FETCH_HEAD^1', 'FETCH_HEAD'], signal)
   if (diff.code !== 0) {
     throw new Unavailable('diff-failed', firstLine(diff.err))
   }
-  return parseNameStatus(diff.out)
+  return parseGitDiffOutput(diff.out)
 }
 
-// A queue branch can differ by thousands of paths, which is neither readable in a log
-// line nor worth carrying as an event property. The count answers how far apart the two
-// answers are, and the sample answers what kind of path is involved.
 function difference(from: Set<string>, against: Set<string>): Difference {
   const sample: string[] = []
   let count = 0
@@ -229,23 +190,12 @@ function difference(from: Set<string>, against: Set<string>): Difference {
   return {count, sample}
 }
 
-// A filter key gates a job on whether any changed file matched it, so the key's answer
-// is `length > 0` and nothing finer. `exportResults` reads it the same way.
-function firedKeys(filter: Filter, files: File[]): Set<string> {
-  return new Set(
-    Object.entries(filter.match(files))
-      .filter(([, matched]) => matched.length > 0)
-      .map(([key]) => key)
-  )
-}
-
-function compare(filter: Filter, apiFiles: File[], gitFiles: File[]): ShadowResult {
-  const api = new Set(apiFiles.map(f => f.filename))
+function compare(input: ShadowInput, api: Set<string>, gitFiles: File[]): ShadowResult {
   const local = new Set(gitFiles.map(f => f.filename))
   const onlyInApi = difference(api, local)
   const onlyInGit = difference(local, api)
-  const apiKeys = firedKeys(filter, apiFiles)
-  const gitKeys = firedKeys(filter, gitFiles)
+  const apiKeys = firedKeys(input.apiResults)
+  const gitKeys = firedKeys(input.filter.match(gitFiles))
   return {
     verdict: onlyInApi.count === 0 && onlyInGit.count === 0 ? 'match' : 'mismatch',
     reason: null,
@@ -254,8 +204,8 @@ function compare(filter: Filter, apiFiles: File[], gitFiles: File[]): ShadowResu
     gitCount: local.size,
     onlyInApi,
     onlyInGit,
-    keysLost: [...apiKeys].filter(k => !gitKeys.has(k)).sort(),
-    keysGained: [...gitKeys].filter(k => !apiKeys.has(k)).sort()
+    keysLost: missing(apiKeys, gitKeys),
+    keysGained: missing(gitKeys, apiKeys)
   }
 }
 
@@ -271,16 +221,17 @@ async function budgeted<T>(work: (signal: AbortSignal) => Promise<T>, ms: number
   return Promise.race([work(controller.signal), expiry]).finally(() => clearTimeout(timer))
 }
 
-export async function compareWithMergeCommit(filter: Filter, apiFiles: File[], pr: PullRequest): Promise<ShadowResult> {
+export async function compareWithMergeCommit(input: ShadowInput): Promise<ShadowResult> {
+  const api = new Set(input.apiFiles.map(f => f.filename))
   try {
-    const gitFiles = await budgeted(async signal => localChangedFiles(pr, signal), BUDGET_MS)
-    return compare(filter, apiFiles, gitFiles)
+    const gitFiles = await budgeted(async signal => localChangedFiles(input.pr, signal), BUDGET_MS)
+    return compare(input, api, gitFiles)
   } catch (error) {
     return {
       verdict: 'unavailable',
       reason: error instanceof Unavailable ? error.reason : 'unknown',
       detail: error instanceof Unavailable ? error.detail : messageOf(error),
-      apiCount: new Set(apiFiles.map(f => f.filename)).size,
+      apiCount: api.size,
       gitCount: null,
       onlyInApi: {count: 0, sample: []},
       onlyInGit: {count: 0, sample: []},
@@ -290,16 +241,9 @@ export async function compareWithMergeCommit(filter: Filter, apiFiles: File[], p
   }
 }
 
-// Without this the only record of a divergence is a log line in one job of one run,
-// which is unreadable at the volume that makes the comparison worth running.
-async function capture(
-  apiKey: string,
-  result: ShadowResult,
-  pr: PullRequest,
-  apiRows: number,
-  durationMs: number
-): Promise<void> {
+async function capture(apiKey: string, input: ShadowInput, result: ShadowResult, durationMs: number): Promise<void> {
   const repo = process.env.GITHUB_REPOSITORY || null
+  const pr = input.pr
   const properties = {
     repo,
     verdict: result.verdict,
@@ -314,21 +258,15 @@ async function capture(
     selection_changed: result.keysLost.length > 0 || result.keysGained.length > 0,
     keys_lost: result.keysLost,
     keys_gained: result.keysGained,
-    // pulls/{n}/files truncates silently at the cap, and the cap counts API rows, so
-    // the tell is how many rows came back. `api_count` cannot stand in: the API path
-    // expands each renamed row into an add plus a delete.
-    api_rows: apiRows,
-    api_truncated: apiRows >= API_FILE_CAP,
-    // Kept beside `api_rows` rather than used as the tell, because the payload's count
-    // is computed when the event fires and reads stale on a pull request whose base
-    // moved. The two disagreeing is itself worth seeing.
+    // `pr_changed_files` reads stale on a pull request whose base moved, so it is
+    // recorded beside the API's own row count rather than used as the truncation tell.
+    api_rows: input.apiRows,
+    api_truncated: input.apiTruncated,
     pr_changed_files: pr.changed_files,
     pr_number: pr.number,
     head_sha: pr.head.sha,
     head_ref: pr.head.ref,
     base_ref: pr.base.ref,
-    // Queue branches carry the cumulative batch diff and page far more than a human
-    // pull request, so they are the population worth reading separately.
     branch_class: pr.head.ref.startsWith('trunk-merge/') ? 'trunk-merge' : 'pull-request',
     is_fork: pr.head.repo?.full_name !== repo,
     duration_ms: durationMs,
@@ -346,7 +284,6 @@ async function capture(
       distinct_id: repo || 'paths-filter-shadow',
       properties
     }),
-    // Whatever the comparison did not spend, so the step's ceiling stays the budget.
     signal: AbortSignal.timeout(Math.max(CAPTURE_FLOOR_MS, BUDGET_MS - durationMs))
   })
   if (!res.ok) {
@@ -368,14 +305,10 @@ function summarize(result: ShadowResult): string {
   return `match (${result.apiCount} files)`
 }
 
-// Never throws: the filter's real answer is already computed by the time this runs,
-// so nothing here is worth failing a CI job over.
-//
-// The token gates the comparison itself, not just the capture. Every workflow that
-// detects changes runs this action, so a comparison whose result cannot be recorded
-// is a merge-ref fetch on the critical path of a gate job in exchange for a log line
-// nobody reads. Fork pull requests get no secrets, so they take this path too.
-export async function report(filter: Filter, apiFiles: File[], apiRows: number, pr: PullRequest): Promise<void> {
+// Never throws: the filter's real answer is already computed by the time this runs. The
+// token gates the comparison itself, so a run that cannot record its result does not pay
+// for a merge-ref fetch. Fork pull requests get no secrets and take that path too.
+export async function report(input: ShadowInput): Promise<void> {
   const apiKey = process.env.PATHS_FILTER_SHADOW_POSTHOG_TOKEN
   if (!apiKey) {
     return
@@ -383,14 +316,14 @@ export async function report(filter: Filter, apiFiles: File[], apiRows: number, 
   try {
     core.startGroup('Shadow: merge-commit change detection')
     const startedAt = Date.now()
-    const result = await compareWithMergeCommit(filter, apiFiles, pr)
+    const result = await compareWithMergeCommit(input)
     const durationMs = Date.now() - startedAt
 
-    // core.info even for a mismatch: a warning becomes an annotation on the run summary
-    // and the checks page, which reads as a problem with the pull request.
+    // core.info even for a mismatch, because a warning becomes an annotation on the
+    // checks page and reads as a problem with the pull request.
     core.info(`shadow: ${summarize(result)} in ${durationMs}ms`)
 
-    await capture(apiKey, result, pr, apiRows, durationMs).catch(error => {
+    await capture(apiKey, input, result, durationMs).catch(error => {
       core.info(`shadow: capture skipped (${messageOf(error)})`)
     })
   } catch (error) {


### PR DESCRIPTION
## Problem

The shadow records which files differ, not whether a job was gated differently. The second number is what decides whether the `pulls/{n}/files` call can be dropped, and the merge ref is gone by the time you ask afterwards.

`api_truncated` reads a payload count that goes stale when the base moves. It flagged a truncation on a pull request the API answered with two files.

## Changes

- Nothing outside CI logs looks different.
- The event records `selection_changed`, `keys_lost` and `keys_gained`: which filter keys answer differently on the two lists. A key gates a job.
- `api_truncated` now reads `api_rows`, since the 3,000-row cap is what truncates. `pr_changed_files` stays for comparison.
- The diff uses `--name-status`, because a filter rule can scope itself to a change status.
- Mechanical: the filter is passed down, `.depot` is re-mirrored, both bundles are rebuilt.

## How did you test this code?

Three Jest cases, each verified to fail with its guard removed: a dropped path that alone holds a key, one whose key a surviving path also holds, and a status-scoped rule.

Not checked: the `api_rows` counter, where a test would assert the octokit mock.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The action README says what the event records.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code implemented the change. Skills: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- `--name-status` was not in scope at first. Matching filter keys needs a real status per file.
- Nothing here draws on non-public material.
