### PR TITLE
chore(ci): narrow CI to the diff on pull requests, and report what it selected

### DIFF
--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -293,6 +293,24 @@ Otherwise the fallback is full on drafts too: `ci-nodejs.yml` has a bare `pull_r
 `turbo-discover.js` (`draft ? 'skip' : 'full'`) and `ci-frontend.yml`'s `fall_back` are the two reference implementations of the draft/ready split; `ci-nodejs.yml` and `ci-e2e-playwright.yml` are the reference for always-full.
 Foot-gun: if the job that selects tests is cancelled mid-flight, its `mode` output is empty — normalize empty-mode **on a draft** to `skip`, or the draft grabs the full matrix and serializes the ready run behind it.
 
+### A selector needs telemetry, or nobody knows whether it bites
+
+A narrowing that falls back on most runs looks identical in the YAML to one that works.
+The Playwright selector was eligible on 2,783 runs over two weeks and narrowed on 167 of them; the rest fell back, most often on one glob.
+That is unreadable without an event, so every selector emits one to the DevEx project (347861): `posthog-ci-test-selection`, `posthog-ci-e2e-spec-selection`, `posthog-ci-jest-selection`, `posthog-ci-nodejs-selection`.
+
+Copy the shape from `capture-jest-selection` in `ci-frontend.yml`:
+
+- Emit **on full runs too**, tagged so they are distinguishable. They are the baseline a narrowed run is measured against.
+- Give the fallback a **closed category** plus an unbounded **detail**. The category is what you group by; the detail is what tells you which glob to attack.
+- Emit the counts from **every** branch of the selector, including the ones that narrow to nothing.
+- `continue-on-error`, `github.run_attempt == '1'`, and the same-repo `if:` — telemetry never reds CI, never double-counts a re-run, and forks have no secret.
+- Do not duplicate timings. `posthog-ci-running-time-job` already carries each job's duration; join it on `run_id`.
+
+What this still does not answer is whether a narrowed run would have **caught** what broke.
+Only backend scores that, in `tools/test_selection_verdict.py`, which reads the run's JUnit and reports recall.
+The cheap oracle for the rest is the queue: the `trunk-merge/**` run tests the same code with the full suite, so a failure there whose file was reachable from the diff and was not selected is a miss, at no extra compute.
+
 ## The hourly master lane
 
 The merge queue's `trunk-merge/**` run tests every commit before it lands, so re-running a heavy suite on the master push tests a commit that CI already covered.

--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -274,8 +274,23 @@ Details: `/depot-github-runners`.
 
 ## Draft vs ready-for-review
 
-Most commits land before a PR is marked ready, and drafts can't merge — so heavy suites should run a narrowed subset on drafts and the full matrix on `ready_for_review` (the merge gate).
-Add `ready_for_review` to the `pull_request` types, and make aggregator "... Tests Pass" jobs treat `skipped` as success so drafts still report.
+The merge gate is the merge queue's run on a `trunk-merge/` branch.
+So a heavy suite runs its narrowed subset on drafts _and_ on ready PRs, and only the queue run takes the full matrix.
+`ci-backend.yml`, `ci-frontend.yml`, `ci-storybook.yml`, and `ci-e2e-playwright.yml` all work this way.
+Exclude the queue with `!startsWith(github.head_ref, 'trunk-merge/')`, or with `draft != true` since those PRs open as drafts — not with `draft == true`.
+
+Still add `ready_for_review` to the `pull_request` types — a `no-ci` draft skips the workflow outright, and that event is what gives it a run — and make aggregator "... Tests Pass" jobs treat `skipped` as success so drafts still report.
+
+What draft state _does_ decide is the fallback when a selection cannot be trusted (config change, oversized diff, selector crash):
+
+- **draft → skip the suite.** Its own ready run selects again, so nothing is lost.
+- **ready → full matrix.** No later run on that PR would cover it, and a narrowed run the selector can't vouch for is false confidence.
+
+The real test is not draft-vs-ready, it is whether a later run on this PR exists to defer to.
+So **draft → skip is only valid when the workflow lists `ready_for_review` in its `pull_request` types and its "... Tests Pass" aggregator treats `skipped` as success.**
+Otherwise the fallback is full on drafts too: `ci-nodejs.yml` has a bare `pull_request:` trigger, so a skipped draft would never get a second run, and `ci-e2e-playwright.yml` skips drafts entirely, so there is no draft run to fall back from.
+
+`turbo-discover.js` (`draft ? 'skip' : 'full'`) and `ci-frontend.yml`'s `fall_back` are the two reference implementations of the draft/ready split; `ci-nodejs.yml` and `ci-e2e-playwright.yml` are the reference for always-full.
 Foot-gun: if the job that selects tests is cancelled mid-flight, its `mode` output is empty — normalize empty-mode **on a draft** to `skip`, or the draft grabs the full matrix and serializes the ready run behind it.
 
 ## The hourly master lane

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -8,8 +8,9 @@ on:
     pull_request:
         # Draft PRs skip E2E entirely — the broad path filter below matches nearly
         # every code PR, and a full stack boot per draft push is the
-        # remaining big per-PR cost. The ready-for-review full run is the merge
-        # gate; use workflow_dispatch to force a run on a draft.
+        # remaining big per-PR cost. Ready PRs run the specs the diff can affect
+        # (see select-specs); the merge queue's trunk-merge/** run is the full suite
+        # that gates master. Use workflow_dispatch to force a run on a draft.
         types: [opened, synchronize, reopened, ready_for_review]
     workflow_dispatch:
         inputs:
@@ -345,17 +346,18 @@ jobs:
     select-specs:
         name: Select affected E2E specs
         needs: [changes]
-        # Narrow the suite only on incremental `synchronize` pushes to a ready
-        # (non-draft) internal PR. Every other trigger — opened, reopened,
-        # ready_for_review, workflow_dispatch, and push to master — skips
-        # this job, leaving empty outputs so the playwright job runs the FULL suite.
-        # The merge gate (ready_for_review run) and the post-merge master run always
-        # run everything, so a selection miss is caught there. Fail-open is FULL,
-        # never skip: over-selection would silently drop coverage.
+        # Narrow the suite on any event of a ready (non-draft) internal PR: opened,
+        # reopened, synchronize, and ready_for_review all diff the same head against
+        # the same base, so they all select the same specs. workflow_dispatch and
+        # push to master skip this job, leaving empty outputs so the playwright job
+        # runs the FULL suite.
+        # `draft != true` also keeps the merge queue on the full suite: its
+        # trunk-merge/** PRs open as drafts, and that run is the gate for master, so
+        # a selection miss is caught there. The post-merge master run is full too.
+        # Fail-open is FULL, never skip: over-selection would silently drop coverage.
         if: |
             needs.changes.outputs.shouldRun == 'true'
             && github.event_name == 'pull_request'
-            && github.event.action == 'synchronize'
             && github.event.pull_request.draft != true
             && github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
@@ -1181,8 +1183,8 @@ jobs:
             # fallback-rate insights live. Emitted whenever the heavy job actually ran, so
             # full runs (this event's `mode=full`, `selection_eligible=false`) provide the
             # test-time baseline that selective runs are measured against. `selection_eligible`
-            # is true only on synchronize pushes where select-specs ran — the fallback-rate
-            # denominator. Telemetry never reds CI (continue-on-error).
+            # is true on the ready internal-PR events where select-specs ran — the
+            # fallback-rate denominator. Telemetry never reds CI (continue-on-error).
             - name: Capture spec selection to DevEx PostHog
               if: github.run_attempt == '1' && (needs.playwright.result == 'success' || needs.playwright.result == 'failure')
               continue-on-error: true

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,11 +1,13 @@
 name: Frontend CI
 on:
     pull_request:
-        # Draft PRs run a narrowed jest selection; ready PRs run the full matrix
-        # (the merge gate). ready_for_review re-triggers the full run on the
-        # current head when a PR leaves draft. To force the full matrix on a
-        # draft, add the `run-ci-frontend` label. The `no-ci` label does the
-        # opposite: it silences this workflow on a draft entirely (prototypes).
+        # PRs run a narrowed jest selection, draft or ready, over two shards. The
+        # merge queue's trunk-merge/** run is the full matrix that gates master.
+        # When selection can't be trusted, a ready PR falls back to the full matrix
+        # and a draft skips jest instead, deferring to its ready run. To force the
+        # full matrix on a PR, add the `run-ci-frontend` label. The `no-ci` label
+        # does the opposite: it silences this workflow on a draft entirely
+        # (prototypes).
         # No labeled/unlabeled triggers: GitHub cannot filter a label trigger by
         # name, so every unrelated label re-ran the full jest matrix against a
         # commit CI had already covered. A label here takes effect from the next
@@ -49,7 +51,8 @@ jobs:
         timeout-minutes: 5
         # A draft PR labeled `no-ci` skips this workflow entirely (prototypes):
         # every other job needs this one, and the gates treat skipped as success.
-        # ready_for_review re-runs everything, so the merge gate is unaffected.
+        # The merge queue's trunk-merge/** run is the gate, so skipping a draft
+        # never weakens what protects master.
         if: >-
             github.event_name != 'pull_request'
             || github.event.pull_request.draft != true
@@ -219,14 +222,14 @@ jobs:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: ${{ runner.temp }}/frontend-exclude.yml
 
-    # Pick which jest tests to run on draft PRs by passing changed files to
+    # Pick which jest tests to run on a PR by passing changed files to
     # `jest --findRelatedTests` (jest's resolver walks the import graph for us).
-    # Skipped on ready PRs and master pushes; the jest job falls back
-    # to its full four-shard matrix in those cases. The ready-for-review
-    # full run is the merge gate. The run-ci-frontend label forces the full
-    # matrix on a draft. When selection can't be trusted on a draft (config
-    # change, oversized diff, selector failure), the draft skips jest entirely
-    # and defers to the ready full run.
+    # Skipped on master pushes and on the merge queue's run, where the jest job
+    # falls back to its full four-shard matrix. That queue run is what gates
+    # master, so it is the only place the full matrix has to run.
+    # The run-ci-frontend label forces the full matrix on a PR. When selection
+    # can't be trusted (config change, oversized diff, selector failure), a ready
+    # PR takes the full matrix and a draft skips jest, deferring to its ready run.
     select-jest-tests:
         name: Select jest tests
         runs-on: ubuntu-latest
@@ -237,7 +240,6 @@ jobs:
         if: |
             !cancelled() && needs.changes.outputs.frontend_code == 'true'
             && github.event_name == 'pull_request'
-            && github.event.pull_request.draft == true
             && !startsWith(github.head_ref, 'trunk-merge/')
             && !contains(github.event.pull_request.labels.*.name, 'run-ci-frontend')
         outputs:
@@ -268,32 +270,43 @@ jobs:
               id: classify
               env:
                   DIFF_OUTCOME: ${{ steps.diff.outcome }}
+                  PR_DRAFT: ${{ github.event.pull_request.draft }}
               run: |
                   set -euo pipefail
 
-                  # Untrusted selection on a draft skips jest entirely (should_run=false
-                  # gates the jest job off); the ready-for-review full run is the gate.
                   # Use this whenever the selector can't reason about the diff — a
-                  # narrowed run it can't vouch for would be false confidence, and a
-                  # full run on every draft push is the spend this selection avoids.
-                  # The run-ci-frontend label forces the full matrix on a draft.
-                  fall_back_to_skip() {
-                      echo "mode=skip" >> "$GITHUB_OUTPUT"
-                      echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-                      echo "should_run=false" >> "$GITHUB_OUTPUT"
-                      echo "changed_files=" >> "$GITHUB_OUTPUT"
+                  # narrowed run it can't vouch for would be false confidence.
+                  # A draft skips jest and defers to its ready run; a ready PR has no
+                  # later run on this PR to defer to, so it takes the full matrix.
+                  # Mirrors the draft/ready fallback turbo-discover.js applies to the
+                  # Django matrices. The run-ci-frontend label forces the full matrix.
+                  fall_back() {
+                      local mode should_run matrix
+                      if [[ "$PR_DRAFT" == "true" ]]; then
+                          echo "::notice::$1; draft skips jest (its ready run selects again)"
+                          mode=skip should_run=false matrix='{"include":[]}'
+                      else
+                          # Empty matrix: the jest job's own default supplies the full
+                          # fanout, so the shard shape is written down in one place.
+                          echo "::notice::$1; running the full jest matrix"
+                          mode=full should_run=true matrix=
+                      fi
+                      {
+                          echo "mode=$mode"
+                          echo "matrix=$matrix"
+                          echo "should_run=$should_run"
+                          echo "changed_files="
+                      } >> "$GITHUB_OUTPUT"
                   }
 
                   if [[ "$DIFF_OUTCOME" != "success" ]] || [[ ! -s /tmp/changed.txt ]]; then
-                      echo "::warning::could not derive changed files; draft skips jest (full run happens on ready for review)"
-                      fall_back_to_skip
+                      fall_back "could not derive changed files"
                       exit 0
                   fi
 
                   changed_count=$(wc -l < /tmp/changed.txt)
                   if [[ "$changed_count" -gt 200 ]]; then
-                      echo "::notice::diff has $changed_count files (>200); draft skips jest (full run happens on ready for review)"
-                      fall_back_to_skip
+                      fall_back "diff has $changed_count files (>200)"
                       exit 0
                   fi
 
@@ -307,8 +320,7 @@ jobs:
                           jest.*.ts|babel.config.js|tsconfig.json|tsconfig.*.json|\
                           package.json|pnpm-lock.yaml|webpack.config.js|\
                           .github/workflows/ci-frontend.yml|.nvmrc)
-                              echo "::notice::config change ($f); draft skips jest (full run happens on ready for review)"
-                              fall_back_to_skip
+                              fall_back "config change ($f)"
                               exit 0
                               ;;
                       esac
@@ -784,12 +796,13 @@ jobs:
 
     jest:
         runs-on: ubuntu-latest
-        # Draft PRs run two selective shards over tests reachable from changed files.
-        # The ready-for-review fanout uses four shards over the full suite.
+        # PRs run two selective shards over the tests reachable from the changed
+        # files. The merge queue runs the full four-shard fanout.
         timeout-minutes: 20
         needs: [changes, select-jest-tests]
-        # A status function is required because select-jest-tests is skipped on ready
-        # PRs and master pushes, and a skipped need would otherwise cascade a skip here.
+        # A status function is required because select-jest-tests is skipped on the
+        # merge queue's run and on master pushes, and a skipped need would otherwise
+        # cascade a skip here.
         # !cancelled() rather than always() so a superseded run's shards stop promptly.
         # Skipped on master push: the merge queue already ran the full matrix for every
         # landed commit, and the hourly scheduled run keeps master's jest coverage and
@@ -802,12 +815,12 @@ jobs:
         strategy:
             # If one test fails, still run the others
             fail-fast: false
-            # On draft PRs, select-jest-tests may narrow this to two jobs
-            # running only the tests reachable from changed frontend source files,
-            # or skip jest entirely (should_run=false) when selection can't be
-            # trusted. On ready PRs and the hourly scheduled run it's skipped, so
-            # we fall back to the full four-chunk fanout. Master pushes do not
-            # reach here at all (see the `if` above).
+            # On PRs, select-jest-tests narrows this to the tests reachable from the
+            # changed frontend source files, skips jest entirely (should_run=false) on
+            # a draft whose selection can't be trusted, or emits the full fanout when a
+            # ready PR's can't be. On the merge queue's run and the hourly scheduled run
+            # the job is skipped and this default applies: the full four-chunk fanout.
+            # Master pushes do not reach here at all (see the `if` above).
             # `segment` is a single fixed value: it survives only as the naming
             # token for job, JUnit file and artifact, which the timings reporter
             # parses as `junit-results-frontend-<segment>-<chunk>`. There used to
@@ -865,7 +878,7 @@ jobs:
                       # matches nothing), and CHANGED_FILES is already scoped to
                       # frontend source files by select-jest-tests. --passWithNoTests
                       # so a changed source file with no related test doesn't fail the
-                      # run — the ready-for-review full matrix is the gate.
+                      # run — the merge queue's trunk-merge/** run is the gate.
                       pnpm --filter=@posthog/frontend build:products
                       # shellcheck disable=SC2086
                       pnpm --filter=@posthog/frontend exec jest \

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -247,6 +247,13 @@ jobs:
             matrix: ${{ steps.classify.outputs.matrix }}
             should_run: ${{ steps.classify.outputs.should_run }}
             changed_files: ${{ steps.classify.outputs.changed_files }}
+            # Telemetry (see capture-jest-selection). Emitted on every path, so a
+            # fallback rate can be read per reason rather than inferred from mode alone.
+            changed_file_count: ${{ steps.classify.outputs.changed_file_count }}
+            selected_file_count: ${{ steps.classify.outputs.selected_file_count }}
+            shard_count: ${{ steps.classify.outputs.shard_count }}
+            full_run_reason_category: ${{ steps.classify.outputs.full_run_reason_category }}
+            full_run_reason_detail: ${{ steps.classify.outputs.full_run_reason_detail }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -280,33 +287,43 @@ jobs:
                   # later run on this PR to defer to, so it takes the full matrix.
                   # Mirrors the draft/ready fallback turbo-discover.js applies to the
                   # Django matrices. The run-ci-frontend label forces the full matrix.
+                  # $1 is a closed category for grouping the telemetry, $2 the unbounded
+                  # detail behind it.
                   fall_back() {
-                      local mode should_run matrix
+                      local mode should_run matrix shards
                       if [[ "$PR_DRAFT" == "true" ]]; then
-                          echo "::notice::$1; draft skips jest (its ready run selects again)"
-                          mode=skip should_run=false matrix='{"include":[]}'
+                          echo "::notice::$1 ($2); draft skips jest (its ready run selects again)"
+                          mode=skip should_run=false shards=0
+                          matrix='{"include":[]}'
                       else
                           # Empty matrix: the jest job's own default supplies the full
                           # fanout, so the shard shape is written down in one place.
-                          echo "::notice::$1; running the full jest matrix"
-                          mode=full should_run=true matrix=
+                          echo "::notice::$1 ($2); running the full jest matrix"
+                          mode=full should_run=true shards=4
+                          matrix=
                       fi
                       {
                           echo "mode=$mode"
                           echo "matrix=$matrix"
                           echo "should_run=$should_run"
                           echo "changed_files="
+                          echo "changed_file_count=${changed_count:-}"
+                          echo "selected_file_count=0"
+                          echo "shard_count=$shards"
+                          echo "full_run_reason_category=$1"
+                          echo "full_run_reason_detail=$2"
                       } >> "$GITHUB_OUTPUT"
                   }
 
                   if [[ "$DIFF_OUTCOME" != "success" ]] || [[ ! -s /tmp/changed.txt ]]; then
-                      fall_back "could not derive changed files"
+                      fall_back diff_unavailable "${DIFF_OUTCOME}"
                       exit 0
                   fi
 
-                  changed_count=$(wc -l < /tmp/changed.txt)
+                  # tr: the count is reported as telemetry now, and BSD wc pads it.
+                  changed_count=$(wc -l < /tmp/changed.txt | tr -d ' ')
                   if [[ "$changed_count" -gt 200 ]]; then
-                      fall_back "diff has $changed_count files (>200)"
+                      fall_back over_ceiling "$changed_count files"
                       exit 0
                   fi
 
@@ -320,7 +337,7 @@ jobs:
                           jest.*.ts|babel.config.js|tsconfig.json|tsconfig.*.json|\
                           package.json|pnpm-lock.yaml|webpack.config.js|\
                           .github/workflows/ci-frontend.yml|.nvmrc)
-                              fall_back "config change ($f)"
+                              fall_back config_change "$f"
                               exit 0
                               ;;
                       esac
@@ -349,10 +366,17 @@ jobs:
                   if [[ -z "$CHANGED_FILES" ]]; then
                       # No frontend source changes (e.g. PR only edits backend or docs)
                       # but `frontend_code` paths-filter still flagged the PR. Skip jest.
-                      echo "mode=selective" >> "$GITHUB_OUTPUT"
-                      echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
-                      echo "should_run=false" >> "$GITHUB_OUTPUT"
-                      echo "changed_files=" >> "$GITHUB_OUTPUT"
+                      {
+                          echo "mode=selective"
+                          echo 'matrix={"include":[]}'
+                          echo "should_run=false"
+                          echo "changed_files="
+                          echo "changed_file_count=$changed_count"
+                          echo "selected_file_count=0"
+                          echo "shard_count=0"
+                          echo "full_run_reason_category="
+                          echo "full_run_reason_detail="
+                      } >> "$GITHUB_OUTPUT"
                       echo "Selective mode: no frontend source files changed, skipping jest"
                       exit 0
                   fi
@@ -361,11 +385,19 @@ jobs:
                   # can make --findRelatedTests approach a full suite. --findRelatedTests
                   # walks jest's import graph from these files and runs the matching
                   # *.test.* files.
-                  echo "mode=selective" >> "$GITHUB_OUTPUT"
-                  echo 'matrix={"include":[{"segment":"app","chunk":1,"shard_count":2},{"segment":"app","chunk":2,"shard_count":2}]}' >> "$GITHUB_OUTPUT"
-                  echo "should_run=true" >> "$GITHUB_OUTPUT"
-                  echo "changed_files=$CHANGED_FILES" >> "$GITHUB_OUTPUT"
-                  echo "Selective mode: $(echo "$CHANGED_FILES" | wc -w) frontend source files"
+                  SELECTED_COUNT=$(echo "$CHANGED_FILES" | wc -w | tr -d ' ')
+                  {
+                      echo "mode=selective"
+                      echo 'matrix={"include":[{"segment":"app","chunk":1,"shard_count":2},{"segment":"app","chunk":2,"shard_count":2}]}'
+                      echo "should_run=true"
+                      echo "changed_files=$CHANGED_FILES"
+                      echo "changed_file_count=$changed_count"
+                      echo "selected_file_count=$SELECTED_COUNT"
+                      echo "shard_count=2"
+                      echo "full_run_reason_category="
+                      echo "full_run_reason_detail="
+                  } >> "$GITHUB_OUTPUT"
+                  echo "Selective mode: $SELECTED_COUNT frontend source files"
 
     frontend-format:
         name: Frontend formatting
@@ -1112,6 +1144,58 @@ jobs:
                   github-token: ${{ steps.telemetry-app-token.outputs.token }}
                   status-job: 'Frontend Tests Pass'
                   runner: 'github'
+
+    # Jest-selection telemetry -> DevEx project (347861), alongside the equivalent
+    # events for the backend (posthog-ci-test-selection) and Playwright
+    # (posthog-ci-e2e-spec-selection). Without it the fallback rate of this selector
+    # is only readable by opening runs one at a time.
+    # Emitted on full runs too — the merge queue's trunk-merge/** run raises a
+    # pull_request event, so `mode=full` there is the baseline selective runs are
+    # measured against. Minutes are not duplicated here: join run_id to the runId on
+    # posthog-ci-running-time-job, which already carries each shard's duration.
+    # Telemetry never reds CI (continue-on-error).
+    # hogli-lint: not-a-required-gate — reads results to describe the run, gates nothing
+    capture-jest-selection:
+        name: Capture jest selection
+        needs: [select-jest-tests, jest]
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        # Either the selector reached a decision, or jest ran without it (the full-run
+        # baseline). Neither holds on a frontend-untouched PR, and there is nothing to
+        # report there. Forks and Dependabot never have the secret.
+        if: >-
+            !cancelled() && github.run_attempt == '1'
+            && github.event_name == 'pull_request'
+            && github.actor != 'dependabot[bot]'
+            && github.event.pull_request.head.repo.full_name == 'PostHog/posthog'
+            && (needs.select-jest-tests.outputs.mode != ''
+                || needs.jest.result == 'success'
+                || needs.jest.result == 'failure')
+        steps:
+            - name: Capture jest selection to DevEx PostHog
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+                  event: 'posthog-ci-jest-selection'
+                  properties: |
+                      {
+                        "mode": ${{ toJSON(needs.select-jest-tests.outputs.mode || 'full') }},
+                        "selection_eligible": ${{ needs.select-jest-tests.result == 'success' }},
+                        "changed_file_count": ${{ needs.select-jest-tests.outputs.changed_file_count || 'null' }},
+                        "selected_file_count": ${{ needs.select-jest-tests.outputs.selected_file_count || 'null' }},
+                        "shard_count": ${{ needs.select-jest-tests.outputs.shard_count || 'null' }},
+                        "full_run_reason_category": ${{ toJSON(needs.select-jest-tests.outputs.full_run_reason_category || '') }},
+                        "full_run_reason_detail": ${{ toJSON(needs.select-jest-tests.outputs.full_run_reason_detail || '') }},
+                        "jest_result": ${{ toJSON(needs.jest.result) }},
+                        "pr_draft": ${{ toJSON(github.event.pull_request.draft) }},
+                        "merge_queue": ${{ startsWith(github.head_ref, 'trunk-merge/') }},
+                        "event_type": ${{ toJSON(github.event.action) }},
+                        "branch": ${{ toJSON(github.head_ref || github.ref_name) }},
+                        "sha": ${{ toJSON(github.sha) }},
+                        "pr_number": ${{ github.event.pull_request.number || 'null' }},
+                        "run_id": ${{ toJSON(github.run_id) }}
+                      }
 
     frontend_tests:
         needs: [jest, jest-replay-shared, frontend-format, frontend-bundle-size, frontend-typescript-checks]

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -47,6 +47,10 @@ jobs:
             # confined to Node source files jest can resolve; anything else is 'full'.
             test_mode: ${{ steps.select-tests.outputs.mode || 'full' }}
             test_files: ${{ steps.select-tests.outputs.files }}
+            # Telemetry (see capture-nodejs-selection). Emitted on every path, so a
+            # fallback rate can be read per reason rather than inferred from mode alone.
+            test_reason: ${{ steps.select-tests.outputs.reason }}
+            test_file_count: ${{ steps.select-tests.outputs.file_count }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -201,25 +205,28 @@ jobs:
               run: |
                   set -uo pipefail
 
+                  # $1 is a closed category, so the telemetry can be grouped by reason.
                   full() {
                       echo "::notice::$1; running the full jest suite"
                       {
                           echo "mode=full"
                           echo "files="
+                          echo "reason=$1"
+                          echo "file_count=${count:-}"
                       } >> "$GITHUB_OUTPUT"
                       exit 0
                   }
 
                   # Master push and the cron skip the paths filter, so every output is empty.
-                  [ "${{ github.event_name }}" = "pull_request" ] || full "not a pull request"
+                  [ "${{ github.event_name }}" = "pull_request" ] || full not_a_pull_request
                   # Trunk's merge-queue branches raise a pull_request event like any other, so
                   # they need excluding by name. That run is the gate for master and must never
                   # be narrowed.
                   case "$HEAD_REF" in
-                      trunk-merge/*) full "merge queue run" ;;
+                      trunk-merge/*) full merge_queue ;;
                   esac
-                  [ "$NODE_FULL" != "true" ] || full "config, lockfile or Rust change"
-                  [ "$NODE_SRC" = "true" ] || full "no resolvable Node source changes"
+                  [ "$NODE_FULL" != "true" ] || full config_change
+                  [ "$NODE_SRC" = "true" ] || full no_node_sources
 
                   # Paths arrive repo-relative; jest runs from nodejs/, so strip the prefix.
                   # `list-files: escape` returns one shell-escaped, space-separated list, so
@@ -228,13 +235,15 @@ jobs:
                   files=$(printf '%s\n' $NODE_SRC_FILES | sed 's|^nodejs/||' | tr '\n' ' ')
                   # shellcheck disable=SC2086
                   count=$(printf '%s\n' $NODE_SRC_FILES | grep -c . || true)
-                  [ "$count" -le 200 ] || full "diff touches $count Node sources (>200)"
-                  [ -n "${files// /}" ] || full "changed-file list came back empty"
+                  [ "$count" -le 200 ] || full over_ceiling
+                  [ -n "${files// /}" ] || full empty_file_list
 
                   echo "::notice::selective jest over $count changed Node source file(s)"
                   {
                       echo "mode=selective"
                       echo "files=$files"
+                      echo "reason="
+                      echo "file_count=$count"
                   } >> "$GITHUB_OUTPUT"
 
     lint:
@@ -971,6 +980,52 @@ jobs:
               uses: ./.github/actions/report-jest-timings
               with:
                   artifacts: ./junit-artifacts
+
+    # Jest-selection telemetry -> DevEx project (347861), alongside the equivalent
+    # events for the backend (posthog-ci-test-selection), the frontend
+    # (posthog-ci-jest-selection) and Playwright (posthog-ci-e2e-spec-selection).
+    # Without it the fallback rate of this selector is only readable by opening runs
+    # one at a time, and this workflow has no other telemetry.
+    # Emitted on full runs too — the merge queue's trunk-merge/** run raises a
+    # pull_request event, so `mode=full` there is the baseline selective runs are
+    # measured against. This workflow captures no job durations, so a saving is read
+    # off the tests job's own conclusion and the run in the Actions API, not from here.
+    # Telemetry never reds CI (continue-on-error).
+    # hogli-lint: not-a-required-gate — reads results to describe the run, gates nothing
+    capture-nodejs-selection:
+        name: Capture Node.js jest selection
+        needs: [changes, tests]
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        # Nothing to report on a PR that never ran the suite. Forks and Dependabot never
+        # have the secret.
+        if: >-
+            !cancelled() && github.run_attempt == '1'
+            && github.event_name == 'pull_request'
+            && github.actor != 'dependabot[bot]'
+            && github.event.pull_request.head.repo.full_name == 'PostHog/posthog'
+            && (needs.tests.result == 'success' || needs.tests.result == 'failure')
+        steps:
+            - name: Capture Node.js jest selection to DevEx PostHog
+              continue-on-error: true
+              uses: PostHog/posthog-github-action@58dea254b598fb5d469c0699c98af8288a7f7650 # v1.2.0
+              with:
+                  posthog-token: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+                  event: 'posthog-ci-nodejs-selection'
+                  properties: |
+                      {
+                        "mode": ${{ toJSON(needs.changes.outputs.test_mode) }},
+                        "selected_file_count": ${{ needs.changes.outputs.test_file_count || 'null' }},
+                        "full_run_reason_category": ${{ toJSON(needs.changes.outputs.test_reason || '') }},
+                        "tests_result": ${{ toJSON(needs.tests.result) }},
+                        "pr_draft": ${{ toJSON(github.event.pull_request.draft) }},
+                        "merge_queue": ${{ startsWith(github.head_ref, 'trunk-merge/') }},
+                        "event_type": ${{ toJSON(github.event.action) }},
+                        "branch": ${{ toJSON(github.head_ref || github.ref_name) }},
+                        "sha": ${{ toJSON(github.sha) }},
+                        "pr_number": ${{ github.event.pull_request.number || 'null' }},
+                        "run_id": ${{ toJSON(github.run_id) }}
+                      }
 
     node_tests:
         # report-test-speed is deliberately not in needs: it is visible but non-gating.

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -43,6 +43,10 @@ jobs:
             pull-requests: read
         outputs:
             nodejs: ${{ steps.nodejs-changes.outputs.nodejs || 'true' }}
+            # Jest selection for the tests job. `mode` is 'selective' only when the diff is
+            # confined to Node source files jest can resolve; anything else is 'full'.
+            test_mode: ${{ steps.select-tests.outputs.mode || 'full' }}
+            test_files: ${{ steps.select-tests.outputs.files }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -67,6 +71,8 @@ jobs:
               if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # node_src_files feeds jest --findRelatedTests in the select step below.
+                  list-files: 'escape'
                   filters: |
                       nodejs:
                         - .github/workflows/ci-nodejs.yml
@@ -108,6 +114,21 @@ jobs:
                         - 'proto/**'
                         - '.github/rust-images.yml'
                         - '.github/actions/rust-compute-affected/**'
+                      # Node sources jest can resolve. Their paths feed --findRelatedTests.
+                      node_src:
+                        - 'nodejs/**/*.ts'
+                        - 'nodejs/**/*.js'
+                        - '!nodejs/**/*.d.ts'
+                      # Anything here invalidates jest's view of the module graph, or changes
+                      # the native addons every suite links, so no narrowed run can be trusted.
+                      node_full:
+                        - 'nodejs/jest*.config.js'
+                        - 'nodejs/package.json'
+                        - 'nodejs/tsconfig*.json'
+                        - 'pnpm-lock.yaml'
+                        - 'rust/**'
+                        - 'proto/**'
+                        - '.github/workflows/ci-nodejs.yml'
 
             - name: Install rust for affected-crate detection
               # Not needed on schedule either: the decision step below already returns
