### PR TITLE
docs(capture): refocus the outputs plan on per-output configuration

### DIFF
--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -2,13 +2,13 @@
 
 Working contract for implementation agents. Steps 1–8 have shipped; each remaining step is one commit in its own PR.
 
-**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. `F6` closes the first objective (the manual fallback); the second — capture prepared for an automated fallback — is then sequenced by promoting the steps under **Objective 2** below into a scheduled stage, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving neither objective leaves as issues.
+**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Step 26 closes the first objective (the manual fallback); the second — capture prepared for an automated fallback — is then sequenced by promoting the steps under **Objective 2** below into a scheduled stage, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving neither objective leaves as issues.
 
 ## Motivation
 
 **Two objectives, one mechanism: an output owns the configuration it produces with.**
 
-**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (F2, F3) are only buildable once configuration is isolated per output (F1): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify. F1–F6 are this objective; F4 is the feature.
+**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 22 and 23) are only buildable once configuration is isolated per output (Step 21): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify. Steps 21–26 are this objective; Step 24 is the feature.
 
 **Objective 2 — prepare capture for an automated fallback.** The switch decision moves to a separate circuit-breaker service; how that service decides is not this plan's concern. Capture's side of the contract is narrow: submit producer health metrics, receive switch signals, and apply a signal at runtime through the failover output it already has — no redeploy. Consumers are out of scope throughout; this plan is capture prep. The steps live under **Objective 2** below, unsequenced until objective 1 closes.
 
@@ -77,8 +77,8 @@ This is the function Step 5 hoists out of the sink into lane resolution.
 
 #### Step 3 · `TopicTable` + startup completeness check
 
