### PR TITLE
chore(ci): start master-red agent via webhook

### DIFF
--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -62,6 +62,13 @@ const SCHEDULED_RUN_INDEX_MAX_LAG_MINUTES = 360
 const SCHEDULED_LANE_LABEL = '(scheduled)'
 const STALE_PAGE_RETRIES = 2
 const STALE_PAGE_RETRY_DELAY_MS = 15000
+// The diagnosis agent is started by POSTing this event to a workflow's incoming-webhook trigger.
+// The alerter sends the incident, not a Slack message: the workflow maps `properties.channel` and
+// `properties.ts` onto the agent's Slack context so the answer still lands under the anchor.
+const INCIDENT_OPENED_EVENT = 'master_ci_incident_opened'
+const WEBHOOK_ATTEMPTS = 3
+const WEBHOOK_RETRY_DELAY_MS = 2000
+const WEBHOOK_TIMEOUT_MS = 10000
 
 const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -337,6 +344,37 @@ function defaultSlackClient(token, fetchImpl) {
     }
 }
 
+// Ask the diagnosis workflow to start, and fail the run if it can't be reached.
+//
+// A direct call, rather than a workflow triggering on the anchor message: the Slack-message trigger
+// crosses regions and drops events with no error on either side, so an agent that never starts
+// leaves no trace anywhere. Here a lost start reddens this run.
+//
+// Retried because not losing the start is the whole point, and bounded because the alert itself has
+// already posted and no later tick tries again (an incident is created once).
+async function startDiagnosisAgent({ url, token, fetchImpl, sleep, core }, payload) {
+    if (!url) {return false}
+    const doFetch = fetchImpl || fetch
+    let lastError = 'unknown'
+    for (let attempt = 1; attempt <= WEBHOOK_ATTEMPTS; attempt++) {
+        try {
+            const res = await doFetch(url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: token } : {}) },
+                body: JSON.stringify(payload),
+                signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
+            })
+            if (res.ok) {return true}
+            lastError = `HTTP ${res.status}`
+        } catch (err) {
+            lastError = err.message
+        }
+        if (attempt < WEBHOOK_ATTEMPTS) {await sleep(WEBHOOK_RETRY_DELAY_MS * attempt)}
+    }
+    core.setFailed(`Could not start the diagnosis agent after ${WEBHOOK_ATTEMPTS} attempts: ${lastError}`)
+    return false
+}
+
 // The bot's own open incident, identified purely by message metadata — no other
 // app sets this event_type, so it is unambiguous without knowing our bot id.
 async function findActiveIncident(slack, channel) {
@@ -601,6 +639,28 @@ module.exports = async ({ context, github, core }, { now: _now, slack: _slack, f
                 thread_ts: posted.ts,
                 text: buildThreadReply({ created: workflows, commitStarted: commitActive }),
             })
+            await startDiagnosisAgent(
+                {
+                    url: process.env.DIAGNOSIS_WEBHOOK_URL,
+                    token: process.env.DIAGNOSIS_WEBHOOK_TOKEN,
+                    fetchImpl: _fetch,
+                    sleep,
+                    core,
+                },
+                {
+                    event: INCIDENT_OPENED_EVENT,
+                    distinct_id: 'ci-alerts-devex',
+                    properties: {
+                        channel,
+                        ts: posted.ts,
+                        workflows: workflows.map((w) => w.name),
+                        commit_streak: commitActive ? commitStreakCount : 0,
+                        since,
+                        latest_commit_sha: latestCommit?.sha || '',
+                        all_failing_runs_url: allFailingRunsUrl,
+                    },
+                }
+            )
             action = 'create'
         } else {
             await slack.update({ channel, ts: active.ts, ...message, metadata, unfurl_links: false })

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -62,9 +62,8 @@ const SCHEDULED_RUN_INDEX_MAX_LAG_MINUTES = 360
 const SCHEDULED_LANE_LABEL = '(scheduled)'
 const STALE_PAGE_RETRIES = 2
 const STALE_PAGE_RETRY_DELAY_MS = 15000
-// The diagnosis agent is started by POSTing this event to a workflow's incoming-webhook trigger.
-// The alerter sends the incident, not a Slack message: the workflow maps `properties.channel` and
-// `properties.ts` onto the agent's Slack context so the answer still lands under the anchor.
+// The workflow behind the webhook reads `properties.channel` and `properties.ts` to reply in the
+// alert thread, so dropping either from the payload leaves the agent's answer with nowhere to land.
 const INCIDENT_OPENED_EVENT = 'master_ci_incident_opened'
 const WEBHOOK_ATTEMPTS = 3
 const WEBHOOK_RETRY_DELAY_MS = 2000
@@ -344,14 +343,7 @@ function defaultSlackClient(token, fetchImpl) {
     }
 }
 