@@ -163,6 +184,58 @@ jobs:
                   fi
 
                   echo "nodejs=false" >> "$GITHUB_OUTPUT"
+
+            # Narrow the jest run to the tests reachable from the changed Node sources.
+            # Verified locally that jest applies --findRelatedTests before --shard, so the
+            # shards still partition the selected set exactly rather than a subset of it.
+            # Fail-open is always FULL, never skip: this workflow has no draft/ready split
+            # and no later run on the PR would cover a miss.
+            - name: Select jest tests
+              id: select-tests
+              env:
+                  NODE_FULL: ${{ steps.filter.outputs.node_full }}
+                  NODE_SRC: ${{ steps.filter.outputs.node_src }}
+                  NODE_SRC_FILES: ${{ steps.filter.outputs.node_src_files }}
+                  # Through env, not inline: a branch name is author-controlled.
+                  HEAD_REF: ${{ github.head_ref }}
+              run: |
+                  set -uo pipefail
+
+                  full() {
+                      echo "::notice::$1; running the full jest suite"
+                      {
+                          echo "mode=full"
+                          echo "files="
+                      } >> "$GITHUB_OUTPUT"
+                      exit 0
+                  }
+
+                  # Master push and the cron skip the paths filter, so every output is empty.
+                  [ "${{ github.event_name }}" = "pull_request" ] || full "not a pull request"
+                  # Trunk's merge-queue branches raise a pull_request event like any other, so
+                  # they need excluding by name. That run is the gate for master and must never
+                  # be narrowed.
+                  case "$HEAD_REF" in
+                      trunk-merge/*) full "merge queue run" ;;
+                  esac
+                  [ "$NODE_FULL" != "true" ] || full "config, lockfile or Rust change"
+                  [ "$NODE_SRC" = "true" ] || full "no resolvable Node source changes"
+
+                  # Paths arrive repo-relative; jest runs from nodejs/, so strip the prefix.
+                  # `list-files: escape` returns one shell-escaped, space-separated list, so
+                  # the splitting shellcheck warns about is exactly what turns it into paths.
+                  # shellcheck disable=SC2086
+                  files=$(printf '%s\n' $NODE_SRC_FILES | sed 's|^nodejs/||' | tr '\n' ' ')
+                  # shellcheck disable=SC2086
+                  count=$(printf '%s\n' $NODE_SRC_FILES | grep -c . || true)
+                  [ "$count" -le 200 ] || full "diff touches $count Node sources (>200)"
+                  [ -n "${files// /}" ] || full "changed-file list came back empty"
+
+                  echo "::notice::selective jest over $count changed Node source file(s)"
+                  {
+                      echo "mode=selective"
+                      echo "files=$files"
+                  } >> "$GITHUB_OUTPUT"
 
     lint:
         # Not on master push — master coverage comes from the hourly run (see `schedule`).
@@ -534,9 +607,21 @@ jobs:
                   JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
                   # New compileHog callers must generate and commit their source-addressed fixture.
                   HOG_BYTECODE_CACHE_REQUIRED: 'true'
+                  TEST_MODE: ${{ needs.changes.outputs.test_mode }}
+                  TEST_FILES: ${{ needs.changes.outputs.test_files }}
               run: |
                   if [ -f nodejs/jest.serial.config.js ]; then
-                    cd nodejs && pnpm run test:${{ matrix.lane }}
+                    # In selective mode append --findRelatedTests to the package script, which
+                    # already carries --shard and --testPathIgnorePatterns. jest resolves the
+                    # related set first and shards that, so the shards stay disjoint.
+                    # --passWithNoTests because a shard can legitimately receive nothing once
+                    # the set is narrowed; the serial script does not set it itself.
+                    if [ "$TEST_MODE" = "selective" ]; then
+                      # shellcheck disable=SC2086
+                      cd nodejs && pnpm run test:${{ matrix.lane }} -- --passWithNoTests --findRelatedTests $TEST_FILES
+                    else
+                      cd nodejs && pnpm run test:${{ matrix.lane }}
+                    fi
                   elif [ "${{ matrix.lane }}" = 'serial' ]; then
                     bin/turbo run test --filter=@posthog/nodejs
                   else

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -36,6 +36,14 @@ jobs:
         outputs:
             python: ${{ steps.filter.outputs.python || 'true' }}
             complexity_files: ${{ steps.filter.outputs.complexity_files }}
+            # Per-tool outputs gating the self-contained pytest steps in code-quality.
+            # Each defaults to true, so master push and the hourly cron — where the filter
+            # is skipped — still run every suite.
+            hogli: ${{ steps.filter.outputs.hogli || 'true' }}
+            owners: ${{ steps.filter.outputs.owners || 'true' }}
+            query_perf: ${{ steps.filter.outputs.query_perf || 'true' }}
+            stamphog: ${{ steps.filter.outputs.stamphog || 'true' }}
+            bin_scripts: ${{ steps.filter.outputs.bin_scripts || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -107,6 +115,43 @@ jobs:
                         # Stamphog policy files validated by the pr-approval-agent suite
                         - '.stamphog/**'
                         - '**/AGENT_APPROVALS.md'
