### PR TITLE
fix(navigation): give the compact sidebar room to breathe

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3196,6 +3196,10 @@ snapshots:
         hash: v1.k794b7964.dea67e50d4956ed1865124e7dba12c5deeb0703b19cac0513c82facb069e6a60.gkkPUZ2bAqgN4OxaM6W5sfI8m4O2uxsHh7xqL1PLsg4
     layout-navigation-eventingestionrestrictiondetails--whole-project--light:
         hash: v1.k794b7964.56e91dee845e8cae758c631b29733ddb23d0bd46c4669cd904032f3f668c8dd9.lrp6-51HhFOiy6Rqy1o5KlQamvWmozjUVC8EQnCPhrU
+    layout-navigation-sidebar--density-comparison--dark:
+        hash: v1.k794b7964.0900d9026ecffa9c2ff0989ee4618cdddfbb184c1ae480b110fc618105865445.KjYyXIZzyGNorxnj3Xo_ymFB0DMbOVFMRj_IPeTgAhI
+    layout-navigation-sidebar--density-comparison--light:
+        hash: v1.k794b7964.1caaa1ff521dfe6a6435dbaa817e05cd8263abd3a5b619d572dcb2c372cece1a.MlYgyHdxlI7nKwGkZHh7jiaPWO3aop7aEJzzWmjW5Rs
     layout-project-tree--all-products--dark:
         hash: v1.k794b7964.f5ecd6decc0aa7b7e9641cc874f81b12d2f73973fc7a991367907c8bf9e6a3cf.GmiqvAu4XbxVgya6Rn15ChvXn-l9XU6ttxGUqmPoi4o
     layout-project-tree--all-products--light:

--- a/frontend/src/layout/panel-layout/ai-first/Nav.scss
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.scss
@@ -1,7 +1,27 @@
+// Density is set through custom properties rather than overriding rules. Tailwind utilities are
+// !important in this app, so a rule that competes with one loses, but a variable it reads wins.
 [data-nav-density='compact'] {
     --button-height-base: var(--button-height-xs);
 
+    // Section and category headers keep the padding of a comfortable row. Once the rows condense,
+    // that space reads as a gap instead of as grouping.
+    --nav-section-trigger-padding-y: 0.125rem;
+    --nav-section-gap: 0.25rem;
+    --lemon-tree-category-gap: 0.5rem;
+    --lemon-tree-category-padding-y: 0.125rem;
+
     .button-primitive {
         font-size: 0.75rem;
+    }
+
+    // The search bar is a control, not a list row, so it stays taller than the rows around it.
+    // At the compact row height the ⌘K badge fills the box from edge to edge.
+    [data-attr='nav-search-bar'] {
+        --button-height-base: var(--button-height-sm);
+
+        .KeyboardShortcut {
+            min-width: 1.125rem;
+            height: 1.125rem;
+        }
     }
 }

