### PR TITLE
feat(ingestion-consumer): commit ledger frontiers

### DIFF
--- a/rust/ingestion-consumer/README.md
+++ b/rust/ingestion-consumer/README.md
@@ -35,7 +35,7 @@ Every delivered message is charged to its partition's ledger during collection, 
 `ingestion_consumer_ledger_uncommitted_offsets{topic,partition}` gauges each partition's window depth; `ingestion_consumer_ledger_uncommitted_events` and `ingestion_consumer_ledger_uncommitted_bytes` gauge the charge those offsets carry, where bytes is the payload plus key plus headers of each message.
 `ingestion_consumer_ledger_stale_slices_total{stage}` counts charges and settlements dropped because their partition was reassigned while they were in flight; a few around a rebalance are expected.
 `ingestion_consumer_ledger_errors_total{stage,kind}` counts contract violations in the ledger's accounting; it must stay 0. A violation resets that partition's ledger, and the consumer keeps running.
-`CONSUMER_OFFSET_LEDGER_SHADOW_ENABLED` (default `true`) is the kill switch: off, the consumer builds no ledger at all, so nothing is charged, settled, forgotten on rebalance, or reported.
+`CONSUMER_OFFSET_LEDGER_MODE` selects the source of offset commits: `off` commits the per-batch max offset and builds no ledger at all, so nothing is charged, settled, forgotten on rebalance, or reported; `shadow` (default) commits the same offset and compares the ledger frontier with it; `commit` commits the ledger frontier after that comparison, and a partition that settles without a frontier stays on its last commit.
 
 ## Debug API
 

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use common_continuous_profiling::ContinuousProfilingConfig;
 use envconfig::Envconfig;
 use rdkafka::ClientConfig;
@@ -6,6 +8,30 @@ use tracing::info;
 use crate::discovery::DiscoveryMode;
 use crate::routing::RoutingStrategy;
 use common_kafka_consumer::config::ConsumerConfigBuilder;
+
+/// Whether the offset ledger observes the commit path or owns it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum LedgerMode {
+    /// Compare the ledger frontier to the existing commit path.
+    #[default]
+    Shadow,
+    /// Commit the ledger frontier after the comparison.
+    Commit,
+}
+
+impl FromStr for LedgerMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_lowercase().as_str() {
+            "shadow" => Ok(Self::Shadow),
+            "commit" => Ok(Self::Commit),
+            other => Err(format!(
+                "unknown consumer offset ledger mode '{other}' (expected 'shadow' or 'commit')"
+            )),
+        }
+    }
+}
 
 /// Configuration for the ingestion consumer.
 ///
