### PR TITLE
fix(signals): label min-priority picker with the range it covers

### DIFF
--- a/products/desktop/packages/ui/src/features/settings/sections/SignalSlackNotificationsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/SignalSlackNotificationsSettings.tsx
@@ -7,16 +7,18 @@ import { SettingsOptionSelect } from "@posthog/ui/features/settings/SettingsOpti
 
 const NOTIFY_ALL_VALUE = "__all__";
 
+// Labels name the range a threshold covers, because the priority digits descend as urgency rises,
+// so a directional word ("and above") reads either way.
 const MIN_PRIORITY_OPTIONS: {
   value: SignalReportPriority | typeof NOTIFY_ALL_VALUE;
   label: string;
 }[] = [
   { value: NOTIFY_ALL_VALUE, label: "All priorities" },
   { value: "P0", label: "P0 only" },
-  { value: "P1", label: "P1 and above" },
-  { value: "P2", label: "P2 and above" },
-  { value: "P3", label: "P3 and above" },
-  { value: "P4", label: "P4 and above" },
+  { value: "P1", label: "P0-P1" },
+  { value: "P2", label: "P0-P2" },
+  { value: "P3", label: "P0-P3" },
+  { value: "P4", label: "P0-P4" },
 ];
 
 interface SignalSlackNotificationsSettingsProps {
@@ -91,7 +93,7 @@ export function SignalSlackNotificationsSettings({
       </SettingsCardRow>
       <SettingsCardRow
         label="Minimum priority"
-        description="Only ping me for reports at or above this priority"
+        description="Only ping me for reports in this priority range. P0 is the most urgent."
       >
         <SettingsOptionSelect
           value={minPriority ?? NOTIFY_ALL_VALUE}

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -190,9 +190,9 @@ class SignalUserAutonomyConfig(UUIDModel):
         related_name="+",
     )
     slack_notification_channel = models.CharField(max_length=255, null=True, blank=True)
-    # When null, every report that has a priority notifies.
     # When set, only reports at or above this priority (P0 highest) notify.
-    # A report with no priority never notifies, whatever this is set to.
+    # When null, every prioritized report notifies. A report with no priority then
+    # notifies only on the reviewer-added path (see slack_inbox_notifications).
     slack_notification_min_priority = models.CharField(max_length=2, choices=AutonomyPriority, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -190,8 +190,9 @@ class SignalUserAutonomyConfig(UUIDModel):
         related_name="+",
     )
     slack_notification_channel = models.CharField(max_length=255, null=True, blank=True)
-    # When null, all priorities (including reports with no priority) notify.
-    # When set, only reports with a priority at or above this value (P0 highest) notify.
+    # When null, every report that has a priority notifies.
+    # When set, only reports at or above this priority (P0 highest) notify.
+    # A report with no priority never notifies, whatever this is set to.
     slack_notification_min_priority = models.CharField(max_length=2, choices=AutonomyPriority, null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -330,7 +330,7 @@ class SignalUserAutonomyConfigSerializer(serializers.ModelSerializer):
             "slack_notification_min_priority": {
                 "help_text": (
                     "Minimum report priority that triggers a Slack notification. P0 is highest. "
-                    "Null means notify on every priority (and reports without a priority judgment)."
+                    "Null means notify on every priority. Reports without a priority judgment never notify."
                 )
             },
         }
@@ -357,7 +357,9 @@ class SignalUserAutonomyConfigCreateSerializer(serializers.Serializer):
         choices=AutonomyPriority.choices,
         required=False,
         allow_null=True,
-        help_text="P0 is highest. Null = notify for every priority.",
+        help_text=(
+            "P0 is highest. Null = notify for every priority. Reports without a priority judgment never notify."
+        ),
     )
 
 

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -330,7 +330,7 @@ class SignalUserAutonomyConfigSerializer(serializers.ModelSerializer):
             "slack_notification_min_priority": {
                 "help_text": (
                     "Minimum report priority that triggers a Slack notification. P0 is highest. "
-                    "Null means notify on every priority. Reports without a priority judgment never notify."
+                    "Null means notify on every priority. When set, reports without a priority judgment do not notify."
                 )
             },
         }
@@ -358,7 +358,7 @@ class SignalUserAutonomyConfigCreateSerializer(serializers.Serializer):
         required=False,
         allow_null=True,
         help_text=(
-            "P0 is highest. Null = notify for every priority. Reports without a priority judgment never notify."
+            "P0 is highest. Null = notify for every priority. When set, reports without a priority judgment do not notify."
         ),
     )
 

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -4079,7 +4079,7 @@ export interface SignalUserAutonomyConfigApi {
      * @nullable
      */
     slack_notification_channel?: string | null
-    /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).
+    /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. Reports without a priority judgment never notify.
      *
      * * `P0` - P0
      * * `P1` - P1

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -4079,7 +4079,7 @@ export interface SignalUserAutonomyConfigApi {
      * @nullable
      */
     slack_notification_channel?: string | null
-    /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. Reports without a priority judgment never notify.
+    /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. When set, reports without a priority judgment do not notify.
      *
      * * `P0` - P0
      * * `P1` - P1

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -1686,6 +1686,6 @@ export const UsersSignalAutonomyCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            'Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. Reports without a priority judgment never notify.\n\n\* `P0` - P0\n\* `P1` - P1\n\* `P2` - P2\n\* `P3` - P3\n\* `P4` - P4'
+            'Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. When set, reports without a priority judgment do not notify.\n\n\* `P0` - P0\n\* `P1` - P1\n\* `P2` - P2\n\* `P3` - P3\n\* `P4` - P4'
         ),
 })

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -1686,6 +1686,6 @@ export const UsersSignalAutonomyCreateBody = /* @__PURE__ */ zod.object({
         ])
         .optional()
         .describe(
-            'Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).\n\n\* `P0` - P0\n\* `P1` - P1\n\* `P2` - P2\n\* `P3` - P3\n\* `P4` - P4'
+            'Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. Reports without a priority judgment never notify.\n\n\* `P0` - P0\n\* `P1` - P1\n\* `P2` - P2\n\* `P3` - P3\n\* `P4` - P4'
         ),
 })