--- a/frontend/src/layout/panel-layout/ai-first/Nav.stories.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.stories.tsx
@@ -1,0 +1,94 @@
+import './Nav.scss'
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { useActions } from 'kea'
+
+import { NavSearchBar } from 'lib/components/NavSearchButton/NavSearchButton'
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+
+import { mswDecorator } from '~/mocks/browser'
+import { SidebarDensity } from '~/queries/schema/schema-general'
+
+import { customProductsLogic } from '../ProjectTree/customProductsLogic'
+import { NavTabBrowse } from './tabs/NavTabBrowse'
+
+/** Enough tools, across enough categories, for "My tools" to show its category headers. */
+const MOCK_TOOLS = [
+    'Product analytics',
+    'Web analytics',
+    'Session replay',
+    'Surveys',
+    'Error tracking',
+    'Experiments',
+    'Feature flags',
+].map((productPath, index) => ({
+    id: `product-${index}`,
+    product_path: productPath,
+    enabled: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+}))
+
+/**
+ * Density comes from `data-nav-density`, which `Nav` sets from the user's sidebar setting.
+ * Setting the attribute here keeps the story independent of the user API.
+ */
+function NavSidebar({ density }: { density: SidebarDensity }): JSX.Element {
+    const { loadCustomProducts } = useActions(customProductsLogic)
+    useOnMountEffect(() => loadCustomProducts())
+
+    return (
+        <div
+            data-nav-density={density}
+            className="flex flex-col w-[var(--project-navbar-width)] h-[640px] bg-surface-tertiary border rounded overflow-hidden"
+        >
+            <div className="px-2 py-1">
+                <NavSearchBar toggleCommand={() => {}} />
+            </div>
+            <NavTabBrowse />
+        </div>
+    )
+}
+
+const meta: Meta<typeof NavSidebar> = {
+    title: 'Layout/Navigation sidebar',
+    component: NavSidebar,
+    parameters: {
+        layout: 'padded',
+        viewMode: 'story',
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/environments/:team_id/user_product_list': () => [200, { results: MOCK_TOOLS }],
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<typeof NavSidebar>
+
+export const Comfortable: Story = {
+    args: { density: 'comfortable' },
+}
+
+export const Compact: Story = {
+    args: { density: 'compact' },
+}
+
+/** Both densities together, so a spacing change to one is visible against the other. */
+export const DensityComparison: Story = {
+    render: () => (
+        <div className="flex gap-4">
+            <div className="flex flex-col gap-1">
+                <span className="text-xs font-semibold text-secondary">Comfortable</span>
+                <NavSidebar density="comfortable" />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="text-xs font-semibold text-secondary">Compact</span>
+                <NavSidebar density="compact" />
+            </div>
+        </div>
+    ),
+}

--- a/frontend/src/layout/panel-layout/ai-first/Nav.stories.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.stories.tsx
@@ -50,9 +50,25 @@ function NavSidebar({ density }: { density: SidebarDensity }): JSX.Element {
     )
 }
 
-const meta: Meta<typeof NavSidebar> = {
+/** Both densities together, so a spacing change to one is visible against the other. */
+function NavSidebarDensities(): JSX.Element {
+    return (
+        <div className="flex gap-4">
+            <div className="flex flex-col gap-1">
+                <span className="text-xs font-semibold text-secondary">Comfortable</span>
+                <NavSidebar density="comfortable" />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="text-xs font-semibold text-secondary">Compact</span>
+                <NavSidebar density="compact" />
+            </div>
+        </div>
+    )
+}
+
+const meta: Meta<typeof NavSidebarDensities> = {
     title: 'Layout/Navigation sidebar',
-    component: NavSidebar,
+    component: NavSidebarDensities,
     parameters: {
         layout: 'padded',
         viewMode: 'story',
@@ -67,28 +83,4 @@ const meta: Meta<typeof NavSidebar> = {
 }
 export default meta
 
-type Story = StoryObj<typeof NavSidebar>
-
-export const Comfortable: Story = {
-    args: { density: 'comfortable' },
-}
-
-export const Compact: Story = {
-    args: { density: 'compact' },
-}
-
-/** Both densities together, so a spacing change to one is visible against the other. */
-export const DensityComparison: Story = {
-    render: () => (
-        <div className="flex gap-4">
-            <div className="flex flex-col gap-1">
-                <span className="text-xs font-semibold text-secondary">Comfortable</span>
-                <NavSidebar density="comfortable" />
-            </div>
-            <div className="flex flex-col gap-1">
-                <span className="text-xs font-semibold text-secondary">Compact</span>
-                <NavSidebar density="compact" />
-            </div>
-        </div>
-    ),
-}
+export const DensityComparison: StoryObj<typeof NavSidebarDensities> = {}

--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -70,7 +70,7 @@ export function SectionTrigger({
     return (
         <Collapsible.Trigger
             className={cn(
-                'flex items-center py-1 cursor-pointer group pl-2 sticky top-0 bg-surface-tertiary z-4 -mx-1 px-2 w-[calc(100%+(var(--spacing)*2))] -outline-offset-2',
+                'flex items-center py-[var(--nav-section-trigger-padding-y,0.25rem)] cursor-pointer group pl-2 sticky top-0 bg-surface-tertiary z-4 -mx-1 px-2 w-[calc(100%+(var(--spacing)*2))] -outline-offset-2',
                 isCollapsed && 'mx-0 w-full px-px'
             )}
         >

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
@@ -329,7 +329,7 @@ export function NavTabBrowse(): JSX.Element {
                         })
                         toggleNavSection('recents')
                     }}
-                    className="mt-2 group/colorful-product-icons colorful-product-icons-true"
+                    className="mt-[var(--nav-section-gap,0.5rem)] group/colorful-product-icons colorful-product-icons-true"
                     data-attr="nav-section-recents"
                 >
                     <SectionTrigger icon={<IconClock />} label="Recents" isCollapsed={isLayoutNavCollapsed} />
@@ -393,7 +393,7 @@ export function NavTabBrowse(): JSX.Element {
                         })
                         toggleNavSection('tools')
                     }}
-                    className="mt-2 group/colorful-product-icons colorful-product-icons-true"
+                    className="mt-[var(--nav-section-gap,0.5rem)] group/colorful-product-icons colorful-product-icons-true"
                     data-attr="nav-section-tools"
                 >
                     <div className="relative">

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -626,7 +626,10 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                             return null
                         }
                         return (
-                            <div key={item.id} className="not-first:mt-3 py-1 px-2 flex items-center">
+                            <div
+                                key={item.id}
+                                className="not-first:mt-[var(--lemon-tree-category-gap,0.75rem)] py-[var(--lemon-tree-category-padding-y,0.25rem)] px-2 flex items-center"
+                            >
                                 <span className="text-xs font-semibold text-tertiary">{item.displayName}</span>
                             </div>
                         )

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -626,8 +626,6 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                             return null
                         }
                         return (
-                            // Spacing reads from variables so a denser container, such as the
-                            // compact nav sidebar, can tighten the header without a new prop.
                             <div
                                 key={item.id}
                                 className="not-first:mt-[var(--lemon-tree-category-gap,0.75rem)] py-[var(--lemon-tree-category-padding-y,0.25rem)] px-2 flex items-center"

--- a/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTree/LemonTree.tsx
@@ -626,6 +626,8 @@ const LemonTreeNode = forwardRef<HTMLDivElement, LemonTreeNodeProps>(
                             return null
                         }
                         return (
+                            // Spacing reads from variables so a denser container, such as the
+                            // compact nav sidebar, can tighten the header without a new prop.
                             <div
                                 key={item.id}
                                 className="not-first:mt-[var(--lemon-tree-category-gap,0.75rem)] py-[var(--lemon-tree-category-padding-y,0.25rem)] px-2 flex items-center"


### PR DESCRIPTION
## Problem

Someone on the compact sidebar density loses the readability the setting is meant to buy.

- The search bar shrinks along with every nav row, so the ⌘K badge sits flush against the box edge with about a pixel on each side.
- Section headers ("Project", "My tools") and category headers ("Analytics", "Behavior") keep the padding of a comfortable row, so the space around them grows relative to the rows they separate.

Refs #76072

## Changes

- The compact search bar keeps a taller box and a smaller ⌘K badge, so the shortcut has room around it.
- Compact section and category headers give back around 45px down a full "My tools" list, so more of the list fits without scrolling.
- Density flows through custom properties that the Tailwind utilities read. Utilities are `!important` in this app, so a rule that competes with one loses whatever its specificity.
- A new `Layout/Navigation sidebar` story renders the sidebar at both densities.

Mechanical: the `LemonTree` category header and the nav section wrappers swap fixed spacing classes for the same values behind a variable. Comfortable density is unchanged.

**Compact, before and after**

![compact-before-after](https://raw.githubusercontent.com/PostHog/pr-assets/1362997773f1ea10d7ee084e584035b4ba7b3982/2026/08/b5230971-dc9b-48b1-9b87-e23bb35236c2.png)

**Both densities after the change**

![after-comparison](https://raw.githubusercontent.com/PostHog/pr-assets/75eed3bba0745572b3560f1a06b326cc285ecd62/2026/08/9145fc1d-c7cd-4e43-86fd-2a1ab777c138.png)

## How did you test this code?

- The screenshots above come from the new story, rendered in Storybook through a headless browser, with the density variables reverted for the "before" column.
- The story is the regression guard. Visual regression now covers compact, which nothing did before.
- `hogli ci:preflight --fix` reported no failures.
- Not run: `pnpm --filter=@posthog/frontend typescript:check`. It was OOM-killed in this sandbox. CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The setting and its options are unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a report in Slack about the compact sidebar. Skills invoked: `/writing-ui-components`, `/writing-pr-descriptions`.

The first attempt overrode the header spacing with rules in `Nav.scss`, then with `!important`. Both lost: Tailwind emits its utilities as `!important` inside `@layer utilities`, and an important declaration in an unlayered sheet ranks below a layered one. Overriding the variable the utility reads wins without the layer fight, and matches the pattern already used in `lemon-skin.scss` and for `--lemon-tree-button-height`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C043VJ93L3B/p1788186980669249)*