+                      # Per-tool groups below gate the pytest steps in code-quality. Each of
+                      # these trees imports only stdlib and its own package — none of them
+                      # imports posthog — so a change under posthog/ cannot affect them and
+                      # they do not need to run on every Python PR. Verify that before adding
+                      # a tree here: a path filter that skips tests is a claim about the
+                      # import graph (see ci-things-already-tried.md, #50137).
+                      # Dependency and workflow changes run all of them.
+                      hogli:
+                        - 'tools/hogli/**'
+                        - 'tools/hogli-commands/**'
+                        - 'hogli.yaml'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
+                      owners:
+                        - 'tools/owners/**'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
+                      query_perf:
+                        - 'tools/query-performance-ai/**'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
+                      stamphog:
+                        - 'tools/pr-approval-agent/**'
+                        - 'products/stamphog/packages/pr-approval-agent/**'
+                        - '.stamphog/**'
+                        - '**/AGENT_APPROVALS.md'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
+                      bin_scripts:
+                        - 'bin/**'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
 
     code-quality:
         needs: changes
@@ -117,6 +162,16 @@ jobs:
 
         name: Python code quality (depot-ubuntu-24.04)
         runs-on: depot-ubuntu-24.04
+        # Read by the per-tool guards on the pytest steps below. These sit inside a
+        # `parallel:` block, where step-level `if:` has no exercised precedent in this
+        # repo — the one existing case can never be false — so the guard is a shell test
+        # on a job-level env var, which behaves the same either way.
+        env:
+            RUN_HOGLI: ${{ needs.changes.outputs.hogli }}
+            RUN_OWNERS: ${{ needs.changes.outputs.owners }}
+            RUN_QUERY_PERF: ${{ needs.changes.outputs.query_perf }}
+            RUN_STAMPHOG: ${{ needs.changes.outputs.stamphog }}
+            RUN_BIN_SCRIPTS: ${{ needs.changes.outputs.bin_scripts }}
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -275,19 +330,27 @@ jobs:
 
                   - name: Run hogli framework tests
                     shell: bash