--- a/products/signals/frontend/inbox/types.ts
+++ b/products/signals/frontend/inbox/types.ts
@@ -41,13 +41,15 @@ export interface EnrichedReviewer {
 /** P0 (highest) – P4 (lowest). Mirrors desktop `SignalReportPriority`. */
 export type SignalReportPriority = 'P0' | 'P1' | 'P2' | 'P3' | 'P4'
 
-/** Threshold options over SignalReportPriority, strictest first. Shared by the auto-start and Slack min-priority selects. */
+/** Threshold options over SignalReportPriority, strictest first. Shared by the auto-start and Slack min-priority selects.
+ * Labels name the range a threshold covers, because the priority digits descend as urgency rises,
+ * so a directional word ("and above") reads either way. */
 export const PRIORITY_THRESHOLD_OPTIONS: { value: SignalReportPriority; label: string }[] = [
     { value: 'P0', label: 'P0 only' },
-    { value: 'P1', label: 'P1 and above' },
-    { value: 'P2', label: 'P2 and above' },
-    { value: 'P3', label: 'P3 and above' },
-    { value: 'P4', label: 'P4 and above' },
+    { value: 'P1', label: 'P0-P1' },
+    { value: 'P2', label: 'P0-P2' },
+    { value: 'P3', label: 'P0-P3' },
+    { value: 'P4', label: 'P0-P4' },
 ]
 
 /** Actionability judgment outcome. Mirrors desktop `SignalReportActionability`. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -77033,7 +77033,7 @@ export namespace Schemas {
          * @nullable
          */
       slack_notification_channel?: string | null;
-      /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority (and reports without a priority judgment).
+      /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. Reports without a priority judgment never notify.
        *
        * * `P0` - P0
        * * `P1` - P1

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -77033,7 +77033,7 @@ export namespace Schemas {
          * @nullable
          */
       slack_notification_channel?: string | null;
-      /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. Reports without a priority judgment never notify.
+      /** Minimum report priority that triggers a Slack notification. P0 is highest. Null means notify on every priority. When set, reports without a priority judgment do not notify.
        *
        * * `P0` - P0
        * * `P1` - P1


### PR DESCRIPTION
## Problem

A person setting up Slack notifications for the self-driving inbox cannot tell which reports "P2 and above" sends.

- The picker offers "P0 only", "P1 and above" … "P4 and above".
- P0 is the most urgent priority, so the digits descend as urgency rises.
- "Above" therefore points toward P0, against the direction the numbers read. A reviewer on our own team read it the other way and assumed the filter was inverted.
- The filter itself is correct. `_meets_min_priority` compares rank indexes with `report_rank <= min_rank`, and `products/signals/backend/test/test_slack_inbox_notifications.py:38` pins it.

## Changes

- The picker now names the range each threshold covers: "P0 only", "P0-P1", "P0-P2", "P0-P3", "P0-P4". No directional word, so nothing depends on knowing that P0 outranks P4.
- The desktop field description reads "Only ping me for reports in this priority range. P0 is the most urgent." It said "at or above this priority", which repeated the ambiguous word.
- Values, filter logic, and stored settings are unchanged. An existing "P2 and above" setting reads as "P0-P2" and behaves identically.
- Mechanical: the labels live in one shared constant per host, so cloud and desktop stay in step. The auto-start control reads only the values from that constant and keeps its own segment labels, so it looks the same.

The rest is a correctness fix to developer-facing text, in the same area:

- The comment on `slack_notification_min_priority` and two serializer `help_text` strings (which reach the public API docs) misstated how reports with no priority behave. They now say a set threshold filters those reports out, which holds on every dispatch path. With a null threshold, only the reviewer-added path delivers them (`test_reviewer_added_unprioritized_report` pins this); the model comment documents that.
- Generated API types regenerated for the `help_text` change.

No screenshot: the surface needs a connected Slack workspace and the `INBOX_SLACK_NOTIFICATIONS` flag, neither of which this sandbox has. The change is the five label strings quoted above.

## How did you test this code?

No behavior changed, so no tests were added.

- Ran `hogli build:openapi` to regenerate the types, and `hogli ci:preflight --fix`, which reported 0 failures.
- Not run: the signals pytest suite. Its database setup exceeded the sandbox timeout. The diff does not touch `_meets_min_priority` or any caller, and the existing parametrized test already covers the filter direction.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The public docs do not quote these labels.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A PostHog engineer setting up their own Slack notifications reported the label as backwards and asked whether the label or the filter was wrong. Investigation showed the filter is correct and consistent with the P0-is-highest convention stated in the model, both serializers, and the tests. The reported fix, "and below" or "up to P3", would have inverted the meaning against that convention, so this PR drops the directional word instead of flipping it.

The stale comment and `help_text` surfaced while confirming the filter direction. They are unrelated to the labels but sit on the same field.

The bot review caught that the first version of that help text overclaimed in the other direction ("never notify"). A follow-up commit rewrote it against the pinned reviewer-added behavior.

Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`. No assignee is set, because the directing engineer's GitHub handle was not verified in this session.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788184506987229)*