-One destination→topic wiring point plus refuse-to-boot on a blank topic, gated behind `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` (default off; see Step 9's arming precondition).
-Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in at Step 9, where `(Pipeline, Lane)` makes the per-mode reachable set explicit.
+One destination→topic wiring point plus refuse-to-boot on a blank topic, gated behind `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` (default off; see Step 22's arming precondition).
+Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in at Step 22, where `(Pipeline, Lane)` makes the per-mode reachable set explicit.
 
 ### Stage B — the two new seams (no caller-visible change)
 
@@ -140,16 +140,16 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 
 The remaining committed work, and it is a mechanism, not a feature: an output owns the configuration it produces with. Once that holds, an emergency fallback to another cluster is *a configuration of an output's targets* rather than a code path — which is what the target architecture said all along.
 
-Each step is small, ships green, and reverts by plain revert. F1–F3 are the mechanism, F4 is the fallback itself, F5 removes what it replaces, and F6 collapses the second stack onto the same model.
+Each step is small, ships green, and reverts by plain revert. Steps 21–23 are the mechanism, Step 24 is the fallback itself, Step 25 removes what it replaces, and Step 26 collapses the second stack onto the same model.
 
-#### Step F1 · An output owns its connection and its topics
+#### Step 21 · An output owns its connection and its topics
 
 - **Goal.** Every leaf output is built from an output-scoped config block — brokers, TLS, and that output's own topic names — instead of reading the one deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can name different clusters and different topics, because neither consults global state to find out where it produces.
-- **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is already exactly this: per-sink, namespaced by sink name (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own connection, its own producer tuning, and its own topics — declared *"Topics (all required — envconfig errors if any are missing)"*, with no defaults. v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted topics. F1 moves v0 onto v1's shape, reusing the struct rather than paralleling it. A v0-specific config model here would leave three to reconcile at Step 20 instead of one.
+- **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is already exactly this: per-sink, namespaced by sink name (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own connection, its own producer tuning, and its own topics — declared *"Topics (all required — envconfig errors if any are missing)"*, with no defaults. v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted topics. Step 21 moves v0 onto v1's shape, reusing the struct rather than paralleling it. A v0-specific config model here would leave three to reconcile at Step 20 instead of one.
 - **Why this is the whole mechanism.** `Output::failover` already composes two arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup` builds it that way. Once a leaf carries its own config, a second cluster with its own topic names is a `setup` change and a values file, with no new trait and no per-feature plumbing.
 - **Size.** M.
 
-#### Step F2 · A reachable output must be configured
+#### Step 22 · A reachable output must be configured
 
 - **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic.
 - **Defaults go.** The `#[envconfig(default = ...)]` on each topic field is what makes a missing or misspelled variable resolve to a compiled-in name instead of failing. A reachable output's topics stop being defaulted; an absent or empty value is a boot failure, which is the behaviour the check was always meant to have.
@@ -157,69 +157,69 @@ Each step is small, ships green, and reverts by plain revert. F1–F3 are the me
 - **Parity proof.** Per-mode refusal tests, and anti-over-demand tests proving a mode is never asked for an output it cannot reach.
 - **Size.** M.
 
-#### Step F3 · Verify an output's topics against its own broker
+#### Step 23 · Verify an output's topics against its own broker
 
 - **Goal.** At boot, probe each reachable output's cluster metadata for the topics that output can produce to, and refuse to start on a missing one. Per output, against that output's own broker — so a fallback pointed at a half-provisioned cluster fails before it can take traffic.
-- **Why it is separate from F2.** F2 is config-only and never touches a broker: it answers "is this wired", instantly, with no connect attempt. F3 answers "does this exist on the cluster we are about to produce to", which is the question that matters when the cluster is one this deployment has never written to.
+- **Why it is separate from Step 22.** Step 22 is config-only and never touches a broker: it answers "is this wired", instantly, with no connect attempt. Step 23 answers "does this exist on the cluster we are about to produce to", which is the question that matters when the cluster is one this deployment has never written to.
 - **Default off**, armed per deployment: on brokers with topic auto-creation the metadata probe can create the topic it is checking, which makes a pass meaningless.
 - **Size.** M.
 
-#### Step F4 · The capture-analytics emergency fallback
+#### Step 24 · The capture-analytics emergency fallback
 
-The consumer of F1–F3, and the reason they exist.
+The consumer of Steps 21–23, and the reason they exist.
 
-- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback, each configured independently under its own F1 namespace (own brokers, own TLS, own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to).
+- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback, each configured independently under its own Step-21 namespace (own brokers, own TLS, own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to).
 - **Arming.** One environment variable, matched exactly against a sentinel — not a truthy value. `"1"`, `"true"`, `"yes"` must not move a fleet's traffic, and any value other than the sentinel refuses to boot rather than quietly running on the primary. Unset is normal operation.
 - **The switch is static at boot.** Exactly one target publishes; arming means setting the variable and rolling the pods. This is deliberate: the failure it answers is "MSK is degraded and a human has decided to move", not a transient the process should react to on its own. Automatic switching is objective 2, and builds on this step's tree.
-- **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so F3 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
+- **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so Step 23 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
 - **Report which target is live** on a gauge, emitted in both states so a dashboard can tell "on the primary" from "pod not reporting".
-- **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (F2).
+- **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (Step 22).
 - **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. These belong in the runbook, not the code.
 - **Size.** M.
 
-#### Step F5 · Retire the S3 fallback
+#### Step 25 · Retire the S3 fallback
 
 - **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*` config, and the Kafka→S3 failover wiring in `setup`.
 - **Why it is safe.** It is off in every production deployment: six `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`, and that one is `apps/capture-analytics/values.dev.yaml`. The infra config notes the IAM role is "wired but unused". Retiring it removes dead break-glass machinery, not a live safety net.
-- **Why F4 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
-- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. F4 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 2: the breaker service's signals drive F4's fallback through the G1 seam; the policy node already composes two outputs.
+- **Why Step 24 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
+- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. Step 24 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 2: the breaker service's signals drive Step 24's fallback through the Step-27 seam; the policy node already composes two outputs.
 - **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive` alert spec and its runbook, and the IAM role in cloud-infra all go with it.
 - **Size.** M.
 
-#### Step F6 · v1 converges on the shared strata
+#### Step 26 · v1 converges on the shared strata
 
 - **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays gated on the per-event response model, as before.
-- **Why it moves up.** After F1 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after F1, and gets more expensive the longer v0 carries a second config model.
+- **Why it moves up.** After Step 21 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after Step 21, and gets more expensive the longer v0 carries a second config model.
 - **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
 - **Size.** M/L.
 
-#### What F2 and F3 would already have caught
+#### What Steps 22 and 23 would already have caught
 
 `KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while `(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow` is a reachable route with a passing test. Replay overflow therefore resolves to the compiled-in `session_recording_snapshot_item_overflow`, while prod-us replay wires `ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`.
 
-F2 fails that at boot: a reachable output with no configured topic. F3 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
+Step 22 fails that at boot: a reachable output with no configured topic. Step 23 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
 
 ## Objective 2 — automated fallback (unsequenced)
 
 Capture's half of an automated fallback, and nothing more. The decision-maker is a separate circuit-breaker service; its internals — how it aggregates, when it trips, whether and how it probes — are outside this plan, and so are consumers. Capture's contract with the service is two channels: producer health metrics out, switch signals in. These steps are promoted into a scheduled stage, with parity proofs, when objective 1 closes; until then they are shapes, not commitments.
 
-### Step G1 · Failover target selection behind a control-plane seam
+### Step 27 · Failover target selection behind a control-plane seam
 
-The failover output's target selection becomes runtime-swappable state — swappable, no request-path locks, the pattern the repartitioning note reuses — with F4's static arming as the boot value. Applying a signal switches which target publishes; no signal, or a silent, dead, or unreachable control plane, holds the current selection, because the absence of a decision must never move traffic. The F4 live-target gauge reports whichever selection is in force. Dark: with no service endpoint configured, behavior is byte-identical to F4's static switch.
+The failover output's target selection becomes runtime-swappable state — swappable, no request-path locks, the pattern the repartitioning note reuses — with Step 24's static arming as the boot value. Applying a signal switches which target publishes; no signal, or a silent, dead, or unreachable control plane, holds the current selection, because the absence of a decision must never move traffic. The Step-24 live-target gauge reports whichever selection is in force. Dark: with no service endpoint configured, behavior is byte-identical to Step 24's static switch.
 
-### Step G2 · Producer health metrics out
+### Step 28 · Producer health metrics out
 
 Each Kafka output reports its own produce-path health — delivery latency, error rates, queue depth — keyed by output, so the service sees the path each deployment actually experiences, dormant fallback included. Transport and cadence are sequencing-time decisions; the standing requirements are per-output attribution and that reporting failure never degrades the produce path.
 
-### Step G3 · Switch signals in
+### Step 29 · Switch signals in
 
-Capture receives switch signals from the service and feeds them to the G1 seam, acknowledging what it applied. The F4 arming variable stays authoritative as the manual override — a human's static decision outranks the service in both directions; exact precedence is settled at sequencing time.
+Capture receives switch signals from the service and feeds them to the Step-27 seam, acknowledging what it applied. The Step-24 arming variable stays authoritative as the manual override — a human's static decision outranks the service in both directions; exact precedence is settled at sequencing time.
 
-Step 10 (the in-process `FailoverMode::Breaker`) dissolved into this contract: trip/probe/recover logic is the service's concern, not capture's. What survives of it is the control-plane seam and the control-plane-down posture, both carried by G1.
+Step 10 (the in-process `FailoverMode::Breaker`) dissolved into this contract: trip/probe/recover logic is the service's concern, not capture's. What survives of it is the control-plane seam and the control-plane-down posture, both carried by Step 27.
 
 ## Deferred work
 
-Not scheduled, and serving neither objective directly. Revive a step by moving it back into a stage above, with its parity proof intact. Steps 9–11 are gone from here: Step 9 was promoted into **F2**, Step 11 became **F6** because F1 makes convergence cheap and delay makes it dearer, and Step 10 dissolved into **Objective 2** above.
+Not scheduled, and serving neither objective directly. Revive a step by moving it back into a stage above, with its parity proof intact. Steps 9–11 are gone from here: Step 9 was promoted into **Step 22**, Step 11 became **Step 26** because Step 21 makes convergence cheap and delay makes it dearer, and Step 10 dissolved into **Objective 2** above.
 
 ### Stage E — prep hoists up; sinks become pure transport
 
@@ -281,7 +281,7 @@ Not built in this PR; this note records where it plugs in so nothing landed here
 
 **Logical shards, decided before the sinks.** The coordinator owns a stable shard function: `shard = hash(key) % N` over the same partition key the sink would hash, with coordinator-owned `N` (not either cluster's partition count). The shard is stamped at prep time — `AddressedPayload` grows `shard: Option<u32>`, `None` meaning "let the producer partition as today". Stamping at prep keeps the decision above the sinks: both clusters of a failover pair see the same shard on the same payload, so a switchover decision is consistent across targets by construction.
 
-**A `ShardRouted` output policy.** Routing lives in the outputs layer as a policy node holding two child outputs (old cluster, new cluster) and a swappable assignment table `shard → Old | New` (an `ArcSwap`, updated by the coordinator's control plane the same way the G1 control-plane seam works). Batch publish splits by assignment and forwards — scatter-gather like the old `Split` composite, no serialization changes (both clusters share the prep/serialization contract, as the retired AI-secondary split proved).
+**A `ShardRouted` output policy.** Routing lives in the outputs layer as a policy node holding two child outputs (old cluster, new cluster) and a swappable assignment table `shard → Old | New` (an `ArcSwap`, updated by the coordinator's control plane the same way the Step-27 control-plane seam works). Batch publish splits by assignment and forwards — scatter-gather like the old `Split` composite, no serialization changes (both clusters share the prep/serialization contract, as the retired AI-secondary split proved).
 
 **Explicit partition pass-through in the sink.** `ProduceRecord` grows `partition: Option<i32>`; the Kafka sink maps `shard` to a concrete partition of its own topic (its table realizes the namespace; a shard→ partition map is the same kind of sink-side data as topic names) and sets it on the record. `None` keeps today's key hashing. The sink still makes no routing decisions — it realizes an address (topic) and a shard (partition) in its own namespace.
 
@@ -301,7 +301,7 @@ The hold window is per-shard and bounded by one producer flush — that is the "
 
 - `AddressedPayload` — carries key + address; grows `shard`.
 - Outputs policy tree — `ShardRouted` slots in beside single/failover/split.
-- The G1 control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
+- The Step-27 control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
 - `ProduceRecord` — grows `partition`; sinks realize shard → partition.
 - Per-pipeline rows + topic tables (Step 18) — a coordinator can retarget one pipeline's row without touching the rest of the deployment.
 
@@ -313,7 +313,7 @@ When all steps land, the five strata hold:
 - **Outputs are the produce surface.** Every pipeline publishes through the `OutputRegistry`; the `Output` policy tree (single | failover) owns all multi-target behavior, composing the way the old sink composites did. The v0 `Event` trait and `FallbackSink` are gone; `SplitKafkaSink` already is, deleted with the retired AI secondary-cluster routing.
 - **Serialization is a seam.** Format × envelope per destination, with content headers carrying encoding coexistence (the lz4 replay design, generalized); a protobuf cutover is an output-level config change.
 - **Sinks are mechanism, and own their namespace.** Payloads carry the abstract `Address`; each sink realizes it in its own namespace at publish time (Kafka: its per-cluster topic table — the swappable seam a repartitioning coordinator plugs into; S3: the buffer path; print/noop: trivially). Sinks make no routing decisions; a failover pair can share one prepared batch because payloads are target-agnostic. Serialization stays output-level (a consumer contract, shared across targets).
-- **The failover switch is signal-drivable.** The failover output's target selection sits behind the G1 control-plane seam; a separate circuit-breaker service supplies the switch signals, capture supplies producer health, and a silent control plane holds the current target.
+- **The failover switch is signal-drivable.** The failover output's target selection sits behind the Step-27 control-plane seam; a separate circuit-breaker service supplies the switch signals, capture supplies producer health, and a silent control plane holds the current target.
 - **v1 resolves topics through the shared `TopicTable`** via `Destination::as_output`. The v1 `Sink`/`Router` trait convergence stays gated on the per-event response model.
 
 ## Agent conventions
@@ -342,15 +342,15 @@ When all steps land, the five strata hold:
 | 7 · Outputs layer with policies; composites retired | done | `feat(capture): outputs layer owns the failover policy` |
 | 8a · Call sites on the table | done | `refactor(capture): call sites publish through outputs` |
 | 8b · `Event` retired | done | `refactor(capture): retire v0 Event trait` |
-| F1 · An output owns its connection and topics | pending | `refactor(capture): outputs carry their own connection and topic config` |
-| F2 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
-| F3 · Verify topics against the broker | pending | `feat(capture): verify each output's topics against its own broker at boot` |
-| F4 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
-| F5 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
-| F6 · v1 convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
-| G1 · Failover selection behind a control-plane seam | objective 2 | `feat(capture): failover target selection behind a control-plane seam` |
-| G2 · Producer health metrics out | objective 2 | `feat(capture): outputs report producer health for the breaker service` |
-| G3 · Switch signals in | objective 2 | `feat(capture): apply breaker switch signals to the failover output` |
+| 21 · An output owns its connection and topics | pending | `refactor(capture): outputs carry their own connection and topic config` |
+| 22 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
+| 23 · Verify topics against the broker | pending | `feat(capture): verify each output's topics against its own broker at boot` |
+| 24 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
+| 25 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
+| 26 · v1 convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
+| 27 · Failover selection behind a control-plane seam | objective 2 | `feat(capture): failover target selection behind a control-plane seam` |
+| 28 · Producer health metrics out | objective 2 | `feat(capture): outputs report producer health for the breaker service` |
+| 29 · Switch signals in | objective 2 | `feat(capture): apply breaker switch signals to the failover output` |
 | 12 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
 | 13 · Typed addresses; AI pipeline | deferred | `refactor(capture): typed per-pipeline lanes; custom redirects and the ai stream become addresses` |
 | 14 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -2,17 +2,19 @@
 
 Working contract for implementation agents. Steps 1–8 have shipped; each remaining step is one commit in its own PR.
 
-**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Step 26 closes the first objective (the manual fallback); the second — capture prepared for an automated fallback — is then sequenced by promoting the steps under **Objective 2** below into a scheduled stage, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving neither objective leaves as issues.
+**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Stage D closes the first objective (the manual fallback); the second (one produce surface) and third (automated fallback) are then sequenced in order by promoting their steps into scheduled stages, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving no objective leaves as issues.
 
 ## Motivation
 
-**Two objectives, one mechanism: an output owns the configuration it produces with.**
+**Three objectives, one mechanism: an output owns the configuration it produces with.**
 
-**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 22 and 23) are only buildable once configuration is isolated per output (Step 21): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify. Steps 21–26 are this objective; Step 24 is the feature.
+**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 22 and 23) are only buildable once configuration is isolated per output (Step 21) and demanded per mode (Step 15a): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Stage D is this objective; Step 24 is the feature.
 
-**Objective 2 — prepare capture for an automated fallback.** The switch decision moves to a separate circuit-breaker service; how that service decides is not this plan's concern. Capture's side of the contract is narrow: submit producer health metrics, receive switch signals, and apply a signal at runtime through the failover output it already has — no redeploy. Consumers are out of scope throughout; this plan is capture prep. The steps live under **Objective 2** below, unsequenced until objective 1 closes.
+**Objective 2 — one produce surface.** The v1 stack is live in production — capture-analytics runs its AI endpoint through it, capture-import runs on it wholesale — and it publishes through its own sinks, so a fallback wired into the outputs layer moves none of its traffic. Convergence is therefore coverage, not hygiene. Stage D already puts both stacks on one config model (Step 26); this objective finishes the job — one publish surface, per-event results, the legacy v1 sink stack deleted (Steps 19d, 20a–c).
 
-The mechanism both objectives ride is the same: make an output carry its own connection and topic configuration, require that configuration for every output a deployment can reach, and verify those topics against that output's own broker at boot. A fallback — manual or signal-driven — is then *a configuration of an output's targets*: no new policy, no new trait, no per-feature code path. `Output::failover` already composes two arbitrary outputs (Step 7); what it lacks is targets configurable independently of each other, and, for objective 2, a target selection that can change while the process runs.
+**Objective 3 — prepare capture for an automated fallback.** The switch decision moves to a separate circuit-breaker service; how that service decides is not this plan's concern. Capture's side of the contract is narrow: submit producer health metrics, receive switch signals, and apply a signal at runtime through the failover output it already has — no redeploy. Consumers are out of scope throughout; this plan is capture prep. Sequenced last: an automatic switch that moves only half the produce paths would be worse than the manual one, so objective 2 comes first.
+
+The mechanism all three objectives ride is the same: make an output carry its own connection and topic configuration, require that configuration for every output a deployment can reach, and verify those topics against that output's own broker at boot. A fallback — manual or signal-driven — is then *a configuration of an output's targets*: no new policy, no new trait, no per-feature code path. `Output::failover` already composes two arbitrary outputs (Step 7); what it lacks is targets configurable independently of each other, and, for objective 3, a target selection that can change while the process runs.
 
 Safety is why this plan is mostly refactoring. Moving production traffic between clusters tolerates no ambient state and no half-understood code path, so every step is one small commit, parity-proven by the Step-1 goldens, revertible by plain revert — and the steps that read as pure structure are what make the boot checks and the runtime switch possible at all.
 
@@ -58,7 +60,7 @@ Steps 1–3 land together with this doc: the routing golden oracle, the pure `ro
 - Wire parity is proven by the Step-1 goldens and existing endpoint/integration tests passing **unmodified**, except where a step explicitly says otherwise.
 - Never mix a mechanical move with a behavior change in one commit.
 - Every step ships green (`cargo test -p capture`, clippy `-D warnings`, fmt) and rolls back by plain revert.
-- The per-event response model (v1 `BatchResponse`) stays out of scope; call sites keep folding per-event results into today's whole-request `CaptureError`.
+- The per-event response model (v1 `BatchResponse`) stays out of scope until objective 2 (Step 19d); call sites keep folding per-event results into today's whole-request `CaptureError`.
 - Sinks read no `ProcessedEventMetadata`. After Step 6 the only consumer of routing metadata is lane resolution.
 
 ## The stages and steps
@@ -140,7 +142,7 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 
 The remaining committed work, and it is a mechanism, not a feature: an output owns the configuration it produces with. Once that holds, an emergency fallback to another cluster is *a configuration of an output's targets* rather than a code path — which is what the target architecture said all along.
 
-Each step is small, ships green, and reverts by plain revert. Steps 21–23 are the mechanism, Step 24 is the fallback itself, Step 25 removes what it replaces, and Step 26 collapses the second stack onto the same model.
+Each step is small, ships green, and reverts by plain revert. Steps 21 and 26 put every output — v1's included — on one config model; Steps 13a and 15a make the reachable set a type; Steps 22 and 23 are the checks that type makes possible; Step 24 is the fallback itself; Step 25 removes what it replaces.
 
 #### Step 21 · An output owns its connection and its topics
 
@@ -149,9 +151,32 @@ Each step is small, ships green, and reverts by plain revert. Steps 21–23 are 
 - **Why this is the whole mechanism.** `Output::failover` already composes two arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup` builds it that way. Once a leaf carries its own config, a second cluster with its own topic names is a `setup` change and a values file, with no new trait and no per-feature plumbing.
 - **Size.** M.
 
+#### Step 26 · v1 converges on the shared config strata
+
+- **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays with objective 2 (Steps 19d, 20a–c).
+- **Why it sits here.** After Step 21 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after Step 21 and gets dearer with every step built over a model v1 has not joined — so it lands before the registry types and boot checks, which then demand and probe v1's topics too.
+- **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
+- **Size.** M/L.
+
+#### Step 13a · Typed per-pipeline lanes
+
+- **Goal.** Lanes become types per pipeline — `AnalyticsLane`, `AiLane`, `SessionReplayLane`, `BasicLane` — so invalid `(pipeline, lane)` pairs are unrepresentable, and admin custom redirects become addresses carrying their own topic outside the lane model: the vocabulary rules above, made code. `resolve` constructs addresses; pipeline and lane kind become projections.
+- **Why it sits here.** Step 15a's registry rows demand topics per lane. With the flat `Lane`, the set of valid lanes per pipeline is runtime knowledge, and the registry keeps a fatal backstop for pairs routing never produces. Typed lanes make the demand total: the fields a row requires are exactly the addresses that exist.
+- **Scope.** The address model only. The AI membership rework (allowlist stamp, `AiRouting` retirement) stays deferred as Step 13b.
+- **Parity proof.** Step-1 goldens unmodified; `resolve` precedence tests retyped with assertions preserved.
+- **Size.** M/L.
+
+#### Step 15a · Per-mode output registries
+
+- **Goal.** The deployment's output registry becomes a concrete type per capture mode — `AnalyticsFamilyOutputs` (analytics, ai, heatmaps, warnings, error tracking rows) for Events/Ai/Import pods, `SessionReplayOutputs` for Recordings pods — with required fields, so the narrow list of what a deployment must wire is the type itself. Rows share backends (one Kafka connection per distinct cluster), so per-row policy trees behave as the single pre-table output did.
+- **Why it sits here.** Step 22's demand is per mode. Without registry types that demand is a hand-written `CaptureMode` → reachable-set map — the unarmable completeness flag reborn as glue the types would later delete. With them, the reachable set *is* the type, and Step 22 reduces to deleting defaults.
+- **Scope.** The registry types and their construction in `setup`. Binding handlers to sealed publish-capability traits over a generic `State<T>` stays deferred as Step 15b.
+- **Parity proof.** Step-1 goldens and integration suites unmodified; per-mode construction tests.
+- **Size.** L.
+
 #### Step 22 · A reachable output must be configured
 
-- **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic.
+- **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic, because its Step-15a registry type has no such row.
 - **Defaults go.** The `#[envconfig(default = ...)]` on each topic field is what makes a missing or misspelled variable resolve to a compiled-in name instead of failing. A reachable output's topics stop being defaulted; an absent or empty value is a boot failure, which is the behaviour the check was always meant to have.
 - **Supersedes** the deployment-wide `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` flag, which demands all ten destinations on every pod and so can be armed nowhere.
 - **Parity proof.** Per-mode refusal tests, and anti-over-demand tests proving a mode is never asked for an output it cannot reach.
@@ -170,11 +195,11 @@ The consumer of Steps 21–23, and the reason they exist.
 
 - **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback, each configured independently under its own Step-21 namespace (own brokers, own TLS, own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to).
 - **Arming.** One environment variable, matched exactly against a sentinel — not a truthy value. `"1"`, `"true"`, `"yes"` must not move a fleet's traffic, and any value other than the sentinel refuses to boot rather than quietly running on the primary. Unset is normal operation.
-- **The switch is static at boot.** Exactly one target publishes; arming means setting the variable and rolling the pods. This is deliberate: the failure it answers is "MSK is degraded and a human has decided to move", not a transient the process should react to on its own. Automatic switching is objective 2, and builds on this step's tree.
+- **The switch is static at boot.** Exactly one target publishes; arming means setting the variable and rolling the pods. This is deliberate: the failure it answers is "MSK is degraded and a human has decided to move", not a transient the process should react to on its own. Automatic switching is objective 3, and builds on this step's tree.
 - **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so Step 23 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
 - **Report which target is live** on a gauge, emitted in both states so a dashboard can tell "on the primary" from "pod not reporting".
 - **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (Step 22).
-- **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. These belong in the runbook, not the code.
+- **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. And until Step 20b, an armed fallback moves only traffic that publishes through the outputs layer — the v1 slice stays on the primary. These belong in the runbook, not the code.
 - **Size.** M.
 
 #### Step 25 · Retire the S3 fallback
@@ -182,16 +207,9 @@ The consumer of Steps 21–23, and the reason they exist.
 - **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*` config, and the Kafka→S3 failover wiring in `setup`.
 - **Why it is safe.** It is off in every production deployment: six `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`, and that one is `apps/capture-analytics/values.dev.yaml`. The infra config notes the IAM role is "wired but unused". Retiring it removes dead break-glass machinery, not a live safety net.
 - **Why Step 24 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
-- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. Step 24 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 2: the breaker service's signals drive Step 24's fallback through the Step-27 seam; the policy node already composes two outputs.
+- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. Step 24 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 3: the breaker service's signals drive Step 24's fallback through the Step-27 seam; the policy node already composes two outputs.
 - **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive` alert spec and its runbook, and the IAM role in cloud-infra all go with it.
 - **Size.** M.
-
-#### Step 26 · v1 converges on the shared strata
-
-- **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays gated on the per-event response model, as before.
-- **Why it moves up.** After Step 21 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after Step 21, and gets more expensive the longer v0 carries a second config model.
-- **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
-- **Size.** M/L.
 
 #### What Steps 22 and 23 would already have caught
 
@@ -199,9 +217,38 @@ The consumer of Steps 21–23, and the reason they exist.
 
 Step 22 fails that at boot: a reachable output with no configured topic. Step 23 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
 
-## Objective 2 — automated fallback (unsequenced)
+## Objective 2 — one produce surface (unsequenced)
 
-Capture's half of an automated fallback, and nothing more. The decision-maker is a separate circuit-breaker service; its internals — how it aggregates, when it trips, whether and how it probes — are outside this plan, and so are consumers. Capture's contract with the service is two channels: producer health metrics out, switch signals in. These steps are promoted into a scheduled stage, with parity proofs, when objective 1 closes; until then they are shapes, not commitments.
+v1 publishes through the shared outputs machinery and the legacy v1 sink stack is deleted, so every policy — the manual fallback, and later the signal-driven switch — applies to all capture traffic uniformly. Stage D's Step 26 does the config-level convergence; these steps finish it, sequenced when objective 1 closes.
+
+### Step 19d · Per-event publish results
+
+`Outputs::publish` reports per-event `SinkResult`s, with a provided fold collapsing to the v0 whole-request response for the call sites that keep it. This is the response-model gate that kept full convergence deferred: v1's `BatchResponse` needs per-event granularity, and after this step nothing is missing it.
+
+### v1 convergence on the outputs machinery (Steps 20a–c)
+
+Goal: v1 endpoints publish through the outputs layer like every other ingress, so fallback/split/dynamic policies apply uniformly. Plan:
+
+1. **Boundary mapping (20a).** After v1 processing (destination decided, result stamped), map each publishable `WrappedEvent` into `ProcessedEvent`: the existing v1 serialize path already produces CapturedEvent-compatible payloads, so the mapping builds the `CapturedEvent` plus a `ProcessedEventMetadata` that makes `pipeline::resolve` reproduce the decided destination (AnalyticsMain → main; Overflow → force_overflow; Historical → historical data type; Dlq → redirect_to_dlq; Custom → redirect_to_topic). `Destination::Drop` events never reach the outputs layer — dropping is a processing decision, recorded in the response.
+2. **Named surfaces (20b).** `CAPTURE_V1_SINKS` names become named output rows, each built from that sink's config; the v1 `Router`/`Sink`/`Event` traits and `serialize_batch` dissolve.
+3. **Response granularity (20b).** `Outputs::publish` already returns per-event `SinkResult`s (Step 19d); `merge_sink_results` consumes them unchanged.
+4. **Parity oracle (20a, 20c).** The v1 pipeline tests and the real-Kafka `v1_sink_integration` suite must pass against the converged path — payload bytes, headers, topics, keys. Documented v1-vs-v0 header deltas (overflow/person-processing decoupling) must be preserved in the mapping, not silently erased. The legacy serializer/header builder survive only as a frozen `cfg(test)` oracle (`legacy_serialize`/`legacy_headers`) the parity suite compares against.
+
+**Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
+
+- The header follows the stamped person-processing intent: the flag, which a `ForceLimited` reason implies on its own (`person_processing_disabled`), so a v0 stamping site cannot keep person processing on for a force-limited key by forgetting the flag.
+  v1 carries no reason on the event — its one stamping site sets the flag directly.
+- The key is dropped on the analytics main/overflow lanes when the person-processing flag is set, and on the AI overflow lane when either the flag or a spread decision is set — nowhere else.
+  The analytics consumers update persons keyed on distinct id, so a person-on burst keeps its key there (spreading one distinct id across partitions contends those updates); the read-only AI overflow consumer takes keyless person-on records safely.
+  Historical, dlq, custom redirects and the AI main topic keep the key regardless.
+
+`overflow_parity.rs` is the oracle: it drives both pipelines over the overflow and rate-limit matrix and pins lane, key presence, and header. Extend it with the mapped v1 destinations rather than reasoning about the two paths separately.
+
+**Accepted deltas:** `sent_at` fractional-second formatting (parse-equal; v1 adopts v0's serializer) and the v1 sink-stage metrics (`capture_v1_serialize_*`, per-sink publish metrics), superseded by the outputs-layer metrics.
+
+## Objective 3 — automated fallback (unsequenced)
+
+Capture's half of an automated fallback, and nothing more. The decision-maker is a separate circuit-breaker service; its internals — how it aggregates, when it trips, whether and how it probes — are outside this plan, and so are consumers. Capture's contract with the service is two channels: producer health metrics out, switch signals in. These steps are promoted into a scheduled stage, with parity proofs, when the objectives before them close; until then they are shapes, not commitments.
 
 ### Step 27 · Failover target selection behind a control-plane seam
 
@@ -219,7 +266,7 @@ Step 10 (the in-process `FailoverMode::Breaker`) dissolved into this contract: t
 
 ## Deferred work
 
-Not scheduled, and serving neither objective directly. Revive a step by moving it back into a stage above, with its parity proof intact. Steps 9–11 are gone from here: Step 9 was promoted into **Step 22**, Step 11 became **Step 26** because Step 21 makes convergence cheap and delay makes it dearer, and Step 10 dissolved into **Objective 2** above.
+Not scheduled, and serving no objective directly. Revive a step by moving it back into a stage above, with its parity proof intact. Steps 9–11 are gone from here: Step 9 was promoted into **Step 22**, Step 11 became **Step 26** because Step 21 makes convergence cheap and delay makes it dearer, and Step 10 dissolved into **Objective 3** above. Step 18 is superseded rather than deferred — its boot verification became Step 23, and retargeting a row is plain configuration once outputs own their config (Steps 21, 15a).
 
 ### Stage E — prep hoists up; sinks become pure transport
 
@@ -231,45 +278,23 @@ Not scheduled, and serving neither objective directly. Revive a step by moving i
 - **Files.** `outputs/mod.rs`, `outputs/registry.rs` (moved), `sinks/*`, `setup.rs`, all capturing test mocks.
 - **Size.** L.
 
-### Per-mode output registries (Step 15)
+### Handlers bound by publish capabilities (Step 15b)
 
-The deployment's output registry is a concrete type — `AnalyticsFamilyOutputs` (analytics, ai, heatmaps, warnings, error tracking rows) for Events/Ai pods, `SessionReplayOutputs` for Recordings pods — with required fields, so the narrow list of what a deployment must wire is the type itself. Handlers bound on sealed capability traits (`PublishesAnalyticsFamily`, `PublishesSessionReplay`); `State<T>` is generic over the registry and `setup` instantiates the monomorphized router per `CaptureMode` (`router` for the analytics family, `session_replay_router` for recordings) — mounting an ingress on a table that cannot publish its family is a compile error. Rows share backends (one Kafka connection, one S3 client, one breaker controller), so per-row policy trees behave as the single pre-table output did. The runtime backstop for a pipeline without a row is an explicit fatal error, structurally dead while ingress mounting and registry type derive from the same mode.
+The half of the per-mode registries Step 15a leaves behind: handlers bind on sealed capability traits (`PublishesAnalyticsFamily`, `PublishesSessionReplay`); `State<T>` goes generic over the Step-15a registry and `setup` instantiates the monomorphized router per `CaptureMode` (`router` for the analytics family, `session_replay_router` for recordings) — mounting an ingress on a table that cannot publish its family is a compile error, and the registry's runtime fatal backstop for a pipeline without a row goes structurally dead.
 
-### Per-pipeline output overrides and boot verification (Step 18)
+### Per-pipeline output overrides and boot verification (Step 18 — superseded)
 
 Each row of a deployment's table can be retargeted independently: `CAPTURE_OUTPUT_<PIPELINE>_BROKERS` points a pipeline's row at another cluster, `CAPTURE_OUTPUT_<PIPELINE>_TOPIC_<LANE>` renames a lane's topic in that row's namespace (existing `KAFKA_*` keys stay the defaults). The row factory builds one sink per pipeline, each with its own `TopicTable` (base config overlaid with that pipeline's overrides via `TopicTable::with_overrides`); producers are shared per distinct broker set, so the no-override configuration still opens exactly one connection. The gating liveness handle lands on the cluster carrying the deployment's ingress pipeline; other clusters' producers are non-gating. Overrides compose only with the plain per-row Kafka path — combining them with S3 fallback or AI secondary routing is refused at boot, since those policy trees assume every row shares one primary cluster.
 
 `CAPTURE_VERIFY_TOPICS_ON_BOOT` (default off) probes cluster metadata for every topic a row can produce to — pipeline-scoped (`TopicTable::topics_for_pipeline`), so an overridden row probes only its own cluster's namespace — and refuses to start on a missing topic. Off by default because brokers with topic auto-creation make the check misleading (the metadata probe itself can create the topic).
 
-### Outputs as an open trait (Step 19)
+### Outputs as an open trait (Steps 19a–c)
 
-`Outputs` is an open trait — a produce surface handling every destination its configuration maps — replacing the closed policy enum. Implementations own payload assembly, namespace realization, backend composition, and policy: `KafkaOutputs` (one cluster: prep + address→topic table + transport sink), `S3Outputs`, `PrintOutputs`/`NoopOutputs`, `FailoverOutputs` and `SplitOutputs` (policies over `Arc<dyn Outputs>`), and the per-mode tables themselves (dispatch-by-pipeline is just another surface; capability traits are markers over `Outputs`). Sinks are pure transport and never see an `Address`: the Kafka sink publishes realized records (concrete topic, key, payload, headers); namespace realization lives in the outputs layer. `publish` reports per-event `SinkResult`s (a provided `publish_folded` collapses to the v0 whole-request response) — the granularity v1's `BatchResponse` requires.
+`Outputs` is an open trait — a produce surface handling every destination its configuration maps — replacing the closed policy enum. Implementations own payload assembly, namespace realization, backend composition, and policy: `KafkaOutputs` (one cluster: prep + address→topic table + transport sink), `S3Outputs`, `PrintOutputs`/`NoopOutputs`, `FailoverOutputs` and `SplitOutputs` (policies over `Arc<dyn Outputs>`), and the per-mode tables themselves (dispatch-by-pipeline is just another surface; capability traits are markers over `Outputs`). Sinks are pure transport and never see an `Address`: the Kafka sink publishes realized records (concrete topic, key, payload, headers); namespace realization lives in the outputs layer. Per-event publish results are Step 19d, promoted into **Objective 2**.
 
 A test-only prototype (`outputs::dynamic`) demonstrates the coordinator-managed surface: `DynamicKafkaOutputs` subscribes to an in-process `KafkaManagerService` (RPC-shaped, acked config pushes) and applies broker add/remove and mapping changes with an enabled-partition set per address — the incremental, key-deterministic drain-and-switch — with tests simulating a topic switchover and a broker switchover end to end.
 
-### v1 convergence on the outputs machinery (Step 20)
-
-Goal: v1 endpoints publish through `dyn Outputs` like every other ingress, so fallback/split/dynamic policies apply uniformly. Plan:
-
-1. **Boundary mapping.** After v1 processing (destination decided, result stamped), map each publishable `WrappedEvent` into `ProcessedEvent`: the existing v1 serialize path already produces CapturedEvent-compatible payloads, so the mapping builds the `CapturedEvent` plus a `ProcessedEventMetadata` that makes `pipeline::resolve` reproduce the decided destination (AnalyticsMain → main; Overflow → force_overflow; Historical → historical data type; Dlq → redirect_to_dlq; Custom → redirect_to_topic). `Destination::Drop` events never reach the outputs layer — dropping is a processing decision, recorded in the response.
-2. **Named surfaces.** `CAPTURE_V1_SINKS` names become named `Arc<dyn Outputs>` rows (each a `KafkaOutputs` built from that sink's config); the v1 `Router`/`Sink`/`Event` traits and `serialize_batch` dissolve.
-3. **Response granularity.** `Outputs::publish` already returns per-event `SinkResult`s; `merge_sink_results` consumes them unchanged.
-4. **Parity oracle.** The v1 pipeline tests and the real-Kafka `v1_sink_integration` suite must pass against the converged path — payload bytes, headers, topics, keys. Documented v1-vs-v0 header deltas (overflow/person-processing decoupling) must be preserved in the mapping, not silently erased. The legacy serializer/header builder survive only as a frozen `cfg(test)` oracle (`legacy_serialize`/`legacy_headers`) the parity suite compares against.
-5. **Plan retirement.** Superseded: see **Retirement** in the header — the doc retires when both objectives are served, not with this step.
-
-**Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
-
-- The header follows the stamped person-processing intent: the flag, which a `ForceLimited` reason implies on its own (`person_processing_disabled`), so a v0 stamping site cannot keep person processing on for a force-limited key by forgetting the flag.
-  v1 carries no reason on the event — its one stamping site sets the flag directly.
-- The key is dropped on the analytics main/overflow lanes when the person-processing flag is set, and on the AI overflow lane when either the flag or a spread decision is set — nowhere else.
-  The analytics consumers update persons keyed on distinct id, so a person-on burst keeps its key there (spreading one distinct id across partitions contends those updates); the read-only AI overflow consumer takes keyless person-on records safely.
-  Historical, dlq, custom redirects and the AI main topic keep the key regardless.
-
-`overflow_parity.rs` is the oracle: it drives both pipelines over the overflow and rate-limit matrix and pins lane, key presence, and header. Extend it with the mapped v1 destinations rather than reasoning about the two paths separately.
-
-**Accepted deltas:** `sent_at` fractional-second formatting (parse-equal; v1 adopts v0's serializer) and the v1 sink-stage metrics (`capture_v1_serialize_*`, per-sink publish metrics), superseded by the outputs-layer metrics.
-
-### AI pipeline and Import mode
+### AI pipeline and Import mode (Step 13b)
 
 - **AI pipeline membership is a name allowlist, resolved once into a stamp.** `AI_EVENT_NAMES` lists the event names on the lane; `DataType::from_event_name` resolves a name against it and stamps `DataType::AiEvents`, on every capture mode, mirroring v1's `Destination::AiEvents`. Everything downstream reads the stamp — `Pipeline::from_metadata` maps it, and the multipart and OTEL AI ingress stamp the same lane at the handler. The allowlist is deliberately not an `$ai_` prefix match: the Node AI pipeline DLQs anything it receives off its own `AI_EVENT_TYPES` list, so a prefixed-but-unlisted name like `$ai_call` must stay on the analytics lane. (The quota predicate `is_llm_event` is separate and *is* prefix-based.) There is no per-batch routing config and no per-deployment divert switch — the rollout-era `AiRouting` mode/allowlist/percentage machinery is retired, and so is the capture-mode predicate that replaced it. A deployment that wants AI traffic on a given topic points `CAPTURE_ANALYTICS_AI_EVENTS_TOPIC` at it.
 - **The AI lanes own dedicated topics.** `TopicTable` grows an `ai_events` row (`CAPTURE_ANALYTICS_AI_EVENTS_TOPIC`, required with default `events_plugin_ingestion_ai`) and an optional `ai_events_overflow` row (`..._OVERFLOW_TOPIC`); there is no `AiLane::Historical` — the divert decision wins over historical, matching v1. The AI overflow valve (overflow topic set) rides `PrepSpec` into `resolve`, so an unarmed deployment never routes the AI lane to overflow, force_overflow included.
@@ -303,7 +328,7 @@ The hold window is per-shard and bounded by one producer flush — that is the "
 - Outputs policy tree — `ShardRouted` slots in beside single/failover/split.
 - The Step-27 control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
 - `ProduceRecord` — grows `partition`; sinks realize shard → partition.
-- Per-pipeline rows + topic tables (Step 18) — a coordinator can retarget one pipeline's row without touching the rest of the deployment.
+- Per-mode registry rows over per-output config (Steps 15a, 21) — a coordinator can retarget one pipeline's row without touching the rest of the deployment.
 
 ## End state
 
@@ -314,7 +339,7 @@ When all steps land, the five strata hold:
 - **Serialization is a seam.** Format × envelope per destination, with content headers carrying encoding coexistence (the lz4 replay design, generalized); a protobuf cutover is an output-level config change.
 - **Sinks are mechanism, and own their namespace.** Payloads carry the abstract `Address`; each sink realizes it in its own namespace at publish time (Kafka: its per-cluster topic table — the swappable seam a repartitioning coordinator plugs into; S3: the buffer path; print/noop: trivially). Sinks make no routing decisions; a failover pair can share one prepared batch because payloads are target-agnostic. Serialization stays output-level (a consumer contract, shared across targets).
 - **The failover switch is signal-drivable.** The failover output's target selection sits behind the Step-27 control-plane seam; a separate circuit-breaker service supplies the switch signals, capture supplies producer health, and a silent control plane holds the current target.
-- **v1 resolves topics through the shared `TopicTable`** via `Destination::as_output`. The v1 `Sink`/`Router` trait convergence stays gated on the per-event response model.
+- **One produce surface.** v1 publishes through the shared outputs machinery (Steps 20a–c); the legacy v1 sink stack, its `Router`/`Sink` traits, and `serialize_batch` are gone.
 
 ## Agent conventions
 
@@ -343,25 +368,27 @@ When all steps land, the five strata hold:
 | 8a · Call sites on the table | done | `refactor(capture): call sites publish through outputs` |
 | 8b · `Event` retired | done | `refactor(capture): retire v0 Event trait` |
 | 21 · An output owns its connection and topics | pending | `refactor(capture): outputs carry their own connection and topic config` |
+| 26 · v1 config convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
+| 13a · Typed per-pipeline lanes | pending | `refactor(capture): typed per-pipeline lanes; custom redirects become addresses` |
+| 15a · Per-mode output registries | pending | `feat(capture): per-mode output registries with required rows` |
 | 22 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
 | 23 · Verify topics against the broker | pending | `feat(capture): verify each output's topics against its own broker at boot` |
 | 24 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
 | 25 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
-| 26 · v1 convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
-| 27 · Failover selection behind a control-plane seam | objective 2 | `feat(capture): failover target selection behind a control-plane seam` |
-| 28 · Producer health metrics out | objective 2 | `feat(capture): outputs report producer health for the breaker service` |
-| 29 · Switch signals in | objective 2 | `feat(capture): apply breaker switch signals to the failover output` |
+| 19d · Per-event publish results | objective 2 | `refactor(capture): Outputs::publish reports per-event results` |
+| 20a · v1 boundary mapping + parity oracle | objective 2 | `feat(capture): v1 boundary mapping onto the shared produce interchange` |
+| 20b · v1 publishes through shared outputs | objective 2 | `feat(capture): v1 endpoints publish through the shared outputs machinery` |
+| 20c · Legacy v1 sink stack deleted | objective 2 | `refactor(capture): delete the legacy v1 sink stack` |
+| 27 · Failover selection behind a control-plane seam | objective 3 | `feat(capture): failover target selection behind a control-plane seam` |
+| 28 · Producer health metrics out | objective 3 | `feat(capture): outputs report producer health for the breaker service` |
+| 29 · Switch signals in | objective 3 | `feat(capture): apply breaker switch signals to the failover output` |
 | 12 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
-| 13 · Typed addresses; AI pipeline | deferred | `refactor(capture): typed per-pipeline lanes; custom redirects and the ai stream become addresses` |
+| 13b · AI membership stamp; `AiRouting` retired | deferred | `refactor(capture): ai lane membership resolves once into a stamp` |
 | 14 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |
-| 15 · Per-mode output registries | deferred | `feat(capture): per-mode output registries; handlers bound by publish capabilities` |
+| 15b · Handlers bound by publish capabilities | deferred | `feat(capture): handlers bound by publish capabilities over per-mode state` |
 | 16 · AI ingress family | deferred | `feat(capture): ai ingress is its own router family with its own capability` |
 | 17 · Topic tables injected into sinks | deferred | `refactor(capture): topic tables are sink-side data, injected at construction` |
-| 18 · Per-pipeline output overrides; boot topic verification | deferred | `feat(capture): per-pipeline output overrides and boot topic verification` |
+| 18 · Per-pipeline output overrides; boot topic verification | superseded | — (boot verification became Step 23; retargeting is configuration after Steps 21, 15a) |
 | 19a · Naming and import hygiene | deferred | `refactor(capture): replace remaining nested paths with imports` + `refactor(capture): name the session replay pipeline consistently` |
 | 19b · Outputs as an open trait; sinks pure transport | deferred | `refactor(capture): outputs own namespace realization; Outputs becomes an open trait` |
 | 19c · Dynamic outputs prototype | deferred | `feat(capture): prototype dynamic outputs with incremental switchover (test-only)` |
-| 19d · Per-event publish results | deferred | `refactor(capture): Outputs::publish reports per-event results` |
-| 20a · v1 boundary mapping + parity oracle | deferred | `feat(capture): v1 boundary mapping onto the shared produce interchange` |
-| 20b · v1 publishes through shared outputs | deferred | `feat(capture): v1 endpoints publish through the shared outputs machinery` |
-| 20c · Legacy v1 sink stack deleted; this plan retired | deferred | `refactor(capture): delete the legacy v1 sink stack` |

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -2,19 +2,21 @@
 
 Working contract for implementation agents. Steps 1–8 have shipped; each remaining step is one commit in its own PR.
 
-**Retirement.** This doc dies with `F6`. Whatever is still load-bearing then — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and the deferred work moves to issues. A plan must not outlive the work it schedules, and after F3 it schedules nothing.
+**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. `F6` closes the first objective (the manual fallback); the second — capture prepared for an automated fallback — is then sequenced by promoting the steps under **Objective 2** below into a scheduled stage, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving neither objective leaves as issues.
 
 ## Motivation
 
-**One driver: an output owns the configuration it produces with.**
+**Two objectives, one mechanism: an output owns the configuration it produces with.**
 
-If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this plan exists to remove.
+**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (F2, F3) are only buildable once configuration is isolated per output (F1): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify. F1–F6 are this objective; F4 is the feature.
 
-The mechanism that buys this is narrow: make an output carry its own connection and topic configuration, require that configuration for every output a deployment can reach, and verify those topics against that output's own broker at boot. A fallback to a second cluster is then *a configuration of an output's targets* — no new policy, no new trait, no per-feature code path. That is what the target architecture below already describes; this plan just stops deferring it behind eleven structural steps.
+**Objective 2 — prepare capture for an automated fallback.** The switch decision moves to a separate circuit-breaker service; how that service decides is not this plan's concern. Capture's side of the contract is narrow: submit producer health metrics, receive switch signals, and apply a signal at runtime through the failover output it already has — no redeploy. Consumers are out of scope throughout; this plan is capture prep. The steps live under **Objective 2** below, unsequenced until objective 1 closes.
 
-`Output::failover` already composes two arbitrary outputs (Step 7). What it lacks is targets that can be configured independently of each other.
+The mechanism both objectives ride is the same: make an output carry its own connection and topic configuration, require that configuration for every output a deployment can reach, and verify those topics against that output's own broker at boot. A fallback — manual or signal-driven — is then *a configuration of an output's targets*: no new policy, no new trait, no per-feature code path. `Output::failover` already composes two arbitrary outputs (Step 7); what it lacks is targets configurable independently of each other, and, for objective 2, a target selection that can change while the process runs.
 
-Steps 1–8 landed the rest of the structure: routing is a pure function, the lane decision is pipeline-layer code, sinks are backend mechanism over prepared payloads, and the outputs layer owns multi-target policy behind one produce surface. The drivers this plan originally sequenced — breaker-driven failover, cluster migration by split/dual-write, and a protobuf cutover behind the serialization seam — are real but not urgent, and are recorded under **Deferred work** rather than scheduled. Each becomes cheaper once outputs are independently configurable, not more expensive.
+Safety is why this plan is mostly refactoring. Moving production traffic between clusters tolerates no ambient state and no half-understood code path, so every step is one small commit, parity-proven by the Step-1 goldens, revertible by plain revert — and the steps that read as pure structure are what make the boot checks and the runtime switch possible at all.
+
+Steps 1–8 landed the structure: routing is a pure function, the lane decision is pipeline-layer code, sinks are backend mechanism over prepared payloads, and the outputs layer owns multi-target policy behind one produce surface. Cluster migration by split/dual-write and a protobuf cutover behind the serialization seam stay recorded under **Deferred work**: real, unscheduled, and cheaper once outputs are independently configurable, not more expensive.
 
 ## Target architecture
 
@@ -52,7 +54,7 @@ Steps 1–3 land together with this doc: the routing golden oracle, the pure `ro
 
 ### Invariants
 
-- Metric names and labels stay stable: `capture_events_rerouted_*`, `capture_primary_sink_health`, `capture_fallback_sink_failovers_total`, `capture_failover_breaker_*`, `capture_event_batch_size`. Renames are out of scope for every step.
+- Metric names and labels stay stable: `capture_events_rerouted_*`, `capture_primary_sink_health`, `capture_fallback_sink_failovers_total`, `capture_event_batch_size`. Renames are out of scope for every step.
 - Wire parity is proven by the Step-1 goldens and existing endpoint/integration tests passing **unmodified**, except where a step explicitly says otherwise.
 - Never mix a mechanical move with a behavior change in one commit.
 - Every step ships green (`cargo test -p capture`, clippy `-D warnings`, fmt) and rolls back by plain revert.
@@ -168,7 +170,7 @@ The consumer of F1–F3, and the reason they exist.
 
 - **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback, each configured independently under its own F1 namespace (own brokers, own TLS, own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to).
 - **Arming.** One environment variable, matched exactly against a sentinel — not a truthy value. `"1"`, `"true"`, `"yes"` must not move a fleet's traffic, and any value other than the sentinel refuses to boot rather than quietly running on the primary. Unset is normal operation.
-- **The switch is static at boot.** Exactly one target publishes; arming means setting the variable and rolling the pods. This is deliberate: the failure it answers is "MSK is degraded and a human has decided to move", not a transient the process should react to on its own. Automatic switching is Step 10's breaker, and stays deferred.
+- **The switch is static at boot.** Exactly one target publishes; arming means setting the variable and rolling the pods. This is deliberate: the failure it answers is "MSK is degraded and a human has decided to move", not a transient the process should react to on its own. Automatic switching is objective 2, and builds on this step's tree.
 - **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so F3 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
 - **Report which target is live** on a gauge, emitted in both states so a dashboard can tell "on the primary" from "pod not reporting".
 - **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (F2).
@@ -180,7 +182,7 @@ The consumer of F1–F3, and the reason they exist.
 - **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*` config, and the Kafka→S3 failover wiring in `setup`.
 - **Why it is safe.** It is off in every production deployment: six `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`, and that one is `apps/capture-analytics/values.dev.yaml`. The infra config notes the IAM role is "wired but unused". Retiring it removes dead break-glass machinery, not a live safety net.
 - **Why F4 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
-- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. F4 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. If an automatic switch is wanted, revive Step 10 (breaker mode) and drive F4's fallback from it; the policy node already composes two outputs.
+- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. F4 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 2: the breaker service's signals drive F4's fallback through the G1 seam; the policy node already composes two outputs.
 - **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive` alert spec and its runbook, and the IAM role in cloud-infra all go with it.
 - **Size.** M.
 
@@ -197,19 +199,27 @@ The consumer of F1–F3, and the reason they exist.
 
 F2 fails that at boot: a reachable output with no configured topic. F3 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
 
+## Objective 2 — automated fallback (unsequenced)
+
+Capture's half of an automated fallback, and nothing more. The decision-maker is a separate circuit-breaker service; its internals — how it aggregates, when it trips, whether and how it probes — are outside this plan, and so are consumers. Capture's contract with the service is two channels: producer health metrics out, switch signals in. These steps are promoted into a scheduled stage, with parity proofs, when objective 1 closes; until then they are shapes, not commitments.
+
+### Step G1 · Failover target selection behind a control-plane seam
+
+The failover output's target selection becomes runtime-swappable state — swappable, no request-path locks, the pattern the repartitioning note reuses — with F4's static arming as the boot value. Applying a signal switches which target publishes; no signal, or a silent, dead, or unreachable control plane, holds the current selection, because the absence of a decision must never move traffic. The F4 live-target gauge reports whichever selection is in force. Dark: with no service endpoint configured, behavior is byte-identical to F4's static switch.
+
+### Step G2 · Producer health metrics out
+
+Each Kafka output reports its own produce-path health — delivery latency, error rates, queue depth — keyed by output, so the service sees the path each deployment actually experiences, dormant fallback included. Transport and cadence are sequencing-time decisions; the standing requirements are per-output attribution and that reporting failure never degrades the produce path.
+
+### Step G3 · Switch signals in
+
+Capture receives switch signals from the service and feeds them to the G1 seam, acknowledging what it applied. The F4 arming variable stays authoritative as the manual override — a human's static decision outranks the service in both directions; exact precedence is settled at sequencing time.
+
+Step 10 (the in-process `FailoverMode::Breaker`) dissolved into this contract: trip/probe/recover logic is the service's concern, not capture's. What survives of it is the control-plane seam and the control-plane-down posture, both carried by G1.
+
 ## Deferred work
 
-Not scheduled. The structure to build on landed in steps 1–8; these are the drivers that no longer justify sequencing ahead of the fallback. Revive a step by moving it back into a stage above, with its parity proof intact.
-
-### Stage D (deferred) — dark failover
-
-Steps 9 and 11 are not here. Step 9 was promoted into **F2**, which the fallback needs; Step 11 became **F6**, because F1 makes convergence cheap and delay makes it dearer. Step 10 stays deferred, and is what F5 points at if the automatic failover it retires is ever wanted back.
-
-#### Step 10 · Breaker failover mode (dark)
-
-- **Goal.** `FailoverMode::Breaker` — a pure clock-injected `Breaker` state machine, half-open single-probe permit, and a `StaticControlPlane` seam, as the second failover mode, dark behind `failover_enabled` (default off; off ⇒ Advisory mode byte-identical).
-- **Parity proof.** 13+ deterministic breaker unit tests; four output-level behavior tests (healthy-primary, open→fallback→recover cycle, control-plane-down, fatal-no-failover). The effective-route gauge harness and a Notify-gated probe-concurrency harness graduate with the feature when it leaves dark mode.
-- **Size.** M.
+Not scheduled, and serving neither objective directly. Revive a step by moving it back into a stage above, with its parity proof intact. Steps 9–11 are gone from here: Step 9 was promoted into **F2**, Step 11 became **F6** because F1 makes convergence cheap and delay makes it dearer, and Step 10 dissolved into **Objective 2** above.
 
 ### Stage E — prep hoists up; sinks become pure transport
 
@@ -245,8 +255,7 @@ Goal: v1 endpoints publish through `dyn Outputs` like every other ingress, so fa
 2. **Named surfaces.** `CAPTURE_V1_SINKS` names become named `Arc<dyn Outputs>` rows (each a `KafkaOutputs` built from that sink's config); the v1 `Router`/`Sink`/`Event` traits and `serialize_batch` dissolve.
 3. **Response granularity.** `Outputs::publish` already returns per-event `SinkResult`s; `merge_sink_results` consumes them unchanged.
 4. **Parity oracle.** The v1 pipeline tests and the real-Kafka `v1_sink_integration` suite must pass against the converged path — payload bytes, headers, topics, keys. Documented v1-vs-v0 header deltas (overflow/person-processing decoupling) must be preserved in the mapping, not silently erased. The legacy serializer/header builder survive only as a frozen `cfg(test)` oracle (`legacy_serialize`/`legacy_headers`) the parity suite compares against.
-5. **Plan retirement.** Superseded: the doc now retires with `F3`, see the header.
-   Anything still load-bearing then (the repartitioning design note, the ordering-vs-person-processing contract) graduates into module docs or `v1/sinks/DESIGN.md` first.
+5. **Plan retirement.** Superseded: see **Retirement** in the header — the doc retires when both objectives are served, not with this step.
 
 **Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
 
@@ -272,7 +281,7 @@ Not built in this PR; this note records where it plugs in so nothing landed here
 
 **Logical shards, decided before the sinks.** The coordinator owns a stable shard function: `shard = hash(key) % N` over the same partition key the sink would hash, with coordinator-owned `N` (not either cluster's partition count). The shard is stamped at prep time — `AddressedPayload` grows `shard: Option<u32>`, `None` meaning "let the producer partition as today". Stamping at prep keeps the decision above the sinks: both clusters of a failover pair see the same shard on the same payload, so a switchover decision is consistent across targets by construction.
 
-**A `ShardRouted` output policy.** Routing lives in the outputs layer as a policy node holding two child outputs (old cluster, new cluster) and a swappable assignment table `shard → Old | New` (an `ArcSwap`, updated by the coordinator's control plane the same way the failover breaker's control plane seam works). Batch publish splits by assignment and forwards — scatter-gather like the old `Split` composite, no serialization changes (both clusters share the prep/serialization contract, as the retired AI-secondary split proved).
+**A `ShardRouted` output policy.** Routing lives in the outputs layer as a policy node holding two child outputs (old cluster, new cluster) and a swappable assignment table `shard → Old | New` (an `ArcSwap`, updated by the coordinator's control plane the same way the G1 control-plane seam works). Batch publish splits by assignment and forwards — scatter-gather like the old `Split` composite, no serialization changes (both clusters share the prep/serialization contract, as the retired AI-secondary split proved).
 
 **Explicit partition pass-through in the sink.** `ProduceRecord` grows `partition: Option<i32>`; the Kafka sink maps `shard` to a concrete partition of its own topic (its table realizes the namespace; a shard→ partition map is the same kind of sink-side data as topic names) and sets it on the record. `None` keeps today's key hashing. The sink still makes no routing decisions — it realizes an address (topic) and a shard (partition) in its own namespace.
 
@@ -292,7 +301,7 @@ The hold window is per-shard and bounded by one producer flush — that is the "
 
 - `AddressedPayload` — carries key + address; grows `shard`.
 - Outputs policy tree — `ShardRouted` slots in beside single/failover/split.
-- Breaker control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
+- The G1 control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
 - `ProduceRecord` — grows `partition`; sinks realize shard → partition.
 - Per-pipeline rows + topic tables (Step 18) — a coordinator can retarget one pipeline's row without touching the rest of the deployment.
 
@@ -304,7 +313,7 @@ When all steps land, the five strata hold:
 - **Outputs are the produce surface.** Every pipeline publishes through the `OutputRegistry`; the `Output` policy tree (single | failover) owns all multi-target behavior, composing the way the old sink composites did. The v0 `Event` trait and `FallbackSink` are gone; `SplitKafkaSink` already is, deleted with the retired AI secondary-cluster routing.
 - **Serialization is a seam.** Format × envelope per destination, with content headers carrying encoding coexistence (the lz4 replay design, generalized); a protobuf cutover is an output-level config change.
 - **Sinks are mechanism, and own their namespace.** Payloads carry the abstract `Address`; each sink realizes it in its own namespace at publish time (Kafka: its per-cluster topic table — the swappable seam a repartitioning coordinator plugs into; S3: the buffer path; print/noop: trivially). Sinks make no routing decisions; a failover pair can share one prepared batch because payloads are target-agnostic. Serialization stays output-level (a consumer contract, shared across targets).
-- **Breaker failover is dark-launched** behind `CAPTURE_FAILOVER_ENABLED` as the failover output's autonomous mode.
+- **The failover switch is signal-drivable.** The failover output's target selection sits behind the G1 control-plane seam; a separate circuit-breaker service supplies the switch signals, capture supplies producer health, and a silent control plane holds the current target.
 - **v1 resolves topics through the shared `TopicTable`** via `Destination::as_output`. The v1 `Sink`/`Router` trait convergence stays gated on the per-event response model.
 
 ## Agent conventions
@@ -339,7 +348,9 @@ When all steps land, the five strata hold:
 | F4 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
 | F5 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
 | F6 · v1 convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
-| 10 · Breaker mode (dark) | deferred | `feat(capture): breaker-driven failover mode (dark)` |
+| G1 · Failover selection behind a control-plane seam | objective 2 | `feat(capture): failover target selection behind a control-plane seam` |
+| G2 · Producer health metrics out | objective 2 | `feat(capture): outputs report producer health for the breaker service` |
+| G3 · Switch signals in | objective 2 | `feat(capture): apply breaker switch signals to the failover output` |
 | 12 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
 | 13 · Typed addresses; AI pipeline | deferred | `refactor(capture): typed per-pipeline lanes; custom redirects and the ai stream become addresses` |
 | 14 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -1,42 +1,20 @@
 # Capture outputs refactor — implementation plan
 
-Working contract for implementation agents. Steps 1–8 have shipped; each
-remaining step is one commit in its own PR.
+Working contract for implementation agents. Steps 1–8 have shipped; each remaining step is one commit in its own PR.
 
-**Retirement.** This doc dies with `F6`. Whatever is still load-bearing then —
-the vocabulary rules, the ordering-vs-person-processing contract, the
-repartitioning design note — graduates into module docs or
-`v1/sinks/DESIGN.md` first, and the deferred work moves to issues. A plan must
-not outlive the work it schedules, and after F3 it schedules nothing.
+**Retirement.** This doc dies with `F6`. Whatever is still load-bearing then — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and the deferred work moves to issues. A plan must not outlive the work it schedules, and after F3 it schedules nothing.
 
 ## Motivation
 
 **One driver: an output owns the configuration it produces with.**
 
-If MSK degrades, capture-analytics must be able to produce to an alternative
-cluster — its brokers, its TLS, its own topic names — and we must know the
-configuration is sound before any traffic moves. Running capture against a
-half-wired cluster is the risk this plan exists to remove.
+If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this plan exists to remove.
 
-The mechanism that buys this is narrow: make an output carry its own connection
-and topic configuration, require that configuration for every output a
-deployment can reach, and verify those topics against that output's own broker
-at boot. A fallback to a second cluster is then *a configuration of an output's
-targets* — no new policy, no new trait, no per-feature code path. That is what
-the target architecture below already describes; this plan just stops deferring
-it behind eleven structural steps.
+The mechanism that buys this is narrow: make an output carry its own connection and topic configuration, require that configuration for every output a deployment can reach, and verify those topics against that output's own broker at boot. A fallback to a second cluster is then *a configuration of an output's targets* — no new policy, no new trait, no per-feature code path. That is what the target architecture below already describes; this plan just stops deferring it behind eleven structural steps.
 
-`Output::failover` already composes two arbitrary outputs (Step 7). What it
-lacks is targets that can be configured independently of each other.
+`Output::failover` already composes two arbitrary outputs (Step 7). What it lacks is targets that can be configured independently of each other.
 
-Steps 1–8 landed the rest of the structure: routing is a pure function, the lane
-decision is pipeline-layer code, sinks are backend mechanism over prepared
-payloads, and the outputs layer owns multi-target policy behind one produce
-surface. The drivers this plan originally sequenced — breaker-driven failover,
-cluster migration by split/dual-write, and a protobuf cutover behind the
-serialization seam — are real but not urgent, and are recorded under **Deferred
-work** rather than scheduled. Each becomes cheaper once outputs are
-independently configurable, not more expensive.
+Steps 1–8 landed the rest of the structure: routing is a pure function, the lane decision is pipeline-layer code, sinks are backend mechanism over prepared payloads, and the outputs layer owns multi-target policy behind one produce surface. The drivers this plan originally sequenced — breaker-driven failover, cluster migration by split/dual-write, and a protobuf cutover behind the serialization seam — are real but not urgent, and are recorded under **Deferred work** rather than scheduled. Each becomes cheaper once outputs are independently configurable, not more expensive.
 
 ## Target architecture
 
@@ -158,125 +136,52 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 
 ### Stage D — outputs carry their own configuration
 
-The remaining committed work, and it is a mechanism, not a feature: an output
-owns the configuration it produces with. Once that holds, an emergency fallback
-to another cluster is *a configuration of an output's targets* rather than a
-code path — which is what the target architecture said all along.
+The remaining committed work, and it is a mechanism, not a feature: an output owns the configuration it produces with. Once that holds, an emergency fallback to another cluster is *a configuration of an output's targets* rather than a code path — which is what the target architecture said all along.
 
-Each step is small, ships green, and reverts by plain revert. F1–F3 are the
-mechanism, F4 is the fallback itself, F5 removes what it replaces, and F6
-collapses the second stack onto the same model.
+Each step is small, ships green, and reverts by plain revert. F1–F3 are the mechanism, F4 is the fallback itself, F5 removes what it replaces, and F6 collapses the second stack onto the same model.
 
 #### Step F1 · An output owns its connection and its topics
 
-- **Goal.** Every leaf output is built from an output-scoped config block —
-  brokers, TLS, and that output's own topic names — instead of reading the one
-  deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can name
-  different clusters and different topics, because neither consults global
-  state to find out where it produces.
-- **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is
-  already exactly this: per-sink, namespaced by sink name
-  (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own
-  connection, its own producer tuning, and its own topics — declared *"Topics
-  (all required — envconfig errors if any are missing)"*, with no defaults.
-  v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted
-  topics. F1 moves v0 onto v1's shape, reusing the struct rather than
-  paralleling it. A v0-specific config model here would leave three to
-  reconcile at Step 20 instead of one.
-- **Why this is the whole mechanism.** `Output::failover` already composes two
-  arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup`
-  builds it that way. Once a leaf carries its own config, a second cluster with
-  its own topic names is a `setup` change and a values file, with no new trait
-  and no per-feature plumbing.
+- **Goal.** Every leaf output is built from an output-scoped config block — brokers, TLS, and that output's own topic names — instead of reading the one deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can name different clusters and different topics, because neither consults global state to find out where it produces.
+- **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is already exactly this: per-sink, namespaced by sink name (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own connection, its own producer tuning, and its own topics — declared *"Topics (all required — envconfig errors if any are missing)"*, with no defaults. v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted topics. F1 moves v0 onto v1's shape, reusing the struct rather than paralleling it. A v0-specific config model here would leave three to reconcile at Step 20 instead of one.
+- **Why this is the whole mechanism.** `Output::failover` already composes two arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup` builds it that way. Once a leaf carries its own config, a second cluster with its own topic names is a `setup` change and a values file, with no new trait and no per-feature plumbing.
 - **Size.** M.
 
 #### Step F2 · A reachable output must be configured
 
-- **Goal.** The configuration an output requires is required in code: an output
-  the deployment's `CaptureMode` can reach must be fully configured or capture
-  refuses to boot. Unreachable outputs are not asked for at all — a Recordings
-  pod is never asked to name an error-tracking topic.
-- **Defaults go.** The `#[envconfig(default = ...)]` on each topic field is what
-  makes a missing or misspelled variable resolve to a compiled-in name instead
-  of failing. A reachable output's topics stop being defaulted; an absent or
-  empty value is a boot failure, which is the behaviour the check was always
-  meant to have.
-- **Supersedes** the deployment-wide `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED`
-  flag, which demands all ten destinations on every pod and so can be armed
-  nowhere.
-- **Parity proof.** Per-mode refusal tests, and anti-over-demand tests proving a
-  mode is never asked for an output it cannot reach.
+- **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic.
+- **Defaults go.** The `#[envconfig(default = ...)]` on each topic field is what makes a missing or misspelled variable resolve to a compiled-in name instead of failing. A reachable output's topics stop being defaulted; an absent or empty value is a boot failure, which is the behaviour the check was always meant to have.
+- **Supersedes** the deployment-wide `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` flag, which demands all ten destinations on every pod and so can be armed nowhere.
+- **Parity proof.** Per-mode refusal tests, and anti-over-demand tests proving a mode is never asked for an output it cannot reach.
 - **Size.** M.
 
 #### Step F3 · Verify an output's topics against its own broker
 
-- **Goal.** At boot, probe each reachable output's cluster metadata for the
-  topics that output can produce to, and refuse to start on a missing one.
-  Per output, against that output's own broker — so a fallback pointed at a
-  half-provisioned cluster fails before it can take traffic.
-- **Why it is separate from F2.** F2 is config-only and never touches a broker:
-  it answers "is this wired", instantly, with no connect attempt. F3 answers
-  "does this exist on the cluster we are about to produce to", which is the
-  question that matters when the cluster is one this deployment has never
-  written to.
-- **Default off**, armed per deployment: on brokers with topic auto-creation the
-  metadata probe can create the topic it is checking, which makes a pass
-  meaningless.
+- **Goal.** At boot, probe each reachable output's cluster metadata for the topics that output can produce to, and refuse to start on a missing one. Per output, against that output's own broker — so a fallback pointed at a half-provisioned cluster fails before it can take traffic.
+- **Why it is separate from F2.** F2 is config-only and never touches a broker: it answers "is this wired", instantly, with no connect attempt. F3 answers "does this exist on the cluster we are about to produce to", which is the question that matters when the cluster is one this deployment has never written to.
+- **Default off**, armed per deployment: on brokers with topic auto-creation the metadata probe can create the topic it is checking, which makes a pass meaningless.
 - **Size.** M.
 
 #### Step F4 · The capture-analytics emergency fallback
 
 The consumer of F1–F3, and the reason they exist.
 
-- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the
-  primary and a fallback, each configured independently under its own F1
-  namespace (own brokers, own TLS, own topic names — the backup cluster does
-  not have to mirror the primary's topic names, and should not have to).
-- **Arming.** One environment variable, matched exactly against a sentinel —
-  not a truthy value. `"1"`, `"true"`, `"yes"` must not move a fleet's traffic,
-  and any value other than the sentinel refuses to boot rather than quietly
-  running on the primary. Unset is normal operation.
-- **The switch is static at boot.** Exactly one target publishes; arming means
-  setting the variable and rolling the pods. This is deliberate: the failure it
-  answers is "MSK is degraded and a human has decided to move", not a transient
-  the process should react to on its own. Automatic switching is Step 10's
-  breaker, and stays deferred.
-- **Both targets are verified, including the dormant one.** The tree holds the
-  fallback whether or not it is armed, so F3 probes its cluster and topics at
-  every boot. A misconfigured backup is then discovered on an ordinary deploy,
-  months before the emergency — which is the entire point. Discovering it while
-  arming is discovering it too late.
-- **Report which target is live** on a gauge, emitted in both states so a
-  dashboard can tell "on the primary" from "pod not reporting".
-- **Scope.** capture-analytics. Other capture modes carry no fallback output and
-  are not asked to configure one (F2).
-- **Known gaps to carry, not solve here.** Consumers have no equivalent switch,
-  so a repoint is not symmetric; capture-import writes the same topics and must
-  be stopped before any drain-to-zero gate; the AI lane's bridges read
-  MSK-era names. These belong in the runbook, not the code.
+- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback, each configured independently under its own F1 namespace (own brokers, own TLS, own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to).
+- **Arming.** One environment variable, matched exactly against a sentinel — not a truthy value. `"1"`, `"true"`, `"yes"` must not move a fleet's traffic, and any value other than the sentinel refuses to boot rather than quietly running on the primary. Unset is normal operation.
+- **The switch is static at boot.** Exactly one target publishes; arming means setting the variable and rolling the pods. This is deliberate: the failure it answers is "MSK is degraded and a human has decided to move", not a transient the process should react to on its own. Automatic switching is Step 10's breaker, and stays deferred.
+- **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so F3 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
+- **Report which target is live** on a gauge, emitted in both states so a dashboard can tell "on the primary" from "pod not reporting".
+- **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (F2).
+- **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. These belong in the runbook, not the code.
 - **Size.** M.
 
 #### Step F5 · Retire the S3 fallback
 
-- **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*`
-  config, and the Kafka→S3 failover wiring in `setup`.
-- **Why it is safe.** It is off in every production deployment: six
-  `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`,
-  and that one is `apps/capture-analytics/values.dev.yaml`. The infra config
-  notes the IAM role is "wired but unused". Retiring it removes dead
-  break-glass machinery, not a live safety net.
-- **Why F4 replaces it.** A second Kafka cluster keeps events in the pipeline —
-  consumers read them normally. S3 parks them behind a separate replay path that
-  has never been exercised in production.
-- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health
-  handle flips and the fallback takes the batch, with no human and no redeploy.
-  F4 is *configuration*: arm and roll. Retiring S3 therefore gives up an
-  automatic response — one that is currently disabled everywhere, so nothing
-  running is lost, but the capability is. If an automatic switch is wanted,
-  revive Step 10 (breaker mode) and drive F4's fallback from it; the policy node
-  already composes two outputs.
-- **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive`
-  alert spec and its runbook, and the IAM role in cloud-infra all go with it.
+- **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*` config, and the Kafka→S3 failover wiring in `setup`.
+- **Why it is safe.** It is off in every production deployment: six `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`, and that one is `apps/capture-analytics/values.dev.yaml`. The infra config notes the IAM role is "wired but unused". Retiring it removes dead break-glass machinery, not a live safety net.
+- **Why F4 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
+- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. F4 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. If an automatic switch is wanted, revive Step 10 (breaker mode) and drive F4's fallback from it; the policy node already composes two outputs.
+- **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive` alert spec and its runbook, and the IAM role in cloud-infra all go with it.
 - **Size.** M.
 
 #### Step F6 · v1 converges on the shared strata
@@ -288,28 +193,17 @@ The consumer of F1–F3, and the reason they exist.
 
 #### What F2 and F3 would already have caught
 
-`KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while
-`(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow` is a
-reachable route with a passing test. Replay overflow therefore resolves to the
-compiled-in `session_recording_snapshot_item_overflow`, while prod-us replay
-wires `ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`.
+`KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while `(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow` is a reachable route with a passing test. Replay overflow therefore resolves to the compiled-in `session_recording_snapshot_item_overflow`, while prod-us replay wires `ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`.
 
-F2 fails that at boot: a reachable output with no configured topic. F3 fails it
-too, if the defaulted name is absent from the cluster. Worth confirming where
-that traffic lands today — unconfirmed, and it predates this plan.
+F2 fails that at boot: a reachable output with no configured topic. F3 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
 
 ## Deferred work
 
-Not scheduled. The structure to build on landed in steps 1–8; these are the
-drivers that no longer justify sequencing ahead of the fallback. Revive a step
-by moving it back into a stage above, with its parity proof intact.
+Not scheduled. The structure to build on landed in steps 1–8; these are the drivers that no longer justify sequencing ahead of the fallback. Revive a step by moving it back into a stage above, with its parity proof intact.
 
 ### Stage D (deferred) — dark failover
 
-Steps 9 and 11 are not here. Step 9 was promoted into **F2**, which the fallback
-needs; Step 11 became **F6**, because F1 makes convergence cheap and delay makes
-it dearer. Step 10 stays deferred, and is what F5 points at if the automatic
-failover it retires is ever wanted back.
+Steps 9 and 11 are not here. Step 9 was promoted into **F2**, which the fallback needs; Step 11 became **F6**, because F1 makes convergence cheap and delay makes it dearer. Step 10 stays deferred, and is what F5 points at if the automatic failover it retires is ever wanted back.
 
 #### Step 10 · Breaker failover mode (dark)
 

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -11,26 +11,32 @@ not outlive the work it schedules, and after F3 it schedules nothing.
 
 ## Motivation
 
-**One driver: ship the emergency Kafka fallback safely.**
+**One driver: an output owns the configuration it produces with.**
 
 If MSK degrades, capture-analytics must be able to produce to an alternative
-cluster — brokers, TLS, and that cluster's own topic names — on an environment
-variable, with the configuration verified before any traffic moves. Running
-capture against a half-wired cluster is the risk this plan exists to remove.
+cluster — its brokers, its TLS, its own topic names — and we must know the
+configuration is sound before any traffic moves. Running capture against a
+half-wired cluster is the risk this plan exists to remove.
 
-The switch is boot-time and total: `config_resolution::resolve` is the only way
-to obtain a `Config`, so an armed deployment cannot hold a producer pointed at
-the primary. Primary and backup are therefore never live at once, which is what
-keeps the remaining work small — the fallback needs no policy tree, no
-per-target topic table, and none of the deferred steps below.
+The mechanism that buys this is narrow: make an output carry its own connection
+and topic configuration, require that configuration for every output a
+deployment can reach, and verify those topics against that output's own broker
+at boot. A fallback to a second cluster is then *a configuration of an output's
+targets* — no new policy, no new trait, no per-feature code path. That is what
+the target architecture below already describes; this plan just stops deferring
+it behind eleven structural steps.
 
-Steps 1–8 landed the structure this rests on: routing is a pure function, the
-lane decision is pipeline-layer code, sinks are backend mechanism over prepared
+`Output::failover` already composes two arbitrary outputs (Step 7). What it
+lacks is targets that can be configured independently of each other.
+
+Steps 1–8 landed the rest of the structure: routing is a pure function, the lane
+decision is pipeline-layer code, sinks are backend mechanism over prepared
 payloads, and the outputs layer owns multi-target policy behind one produce
-surface. That is enough. The three drivers this plan originally served —
-breaker-driven failover, cluster migration by split/dual-write, and a protobuf
-cutover behind the serialization seam — are real but not urgent, and are
-recorded under **Deferred work** rather than sequenced.
+surface. The drivers this plan originally sequenced — breaker-driven failover,
+cluster migration by split/dual-write, and a protobuf cutover behind the
+serialization seam — are real but not urgent, and are recorded under **Deferred
+work** rather than scheduled. Each becomes cheaper once outputs are
+independently configurable, not more expensive.
 
 ## Target architecture
 
@@ -150,73 +156,76 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 - **Parity proof.** All endpoint/integration suites green; grep proves `Event` call-site-free before the deletion half.
 - **Size.** M/L. May split into per-call-site commits if the diff grows.
 
-### Stage D — the fallback ships
+### Stage D — outputs carry their own configuration
 
-The remaining committed work. Each step is small, ships green, and reverts by
-plain revert. Everything after this stage is deferred, not scheduled.
+The remaining committed work, and it is a mechanism, not a feature: an output
+owns the configuration it produces with. Once that holds, an emergency fallback
+to another cluster is *a configuration of an output's targets* rather than a
+code path — which is what the target architecture said all along.
 
-#### Step F1 · Fallback topics are configuration
+Each step is small, ships green, and reverts by plain revert.
 
-- **Goal.** The emergency switch carries the backup cluster's own topic names,
-  not just its brokers. Separate `CAPTURE_ANALYTICS_KAFKA_EMERGENCY_BACKUP_TOPIC_*`
-  variables, applied by `EmergencyKafkaFallback::apply` alongside hosts and TLS,
-  required while armed and ignored otherwise — the same contract the hosts
-  variable already has.
-- **Why it needs nothing else.** The switch rewrites `Config` at boot, so the
-  resolved config names exactly one cluster. `TopicTable::from(&config)` reads
-  the backup names with no per-target plumbing, no `Output::failover`, and no
-  prep hoist.
-- **Cross-repo.** Removes the reason `posthog-cloud-infra#10065` must mirror
-  MSK-era topic names on warpstream-ingestion, and with it the terraform
-  imports that mirroring forces. Also closes the AI-lane gap: the Bento MSK
-  bridges never see `ingestion-ai-msk-*` on WarpStream, so an armed deployment
-  can name `ingestion-ai-main-*` directly.
-- **Size.** S.
+#### Step F1 · An output owns its connection and its topics
 
-#### Step F2 · Mode-scoped output config
-
-- **Goal.** `TopicTable::check_complete` demands only the destinations the
-  deployment's `CaptureMode` can reach: an Events/Ai pod the analytics family
-  plus the armed fallback set, a Recordings pod main/replay-overflow/dlq. This
-  is what makes `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` armable at all —
-  today it demands all ten destinations on every pod, so no deployment can turn
-  it on.
-- **Arming precondition.** The flag stays off in every deployment until this
-  step lands *and* the chart env is audited for explicitly-blank topic values.
-  The mode-blind check demands every registered topic on every pod, so a
-  recordings or import deployment that sets an analytics topic to `""` would
-  crashloop the fleet at boot rather than degrade.
-- **Parity proof.** Per-mode refusal + anti-over-demand tests.
+- **Goal.** Every leaf output is built from an output-scoped config block —
+  brokers, TLS, and that output's own topic names — instead of reading the one
+  deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can name
+  different clusters and different topics, because neither consults global
+  state to find out where it produces.
+- **Why this is the whole mechanism.** `Output::failover` already composes two
+  arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup`
+  builds it that way. Once a leaf carries its own config, a Kafka→Kafka
+  fallback with its own topic names is a `setup` change and a values file, with
+  no new policy, no new trait, and no per-feature plumbing.
+- **Non-goal.** How any particular fallback is triggered, named, or armed. That
+  is a consumer of this mechanism and is specified separately.
 - **Size.** M.
 
-#### Step F3 · Boot topic verification
+#### Step F2 · A reachable output must be configured
 
-- **Goal.** Probe the *resolved* cluster's metadata for every topic the mode can
-  reach and refuse to start on a missing one, so arming the switch against a
-  half-provisioned backup fails at boot rather than at first produce.
-- **Why it is separate from F2.** `check_complete` is config-only and
-  deliberately never touches a broker — it answers "is this wired?", instantly.
-  F3 answers "does this exist on the cluster we are about to produce to?", which
-  is the question that matters when the cluster changes underneath you.
+- **Goal.** The configuration an output requires is required in code: an output
+  the deployment's `CaptureMode` can reach must be fully configured or capture
+  refuses to boot. Unreachable outputs are not asked for at all — a Recordings
+  pod is never asked to name an error-tracking topic.
+- **Defaults go.** The `#[envconfig(default = ...)]` on each topic field is what
+  makes a missing or misspelled variable resolve to a compiled-in name instead
+  of failing. A reachable output's topics stop being defaulted; an absent or
+  empty value is a boot failure, which is the behaviour the check was always
+  meant to have.
+- **Supersedes** the deployment-wide `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED`
+  flag, which demands all ten destinations on every pod and so can be armed
+  nowhere.
+- **Parity proof.** Per-mode refusal tests, and anti-over-demand tests proving a
+  mode is never asked for an output it cannot reach.
+- **Size.** M.
+
+#### Step F3 · Verify an output's topics against its own broker
+
+- **Goal.** At boot, probe each reachable output's cluster metadata for the
+  topics that output can produce to, and refuse to start on a missing one.
+  Per output, against that output's own broker — so a fallback pointed at a
+  half-provisioned cluster fails before it can take traffic.
+- **Why it is separate from F2.** F2 is config-only and never touches a broker:
+  it answers "is this wired", instantly, with no connect attempt. F3 answers
+  "does this exist on the cluster we are about to produce to", which is the
+  question that matters when the cluster is one this deployment has never
+  written to.
 - **Default off**, armed per deployment: on brokers with topic auto-creation the
   metadata probe can create the topic it is checking, which makes a pass
   meaningless.
 - **Size.** M.
 
-#### Prerequisite · topics must be wired explicitly
+#### What F2 and F3 would already have caught
 
-Every topic field carries an `#[envconfig(default = ...)]`, so a missing or
-misspelled variable resolves to a compiled-in name instead of failing. F2 cannot
-see that, and F3 only catches it when the defaulted name is absent from the
-cluster. The charts side must set every topic a mode reaches before either check
-is armed.
+`KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while
+`(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow` is a
+reachable route with a passing test. Replay overflow therefore resolves to the
+compiled-in `session_recording_snapshot_item_overflow`, while prod-us replay
+wires `ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`.
 
-The live example: `KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the
-charts repo, while `(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow`
-is a reachable route with a passing test — so replay overflow resolves to the
-compiled-in `session_recording_snapshot_item_overflow` while prod-us replay wires
-`ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`. Confirm
-where that traffic actually lands before arming anything.
+F2 fails that at boot: a reachable output with no configured topic. F3 fails it
+too, if the defaulted name is absent from the cluster. Worth confirming where
+that traffic lands today — unconfirmed, and it predates this plan.
 
 ## Deferred work
 
@@ -362,9 +371,9 @@ When all steps land, the five strata hold:
 | 7 · Outputs layer with policies; composites retired | done | `feat(capture): outputs layer owns the failover policy` |
 | 8a · Call sites on the table | done | `refactor(capture): call sites publish through outputs` |
 | 8b · `Event` retired | done | `refactor(capture): retire v0 Event trait` |
-| F1 · Fallback topics are configuration | pending | `feat(capture): emergency fallback carries its own topic names` |
-| F2 · Mode-scoped output config | pending | `refactor(capture): mode-scoped topic table completeness` |
-| F3 · Boot topic verification | pending | `feat(capture): verify reachable topics against the cluster at boot` |
+| F1 · An output owns its connection and topics | pending | `refactor(capture): outputs carry their own connection and topic config` |
+| F2 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
+| F3 · Verify topics against the broker | pending | `feat(capture): verify each output's topics against its own broker at boot` |
 | 10 · Breaker mode (dark) | deferred | `feat(capture): breaker-driven failover mode (dark)` |
 | 11 · v1 convergence | deferred | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
 | 12 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -3,7 +3,7 @@
 Working contract for implementation agents. Steps 1–8 have shipped; each
 remaining step is one commit in its own PR.
 
-**Retirement.** This doc dies with `F3`. Whatever is still load-bearing then —
+**Retirement.** This doc dies with `F6`. Whatever is still load-bearing then —
 the vocabulary rules, the ordering-vs-person-processing contract, the
 repartitioning design note — graduates into module docs or
 `v1/sinks/DESIGN.md` first, and the deferred work moves to issues. A plan must
@@ -163,7 +163,9 @@ owns the configuration it produces with. Once that holds, an emergency fallback
 to another cluster is *a configuration of an output's targets* rather than a
 code path — which is what the target architecture said all along.
 
-Each step is small, ships green, and reverts by plain revert.
+Each step is small, ships green, and reverts by plain revert. F1–F3 are the
+mechanism, F4 is the fallback itself, F5 removes what it replaces, and F6
+collapses the second stack onto the same model.
 
 #### Step F1 · An output owns its connection and its topics
 
@@ -172,13 +174,20 @@ Each step is small, ships green, and reverts by plain revert.
   deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can name
   different clusters and different topics, because neither consults global
   state to find out where it produces.
+- **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is
+  already exactly this: per-sink, namespaced by sink name
+  (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own
+  connection, its own producer tuning, and its own topics — declared *"Topics
+  (all required — envconfig errors if any are missing)"*, with no defaults.
+  v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted
+  topics. F1 moves v0 onto v1's shape, reusing the struct rather than
+  paralleling it. A v0-specific config model here would leave three to
+  reconcile at Step 20 instead of one.
 - **Why this is the whole mechanism.** `Output::failover` already composes two
   arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup`
-  builds it that way. Once a leaf carries its own config, a Kafka→Kafka
-  fallback with its own topic names is a `setup` change and a values file, with
-  no new policy, no new trait, and no per-feature plumbing.
-- **Non-goal.** How any particular fallback is triggered, named, or armed. That
-  is a consumer of this mechanism and is specified separately.
+  builds it that way. Once a leaf carries its own config, a second cluster with
+  its own topic names is a `setup` change and a values file, with no new trait
+  and no per-feature plumbing.
 - **Size.** M.
 
 #### Step F2 · A reachable output must be configured
@@ -215,6 +224,68 @@ Each step is small, ships green, and reverts by plain revert.
   meaningless.
 - **Size.** M.
 
+#### Step F4 · The capture-analytics emergency fallback
+
+The consumer of F1–F3, and the reason they exist.
+
+- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the
+  primary and a fallback, each configured independently under its own F1
+  namespace (own brokers, own TLS, own topic names — the backup cluster does
+  not have to mirror the primary's topic names, and should not have to).
+- **Arming.** One environment variable, matched exactly against a sentinel —
+  not a truthy value. `"1"`, `"true"`, `"yes"` must not move a fleet's traffic,
+  and any value other than the sentinel refuses to boot rather than quietly
+  running on the primary. Unset is normal operation.
+- **The switch is static at boot.** Exactly one target publishes; arming means
+  setting the variable and rolling the pods. This is deliberate: the failure it
+  answers is "MSK is degraded and a human has decided to move", not a transient
+  the process should react to on its own. Automatic switching is Step 10's
+  breaker, and stays deferred.
+- **Both targets are verified, including the dormant one.** The tree holds the
+  fallback whether or not it is armed, so F3 probes its cluster and topics at
+  every boot. A misconfigured backup is then discovered on an ordinary deploy,
+  months before the emergency — which is the entire point. Discovering it while
+  arming is discovering it too late.
+- **Report which target is live** on a gauge, emitted in both states so a
+  dashboard can tell "on the primary" from "pod not reporting".
+- **Scope.** capture-analytics. Other capture modes carry no fallback output and
+  are not asked to configure one (F2).
+- **Known gaps to carry, not solve here.** Consumers have no equivalent switch,
+  so a repoint is not symmetric; capture-import writes the same topics and must
+  be stopped before any drain-to-zero gate; the AI lane's bridges read
+  MSK-era names. These belong in the runbook, not the code.
+- **Size.** M.
+
+#### Step F5 · Retire the S3 fallback
+
+- **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*`
+  config, and the Kafka→S3 failover wiring in `setup`.
+- **Why it is safe.** It is off in every production deployment: six
+  `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`,
+  and that one is `apps/capture-analytics/values.dev.yaml`. The infra config
+  notes the IAM role is "wired but unused". Retiring it removes dead
+  break-glass machinery, not a live safety net.
+- **Why F4 replaces it.** A second Kafka cluster keeps events in the pipeline —
+  consumers read them normally. S3 parks them behind a separate replay path that
+  has never been exercised in production.
+- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health
+  handle flips and the fallback takes the batch, with no human and no redeploy.
+  F4 is *configuration*: arm and roll. Retiring S3 therefore gives up an
+  automatic response — one that is currently disabled everywhere, so nothing
+  running is lost, but the capability is. If an automatic switch is wanted,
+  revive Step 10 (breaker mode) and drive F4's fallback from it; the policy node
+  already composes two outputs.
+- **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive`
+  alert spec and its runbook, and the IAM role in cloud-infra all go with it.
+- **Size.** M.
+
+#### Step F6 · v1 converges on the shared strata
+
+- **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays gated on the per-event response model, as before.
+- **Why it moves up.** After F1 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after F1, and gets more expensive the longer v0 carries a second config model.
+- **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
+- **Size.** M/L.
+
 #### What F2 and F3 would already have caught
 
 `KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while
@@ -233,21 +304,18 @@ Not scheduled. The structure to build on landed in steps 1–8; these are the
 drivers that no longer justify sequencing ahead of the fallback. Revive a step
 by moving it back into a stage above, with its parity proof intact.
 
-### Stage D (deferred) — dark failover, convergence
+### Stage D (deferred) — dark failover
 
-Step 9 is not here: it was promoted to **F2** above, which the fallback needs.
+Steps 9 and 11 are not here. Step 9 was promoted into **F2**, which the fallback
+needs; Step 11 became **F6**, because F1 makes convergence cheap and delay makes
+it dearer. Step 10 stays deferred, and is what F5 points at if the automatic
+failover it retires is ever wanted back.
 
 #### Step 10 · Breaker failover mode (dark)
 
 - **Goal.** `FailoverMode::Breaker` — a pure clock-injected `Breaker` state machine, half-open single-probe permit, and a `StaticControlPlane` seam, as the second failover mode, dark behind `failover_enabled` (default off; off ⇒ Advisory mode byte-identical).
 - **Parity proof.** 13+ deterministic breaker unit tests; four output-level behavior tests (healthy-primary, open→fallback→recover cycle, control-plane-down, fatal-no-failover). The effective-route gauge harness and a Notify-gated probe-concurrency harness graduate with the feature when it leaves dark mode.
 - **Size.** M.
-
-#### Step 11 · v1 converges on the shared strata
-
-- **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays gated on the per-event response model, as before.
-- **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
-- **Size.** M/L.
 
 ### Stage E — prep hoists up; sinks become pure transport
 
@@ -374,8 +442,10 @@ When all steps land, the five strata hold:
 | F1 · An output owns its connection and topics | pending | `refactor(capture): outputs carry their own connection and topic config` |
 | F2 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
 | F3 · Verify topics against the broker | pending | `feat(capture): verify each output's topics against its own broker at boot` |
+| F4 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
+| F5 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
+| F6 · v1 convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
 | 10 · Breaker mode (dark) | deferred | `feat(capture): breaker-driven failover mode (dark)` |
-| 11 · v1 convergence | deferred | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
 | 12 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
 | 13 · Typed addresses; AI pipeline | deferred | `refactor(capture): typed per-pipeline lanes; custom redirects and the ai stream become addresses` |
 | 14 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -1,16 +1,36 @@
 # Capture outputs refactor — implementation plan
 
-Working contract for implementation agents. This doc is the first commit of the draft PR; each `Step N` below becomes one commit in this combined PR and later graduates to its own standalone PR.
+Working contract for implementation agents. Steps 1–8 have shipped; each
+remaining step is one commit in its own PR.
+
+**Retirement.** This doc dies with `F3`. Whatever is still load-bearing then —
+the vocabulary rules, the ordering-vs-person-processing contract, the
+repartitioning design note — graduates into module docs or
+`v1/sinks/DESIGN.md` first, and the deferred work moves to issues. A plan must
+not outlive the work it schedules, and after F3 it schedules nothing.
 
 ## Motivation
 
-Three drivers, in order:
+**One driver: ship the emergency Kafka fallback safely.**
 
-1. **Safe automatic failover**: Kafka-primary / S3-secondary failover as an output policy over any two targets, driven by a health breaker.
-2. **Cluster migrations without code changes**: split (AI → WarpStream) and dual-write become configuration of an output's targets, as in the Node.js `IngestionOutputs` module — capture and Node converge on the same model.
-3. **Payload format evolution**: a protobuf cutover becomes an output-level config change behind the serialization seam, rolled out with content-header coexistence like the replay lz4 envelope.
+If MSK degrades, capture-analytics must be able to produce to an alternative
+cluster — brokers, TLS, and that cluster's own topic names — on an environment
+variable, with the configuration verified before any traffic moves. Running
+capture against a half-wired cluster is the risk this plan exists to remove.
 
-None of these fit the current shape: routing policy, serialization choice, and multi-target behavior are all tangled into the sink layer, so every one of them requires new sink composites with information smuggled through serialized records.
+The switch is boot-time and total: `config_resolution::resolve` is the only way
+to obtain a `Config`, so an armed deployment cannot hold a producer pointed at
+the primary. Primary and backup are therefore never live at once, which is what
+keeps the remaining work small — the fallback needs no policy tree, no
+per-target topic table, and none of the deferred steps below.
+
+Steps 1–8 landed the structure this rests on: routing is a pure function, the
+lane decision is pipeline-layer code, sinks are backend mechanism over prepared
+payloads, and the outputs layer owns multi-target policy behind one produce
+surface. That is enough. The three drivers this plan originally served —
+breaker-driven failover, cluster migration by split/dual-write, and a protobuf
+cutover behind the serialization seam — are real but not urgent, and are
+recorded under **Deferred work** rather than sequenced.
 
 ## Target architecture
 
@@ -130,15 +150,83 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 - **Parity proof.** All endpoint/integration suites green; grep proves `Event` call-site-free before the deletion half.
 - **Size.** M/L. May split into per-call-site commits if the diff grows.
 
-### Stage D — completeness, dark failover, convergence
+### Stage D — the fallback ships
 
-#### Step 9 · Mode-scoped registry completeness
+The remaining committed work. Each step is small, ships green, and reverts by
+plain revert. Everything after this stage is deferred, not scheduled.
 
-- **Goal.** `TopicTable::check_complete` scopes its demand per `CaptureMode`: an Events/Ai pod demands the analytics family, a Recordings pod main/replay-overflow/dlq only.
-- **Arming precondition.** `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` stays off in every deployment until this step lands and the chart env is audited for explicitly-blank topic values.
-  The mode-blind check demands every registered topic on every pod, so a recordings or import deployment that sets an analytics topic to `""` would crashloop the fleet at boot, not degrade.
+#### Step F1 · Fallback topics are configuration
+
+- **Goal.** The emergency switch carries the backup cluster's own topic names,
+  not just its brokers. Separate `CAPTURE_ANALYTICS_KAFKA_EMERGENCY_BACKUP_TOPIC_*`
+  variables, applied by `EmergencyKafkaFallback::apply` alongside hosts and TLS,
+  required while armed and ignored otherwise — the same contract the hosts
+  variable already has.
+- **Why it needs nothing else.** The switch rewrites `Config` at boot, so the
+  resolved config names exactly one cluster. `TopicTable::from(&config)` reads
+  the backup names with no per-target plumbing, no `Output::failover`, and no
+  prep hoist.
+- **Cross-repo.** Removes the reason `posthog-cloud-infra#10065` must mirror
+  MSK-era topic names on warpstream-ingestion, and with it the terraform
+  imports that mirroring forces. Also closes the AI-lane gap: the Bento MSK
+  bridges never see `ingestion-ai-msk-*` on WarpStream, so an armed deployment
+  can name `ingestion-ai-main-*` directly.
+- **Size.** S.
+
+#### Step F2 · Mode-scoped output config
+
+- **Goal.** `TopicTable::check_complete` demands only the destinations the
+  deployment's `CaptureMode` can reach: an Events/Ai pod the analytics family
+  plus the armed fallback set, a Recordings pod main/replay-overflow/dlq. This
+  is what makes `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` armable at all —
+  today it demands all ten destinations on every pod, so no deployment can turn
+  it on.
+- **Arming precondition.** The flag stays off in every deployment until this
+  step lands *and* the chart env is audited for explicitly-blank topic values.
+  The mode-blind check demands every registered topic on every pod, so a
+  recordings or import deployment that sets an analytics topic to `""` would
+  crashloop the fleet at boot rather than degrade.
 - **Parity proof.** Per-mode refusal + anti-over-demand tests.
 - **Size.** M.
+
+#### Step F3 · Boot topic verification
+
+- **Goal.** Probe the *resolved* cluster's metadata for every topic the mode can
+  reach and refuse to start on a missing one, so arming the switch against a
+  half-provisioned backup fails at boot rather than at first produce.
+- **Why it is separate from F2.** `check_complete` is config-only and
+  deliberately never touches a broker — it answers "is this wired?", instantly.
+  F3 answers "does this exist on the cluster we are about to produce to?", which
+  is the question that matters when the cluster changes underneath you.
+- **Default off**, armed per deployment: on brokers with topic auto-creation the
+  metadata probe can create the topic it is checking, which makes a pass
+  meaningless.
+- **Size.** M.
+
+#### Prerequisite · topics must be wired explicitly
+
+Every topic field carries an `#[envconfig(default = ...)]`, so a missing or
+misspelled variable resolves to a compiled-in name instead of failing. F2 cannot
+see that, and F3 only catches it when the defaulted name is absent from the
+cluster. The charts side must set every topic a mode reaches before either check
+is armed.
+
+The live example: `KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the
+charts repo, while `(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow`
+is a reachable route with a passing test — so replay overflow resolves to the
+compiled-in `session_recording_snapshot_item_overflow` while prod-us replay wires
+`ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`. Confirm
+where that traffic actually lands before arming anything.
+
+## Deferred work
+
+Not scheduled. The structure to build on landed in steps 1–8; these are the
+drivers that no longer justify sequencing ahead of the fallback. Revive a step
+by moving it back into a stage above, with its parity proof intact.
+
+### Stage D (deferred) — dark failover, convergence
+
+Step 9 is not here: it was promoted to **F2** above, which the fallback needs.
 
 #### Step 10 · Breaker failover mode (dark)
 
@@ -186,7 +274,7 @@ Goal: v1 endpoints publish through `dyn Outputs` like every other ingress, so fa
 2. **Named surfaces.** `CAPTURE_V1_SINKS` names become named `Arc<dyn Outputs>` rows (each a `KafkaOutputs` built from that sink's config); the v1 `Router`/`Sink`/`Event` traits and `serialize_batch` dissolve.
 3. **Response granularity.** `Outputs::publish` already returns per-event `SinkResult`s; `merge_sink_results` consumes them unchanged.
 4. **Parity oracle.** The v1 pipeline tests and the real-Kafka `v1_sink_integration` suite must pass against the converged path — payload bytes, headers, topics, keys. Documented v1-vs-v0 header deltas (overflow/person-processing decoupling) must be preserved in the mapping, not silently erased. The legacy serializer/header builder survive only as a frozen `cfg(test)` oracle (`legacy_serialize`/`legacy_headers`) the parity suite compares against.
-5. **Plan retirement.** The 20c commit deletes this document — the plan must not outlive its last step.
+5. **Plan retirement.** Superseded: the doc now retires with `F3`, see the header.
    Anything still load-bearing then (the repartitioning design note, the ordering-vs-person-processing contract) graduates into module docs or `v1/sinks/DESIGN.md` first.
 
 **Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
@@ -274,20 +362,22 @@ When all steps land, the five strata hold:
 | 7 · Outputs layer with policies; composites retired | done | `feat(capture): outputs layer owns the failover policy` |
 | 8a · Call sites on the table | done | `refactor(capture): call sites publish through outputs` |
 | 8b · `Event` retired | done | `refactor(capture): retire v0 Event trait` |
-| 9 · Mode-scoped completeness | pending | `refactor(capture): mode-scoped output registry completeness` |
-| 10 · Breaker mode (dark) | pending | `feat(capture): breaker-driven failover mode (dark)` |
-| 11 · v1 convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
-| 12 · Prep hoist; `PublishEvents` retired | pending | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
-| 13 · Typed addresses; AI pipeline | pending | `refactor(capture): typed per-pipeline lanes; custom redirects and the ai stream become addresses` |
-| 14 · Sinks realize namespaces | pending | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |
-| 15 · Per-mode output registries | pending | `feat(capture): per-mode output registries; handlers bound by publish capabilities` |
-| 16 · AI ingress family | pending | `feat(capture): ai ingress is its own router family with its own capability` |
-| 17 · Topic tables injected into sinks | pending | `refactor(capture): topic tables are sink-side data, injected at construction` |
-| 18 · Per-pipeline output overrides; boot topic verification | pending | `feat(capture): per-pipeline output overrides and boot topic verification` |
-| 19a · Naming and import hygiene | pending | `refactor(capture): replace remaining nested paths with imports` + `refactor(capture): name the session replay pipeline consistently` |
-| 19b · Outputs as an open trait; sinks pure transport | pending | `refactor(capture): outputs own namespace realization; Outputs becomes an open trait` |
-| 19c · Dynamic outputs prototype | pending | `feat(capture): prototype dynamic outputs with incremental switchover (test-only)` |
-| 19d · Per-event publish results | pending | `refactor(capture): Outputs::publish reports per-event results` |
-| 20a · v1 boundary mapping + parity oracle | pending | `feat(capture): v1 boundary mapping onto the shared produce interchange` |
-| 20b · v1 publishes through shared outputs | pending | `feat(capture): v1 endpoints publish through the shared outputs machinery` |
-| 20c · Legacy v1 sink stack deleted; this plan retired | pending | `refactor(capture): delete the legacy v1 sink stack` |
+| F1 · Fallback topics are configuration | pending | `feat(capture): emergency fallback carries its own topic names` |
+| F2 · Mode-scoped output config | pending | `refactor(capture): mode-scoped topic table completeness` |
+| F3 · Boot topic verification | pending | `feat(capture): verify reachable topics against the cluster at boot` |
+| 10 · Breaker mode (dark) | deferred | `feat(capture): breaker-driven failover mode (dark)` |
+| 11 · v1 convergence | deferred | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
+| 12 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
+| 13 · Typed addresses; AI pipeline | deferred | `refactor(capture): typed per-pipeline lanes; custom redirects and the ai stream become addresses` |
+| 14 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |
+| 15 · Per-mode output registries | deferred | `feat(capture): per-mode output registries; handlers bound by publish capabilities` |
+| 16 · AI ingress family | deferred | `feat(capture): ai ingress is its own router family with its own capability` |
+| 17 · Topic tables injected into sinks | deferred | `refactor(capture): topic tables are sink-side data, injected at construction` |
+| 18 · Per-pipeline output overrides; boot topic verification | deferred | `feat(capture): per-pipeline output overrides and boot topic verification` |
+| 19a · Naming and import hygiene | deferred | `refactor(capture): replace remaining nested paths with imports` + `refactor(capture): name the session replay pipeline consistently` |
+| 19b · Outputs as an open trait; sinks pure transport | deferred | `refactor(capture): outputs own namespace realization; Outputs becomes an open trait` |
+| 19c · Dynamic outputs prototype | deferred | `feat(capture): prototype dynamic outputs with incremental switchover (test-only)` |
+| 19d · Per-event publish results | deferred | `refactor(capture): Outputs::publish reports per-event results` |
+| 20a · v1 boundary mapping + parity oracle | deferred | `feat(capture): v1 boundary mapping onto the shared produce interchange` |
+| 20b · v1 publishes through shared outputs | deferred | `feat(capture): v1 endpoints publish through the shared outputs machinery` |
+| 20c · Legacy v1 sink stack deleted; this plan retired | deferred | `refactor(capture): delete the legacy v1 sink stack` |

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -2,15 +2,15 @@
 
 Working contract for implementation agents. Steps 1–8 have shipped; each remaining step is one commit in its own PR.
 
-**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Stage D closes the first objective (the manual fallback); the second (one produce surface) and third (automated fallback) are then sequenced in order by scheduling their steps, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving no objective leaves as issues.
+**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Step 16 closes the first objective (the manual fallback); the second (one produce surface) and third (automated fallback) are then sequenced in order by scheduling their steps, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving no objective leaves as issues.
 
 ## Motivation
 
 **Three objectives, one mechanism: an output owns the configuration it produces with.**
 
-**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 13 and 14) are only buildable once configuration is isolated per output (Step 9) and demanded per mode (Step 12): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Stage D is its remaining work; Step 15 is the feature.
+**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 13 and 14) are only buildable once configuration is isolated per output (Step 9) and demanded per mode (Step 12): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Steps 9–16 are its remaining work; Step 15 is the feature.
 
-**Objective 2 — one produce surface.** The v1 stack is live in production — capture-analytics runs its AI endpoint through it, capture-import runs on it wholesale — and it publishes through its own sinks, so a fallback wired into the outputs layer moves none of its traffic. Convergence is therefore coverage, not hygiene. Stage D already puts both stacks on one config model (Step 10); this objective finishes the job — one publish surface, per-event results, the legacy v1 sink stack deleted (Steps 17–20).
+**Objective 2 — one produce surface.** The v1 stack is live in production — capture-analytics runs its AI endpoint through it, capture-import runs on it wholesale — and it publishes through its own sinks, so a fallback wired into the outputs layer moves none of its traffic. Convergence is therefore coverage, not hygiene. Objective 1 already puts both stacks on one config model (Step 10); this objective finishes the job — one publish surface, per-event results, the legacy v1 sink stack deleted (Steps 17–20).
 
 **Objective 3 — prepare capture for an automated fallback.** The switch decision moves to a separate circuit-breaker service; how that service decides is not this plan's concern. Capture's side of the contract is narrow: submit producer health metrics, receive switch signals, and apply a signal at runtime through the failover output it already has — no redeploy. Consumers are out of scope throughout; this plan is capture prep. Sequenced last: an automatic switch that moves only half the produce paths would be worse than the manual one, so objective 2 comes first.
 
@@ -65,26 +65,26 @@ Steps 1–3 land together with this doc: the routing golden oracle, the pure `ro
 
 ## Objective 1 — ship a manual fallback
 
-### Stage A — oracle and groundwork (shipped)
+Steps 1–8, shipped, landed the structure this objective stands on. The remaining committed work is a mechanism, not a feature: an output owns the configuration it produces with. Once that holds, an emergency fallback to another cluster is *a configuration of an output's targets* rather than a code path — which is what the target architecture said all along.
 
-#### Step 1 · Consolidate the routing golden oracle
+Each step is small, ships green, and reverts by plain revert. Steps 9 and 10 put every output — v1's included — on one config model; Steps 11 and 12 make the reachable set a type; Steps 13 and 14 are the checks that type makes possible; Step 15 is the fallback itself; Step 16 removes what it replaces.
+
+### Step 1 · Consolidate the routing golden oracle
 
 The `assert_routing` suite pins topic + partition key + every stamped header + the rerouted counters for all pipelines and lanes. It is the parity instrument for every later step.
 
-#### Step 2 · Extract routing into a pure `route()`
+### Step 2 · Extract routing into a pure `route()`
 
 `route(&ProcessedEventMetadata, ai_events_overflow_armed) -> Result<Route { target, ordering }, CaptureError>`, consulted by the sink.
 The decision is the target `Output` plus the customer-facing `OrderingGuarantee` the sink realizes as a partition key; side effects are implied by the target rather than carried as decision data, the AI overflow valve rides in as an explicit argument to keep the function pure, and a replay decision with no session id is rejected rather than returned unrealizable.
 This is the function Step 5 hoists out of the sink into lane resolution.
 
-#### Step 3 · `TopicTable` + startup completeness check
+### Step 3 · `TopicTable` + startup completeness check
 
 One destination→topic wiring point plus refuse-to-boot on a blank topic, gated behind `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` (default off; see Step 13's arming precondition).
 Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in at Step 13, where `(Pipeline, Lane)` makes the per-mode reachable set explicit.
 
-### Stage B — the two new seams (shipped; no caller-visible change)
-
-#### Step 4 · Serialization layer: format × envelope
+### Step 4 · Serialization layer: format × envelope
 
 - **Goal.** New `serialization` module: `Format` (event → payload bytes + `content-type`) with `Json` as the only impl, `Envelope` (bytes → bytes + `content-encoding`) with `None` and `Lz4` (the replay 4-byte LE size-prefix block format, moved verbatim), and a `Serializer` composing one of each. `prepare_record` calls the serializer instead of inlining `serde_json::to_string` + the lz4 branch. Replay's serializer is `Json × Lz4` when `kafka_replay_envelope_compression` says so; everything else `Json × None`.
 - **Explicitly not in the serializer:** partition keys, routing headers, topics. Bytes and content headers only.
@@ -93,7 +93,7 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 - **Risk / rollback.** Low — mechanical hoist. Revert.
 - **Size.** M.
 
-#### Step 5 · `Pipeline` + `Lane`; the lane decision becomes pipeline-layer code
+### Step 5 · `Pipeline` + `Lane`; the lane decision becomes pipeline-layer code
 
 - **Goal.** Introduce the address pair and relocate the decision logic:
   - `Pipeline { Analytics, Heatmaps, Warnings, ErrorTracking, Replay }` (`Pipeline::from_data_type` extracts the pipeline half of `DataType`).
@@ -105,9 +105,7 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 - **Risk / rollback.** Low-medium — mechanical relocation. Revert.
 - **Size.** M/L.
 
-### Stage C — sinks become mechanism, outputs become the API (shipped)
-
-#### Step 6 · Narrow the Kafka sink to backend mechanism
+### Step 6 · Narrow the Kafka sink to backend mechanism
 
 - **Goal.** New `sinks/sink.rs`: `PreparedPayload { uuid, record: ProduceRecord }` (serialized, addressed) is the sink input; `trait Sink { publish(Vec<PreparedPayload>) -> Vec<SinkResult>; flush() }` — no prepare on the trait, no metadata access — plus `Outcome` and `fold_results` (first failure wins). Kafka: `prepare_batch` (serial <8 / scatter-gather ≥8, fail-fast) extracted from `send_batch` as an inherent method the outputs layer will call; `impl Sink` = serial enqueue + fail-fast ack drain, reporting batch-uniform per-event results (the per-event surface refines only with the response model). `Event::send_batch` becomes the bridge: prep → publish → fold. Kafka only — s3/print/noop gain mechanism impls with the outputs layer, which is what needs them.
 - **Sequencing decision.** `FallbackSink` is never ported onto the mechanism trait: the outputs layer owns multi-target policies (single | failover) from its first commit, built from the same config, and the Event-era composite is deleted when its last caller migrates. `SplitKafkaSink` is already gone — deleted with the retired AI secondary-cluster routing — so split survives only as a policy shape the outputs layer grows back when a cluster migration needs it.
@@ -116,7 +114,7 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 - **Risk / rollback.** Medium-high — core mechanism. Revert.
 - **Size.** L.
 
-#### Step 7 · Outputs layer with policies; composites retired
+### Step 7 · Outputs layer with policies; composites retired
 
 - **Goal.** New `outputs` module — the produce surface, with multi-target policy ownership from day one:
   - `Output`: a single backend, or a policy composing two *outputs* — today `failover` (health-gated Kafka→S3: skip primary while the advisory handle is unhealthy, re-publish the batch on a retriable failure, fatal never fails over). Targets are outputs themselves, so a future policy (a split for the next cluster migration) composes over pairs the way the old composites did. Policies operate on *events*, before prep — each target resolves topics and serializes for itself, exactly like the old per-sink `send_batch` paths, so parity is structural.
@@ -130,7 +128,7 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 - **Risk / rollback.** Medium. Revert.
 - **Size.** L.
 
-#### Step 8 · Call sites migrate to the table; `Event` retired
+### Step 8 · Call sites migrate to the table; `Event` retired
 
 - **Goal.** All four call sites (`events/analytics.rs`, `ai_endpoint.rs`, `otel/mod.rs`, `events/recordings.rs`) publish via `OutputRegistry::publish`, recording `capture_event_batch_size` at the call site; `State` and test mocks retype; then delete the v0 `Event` trait, its `Box<T>` blanket, the outputs facade, and the `Event` impls on Kafka, S3, print, noop, and the test mock.
 - **`State` drops its trait object.** `State.sink: Arc<dyn Event>` becomes `State.outputs: Arc<OutputRegistry>` — a concrete type, since `Output::single` already accepts any leaf. The substitution seam moves down to the leaf: `PublishEvents` and `Output::single` become `pub` so the `tests/` suites can stand their own capturing sinks in (`test_sink` is `cfg(test)`-gated and unreachable from there), and pipeline tests drive the real table and policy path instead of bypassing the outputs layer.
@@ -138,27 +136,21 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 - **Parity proof.** All endpoint/integration suites green; grep proves `Event` call-site-free before the deletion half.
 - **Size.** M/L. May split into per-call-site commits if the diff grows.
 
-### Stage D — outputs carry their own configuration
-
-The remaining committed work, and it is a mechanism, not a feature: an output owns the configuration it produces with. Once that holds, an emergency fallback to another cluster is *a configuration of an output's targets* rather than a code path — which is what the target architecture said all along.
-
-Each step is small, ships green, and reverts by plain revert. Steps 9 and 10 put every output — v1's included — on one config model; Steps 11 and 12 make the reachable set a type; Steps 13 and 14 are the checks that type makes possible; Step 15 is the fallback itself; Step 16 removes what it replaces.
-
-#### Step 9 · An output owns its connection and its topics
+### Step 9 · An output owns its connection and its topics
 
 - **Goal.** Every leaf output is built from an output-scoped config block — brokers, TLS, and that output's own topic names — instead of reading the one deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can name different clusters and different topics, because neither consults global state to find out where it produces.
 - **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is already exactly this: per-sink, namespaced by sink name (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own connection, its own producer tuning, and its own topics — declared *"Topics (all required — envconfig errors if any are missing)"*, with no defaults. v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted topics. Step 9 moves v0 onto v1's shape, reusing the struct rather than paralleling it. A v0-specific config model here would leave three to reconcile at Steps 18–20 instead of one.
 - **Why this is the whole mechanism.** `Output::failover` already composes two arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup` builds it that way. Once a leaf carries its own config, a second cluster with its own topic names is a `setup` change and a values file, with no new trait and no per-feature plumbing.
 - **Size.** M.
 
-#### Step 10 · v1 converges on the shared config strata
+### Step 10 · v1 converges on the shared config strata
 
 - **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays with objective 2 (Steps 17–20).
 - **Why it sits here.** After Step 9 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after Step 9 and gets dearer with every step built over a model v1 has not joined — so it lands before the registry types and boot checks, which then demand and probe v1's topics too.
 - **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
 - **Size.** M/L.
 
-#### Step 11 · Typed per-pipeline lanes
+### Step 11 · Typed per-pipeline lanes
 
 - **Goal.** Lanes become types per pipeline — `AnalyticsLane`, `AiLane`, `SessionReplayLane`, `BasicLane` — so invalid `(pipeline, lane)` pairs are unrepresentable, and admin custom redirects become addresses carrying their own topic outside the lane model: the vocabulary rules above, made code. `resolve` constructs addresses; pipeline and lane kind become projections.
 - **Why it sits here.** Step 12's registry rows demand topics per lane. With the flat `Lane`, the set of valid lanes per pipeline is runtime knowledge, and the registry keeps a fatal backstop for pairs routing never produces. Typed lanes make the demand total: the fields a row requires are exactly the addresses that exist.
@@ -166,7 +158,7 @@ Each step is small, ships green, and reverts by plain revert. Steps 9 and 10 put
 - **Parity proof.** Step-1 goldens unmodified; `resolve` precedence tests retyped with assertions preserved.
 - **Size.** M/L.
 
-#### Step 12 · Per-mode output registries
+### Step 12 · Per-mode output registries
 
 - **Goal.** The deployment's output registry becomes a concrete type per capture mode — `AnalyticsFamilyOutputs` (analytics, ai, heatmaps, warnings, error tracking rows) for Events/Ai/Import pods, `SessionReplayOutputs` for Recordings pods — with required fields, so the narrow list of what a deployment must wire is the type itself. Rows share backends (one Kafka connection per distinct cluster), so per-row policy trees behave as the single pre-table output did.
 - **Why it sits here.** Step 13's demand is per mode. Without registry types that demand is a hand-written `CaptureMode` → reachable-set map — the unarmable completeness flag reborn as glue the types would later delete. With them, the reachable set *is* the type, and Step 13 reduces to deleting defaults.
@@ -174,7 +166,7 @@ Each step is small, ships green, and reverts by plain revert. Steps 9 and 10 put
 - **Parity proof.** Step-1 goldens and integration suites unmodified; per-mode construction tests.
 - **Size.** L.
 
-#### Step 13 · A reachable output must be configured
+### Step 13 · A reachable output must be configured
 
 - **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic, because its Step-12 registry type has no such row.
 - **Defaults go.** The `#[envconfig(default = ...)]` on each topic field is what makes a missing or misspelled variable resolve to a compiled-in name instead of failing. A reachable output's topics stop being defaulted; an absent or empty value is a boot failure, which is the behaviour the check was always meant to have.
@@ -182,14 +174,14 @@ Each step is small, ships green, and reverts by plain revert. Steps 9 and 10 put
 - **Parity proof.** Per-mode refusal tests, and anti-over-demand tests proving a mode is never asked for an output it cannot reach.
 - **Size.** M.
 
-#### Step 14 · Verify an output's topics against its own broker
+### Step 14 · Verify an output's topics against its own broker
 
 - **Goal.** At boot, probe each reachable output's cluster metadata for the topics that output can produce to, and refuse to start on a missing one. Per output, against that output's own broker — so a fallback pointed at a half-provisioned cluster fails before it can take traffic.
 - **Why it is separate from Step 13.** Step 13 is config-only and never touches a broker: it answers "is this wired", instantly, with no connect attempt. Step 14 answers "does this exist on the cluster we are about to produce to", which is the question that matters when the cluster is one this deployment has never written to.
 - **Default off**, armed per deployment: on brokers with topic auto-creation the metadata probe can create the topic it is checking, which makes a pass meaningless.
 - **Size.** M.
 
-#### Step 15 · The capture-analytics emergency fallback
+### Step 15 · The capture-analytics emergency fallback
 
 The consumer of Steps 9, 13, and 14, and the reason they exist.
 
@@ -202,7 +194,7 @@ The consumer of Steps 9, 13, and 14, and the reason they exist.
 - **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. And until Step 19, an armed fallback moves only traffic that publishes through the outputs layer — the v1 slice stays on the primary. These belong in the runbook, not the code.
 - **Size.** M.
 
-#### Step 16 · Retire the S3 fallback
+### Step 16 · Retire the S3 fallback
 
 - **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*` config, and the Kafka→S3 failover wiring in `setup`.
 - **Why it is safe.** It is off in every production deployment: six `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`, and that one is `apps/capture-analytics/values.dev.yaml`. The infra config notes the IAM role is "wired but unused". Retiring it removes dead break-glass machinery, not a live safety net.
@@ -211,7 +203,7 @@ The consumer of Steps 9, 13, and 14, and the reason they exist.
 - **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive` alert spec and its runbook, and the IAM role in cloud-infra all go with it.
 - **Size.** M.
 
-#### What Steps 13 and 14 would already have caught
+### What Steps 13 and 14 would already have caught
 
 `KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while `(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow` is a reachable route with a passing test. Replay overflow therefore resolves to the compiled-in `session_recording_snapshot_item_overflow`, while prod-us replay wires `ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`.
 
@@ -219,7 +211,7 @@ Step 13 fails that at boot: a reachable output with no configured topic. Step 14
 
 ## Objective 2 — one produce surface (unsequenced)
 
-v1 publishes through the shared outputs machinery and the legacy v1 sink stack is deleted, so every policy — the manual fallback, and later the signal-driven switch — applies to all capture traffic uniformly. Stage D's Step 10 does the config-level convergence; these steps finish it, sequenced when objective 1 closes.
+v1 publishes through the shared outputs machinery and the legacy v1 sink stack is deleted, so every policy — the manual fallback, and later the signal-driven switch — applies to all capture traffic uniformly. Objective 1's Step 10 does the config-level convergence; these steps finish it, sequenced when objective 1 closes.
 
 ### Step 17 · Per-event publish results
 

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -2,19 +2,19 @@
 
 Working contract for implementation agents. Steps 1–8 have shipped; each remaining step is one commit in its own PR.
 
-**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Step 16 closes the first objective (the manual fallback); the second (one produce surface) and third (automated fallback) are then sequenced in order by scheduling their steps, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving no objective leaves as issues.
+**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Step 17 closes the first objective (the manual fallback); the second (one produce surface) and third (automated fallback) are then sequenced in order by scheduling their steps, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving no objective leaves as issues.
 
 ## Motivation
 
-**Three objectives, one mechanism: an output owns the configuration it produces with.**
+**Three objectives, one mechanism: configuration lives with what uses it — a named producer owns its connection, an output owns its topics and names its producer.**
 
-**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 13 and 14) are only buildable once configuration is isolated per output (Step 9) and demanded per mode (Step 12): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Steps 9–16 are its remaining work; Step 15 is the feature.
+**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 14 and 15) are only buildable once configuration is isolated per producer and output (Steps 9 and 10) and demanded per mode (Step 13): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Steps 9–17 are its remaining work; Step 16 is the feature.
 
-**Objective 2 — one produce surface.** The v1 stack is live in production — capture-analytics runs its AI endpoint through it, capture-import runs on it wholesale — and it publishes through its own sinks, so a fallback wired into the outputs layer moves none of its traffic. Convergence is therefore coverage, not hygiene. Objective 1 already puts both stacks on one config model (Step 10); this objective finishes the job — one publish surface, per-event results, the legacy v1 sink stack deleted (Steps 17–20).
+**Objective 2 — one produce surface.** The v1 stack is live in production — capture-analytics runs its AI endpoint through it, capture-import runs on it wholesale — and it publishes through its own sinks, so a fallback wired into the outputs layer moves none of its traffic. Convergence is therefore coverage, not hygiene. Objective 1 already puts both stacks on one config model (Step 11); this objective finishes the job — one publish surface, per-event results, the legacy v1 sink stack deleted (Steps 18–21).
 
 **Objective 3 — prepare capture for an automated fallback.** The switch decision moves to a separate circuit-breaker service; how that service decides is not this plan's concern. Capture's side of the contract is narrow: submit producer health metrics, receive switch signals, and apply a signal at runtime through the failover output it already has — no redeploy. Consumers are out of scope throughout; this plan is capture prep. Sequenced last: an automatic switch that moves only half the produce paths would be worse than the manual one, so objective 2 comes first.
 
-The mechanism all three objectives ride is the same: make an output carry its own connection and topic configuration, require that configuration for every output a deployment can reach, and verify those topics against that output's own broker at boot. A fallback — manual or signal-driven — is then *a configuration of an output's targets*: no new policy, no new trait, no per-feature code path. `Output::failover` already composes two arbitrary outputs (Step 7); what it lacks is targets configurable independently of each other, and, for objective 3, a target selection that can change while the process runs.
+The mechanism all three objectives ride is the same: producers are named, carry their own connection configuration, and are instantiated once; an output pairs its own topic configuration with the name of the producer it publishes through; every output a deployment can reach must be fully configured; and each output's topics are verified against its producer's broker at boot. A fallback — manual or signal-driven — is then *a configuration of an output's targets*: no new policy, no new trait, no per-feature code path. `Output::failover` already composes two arbitrary outputs (Step 7); what it lacks is targets configurable independently of each other, and, for objective 3, a target selection that can change while the process runs.
 
 Safety is why this plan is mostly refactoring. Moving production traffic between clusters tolerates no ambient state and no half-understood code path, so every step is one small commit, parity-proven by the Step-1 goldens, revertible by plain revert — and the steps that read as pure structure are what make the boot checks and the runtime switch possible at all.
 
@@ -22,26 +22,30 @@ Steps 1–8 landed the structure: routing is a pure function, the lane decision 
 
 ## Target architecture
 
-Layer `rust/capture`'s produce path into five strata with one-way dependencies:
+Layer `rust/capture`'s produce path into five strata with one-way dependencies, publishing through a pool of named producers:
 
 ```text
 edge              → Pipeline {Analytics, Heatmaps, Warnings, ErrorTracking, Replay}
 pipeline steps    → stamp intent (restrictions, overflow, historical)
 lane resolution   → Address {(Pipeline, Lane {Main, Overflow, Historical}) | Dlq | Custom(topic)}
                      + key policy + headers
-outputs           → (Pipeline, Lane) → output = 1..n targets + selection policy
-                     (single | failover(health) | split(token) | dual-write(pct))
+outputs           → Address → output = 1..n targets + selection policy
+                     (single | failover(health) | split(token) | dual-write(pct));
+                     target = own topics + a named producer
 serialization     → per-output: format (json | protobuf…) × envelope (none | lz4);
                      stamps content-type/encoding headers; produces sink-agnostic payload
 sinks             → single backend: wrap payload into wire record (topic/key vs object key),
                      enqueue, ack. Kafka, S3, print, noop.
+producers         → named connections (brokers, TLS, tuning), instantiated once;
+                     shared by every output that names them
 ```
 
 - **Pipeline** is decided at the edge (endpoint + event name) — the high-level "which product stream is this" classification.
 - **Lane** is decided once, at the end of a pipeline, by folding the intent stamped during processing (restrictions, overflow reasons, historical flag) through one precedence chain. Today that chain is `route()` inside the Kafka sink; it moves up and runs before anything is serialized.
-- **Output** is the named destination an event is published to, addressed by `(Pipeline, Lane)`. An output owns 1..n targets and the policy that picks between them per batch. All multi-target behavior lives here and only here.
+- **Output** is the named destination an event is published to, addressed by `(Pipeline, Lane)`. An output owns 1..n targets and the policy that picks between them per batch. All multi-target behavior lives here and only here. A target pairs its own topic names with the name of the producer it publishes through; connection config lives with the producer, never the output.
 - **Serialization** is a contract with the *consumers of a destination*, not a property of a transport. Each output names its format and envelope; the produced payload is sink-agnostic bytes plus the content headers that let old and new encodings coexist on a topic during migration (the existing replay lz4 `content-encoding` design, generalized).
 - **Sink** is a single backend. It turns an addressed, serialized payload into its wire shape and acks it. It reads no event metadata and makes no decision.
+- **Producer** is a named connection — brokers, TLS, client tuning — configured under its own namespace and instantiated once per deployment, the Node.js ingestion `KafkaProducerRegistry` model. Outputs reference producers by name and share the instance; nothing else opens a connection.
 
 ## Starting point
 
@@ -51,8 +55,9 @@ Steps 1–3 land together with this doc: the routing golden oracle, the pure `ro
 
 - An event's **Address** is a lane of its pipeline (lanes typed per pipeline — `AnalyticsLane`, `AiLane`, `SessionReplayLane`, `BasicLane` — so invalid pairs are unrepresentable), or an admin **custom redirect** that carries its own topic outside the lane model. Pipeline and lane kind are projections; construction goes through `resolve`. Never reintroduce a flat destination enum that conflates pipeline and lane.
 - **Output** = the addressed destination: targets + selection policy + serializer. **OutputRegistry** = the `(Pipeline, Lane)` → output mapping with the per-mode completeness check. The Step-3 **TopicTable** (destination → topic) is absorbed into the registry's targets.
-- **Destination** = a routed topic slot (`AnalyticsMain`, `Dlq`, `AiEvents`, `Custom`). One word across both stacks: v0's `sinks::registry::Destination` and v1's `v1::sinks::types::Destination` are the same concept and converge at Steps 18–20. Never name a backend policy tree an `Output` *and* a routed topic an `Output`.
+- **Destination** = a routed topic slot (`AnalyticsMain`, `Dlq`, `AiEvents`, `Custom`). One word across both stacks: v0's `sinks::registry::Destination` and v1's `v1::sinks::types::Destination` are the same concept and converge at Steps 19–21. Never name a backend policy tree an `Output` *and* a routed topic an `Output`.
 - **Sink** = backend mechanism. Kafka, S3, print, noop. Nothing else is a sink; a thing that picks between sinks is an output policy.
+- **Producer** = a named, once-instantiated connection. Producer config never carries topic names, and an output block never carries connection config; an output that must move clusters changes which producer name it points at.
 - **Serializer** = format × envelope. Formats and envelopes compose; neither knows about sinks or outputs.
 
 ### Invariants
@@ -61,14 +66,14 @@ Steps 1–3 land together with this doc: the routing golden oracle, the pure `ro
 - Wire parity is proven by the Step-1 goldens and existing endpoint/integration tests passing **unmodified**, except where a step explicitly says otherwise.
 - Never mix a mechanical move with a behavior change in one commit.
 - Every step ships green (`cargo test -p capture`, clippy `-D warnings`, fmt) and rolls back by plain revert.
-- The per-event response model (v1 `BatchResponse`) stays out of scope until objective 2 (Step 17); call sites keep folding per-event results into today's whole-request `CaptureError`.
+- The per-event response model (v1 `BatchResponse`) stays out of scope until objective 2 (Step 18); call sites keep folding per-event results into today's whole-request `CaptureError`.
 - Sinks read no `ProcessedEventMetadata`. After Step 6 the only consumer of routing metadata is lane resolution.
 
 ## Objective 1 — ship a manual fallback
 
-Steps 1–8, shipped, landed the structure this objective stands on. The remaining committed work is a mechanism, not a feature: an output owns the configuration it produces with. Once that holds, an emergency fallback to another cluster is *a configuration of an output's targets* rather than a code path — which is what the target architecture said all along.
+Steps 1–8, shipped, landed the structure this objective stands on. The remaining committed work is a mechanism, not a feature: producers own their connections, outputs own their topics and name their producer. Once that holds, an emergency fallback to another cluster is *a configuration of an output's targets* rather than a code path — which is what the target architecture said all along.
 
-Each step is small, ships green, and reverts by plain revert. Steps 9 and 10 put every output — v1's included — on one config model; Steps 11 and 12 make the reachable set a type; Steps 13 and 14 are the checks that type makes possible; Step 15 is the fallback itself; Step 16 removes what it replaces.
+Each step is small, ships green, and reverts by plain revert. Steps 9–11 put every output — v1's included — on one config model; Steps 12 and 13 make the reachable set a type; Steps 14 and 15 are the checks that type makes possible; Step 16 is the fallback itself; Step 17 removes what it replaces.
 
 ### Step 1 · Consolidate the routing golden oracle
 
@@ -82,8 +87,8 @@ This is the function Step 5 hoists out of the sink into lane resolution.
 
 ### Step 3 · `TopicTable` + startup completeness check
 
-One destination→topic wiring point plus refuse-to-boot on a blank topic, gated behind `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` (default off; see Step 13's arming precondition).
-Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in at Step 13, where `(Pipeline, Lane)` makes the per-mode reachable set explicit.
+One destination→topic wiring point plus refuse-to-boot on a blank topic, gated behind `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` (default off; see Step 14's arming precondition).
+Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in at Step 14, where `(Pipeline, Lane)` makes the per-mode reachable set explicit.
 
 ### Step 4 · Serialization layer: format × envelope
 
@@ -133,99 +138,106 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 
 - **Goal.** All four call sites (`events/analytics.rs`, `ai_endpoint.rs`, `otel/mod.rs`, `events/recordings.rs`) publish via `OutputRegistry::publish`, recording `capture_event_batch_size` at the call site; `State` and test mocks retype; then delete the v0 `Event` trait, its `Box<T>` blanket, the outputs facade, and the `Event` impls on Kafka, S3, print, noop, and the test mock.
 - **`State` drops its trait object.** `State.sink: Arc<dyn Event>` becomes `State.outputs: Arc<OutputRegistry>` — a concrete type, since `Output::single` already accepts any leaf. The substitution seam moves down to the leaf: `PublishEvents` and `Output::single` become `pub` so the `tests/` suites can stand their own capturing sinks in (`test_sink` is `cfg(test)`-gated and unreachable from there), and pipeline tests drive the real table and policy path instead of bypassing the outputs layer.
-- **`kafka_send` survives this step.** It is not reachable only from `Event::send`: `PublishEvents::publish_events` calls it on its one-event branch, and that is the production single-event path (recordings publishes one event per call). Deleting it means re-expressing that branch over `prepare_batch` + `Sink::publish` + `fold_results`, which adds a task spawn per single event and drops the `ack_wait_one` span — a behavior change, and this step is a mechanical move. Step 24 retires it with the prep hoist.
+- **`kafka_send` survives this step.** It is not reachable only from `Event::send`: `PublishEvents::publish_events` calls it on its one-event branch, and that is the production single-event path (recordings publishes one event per call). Deleting it means re-expressing that branch over `prepare_batch` + `Sink::publish` + `fold_results`, which adds a task spawn per single event and drops the `ack_wait_one` span — a behavior change, and this step is a mechanical move. Step 25 retires it with the prep hoist.
 - **Parity proof.** All endpoint/integration suites green; grep proves `Event` call-site-free before the deletion half.
 - **Size.** M/L. May split into per-call-site commits if the diff grows.
 
-### Step 9 · An output owns its connection and its topics
+### Step 9 · Named producers, instantiated once
 
-- **Goal.** Every leaf output is built from an output-scoped config block — brokers, TLS, and that output's own topic names — instead of reading the one deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can name different clusters and different topics, because neither consults global state to find out where it produces.
-- **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is already exactly this: per-sink, namespaced by sink name (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own connection, its own producer tuning, and its own topics — declared *"Topics (all required — envconfig errors if any are missing)"*, with no defaults. v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted topics. Step 9 moves v0 onto v1's shape, reusing the struct rather than paralleling it. A v0-specific config model here would leave three to reconcile at Steps 18–20 instead of one.
-- **Why this is the whole mechanism.** `Output::failover` already composes two arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup` builds it that way. Once a leaf carries its own config, a second cluster with its own topic names is a `setup` change and a values file, with no new trait and no per-feature plumbing.
+- **Goal.** Producers become named resources, mirroring the Node.js ingestion model (`KafkaProducerRegistry`): each producer is declared under its own env namespace (`CAPTURE_PRODUCER_<NAME>_*`), carries only connection config — brokers, TLS, client tuning — and is instantiated exactly once at startup; everything publishing through it holds the shared handle. The connection half of the deployment-wide `KafkaConfig` becomes the config of one named producer, and behavior is byte-identical.
+- **Why connections split from outputs.** Two outputs on the same cluster must not open two connections, and an output moving to another cluster must not drag its neighbors along — sharing by name makes both properties structural instead of setup-time bookkeeping. The namespaced parsing is v1's pattern (`Envconfig::init_from_hashmap` under a name prefix, as `CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS` does today), reused rather than paralleled.
+- **Parity proof.** Step-1 goldens and integration suites unmodified; a construction test pins one producer instance in the no-override configuration.
 - **Size.** M.
 
-### Step 10 · v1 converges on the shared config strata
+### Step 10 · An output owns its topics and names its producer
 
-- **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays with objective 2 (Steps 17–20).
-- **Why it sits here.** After Step 9 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after Step 9 and gets dearer with every step built over a model v1 has not joined — so it lands before the registry types and boot checks, which then demand and probe v1's topics too.
+- **Goal.** Every leaf output is built from an output-scoped config block carrying that output's own topic names and the name of the producer it publishes through — instead of reading the one deployment-wide `KafkaConfig`. Connection config never appears in an output block: two outputs in the same tree can name different producers (different clusters) or the same one (one shared connection), and neither consults global state to find out where it produces.
+- **v1 keeps one model to converge onto.** `v1::sinks::kafka::Config` bundles connection and topics per sink. Splitting v0 into named producers and output blocks, reusing v1's namespaced parsing, keeps Step 11 a mapping onto one shared shape rather than a reconciliation of three. Topic defaults survive this step — deleting them is Step 14's job, once the reachable set is typed.
+- **Why this is the whole mechanism.** `Output::failover` already composes two arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup` builds it that way. Once a leaf pairs its own topics with a producer name, a second cluster is one more named producer plus an output block naming it — a `setup` change and a values file, with no new trait and no per-feature plumbing.
+- **Size.** M.
+
+### Step 11 · v1 converges on the shared config strata
+
+- **Goal.** v1 joins the producers-and-outputs model: each `CAPTURE_V1_SINK_*` config splits into a named producer and that sink's output topic rows; v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays with objective 2 (Steps 18–21).
+- **Why it sits here.** After Steps 9 and 10 a destination is topics plus a producer name everywhere but v1, whose per-sink config still bundles the two. Convergence is cheapest immediately after Step 10 and gets dearer with every step built over a model v1 has not joined — so it lands before the registry types and boot checks, which then demand and probe v1's topics too.
 - **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
 - **Size.** M/L.
 
-### Step 11 · Typed per-pipeline lanes
+### Step 12 · Typed per-pipeline lanes
 
 - **Goal.** Lanes become types per pipeline — `AnalyticsLane`, `AiLane`, `SessionReplayLane`, `BasicLane` — so invalid `(pipeline, lane)` pairs are unrepresentable: the rest of the vocabulary rules above, made code (admin redirects already sit outside the lane model as `Address::Dlq` / `Address::Custom`). There is no `AiLane::Historical` — the AI divert wins over historical, matching v1. Pipeline and lane kind become projections.
-- **Why it sits here.** Step 12's registry rows demand topics per lane. With the flat `Lane`, the set of valid lanes per pipeline is runtime knowledge, and the registry keeps a fatal backstop for pairs routing never produces. Typed lanes make the demand total: the fields a row requires are exactly the addresses that exist.
+- **Why it sits here.** Step 13's registry rows demand topics per lane. With the flat `Lane`, the set of valid lanes per pipeline is runtime knowledge, and the registry keeps a fatal backstop for pairs routing never produces. Typed lanes make the demand total: the fields a row requires are exactly the addresses that exist.
 - **Scope.** The address model only.
 - **Parity proof.** Step-1 goldens unmodified; `resolve` precedence tests retyped with assertions preserved.
 - **Size.** M/L.
 
-### Step 12 · Per-mode output registries
+### Step 13 · Per-mode output registries
 
-- **Goal.** The deployment's output registry becomes a concrete type per capture mode — `AnalyticsFamilyOutputs` (analytics, ai, heatmaps, warnings, error tracking rows) for Events/Ai/Import pods, `SessionReplayOutputs` for Recordings pods — with required fields, so the narrow list of what a deployment must wire is the type itself. Rows share backends (one Kafka connection per distinct cluster), so per-row policy trees behave as the single pre-table output did.
-- **Why it sits here.** Step 13's demand is per mode. Without registry types that demand is a hand-written `CaptureMode` → reachable-set map — the unarmable completeness flag reborn as glue the types would later delete. With them, the reachable set *is* the type, and Step 13 reduces to deleting defaults.
-- **Scope.** The registry types and their construction in `setup`. Binding handlers to sealed publish-capability traits over a generic `State<T>` stays deferred as Step 27.
+- **Goal.** The deployment's output registry becomes a concrete type per capture mode — `AnalyticsFamilyOutputs` (analytics, ai, heatmaps, warnings, error tracking rows) for Events/Ai/Import pods, `SessionReplayOutputs` for Recordings pods — with required fields, so the narrow list of what a deployment must wire is the type itself. Rows share producers by name — every row naming the same producer publishes through the one instance — so per-row policy trees behave as the single pre-table output did.
+- **Why it sits here.** Step 14's demand is per mode. Without registry types that demand is a hand-written `CaptureMode` → reachable-set map — the unarmable completeness flag reborn as glue the types would later delete. With them, the reachable set *is* the type, and Step 14 reduces to deleting defaults.
+- **Scope.** The registry types and their construction in `setup`. Binding handlers to sealed publish-capability traits over a generic `State<T>` stays deferred as Step 28.
 - **Parity proof.** Step-1 goldens and integration suites unmodified; per-mode construction tests.
 - **Size.** L.
 
-### Step 13 · A reachable output must be configured
+### Step 14 · A reachable output must be configured
 
-- **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic, because its Step-12 registry type has no such row.
+- **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured — topics, and a producer name the deployment defines — or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic, because its Step-13 registry type has no such row.
 - **Defaults go.** The `#[envconfig(default = ...)]` on each topic field is what makes a missing or misspelled variable resolve to a compiled-in name instead of failing. A reachable output's topics stop being defaulted; an absent or empty value is a boot failure, which is the behaviour the check was always meant to have.
 - **Supersedes** the deployment-wide `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` flag, which demands all ten destinations on every pod and so can be armed nowhere.
 - **Parity proof.** Per-mode refusal tests, and anti-over-demand tests proving a mode is never asked for an output it cannot reach.
 - **Size.** M.
 
-### Step 14 · Verify an output's topics against its own broker
+### Step 15 · Verify an output's topics against its producer's broker
 
-- **Goal.** At boot, probe each reachable output's cluster metadata for the topics that output can produce to, and refuse to start on a missing one. Per output, against that output's own broker — so a fallback pointed at a half-provisioned cluster fails before it can take traffic.
-- **Why it is separate from Step 13.** Step 13 is config-only and never touches a broker: it answers "is this wired", instantly, with no connect attempt. Step 14 answers "does this exist on the cluster we are about to produce to", which is the question that matters when the cluster is one this deployment has never written to.
+- **Goal.** At boot, probe each reachable output's cluster metadata for the topics that output can produce to, and refuse to start on a missing one. Per output, against the broker of the producer it names — one probe per distinct producer — so a fallback pointed at a half-provisioned cluster fails before it can take traffic.
+- **Why it is separate from Step 14.** Step 14 is config-only and never touches a broker: it answers "is this wired", instantly, with no connect attempt. Step 15 answers "does this exist on the cluster we are about to produce to", which is the question that matters when the cluster is one this deployment has never written to.
 - **Default off**, armed per deployment: on brokers with topic auto-creation the metadata probe can create the topic it is checking, which makes a pass meaningless.
 - **Size.** M.
 
-### Step 15 · The capture-analytics emergency fallback
+### Step 16 · The capture-analytics emergency fallback
 
-The consumer of Steps 9, 13, and 14, and the reason they exist.
+The consumer of Steps 9, 10, 14, and 15, and the reason they exist.
 
-- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback, each configured independently under its own Step-9 namespace (own brokers, own TLS, own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to).
+- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback. Each names its own producer, configured under that producer's Step-9 namespace (own brokers, own TLS), and carries its own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to.
 - **Arming.** One environment variable, matched exactly against a sentinel — not a truthy value. `"1"`, `"true"`, `"yes"` must not move a fleet's traffic, and any value other than the sentinel refuses to boot rather than quietly running on the primary. Unset is normal operation.
 - **The switch is static at boot.** Exactly one target publishes; arming means setting the variable and rolling the pods. This is deliberate: the failure it answers is "MSK is degraded and a human has decided to move", not a transient the process should react to on its own. Automatic switching is objective 3, and builds on this step's tree.
-- **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so Step 14 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
+- **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so Step 15 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
 - **Report which target is live** on a gauge, emitted in both states so a dashboard can tell "on the primary" from "pod not reporting".
-- **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (Step 13).
-- **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. And until Step 19, an armed fallback moves only traffic that publishes through the outputs layer — the v1 slice stays on the primary. These belong in the runbook, not the code.
+- **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (Step 14).
+- **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. And until Step 20, an armed fallback moves only traffic that publishes through the outputs layer — the v1 slice stays on the primary. These belong in the runbook, not the code.
 - **Size.** M.
 
-### Step 16 · Retire the S3 fallback
+### Step 17 · Retire the S3 fallback
 
 - **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*` config, and the Kafka→S3 failover wiring in `setup`.
 - **Why it is safe.** It is off in every production deployment: six `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`, and that one is `apps/capture-analytics/values.dev.yaml`. The infra config notes the IAM role is "wired but unused". Retiring it removes dead break-glass machinery, not a live safety net.
-- **Why Step 15 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
-- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. Step 15 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 3: the breaker service's signals drive Step 15's fallback through the Step-21 seam; the policy node already composes two outputs.
+- **Why Step 16 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
+- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. Step 16 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 3: the breaker service's signals drive Step 16's fallback through the Step-22 seam; the policy node already composes two outputs.
 - **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive` alert spec and its runbook, and the IAM role in cloud-infra all go with it.
 - **Size.** M.
 
-### What Steps 13 and 14 would already have caught
+### What Steps 14 and 15 would already have caught
 
 `KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while `(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow` is a reachable route with a passing test. Replay overflow therefore resolves to the compiled-in `session_recording_snapshot_item_overflow`, while prod-us replay wires `ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`.
 
-Step 13 fails that at boot: a reachable output with no configured topic. Step 14 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
+Step 14 fails that at boot: a reachable output with no configured topic. Step 15 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
 
 ## Objective 2 — one produce surface (unsequenced)
 
-v1 publishes through the shared outputs machinery and the legacy v1 sink stack is deleted, so every policy — the manual fallback, and later the signal-driven switch — applies to all capture traffic uniformly. Objective 1's Step 10 does the config-level convergence; these steps finish it, sequenced when objective 1 closes.
+v1 publishes through the shared outputs machinery and the legacy v1 sink stack is deleted, so every policy — the manual fallback, and later the signal-driven switch — applies to all capture traffic uniformly. Objective 1's Step 11 does the config-level convergence; these steps finish it, sequenced when objective 1 closes.
 
-### Step 17 · Per-event publish results
+### Step 18 · Per-event publish results
 
 `Outputs::publish` reports per-event `SinkResult`s, with a provided fold collapsing to the v0 whole-request response for the call sites that keep it. This is the response-model gate that kept full convergence deferred: v1's `BatchResponse` needs per-event granularity, and after this step nothing is missing it.
 
-### v1 convergence on the outputs machinery (Steps 18–20)
+### v1 convergence on the outputs machinery (Steps 19–21)
 
 Goal: v1 endpoints publish through the outputs layer like every other ingress, so fallback/split/dynamic policies apply uniformly. Plan:
 
-1. **Boundary mapping (18).** After v1 processing (destination decided, result stamped), map each publishable `WrappedEvent` into `ProcessedEvent`: the existing v1 serialize path already produces CapturedEvent-compatible payloads, so the mapping builds the `CapturedEvent` plus a `ProcessedEventMetadata` that makes `pipeline::resolve` reproduce the decided destination (AnalyticsMain → main; Overflow → force_overflow; Historical → historical data type; Dlq → redirect_to_dlq; Custom → redirect_to_topic). `Destination::Drop` events never reach the outputs layer — dropping is a processing decision, recorded in the response.
-2. **Named surfaces (19).** `CAPTURE_V1_SINKS` names become named output rows, each built from that sink's config; the v1 `Router`/`Sink`/`Event` traits and `serialize_batch` dissolve.
-3. **Response granularity (19).** `Outputs::publish` already returns per-event `SinkResult`s (Step 17); `merge_sink_results` consumes them unchanged.
-4. **Parity oracle (18, 20).** The v1 pipeline tests and the real-Kafka `v1_sink_integration` suite must pass against the converged path — payload bytes, headers, topics, keys. Documented v1-vs-v0 header deltas (overflow/person-processing decoupling) must be preserved in the mapping, not silently erased. The legacy serializer/header builder survive only as a frozen `cfg(test)` oracle (`legacy_serialize`/`legacy_headers`) the parity suite compares against.
+1. **Boundary mapping (19).** After v1 processing (destination decided, result stamped), map each publishable `WrappedEvent` into `ProcessedEvent`: the existing v1 serialize path already produces CapturedEvent-compatible payloads, so the mapping builds the `CapturedEvent` plus a `ProcessedEventMetadata` that makes `pipeline::resolve` reproduce the decided destination (AnalyticsMain → main; Overflow → force_overflow; Historical → historical data type; Dlq → redirect_to_dlq; Custom → redirect_to_topic). `Destination::Drop` events never reach the outputs layer — dropping is a processing decision, recorded in the response.
+2. **Named surfaces (20).** `CAPTURE_V1_SINKS` names become named output rows, each built from that sink's config; the v1 `Router`/`Sink`/`Event` traits and `serialize_batch` dissolve.
+3. **Response granularity (20).** `Outputs::publish` already returns per-event `SinkResult`s (Step 18); `merge_sink_results` consumes them unchanged.
+4. **Parity oracle (19, 21).** The v1 pipeline tests and the real-Kafka `v1_sink_integration` suite must pass against the converged path — payload bytes, headers, topics, keys. Documented v1-vs-v0 header deltas (overflow/person-processing decoupling) must be preserved in the mapping, not silently erased. The legacy serializer/header builder survive only as a frozen `cfg(test)` oracle (`legacy_serialize`/`legacy_headers`) the parity suite compares against.
 
 **Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
 
@@ -243,25 +255,25 @@ Goal: v1 endpoints publish through the outputs layer like every other ingress, s
 
 Capture's half of an automated fallback, and nothing more. The decision-maker is a separate circuit-breaker service; its internals — how it aggregates, when it trips, whether and how it probes — are outside this plan, and so are consumers. Capture's contract with the service is two channels: producer health metrics out, switch signals in. These steps are scheduled, with parity proofs, when the objectives before them close; until then they are shapes, not commitments.
 
-### Step 21 · Failover target selection behind a control-plane seam
+### Step 22 · Failover target selection behind a control-plane seam
 
-The failover output's target selection becomes runtime-swappable state — swappable, no request-path locks, the pattern the repartitioning note reuses — with Step 15's static arming as the boot value. Applying a signal switches which target publishes; no signal, or a silent, dead, or unreachable control plane, holds the current selection, because the absence of a decision must never move traffic. The Step-15 live-target gauge reports whichever selection is in force. Dark: with no service endpoint configured, behavior is byte-identical to Step 15's static switch.
+The failover output's target selection becomes runtime-swappable state — swappable, no request-path locks, the pattern the repartitioning note reuses — with Step 16's static arming as the boot value. Applying a signal switches which target publishes; no signal, or a silent, dead, or unreachable control plane, holds the current selection, because the absence of a decision must never move traffic. The Step-16 live-target gauge reports whichever selection is in force. Dark: with no service endpoint configured, behavior is byte-identical to Step 16's static switch.
 
-### Step 22 · Producer health metrics out
+### Step 23 · Producer health metrics out
 
-Each Kafka output reports its own produce-path health — delivery latency, error rates, queue depth — keyed by output, so the service sees the path each deployment actually experiences, dormant fallback included. Transport and cadence are sequencing-time decisions; the standing requirements are per-output attribution and that reporting failure never degrades the produce path.
+Each named producer reports its own produce-path health — delivery latency, error rates, queue depth — keyed by producer name, so the service sees the path each deployment actually experiences, the dormant fallback's producer included. Transport and cadence are sequencing-time decisions; the standing requirements are per-producer attribution and that reporting failure never degrades the produce path.
 
-### Step 23 · Switch signals in
+### Step 24 · Switch signals in
 
-Capture receives switch signals from the service and feeds them to the Step-21 seam, acknowledging what it applied. The Step-15 arming variable stays authoritative as the manual override — a human's static decision outranks the service in both directions; exact precedence is settled at sequencing time.
+Capture receives switch signals from the service and feeds them to the Step-22 seam, acknowledging what it applied. The Step-16 arming variable stays authoritative as the manual override — a human's static decision outranks the service in both directions; exact precedence is settled at sequencing time.
 
-An earlier in-process breaker step (`FailoverMode::Breaker`) dissolved into this contract: trip/probe/recover logic is the service's concern, not capture's. What survives of it is the control-plane seam and the control-plane-down posture, both carried by Step 21.
+An earlier in-process breaker step (`FailoverMode::Breaker`) dissolved into this contract: trip/probe/recover logic is the service's concern, not capture's. What survives of it is the control-plane seam and the control-plane-down posture, both carried by Step 22.
 
 ## Deferred work
 
-Not scheduled, and serving no objective directly. Revive a step by moving it under an objective above, with its parity proof intact. Step 30 is superseded rather than deferred — its boot verification became Step 14, and retargeting a row is plain configuration once outputs own their config (Steps 9 and 12).
+Not scheduled, and serving no objective directly. Revive a step by moving it under an objective above, with its parity proof intact. Step 31 is superseded rather than deferred — its boot verification became Step 15, and retargeting a row is plain configuration once outputs own their config (Steps 10 and 13).
 
-### Prep hoists into the outputs layer; `PublishEvents` retired (Step 24)
+### Prep hoists into the outputs layer; `PublishEvents` retired (Step 25)
 
 - **Goal.** Sinks take prepared payloads as input, full stop. `PrepSpec` (registry + per-destination serializers) moves payload assembly — lane resolution, serialization, header stamps, topic and partition key, and the scatter-gather batch prep — into the outputs layer; the `(pipeline, lane)` → output bridge and the `TopicTable` move with it (`outputs::topics`). The `PublishEvents` trait is deleted; every backend (Kafka, S3, print, noop) preps identically via its output's spec, and the Kafka sink is reduced to producer + enqueue + ack drain. The boot completeness check moves to `setup::create_output`.
 - **Test posture change (deliberate).** Capturing mocks intercept *published payloads*, not `ProcessedEvent`s, so ~60 assertions that read metadata stamps migrate to wire-level outcomes: topic, partition key, headers, and payload bytes (deserialized for content checks). The declarative `ExpectedEvent` checkers recompute the expected record from the same expectations, so test bodies stay put. Wire-level assertions also pin a semantic the metadata-level ones couldn't see: replay events redirected to dlq/custom topics partition on the event key, not the session id.
@@ -269,19 +281,19 @@ Not scheduled, and serving no objective directly. Revive a step by moving it und
 - **Files.** `outputs/mod.rs`, `outputs/registry.rs` (moved), `sinks/*`, `setup.rs`, all capturing test mocks.
 - **Size.** L.
 
-### Handlers bound by publish capabilities (Step 27)
+### Handlers bound by publish capabilities (Step 28)
 
-The half of the per-mode registries Step 12 leaves behind: handlers bind on sealed capability traits (`PublishesAnalyticsFamily`, `PublishesSessionReplay`); `State<T>` goes generic over the Step-12 registry and `setup` instantiates the monomorphized router per `CaptureMode` (`router` for the analytics family, `session_replay_router` for recordings) — mounting an ingress on a table that cannot publish its family is a compile error, and the registry's runtime fatal backstop for a pipeline without a row goes structurally dead.
+The half of the per-mode registries Step 13 leaves behind: handlers bind on sealed capability traits (`PublishesAnalyticsFamily`, `PublishesSessionReplay`); `State<T>` goes generic over the Step-13 registry and `setup` instantiates the monomorphized router per `CaptureMode` (`router` for the analytics family, `session_replay_router` for recordings) — mounting an ingress on a table that cannot publish its family is a compile error, and the registry's runtime fatal backstop for a pipeline without a row goes structurally dead.
 
-### Per-pipeline output overrides and boot verification (Step 30 — superseded)
+### Per-pipeline output overrides and boot verification (Step 31 — superseded)
 
 Each row of a deployment's table can be retargeted independently: `CAPTURE_OUTPUT_<PIPELINE>_BROKERS` points a pipeline's row at another cluster, `CAPTURE_OUTPUT_<PIPELINE>_TOPIC_<LANE>` renames a lane's topic in that row's namespace (existing `KAFKA_*` keys stay the defaults). The row factory builds one sink per pipeline, each with its own `TopicTable` (base config overlaid with that pipeline's overrides via `TopicTable::with_overrides`); producers are shared per distinct broker set, so the no-override configuration still opens exactly one connection. The gating liveness handle lands on the cluster carrying the deployment's ingress pipeline; other clusters' producers are non-gating. Overrides compose only with the plain per-row Kafka path — combining them with S3 fallback or AI secondary routing is refused at boot, since those policy trees assume every row shares one primary cluster.
 
 `CAPTURE_VERIFY_TOPICS_ON_BOOT` (default off) probes cluster metadata for every topic a row can produce to — pipeline-scoped (`TopicTable::topics_for_pipeline`), so an overridden row probes only its own cluster's namespace — and refuses to start on a missing topic. Off by default because brokers with topic auto-creation make the check misleading (the metadata probe itself can create the topic).
 
-### Outputs as an open trait (Steps 31–33)
+### Outputs as an open trait (Steps 32–34)
 
-`Outputs` is an open trait — a produce surface handling every destination its configuration maps — replacing the closed policy enum. Implementations own payload assembly, namespace realization, backend composition, and policy: `KafkaOutputs` (one cluster: prep + address→topic table + transport sink), `S3Outputs`, `PrintOutputs`/`NoopOutputs`, `FailoverOutputs` and `SplitOutputs` (policies over `Arc<dyn Outputs>`), and the per-mode tables themselves (dispatch-by-pipeline is just another surface; capability traits are markers over `Outputs`). Sinks are pure transport and never see an `Address`: the Kafka sink publishes realized records (concrete topic, key, payload, headers); namespace realization lives in the outputs layer. Per-event publish results are Step 17, promoted into **Objective 2**.
+`Outputs` is an open trait — a produce surface handling every destination its configuration maps — replacing the closed policy enum. Implementations own payload assembly, namespace realization, backend composition, and policy: `KafkaOutputs` (one cluster: prep + address→topic table + transport sink), `S3Outputs`, `PrintOutputs`/`NoopOutputs`, `FailoverOutputs` and `SplitOutputs` (policies over `Arc<dyn Outputs>`), and the per-mode tables themselves (dispatch-by-pipeline is just another surface; capability traits are markers over `Outputs`). Sinks are pure transport and never see an `Address`: the Kafka sink publishes realized records (concrete topic, key, payload, headers); namespace realization lives in the outputs layer. Per-event publish results are Step 18, promoted into **Objective 2**.
 
 A test-only prototype (`outputs::dynamic`) demonstrates the coordinator-managed surface: `DynamicKafkaOutputs` subscribes to an in-process `KafkaManagerService` (RPC-shaped, acked config pushes) and applies broker add/remove and mapping changes with an enabled-partition set per address — the incremental, key-deterministic drain-and-switch — with tests simulating a topic switchover and a broker switchover end to end.
 
@@ -291,7 +303,7 @@ Not built in this PR; this note records where it plugs in so nothing landed here
 
 **Logical shards, decided before the sinks.** The coordinator owns a stable shard function: `shard = hash(key) % N` over the same partition key the sink would hash, with coordinator-owned `N` (not either cluster's partition count). The shard is stamped at prep time — `AddressedPayload` grows `shard: Option<u32>`, `None` meaning "let the producer partition as today". Stamping at prep keeps the decision above the sinks: both clusters of a failover pair see the same shard on the same payload, so a switchover decision is consistent across targets by construction.
 
-**A `ShardRouted` output policy.** Routing lives in the outputs layer as a policy node holding two child outputs (old cluster, new cluster) and a swappable assignment table `shard → Old | New` (an `ArcSwap`, updated by the coordinator's control plane the same way the Step-21 control-plane seam works). Batch publish splits by assignment and forwards — scatter-gather like the old `Split` composite, no serialization changes (both clusters share the prep/serialization contract, as the retired AI-secondary split proved).
+**A `ShardRouted` output policy.** Routing lives in the outputs layer as a policy node holding two child outputs (old cluster, new cluster) and a swappable assignment table `shard → Old | New` (an `ArcSwap`, updated by the coordinator's control plane the same way the Step-22 control-plane seam works). Batch publish splits by assignment and forwards — scatter-gather like the old `Split` composite, no serialization changes (both clusters share the prep/serialization contract, as the retired AI-secondary split proved).
 
 **Explicit partition pass-through in the sink.** `ProduceRecord` grows `partition: Option<i32>`; the Kafka sink maps `shard` to a concrete partition of its own topic (its table realizes the namespace; a shard→ partition map is the same kind of sink-side data as topic names) and sets it on the record. `None` keeps today's key hashing. The sink still makes no routing decisions — it realizes an address (topic) and a shard (partition) in its own namespace.
 
@@ -311,9 +323,9 @@ The hold window is per-shard and bounded by one producer flush — that is the "
 
 - `AddressedPayload` — carries key + address; grows `shard`.
 - Outputs policy tree — `ShardRouted` slots in beside single/failover/split.
-- The Step-21 control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
+- The Step-22 control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
 - `ProduceRecord` — grows `partition`; sinks realize shard → partition.
-- Per-mode registry rows over per-output config (Steps 9 and 12) — a coordinator can retarget one pipeline's row without touching the rest of the deployment.
+- Per-mode registry rows over per-output config (Steps 10 and 13) — a coordinator can retarget one pipeline's row without touching the rest of the deployment.
 
 ## End state
 
@@ -321,10 +333,11 @@ When all steps land, the five strata hold:
 
 - **Pipelines and lanes.** `pipeline::resolve` is the one lane decision (dlq > custom > historical > overflow > main), pure over `ProcessedEventMetadata`; `Pipeline`/`Lane` are the event's address.
 - **Outputs are the produce surface.** Every pipeline publishes through the `OutputRegistry`; the `Output` policy tree (single | failover) owns all multi-target behavior, composing the way the old sink composites did. The v0 `Event` trait and `FallbackSink` are gone; `SplitKafkaSink` already is, deleted with the retired AI secondary-cluster routing.
+- **Producers are named and shared.** Connection config lives with a named producer, instantiated once per deployment; an output pairs its own topics with a producer name, so pointing an output at another cluster is a name swap plus that producer's config block.
 - **Serialization is a seam.** Format × envelope per destination, with content headers carrying encoding coexistence (the lz4 replay design, generalized); a protobuf cutover is an output-level config change.
 - **Sinks are mechanism, and own their namespace.** Payloads carry the abstract `Address`; each sink realizes it in its own namespace at publish time (Kafka: its per-cluster topic table — the swappable seam a repartitioning coordinator plugs into; S3: the buffer path; print/noop: trivially). Sinks make no routing decisions; a failover pair can share one prepared batch because payloads are target-agnostic. Serialization stays output-level (a consumer contract, shared across targets).
-- **The failover switch is signal-drivable.** The failover output's target selection sits behind the Step-21 control-plane seam; a separate circuit-breaker service supplies the switch signals, capture supplies producer health, and a silent control plane holds the current target.
-- **One produce surface.** v1 publishes through the shared outputs machinery (Steps 18–20); the legacy v1 sink stack, its `Router`/`Sink` traits, and `serialize_batch` are gone.
+- **The failover switch is signal-drivable.** The failover output's target selection sits behind the Step-22 control-plane seam; a separate circuit-breaker service supplies the switch signals, capture supplies producer health, and a silent control plane holds the current target.
+- **One produce surface.** v1 publishes through the shared outputs machinery (Steps 19–21); the legacy v1 sink stack, its `Router`/`Sink` traits, and `serialize_batch` are gone.
 
 ## Agent conventions
 
@@ -352,28 +365,29 @@ When all steps land, the five strata hold:
 | 7 · Outputs layer with policies; composites retired | done | `feat(capture): outputs layer owns the failover policy` |
 | 8a · Call sites on the table | done | `refactor(capture): call sites publish through outputs` |
 | 8b · `Event` retired | done | `refactor(capture): retire v0 Event trait` |
-| 9 · An output owns its connection and topics | pending | `refactor(capture): outputs carry their own connection and topic config` |
-| 10 · v1 config convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
-| 11 · Typed per-pipeline lanes | pending | `refactor(capture): typed per-pipeline lanes; custom redirects become addresses` |
-| 12 · Per-mode output registries | pending | `feat(capture): per-mode output registries with required rows` |
-| 13 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
-| 14 · Verify topics against the broker | pending | `feat(capture): verify each output's topics against its own broker at boot` |
-| 15 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
-| 16 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
-| 17 · Per-event publish results | objective 2 | `refactor(capture): Outputs::publish reports per-event results` |
-| 18 · v1 boundary mapping + parity oracle | objective 2 | `feat(capture): v1 boundary mapping onto the shared produce interchange` |
-| 19 · v1 publishes through shared outputs | objective 2 | `feat(capture): v1 endpoints publish through the shared outputs machinery` |
-| 20 · Legacy v1 sink stack deleted | objective 2 | `refactor(capture): delete the legacy v1 sink stack` |
-| 21 · Failover selection behind a control-plane seam | objective 3 | `feat(capture): failover target selection behind a control-plane seam` |
-| 22 · Producer health metrics out | objective 3 | `feat(capture): outputs report producer health for the breaker service` |
-| 23 · Switch signals in | objective 3 | `feat(capture): apply breaker switch signals to the failover output` |
-| 24 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
-| 25 · AI membership stamp; `AiRouting` retired | done | — (landed with the AI lane rollout, outside this plan's sequence) |
-| 26 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |
-| 27 · Handlers bound by publish capabilities | deferred | `feat(capture): handlers bound by publish capabilities over per-mode state` |
-| 28 · AI ingress family | deferred | `feat(capture): ai ingress is its own router family with its own capability` |
-| 29 · Topic tables injected into sinks | deferred | `refactor(capture): topic tables are sink-side data, injected at construction` |
-| 30 · Per-pipeline output overrides; boot topic verification | superseded | — (boot verification became Step 14; retargeting is configuration after Steps 9 and 12) |
-| 31 · Naming and import hygiene | deferred | `refactor(capture): replace remaining nested paths with imports` + `refactor(capture): name the session replay pipeline consistently` |
-| 32 · Outputs as an open trait; sinks pure transport | deferred | `refactor(capture): outputs own namespace realization; Outputs becomes an open trait` |
-| 33 · Dynamic outputs prototype | deferred | `feat(capture): prototype dynamic outputs with incremental switchover (test-only)` |
+| 9 · Named producers, instantiated once | pending | `refactor(capture): named producers own their connection config` |
+| 10 · An output owns its topics and names its producer | pending | `refactor(capture): outputs carry their own topics and name their producer` |
+| 11 · v1 config convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
+| 12 · Typed per-pipeline lanes | pending | `refactor(capture): typed per-pipeline lanes` |
+| 13 · Per-mode output registries | pending | `feat(capture): per-mode output registries with required rows` |
+| 14 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
+| 15 · Verify topics against the producer's broker | pending | `feat(capture): verify each output's topics against its producer's broker at boot` |
+| 16 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
+| 17 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
+| 18 · Per-event publish results | objective 2 | `refactor(capture): Outputs::publish reports per-event results` |
+| 19 · v1 boundary mapping + parity oracle | objective 2 | `feat(capture): v1 boundary mapping onto the shared produce interchange` |
+| 20 · v1 publishes through shared outputs | objective 2 | `feat(capture): v1 endpoints publish through the shared outputs machinery` |
+| 21 · Legacy v1 sink stack deleted | objective 2 | `refactor(capture): delete the legacy v1 sink stack` |
+| 22 · Failover selection behind a control-plane seam | objective 3 | `feat(capture): failover target selection behind a control-plane seam` |
+| 23 · Producer health metrics out | objective 3 | `feat(capture): producers report health for the breaker service` |
+| 24 · Switch signals in | objective 3 | `feat(capture): apply breaker switch signals to the failover output` |
+| 25 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
+| 26 · AI membership stamp; `AiRouting` retired | done | — (landed with the AI lane rollout, outside this plan's sequence) |
+| 27 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |
+| 28 · Handlers bound by publish capabilities | deferred | `feat(capture): handlers bound by publish capabilities over per-mode state` |
+| 29 · AI ingress family | deferred | `feat(capture): ai ingress is its own router family with its own capability` |
+| 30 · Topic tables injected into sinks | deferred | `refactor(capture): topic tables are sink-side data, injected at construction` |
+| 31 · Per-pipeline output overrides; boot topic verification | superseded | — (boot verification became Step 15; retargeting is configuration after Steps 10 and 13) |
+| 32 · Naming and import hygiene | deferred | `refactor(capture): replace remaining nested paths with imports` + `refactor(capture): name the session replay pipeline consistently` |
+| 33 · Outputs as an open trait; sinks pure transport | deferred | `refactor(capture): outputs own namespace realization; Outputs becomes an open trait` |
+| 34 · Dynamic outputs prototype | deferred | `feat(capture): prototype dynamic outputs with incremental switchover (test-only)` |

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -8,9 +8,9 @@ Working contract for implementation agents. Steps 1–8 have shipped; each remai
 
 **Three objectives, one mechanism: an output owns the configuration it produces with.**
 
-**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 22 and 23) are only buildable once configuration is isolated per output (Step 21) and demanded per mode (Step 15a): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Stage D is this objective; Step 24 is the feature.
+**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 13 and 14) are only buildable once configuration is isolated per output (Step 9) and demanded per mode (Step 12): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Stage D is this objective; Step 15 is the feature.
 
-**Objective 2 — one produce surface.** The v1 stack is live in production — capture-analytics runs its AI endpoint through it, capture-import runs on it wholesale — and it publishes through its own sinks, so a fallback wired into the outputs layer moves none of its traffic. Convergence is therefore coverage, not hygiene. Stage D already puts both stacks on one config model (Step 26); this objective finishes the job — one publish surface, per-event results, the legacy v1 sink stack deleted (Steps 19d, 20a–c).
+**Objective 2 — one produce surface.** The v1 stack is live in production — capture-analytics runs its AI endpoint through it, capture-import runs on it wholesale — and it publishes through its own sinks, so a fallback wired into the outputs layer moves none of its traffic. Convergence is therefore coverage, not hygiene. Stage D already puts both stacks on one config model (Step 10); this objective finishes the job — one publish surface, per-event results, the legacy v1 sink stack deleted (Steps 17–20).
 
 **Objective 3 — prepare capture for an automated fallback.** The switch decision moves to a separate circuit-breaker service; how that service decides is not this plan's concern. Capture's side of the contract is narrow: submit producer health metrics, receive switch signals, and apply a signal at runtime through the failover output it already has — no redeploy. Consumers are out of scope throughout; this plan is capture prep. Sequenced last: an automatic switch that moves only half the produce paths would be worse than the manual one, so objective 2 comes first.
 
@@ -50,7 +50,7 @@ Steps 1–3 land together with this doc: the routing golden oracle, the pure `ro
 
 - An event's **Address** is a lane of its pipeline (lanes typed per pipeline — `AnalyticsLane`, `AiLane`, `SessionReplayLane`, `BasicLane` — so invalid pairs are unrepresentable), or an admin **custom redirect** that carries its own topic outside the lane model. Pipeline and lane kind are projections; construction goes through `resolve`. Never reintroduce a flat destination enum that conflates pipeline and lane.
 - **Output** = the addressed destination: targets + selection policy + serializer. **OutputRegistry** = the `(Pipeline, Lane)` → output mapping with the per-mode completeness check. The Step-3 **TopicTable** (destination → topic) is absorbed into the registry's targets.
-- **Destination** = a routed topic slot (`AnalyticsMain`, `Dlq`, `AiEvents`, `Custom`). One word across both stacks: v0's `sinks::registry::Destination` and v1's `v1::sinks::types::Destination` are the same concept and converge at Step 20. Never name a backend policy tree an `Output` *and* a routed topic an `Output`.
+- **Destination** = a routed topic slot (`AnalyticsMain`, `Dlq`, `AiEvents`, `Custom`). One word across both stacks: v0's `sinks::registry::Destination` and v1's `v1::sinks::types::Destination` are the same concept and converge at Steps 18–20. Never name a backend policy tree an `Output` *and* a routed topic an `Output`.
 - **Sink** = backend mechanism. Kafka, S3, print, noop. Nothing else is a sink; a thing that picks between sinks is an output policy.
 - **Serializer** = format × envelope. Formats and envelopes compose; neither knows about sinks or outputs.
 
@@ -60,7 +60,7 @@ Steps 1–3 land together with this doc: the routing golden oracle, the pure `ro
 - Wire parity is proven by the Step-1 goldens and existing endpoint/integration tests passing **unmodified**, except where a step explicitly says otherwise.
 - Never mix a mechanical move with a behavior change in one commit.
 - Every step ships green (`cargo test -p capture`, clippy `-D warnings`, fmt) and rolls back by plain revert.
-- The per-event response model (v1 `BatchResponse`) stays out of scope until objective 2 (Step 19d); call sites keep folding per-event results into today's whole-request `CaptureError`.
+- The per-event response model (v1 `BatchResponse`) stays out of scope until objective 2 (Step 17); call sites keep folding per-event results into today's whole-request `CaptureError`.
 - Sinks read no `ProcessedEventMetadata`. After Step 6 the only consumer of routing metadata is lane resolution.
 
 ## The stages and steps
@@ -79,8 +79,8 @@ This is the function Step 5 hoists out of the sink into lane resolution.
 
 #### Step 3 · `TopicTable` + startup completeness check
 
-One destination→topic wiring point plus refuse-to-boot on a blank topic, gated behind `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` (default off; see Step 22's arming precondition).
-Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in at Step 22, where `(Pipeline, Lane)` makes the per-mode reachable set explicit.
+One destination→topic wiring point plus refuse-to-boot on a blank topic, gated behind `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` (default off; see Step 13's arming precondition).
+Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in at Step 13, where `(Pipeline, Lane)` makes the per-mode reachable set explicit.
 
 ### Stage B — the two new seams (no caller-visible change)
 
@@ -134,7 +134,7 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 
 - **Goal.** All four call sites (`events/analytics.rs`, `ai_endpoint.rs`, `otel/mod.rs`, `events/recordings.rs`) publish via `OutputRegistry::publish`, recording `capture_event_batch_size` at the call site; `State` and test mocks retype; then delete the v0 `Event` trait, its `Box<T>` blanket, the outputs facade, and the `Event` impls on Kafka, S3, print, noop, and the test mock.
 - **`State` drops its trait object.** `State.sink: Arc<dyn Event>` becomes `State.outputs: Arc<OutputRegistry>` — a concrete type, since `Output::single` already accepts any leaf. The substitution seam moves down to the leaf: `PublishEvents` and `Output::single` become `pub` so the `tests/` suites can stand their own capturing sinks in (`test_sink` is `cfg(test)`-gated and unreachable from there), and pipeline tests drive the real table and policy path instead of bypassing the outputs layer.
-- **`kafka_send` survives this step.** It is not reachable only from `Event::send`: `PublishEvents::publish_events` calls it on its one-event branch, and that is the production single-event path (recordings publishes one event per call). Deleting it means re-expressing that branch over `prepare_batch` + `Sink::publish` + `fold_results`, which adds a task spawn per single event and drops the `ack_wait_one` span — a behavior change, and this step is a mechanical move. Step 12 retires it with the prep hoist.
+- **`kafka_send` survives this step.** It is not reachable only from `Event::send`: `PublishEvents::publish_events` calls it on its one-event branch, and that is the production single-event path (recordings publishes one event per call). Deleting it means re-expressing that branch over `prepare_batch` + `Sink::publish` + `fold_results`, which adds a task spawn per single event and drops the `ack_wait_one` span — a behavior change, and this step is a mechanical move. Step 24 retires it with the prep hoist.
 - **Parity proof.** All endpoint/integration suites green; grep proves `Event` call-site-free before the deletion half.
 - **Size.** M/L. May split into per-call-site commits if the diff grows.
 
@@ -142,97 +142,97 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 
 The remaining committed work, and it is a mechanism, not a feature: an output owns the configuration it produces with. Once that holds, an emergency fallback to another cluster is *a configuration of an output's targets* rather than a code path — which is what the target architecture said all along.
 
-Each step is small, ships green, and reverts by plain revert. Steps 21 and 26 put every output — v1's included — on one config model; Steps 13a and 15a make the reachable set a type; Steps 22 and 23 are the checks that type makes possible; Step 24 is the fallback itself; Step 25 removes what it replaces.
+Each step is small, ships green, and reverts by plain revert. Steps 9 and 10 put every output — v1's included — on one config model; Steps 11 and 12 make the reachable set a type; Steps 13 and 14 are the checks that type makes possible; Step 15 is the fallback itself; Step 16 removes what it replaces.
 
-#### Step 21 · An output owns its connection and its topics
+#### Step 9 · An output owns its connection and its topics
 
 - **Goal.** Every leaf output is built from an output-scoped config block — brokers, TLS, and that output's own topic names — instead of reading the one deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can name different clusters and different topics, because neither consults global state to find out where it produces.
-- **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is already exactly this: per-sink, namespaced by sink name (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own connection, its own producer tuning, and its own topics — declared *"Topics (all required — envconfig errors if any are missing)"*, with no defaults. v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted topics. Step 21 moves v0 onto v1's shape, reusing the struct rather than paralleling it. A v0-specific config model here would leave three to reconcile at Step 20 instead of one.
+- **Adopt v1's model; do not invent a third.** `v1::sinks::kafka::Config` is already exactly this: per-sink, namespaced by sink name (`CAPTURE_V1_SINK_MSK_KAFKA_HOSTS` → key `HOSTS`), carrying its own connection, its own producer tuning, and its own topics — declared *"Topics (all required — envconfig errors if any are missing)"*, with no defaults. v0 is the stack with one deployment-wide `KafkaConfig` and ten defaulted topics. Step 9 moves v0 onto v1's shape, reusing the struct rather than paralleling it. A v0-specific config model here would leave three to reconcile at Steps 18–20 instead of one.
 - **Why this is the whole mechanism.** `Output::failover` already composes two arbitrary outputs (Step 7). It is typed Kafka→S3 today only because `setup` builds it that way. Once a leaf carries its own config, a second cluster with its own topic names is a `setup` change and a values file, with no new trait and no per-feature plumbing.
 - **Size.** M.
 
-#### Step 26 · v1 converges on the shared config strata
+#### Step 10 · v1 converges on the shared config strata
 
-- **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays with objective 2 (Steps 19d, 20a–c).
-- **Why it sits here.** After Step 21 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after Step 21 and gets dearer with every step built over a model v1 has not joined — so it lands before the registry types and boot checks, which then demand and probe v1's topics too.
+- **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays with objective 2 (Steps 17–20).
+- **Why it sits here.** After Step 9 both stacks configure a destination the same way — per sink, namespaced, topics required — so the two differ in routing and response granularity, not in how a producer learns where it produces. Convergence is cheapest immediately after Step 9 and gets dearer with every step built over a model v1 has not joined — so it lands before the registry types and boot checks, which then demand and probe v1's topics too.
 - **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
 - **Size.** M/L.
 
-#### Step 13a · Typed per-pipeline lanes
+#### Step 11 · Typed per-pipeline lanes
 
 - **Goal.** Lanes become types per pipeline — `AnalyticsLane`, `AiLane`, `SessionReplayLane`, `BasicLane` — so invalid `(pipeline, lane)` pairs are unrepresentable, and admin custom redirects become addresses carrying their own topic outside the lane model: the vocabulary rules above, made code. `resolve` constructs addresses; pipeline and lane kind become projections.
-- **Why it sits here.** Step 15a's registry rows demand topics per lane. With the flat `Lane`, the set of valid lanes per pipeline is runtime knowledge, and the registry keeps a fatal backstop for pairs routing never produces. Typed lanes make the demand total: the fields a row requires are exactly the addresses that exist.
-- **Scope.** The address model only. The AI membership rework (allowlist stamp, `AiRouting` retirement) stays deferred as Step 13b.
+- **Why it sits here.** Step 12's registry rows demand topics per lane. With the flat `Lane`, the set of valid lanes per pipeline is runtime knowledge, and the registry keeps a fatal backstop for pairs routing never produces. Typed lanes make the demand total: the fields a row requires are exactly the addresses that exist.
+- **Scope.** The address model only. The AI membership rework (allowlist stamp, `AiRouting` retirement) stays deferred as Step 25.
 - **Parity proof.** Step-1 goldens unmodified; `resolve` precedence tests retyped with assertions preserved.
 - **Size.** M/L.
 
-#### Step 15a · Per-mode output registries
+#### Step 12 · Per-mode output registries
 
 - **Goal.** The deployment's output registry becomes a concrete type per capture mode — `AnalyticsFamilyOutputs` (analytics, ai, heatmaps, warnings, error tracking rows) for Events/Ai/Import pods, `SessionReplayOutputs` for Recordings pods — with required fields, so the narrow list of what a deployment must wire is the type itself. Rows share backends (one Kafka connection per distinct cluster), so per-row policy trees behave as the single pre-table output did.
-- **Why it sits here.** Step 22's demand is per mode. Without registry types that demand is a hand-written `CaptureMode` → reachable-set map — the unarmable completeness flag reborn as glue the types would later delete. With them, the reachable set *is* the type, and Step 22 reduces to deleting defaults.
-- **Scope.** The registry types and their construction in `setup`. Binding handlers to sealed publish-capability traits over a generic `State<T>` stays deferred as Step 15b.
+- **Why it sits here.** Step 13's demand is per mode. Without registry types that demand is a hand-written `CaptureMode` → reachable-set map — the unarmable completeness flag reborn as glue the types would later delete. With them, the reachable set *is* the type, and Step 13 reduces to deleting defaults.
+- **Scope.** The registry types and their construction in `setup`. Binding handlers to sealed publish-capability traits over a generic `State<T>` stays deferred as Step 27.
 - **Parity proof.** Step-1 goldens and integration suites unmodified; per-mode construction tests.
 - **Size.** L.
 
-#### Step 22 · A reachable output must be configured
+#### Step 13 · A reachable output must be configured
 
-- **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic, because its Step-15a registry type has no such row.
+- **Goal.** The configuration an output requires is required in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot. Unreachable outputs are not asked for at all — a Recordings pod is never asked to name an error-tracking topic, because its Step-12 registry type has no such row.
 - **Defaults go.** The `#[envconfig(default = ...)]` on each topic field is what makes a missing or misspelled variable resolve to a compiled-in name instead of failing. A reachable output's topics stop being defaulted; an absent or empty value is a boot failure, which is the behaviour the check was always meant to have.
 - **Supersedes** the deployment-wide `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` flag, which demands all ten destinations on every pod and so can be armed nowhere.
 - **Parity proof.** Per-mode refusal tests, and anti-over-demand tests proving a mode is never asked for an output it cannot reach.
 - **Size.** M.
 
-#### Step 23 · Verify an output's topics against its own broker
+#### Step 14 · Verify an output's topics against its own broker
 
 - **Goal.** At boot, probe each reachable output's cluster metadata for the topics that output can produce to, and refuse to start on a missing one. Per output, against that output's own broker — so a fallback pointed at a half-provisioned cluster fails before it can take traffic.
-- **Why it is separate from Step 22.** Step 22 is config-only and never touches a broker: it answers "is this wired", instantly, with no connect attempt. Step 23 answers "does this exist on the cluster we are about to produce to", which is the question that matters when the cluster is one this deployment has never written to.
+- **Why it is separate from Step 13.** Step 13 is config-only and never touches a broker: it answers "is this wired", instantly, with no connect attempt. Step 14 answers "does this exist on the cluster we are about to produce to", which is the question that matters when the cluster is one this deployment has never written to.
 - **Default off**, armed per deployment: on brokers with topic auto-creation the metadata probe can create the topic it is checking, which makes a pass meaningless.
 - **Size.** M.
 
-#### Step 24 · The capture-analytics emergency fallback
+#### Step 15 · The capture-analytics emergency fallback
 
-The consumer of Steps 21–23, and the reason they exist.
+The consumer of Steps 9, 13, and 14, and the reason they exist.
 
-- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback, each configured independently under its own Step-21 namespace (own brokers, own TLS, own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to).
+- **Shape.** The deployment's outputs tree carries *both* Kafka outputs: the primary and a fallback, each configured independently under its own Step-9 namespace (own brokers, own TLS, own topic names — the backup cluster does not have to mirror the primary's topic names, and should not have to).
 - **Arming.** One environment variable, matched exactly against a sentinel — not a truthy value. `"1"`, `"true"`, `"yes"` must not move a fleet's traffic, and any value other than the sentinel refuses to boot rather than quietly running on the primary. Unset is normal operation.
 - **The switch is static at boot.** Exactly one target publishes; arming means setting the variable and rolling the pods. This is deliberate: the failure it answers is "MSK is degraded and a human has decided to move", not a transient the process should react to on its own. Automatic switching is objective 3, and builds on this step's tree.
-- **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so Step 23 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
+- **Both targets are verified, including the dormant one.** The tree holds the fallback whether or not it is armed, so Step 14 probes its cluster and topics at every boot. A misconfigured backup is then discovered on an ordinary deploy, months before the emergency — which is the entire point. Discovering it while arming is discovering it too late.
 - **Report which target is live** on a gauge, emitted in both states so a dashboard can tell "on the primary" from "pod not reporting".
-- **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (Step 22).
-- **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. And until Step 20b, an armed fallback moves only traffic that publishes through the outputs layer — the v1 slice stays on the primary. These belong in the runbook, not the code.
+- **Scope.** capture-analytics. Other capture modes carry no fallback output and are not asked to configure one (Step 13).
+- **Known gaps to carry, not solve here.** Consumers have no equivalent switch, so a repoint is not symmetric; capture-import writes the same topics and must be stopped before any drain-to-zero gate; the AI lane's bridges read MSK-era names. And until Step 19, an armed fallback moves only traffic that publishes through the outputs layer — the v1 slice stays on the primary. These belong in the runbook, not the code.
 - **Size.** M.
 
-#### Step 25 · Retire the S3 fallback
+#### Step 16 · Retire the S3 fallback
 
 - **Goal.** Delete `S3Sink`, its `PublishEvents` impl, the `s3_fallback_*` config, and the Kafka→S3 failover wiring in `setup`.
 - **Why it is safe.** It is off in every production deployment: six `S3_FALLBACK_ENABLED: "false"` across the charts apps against one `"true"`, and that one is `apps/capture-analytics/values.dev.yaml`. The infra config notes the IAM role is "wired but unused". Retiring it removes dead break-glass machinery, not a live safety net.
-- **Why Step 24 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
-- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. Step 24 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 3: the breaker service's signals drive Step 24's fallback through the Step-27 seam; the policy node already composes two outputs.
+- **Why Step 15 replaces it.** A second Kafka cluster keeps events in the pipeline — consumers read them normally. S3 parks them behind a separate replay path that has never been exercised in production.
+- **The trade, stated plainly.** S3 failover is *automatic*: the advisory health handle flips and the fallback takes the batch, with no human and no redeploy. Step 15 is *configuration*: arm and roll. Retiring S3 therefore gives up an automatic response — one that is currently disabled everywhere, so nothing running is lost, but the capability is. Getting it back, done properly, is objective 3: the breaker service's signals drive Step 15's fallback through the Step-21 seam; the policy node already composes two outputs.
 - **Cross-repo.** Six chart values, the `CaptureAnalyticsV0S3FallbackActive` alert spec and its runbook, and the IAM role in cloud-infra all go with it.
 - **Size.** M.
 
-#### What Steps 22 and 23 would already have caught
+#### What Steps 13 and 14 would already have caught
 
 `KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while `(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow` is a reachable route with a passing test. Replay overflow therefore resolves to the compiled-in `session_recording_snapshot_item_overflow`, while prod-us replay wires `ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`.
 
-Step 22 fails that at boot: a reachable output with no configured topic. Step 23 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
+Step 13 fails that at boot: a reachable output with no configured topic. Step 14 fails it too, if the defaulted name is absent from the cluster. Worth confirming where that traffic lands today — unconfirmed, and it predates this plan.
 
 ## Objective 2 — one produce surface (unsequenced)
 
-v1 publishes through the shared outputs machinery and the legacy v1 sink stack is deleted, so every policy — the manual fallback, and later the signal-driven switch — applies to all capture traffic uniformly. Stage D's Step 26 does the config-level convergence; these steps finish it, sequenced when objective 1 closes.
+v1 publishes through the shared outputs machinery and the legacy v1 sink stack is deleted, so every policy — the manual fallback, and later the signal-driven switch — applies to all capture traffic uniformly. Stage D's Step 10 does the config-level convergence; these steps finish it, sequenced when objective 1 closes.
 
-### Step 19d · Per-event publish results
+### Step 17 · Per-event publish results
 
 `Outputs::publish` reports per-event `SinkResult`s, with a provided fold collapsing to the v0 whole-request response for the call sites that keep it. This is the response-model gate that kept full convergence deferred: v1's `BatchResponse` needs per-event granularity, and after this step nothing is missing it.
 
-### v1 convergence on the outputs machinery (Steps 20a–c)
+### v1 convergence on the outputs machinery (Steps 18–20)
 
 Goal: v1 endpoints publish through the outputs layer like every other ingress, so fallback/split/dynamic policies apply uniformly. Plan:
 
-1. **Boundary mapping (20a).** After v1 processing (destination decided, result stamped), map each publishable `WrappedEvent` into `ProcessedEvent`: the existing v1 serialize path already produces CapturedEvent-compatible payloads, so the mapping builds the `CapturedEvent` plus a `ProcessedEventMetadata` that makes `pipeline::resolve` reproduce the decided destination (AnalyticsMain → main; Overflow → force_overflow; Historical → historical data type; Dlq → redirect_to_dlq; Custom → redirect_to_topic). `Destination::Drop` events never reach the outputs layer — dropping is a processing decision, recorded in the response.
-2. **Named surfaces (20b).** `CAPTURE_V1_SINKS` names become named output rows, each built from that sink's config; the v1 `Router`/`Sink`/`Event` traits and `serialize_batch` dissolve.
-3. **Response granularity (20b).** `Outputs::publish` already returns per-event `SinkResult`s (Step 19d); `merge_sink_results` consumes them unchanged.
-4. **Parity oracle (20a, 20c).** The v1 pipeline tests and the real-Kafka `v1_sink_integration` suite must pass against the converged path — payload bytes, headers, topics, keys. Documented v1-vs-v0 header deltas (overflow/person-processing decoupling) must be preserved in the mapping, not silently erased. The legacy serializer/header builder survive only as a frozen `cfg(test)` oracle (`legacy_serialize`/`legacy_headers`) the parity suite compares against.
+1. **Boundary mapping (18).** After v1 processing (destination decided, result stamped), map each publishable `WrappedEvent` into `ProcessedEvent`: the existing v1 serialize path already produces CapturedEvent-compatible payloads, so the mapping builds the `CapturedEvent` plus a `ProcessedEventMetadata` that makes `pipeline::resolve` reproduce the decided destination (AnalyticsMain → main; Overflow → force_overflow; Historical → historical data type; Dlq → redirect_to_dlq; Custom → redirect_to_topic). `Destination::Drop` events never reach the outputs layer — dropping is a processing decision, recorded in the response.
+2. **Named surfaces (19).** `CAPTURE_V1_SINKS` names become named output rows, each built from that sink's config; the v1 `Router`/`Sink`/`Event` traits and `serialize_batch` dissolve.
+3. **Response granularity (19).** `Outputs::publish` already returns per-event `SinkResult`s (Step 17); `merge_sink_results` consumes them unchanged.
+4. **Parity oracle (18, 20).** The v1 pipeline tests and the real-Kafka `v1_sink_integration` suite must pass against the converged path — payload bytes, headers, topics, keys. Documented v1-vs-v0 header deltas (overflow/person-processing decoupling) must be preserved in the mapping, not silently erased. The legacy serializer/header builder survive only as a frozen `cfg(test)` oracle (`legacy_serialize`/`legacy_headers`) the parity suite compares against.
 
 **Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
 
@@ -250,27 +250,27 @@ Goal: v1 endpoints publish through the outputs layer like every other ingress, s
 
 Capture's half of an automated fallback, and nothing more. The decision-maker is a separate circuit-breaker service; its internals — how it aggregates, when it trips, whether and how it probes — are outside this plan, and so are consumers. Capture's contract with the service is two channels: producer health metrics out, switch signals in. These steps are promoted into a scheduled stage, with parity proofs, when the objectives before them close; until then they are shapes, not commitments.
 
-### Step 27 · Failover target selection behind a control-plane seam
+### Step 21 · Failover target selection behind a control-plane seam
 
-The failover output's target selection becomes runtime-swappable state — swappable, no request-path locks, the pattern the repartitioning note reuses — with Step 24's static arming as the boot value. Applying a signal switches which target publishes; no signal, or a silent, dead, or unreachable control plane, holds the current selection, because the absence of a decision must never move traffic. The Step-24 live-target gauge reports whichever selection is in force. Dark: with no service endpoint configured, behavior is byte-identical to Step 24's static switch.
+The failover output's target selection becomes runtime-swappable state — swappable, no request-path locks, the pattern the repartitioning note reuses — with Step 15's static arming as the boot value. Applying a signal switches which target publishes; no signal, or a silent, dead, or unreachable control plane, holds the current selection, because the absence of a decision must never move traffic. The Step-15 live-target gauge reports whichever selection is in force. Dark: with no service endpoint configured, behavior is byte-identical to Step 15's static switch.
 
-### Step 28 · Producer health metrics out
+### Step 22 · Producer health metrics out
 
 Each Kafka output reports its own produce-path health — delivery latency, error rates, queue depth — keyed by output, so the service sees the path each deployment actually experiences, dormant fallback included. Transport and cadence are sequencing-time decisions; the standing requirements are per-output attribution and that reporting failure never degrades the produce path.
 
-### Step 29 · Switch signals in
+### Step 23 · Switch signals in
 
-Capture receives switch signals from the service and feeds them to the Step-27 seam, acknowledging what it applied. The Step-24 arming variable stays authoritative as the manual override — a human's static decision outranks the service in both directions; exact precedence is settled at sequencing time.
+Capture receives switch signals from the service and feeds them to the Step-21 seam, acknowledging what it applied. The Step-15 arming variable stays authoritative as the manual override — a human's static decision outranks the service in both directions; exact precedence is settled at sequencing time.
 
-Step 10 (the in-process `FailoverMode::Breaker`) dissolved into this contract: trip/probe/recover logic is the service's concern, not capture's. What survives of it is the control-plane seam and the control-plane-down posture, both carried by Step 27.
+An earlier in-process breaker step (`FailoverMode::Breaker`) dissolved into this contract: trip/probe/recover logic is the service's concern, not capture's. What survives of it is the control-plane seam and the control-plane-down posture, both carried by Step 21.
 
 ## Deferred work
 
-Not scheduled, and serving no objective directly. Revive a step by moving it back into a stage above, with its parity proof intact. Steps 9–11 are gone from here: Step 9 was promoted into **Step 22**, Step 11 became **Step 26** because Step 21 makes convergence cheap and delay makes it dearer, and Step 10 dissolved into **Objective 3** above. Step 18 is superseded rather than deferred — its boot verification became Step 23, and retargeting a row is plain configuration once outputs own their config (Steps 21, 15a).
+Not scheduled, and serving no objective directly. Revive a step by moving it back into a stage above, with its parity proof intact. Step 30 is superseded rather than deferred — its boot verification became Step 14, and retargeting a row is plain configuration once outputs own their config (Steps 9 and 12).
 
 ### Stage E — prep hoists up; sinks become pure transport
 
-#### Step 12 · Prep hoists into the outputs layer; `PublishEvents` retired
+#### Step 24 · Prep hoists into the outputs layer; `PublishEvents` retired
 
 - **Goal.** Sinks take prepared payloads as input, full stop. `PrepSpec` (registry + per-destination serializers) moves payload assembly — lane resolution, serialization, header stamps, topic and partition key, and the scatter-gather batch prep — into the outputs layer; the `(pipeline, lane)` → output bridge and the `TopicTable` move with it (`outputs::topics`). The `PublishEvents` trait is deleted; every backend (Kafka, S3, print, noop) preps identically via its output's spec, and the Kafka sink is reduced to producer + enqueue + ack drain. The boot completeness check moves to `setup::create_output`.
 - **Test posture change (deliberate).** Capturing mocks intercept *published payloads*, not `ProcessedEvent`s, so ~60 assertions that read metadata stamps migrate to wire-level outcomes: topic, partition key, headers, and payload bytes (deserialized for content checks). The declarative `ExpectedEvent` checkers recompute the expected record from the same expectations, so test bodies stay put. Wire-level assertions also pin a semantic the metadata-level ones couldn't see: replay events redirected to dlq/custom topics partition on the event key, not the session id.
@@ -278,27 +278,27 @@ Not scheduled, and serving no objective directly. Revive a step by moving it bac
 - **Files.** `outputs/mod.rs`, `outputs/registry.rs` (moved), `sinks/*`, `setup.rs`, all capturing test mocks.
 - **Size.** L.
 
-### Handlers bound by publish capabilities (Step 15b)
+### AI pipeline and Import mode (Step 25)
 
-The half of the per-mode registries Step 15a leaves behind: handlers bind on sealed capability traits (`PublishesAnalyticsFamily`, `PublishesSessionReplay`); `State<T>` goes generic over the Step-15a registry and `setup` instantiates the monomorphized router per `CaptureMode` (`router` for the analytics family, `session_replay_router` for recordings) — mounting an ingress on a table that cannot publish its family is a compile error, and the registry's runtime fatal backstop for a pipeline without a row goes structurally dead.
+- **AI pipeline membership is a name allowlist, resolved once into a stamp.** `AI_EVENT_NAMES` lists the event names on the lane; `DataType::from_event_name` resolves a name against it and stamps `DataType::AiEvents`, on every capture mode, mirroring v1's `Destination::AiEvents`. Everything downstream reads the stamp — `Pipeline::from_metadata` maps it, and the multipart and OTEL AI ingress stamp the same lane at the handler. The allowlist is deliberately not an `$ai_` prefix match: the Node AI pipeline DLQs anything it receives off its own `AI_EVENT_TYPES` list, so a prefixed-but-unlisted name like `$ai_call` must stay on the analytics lane. (The quota predicate `is_llm_event` is separate and *is* prefix-based.) There is no per-batch routing config and no per-deployment divert switch — the rollout-era `AiRouting` mode/allowlist/percentage machinery is retired, and so is the capture-mode predicate that replaced it. A deployment that wants AI traffic on a given topic points `CAPTURE_ANALYTICS_AI_EVENTS_TOPIC` at it.
+- **The AI lanes own dedicated topics.** `TopicTable` grows an `ai_events` row (`CAPTURE_ANALYTICS_AI_EVENTS_TOPIC`, required with default `events_plugin_ingestion_ai`) and an optional `ai_events_overflow` row (`..._OVERFLOW_TOPIC`); there is no `AiLane::Historical` — the divert decision wins over historical, matching v1. The AI overflow valve (overflow topic set) rides `PrepSpec` into `resolve`, so an unarmed deployment never routes the AI lane to overflow, force_overflow included.
+- **Import mode** is an analytics-family deployment on `router::router`; it mounts `/i/v0/ai/batch` (gated batch handler) but not the ai/otel handlers, and shares the Events topic requirements.
 
-### Per-pipeline output overrides and boot verification (Step 18 — superseded)
+### Handlers bound by publish capabilities (Step 27)
+
+The half of the per-mode registries Step 12 leaves behind: handlers bind on sealed capability traits (`PublishesAnalyticsFamily`, `PublishesSessionReplay`); `State<T>` goes generic over the Step-12 registry and `setup` instantiates the monomorphized router per `CaptureMode` (`router` for the analytics family, `session_replay_router` for recordings) — mounting an ingress on a table that cannot publish its family is a compile error, and the registry's runtime fatal backstop for a pipeline without a row goes structurally dead.
+
+### Per-pipeline output overrides and boot verification (Step 30 — superseded)
 
 Each row of a deployment's table can be retargeted independently: `CAPTURE_OUTPUT_<PIPELINE>_BROKERS` points a pipeline's row at another cluster, `CAPTURE_OUTPUT_<PIPELINE>_TOPIC_<LANE>` renames a lane's topic in that row's namespace (existing `KAFKA_*` keys stay the defaults). The row factory builds one sink per pipeline, each with its own `TopicTable` (base config overlaid with that pipeline's overrides via `TopicTable::with_overrides`); producers are shared per distinct broker set, so the no-override configuration still opens exactly one connection. The gating liveness handle lands on the cluster carrying the deployment's ingress pipeline; other clusters' producers are non-gating. Overrides compose only with the plain per-row Kafka path — combining them with S3 fallback or AI secondary routing is refused at boot, since those policy trees assume every row shares one primary cluster.
 
 `CAPTURE_VERIFY_TOPICS_ON_BOOT` (default off) probes cluster metadata for every topic a row can produce to — pipeline-scoped (`TopicTable::topics_for_pipeline`), so an overridden row probes only its own cluster's namespace — and refuses to start on a missing topic. Off by default because brokers with topic auto-creation make the check misleading (the metadata probe itself can create the topic).
 
-### Outputs as an open trait (Steps 19a–c)
+### Outputs as an open trait (Steps 31–33)
 
-`Outputs` is an open trait — a produce surface handling every destination its configuration maps — replacing the closed policy enum. Implementations own payload assembly, namespace realization, backend composition, and policy: `KafkaOutputs` (one cluster: prep + address→topic table + transport sink), `S3Outputs`, `PrintOutputs`/`NoopOutputs`, `FailoverOutputs` and `SplitOutputs` (policies over `Arc<dyn Outputs>`), and the per-mode tables themselves (dispatch-by-pipeline is just another surface; capability traits are markers over `Outputs`). Sinks are pure transport and never see an `Address`: the Kafka sink publishes realized records (concrete topic, key, payload, headers); namespace realization lives in the outputs layer. Per-event publish results are Step 19d, promoted into **Objective 2**.
+`Outputs` is an open trait — a produce surface handling every destination its configuration maps — replacing the closed policy enum. Implementations own payload assembly, namespace realization, backend composition, and policy: `KafkaOutputs` (one cluster: prep + address→topic table + transport sink), `S3Outputs`, `PrintOutputs`/`NoopOutputs`, `FailoverOutputs` and `SplitOutputs` (policies over `Arc<dyn Outputs>`), and the per-mode tables themselves (dispatch-by-pipeline is just another surface; capability traits are markers over `Outputs`). Sinks are pure transport and never see an `Address`: the Kafka sink publishes realized records (concrete topic, key, payload, headers); namespace realization lives in the outputs layer. Per-event publish results are Step 17, promoted into **Objective 2**.
 
 A test-only prototype (`outputs::dynamic`) demonstrates the coordinator-managed surface: `DynamicKafkaOutputs` subscribes to an in-process `KafkaManagerService` (RPC-shaped, acked config pushes) and applies broker add/remove and mapping changes with an enabled-partition set per address — the incremental, key-deterministic drain-and-switch — with tests simulating a topic switchover and a broker switchover end to end.
-
-### AI pipeline and Import mode (Step 13b)
-
-- **AI pipeline membership is a name allowlist, resolved once into a stamp.** `AI_EVENT_NAMES` lists the event names on the lane; `DataType::from_event_name` resolves a name against it and stamps `DataType::AiEvents`, on every capture mode, mirroring v1's `Destination::AiEvents`. Everything downstream reads the stamp — `Pipeline::from_metadata` maps it, and the multipart and OTEL AI ingress stamp the same lane at the handler. The allowlist is deliberately not an `$ai_` prefix match: the Node AI pipeline DLQs anything it receives off its own `AI_EVENT_TYPES` list, so a prefixed-but-unlisted name like `$ai_call` must stay on the analytics lane. (The quota predicate `is_llm_event` is separate and *is* prefix-based.) There is no per-batch routing config and no per-deployment divert switch — the rollout-era `AiRouting` mode/allowlist/percentage machinery is retired, and so is the capture-mode predicate that replaced it. A deployment that wants AI traffic on a given topic points `CAPTURE_ANALYTICS_AI_EVENTS_TOPIC` at it.
-- **The AI lanes own dedicated topics.** `TopicTable` grows an `ai_events` row (`CAPTURE_ANALYTICS_AI_EVENTS_TOPIC`, required with default `events_plugin_ingestion_ai`) and an optional `ai_events_overflow` row (`..._OVERFLOW_TOPIC`); there is no `AiLane::Historical` — the divert decision wins over historical, matching v1. The AI overflow valve (overflow topic set) rides `PrepSpec` into `resolve`, so an unarmed deployment never routes the AI lane to overflow, force_overflow included.
-- **Import mode** is an analytics-family deployment on `router::router`; it mounts `/i/v0/ai/batch` (gated batch handler) but not the ai/otel handlers, and shares the Events topic requirements.
 
 ## Repartitioning coordinator (design note)
 
@@ -306,7 +306,7 @@ Not built in this PR; this note records where it plugs in so nothing landed here
 
 **Logical shards, decided before the sinks.** The coordinator owns a stable shard function: `shard = hash(key) % N` over the same partition key the sink would hash, with coordinator-owned `N` (not either cluster's partition count). The shard is stamped at prep time — `AddressedPayload` grows `shard: Option<u32>`, `None` meaning "let the producer partition as today". Stamping at prep keeps the decision above the sinks: both clusters of a failover pair see the same shard on the same payload, so a switchover decision is consistent across targets by construction.
 
-**A `ShardRouted` output policy.** Routing lives in the outputs layer as a policy node holding two child outputs (old cluster, new cluster) and a swappable assignment table `shard → Old | New` (an `ArcSwap`, updated by the coordinator's control plane the same way the Step-27 control-plane seam works). Batch publish splits by assignment and forwards — scatter-gather like the old `Split` composite, no serialization changes (both clusters share the prep/serialization contract, as the retired AI-secondary split proved).
+**A `ShardRouted` output policy.** Routing lives in the outputs layer as a policy node holding two child outputs (old cluster, new cluster) and a swappable assignment table `shard → Old | New` (an `ArcSwap`, updated by the coordinator's control plane the same way the Step-21 control-plane seam works). Batch publish splits by assignment and forwards — scatter-gather like the old `Split` composite, no serialization changes (both clusters share the prep/serialization contract, as the retired AI-secondary split proved).
 
 **Explicit partition pass-through in the sink.** `ProduceRecord` grows `partition: Option<i32>`; the Kafka sink maps `shard` to a concrete partition of its own topic (its table realizes the namespace; a shard→ partition map is the same kind of sink-side data as topic names) and sets it on the record. `None` keeps today's key hashing. The sink still makes no routing decisions — it realizes an address (topic) and a shard (partition) in its own namespace.
 
@@ -326,9 +326,9 @@ The hold window is per-shard and bounded by one producer flush — that is the "
 
 - `AddressedPayload` — carries key + address; grows `shard`.
 - Outputs policy tree — `ShardRouted` slots in beside single/failover/split.
-- The Step-27 control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
+- The Step-21 control-plane seam — the pattern for the coordinator's assignment updates (swappable state, no request-path locks).
 - `ProduceRecord` — grows `partition`; sinks realize shard → partition.
-- Per-mode registry rows over per-output config (Steps 15a, 21) — a coordinator can retarget one pipeline's row without touching the rest of the deployment.
+- Per-mode registry rows over per-output config (Steps 9 and 12) — a coordinator can retarget one pipeline's row without touching the rest of the deployment.
 
 ## End state
 
@@ -338,8 +338,8 @@ When all steps land, the five strata hold:
 - **Outputs are the produce surface.** Every pipeline publishes through the `OutputRegistry`; the `Output` policy tree (single | failover) owns all multi-target behavior, composing the way the old sink composites did. The v0 `Event` trait and `FallbackSink` are gone; `SplitKafkaSink` already is, deleted with the retired AI secondary-cluster routing.
 - **Serialization is a seam.** Format × envelope per destination, with content headers carrying encoding coexistence (the lz4 replay design, generalized); a protobuf cutover is an output-level config change.
 - **Sinks are mechanism, and own their namespace.** Payloads carry the abstract `Address`; each sink realizes it in its own namespace at publish time (Kafka: its per-cluster topic table — the swappable seam a repartitioning coordinator plugs into; S3: the buffer path; print/noop: trivially). Sinks make no routing decisions; a failover pair can share one prepared batch because payloads are target-agnostic. Serialization stays output-level (a consumer contract, shared across targets).
-- **The failover switch is signal-drivable.** The failover output's target selection sits behind the Step-27 control-plane seam; a separate circuit-breaker service supplies the switch signals, capture supplies producer health, and a silent control plane holds the current target.
-- **One produce surface.** v1 publishes through the shared outputs machinery (Steps 20a–c); the legacy v1 sink stack, its `Router`/`Sink` traits, and `serialize_batch` are gone.
+- **The failover switch is signal-drivable.** The failover output's target selection sits behind the Step-21 control-plane seam; a separate circuit-breaker service supplies the switch signals, capture supplies producer health, and a silent control plane holds the current target.
+- **One produce surface.** v1 publishes through the shared outputs machinery (Steps 18–20); the legacy v1 sink stack, its `Router`/`Sink` traits, and `serialize_batch` are gone.
 
 ## Agent conventions
 
@@ -367,28 +367,28 @@ When all steps land, the five strata hold:
 | 7 · Outputs layer with policies; composites retired | done | `feat(capture): outputs layer owns the failover policy` |
 | 8a · Call sites on the table | done | `refactor(capture): call sites publish through outputs` |
 | 8b · `Event` retired | done | `refactor(capture): retire v0 Event trait` |
-| 21 · An output owns its connection and topics | pending | `refactor(capture): outputs carry their own connection and topic config` |
-| 26 · v1 config convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
-| 13a · Typed per-pipeline lanes | pending | `refactor(capture): typed per-pipeline lanes; custom redirects become addresses` |
-| 15a · Per-mode output registries | pending | `feat(capture): per-mode output registries with required rows` |
-| 22 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
-| 23 · Verify topics against the broker | pending | `feat(capture): verify each output's topics against its own broker at boot` |
-| 24 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
-| 25 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
-| 19d · Per-event publish results | objective 2 | `refactor(capture): Outputs::publish reports per-event results` |
-| 20a · v1 boundary mapping + parity oracle | objective 2 | `feat(capture): v1 boundary mapping onto the shared produce interchange` |
-| 20b · v1 publishes through shared outputs | objective 2 | `feat(capture): v1 endpoints publish through the shared outputs machinery` |
-| 20c · Legacy v1 sink stack deleted | objective 2 | `refactor(capture): delete the legacy v1 sink stack` |
-| 27 · Failover selection behind a control-plane seam | objective 3 | `feat(capture): failover target selection behind a control-plane seam` |
-| 28 · Producer health metrics out | objective 3 | `feat(capture): outputs report producer health for the breaker service` |
-| 29 · Switch signals in | objective 3 | `feat(capture): apply breaker switch signals to the failover output` |
-| 12 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
-| 13b · AI membership stamp; `AiRouting` retired | deferred | `refactor(capture): ai lane membership resolves once into a stamp` |
-| 14 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |
-| 15b · Handlers bound by publish capabilities | deferred | `feat(capture): handlers bound by publish capabilities over per-mode state` |
-| 16 · AI ingress family | deferred | `feat(capture): ai ingress is its own router family with its own capability` |
-| 17 · Topic tables injected into sinks | deferred | `refactor(capture): topic tables are sink-side data, injected at construction` |
-| 18 · Per-pipeline output overrides; boot topic verification | superseded | — (boot verification became Step 23; retargeting is configuration after Steps 21, 15a) |
-| 19a · Naming and import hygiene | deferred | `refactor(capture): replace remaining nested paths with imports` + `refactor(capture): name the session replay pipeline consistently` |
-| 19b · Outputs as an open trait; sinks pure transport | deferred | `refactor(capture): outputs own namespace realization; Outputs becomes an open trait` |
-| 19c · Dynamic outputs prototype | deferred | `feat(capture): prototype dynamic outputs with incremental switchover (test-only)` |
+| 9 · An output owns its connection and topics | pending | `refactor(capture): outputs carry their own connection and topic config` |
+| 10 · v1 config convergence | pending | `refactor(capture): v1 resolves through shared pipeline/lane strata` |
+| 11 · Typed per-pipeline lanes | pending | `refactor(capture): typed per-pipeline lanes; custom redirects become addresses` |
+| 12 · Per-mode output registries | pending | `feat(capture): per-mode output registries with required rows` |
+| 13 · A reachable output must be configured | pending | `feat(capture): require configuration for every reachable output` |
+| 14 · Verify topics against the broker | pending | `feat(capture): verify each output's topics against its own broker at boot` |
+| 15 · capture-analytics emergency fallback | pending | `feat(capture): emergency fallback output for capture-analytics` |
+| 16 · Retire the S3 fallback | pending | `refactor(capture): delete the s3 fallback output` |
+| 17 · Per-event publish results | objective 2 | `refactor(capture): Outputs::publish reports per-event results` |
+| 18 · v1 boundary mapping + parity oracle | objective 2 | `feat(capture): v1 boundary mapping onto the shared produce interchange` |
+| 19 · v1 publishes through shared outputs | objective 2 | `feat(capture): v1 endpoints publish through the shared outputs machinery` |
+| 20 · Legacy v1 sink stack deleted | objective 2 | `refactor(capture): delete the legacy v1 sink stack` |
+| 21 · Failover selection behind a control-plane seam | objective 3 | `feat(capture): failover target selection behind a control-plane seam` |
+| 22 · Producer health metrics out | objective 3 | `feat(capture): outputs report producer health for the breaker service` |
+| 23 · Switch signals in | objective 3 | `feat(capture): apply breaker switch signals to the failover output` |
+| 24 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
+| 25 · AI membership stamp; `AiRouting` retired | deferred | `refactor(capture): ai lane membership resolves once into a stamp` |
+| 26 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |
+| 27 · Handlers bound by publish capabilities | deferred | `feat(capture): handlers bound by publish capabilities over per-mode state` |
+| 28 · AI ingress family | deferred | `feat(capture): ai ingress is its own router family with its own capability` |
+| 29 · Topic tables injected into sinks | deferred | `refactor(capture): topic tables are sink-side data, injected at construction` |
+| 30 · Per-pipeline output overrides; boot topic verification | superseded | — (boot verification became Step 14; retargeting is configuration after Steps 9 and 12) |
+| 31 · Naming and import hygiene | deferred | `refactor(capture): replace remaining nested paths with imports` + `refactor(capture): name the session replay pipeline consistently` |
+| 32 · Outputs as an open trait; sinks pure transport | deferred | `refactor(capture): outputs own namespace realization; Outputs becomes an open trait` |
+| 33 · Dynamic outputs prototype | deferred | `feat(capture): prototype dynamic outputs with incremental switchover (test-only)` |

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -2,13 +2,13 @@
 
 Working contract for implementation agents. Steps 1–8 have shipped; each remaining step is one commit in its own PR.
 
-**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Stage D closes the first objective (the manual fallback); the second (one produce surface) and third (automated fallback) are then sequenced in order by promoting their steps into scheduled stages, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving no objective leaves as issues.
+**Retirement.** This doc dies when it schedules nothing and owns no unsequenced objective. Stage D closes the first objective (the manual fallback); the second (one produce surface) and third (automated fallback) are then sequenced in order by scheduling their steps, parity proofs intact. Whatever is still load-bearing at the end — the vocabulary rules, the ordering-vs-person-processing contract, the repartitioning design note — graduates into module docs or `v1/sinks/DESIGN.md` first, and only work serving no objective leaves as issues.
 
 ## Motivation
 
 **Three objectives, one mechanism: an output owns the configuration it produces with.**
 
-**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 13 and 14) are only buildable once configuration is isolated per output (Step 9) and demanded per mode (Step 12): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Stage D is this objective; Step 15 is the feature.
+**Objective 1 — ship a manual fallback.** If MSK degrades, capture-analytics must be able to produce to an alternative cluster — its brokers, its TLS, its own topic names — armed by one environment variable and a pod roll, and we must know the configuration is sound before any traffic moves. Running capture against a half-wired cluster is the risk this objective removes, and the boot-time checks that remove it (Steps 13 and 14) are only buildable once configuration is isolated per output (Step 9) and demanded per mode (Step 12): a single deployment-wide `KafkaConfig` with ten defaulted topic names is exactly what a startup check cannot verify, and a check that demands all ten rows on every pod can be armed nowhere. Stage D is its remaining work; Step 15 is the feature.
 
 **Objective 2 — one produce surface.** The v1 stack is live in production — capture-analytics runs its AI endpoint through it, capture-import runs on it wholesale — and it publishes through its own sinks, so a fallback wired into the outputs layer moves none of its traffic. Convergence is therefore coverage, not hygiene. Stage D already puts both stacks on one config model (Step 10); this objective finishes the job — one publish surface, per-event results, the legacy v1 sink stack deleted (Steps 17–20).
 
@@ -63,9 +63,9 @@ Steps 1–3 land together with this doc: the routing golden oracle, the pure `ro
 - The per-event response model (v1 `BatchResponse`) stays out of scope until objective 2 (Step 17); call sites keep folding per-event results into today's whole-request `CaptureError`.
 - Sinks read no `ProcessedEventMetadata`. After Step 6 the only consumer of routing metadata is lane resolution.
 
-## The stages and steps
+## Objective 1 — ship a manual fallback
 
-### Stage A — oracle and groundwork
+### Stage A — oracle and groundwork (shipped)
 
 #### Step 1 · Consolidate the routing golden oracle
 
@@ -82,7 +82,7 @@ This is the function Step 5 hoists out of the sink into lane resolution.
 One destination→topic wiring point plus refuse-to-boot on a blank topic, gated behind `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED` (default off; see Step 13's arming precondition).
 Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in at Step 13, where `(Pipeline, Lane)` makes the per-mode reachable set explicit.
 
-### Stage B — the two new seams (no caller-visible change)
+### Stage B — the two new seams (shipped; no caller-visible change)
 
 #### Step 4 · Serialization layer: format × envelope
 
@@ -105,7 +105,7 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 - **Risk / rollback.** Low-medium — mechanical relocation. Revert.
 - **Size.** M/L.
 
-### Stage C — sinks become mechanism, outputs become the API
+### Stage C — sinks become mechanism, outputs become the API (shipped)
 
 #### Step 6 · Narrow the Kafka sink to backend mechanism
 
@@ -248,7 +248,7 @@ Goal: v1 endpoints publish through the outputs layer like every other ingress, s
 
 ## Objective 3 — automated fallback (unsequenced)
 
-Capture's half of an automated fallback, and nothing more. The decision-maker is a separate circuit-breaker service; its internals — how it aggregates, when it trips, whether and how it probes — are outside this plan, and so are consumers. Capture's contract with the service is two channels: producer health metrics out, switch signals in. These steps are promoted into a scheduled stage, with parity proofs, when the objectives before them close; until then they are shapes, not commitments.
+Capture's half of an automated fallback, and nothing more. The decision-maker is a separate circuit-breaker service; its internals — how it aggregates, when it trips, whether and how it probes — are outside this plan, and so are consumers. Capture's contract with the service is two channels: producer health metrics out, switch signals in. These steps are scheduled, with parity proofs, when the objectives before them close; until then they are shapes, not commitments.
 
 ### Step 21 · Failover target selection behind a control-plane seam
 
@@ -266,11 +266,9 @@ An earlier in-process breaker step (`FailoverMode::Breaker`) dissolved into this
 
 ## Deferred work
 
-Not scheduled, and serving no objective directly. Revive a step by moving it back into a stage above, with its parity proof intact. Step 30 is superseded rather than deferred — its boot verification became Step 14, and retargeting a row is plain configuration once outputs own their config (Steps 9 and 12).
+Not scheduled, and serving no objective directly. Revive a step by moving it under an objective above, with its parity proof intact. Step 30 is superseded rather than deferred — its boot verification became Step 14, and retargeting a row is plain configuration once outputs own their config (Steps 9 and 12).
 
-### Stage E — prep hoists up; sinks become pure transport
-
-#### Step 24 · Prep hoists into the outputs layer; `PublishEvents` retired
+### Prep hoists into the outputs layer; `PublishEvents` retired (Step 24)
 
 - **Goal.** Sinks take prepared payloads as input, full stop. `PrepSpec` (registry + per-destination serializers) moves payload assembly — lane resolution, serialization, header stamps, topic and partition key, and the scatter-gather batch prep — into the outputs layer; the `(pipeline, lane)` → output bridge and the `TopicTable` move with it (`outputs::topics`). The `PublishEvents` trait is deleted; every backend (Kafka, S3, print, noop) preps identically via its output's spec, and the Kafka sink is reduced to producer + enqueue + ack drain. The boot completeness check moves to `setup::create_output`.
 - **Test posture change (deliberate).** Capturing mocks intercept *published payloads*, not `ProcessedEvent`s, so ~60 assertions that read metadata stamps migrate to wire-level outcomes: topic, partition key, headers, and payload bytes (deserialized for content checks). The declarative `ExpectedEvent` checkers recompute the expected record from the same expectations, so test bodies stay put. Wire-level assertions also pin a semantic the metadata-level ones couldn't see: replay events redirected to dlq/custom topics partition on the event key, not the session id.

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -27,7 +27,8 @@ Layer `rust/capture`'s produce path into five strata with one-way dependencies:
 ```text
 edge              → Pipeline {Analytics, Heatmaps, Warnings, ErrorTracking, Replay}
 pipeline steps    → stamp intent (restrictions, overflow, historical)
-lane resolution   → Lane {Main, Overflow, Historical, Dlq, Custom} + key policy + headers
+lane resolution   → Address {(Pipeline, Lane {Main, Overflow, Historical}) | Dlq | Custom(topic)}
+                     + key policy + headers
 outputs           → (Pipeline, Lane) → output = 1..n targets + selection policy
                      (single | failover(health) | split(token) | dual-write(pct))
 serialization     → per-output: format (json | protobuf…) × envelope (none | lz4);
@@ -97,8 +98,8 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 
 - **Goal.** Introduce the address pair and relocate the decision logic:
   - `Pipeline { Analytics, Heatmaps, Warnings, ErrorTracking, Replay }` (`Pipeline::from_data_type` extracts the pipeline half of `DataType`).
-  - `Lane { Main, Overflow, Historical, Dlq, Custom(&str) }`.
-  - `pipeline::resolve(&ProcessedEventMetadata) -> Result<LaneDecision { pipeline, lane, ordering }, CaptureError>` — Step-2's `route()` moved out of the sink module wholesale, precedence unchanged (dlq > custom > historical > overflow > main), pure (no counters, no headers, no I/O). `OrderingGuarantee` moves with it as decision *data*.
+  - `Lane { Main, Overflow, Historical }`, with `Address` carrying the admin redirects (`Dlq`, `Custom(topic)`) outside the lane model.
+  - `pipeline::resolve(&ProcessedEventMetadata) -> Result<AddressDecision { address, ordering }, CaptureError>` — Step-2's `route()` moved out of the sink module wholesale, precedence unchanged (dlq > custom > historical > overflow > main), pure (no counters, no headers, no I/O). `OrderingGuarantee` moves with it as decision *data*.
   - The sink keeps a private `output_for((pipeline, lane)) -> Output` bridge and still *invokes* `resolve` from its prep path — the invocation site moves up in Step 7 when the outputs layer exists to own it. This keeps the commit a pure relocation: no metadata changes, no call-site changes, goldens byte-identical.
 - **Files.** `rust/capture/src/pipeline.rs` (new); `rust/capture/src/sinks/kafka.rs` (drops `route()`/`Route`/`OrderingGuarantee`, gains the `output_for` bridge); `rust/capture/src/lib.rs`.
 - **Parity proof.** Step-1 goldens unmodified. `route()`'s precedence tests move to `pipeline::tests` with assertions preserved, plus a pipeline classification test.
@@ -152,9 +153,9 @@ Step 7 absorbs it into the `OutputRegistry`; the mode-scoped demand is folded in
 
 ### Step 11 · Typed per-pipeline lanes
 
-- **Goal.** Lanes become types per pipeline — `AnalyticsLane`, `AiLane`, `SessionReplayLane`, `BasicLane` — so invalid `(pipeline, lane)` pairs are unrepresentable, and admin custom redirects become addresses carrying their own topic outside the lane model: the vocabulary rules above, made code. `resolve` constructs addresses; pipeline and lane kind become projections.
+- **Goal.** Lanes become types per pipeline — `AnalyticsLane`, `AiLane`, `SessionReplayLane`, `BasicLane` — so invalid `(pipeline, lane)` pairs are unrepresentable: the rest of the vocabulary rules above, made code (admin redirects already sit outside the lane model as `Address::Dlq` / `Address::Custom`). There is no `AiLane::Historical` — the AI divert wins over historical, matching v1. Pipeline and lane kind become projections.
 - **Why it sits here.** Step 12's registry rows demand topics per lane. With the flat `Lane`, the set of valid lanes per pipeline is runtime knowledge, and the registry keeps a fatal backstop for pairs routing never produces. Typed lanes make the demand total: the fields a row requires are exactly the addresses that exist.
-- **Scope.** The address model only. The AI membership rework (allowlist stamp, `AiRouting` retirement) stays deferred as Step 25.
+- **Scope.** The address model only.
 - **Parity proof.** Step-1 goldens unmodified; `resolve` precedence tests retyped with assertions preserved.
 - **Size.** M/L.
 
@@ -268,12 +269,6 @@ Not scheduled, and serving no objective directly. Revive a step by moving it und
 - **Files.** `outputs/mod.rs`, `outputs/registry.rs` (moved), `sinks/*`, `setup.rs`, all capturing test mocks.
 - **Size.** L.
 
-### AI pipeline and Import mode (Step 25)
-
-- **AI pipeline membership is a name allowlist, resolved once into a stamp.** `AI_EVENT_NAMES` lists the event names on the lane; `DataType::from_event_name` resolves a name against it and stamps `DataType::AiEvents`, on every capture mode, mirroring v1's `Destination::AiEvents`. Everything downstream reads the stamp — `Pipeline::from_metadata` maps it, and the multipart and OTEL AI ingress stamp the same lane at the handler. The allowlist is deliberately not an `$ai_` prefix match: the Node AI pipeline DLQs anything it receives off its own `AI_EVENT_TYPES` list, so a prefixed-but-unlisted name like `$ai_call` must stay on the analytics lane. (The quota predicate `is_llm_event` is separate and *is* prefix-based.) There is no per-batch routing config and no per-deployment divert switch — the rollout-era `AiRouting` mode/allowlist/percentage machinery is retired, and so is the capture-mode predicate that replaced it. A deployment that wants AI traffic on a given topic points `CAPTURE_ANALYTICS_AI_EVENTS_TOPIC` at it.
-- **The AI lanes own dedicated topics.** `TopicTable` grows an `ai_events` row (`CAPTURE_ANALYTICS_AI_EVENTS_TOPIC`, required with default `events_plugin_ingestion_ai`) and an optional `ai_events_overflow` row (`..._OVERFLOW_TOPIC`); there is no `AiLane::Historical` — the divert decision wins over historical, matching v1. The AI overflow valve (overflow topic set) rides `PrepSpec` into `resolve`, so an unarmed deployment never routes the AI lane to overflow, force_overflow included.
-- **Import mode** is an analytics-family deployment on `router::router`; it mounts `/i/v0/ai/batch` (gated batch handler) but not the ai/otel handlers, and shares the Events topic requirements.
-
 ### Handlers bound by publish capabilities (Step 27)
 
 The half of the per-mode registries Step 12 leaves behind: handlers bind on sealed capability traits (`PublishesAnalyticsFamily`, `PublishesSessionReplay`); `State<T>` goes generic over the Step-12 registry and `setup` instantiates the monomorphized router per `CaptureMode` (`router` for the analytics family, `session_replay_router` for recordings) — mounting an ingress on a table that cannot publish its family is a compile error, and the registry's runtime fatal backstop for a pipeline without a row goes structurally dead.
@@ -373,7 +368,7 @@ When all steps land, the five strata hold:
 | 22 · Producer health metrics out | objective 3 | `feat(capture): outputs report producer health for the breaker service` |
 | 23 · Switch signals in | objective 3 | `feat(capture): apply breaker switch signals to the failover output` |
 | 24 · Prep hoist; `PublishEvents` retired | deferred | `refactor(capture): hoist prep into outputs; sinks take prepared payloads only` |
-| 25 · AI membership stamp; `AiRouting` retired | deferred | `refactor(capture): ai lane membership resolves once into a stamp` |
+| 25 · AI membership stamp; `AiRouting` retired | done | — (landed with the AI lane rollout, outside this plan's sequence) |
 | 26 · Sinks realize namespaces | deferred | `refactor(capture): payloads carry addresses; sinks realize them in their own namespace` |
 | 27 · Handlers bound by publish capabilities | deferred | `feat(capture): handlers bound by publish capabilities over per-mode state` |
 | 28 · AI ingress family | deferred | `feat(capture): ai ingress is its own router family with its own capability` |


### PR DESCRIPTION
## Problem

The plan sequenced three drivers — breaker-driven failover, cluster migration by split/dual-write, and a protobuf cutover behind the serialization seam. Configuring an output independently was not one of them.

So the pieces needed to point one output at a different cluster ended up scattered across the uncommitted back half: mode-scoped completeness in step 9, per-mode config shape in 15, topic tables injected at construction in 17, and boot topic verification in 18 — which additionally **refuses** the combination outright: *"combining them with S3 fallback or AI secondary routing is refused at boot, since those policy trees assume every row shares one primary cluster."*

`Output::failover` has composed two arbitrary outputs since step 7. What it lacks is targets that can be configured independently of each other.

## Changes

Docs only. No code.

**The driver becomes the mechanism, not a feature:** an output owns the configuration it produces with. Three steps:

- **F1 · An output owns its connection and its topics.** Every leaf output is built from an output-scoped config block — brokers, TLS, that output's own topic names — instead of reading the one deployment-wide `KafkaConfig`. Two Kafka outputs in the same tree can then name different clusters and different topics. Explicit non-goal: how any particular fallback is triggered or armed. That is a consumer of this mechanism, specified separately.
- **F2 · A reachable output must be configured.** The requirement lives in code: an output the deployment's `CaptureMode` can reach must be fully configured or capture refuses to boot; an unreachable one is never asked for. **The `#[envconfig(default = ...)]` on each topic field goes** — that default is what makes a missing or misspelled variable resolve to a compiled-in name instead of failing. Supersedes `CAPTURE_OUTPUTS_COMPLETENESS_CHECK_ENABLED`, which demands all ten destinations on every pod and so can be armed nowhere.
- **F3 · Verify an output's topics against its own broker.** At boot, probe each reachable output's cluster metadata and refuse to start on a missing topic — per output, against that output's own broker, so a target pointed at a half-provisioned cluster fails before it can take traffic. Kept separate from F2 because F2 is config-only and never touches a broker: "is this wired" versus "does this exist on the cluster we are about to produce to". Default off, since brokers with topic auto-creation can create the topic the probe is checking.

**Steps 10–20 move to Deferred** with their parity proofs intact, marked `deferred` in the tracker rather than deleted, revived by moving one back into a stage above. Each becomes cheaper once outputs are independently configurable, not more expensive.

**The doc now retires with F3** rather than with step 20c, so it does not outlive the work it schedules.

### What F2 and F3 would already have caught

`KAFKA_REPLAY_OVERFLOW_TOPIC` appears in **no file** in the charts repo, while `(Pipeline::Replay, Lane::Overflow) → Destination::SessionReplayOverflow` is a reachable route with a passing test. Replay overflow therefore resolves to the compiled-in `session_recording_snapshot_item_overflow`, while prod-us replay wires `ingestion-sessionreplay-overflow-64` under `KAFKA_OVERFLOW_TOPIC`.

F2 fails that at boot as a reachable output with no configured topic; F3 fails it too if the defaulted name is absent from the cluster. Unconfirmed and predating this plan — worth checking where that traffic lands today.

## How did you test this code?

Docs only — nothing to run. Every claim about current behaviour was checked against the tree: the `#[envconfig(default)]` on each topic field, `check_complete` walking all of `Destination::REGISTERED`, `KafkaSinkBase` already holding its own `Arc<TopicTable>`, `Output::failover` composing two arbitrary outputs, and the charts grep for `KAFKA_REPLAY_OVERFLOW_TOPIC`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This PR is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude in a Claude Code session, from the author's decision to prioritise per-output configuration and defer the rest.
- The author's calls: outputs get proper per-output config rather than a boot-time rewrite of one shared config; the requirement to be configured lives in code rather than in a charts audit; steps 7–8 land while 9–20 freeze.
- The first commit here wrote the stage around the existing prototype's arming mechanism; the second corrects it to specify the mechanism only.