-                    run: pytest tools/hogli/tests -v --junitxml=junit-hogli.xml
+                    run: |
+                        [ "$RUN_HOGLI" = "true" ] || { echo "hogli unchanged — skipping"; exit 0; }
+                        pytest tools/hogli/tests -v --junitxml=junit-hogli.xml
 
                   - name: Run hogli extension tests
                     shell: bash
-                    run: pytest tools/hogli-commands/hogli_commands/tests -v --junitxml=junit-hogli-commands.xml
+                    run: |
+                        [ "$RUN_HOGLI" = "true" ] || { echo "hogli unchanged — skipping"; exit 0; }
+                        pytest tools/hogli-commands/hogli_commands/tests -v --junitxml=junit-hogli-commands.xml
 
                   - name: Run owners resolver tests
                     shell: bash
-                    run: pytest tools/owners/tests -v --junitxml=junit-owners.xml
+                    run: |
+                        [ "$RUN_OWNERS" = "true" ] || { echo "tools/owners unchanged — skipping"; exit 0; }
+                        pytest tools/owners/tests -v --junitxml=junit-owners.xml
 
                   - name: Run query-performance-ai tests
                     shell: bash
-                    run: pytest tools/query-performance-ai/query_performance_ai -v --junitxml=junit-query-performance-ai.xml
+                    run: |
+                        [ "$RUN_QUERY_PERF" = "true" ] || { echo "query-performance-ai unchanged — skipping"; exit 0; }
+                        pytest tools/query-performance-ai/query_performance_ai -v --junitxml=junit-query-performance-ai.xml
 
                   - name: Run pr-approval-agent (stamphog) tests
                     shell: bash