-// Ask the diagnosis workflow to start, and fail the run if it can't be reached.
-//
-// A direct call, rather than a workflow triggering on the anchor message: the Slack-message trigger
-// crosses regions and drops events with no error on either side, so an agent that never starts
-// leaves no trace anywhere. Here a lost start reddens this run.
-//
-// Retried because not losing the start is the whole point, and bounded because the alert itself has
-// already posted and no later tick tries again (an incident is created once).
+// Only an incident's first tick calls this, so a start lost here is never retried by a later tick.
 async function startDiagnosisAgent({ url, token, fetchImpl, sleep, core }, payload) {
     if (!url) {return false}
     const doFetch = fetchImpl || fetch

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -344,15 +344,18 @@ function defaultSlackClient(token, fetchImpl) {
 }
 
 // Only an incident's first tick calls this, so a start lost here is never retried by a later tick.
-async function startDiagnosisAgent({ url, token, fetchImpl, sleep, core }, payload) {
+async function startDiagnosisAgent({ url, fetchImpl, sleep, core }, payload) {
     if (!url) {return false}
+    // The url is the only thing guarding the endpoint, and a variable is not masked in this public
+    // repo's logs, so register it before any code path can print it.
+    core.setSecret(url)
     const doFetch = fetchImpl || fetch
     let lastError = 'unknown'
     for (let attempt = 1; attempt <= WEBHOOK_ATTEMPTS; attempt++) {
         try {
             const res = await doFetch(url, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: token } : {}) },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
                 signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
             })
@@ -632,13 +635,7 @@ module.exports = async ({ context, github, core }, { now: _now, slack: _slack, f
                 text: buildThreadReply({ created: workflows, commitStarted: commitActive }),
             })
             await startDiagnosisAgent(
-                {
-                    url: process.env.DIAGNOSIS_WEBHOOK_URL,
-                    token: process.env.DIAGNOSIS_WEBHOOK_TOKEN,
-                    fetchImpl: _fetch,
-                    sleep,
-                    core,
-                },
+                { url: process.env.DIAGNOSIS_WEBHOOK_URL, fetchImpl: _fetch, sleep, core },
                 {
                     event: INCIDENT_OPENED_EVENT,
                     distinct_id: 'ci-alerts-devex',

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -133,9 +133,25 @@ const commitsAt = (ageMins) => [
     },
 ]
 
-function run(github, { history = [], now = minutes(0), env = {} } = {}) {
+// Stand-in for the diagnosis webhook endpoint. `statuses` is consumed one per attempt, so a test
+// can make the first call fail and the retry succeed.
+function makeWebhook(statuses = [200]) {
+    let call = 0
+    return recordingFn(() => {
+        const status = statuses[Math.min(call++, statuses.length - 1)]
+        return Promise.resolve({ ok: status >= 200 && status < 300, status })
+    })
+}
+
+function run(github, { history = [], now = minutes(0), env = {}, fetch: fetchImpl } = {}) {
     const outputs = {}
-    const core = { setOutput: (k, v) => (outputs[k] = v), info: () => {}, warning: () => {} }
+    const failures = []
+    const core = {
+        setOutput: (k, v) => (outputs[k] = v),
+        info: () => {},
+        warning: () => {},
+        setFailed: (m) => failures.push(m),
+    }
     const slack = makeSlack(history)
     Object.assign(process.env, {
         SLACK_CHANNEL: 'C0AS64N6DJL',
@@ -148,12 +164,14 @@ function run(github, { history = [], now = minutes(0), env = {} } = {}) {
         SCHEDULED_FAILURE_MINUTES_THRESHOLD: '150',
         ACTIVITY_WINDOW_MINUTES: '120',
         COMMIT_FAILURE_STREAK_THRESHOLD: '10',
+        DIAGNOSIS_WEBHOOK_URL: '',
+        DIAGNOSIS_WEBHOOK_TOKEN: '',
         ...env,
     })
     return ciAlertsDevex(
         { context: { repo: { owner: 'PostHog', repo: 'posthog' } }, github, core },
-        { now, slack, sleep: () => Promise.resolve() }
-    ).then(() => ({ slack, outputs }))
+        { now, slack, fetch: fetchImpl, sleep: () => Promise.resolve() }
+    ).then(() => ({ slack, outputs, failures }))
 }
 
 describe('ci-alerts-devex', () => {
@@ -200,6 +218,76 @@ describe('ci-alerts-devex', () => {
             assert.match(thread.text, /is now failing master/)
         })
     }
+
+    // The diagnosis agent is started by this script rather than by a workflow trigger on the anchor
+    // message, so the cases that matter are "started once, with the thread it must answer in" and
+    // "a start that did not happen turns this run red".
+    describe('diagnosis agent start', () => {
+        const webhookEnv = { DIAGNOSIS_WEBHOOK_URL: 'https://webhooks.test/start', DIAGNOSIS_WEBHOOK_TOKEN: 'Bearer t' }
+        const fiveFailures = () =>
+            createGithubMock({
+                'ci-backend.yml': runs('Backend CI', Array(5).fill('failure')),
+                'ci-frontend.yml': runs('Frontend CI', ['success']),
+            })
+
+        it('posts the incident and the anchor thread it must answer in', async () => {
+            const fetch = makeWebhook()
+            const { outputs, failures } = await run(fiveFailures(), { env: webhookEnv, fetch })
+
+            assert.equal(outputs.action, 'create')
+            assert.deepEqual(failures, [])
+            assert.equal(fetch.calls.length, 1)
+
+            const [url, init] = fetch.calls[0]
+            assert.equal(url, 'https://webhooks.test/start')
+            assert.equal(init.headers.Authorization, 'Bearer t')
+            const body = JSON.parse(init.body)
+            assert.equal(body.event, 'master_ci_incident_opened')
+            assert.equal(body.properties.channel, 'C0AS64N6DJL')
+            assert.equal(body.properties.ts, '111.222') // the anchor, so the agent replies under it
+            assert.deepEqual(body.properties.workflows, ['Backend CI'])
+        })
+
+        it('retries a failed start rather than losing it', async () => {
+            const fetch = makeWebhook([502, 200])
+            const { failures } = await run(fiveFailures(), { env: webhookEnv, fetch })
+
+            assert.equal(fetch.calls.length, 2)
+            assert.deepEqual(failures, [])
+        })
+
+        it('fails the run when the start never lands', async () => {
+            const fetch = makeWebhook([500])
+            const { outputs, failures } = await run(fiveFailures(), { env: webhookEnv, fetch })
+
+            assert.equal(fetch.calls.length, 3)
+            assert.equal(failures.length, 1)
+            assert.match(failures[0], /HTTP 500/)
+            // The alert itself still posted; only the agent start is missing.
+            assert.equal(outputs.action, 'create')
+        })
+
+        it('stays quiet when no webhook is configured', async () => {
+            const fetch = makeWebhook()
+            const { outputs, failures } = await run(fiveFailures(), { fetch })
+
+            assert.equal(outputs.action, 'create')
+            assert.equal(fetch.calls.length, 0)
+            assert.deepEqual(failures, [])
+        })
+
+        it('does not start a second agent while the incident stays open', async () => {
+            const fetch = makeWebhook()
+            const github = createGithubMock({
+                'ci-backend.yml': runs('Backend CI', Array(8).fill('failure')),
+                'ci-frontend.yml': runs('Frontend CI', ['success']),
+            })
+            const { outputs } = await run(github, { history: [activeAnchor()], env: webhookEnv, fetch })
+
+            assert.equal(outputs.action, 'update')
+            assert.equal(fetch.calls.length, 0)
+        })
+    })
 
     it('updates the existing anchor instead of posting a duplicate (regression)', async () => {
         const github = createGithubMock({

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -150,6 +150,7 @@ function run(github, { history = [], now = minutes(0), env = {}, fetch: fetchImp
         info: () => {},
         warning: () => {},
         setFailed: (m) => failures.push(m),
+        setSecret: () => {},
     }
     const slack = makeSlack(history)
     Object.assign(process.env, {
@@ -164,7 +165,6 @@ function run(github, { history = [], now = minutes(0), env = {}, fetch: fetchImp
         ACTIVITY_WINDOW_MINUTES: '120',
         COMMIT_FAILURE_STREAK_THRESHOLD: '10',
         DIAGNOSIS_WEBHOOK_URL: '',
-        DIAGNOSIS_WEBHOOK_TOKEN: '',
         ...env,
     })
     return ciAlertsDevex(
@@ -219,7 +219,7 @@ describe('ci-alerts-devex', () => {
     }
 
     describe('diagnosis agent start', () => {
-        const webhookEnv = { DIAGNOSIS_WEBHOOK_URL: 'https://webhooks.test/start', DIAGNOSIS_WEBHOOK_TOKEN: 'Bearer t' }
+        const webhookEnv = { DIAGNOSIS_WEBHOOK_URL: 'https://webhooks.test/start' }
         const fiveFailures = () =>
             createGithubMock({
                 'ci-backend.yml': runs('Backend CI', Array(5).fill('failure')),
@@ -236,7 +236,6 @@ describe('ci-alerts-devex', () => {
 
             const [url, init] = fetch.calls[0]
             assert.equal(url, 'https://webhooks.test/start')
-            assert.equal(init.headers.Authorization, 'Bearer t')
             const body = JSON.parse(init.body)
             assert.equal(body.event, 'master_ci_incident_opened')
             assert.equal(body.properties.channel, 'C0AS64N6DJL')

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -133,8 +133,7 @@ const commitsAt = (ageMins) => [
     },
 ]
 
-// Stand-in for the diagnosis webhook endpoint. `statuses` is consumed one per attempt, so a test
-// can make the first call fail and the retry succeed.
+// Stand-in for the diagnosis webhook endpoint, one status per attempt.
 function makeWebhook(statuses = [200]) {
     let call = 0
     return recordingFn(() => {
@@ -219,9 +218,6 @@ describe('ci-alerts-devex', () => {
         })
     }
 
-    // The diagnosis agent is started by this script rather than by a workflow trigger on the anchor
-    // message, so the cases that matter are "started once, with the thread it must answer in" and
-    // "a start that did not happen turns this run red".
     describe('diagnosis agent start', () => {
         const webhookEnv = { DIAGNOSIS_WEBHOOK_URL: 'https://webhooks.test/start', DIAGNOSIS_WEBHOOK_TOKEN: 'Bearer t' }
         const fiveFailures = () =>

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -107,6 +107,11 @@ jobs:
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEVEX_BOT_TOKEN }}
+                  # Incoming-webhook trigger of the workflow that starts the master-red diagnosis
+                  # agent. Unset means no agent: the Slack alert still posts. Set and unreachable
+                  # fails this run, because a start that vanishes is the failure mode being fixed.
+                  DIAGNOSIS_WEBHOOK_URL: ${{ secrets.MASTER_RED_DIAGNOSIS_WEBHOOK_URL }}
+                  DIAGNOSIS_WEBHOOK_TOKEN: ${{ secrets.MASTER_RED_DIAGNOSIS_WEBHOOK_TOKEN }}
               with:
                   github-token: ${{ steps.app-token.outputs.token || github.token }}
                   script: |

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -108,11 +108,10 @@ jobs:
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEVEX_BOT_TOKEN }}
                   # Incoming-webhook trigger of the master-red diagnosis workflow. Unset skips the
-                  # call and still posts the Slack alert; set and unreachable fails this run. The URL
-                  # is a variable, not a secret: it identifies the workflow, the auth header guards
-                  # it, and repository secrets are capped at 100 across the whole repo.
+                  # call and still posts the Slack alert; set and unreachable fails this run. A
+                  # variable rather than a secret, because this repo sits two under GitHub's cap of
+                  # 100 secrets; the script masks the value so a public log cannot leak it.
                   DIAGNOSIS_WEBHOOK_URL: ${{ vars.MASTER_RED_DIAGNOSIS_WEBHOOK_URL }}
-                  DIAGNOSIS_WEBHOOK_TOKEN: ${{ secrets.MASTER_RED_DIAGNOSIS_WEBHOOK_TOKEN }}
               with:
                   github-token: ${{ steps.app-token.outputs.token || github.token }}
                   script: |

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -107,9 +107,8 @@ jobs:
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEVEX_BOT_TOKEN }}
-                  # Incoming-webhook trigger of the workflow that starts the master-red diagnosis
-                  # agent. Unset means no agent: the Slack alert still posts. Set and unreachable
-                  # fails this run, because a start that vanishes is the failure mode being fixed.
+                  # Incoming-webhook trigger of the master-red diagnosis workflow. Unset skips the
+                  # call and still posts the Slack alert; set and unreachable fails this run.
                   DIAGNOSIS_WEBHOOK_URL: ${{ secrets.MASTER_RED_DIAGNOSIS_WEBHOOK_URL }}
                   DIAGNOSIS_WEBHOOK_TOKEN: ${{ secrets.MASTER_RED_DIAGNOSIS_WEBHOOK_TOKEN }}
               with:

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -108,8 +108,10 @@ jobs:
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_DEVEX_BOT_TOKEN }}
                   # Incoming-webhook trigger of the master-red diagnosis workflow. Unset skips the
-                  # call and still posts the Slack alert; set and unreachable fails this run.
-                  DIAGNOSIS_WEBHOOK_URL: ${{ secrets.MASTER_RED_DIAGNOSIS_WEBHOOK_URL }}
+                  # call and still posts the Slack alert; set and unreachable fails this run. The URL
+                  # is a variable, not a secret: it identifies the workflow, the auth header guards
+                  # it, and repository secrets are capped at 100 across the whole repo.
+                  DIAGNOSIS_WEBHOOK_URL: ${{ vars.MASTER_RED_DIAGNOSIS_WEBHOOK_URL }}
                   DIAGNOSIS_WEBHOOK_TOKEN: ${{ secrets.MASTER_RED_DIAGNOSIS_WEBHOOK_TOKEN }}
               with:
                   github-token: ${{ steps.app-token.outputs.token || github.token }}


### PR DESCRIPTION
## Problem

- A master-red alert can sit unanswered: the agent that diagnoses it started for one of the last three incidents, and the two misses left no error anywhere.
- The [diagnosis workflow](https://us.posthog.com/project/2/workflows/01a043a0-72db-0000-9113-03fe7b9c7aaf/workflow) triggered on the alert message the DevEx bot posts, so the agent only ran if that Slack message reached the workflow engine.
- Slack delivers every callback to `eu.posthog.com`, which forwards a copy to `us.posthog.com`, which emits an internal event the workflow filters on.
- Eight points on that path drop a message with no log, no metric and no error. Two of them are a Celery hand-off with no retries and a fire-and-forget Kafka produce.

## Changes

- The alerter now asks the workflow to start, instead of waiting for it to notice a Slack message. A start that never lands turns the alerter run red, so a missing diagnosis is visible.
- `startDiagnosisAgent` POSTs the incident to the workflow's incoming-webhook trigger when an incident opens. It retries three times with backoff and a 10 second timeout.
- The payload carries the anchor channel and timestamp, so the agent still answers in the alert thread.
- The webhook URL is a repository variable, not a secret. This repo already sits at 98 of GitHub's cap of 100 secrets, and that cap silently dropped a token once before. The script calls `core.setSecret` on the URL, so a public workflow log cannot leak it.
- An unset `DIAGNOSIS_WEBHOOK_URL` skips the call. The Slack alert is unchanged either way.

The alerter only calls on incident open, never on the per-tick anchor refresh, so one incident starts one agent.

> [!NOTE]
> The workflow's own trigger moves from Slack message to incoming webhook. That change is staged as a draft on the workflow and is not in this diff. Publish it and set `MASTER_RED_DIAGNOSIS_WEBHOOK_URL` together, because the alerter and the workflow have to agree on the payload.

**Before**

```mermaid
flowchart LR
    A{{Alerter}} --> B[Slack anchor]
    B --> C[eu.posthog.com]
    C --> D[us.posthog.com]
    D --> E[Internal events]
    E --> F{{Diagnosis agent}}
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,F phBlue;
    class C,D,E phRed;
    class B phGray;
```

**After**

```mermaid
flowchart LR
    A{{Alerter}} --> B[Slack anchor]
    A --> W[Webhook trigger]
    W --> F{{Diagnosis agent}}
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,F phBlue;
    class W phYellow;
    class B phGray;
```

No UI changes.

## How did you test this code?

Five cases in `.github/scripts/ci-alerts-devex.test.js`, run with `node --test`. Each covers a regression no existing test caught, because none of them knew about the webhook:

- A new incident posts the incident with the anchor timestamp, so a wrong timestamp cannot silently break the thread reply.
- A 502 on the first attempt retries and succeeds, so a transient failure cannot lose the start.
- Three failures call `core.setFailed`, so a lost start cannot pass as a green run.
- An unset URL makes no call, so the alerter keeps working before the variable exists.
- An open incident makes no call, so a long incident cannot start an agent every five minutes.

Not checked: the POST never ran against a real endpoint, and the workflow trigger change is configuration that this branch cannot verify.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.

The session started from a question about why the diagnosis agent stopped answering alerts, and traced the Slack path through region proxy logs and workflow run metrics before touching code. The first plan was to add instrumentation to the existing Slack trigger path. That was dropped: the path crosses two regions and a Kafka topic to deliver a message the alerter already holds, so removing it beats observing it.

An auth header on the webhook was also dropped, after checking the secret count against the cap. The URL is the capability, and masking it costs no quota.

The matching workflow draft sets the trigger's event name to `$slack_message_received`, maps the request body into event properties, and rewrites the agent prompt to read the incident fields rather than a Slack message body.
