### PR TITLE
feat(kafka-consumer): add shared consumer crate with offset ledger

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2905,6 +2905,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-kafka-consumer"
+version = "0.1.0"
+dependencies = [
+ "rdkafka",
+]
+
+[[package]]
 name = "common-liveness"
 version = "0.1.0"
 
@@ -6158,6 +6165,7 @@ dependencies = [
  "chrono",
  "common-alloc",
  "common-continuous-profiling",
+ "common-kafka-consumer",
  "dashmap 6.1.0",
  "envconfig",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "common/dns",
   "common/health",
   "common/kafka",
+  "common/kafka-consumer",
   "common/liveness",
   "common/lifecycle",
   "common/limiters",

--- a/rust/common/kafka-consumer/Cargo.toml
+++ b/rust/common/kafka-consumer/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "common-kafka-consumer"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rdkafka = { workspace = true }

--- a/rust/common/kafka-consumer/README.md
+++ b/rust/common/kafka-consumer/README.md
@@ -7,4 +7,4 @@ Kafka consumption primitives shared by stateful services.
 - `config`: `ConsumerConfigBuilder`, the rdkafka `ClientConfig` builder with PostHog consumer defaults.
 - `types`: `Offset`.
 - `charge`: `Charge`, a message's cost (events and bytes) against consumer admission budgets.
-- `ledger`: `OffsetLedger`, per-partition offset accounting: completion in any order, an observable contiguous frontier, and explicit consumption at commit points.
+- `ledger`: `OffsetLedger`, offset accounting scoped to one partition assignment: completion in any order, an observable contiguous frontier, and explicit consumption at commit points.

--- a/rust/common/kafka-consumer/README.md
+++ b/rust/common/kafka-consumer/README.md
@@ -1,9 +1,10 @@
 # common-kafka-consumer
 
-Kafka consumption core for stateful services: poll, demux to groups, budget-gated admission, contiguous-frontier commits, bounded drain on revoke, per-partition stall watchdog, and commit verification.
-
-The design is the domain side of the driver-model doc in `rust/ingestion-consumer/docs/driver-model.md` (§3.1-§3.7). That doc's §8 is the vocabulary authority for names in this crate.
+Kafka consumption primitives shared by stateful services.
 
 ## Modules
 
 - `config`: `ConsumerConfigBuilder`, the rdkafka `ClientConfig` builder with PostHog consumer defaults.
+- `types`: `Offset`.
+- `charge`: `Charge`, a message's cost (events and bytes) against consumer admission budgets.
+- `ledger`: `OffsetLedger`, per-partition offset accounting: completion in any order, an observable contiguous frontier, and explicit consumption at commit points.

--- a/rust/common/kafka-consumer/README.md
+++ b/rust/common/kafka-consumer/README.md
@@ -1,0 +1,9 @@
+# common-kafka-consumer
+
+Kafka consumption core for stateful services: poll, demux to groups, budget-gated admission, contiguous-frontier commits, bounded drain on revoke, per-partition stall watchdog, and commit verification.
+
+The design is the domain side of the driver-model doc in `rust/ingestion-consumer/docs/driver-model.md` (§3.1-§3.7). That doc's §8 is the vocabulary authority for names in this crate.
+
+## Modules
+
+- `config`: `ConsumerConfigBuilder`, the rdkafka `ClientConfig` builder with PostHog consumer defaults.

--- a/rust/common/kafka-consumer/src/charge.rs
+++ b/rust/common/kafka-consumer/src/charge.rs
@@ -1,0 +1,39 @@
+use std::iter::Sum;
+use std::ops::{Add, AddAssign};
+
+/// A message's cost against later consumer admission budgets.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Charge {
+    pub events: u64,
+    pub bytes: u64,
+}
+
+impl Charge {
+    pub const ZERO: Charge = Charge {
+        events: 0,
+        bytes: 0,
+    };
+}
+
+impl Add for Charge {
+    type Output = Charge;
+
+    fn add(self, rhs: Charge) -> Self::Output {
+        Charge {
+            events: self.events + rhs.events,
+            bytes: self.bytes + rhs.bytes,
+        }
+    }
+}
+
+impl AddAssign for Charge {
+    fn add_assign(&mut self, rhs: Charge) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sum for Charge {
+    fn sum<I: Iterator<Item = Charge>>(iter: I) -> Self {
+        iter.fold(Charge::ZERO, Add::add)
+    }
+}

--- a/rust/common/kafka-consumer/src/config.rs
+++ b/rust/common/kafka-consumer/src/config.rs
@@ -243,6 +243,33 @@ mod tests {
     use super::*;
 
     #[test]
+    fn batch_consumer_defaults_are_stable() {
+        let config = ConsumerConfigBuilder::for_batch_consumer("kafka:9092", "g").build();
+
+        let mut entries: Vec<(String, String)> = config
+            .config_map()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        entries.sort();
+
+        assert_eq!(
+            entries,
+            [
+                ("enable.auto.commit", "false"),
+                ("enable.auto.offset.store", "false"),
+                ("group.id", "g"),
+                ("heartbeat.interval.ms", "5000"),
+                ("max.poll.interval.ms", "300000"),
+                ("metadata.broker.list", "kafka:9092"),
+                ("session.timeout.ms", "60000"),
+                ("socket.timeout.ms", "10000"),
+            ]
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+        );
+    }
+
+    #[test]
     fn strips_classic_keys_under_consumer_protocol() {
         let config = ConsumerConfigBuilder::for_batch_consumer("kafka:9092", "g")
             .with_sticky_partition_assignment(Some("pod-1"), true)

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -21,13 +21,13 @@ pub struct TakenFrontier {
 #[derive(Debug, Default)]
 pub struct OffsetLedger {
     /// The offset of `slots[0]`; `None` until the first delivery.
-    base: Option<Offset>,
+    base_offset: Option<Offset>,
     /// Number of completed slots at the front of the window, kept current on
     /// every completion so `frontier` stays O(1).
     prefix: usize,
     /// A dense sliding window over one contiguous offset range: `charge`
     /// appends at the back, `take_frontier` pops the front, and `complete`
-    /// indexes by offset minus `base`. Every operation is amortized constant
+    /// indexes by offset minus `base_offset`. Every operation is amortized constant
     /// time per offset.
     slots: VecDeque<Slot>,
 }
@@ -44,10 +44,13 @@ impl OffsetLedger {
     pub fn charge(&mut self, offsets: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
         let mut total = Charge::ZERO;
         for (offset, charge) in offsets {
-            let base = *self.base.get_or_insert(offset);
-            let end = base + self.slots.len();
-            assert!(offset >= end, "offset {offset} was not delivered in order");
-            for _ in 0..offset - end {
+            let base_offset = *self.base_offset.get_or_insert(offset);
+            let end_offset = base_offset + self.slots.len();
+            assert!(
+                offset >= end_offset,
+                "offset {offset} was not delivered in order"
+            );
+            for _ in 0..offset - end_offset {
                 self.slots.push_back(Slot {
                     complete: true,
                     charge: Charge::ZERO,
@@ -64,12 +67,13 @@ impl OffsetLedger {
 
     /// Mark delivered offsets complete in any order.
     pub fn complete(&mut self, offsets: &[Offset]) {
-        let base = self.base.expect("completion before any delivery");
+        let base_offset = self.base_offset.expect("completion before any delivery");
         for &offset in offsets {
-            let index = usize::try_from(offset - base).expect("completion below the window base");
+            let slot_index =
+                usize::try_from(offset - base_offset).expect("completion below the window base");
             let slot = self
                 .slots
-                .get_mut(index)
+                .get_mut(slot_index)
                 .expect("completion for an uncharged offset");
             assert!(!slot.complete, "offset {offset} completed twice");
             slot.complete = true;
@@ -87,23 +91,26 @@ impl OffsetLedger {
     /// filler ends the completed prefix; a commit one past it is still correct
     /// because a gap holds no messages.
     pub fn frontier(&self) -> Option<Offset> {
-        let base = self.base?;
-        (self.prefix > 0).then(|| base + (self.prefix - 1))
+        let base_offset = self.base_offset?;
+        (self.prefix > 0).then(|| base_offset + (self.prefix - 1))
     }
 
     /// Consume the contiguous completed prefix previously observable through
     /// `frontier`. This is intentionally separate from `complete` for shadow
     /// comparisons against the current commit path.
     pub fn take_frontier(&mut self) -> Option<TakenFrontier> {
-        let offset = self.frontier()?;
+        let frontier_offset = self.frontier()?;
         let charge = self
             .slots
             .drain(..self.prefix)
             .map(|slot| slot.charge)
             .sum();
-        self.base = Some(offset + 1);
+        self.base_offset = Some(frontier_offset + 1);
         self.prefix = 0;
-        Some(TakenFrontier { offset, charge })
+        Some(TakenFrontier {
+            offset: frontier_offset,
+            charge,
+        })
     }
 
     pub fn len(&self) -> usize {

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -21,6 +21,11 @@ pub struct TakenFrontier {
 /// commit. Observing the frontier never changes it; a commit point consumes
 /// it with `take_frontier`.
 ///
+/// Charge every record the poll delivers, including records the caller drops
+/// without processing: an omitted offset is indistinguishable from an offset
+/// Kafka never delivered, and the frontier commits past it as if it held no
+/// message.
+///
 /// A ledger lives for one partition assignment: create it on assign, drop it
 /// on revoke. Kafka replays a partition from its committed offset after a
 /// rebalance, so a ledger kept across assignments sees the replay as

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -16,8 +16,10 @@ pub struct TakenFrontier {
     pub charge: Charge,
 }
 
-/// Per-partition delivered-offset ledger. Completion only marks slots; commit
-/// paths explicitly consume the contiguous prefix after observing it.
+/// Per-partition offset accounting: record offsets as they are delivered,
+/// complete them in any order, and read the highest offset that is safe to
+/// commit. Observing the frontier never changes it; a commit point consumes
+/// it with `take_frontier`.
 ///
 /// A ledger lives for one partition assignment: create it on assign, drop it
 /// on revoke. Kafka replays a partition from its committed offset after a
@@ -46,9 +48,8 @@ impl OffsetLedger {
     }
 
     /// Record offsets in delivery order and return their total charge. An
-    /// offset gap (transaction control records) gets pre-completed zero-charge
-    /// filler slots, so the window stays dense and the frontier walks over the
-    /// gap.
+    /// offset gap (transaction control records) never blocks the frontier and
+    /// carries no charge.
     ///
     /// # Panics
     ///
@@ -64,6 +65,8 @@ impl OffsetLedger {
                 offset >= next_offset,
                 "offset {offset} delivered below the window's next offset {next_offset}"
             );
+            // A gap becomes pre-completed zero-charge filler so the index
+            // math stays aligned with offsets.
             for _ in 0..offset - next_offset {
                 self.slots.push_back(Slot {
                     complete: true,
@@ -108,17 +111,17 @@ impl OffsetLedger {
         }
     }
 
-    /// Highest contiguous completed offset. This can be a gap offset when
-    /// filler ends the completed prefix; a commit one past it is still correct
-    /// because a gap holds no messages.
+    /// Highest offset with nothing incomplete at or below it, or `None`
+    /// before the first completion. Committing one past it is always safe,
+    /// even when a trailing gap makes this a gap offset.
     pub fn frontier(&self) -> Option<Offset> {
         let base_offset = self.base_offset?;
         (self.prefix > 0).then(|| base_offset + (self.prefix - 1))
     }
 
-    /// Consume the contiguous completed prefix previously observable through
-    /// `frontier`. This is intentionally separate from `complete` for shadow
-    /// comparisons against the current commit path.
+    /// Take the frontier and the charge of everything at or below it,
+    /// forgetting that span. Kept separate from `complete` so that reading
+    /// the frontier has no side effects and only commit points consume it.
     pub fn take_frontier(&mut self) -> Option<TakenFrontier> {
         let frontier_offset = self.frontier()?;
         let charge = self

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -18,6 +18,14 @@ pub struct TakenFrontier {
 
 /// Per-partition delivered-offset ledger. Completion only marks slots; commit
 /// paths explicitly consume the contiguous prefix after observing it.
+///
+/// A ledger lives for one partition assignment: create it on assign, drop it
+/// on revoke. Kafka replays a partition from its committed offset after a
+/// rebalance, so a ledger kept across assignments sees the replay as
+/// duplicate delivery and panics. Completions from a previous assignment's
+/// in-flight work must be discarded before they reach the new ledger; it
+/// never charged those offsets and panics on them too (see the panic
+/// contracts on `charge` and `complete`).
 #[derive(Debug, Default)]
 pub struct OffsetLedger {
     /// The offset of `slots[0]`; `None` until the first delivery.
@@ -41,6 +49,12 @@ impl OffsetLedger {
     /// offset gap (transaction control records) gets pre-completed zero-charge
     /// filler slots, so the window stays dense and the frontier walks over the
     /// gap.
+    ///
+    /// # Panics
+    ///
+    /// When an offset is not above every offset already recorded. Duplicate
+    /// or out-of-order delivery is a caller bug, and recording it would
+    /// corrupt the commit accounting.
     pub fn charge(&mut self, offsets: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
         let mut total = Charge::ZERO;
         for (offset, charge) in offsets {
@@ -66,6 +80,13 @@ impl OffsetLedger {
     }
 
     /// Mark delivered offsets complete in any order.
+    ///
+    /// # Panics
+    ///
+    /// When an offset was never charged, was completed before, or was already
+    /// consumed by `take_frontier`. Each case means the completion does not
+    /// belong to this ledger's window, and marking it would corrupt the
+    /// commit accounting.
     pub fn complete(&mut self, offsets: &[Offset]) {
         let base_offset = self.base_offset.expect("completion before any delivery");
         for &offset in offsets {

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -45,12 +45,12 @@ impl OffsetLedger {
         let mut total = Charge::ZERO;
         for (offset, charge) in offsets {
             let base_offset = *self.base_offset.get_or_insert(offset);
-            let end_offset = base_offset + self.slots.len();
+            let next_offset = base_offset + self.slots.len();
             assert!(
-                offset >= end_offset,
-                "offset {offset} was not delivered in order"
+                offset >= next_offset,
+                "offset {offset} delivered below the window's next offset {next_offset}"
             );
-            for _ in 0..offset - end_offset {
+            for _ in 0..offset - next_offset {
                 self.slots.push_back(Slot {
                     complete: true,
                     charge: Charge::ZERO,

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -16,17 +16,19 @@ pub struct TakenFrontier {
     pub charge: Charge,
 }
 
-/// Per-partition delivered-offset ledger, stored as a dense ring over one
-/// contiguous offset range so that completion is an index lookup instead of a
-/// scan. Completion only marks slots; commit paths explicitly consume the
-/// contiguous prefix after observing it.
+/// Per-partition delivered-offset ledger. Completion only marks slots; commit
+/// paths explicitly consume the contiguous prefix after observing it.
 #[derive(Debug, Default)]
 pub struct OffsetLedger {
     /// The offset of `slots[0]`; `None` until the first delivery.
     base: Option<i64>,
-    /// Number of completed slots at the front of the ring, kept current on
+    /// Number of completed slots at the front of the window, kept current on
     /// every completion so `frontier` stays O(1).
     prefix: usize,
+    /// A dense sliding window over one contiguous offset range: `charge`
+    /// appends at the back, `take_frontier` pops the front, and `complete`
+    /// indexes by offset minus `base`. Every operation is amortized constant
+    /// time per offset.
     slots: VecDeque<Slot>,
 }
 
@@ -37,7 +39,7 @@ impl OffsetLedger {
 
     /// Record offsets in delivery order and return their total charge. An
     /// offset gap (transaction control records) gets pre-completed zero-charge
-    /// filler slots, so the ring stays dense and the frontier walks over the
+    /// filler slots, so the window stays dense and the frontier walks over the
     /// gap.
     pub fn charge(&mut self, offsets: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
         let mut total = Charge::ZERO;
@@ -67,7 +69,7 @@ impl OffsetLedger {
     pub fn complete(&mut self, offsets: &[Offset]) {
         let base = self.base.expect("completion before any delivery");
         for offset in offsets {
-            let index = usize::try_from(offset.0 - base).expect("completion below the ring base");
+            let index = usize::try_from(offset.0 - base).expect("completion below the window base");
             let slot = self
                 .slots
                 .get_mut(index)
@@ -172,7 +174,7 @@ mod tests {
     }
 
     #[test]
-    fn the_ring_continues_across_take_frontier() {
+    fn the_window_slides_across_take_frontier() {
         let mut ledger = OffsetLedger::new();
         ledger.charge([charge(0), charge(1)]);
         ledger.complete(&[Offset(0), Offset(1)]);

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -9,7 +9,8 @@ struct Slot {
     charge: Charge,
 }
 
-/// A consumed contiguous prefix and the charge it covers.
+/// A consumed contiguous prefix: its commit-ready frontier and the charge it
+/// covers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TakenFrontier {
     pub offset: Offset,
@@ -17,9 +18,9 @@ pub struct TakenFrontier {
 }
 
 /// Per-partition offset accounting: record offsets as they are delivered,
-/// complete them in any order, and read the highest offset that is safe to
-/// commit. Observing the frontier never changes it; a commit point consumes
-/// it with `take_frontier`.
+/// complete them in any order, and read the frontier in Kafka's
+/// committed-offset representation. Observing the frontier never changes it;
+/// a commit point consumes it with `take_frontier`.
 ///
 /// Charge every record the poll delivers, including records the caller drops
 /// without processing: an omitted offset is indistinguishable from an offset
@@ -116,17 +117,17 @@ impl OffsetLedger {
         }
     }
 
-    /// Highest offset with nothing incomplete at or below it, or `None`
-    /// before the first completion. Committing one past it is always safe,
-    /// even when a trailing gap makes this a gap offset.
+    /// The next offset to read: one past the highest contiguous completed
+    /// offset, in Kafka's committed-offset representation, so a commit uses
+    /// it verbatim. `None` before the first completion.
     pub fn frontier(&self) -> Option<Offset> {
         let base_offset = self.base_offset?;
-        (self.prefix > 0).then(|| base_offset + (self.prefix - 1))
+        (self.prefix > 0).then(|| base_offset + self.prefix)
     }
 
-    /// Take the frontier and the charge of everything at or below it,
-    /// forgetting that span. Kept separate from `complete` so that reading
-    /// the frontier has no side effects and only commit points consume it.
+    /// Take the frontier and the charge of everything below it, forgetting
+    /// that span. Kept separate from `complete` so that reading the frontier
+    /// has no side effects and only commit points consume it.
     pub fn take_frontier(&mut self) -> Option<TakenFrontier> {
         let frontier_offset = self.frontier()?;
         let charge = self
@@ -134,7 +135,7 @@ impl OffsetLedger {
             .drain(..self.prefix)
             .map(|slot| slot.charge)
             .sum();
-        self.base_offset = Some(frontier_offset + 1);
+        self.base_offset = Some(frontier_offset);
         self.prefix = 0;
         Some(TakenFrontier {
             offset: frontier_offset,
@@ -173,7 +174,7 @@ mod tests {
         assert_eq!(ledger.frontier(), None);
         assert_eq!(ledger.take_frontier(), None);
         ledger.complete(&[Offset(0), Offset(1)]);
-        assert_eq!(ledger.frontier(), Some(Offset(2)));
+        assert_eq!(ledger.frontier(), Some(Offset(3)));
     }
 
     #[test]
@@ -182,11 +183,11 @@ mod tests {
         ledger.charge([charge(0), charge(1), charge(2)]);
         ledger.complete(&[Offset(0)]);
         let taken = ledger.take_frontier().unwrap();
-        assert_eq!(taken.offset, Offset(0));
+        assert_eq!(taken.offset, Offset(1));
         assert_eq!(taken.charge.events, 1);
         assert_eq!(ledger.len(), 2);
         ledger.complete(&[Offset(1), Offset(2)]);
-        assert_eq!(ledger.frontier(), Some(Offset(2)));
+        assert_eq!(ledger.frontier(), Some(Offset(3)));
         assert_eq!(ledger.take_frontier().unwrap().charge.events, 2);
     }
 
@@ -230,8 +231,8 @@ mod tests {
         let mut ledger = OffsetLedger::new();
         ledger.charge([charge(0), charge(1)]);
         ledger.complete(&[Offset(0), Offset(1)]);
-        assert_eq!(ledger.frontier(), Some(Offset(1)));
-        assert_eq!(ledger.frontier(), Some(Offset(1)));
+        assert_eq!(ledger.frontier(), Some(Offset(2)));
+        assert_eq!(ledger.frontier(), Some(Offset(2)));
         assert_eq!(ledger.take_frontier().unwrap().charge.events, 2);
         assert_eq!(ledger.len(), 0);
     }
@@ -241,7 +242,7 @@ mod tests {
         let mut ledger = OffsetLedger::new();
         ledger.charge([charge(0), charge(3)]);
         ledger.complete(&[Offset(0), Offset(3)]);
-        assert_eq!(ledger.frontier(), Some(Offset(3)));
+        assert_eq!(ledger.frontier(), Some(Offset(4)));
     }
 
     #[test]
@@ -249,10 +250,10 @@ mod tests {
         let mut ledger = OffsetLedger::new();
         ledger.charge([charge(0), charge(3)]);
         ledger.complete(&[Offset(0)]);
-        assert_eq!(ledger.frontier(), Some(Offset(2)));
+        assert_eq!(ledger.frontier(), Some(Offset(3)));
         ledger.complete(&[Offset(3)]);
         let taken = ledger.take_frontier().unwrap();
-        assert_eq!(taken.offset, Offset(3));
+        assert_eq!(taken.offset, Offset(4));
         assert_eq!(taken.charge.events, 2);
     }
 
@@ -264,7 +265,7 @@ mod tests {
         ledger.take_frontier().unwrap();
         ledger.charge([charge(2)]);
         ledger.complete(&[Offset(2)]);
-        assert_eq!(ledger.frontier(), Some(Offset(2)));
+        assert_eq!(ledger.frontier(), Some(Offset(3)));
         assert_eq!(ledger.take_frontier().unwrap().charge.events, 1);
     }
 }

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -166,8 +166,58 @@ mod tests {
         ledger.charge([charge(0), charge(1), charge(2)]);
         ledger.complete(&[Offset(2)]);
         assert_eq!(ledger.frontier(), None);
+        assert_eq!(ledger.take_frontier(), None);
         ledger.complete(&[Offset(0), Offset(1)]);
         assert_eq!(ledger.frontier(), Some(Offset(2)));
+    }
+
+    #[test]
+    fn a_partial_take_keeps_the_remainder_completable() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0), charge(1), charge(2)]);
+        ledger.complete(&[Offset(0)]);
+        let taken = ledger.take_frontier().unwrap();
+        assert_eq!(taken.offset, Offset(0));
+        assert_eq!(taken.charge.events, 1);
+        assert_eq!(ledger.len(), 2);
+        ledger.complete(&[Offset(1), Offset(2)]);
+        assert_eq!(ledger.frontier(), Some(Offset(2)));
+        assert_eq!(ledger.take_frontier().unwrap().charge.events, 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "delivered below the window's next offset")]
+    fn duplicate_delivery_panics() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0), charge(1)]);
+        ledger.charge([charge(1)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "completed twice")]
+    fn double_completion_panics() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0)]);
+        ledger.complete(&[Offset(0)]);
+        ledger.complete(&[Offset(0)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "completion for an uncharged offset")]
+    fn completing_an_undelivered_offset_panics() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0)]);
+        ledger.complete(&[Offset(5)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "completion below the window base")]
+    fn completing_below_the_window_after_a_take_panics() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0), charge(1)]);
+        ledger.complete(&[Offset(0)]);
+        ledger.take_frontier().unwrap();
+        ledger.complete(&[Offset(0)]);
     }
 
     #[test]

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -21,7 +21,7 @@ pub struct TakenFrontier {
 #[derive(Debug, Default)]
 pub struct OffsetLedger {
     /// The offset of `slots[0]`; `None` until the first delivery.
-    base: Option<i64>,
+    base: Option<Offset>,
     /// Number of completed slots at the front of the window, kept current on
     /// every completion so `frontier` stays O(1).
     prefix: usize,
@@ -44,13 +44,10 @@ impl OffsetLedger {
     pub fn charge(&mut self, offsets: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
         let mut total = Charge::ZERO;
         for (offset, charge) in offsets {
-            let base = *self.base.get_or_insert(offset.0);
-            let end = base + self.slots.len() as i64;
-            assert!(
-                offset.0 >= end,
-                "offset {offset} was not delivered in order"
-            );
-            for _ in end..offset.0 {
+            let base = *self.base.get_or_insert(offset);
+            let end = base + self.slots.len();
+            assert!(offset >= end, "offset {offset} was not delivered in order");
+            for _ in 0..offset - end {
                 self.slots.push_back(Slot {
                     complete: true,
                     charge: Charge::ZERO,
@@ -68,8 +65,8 @@ impl OffsetLedger {
     /// Mark delivered offsets complete in any order.
     pub fn complete(&mut self, offsets: &[Offset]) {
         let base = self.base.expect("completion before any delivery");
-        for offset in offsets {
-            let index = usize::try_from(offset.0 - base).expect("completion below the window base");
+        for &offset in offsets {
+            let index = usize::try_from(offset - base).expect("completion below the window base");
             let slot = self
                 .slots
                 .get_mut(index)
@@ -91,7 +88,7 @@ impl OffsetLedger {
     /// because a gap holds no messages.
     pub fn frontier(&self) -> Option<Offset> {
         let base = self.base?;
-        (self.prefix > 0).then(|| Offset(base + self.prefix as i64 - 1))
+        (self.prefix > 0).then(|| base + (self.prefix - 1))
     }
 
     /// Consume the contiguous completed prefix previously observable through
@@ -104,7 +101,7 @@ impl OffsetLedger {
             .drain(..self.prefix)
             .map(|slot| slot.charge)
             .sum();
-        *self.base.as_mut().expect("frontier implies a base") += self.prefix as i64;
+        self.base = Some(offset + 1);
         self.prefix = 0;
         Some(TakenFrontier { offset, charge })
     }

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -5,9 +5,8 @@ use crate::types::Offset;
 
 #[derive(Debug)]
 struct Slot {
-    offset: Offset,
-    charge: Charge,
     complete: bool,
+    charge: Charge,
 }
 
 /// A consumed contiguous prefix and the charge it covers.
@@ -17,10 +16,17 @@ pub struct TakenFrontier {
     pub charge: Charge,
 }
 
-/// Per-partition delivered-offset ledger. Completion only marks slots; commit
-/// paths explicitly consume the contiguous prefix after observing it.
+/// Per-partition delivered-offset ledger, stored as a dense ring over one
+/// contiguous offset range so that completion is an index lookup instead of a
+/// scan. Completion only marks slots; commit paths explicitly consume the
+/// contiguous prefix after observing it.
 #[derive(Debug, Default)]
 pub struct OffsetLedger {
+    /// The offset of `slots[0]`; `None` until the first delivery.
+    base: Option<i64>,
+    /// Number of completed slots at the front of the ring, kept current on
+    /// every completion so `frontier` stays O(1).
+    prefix: usize,
     slots: VecDeque<Slot>,
 }
 
@@ -29,20 +35,28 @@ impl OffsetLedger {
         Self::default()
     }
 
-    /// Record offsets in delivery order and return their total charge.
+    /// Record offsets in delivery order and return their total charge. An
+    /// offset gap (transaction control records) gets pre-completed zero-charge
+    /// filler slots, so the ring stays dense and the frontier walks over the
+    /// gap.
     pub fn charge(&mut self, offsets: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
         let mut total = Charge::ZERO;
         for (offset, charge) in offsets {
-            if let Some(last) = self.slots.back() {
-                assert!(
-                    offset > last.offset,
-                    "offset {offset} was not delivered in order"
-                );
+            let base = *self.base.get_or_insert(offset.0);
+            let end = base + self.slots.len() as i64;
+            assert!(
+                offset.0 >= end,
+                "offset {offset} was not delivered in order"
+            );
+            for _ in end..offset.0 {
+                self.slots.push_back(Slot {
+                    complete: true,
+                    charge: Charge::ZERO,
+                });
             }
             self.slots.push_back(Slot {
-                offset,
-                charge,
                 complete: false,
+                charge,
             });
             total += charge;
         }
@@ -51,42 +65,54 @@ impl OffsetLedger {
 
     /// Mark delivered offsets complete in any order.
     pub fn complete(&mut self, offsets: &[Offset]) {
+        let base = self.base.expect("completion before any delivery");
         for offset in offsets {
+            let index = usize::try_from(offset.0 - base).expect("completion below the ring base");
             let slot = self
                 .slots
-                .iter_mut()
-                .find(|slot| slot.offset == *offset)
+                .get_mut(index)
                 .expect("completion for an uncharged offset");
             assert!(!slot.complete, "offset {offset} completed twice");
             slot.complete = true;
         }
+        while self
+            .slots
+            .get(self.prefix)
+            .is_some_and(|slot| slot.complete)
+        {
+            self.prefix += 1;
+        }
     }
 
-    /// Highest complete delivered offset before the first incomplete slot.
+    /// Highest contiguous completed offset. This can be a gap offset when
+    /// filler ends the completed prefix; a commit one past it is still correct
+    /// because a gap holds no messages.
     pub fn frontier(&self) -> Option<Offset> {
-        self.slots
-            .iter()
-            .take_while(|slot| slot.complete)
-            .last()
-            .map(|slot| slot.offset)
+        let base = self.base?;
+        (self.prefix > 0).then(|| Offset(base + self.prefix as i64 - 1))
     }
 
     /// Consume the contiguous completed prefix previously observable through
     /// `frontier`. This is intentionally separate from `complete` for shadow
     /// comparisons against the current commit path.
     pub fn take_frontier(&mut self) -> Option<TakenFrontier> {
-        let mut charge = Charge::ZERO;
-        let mut offset = None;
-        while self.slots.front().is_some_and(|slot| slot.complete) {
-            let slot = self.slots.pop_front().expect("front checked");
-            charge += slot.charge;
-            offset = Some(slot.offset);
-        }
-        offset.map(|offset| TakenFrontier { offset, charge })
+        let offset = self.frontier()?;
+        let charge = self
+            .slots
+            .drain(..self.prefix)
+            .map(|slot| slot.charge)
+            .sum();
+        *self.base.as_mut().expect("frontier implies a base") += self.prefix as i64;
+        self.prefix = 0;
+        Some(TakenFrontier { offset, charge })
     }
 
     pub fn len(&self) -> usize {
         self.slots.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
     }
 }
 
@@ -131,5 +157,29 @@ mod tests {
         ledger.charge([charge(0), charge(3)]);
         ledger.complete(&[Offset(0), Offset(3)]);
         assert_eq!(ledger.frontier(), Some(Offset(3)));
+    }
+
+    #[test]
+    fn gap_filler_carries_no_charge_and_the_frontier_walks_over_it() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0), charge(3)]);
+        ledger.complete(&[Offset(0)]);
+        assert_eq!(ledger.frontier(), Some(Offset(2)));
+        ledger.complete(&[Offset(3)]);
+        let taken = ledger.take_frontier().unwrap();
+        assert_eq!(taken.offset, Offset(3));
+        assert_eq!(taken.charge.events, 2);
+    }
+
+    #[test]
+    fn the_ring_continues_across_take_frontier() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0), charge(1)]);
+        ledger.complete(&[Offset(0), Offset(1)]);
+        ledger.take_frontier().unwrap();
+        ledger.charge([charge(2)]);
+        ledger.complete(&[Offset(2)]);
+        assert_eq!(ledger.frontier(), Some(Offset(2)));
+        assert_eq!(ledger.take_frontier().unwrap().charge.events, 1);
     }
 }

--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -1,0 +1,135 @@
+use std::collections::VecDeque;
+
+use crate::charge::Charge;
+use crate::types::Offset;
+
+#[derive(Debug)]
+struct Slot {
+    offset: Offset,
+    charge: Charge,
+    complete: bool,
+}
+
+/// A consumed contiguous prefix and the charge it covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TakenFrontier {
+    pub offset: Offset,
+    pub charge: Charge,
+}
+
+/// Per-partition delivered-offset ledger. Completion only marks slots; commit
+/// paths explicitly consume the contiguous prefix after observing it.
+#[derive(Debug, Default)]
+pub struct OffsetLedger {
+    slots: VecDeque<Slot>,
+}
+
+impl OffsetLedger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record offsets in delivery order and return their total charge.
+    pub fn charge(&mut self, offsets: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
+        let mut total = Charge::ZERO;
+        for (offset, charge) in offsets {
+            if let Some(last) = self.slots.back() {
+                assert!(
+                    offset > last.offset,
+                    "offset {offset} was not delivered in order"
+                );
+            }
+            self.slots.push_back(Slot {
+                offset,
+                charge,
+                complete: false,
+            });
+            total += charge;
+        }
+        total
+    }
+
+    /// Mark delivered offsets complete in any order.
+    pub fn complete(&mut self, offsets: &[Offset]) {
+        for offset in offsets {
+            let slot = self
+                .slots
+                .iter_mut()
+                .find(|slot| slot.offset == *offset)
+                .expect("completion for an uncharged offset");
+            assert!(!slot.complete, "offset {offset} completed twice");
+            slot.complete = true;
+        }
+    }
+
+    /// Highest complete delivered offset before the first incomplete slot.
+    pub fn frontier(&self) -> Option<Offset> {
+        self.slots
+            .iter()
+            .take_while(|slot| slot.complete)
+            .last()
+            .map(|slot| slot.offset)
+    }
+
+    /// Consume the contiguous completed prefix previously observable through
+    /// `frontier`. This is intentionally separate from `complete` for shadow
+    /// comparisons against the current commit path.
+    pub fn take_frontier(&mut self) -> Option<TakenFrontier> {
+        let mut charge = Charge::ZERO;
+        let mut offset = None;
+        while self.slots.front().is_some_and(|slot| slot.complete) {
+            let slot = self.slots.pop_front().expect("front checked");
+            charge += slot.charge;
+            offset = Some(slot.offset);
+        }
+        offset.map(|offset| TakenFrontier { offset, charge })
+    }
+
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn charge(offset: i64) -> (Offset, Charge) {
+        (
+            Offset(offset),
+            Charge {
+                events: 1,
+                bytes: 10,
+            },
+        )
+    }
+
+    #[test]
+    fn out_of_order_completion_does_not_move_the_frontier() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0), charge(1), charge(2)]);
+        ledger.complete(&[Offset(2)]);
+        assert_eq!(ledger.frontier(), None);
+        ledger.complete(&[Offset(0), Offset(1)]);
+        assert_eq!(ledger.frontier(), Some(Offset(2)));
+    }
+
+    #[test]
+    fn frontier_is_idempotent_and_take_drains_it() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0), charge(1)]);
+        ledger.complete(&[Offset(0), Offset(1)]);
+        assert_eq!(ledger.frontier(), Some(Offset(1)));
+        assert_eq!(ledger.frontier(), Some(Offset(1)));
+        assert_eq!(ledger.take_frontier().unwrap().charge.events, 2);
+        assert_eq!(ledger.len(), 0);
+    }
+
+    #[test]
+    fn delivery_gaps_do_not_block_delivered_offsets() {
+        let mut ledger = OffsetLedger::new();
+        ledger.charge([charge(0), charge(3)]);
+        ledger.complete(&[Offset(0), Offset(3)]);
+        assert_eq!(ledger.frontier(), Some(Offset(3)));
+    }
+}

--- a/rust/common/kafka-consumer/src/lib.rs
+++ b/rust/common/kafka-consumer/src/lib.rs
@@ -1,0 +1,7 @@
+//! Kafka consumption core for stateful services.
+//!
+//! The vocabulary follows `rust/ingestion-consumer/docs/driver-model.md` §8:
+//! the top-level component is the consumer loop, a driver is the single owner
+//! of one unit's state, and a group is one routing key's messages from one poll.
+
+pub mod config;

--- a/rust/common/kafka-consumer/src/lib.rs
+++ b/rust/common/kafka-consumer/src/lib.rs
@@ -4,4 +4,7 @@
 //! the top-level component is the consumer loop, a driver is the single owner
 //! of one unit's state, and a group is one routing key's messages from one poll.
 
+pub mod charge;
 pub mod config;
+pub mod ledger;
+pub mod types;

--- a/rust/common/kafka-consumer/src/lib.rs
+++ b/rust/common/kafka-consumer/src/lib.rs
@@ -8,3 +8,8 @@ pub mod charge;
 pub mod config;
 pub mod ledger;
 pub mod types;
+
+pub use charge::Charge;
+pub use config::ConsumerConfigBuilder;
+pub use ledger::{OffsetLedger, TakenFrontier};
+pub use types::Offset;

--- a/rust/common/kafka-consumer/src/lib.rs
+++ b/rust/common/kafka-consumer/src/lib.rs
@@ -1,8 +1,4 @@
-//! Kafka consumption core for stateful services.
-//!
-//! The vocabulary follows `rust/ingestion-consumer/docs/driver-model.md` §8:
-//! the top-level component is the consumer loop, a driver is the single owner
-//! of one unit's state, and a group is one routing key's messages from one poll.
+//! Kafka consumption primitives shared by stateful services.
 
 pub mod charge;
 pub mod config;

--- a/rust/common/kafka-consumer/src/types.rs
+++ b/rust/common/kafka-consumer/src/types.rs
@@ -1,8 +1,25 @@
 use std::fmt;
+use std::ops::{Add, Sub};
 
 /// A Kafka message offset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Offset(pub i64);
+
+impl Sub for Offset {
+    type Output = i64;
+
+    fn sub(self, rhs: Offset) -> i64 {
+        self.0 - rhs.0
+    }
+}
+
+impl Add<usize> for Offset {
+    type Output = Offset;
+
+    fn add(self, rhs: usize) -> Offset {
+        Offset(self.0 + rhs as i64)
+    }
+}
 
 impl fmt::Display for Offset {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/rust/common/kafka-consumer/src/types.rs
+++ b/rust/common/kafka-consumer/src/types.rs
@@ -1,0 +1,11 @@
+use std::fmt;
+
+/// A Kafka message offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Offset(pub i64);
+
+impl fmt::Display for Offset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/rust/ingestion-consumer/Cargo.toml
+++ b/rust/ingestion-consumer/Cargo.toml
@@ -9,6 +9,7 @@ axum = { workspace = true }
 chrono = { workspace = true }
 common-alloc = { path = "../common/alloc" }
 common-continuous-profiling = { path = "../common/continuous_profiling" }
+common-kafka-consumer = { path = "../common/kafka-consumer" }
 dashmap = { workspace = true }
 envconfig = { workspace = true }
 futures = { workspace = true }

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -4,8 +4,8 @@ use rdkafka::ClientConfig;
 use tracing::info;
 
 use crate::discovery::DiscoveryMode;
-use crate::kafka_config::ConsumerConfigBuilder;
 use crate::routing::RoutingStrategy;
+use common_kafka_consumer::config::ConsumerConfigBuilder;
 
 /// Configuration for the ingestion consumer.
 ///

--- a/rust/ingestion-consumer/src/lib.rs
+++ b/rust/ingestion-consumer/src/lib.rs
@@ -5,7 +5,6 @@ pub mod debug_recorder;
 pub mod discovery;
 pub mod dispatcher;
 pub mod grpc_transport;
-pub mod kafka_config;
 pub mod kafka_stats;
 pub mod order_sentinel;
 pub mod readiness;


### PR DESCRIPTION
## Problem

- The driver-model plan (#91468) rebuilds the ingestion consumer's commit path around an offset ledger. No crate exists yet to hold consumer code shared beyond one service.
- This is cycle 2 of that plan. The crate and the ledger land unused, so the next PR can shadow-compare the frontier against the current commit calculation.

## Changes

- Adds the `common-kafka-consumer` crate with `Offset`, `Charge` (a message's events and bytes cost), and `OffsetLedger`. Nothing user-visible changes; there are no runtime callers yet.
- `OffsetLedger` stores one contiguous offset range as a dense sliding window, so completing an offset is an index lookup, not a scan of pending slots.
- `complete` only marks, `frontier` observes without consuming, and `take_frontier` consumes. The split lets the shadow PR read the frontier before anything advances.
- A ledger lives for one partition assignment; duplicate deliveries and foreign completions panic, and the docs state the create-on-assign, drop-on-revoke rule.
- Offset gaps (transaction control records) become pre-completed zero-charge filler slots, so the frontier walks over them.
- Mechanical: moves the consumer's Kafka config builder into the crate unchanged and pins its defaults with a fixture test.

## How did you test this code?

- Unit tests in the crate: out-of-order completion holds the frontier, the window slides across `take_frontier` including a partial take, gap filler carries no charge, every documented panic is pinned with `should_panic`, and the config defaults stay pinned.
- Not checked: behavior under a runtime caller, because none exists until the next PR in the stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The crate README lists the modules.