@@ -297,6 +360,7 @@ jobs:
                     # both exist, because that merge can add a file at the old path next to the new
                     # tree.
                     run: |
+                        [ "$RUN_STAMPHOG" = "true" ] || { echo "pr-approval-agent unchanged — skipping"; exit 0; }
                         found=0
                         for dir in products/stamphog/packages/pr-approval-agent tools/pr-approval-agent; do
                           [ -d "$dir" ] || continue
@@ -310,13 +374,17 @@ jobs:
 
                   - name: Run dependency detection script tests
                     shell: bash
-                    run: pytest bin/test/test_find_python_dependencies.py -v --junitxml=junit-dependency-detection.xml
+                    run: |
+                        [ "$RUN_BIN_SCRIPTS" = "true" ] || { echo "bin/ unchanged — skipping"; exit 0; }
+                        pytest bin/test/test_find_python_dependencies.py -v --junitxml=junit-dependency-detection.xml
 
             - name: Upload test results
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               if: always()
               with:
                   name: junit-results-hogli
+                  # A gated-off suite writes no junit file, which is now the common case.
+                  if-no-files-found: ignore
                   path: |
                       junit-hogli.xml
                       junit-hogli-commands.xml
@@ -329,6 +397,7 @@ jobs:
               if: always()
               with:
                   name: junit-results-dependency-detection