@@ -167,6 +193,12 @@ pub struct Config {
     /// CONSUMER_MAX_BACKGROUND_TASKS setting used by the Kafka consumer wrapper.
     #[envconfig(from = "CONSUMER_MAX_BACKGROUND_TASKS", default = "1")]
     pub consumer_max_background_tasks: usize,
+
+    /// The source of offset commits. `shadow` compares the shared ledger
+    /// frontier with the current calculation, while `commit` commits the
+    /// frontier after that comparison.
+    #[envconfig(from = "CONSUMER_OFFSET_LEDGER_MODE", default = "shadow")]
+    pub consumer_offset_ledger_mode: LedgerMode,
 
     // ---- Debug API ----
     /// Serve the real-time debug API (`/debug/load`, `/debug/state`,
@@ -472,5 +504,18 @@ impl Config {
         builder = builder.strip_classic_protocol_keys_if_consumer();
 
         builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LedgerMode;
+    use std::str::FromStr;
+
+    #[test]
+    fn ledger_mode_parses_known_values() {
+        assert_eq!(LedgerMode::from_str(" SHADOW "), Ok(LedgerMode::Shadow));
+        assert_eq!(LedgerMode::from_str("commit"), Ok(LedgerMode::Commit));
+        assert!(LedgerMode::from_str("off").is_err());
     }
 }

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -9,10 +9,14 @@ use crate::discovery::DiscoveryMode;
 use crate::routing::RoutingStrategy;
 use common_kafka_consumer::config::ConsumerConfigBuilder;
 
-/// Whether the offset ledger observes the commit path or owns it.
+/// Whether the consumer keeps an offset ledger, and whether that ledger
+/// observes the commit path or owns it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum LedgerMode {
-    /// Compare the ledger frontier to the existing commit path.
+    /// No ledger: commit the per-batch max offset as before. Nothing is
+    /// charged, settled, forgotten on rebalance, or reported.
+    Off,
+    /// Commit the per-batch max offset and compare the ledger frontier to it.
     #[default]
     Shadow,
     /// Commit the ledger frontier after the comparison.
@@ -24,10 +28,11 @@ impl FromStr for LedgerMode {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value.trim().to_lowercase().as_str() {
+            "off" => Ok(Self::Off),
             "shadow" => Ok(Self::Shadow),
             "commit" => Ok(Self::Commit),
             other => Err(format!(
-                "unknown consumer offset ledger mode '{other}' (expected 'shadow' or 'commit')"
+                "unknown consumer offset ledger mode '{other}' (expected 'off', 'shadow' or 'commit')"
             )),
         }
     }
@@ -194,9 +199,11 @@ pub struct Config {
     #[envconfig(from = "CONSUMER_MAX_BACKGROUND_TASKS", default = "1")]
     pub consumer_max_background_tasks: usize,
 
-    /// The source of offset commits. `shadow` compares the shared ledger
-    /// frontier with the current calculation, while `commit` commits the
-    /// frontier after that comparison.
+    /// The source of offset commits. `off` commits the per-batch max offset
+    /// and keeps no ledger. `shadow` commits the same offset and compares the
+    /// ledger frontier with it, reporting disagreements. `commit` commits the
+    /// ledger frontier after that comparison. Fall back to `off` only if the
+    /// ledger's accounting or metrics are implicated in a problem.
     #[envconfig(from = "CONSUMER_OFFSET_LEDGER_MODE", default = "shadow")]
     pub consumer_offset_ledger_mode: LedgerMode,
 
@@ -229,15 +236,6 @@ pub struct Config {
     pub consumer_order_sentinel_enabled: bool,
 
     // ---- Offset ledger ----
-    /// Kill switch for the shadow offset ledger. The ledger accounts every
-    /// delivered offset and reports where its frontier disagrees with the
-    /// offset the consumer commits; it never changes what is committed.
-    /// Off, the consumer builds no ledger: nothing is charged, settled,
-    /// forgotten on rebalance, or reported. Disable it only if its
-    /// accounting or metrics are implicated in a problem.
-    #[envconfig(from = "CONSUMER_OFFSET_LEDGER_SHADOW_ENABLED", default = "true")]
-    pub consumer_offset_ledger_shadow_enabled: bool,
-
     // ---- Worker transport ----
     /// Comma-separated list of worker HTTP URLs. Readiness probes hit these
     /// directly; each worker's gRPC stream address is derived from its URL's
@@ -514,8 +512,9 @@ mod tests {
 
     #[test]
     fn ledger_mode_parses_known_values() {
+        assert_eq!(LedgerMode::from_str("off"), Ok(LedgerMode::Off));
         assert_eq!(LedgerMode::from_str(" SHADOW "), Ok(LedgerMode::Shadow));
         assert_eq!(LedgerMode::from_str("commit"), Ok(LedgerMode::Commit));
-        assert!(LedgerMode::from_str("off").is_err());
+        assert!(LedgerMode::from_str("on").is_err());
     }
 }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use common_kafka_consumer::{
-    Charge, GroupCompletion, Offset, Partition, TopicOffsetLedger, TopicPartition,
+    Charge, GroupCompletion, Offset, Partition, Settlement, TopicOffsetLedger, TopicPartition,
 };
 use futures::StreamExt;
 use lifecycle::Handle;
@@ -16,7 +16,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use crate::batcher::{make_batch_id, Batcher, BatcherOutputs};
-use crate::config::Config;
+use crate::config::{Config, LedgerMode};
 use crate::debug_recorder::{record_if, DebugEventKind, DebugRecorder, PartitionOffset};
 use crate::discovery::DiscoveryMode;
 use crate::dispatcher::Dispatcher;
@@ -200,6 +200,8 @@ pub struct IngestionConsumerOptions {
     pub deferred_flush_timeout: Duration,
     /// Debug event recorder; `None` unless `DEBUG_API_ENABLED`.
     pub debug_recorder: Option<Arc<DebugRecorder>>,
+    /// Whether the offset ledger observes or owns the commit path.
+    pub ledger_mode: LedgerMode,
 }
 
 /// The main consumer loop: reads from Kafka, demuxes each poll into groups,
@@ -224,6 +226,8 @@ pub struct IngestionConsumer {
     /// Debug event recorder; `None` unless `DEBUG_API_ENABLED`.
     debug_recorder: Option<Arc<DebugRecorder>>,
     ledger_shadow: LedgerShadow,
+    /// Selects whether commits come from the batch spans or the ledger.
+    ledger_mode: LedgerMode,
 }
 
 impl IngestionConsumer {
@@ -255,6 +259,7 @@ impl IngestionConsumer {
             commit_sentinel,
             debug_recorder: options.debug_recorder,
             ledger_shadow: LedgerShadow::new(topic_offset_ledger),
+            ledger_mode: options.ledger_mode,
             consumer: Arc::new(consumer),
             batcher,
             outputs: Some(outputs),
@@ -329,6 +334,7 @@ impl IngestionConsumer {
             commit_sentinel,
             debug_recorder,
             ledger_shadow: LedgerShadow::new(topic_offset_ledger),
+            ledger_mode: config.consumer_offset_ledger_mode,
             batcher,
             outputs: Some(outputs),
             transport,
@@ -691,7 +697,8 @@ impl IngestionConsumer {
         })
     }
 
-    /// Commit the max offset for each topic-partition.
+    /// Commit either the existing per-batch max offset or the verified ledger
+    /// frontier for each topic-partition.
     fn commit_offsets(
         &self,
         partitions: &HashMap<TopicPartition, PartitionDeliveries>,
@@ -704,37 +711,116 @@ impl IngestionConsumer {
             return Ok(());
         }
 
-        // Validate contiguity/monotonicity per partition before committing, so
-        // a violation is attributed to the batch that caused it.
-        self.commit_sentinel.check_commit(
+        match self.ledger_mode {
+            LedgerMode::Shadow => self.commit_offset_spans(partitions),
+            LedgerMode::Commit => self.commit_frontiers(partitions),
+        }
+    }
+
+    /// Shadow mode: commit the per-batch max offsets unchanged, then settle
+    /// the ledger against them for comparison only.
+    fn commit_offset_spans(
+        &self,
+        partitions: &HashMap<TopicPartition, PartitionDeliveries>,
+    ) -> anyhow::Result<()> {
+        self.submit_commit(
             partitions
                 .iter()
                 .map(|(topic_partition, partition)| (topic_partition, &partition.span)),
-        );
+        )?;
+        for (topic_partition, partition) in partitions {
+            if self.settle(topic_partition, partition).is_some() {
+                self.ledger_shadow.drain(topic_partition);
+            }
+        }
+        Ok(())
+    }
+
+    /// Commit mode: settle the batch against the ledger and commit each
+    /// partition's frontier. A partition without a frontier is not committed
+    /// and stays on its last committed offset.
+    fn commit_frontiers(
+        &self,
+        partitions: &HashMap<TopicPartition, PartitionDeliveries>,
+    ) -> anyhow::Result<()> {
+        let mut settled = Vec::with_capacity(partitions.len());
+        let mut frontier_spans = Vec::with_capacity(partitions.len());
+        for (topic_partition, partition) in partitions {
+            let Some(settlement) = self.settle(topic_partition, partition) else {
+                continue;
+            };
+            settled.push(topic_partition);
+            if let Some(span) = frontier_span(&partition.span, settlement.frontier) {
+                frontier_spans.push((topic_partition, span));
+            }
+        }
+
+        if frontier_spans.is_empty() {
+            warn!("No ledger frontier available for completed offsets; skipping commit");
+            return Ok(());
+        }
+
+        self.submit_commit(
+            frontier_spans
+                .iter()
+                .map(|(topic_partition, span)| (*topic_partition, span)),
+        )?;
+        for topic_partition in settled {
+            self.ledger_shadow.drain(topic_partition);
+        }
+        Ok(())
+    }
+
+    /// Settle one partition's slice of a batch against the ledger.
+    fn settle(
+        &self,
+        topic_partition: &TopicPartition,
+        partition: &PartitionDeliveries,
+    ) -> Option<Settlement> {
+        self.ledger_shadow.settle(
+            topic_partition,
+            partition.generation,
+            partition.charges.iter().map(|(offset, _)| *offset),
+            &partition.span,
+        )
+    }
+
+    /// Validate and submit one commit to Kafka.
+    fn submit_commit<'a>(
+        &self,
+        spans: impl IntoIterator<Item = (&'a TopicPartition, &'a OffsetSpan)>,
+    ) -> anyhow::Result<()> {
+        let spans: Vec<_> = spans.into_iter().collect();
+        // Validate contiguity/monotonicity per partition before committing, so
+        // a violation is attributed to the batch that caused it.
+        self.commit_sentinel.check_commit(spans.iter().copied());
 
         let mut tpl = TopicPartitionList::new();
-        for (topic_partition, partition) in partitions {
+        for (topic_partition, span) in &spans {
             // Commit offset + 1 (Kafka convention: committed offset = next to read)
             tpl.add_partition_offset(
                 &topic_partition.topic,
                 topic_partition.partition,
-                rdkafka::Offset::Offset(partition.span.last + 1),
+                rdkafka::Offset::Offset(span.last + 1),
             )?;
         }
 
         self.consumer.commit(&tpl, CommitMode::Async)?;
-        for (topic_partition, partition) in partitions {
-            self.ledger_shadow.settle(
-                topic_partition,
-                partition.generation,
-                partition.charges.iter().map(|(offset, _)| *offset),
-                &partition.span,
-            );
-        }
         counter!("ingestion_consumer_offset_commits_total").increment(1);
 
         Ok(())
     }
+}
+
+/// Map a settled frontier back to the span the commit path submits: the
+/// frontier is next-to-read and the span is last-processed, so the commit
+/// adds the 1 back and submits the frontier verbatim. `None` for a partition
+/// that settled without a frontier; it stays on its last commit.
+fn frontier_span(span: &OffsetSpan, frontier: Option<Offset>) -> Option<OffsetSpan> {
+    frontier.map(|frontier| OffsetSpan {
+        first: span.first,
+        last: frontier.0 - 1,
+    })
 }
 
 /// Emit the per-poll parity metrics (received counts, batch sizes,
@@ -1010,5 +1096,37 @@ mod tests {
 
         assert_eq!(in_flight[0].covered, 0);
         assert_eq!(in_flight[0].accepted, 0);
+    }
+
+    #[test]
+    fn frontier_span_submits_the_frontier_verbatim() {
+        let span = OffsetSpan {
+            first: 10,
+            last: 11,
+        };
+        assert_eq!(
+            frontier_span(&span, Some(Offset(12))),
+            Some(OffsetSpan {
+                first: 10,
+                last: 11
+            })
+        );
+        assert_eq!(
+            frontier_span(&span, Some(Offset(11))),
+            Some(OffsetSpan {
+                first: 10,
+                last: 10
+            }),
+            "a frontier trailing the span wins"
+        );
+    }
+
+    #[test]
+    fn a_partition_without_a_frontier_is_not_committed() {
+        let span = OffsetSpan {
+            first: 20,
+            last: 21,
+        };
+        assert_eq!(frontier_span(&span, None), None);
     }
 }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -245,8 +245,9 @@ impl IngestionConsumer {
     ) -> Self {
         // Share the context's commit sentinel and ledger so rebalance
         // callbacks reset the same baselines the commit path checks against.
-        // The shadow runs whenever the context carries a ledger: `new` reads
-        // the kill switch, and a detached context always carries one.
+        // The shadow runs whenever the context carries a ledger: `new` builds
+        // one unless the mode is off, and a detached context always carries
+        // one.
         let commit_sentinel = consumer.context().commit_sentinel();
         let topic_offset_ledger = consumer.context().topic_offset_ledger();
         let (batcher, outputs) = Batcher::new(
@@ -307,8 +308,7 @@ impl IngestionConsumer {
         key_sentinel.set_enabled(config.consumer_order_sentinel_enabled);
         // Off, the consumer has no ledger at all: the rebalance callbacks
         // have nothing to forget and the shadow nothing to charge.
-        let topic_offset_ledger = config
-            .consumer_offset_ledger_shadow_enabled
+        let topic_offset_ledger = (config.consumer_offset_ledger_mode != LedgerMode::Off)
             .then(|| Arc::new(TopicOffsetLedger::new()));
         let mut context = SentinelContext::new(
             Arc::clone(&commit_sentinel),
@@ -712,13 +712,14 @@ impl IngestionConsumer {
         }
 
         match self.ledger_mode {
-            LedgerMode::Shadow => self.commit_offset_spans(partitions),
+            LedgerMode::Off | LedgerMode::Shadow => self.commit_offset_spans(partitions),
             LedgerMode::Commit => self.commit_frontiers(partitions),
         }
     }
 
-    /// Shadow mode: commit the per-batch max offsets unchanged, then settle
-    /// the ledger against them for comparison only.
+    /// Off and shadow modes: commit the per-batch max offsets unchanged, then
+    /// settle the ledger against them for comparison only. Off has no ledger,
+    /// so the settlement is a no-op there.
     fn commit_offset_spans(
         &self,
         partitions: &HashMap<TopicPartition, PartitionDeliveries>,

--- a/rust/ingestion-consumer/src/ledger_shadow.rs
+++ b/rust/ingestion-consumer/src/ledger_shadow.rs
@@ -14,8 +14,8 @@ use tracing::{info, warn};
 use crate::order_sentinel::OffsetSpan;
 
 /// Runs the offset ledger next to the current commit path without taking
-/// part in commit choice. Without a ledger every call is a no-op: the kill
-/// switch leaves the consumer with no ledger at all, so nothing is charged,
+/// part in commit choice. Without a ledger every call is a no-op: the off
+/// mode leaves the consumer with no ledger at all, so nothing is charged,
 /// settled, or forgotten anywhere.
 pub(crate) struct LedgerShadow {
     ledger: Option<Arc<TopicOffsetLedger>>,

--- a/rust/ingestion-consumer/src/ledger_shadow.rs
+++ b/rust/ingestion-consumer/src/ledger_shadow.rs
@@ -67,27 +67,37 @@ impl LedgerShadow {
         }
     }
 
-    /// Settle one batch's slice of a partition: complete its offsets, compare
-    /// the frontier with the commit the batch submits, and drain the
-    /// completed prefix.
+    /// Settle one batch's slice of a partition: complete its offsets and
+    /// compare the frontier with the commit the batch submits. Returns the
+    /// settlement, or `None` when the ledger rejected the slice. The window
+    /// holds the offsets until `drain`.
     pub(crate) fn settle(
         &self,
         topic_partition: &TopicPartition,
         stamp: u64,
         offsets: impl IntoIterator<Item = Offset>,
         span: &OffsetSpan,
-    ) {
+    ) -> Option<Settlement> {
         let Some(ledger) = &self.ledger else {
-            return;
+            return None;
         };
         let settlement = match ledger.settle(topic_partition, stamp, offsets) {
             Ok(settlement) => settlement,
             Err(rejection) => {
                 count_rejection("settle", topic_partition, rejection);
-                return;
+                return None;
             }
         };
         self.observe(topic_partition, &settlement, span, stamp);
+        Some(settlement)
+    }
+
+    /// Drain a settled partition's completed prefix and publish what its
+    /// window still holds.
+    pub(crate) fn drain(&self, topic_partition: &TopicPartition) {
+        let Some(ledger) = &self.ledger else {
+            return;
+        };
         ledger.take_frontier(topic_partition);
         set_held_gauges(
             &topic_partition.topic,
@@ -268,19 +278,20 @@ mod tests {
         ledger.forget_partitions([("events", 0)]);
         shadow.charge(&reassigned, 1, &charges(&[10]));
 
-        shadow.settle(&reassigned, 0, [Offset(10)], &span(10, 10));
-        shadow.settle(&live, 0, [Offset(20)], &span(20, 20));
-
-        assert_eq!(
-            ledger.held(&reassigned).offsets,
-            1,
+        assert!(
+            shadow
+                .settle(&reassigned, 0, [Offset(10)], &span(10, 10))
+                .is_none(),
             "the stale batch settles nothing against the new ledger"
         );
-        assert_eq!(
-            ledger.held(&live).offsets,
-            0,
-            "the live batch settles and drains"
-        );
+        let settlement = shadow
+            .settle(&live, 0, [Offset(20)], &span(20, 20))
+            .expect("the live batch settles");
+        assert_eq!(settlement.frontier, Some(Offset(21)));
+        shadow.drain(&live);
+
+        assert_eq!(ledger.held(&reassigned).offsets, 1);
+        assert_eq!(ledger.held(&live).offsets, 0, "the live batch drains");
     }
 
     #[test]
@@ -289,7 +300,11 @@ mod tests {
         let held = tp("events", 0);
         shadow.charge(&held, 0, &charges(&[10, 11]));
 
-        shadow.settle(&held, 0, [Offset(11)], &span(11, 11));
+        let settlement = shadow
+            .settle(&held, 0, [Offset(11)], &span(11, 11))
+            .expect("the batch settles");
+        assert_eq!(settlement.frontier, None);
+        shadow.drain(&held);
 
         assert_eq!(ledger.held(&held).offsets, 2);
     }
@@ -299,7 +314,8 @@ mod tests {
         let shadow = LedgerShadow::new(None);
         let p0 = tp("events", 0);
         shadow.charge(&p0, 0, &charges(&[10]));
-        shadow.settle(&p0, 0, [Offset(10)], &span(10, 10));
+        assert!(shadow.settle(&p0, 0, [Offset(10)], &span(10, 10)).is_none());
+        shadow.drain(&p0);
 
         assert_eq!(shadow.generations_version(), 0);
         assert_eq!(shadow.generation(&p0), 0);
@@ -362,6 +378,7 @@ mod tests {
         shadow.charge(&p0, 1, &charges(&[11]));
         assert_eq!(ledger.held(&p0).offsets, 1);
         shadow.settle(&p0, 1, [Offset(11)], &span(11, 11));
+        shadow.drain(&p0);
         assert_eq!(
             ledger.held(&p0).offsets,
             0,
@@ -382,6 +399,7 @@ mod tests {
 
         shadow.charge(&p0, 1, &charges(&[11]));
         shadow.settle(&p0, 1, [Offset(11)], &span(11, 11));
+        shadow.drain(&p0);
         assert_eq!(
             ledger.held(&p0).offsets,
             0,

--- a/rust/ingestion-consumer/tests/e2e_integration_test.rs
+++ b/rust/ingestion-consumer/tests/e2e_integration_test.rs
@@ -15,15 +15,17 @@ use lifecycle::{ComponentOptions, Manager};
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
-use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::consumer::{BaseConsumer, Consumer, StreamConsumer};
 use rdkafka::message::{Header, OwnedHeaders};
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::Timeout;
+use rdkafka::TopicPartitionList;
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use common_kafka_consumer::{TopicOffsetLedger, TopicPartition};
+use ingestion_consumer::config::LedgerMode;
 use ingestion_consumer::consumer::{IngestionConsumer, IngestionConsumerOptions};
 use ingestion_consumer::discovery::reconcile_membership;
 use ingestion_consumer::dispatcher::Dispatcher;
@@ -434,6 +436,7 @@ struct Harness {
     pub ledger: Arc<TopicOffsetLedger>,
     max_in_flight: usize,
     deferred_flush_timeout: Duration,
+    ledger_mode: LedgerMode,
 }
 
 /// Build a Kafka consumer subscribed to `topic` in `group_id`, configured like
@@ -530,6 +533,7 @@ impl Harness {
             registry_config,
             0,
             ComponentOptions::new(),
+            LedgerMode::Shadow,
         )
         .await
     }
@@ -552,6 +556,7 @@ impl Harness {
             ComponentOptions::new()
                 .with_liveness_deadline(liveness_deadline)
                 .with_stall_threshold(stall_threshold),
+            LedgerMode::Shadow,
         )
         .await
     }
@@ -569,6 +574,24 @@ impl Harness {
             fast_registry_config(),
             batch_size_bytes,
             ComponentOptions::new(),
+            LedgerMode::Shadow,
+        )
+        .await
+    }
+
+    /// Single worker and partition, ledger commit mode: the Kafka commit
+    /// comes from the ledger frontier instead of the batch spans.
+    async fn start_commit_mode(topic: &str) -> Self {
+        Self::start_inner(
+            topic,
+            1,
+            1,
+            1,
+            Duration::from_secs(60),
+            fast_registry_config(),
+            0,
+            ComponentOptions::new(),
+            LedgerMode::Commit,
         )
         .await
     }
@@ -583,6 +606,7 @@ impl Harness {
         registry_config: WorkerRegistryConfig,
         batch_size_bytes: usize,
         component_options: ComponentOptions,
+        ledger_mode: LedgerMode,
     ) -> Self {
         create_topic(topic, partitions).await;
 
@@ -636,6 +660,7 @@ impl Harness {
                 group_id: "e2e-test".to_string(),
                 deferred_flush_timeout,
                 debug_recorder: None,
+                ledger_mode,
             },
             handle,
         );
@@ -658,6 +683,7 @@ impl Harness {
             ledger,
             max_in_flight,
             deferred_flush_timeout,
+            ledger_mode,
         }
     }
 
@@ -712,6 +738,7 @@ impl Harness {
                 group_id: "e2e-test".to_string(),
                 deferred_flush_timeout: self.deferred_flush_timeout,
                 debug_recorder: None,
+                ledger_mode: self.ledger_mode,
             },
             handle,
         );
@@ -731,6 +758,25 @@ impl Harness {
             return true;
         };
         tokio::time::timeout(timeout, task).await.is_ok()
+    }
+
+    /// The group's committed offset for one partition of the harness topic;
+    /// `None` while nothing is committed.
+    fn committed_offset(&self, partition: i32) -> Option<i64> {
+        let probe: BaseConsumer = ClientConfig::new()
+            .set("bootstrap.servers", KAFKA_BROKERS)
+            .set("group.id", &self.group_id)
+            .create()
+            .expect("committed-offset probe");
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_partition(&self.topic, partition);
+        let committed = probe
+            .committed_offsets(tpl, Duration::from_secs(2))
+            .expect("fetch committed offsets");
+        match committed.elements()[0].offset() {
+            rdkafka::Offset::Offset(offset) => Some(offset),
+            _ => None,
+        }
     }
 
     async fn wait_for(&self, total: usize, timeout: Duration) {
@@ -1972,6 +2018,50 @@ async fn consumer_crash_before_commit_redelivers_without_loss() {
     harness.stop().await;
 }
 
+/// Commit mode: the broker-committed offset is the ledger frontier — one past
+/// everything the workers accepted — and a restart resumes from it with no
+/// loss and no redelivery.
+#[tokio::test]
+async fn commit_mode_commits_the_ledger_frontier() {
+    let topic = format!("e2e-ledger-commit-{}", Uuid::new_v4());
+    let mut harness = Harness::start_commit_mode(&topic).await;
+    let producer = make_producer();
+
+    for seq in 0..10usize {
+        produce(&producer, &topic, 0, "tok", "user-1", seq).await;
+    }
+    harness.wait_for(10, Duration::from_secs(15)).await;
+    wait_until(
+        Duration::from_secs(10),
+        "the committed offset to reach the frontier",
+        || harness.committed_offset(0) == Some(10),
+    )
+    .await;
+
+    // A clean frontier is a usable resume point: after a crash, only the new
+    // messages arrive.
+    harness.crash_consumer();
+    harness.restart_consumer(fast_registry_config()).await;
+    for seq in 10..15usize {
+        produce(&producer, &topic, 0, "tok", "user-1", seq).await;
+    }
+    harness.wait_for(15, Duration::from_secs(15)).await;
+    wait_until(
+        Duration::from_secs(10),
+        "the committed offset to reach the new frontier",
+        || harness.committed_offset(0) == Some(15),
+    )
+    .await;
+
+    let total: usize = harness.workers.iter().map(|w| w.count()).sum();
+    assert_eq!(
+        total, 15,
+        "a committed frontier behind the accepted work would redeliver here"
+    );
+
+    harness.stop().await;
+}
+
 /// A worker that processes a batch but whose ACK is lost is indistinguishable
 /// from a failed send, so the consumer replays the batch: duplicates are the
 /// accepted cost of at-least-once, loss never is, and the replay lands behind
@@ -2492,6 +2582,7 @@ async fn second_consumer_joining_the_group_preserves_all_messages() {
             group_id: "e2e-test".to_string(),
             deferred_flush_timeout: Duration::from_secs(60),
             debug_recorder: None,
+            ledger_mode: LedgerMode::Shadow,
         },
         handle2,
     );
@@ -2599,6 +2690,7 @@ async fn partition_lost_and_regained_keeps_the_consumer_alive() {
             group_id: "e2e-test".to_string(),
             deferred_flush_timeout: Duration::from_secs(60),
             debug_recorder: None,
+            ledger_mode: LedgerMode::Shadow,
         },
         handle2,
     );
@@ -2712,6 +2804,7 @@ async fn fenced_static_member_exits_on_fatal_error() {
             group_id: "e2e-test".to_string(),
             deferred_flush_timeout: Duration::from_secs(60),
             debug_recorder: None,
+            ledger_mode: LedgerMode::Shadow,
         },
         handle,
     );


### PR DESCRIPTION
## Problem

- #91764 runs the offset ledger next to the current commit path and only reports disagreements. Operators have no way to let the ledger frontier own the commit.
- Later cycles of the driver-model plan (#91468) complete work at finer granularity than a batch. Those commits must come from the ledger, so the switch has to exist first, behind a default that keeps today's behavior.

## Changes

- New env var `CONSUMER_OFFSET_LEDGER_MODE`, `shadow` or `commit`. The default is `shadow`, so nothing changes unless it is set.
- In `commit` mode the consumer commits each partition's ledger frontier instead of the batch's max offset. The batch still settles against the ledger first, so the mismatch counter from #91764 keeps reporting.
- A partition with no frontier yet is not committed and stays on its last committed offset. When no partition has a frontier, the commit is skipped with a warning.
- The commit sentinel validates the frontier spans, so a frontier behind the previous commit is still flagged.
- Mechanical: the mode is threaded through the consumer options and the e2e harness.

> [!NOTE]
> The commit sentinel's gap alert still reads a frontier that walks over a transaction control record as a skipped offset. The gaps counter from the #91764 follow-up retires that alert.

## How did you test this code?

- Unit tests: a frontier maps back to the span the commit path submits verbatim, and a partition without a frontier is left out of the commit. The mode parses case-insensitively and rejects unknown values.
- e2e `commit_mode_commits_the_ledger_frontier`: the broker-committed offset reaches the frontier, and a crash and restart resumes from it with no loss and no redelivery. It catches a committed frontier off by one in either direction.
- Not checked: commit mode on production traffic. The mismatch counter staying at zero in shadow mode is the signal for switching.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None.
