### PR TITLE
fix(replay): update observations tab in replay

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PlayerSidebar.tsx
+++ b/frontend/src/scenes/session-recordings/player/PlayerSidebar.tsx
@@ -106,7 +106,7 @@ export function PlayerSidebar(): JSX.Element {
                             // The root scrolls, not the bar, so the scrollbar cannot collide with the bar's bottom-anchored underline
                             barClassName="!mb-0 w-max min-w-full !overflow-x-visible"
                             size="small"
-                            className="overflow-x-auto overflow-y-clip"
+                            className="overflow-x-auto overflow-y-clip !self-start"
                         />
                         <div className="flex flex-1 border-b shrink-0" />
                         <div className="flex gap-1 border-b end">

--- a/products/replay_vision/frontend/components/ObservationCard.tsx
+++ b/products/replay_vision/frontend/components/ObservationCard.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react'
-
 import { IconCopy, IconRewindPlay, IconSparkles } from '@posthog/icons'
 import { LemonButton, LemonTag, Link, Spinner, Tooltip } from '@posthog/lemon-ui'
 
@@ -11,17 +9,19 @@ import type { ReplayObservationApi } from '../generated/api.schemas'
 import {
     type ClassifierScannerConfig,
     type ScorerScannerConfig,
+    SUCCEEDED_OUTPUT_LABEL,
     configFromSnapshot,
     failureKindDescription,
     ineligibleKindDescription,
     parseFailureReason,
     parseIneligibleReason,
-    scannerTypeLabel,
 } from '../replay_scanners/types'
 import { citedTextToPlainText, parseCitedSegments } from '../utils/citations'
 import { readReasoning, scannerLabel } from '../utils/observation'
+import { LabeledRow } from './LabeledRow'
 import { ObservationProgressBar } from './ObservationProgressBar'
 import { ObservationRetryButton } from './ObservationRetryButton'
+import { ScannerTypeBadge } from './ScannerTypeBadge'
 
 export function ObservationStatusTag({
     status,
@@ -152,8 +152,13 @@ export function ObservationPrimaryOutput({
     const prompt = showPrompt ? promptText : null
     // Tooltip carries the prompt only when it isn't printed inline.
     const promptTooltip = prompt ? null : promptText
-    const summaryClass = expandSummary ? 'text-sm whitespace-pre-wrap' : compact ? 'text-sm truncate' : 'text-sm'
-    const bodyClass = compact ? 'text-sm truncate' : 'text-sm'
+    const textClass = 'text-sm'
+    const summaryClass = expandSummary
+        ? `${textClass} whitespace-pre-wrap`
+        : compact
+          ? `${textClass} truncate`
+          : textClass
+    const bodyClass = compact ? `${textClass} truncate` : textClass
     const promptClass = 'text-xs text-muted'
 
     if (scannerType === 'monitor') {
@@ -189,7 +194,7 @@ export function ObservationPrimaryOutput({
             <div className="flex flex-col gap-1">
                 {(title || showCopy) && (
                     <div className="flex items-start justify-between gap-2">
-                        {title && <span className="font-semibold text-sm">{title}</span>}
+                        {title && <span className={`font-semibold ${textClass}`}>{title}</span>}
                         {showCopy && (
                             <LemonButton
                                 size="xsmall"
@@ -250,7 +255,7 @@ export function ObservationPrimaryOutput({
                 <div className="flex flex-col gap-1">
                     <div className="flex flex-wrap gap-1">
                         {empty ? (
-                            <span className="text-muted text-sm">No categories</span>
+                            <span className={`text-muted ${textClass}`}>No categories</span>
                         ) : (
                             <>
                                 {fixedTags.map((tag, index) => (
@@ -269,7 +274,7 @@ export function ObservationPrimaryOutput({
         if (configuredTags.length === 0 && empty) {
             return (
                 <div className="flex flex-col gap-1">
-                    <span className="text-muted text-sm">No categories</span>
+                    <span className={`text-muted ${textClass}`}>No categories</span>
                     {prompt && <span className={promptClass}>{prompt}</span>}
                 </div>
             )
@@ -296,7 +301,7 @@ export function ObservationPrimaryOutput({
         return (
             <div className="flex flex-col gap-1">
                 <Tooltip title={promptTooltip}>
-                    <span className="text-sm self-start">
+                    <span className={`${textClass} self-start`}>
                         <span className="font-semibold text-base">{score ?? '—'}</span>
                         {scaleMax !== null && <span className="text-muted"> / {scaleMax}</span>}
                         {displayLabel && <span className="text-muted"> — {displayLabel}</span>}
@@ -340,7 +345,14 @@ export function ObservationPrimaryOutput({
     )
 }
 
-export function ObservationConfidence({ result }: { result: Record<string, unknown> }): JSX.Element | null {
+export function ObservationConfidence({
+    result,
+    standalone = false,
+}: {
+    result: Record<string, unknown>
+    /** For surfaces with no "Confidence" label of their own: the tag names the metric and the percentage is dropped. */
+    standalone?: boolean
+}): JSX.Element | null {
     if (typeof result.confidence !== 'number') {
         return null
     }
@@ -352,6 +364,13 @@ export function ObservationConfidence({ result }: { result: Record<string, unkno
             : value >= 0.5
               ? ({ type: 'warning', label: 'Medium' } as const)
               : ({ type: 'danger', label: 'Low' } as const)
+    if (standalone) {
+        return (
+            <Tooltip title={`Confidence: ${pct}%`}>
+                <LemonTag type={type}>{`${label} confidence`}</LemonTag>
+            </Tooltip>
+        )
+    }
     return (
         <div className="flex items-center gap-2">
             <LemonTag type={type}>{label}</LemonTag>
@@ -374,27 +393,36 @@ export function ObservationResultSummary({ observation }: { observation: ReplayO
 
 export function FailureDetail({ errorReason }: { errorReason: string }): JSX.Element {
     const parsed = parseFailureReason(errorReason)
-    if (!parsed) {
-        return <div className="text-danger text-sm">{errorReason}</div>
-    }
     return (
-        <div className="space-y-1">
-            <div className="font-semibold text-danger text-sm">{parsed.label}</div>
-            <div className="text-muted text-xs">{failureKindDescription(parsed.kind)}</div>
-            {parsed.message && <div className="text-muted text-xs font-mono">{parsed.message}</div>}
+        <div className="flex flex-col gap-2">
+            <LabeledRow label="Reason">
+                <p className="text-sm text-default m-0 leading-snug">
+                    {parsed ? failureKindDescription(parsed.kind) : errorReason}
+                </p>
+            </LabeledRow>
+            {parsed?.message && (
+                <LabeledRow label="Details">
+                    <p className="text-sm text-default m-0 leading-snug font-mono">{parsed.message}</p>
+                </LabeledRow>
+            )}
         </div>
     )
 }
 
 export function IneligibleDetail({ errorReason }: { errorReason: string }): JSX.Element {
     const parsed = parseIneligibleReason(errorReason)
-    if (!parsed) {
-        return <div className="text-muted text-sm">{errorReason}</div>
-    }
     return (
-        <div className="space-y-1">
-            <div className="font-semibold text-sm">{parsed.label}</div>
-            {parsed.message && <div className="text-muted text-xs">{parsed.message}</div>}
+        <div className="flex flex-col gap-2">
+            <LabeledRow label="Reason">
+                <p className="text-sm text-default m-0 leading-snug">
+                    {parsed ? ineligibleKindDescription(parsed.kind) : errorReason}
+                </p>
+            </LabeledRow>
+            {parsed?.message && (
+                <LabeledRow label="Details">
+                    <p className="text-sm text-default m-0 leading-snug">{parsed.message}</p>
+                </LabeledRow>
+            )}
         </div>
     )
 }
@@ -413,7 +441,6 @@ export function ObservationDockCard({
     const snapshot = observation.scanner_snapshot
     const scannerType = snapshot?.scanner_type
     const result = readResult(observation)
-    const [reasoningExpanded, setReasoningExpanded] = useState(false)
     // Summarizers excluded: their primary output already is the full text
     const reasoning =
         observation.status === 'succeeded' && scannerType !== 'summarizer' ? readReasoning(observation) : null
@@ -422,12 +449,20 @@ export function ObservationDockCard({
         <div className="border rounded p-3 bg-surface-primary space-y-2">
             <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2 min-w-0">
-                    <ObservationStatusTag status={observation.status} errorReason={observation.error_reason} />
+                    {observation.status !== 'succeeded' && (
+                        <ObservationStatusTag status={observation.status} errorReason={observation.error_reason} />
+                    )}
                     <span className="font-semibold text-sm truncate">{scannerLabel(observation)}</span>
-                    {scannerType && <span className="text-muted text-xs">{scannerTypeLabel(scannerType)}</span>}
+                    {scannerType && (
+                        <span className="shrink-0">
+                            <ScannerTypeBadge scannerType={scannerType} size="small" />
+                        </span>
+                    )}
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
-                    {observation.status === 'succeeded' && result && <ObservationConfidence result={result} />}
+                    {observation.status === 'succeeded' && result && (
+                        <ObservationConfidence result={result} standalone />
+                    )}
                     <Link to={urls.replayVisionObservation(observation.id)} className="text-xs whitespace-nowrap">
                         View details
                     </Link>
@@ -466,27 +501,22 @@ export function ObservationDockCard({
 
             {observation.status === 'succeeded' && snapshot && result && (
                 <>
-                    <ObservationPrimaryOutput
-                        observation={observation}
-                        compact
-                        onSeek={onSeek}
-                        expandSummary
-                        copyable
-                    />
+                    <LabeledRow label={scannerType ? SUCCEEDED_OUTPUT_LABEL[scannerType] : 'Result'}>
+                        <ObservationPrimaryOutput
+                            observation={observation}
+                            compact
+                            showPrompt={false}
+                            onSeek={onSeek}
+                            expandSummary
+                            copyable
+                        />
+                    </LabeledRow>
                     {reasoning && (
-                        <div className="flex flex-col gap-1.5 items-start">
-                            <p className={`text-sm whitespace-pre-wrap m-0 ${reasoningExpanded ? '' : 'line-clamp-2'}`}>
+                        <LabeledRow label="Model reasoning">
+                            <p className="text-sm text-default whitespace-pre-wrap m-0 leading-snug">
                                 <CitedText text={reasoning} segments={result.reasoning_segments} onSeek={onSeek} />
                             </p>
-                            <LemonButton
-                                size="xsmall"
-                                type="tertiary"
-                                onClick={() => setReasoningExpanded(!reasoningExpanded)}
-                                data-attr="vision-observation-reasoning-toggle"
-                            >
-                                {reasoningExpanded ? 'Show less' : 'Show more'}
-                            </LemonButton>
-                        </div>
+                        </LabeledRow>
                     )}
                 </>
             )}

--- a/products/replay_vision/frontend/components/PlayerSidebarObservationsTab.tsx
+++ b/products/replay_vision/frontend/components/PlayerSidebarObservationsTab.tsx
@@ -13,6 +13,7 @@ import { visionQuotaLogic } from '../logics/visionQuotaLogic'
 import { quotaUx } from '../utils/quotaProjection'
 import { visionSurfaceShown } from '../utils/visionSurface'
 import { ObservationDockCard } from './ObservationCard'
+import { ScannerTypeBadge } from './ScannerTypeBadge'
 
 export function PlayerSidebarObservationsTab(): JSX.Element | null {
     const { sessionRecordingId, logicProps } = useValues(sessionRecordingPlayerLogic)
@@ -82,7 +83,9 @@ function ScannerPicker({
                                 >
                                     <span className="flex items-center justify-between gap-2 w-full">
                                         <span className="truncate">{scanner.name}</span>
-                                        <span className="text-muted text-xs shrink-0">{scanner.scanner_type}</span>
+                                        <span className="shrink-0">
+                                            <ScannerTypeBadge scannerType={scanner.scanner_type} size="small" />
+                                        </span>
                                     </span>
                                 </LemonButton>
                             ))

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -62,7 +62,7 @@ import {
     parseFailureReason,
     parseIneligibleReason,
     OBSERVATION_TRIGGER_TAG,
-    type ScannerType,
+    SUCCEEDED_OUTPUT_LABEL,
 } from '../replay_scanners/types'
 import { scannerLabel } from '../utils/observation'
 import { ObservationLabelControl } from './ObservationLabelControl'
@@ -73,13 +73,6 @@ export const scene: SceneExport = {
     component: ReplayObservationSceneComponent,
     logic: replayObservationSceneLogic,
     productKey: ProductKey.REPLAY_VISION,
-}
-
-const SUCCEEDED_OUTPUT_LABEL: Record<ScannerType, string> = {
-    classifier: 'Categories',
-    summarizer: 'Summary',
-    monitor: 'Verdict',
-    scorer: 'Score',
 }
 
 function AutoSeekToTime({

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -332,6 +332,14 @@ export function scannerTypeOutputHint(scannerType: ScannerType): string {
     return SCANNER_TYPE_OUTPUT_HINT[scannerType]
 }
 
+/** Section label for a succeeded observation's primary output, shared by the detail page and the dock card. */
+export const SUCCEEDED_OUTPUT_LABEL: Record<ScannerType, string> = {
+    classifier: 'Categories',
+    summarizer: 'Summary',
+    monitor: 'Verdict',
+    scorer: 'Score',
+}
+
 export function createdByLabel(user: ScannerCreatedBy | null): string {
     if (!user) {
         return ''


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->
Observation tab's details were a bit disorganized and too much information.

## Changes

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->
- Card sections are now labeled (`LabeledRow`) matching the observation details page
- Primary output moved to the top
- Dropped the Prompt row
- Model reasoning shows in full
- Status tag only renders when an observation has not succeeded
- Confidence is one self-describing tag ("High confidence"), percentage in a tooltip
- Scanner type uses `ScannerTypeBadge` in the card header and the picker dropdown
- `SUCCEEDED_OUTPUT_LABEL` added into `replay_scanners/types.ts`
<img width="888" height="926" alt="Screenshot 2026-08-31 at 15 28 42" src="https://github.com/user-attachments/assets/5ac15bea-7818-422b-92bf-ace67696343e" />


## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