+                  if-no-files-found: ignore
                   path: junit-dependency-detection.xml
 
     # Collate job - single required status check for branch protection.

--- a/docs/internal/ci-things-already-tried.md
+++ b/docs/internal/ci-things-already-tried.md
@@ -172,7 +172,31 @@ The selection was also active for draft PRs only for some time. The team wanted 
 [#85530](https://github.com/PostHog/posthog/pull/85530) then extended the selection to PRs that are ready for review. [#88265](https://github.com/PostHog/posthog/pull/88265) put the Django selection and the product selection in one job.
 Read the comment at the top of `.github/workflows/ci-backend.yml` for the current rules.
 
+The jest and Playwright suites made the same move later, so `ready_for_review` no longer buys a full matrix anywhere.
+Selection now runs on drafts and ready PRs alike in `ci-backend.yml`, `ci-frontend.yml`, `ci-storybook.yml`, and `ci-e2e-playwright.yml`, and the merge queue's `trunk-merge/**` run is the only full gate.
+What still differs by draft state is the fallback when a selection cannot be trusted: a draft skips the suite and defers to its ready run, a ready PR takes the full matrix because no later run on that PR would cover it.
+
 _Also asked as:_ snob, is test selection on, why does CI run all the tests, do we select tests on PRs
+
+### Narrow the product test matrix when the backend selector returns `full`
+
+**Verdict: rejected** · Aug 2026 · read off the Turbo task graph, not measured
+
+On a legacy diff `turbo-discover.js` sets `products = allProducts`, roughly 30 matrix groups and the larger half of a full backend run.
+It already computes `mustRunProducts` (Turbo-affected products, their tach dependents, and the schema-affected set), but applies it only when the selection verdict is `selected`.
+Applying it on a `full` verdict too looks like free money.
+
+It is not. `backend:test` in `turbo.json` declares product-local inputs only — `backend/**/*.py`, `stats/`, `skills/`, `scripts/`, plus `../../pyproject.toml`, `../../uv.lock`, and `../../common/**/*.py`.
+No product task reads `posthog/**` or `ee/**`.
+So Turbo cannot see the core-to-product edge at all, and on a diff that touches only `posthog/` the affected set is empty, the tach dependents of an empty set are empty, and `mustRunProducts` comes out empty.
+Narrowing to it would run zero product tests on a core change that every product imports.
+
+The `selected` guard is what makes the existing narrowing safe: `narrowedProducts` unions `mustRunProducts` with the products Snob's import graph actually reached, and that union is the only thing covering the core-to-product edge.
+A `full` verdict means Snob produced no trustworthy set, so there is nothing to union.
+
+To go after those minutes, reduce how often the verdict is `full` — the `MAX_CHANGED_FILES = 50` bail and the `FULL_RUN_PATTERNS` list in `tools/snob_backend_test_selection_shadow.py` are the levers, and both change recall, so measure with the shadow first.
+
+_Also asked as:_ skip product tests on a full run, narrow the product matrix, why do all products run when I only changed core
 
 ### Disable the pytest `unraisableexception` and `threadexception` plugins
 


### PR DESCRIPTION
## Problem

An engineer opening a one-file frontend PR waits for the full four-shard jest matrix, and a Node.js PR waits for the entire Node jest suite. Neither suite can be affected by most of what those PRs change.

Four suites run wider than the diff can reach on a pull request:

- Jest ran its full matrix on every ready PR, selecting only on drafts.
- Playwright selected specs only on `synchronize`, so `opened`, `reopened` and `ready_for_review` took the whole suite.
- Python CI ran six pytest suites for self-contained dev tools on every Python PR.
- Node.js CI ran its entire jest suite whenever it ran at all.

Underneath all four is one stale assumption: that `ready_for_review` is the merge gate. It is not. The queue's `trunk-merge/**` run is, and it always runs everything.

Stacked on [#93229](https://github.com/PostHog/posthog/pull/93229), which moves master coverage for five workflows to an hourly cron. That PR touches the same three workflow files, so this is a stack rather than two independent PRs.

## Changes

**Pull requests now run only what the diff reaches.**

- A one-file frontend PR runs 2 selective jest shards instead of 4 full ones, draft or ready.
- A Playwright-affecting PR selects specs on every ready-PR event, not just `synchronize`. Those events diff the same head against the same base, so they select the same specs.
- A Python PR that touches no dev tool skips six pytest suites. They were about 133s of the job's 595s of step time, on the 44% of PRs that reach it.
- A Node.js PR runs jest over the tests reachable from the changed sources, via `--findRelatedTests`.

**Every selector now reports what it decided.** Two new events land in the DevEx project: `posthog-ci-jest-selection` and `posthog-ci-nodejs-selection`. This is the part that makes the rest reviewable after merge, and the reason it is here rather than in a follow-up:

- A narrowing that falls back on most runs looks identical in the YAML to one that works. The Playwright selector was eligible on 2,783 runs over 14 days and narrowed on **167 of them**. The other 94% fell back, 1,758 of those on one glob list. Selected runs took 63s of test time against roughly 515s full.
- Each selector gained a closed reason category and an unbounded detail, reported from every branch including the ones that narrow to nothing. So a fallback rate reads per reason, rather than being inferred from `mode` alone.
- Full runs emit too, tagged `merge_queue` where they came from the queue. They are the baseline a narrowed run is measured against.
- Timings are not duplicated. `posthog-ci-running-time-job` already carries each job's duration and joins on `run_id`.

The skill and `ci-things-already-tried.md` commits are documentation. Nothing a PostHog user sees changes.

Where every suite lands once this merges:

![ci-stage-matrix](https://raw.githubusercontent.com/PostHog/pr-assets/8093ce72e98784d836880fd4390e9d598d89e129/2026/08/ffc59c17-f5f3-45cb-86c5-0f0d4806cd7b.png)

Read each cell as "given the workflow runs at all". A paths filter gates every row on all three PR stages. `selected` versus `full` says whether a selector narrows the suite once it does run.

> [!WARNING]
> One silent failure mode came up. The Node.js selector first gated only on `pull_request`, and Trunk's merge-queue branches raise exactly that event, so the queue would have run a narrowed suite. The queue is now excluded by branch name, and the simulation below covers that case.

### What this still does not answer

The events say what each selector **decided**. They do not say whether a narrowed run would have **caught** what broke.

Only the backend scores that, in `tools/test_selection_verdict.py`, which reads the run's JUnit and reports recall. It writes a 90-day artifact rather than an event, so `posthog-ci-test-selection-verdict` holds 2 events, both from 24 Aug, and there is no standing recall number for any selector.

The cheap oracle for the rest needs no shadow build. The queue's `trunk-merge/**` run tests the same code with the full suite, so a failure there whose file was reachable from the diff and was not in the selected set is a selection miss, at no extra compute. Some queue failures are genuine interaction-with-master failures instead, which is why the reachability intersection matters rather than a raw failure count. Follow-up, not this PR.

### Three claims that were checked rather than assumed

**Path-gating the Python suites is a claim about the import graph.** Each of those trees imports only stdlib and its own package, and none imports `posthog`. [#50137](https://github.com/PostHog/posthog/pull/50137) was reverted for making the same kind of claim without checking.

**jest applies `--findRelatedTests` before `--shard`.** For one changed source with 3 related serial tests, shards 1/3, 2/3 and 3/3 returned 1, 1 and 1, so the shards partition the selected set rather than subsetting a subset. It also composes with the `--testPathIgnorePatterns` the package scripts pass, unlike `--testPathPatterns`.

**Step-level `if:` inside a `parallel:` block is unproven here.** The repo's only example has a condition that cannot be false when its job runs, so the Python guards use a shell test on a job-level env var, which behaves the same either way.

## How did you test this code?

No new automated tests. The change is workflow triggers, job conditions and shell guards, which this repo covers with linters rather than unit tests.

- `bin/hogli lint:workflows` passes, 8 checks across 131 workflows.
- `actionlint` reports three fewer findings than before on the touched workflows, and none added. The three are `SC2129` style warnings that the grouped `>>` redirects removed.
- `bin/hogli ci:preflight --strict` passes.

Simulated both jest selectors over all 16 branches, extracting the step bodies from the workflows so the simulation tracks the real scripts rather than a copy:

<details>
<summary>Simulation output</summary>

```text
ci-frontend.yml — Build narrowed matrix (classify)
  [ok] diff unavailable, draft=true
  [ok] over ceiling, draft=true
  [ok] config change, draft=true
  [ok] diff unavailable, draft=false
  [ok] over ceiling, draft=false
  [ok] config change, draft=false
  [ok] no frontend sources
  [ok] selective, ready PR
  [ok] selective, draft
ci-nodejs.yml — Select jest tests (select-tests)
  [ok] master push
  [ok] hourly cron
  [ok] merge queue
  [ok] config change
  [ok] no node sources
  [ok] over ceiling
  [ok] selective
```

</details>

That caught one real fragility: the changed-file count now leaves the workflow as an event property, and BSD `wc` pads it.

Also rendered each capture payload for the cases where a field can come back empty, including the merge-queue run where every selector output is absent, and asserted it parses as JSON.

Not checked, and worth knowing before merge:

- Neither new PR-side selector can be exercised by this PR. Its own diff touches `ci-python.yml` and `ci-nodejs.yml`, which every per-tool group and the `node_full` group match, so both run full here. A later Python-only or Node-only PR is what will show the skips.
- The selective jest path has not run on GitHub either, for the same reason: this diff touches `ci-frontend.yml`, a config-change trigger.
- The two new events have never been emitted. The first ready PR after merge is the real test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/ci-things-already-tried.md` and the `authoring-ci-workflows` skill are updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code. Skills invoked: `/authoring-ci-workflows`, `/stacking-prs`, `/writing-pr-descriptions`.

This PR previously combined the PR-side selection with the master-cadence change, and #91841 was closed into it. It is now the top of a two-layer stack, with the cadence change split out as #93229. The split follows the risk seam: the cadence half has a precedent already running on master and a coupling that punishes splitting, while this half introduces three selectors whose behavior the PR cannot exercise on itself. That gap is what the selection telemetry closes, and it was added in this session in response to review feedback asking how the narrowing would be proven.

The stack was rebased onto master after #93176 collapsed the jest matrix from `FOSS`×`EE` to one `app` segment. The ready-PR `FOSS` shards this PR proposed no longer exist, so a ready PR now takes the same two selective shards as a draft.

The fallback numbers quoted for the Playwright selector come from querying the existing `posthog-ci-e2e-spec-selection` event in the DevEx project, not from reading the YAML. The repo already runs the shadow-comparison pattern for a related question: `.github/actions/paths-filter/src/shadow.ts` derives the changed-file list locally and reports disagreement with the GitHub API without acting on it. A full shadow of test selection was considered and rejected for now, because running selected and full on every PR costs roughly what the change saves. The queue-run comparison described in Changes gets most of the signal for free.
