### PR TITLE
fix(error-tracking): stop retention deleting live symbol sets

### DIFF
--- a/products/error_tracking/backend/logic/symbol_sets.py
+++ b/products/error_tracking/backend/logic/symbol_sets.py
@@ -7,12 +7,14 @@ the CLI-facing upload contract and are surfaced verbatim by the views.
 """
 
 import hashlib
+import datetime
 from dataclasses import dataclass
 from typing import Any
 
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
+from django.utils import timezone
 
 import structlog
 import posthoganalytics
@@ -29,6 +31,12 @@ logger = structlog.get_logger(__name__)
 
 ONE_HUNDRED_MEGABYTES = 1024 * 1024 * 100
 PRESIGNED_MULTIPLE_UPLOAD_TIMEOUT = 60 * 5
+
+# An upload rewrites `last_used` only when the stored value is older than this. `last_used` is part
+# of `et_symset_bucket_cleanup_idx`, so every write churns that index, and a monorepo that uploads
+# thousands of chunks per merge would rewrite all of them on each run. Cymbal throttles its own
+# `last_used` writes over the same window for the same reason.
+LAST_USED_UPLOAD_REFRESH_INTERVAL = datetime.timedelta(hours=12)
 
 
 class SymbolSetNotFoundError(Exception):
@@ -141,6 +149,23 @@ def create_symbol_set(
         ErrorTrackingStackFrame.objects.filter(team=team, symbol_set=symbol_set).delete()
 
         return symbol_set
+
+
+def refresh_last_used(team: Team, chunk_ids: list[str]) -> None:
+    """Mark every symbol set the upload referenced as still in use.
+
+    Retention deletes a symbol set once `last_used` falls outside its window. In event release
+    mode the chunk id is derived from the chunk content, so one row serves every release that
+    ships that chunk, and re-uploading an unchanged chunk writes nothing. Without this call the
+    row ages out while the chunk is still deployed, and the next exception from it cannot be
+    symbolicated until a later deploy recreates the row.
+    """
+    now = timezone.now()
+    ErrorTrackingSymbolSet.objects.filter(
+        Q(last_used__isnull=True) | Q(last_used__lt=now - LAST_USED_UPLOAD_REFRESH_INTERVAL),
+        team=team,
+        ref__in=chunk_ids,
+    ).update(last_used=now)
 
 
 @posthoganalytics.scoped()
@@ -274,6 +299,8 @@ def bulk_create_symbol_sets(
         # We update only the symbol sets we modified the release of - for all others, this is a no-op (we assume they were uploaded
         # during a prior attempt or something).
         ErrorTrackingSymbolSet.objects.bulk_update(to_update, ["release", "content_hash", "storage_ptr"])
+
+        refresh_last_used(team, chunk_ids)
 
     return id_url_map
 

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -387,8 +387,10 @@ class ErrorTrackingSymbolSet(UUIDTModel):
     # with one
     release = models.ForeignKey(ErrorTrackingRelease, null=True, on_delete=models.CASCADE)
 
-    # When a symbol set is loaded, last_used is set, so we can track how often
-    # symbol sets are used, and cleanup ones not used for a long time
+    # Retention deletes a symbol set once last_used falls outside its window. Two paths write it:
+    # symbolication, when it loads the set, and a bulk upload, for every chunk id in the request.
+    # The upload must write it because event release mode derives chunk ids from content, so one
+    # row can serve many releases without symbolication ever touching it.
     last_used = models.DateTimeField(null=True, blank=True)
 
     def delete(self, *args, **kwargs):

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1,5 +1,5 @@
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
@@ -989,7 +989,7 @@ class TestErrorTracking(APIBaseTest):
         assert str(symbol_set.id) == symbol_set_upload_response["symbol_set_id"]
         assert symbol_set_upload_response["presigned_url"]["fields"]["key"] == symbol_set.storage_ptr
         assert "fallback_presigned_url" not in symbol_set_upload_response
-        assert symbol_set.last_used is None
+        assert symbol_set.last_used is not None
 
     def test_bulk_start_upload_includes_fallback_presigned_url_when_accelerated(self) -> None:
         chunk_id = str(uuid7())
@@ -1055,10 +1055,11 @@ class TestErrorTracking(APIBaseTest):
         existing_symbol_set.refresh_from_db()
         assert existing_symbol_set.storage_ptr == "existing"
         assert existing_symbol_set.release_id == release.id
+        assert existing_symbol_set.last_used is not None
 
         new_symbol_set = ErrorTrackingSymbolSet.objects.get(ref=new_chunk_id)
         assert new_symbol_set.release_id == release.id
-        assert new_symbol_set.last_used is None
+        assert new_symbol_set.last_used is not None
         assert id_map[str(new_chunk_id)]["symbol_set_id"] == str(new_symbol_set.id)
 
         assert patched_capture.call_args.args[0] == "error_tracking_symbol_set_upload_started"
@@ -1070,6 +1071,44 @@ class TestErrorTracking(APIBaseTest):
             "total_chunks": 2,
             "chunks_skipped": 1,
         }
+
+    @parameterized.expand(
+        [
+            ("never_used", None, True),
+            ("used_before_the_refresh_interval", timedelta(hours=13), True),
+            ("used_within_the_refresh_interval", timedelta(hours=1), False),
+        ]
+    )
+    def test_bulk_start_upload_marks_unchanged_symbol_sets_as_used(
+        self, _name: str, last_used_age: timedelta | None, expect_refresh: bool
+    ) -> None:
+        chunk_id = str(uuid7())
+        last_used = None if last_used_age is None else timezone.now() - last_used_age
+        symbol_set = ErrorTrackingSymbolSet.objects.create(
+            team=self.team,
+            ref=chunk_id,
+            storage_ptr="existing",
+            content_hash="already_uploaded",
+            last_used=last_used,
+        )
+
+        before_upload = timezone.now()
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/symbol_sets/bulk_start_upload",
+            data={"symbol_sets": [{"chunk_id": chunk_id, "content_hash": "already_uploaded"}]},
+            format="json",
+        )
+        after_upload = timezone.now()
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["id_map"] == {}
+
+        symbol_set.refresh_from_db()
+        if expect_refresh:
+            assert symbol_set.last_used is not None
+            assert before_upload <= symbol_set.last_used <= after_upload
+        else:
+            assert symbol_set.last_used == last_used
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

A team on `--release-mode=event` loses symbolication for chunks that are still deployed. Every stack frame from such a chunk stays minified until the next deploy, and a team that stopped deploying never gets it back.

- Retention deletes a symbol set once `last_used` falls outside its 30 day window ([`activities.py:38`](https://github.com/PostHog/posthog/blob/master/products/error_tracking/backend/temporal/symbol_set_cleanup/activities.py#L38-L43)).
- Only symbolication wrote `last_used`. The upload path never touched it, and `bulk_create_symbol_sets` did nothing at all for a chunk whose content was unchanged.
- Symbol-set release mode hid the gap. It creates a new chunk id per build, so every deploy created a fresh row and the live bundle was never older than the last deploy.
- Event release mode derives the chunk id from the chunk content. One row then serves every release that ships an unchanged chunk, so `last_used` records only when the chunk last threw an exception.
- A vendor chunk that throws nothing for 30 days is therefore deleted while it is live.

## Changes

- `bulk_start_upload` now marks every chunk id in the request as used, including the chunks it skips as unchanged. A deploy keeps the symbol sets of the bundle it ships.
- The refresh is throttled to 12 hours. `last_used` is part of `et_symset_bucket_cleanup_idx`, so a monorepo that uploads thousands of chunks per merge would otherwise rewrite every row on each run. Cymbal throttles its own `last_used` writes over the same window.
- The alternative was a separate `last_uploaded` column plus a `greatest(last_used, last_uploaded)` retention filter. It reads better but needs a migration and a change to the cleanup query, and it buys nothing the single column does not already give.
- No UI changes. The symbol sets table already renders `last_used`, and it now moves on upload as well as on symbolication.

> [!NOTE]
> Symbol sets that retention already deleted do not come back. The next upload recreates them, because the row is gone and the upload no longer finds a matching content hash.

## How did you test this code?

- Added 3 parameterized cases in `test_bulk_start_upload_marks_unchanged_symbol_sets_as_used`. They catch a regression that drops the refresh, and one that inverts the throttle comparison so the refresh never runs. No existing test covered what an upload does to `last_used`.
- Extended `test_bulk_start_upload_skips_uploaded_symbol_sets`, which already covers the skip path, with the assertion that a skipped symbol set is still marked as used.
- Removing the `refresh_last_used` call fails 4 of these and passes the throttle case, which expects no write.
- Ran the error tracking API suite, the symbol set cleanup workflow tests, the facade suite, `hogli lint:tach`, `hogli ci:preflight --strict`, and repo-wide mypy.
- Not tested manually against a real CLI upload. The behavior is covered through the HTTP endpoint instead.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The change restores the retention behavior the docs already describe.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by @ablaszkiewicz.

The session started as an audit rather than a fix. The question was whether the recent event release mode work missed anything outside the CLI, and the symbol set retention job was the first thing checked. Reading the cleanup activity, the Dagster `last_used` backfill, the cymbal write path, and the CLI inject and upload paths together is what showed that stable chunk ids break the job's assumption.

The audit found four other items that are not in this PR: releases carry no symbol sets in event mode so the symbol sets table Release column and its release search are dead, a content-addressed chunk id can collide between two apps in one team, `reissue_upload` leaves the previous S3 object behind, and `$release_id` is missing from the taxonomy.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Nothing in this PR draws on material that is not already in this repository.
