### PR TITLE
fix(desktop): skip local Codex Auto permission prompts

### DIFF
--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -15,7 +15,10 @@ import type {
   AppServerRpc,
 } from "./app-server-client";
 import { AppServerRequestError } from "./app-server-client";
-import { CodexAppServerAgent } from "./codex-app-server-agent";
+import {
+  CodexAppServerAgent,
+  shouldAutoAcceptLocalApproval,
+} from "./codex-app-server-agent";
 import { sandboxPolicyFor } from "./session-config";
 
 // Required-field invariants the native codex app-server enforces on each request.
@@ -103,6 +106,68 @@ function makeFakeClient(
 }
 
 const init = { protocolVersion: 1 } as unknown as InitializeRequest;
+
+describe("shouldAutoAcceptLocalApproval", () => {
+  type AutoApprovalInput = Parameters<typeof shouldAutoAcceptLocalApproval>[0];
+  const workspaceWrite = {
+    type: "workspaceWrite" as const,
+    networkAccess: false,
+  };
+  const base: AutoApprovalInput = {
+    environment: "local" as const,
+    mode: "auto",
+    sandboxPolicy: workspaceWrite,
+    method: "item/commandExecution/requestApproval",
+    detail: {},
+    hasMcpToolCall: false,
+  };
+
+  const cases: Array<{
+    input: Partial<AutoApprovalInput>;
+    expected: boolean;
+  }> = [
+    { input: {}, expected: true },
+    {
+      input: { method: "item/fileChange/requestApproval" },
+      expected: true,
+    },
+    { input: { environment: "cloud" }, expected: false },
+    { input: { mode: "plan" }, expected: false },
+    {
+      input: { sandboxPolicy: { type: "dangerFullAccess" } },
+      expected: false,
+    },
+    { input: { hasMcpToolCall: true }, expected: false },
+    { input: { detail: { reason: "needs network" } }, expected: false },
+    {
+      input: { detail: { networkApprovalContext: {} } },
+      expected: false,
+    },
+    {
+      input: {
+        detail: {
+          additionalPermissions: { network: { enabled: true } },
+        },
+      },
+      expected: false,
+    },
+    {
+      input: { detail: { proposedNetworkPolicyAmendments: [{}] } },
+      expected: false,
+    },
+    {
+      input: {
+        method: "item/fileChange/requestApproval",
+        detail: { grantRoot: "/outside" },
+      },
+      expected: false,
+    },
+  ];
+
+  it.each(cases)("returns $expected for $input", ({ input, expected }) => {
+    expect(shouldAutoAcceptLocalApproval({ ...base, ...input })).toBe(expected);
+  });
+});
 
 describe("CodexAppServerAgent", () => {
   const tokenUsage = (last: Record<string, number>) => ({
@@ -1820,7 +1885,10 @@ describe("CodexAppServerAgent", () => {
     });
     // Default mode is "auto" → editing allowed. A prior plan/read-only turn's
     // readOnly sandbox persists on the thread, so auto must state its sandbox.
-    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    await agent.newSession({
+      cwd: "/r",
+      _meta: { environment: "local" },
+    } as unknown as NewSessionRequest);
     const done = agent.prompt({
       sessionId: "t",
       prompt: [{ type: "text", text: "go" }],
@@ -1831,9 +1899,11 @@ describe("CodexAppServerAgent", () => {
     const turnStart = stub.requests.find((r) => r.method === "turn/start");
     const params = turnStart?.params as {
       sandboxPolicy?: unknown;
+      approvalPolicy?: string;
       collaborationMode?: unknown;
     };
     expect(params.sandboxPolicy).toEqual(sandboxPolicyFor("auto"));
+    expect(params.approvalPolicy).toBe("on-request");
     // Default collaboration is pushed every turn so switching back from Plan reverts.
     expect(params.collaborationMode).toEqual({
       mode: "default",
@@ -1904,6 +1974,9 @@ describe("CodexAppServerAgent", () => {
     expect(
       (turnStart?.params as { sandboxPolicy?: unknown }).sandboxPolicy,
     ).toBeUndefined();
+    expect(
+      (turnStart?.params as { approvalPolicy?: string }).approvalPolicy,
+    ).toBe("on-request");
   });
 
   it("returns mode + model + thought_level configOptions and emits config_option_update", async () => {

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -114,6 +114,48 @@ const POLICY_ERROR_MESSAGE =
 const GENERIC_FATAL_ERROR_MESSAGE =
   "The agent stopped before completing this request. Please try again.";
 
+type ApprovalRequestDetail = {
+  itemId?: string;
+  command?: string;
+  changes?: AppServerItem["changes"];
+  availableDecisions?: unknown[];
+  reason?: string | null;
+  grantRoot?: string | null;
+  networkApprovalContext?: unknown;
+  additionalPermissions?: unknown;
+  proposedNetworkPolicyAmendments?: unknown[] | null;
+};
+
+export function shouldAutoAcceptLocalApproval(input: {
+  environment?: "local" | "cloud";
+  mode: string;
+  sandboxPolicy?: CodexSandboxPolicy;
+  method: string;
+  detail: ApprovalRequestDetail;
+  hasMcpToolCall: boolean;
+}): boolean {
+  if (
+    input.environment !== "local" ||
+    input.mode !== "auto" ||
+    input.sandboxPolicy?.type !== "workspaceWrite" ||
+    input.hasMcpToolCall ||
+    input.detail.reason
+  ) {
+    return false;
+  }
+  if (input.method === APP_SERVER_REQUESTS.FILE_CHANGE_APPROVAL) {
+    return !input.detail.grantRoot;
+  }
+  if (input.method !== APP_SERVER_REQUESTS.COMMAND_APPROVAL) {
+    return false;
+  }
+  return (
+    input.detail.networkApprovalContext == null &&
+    input.detail.additionalPermissions == null &&
+    !input.detail.proposedNetworkPolicyAmendments?.length
+  );
+}
+
 type AppServerSessionMeta = {
   // The host sends either a plain string or the Claude-style `{ append }` form.
   systemPrompt?: string | { append?: string };
@@ -2212,12 +2254,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       return { decision: "decline" };
     }
     const isFileChange = method === APP_SERVER_REQUESTS.FILE_CHANGE_APPROVAL;
-    const detail = params as {
-      itemId?: string;
-      command?: string;
-      changes?: AppServerItem["changes"];
-      availableDecisions?: unknown[];
-    };
+    const detail = params as ApprovalRequestDetail;
     // codex lists the decisions valid for this prompt. An "approve and remember"
     // decision is echoed back verbatim: either the string "acceptForSession" or the
     // acceptWithExecpolicyAmendment object carrying the proposed allowlist amendment.
@@ -2247,6 +2284,18 @@ export class CodexAppServerAgent extends BaseAcpAgent {
     // Codex has no MCP-specific approval; a known MCP call surfaces the real server/tool/args
     // so the host renders the proper MCP permission (incl. PostHog `exec` unwrapping).
     const mcp = this.mcp.byItemId(detail.itemId);
+    if (
+      shouldAutoAcceptLocalApproval({
+        environment: this.environment,
+        mode: this.config.mode,
+        sandboxPolicy: this.sandboxPolicyForTurn(),
+        method,
+        detail,
+        hasMcpToolCall: Boolean(mcp),
+      })
+    ) {
+      return { decision: "accept" };
+    }
     if (mcp && this.shouldAutoAcceptMcpToolCall(mcp)) {
       return { decision: "accept" };
     }


### PR DESCRIPTION
## Problem

Local Codex Auto runs can prompt before allowed workspace edits, interrupting hands-off execution.

## Changes

- Local Codex Auto turns skip approval prompts when the macOS workspace sandbox is active.

