### PR TITLE
chore(owners): point dead team slugs at their live GitHub teams

### DIFF
--- a/docs/published/docs/mcp-analytics/owners.yaml
+++ b/docs/published/docs/mcp-analytics/owners.yaml
@@ -1,3 +1,3 @@
 version: 1
 owners:
-    - team-mcp-analytics
+    - mcp-analytics

--- a/owners.yaml
+++ b/owners.yaml
@@ -10,8 +10,6 @@ teams:
         slack: '#team-ai-research'
         # The team keeps bot output out of its own channel, so automation posts here instead.
         notifications: '#bots-ai-research'
-    apm:
-        slack: '#team-apm'
     batch-exports:
         slack: '#team-batch-exports'
     clickhouse:

--- a/owners.yaml
+++ b/owners.yaml
@@ -10,16 +10,14 @@ teams:
         slack: '#team-ai-research'
         # The team keeps bot output out of its own channel, so automation posts here instead.
         notifications: '#bots-ai-research'
+    apm:
+        slack: '#team-apm'
     batch-exports:
         slack: '#team-batch-exports'
     clickhouse:
         slack: '#team-clickhouse'
     conversations:
         slack: '#team-conversations'
-    # The 'logs' and 'apm' GitHub teams have identical membership: APM ("Logs,
-    # Metrics and Traces") absorbed logs, and #team-apm is where it lives.
-    logs:
-        slack: '#team-apm'
     platform-ux:
         slack: '#team-platform-ux'
     team-data-stack:

--- a/owners.yaml
+++ b/owners.yaml
@@ -2,7 +2,7 @@ version: 1
 owners: []
 # Slack channel per team, declared once for the whole repo (root-only registry).
 # A team only needs an entry where the derived '#<slug>' is wrong or missing; the
-# other 24 slugs in use derive correctly and are deliberately absent.
+# other 23 slugs in use derive correctly and are deliberately absent.
 teams:
     # GitHub team slugs that predate the 'team-' convention: the slug is right,
     # the channel just doesn't match it.
@@ -18,6 +18,8 @@ teams:
         slack: '#team-clickhouse'
     conversations:
         slack: '#team-conversations'
+    mcp-analytics:
+        slack: '#team-mcp-analytics'
     platform-ux:
         slack: '#team-platform-ux'
     team-data-stack:
@@ -52,7 +54,7 @@ rules:
           - '/rust/bin/'
       owners: team-devex
     - match: '/bin/inject_mcp_intents.py'
-      owners: team-mcp-analytics
+      owners: mcp-analytics
     - match: '/.agents/skills/manage-dashboard-widgets/'
       owners: team-analytics-platform
     - match: '/.claude/'

--- a/posthog/temporal/owners.yaml
+++ b/posthog/temporal/owners.yaml
@@ -14,7 +14,7 @@ rules:
     - match: '/exports/'
       owners: team-analytics-platform
     - match: '/logs_alerting/'
-      owners: logs
+      owners: apm
     - match: '/mcp_analytics/'
       owners: team-mcp-analytics
     - match: '/messaging/'

--- a/posthog/temporal/owners.yaml
+++ b/posthog/temporal/owners.yaml
@@ -14,7 +14,7 @@ rules:
     - match: '/exports/'
       owners: team-analytics-platform
     - match: '/logs_alerting/'
-      owners: apm
+      owners: team-apm
     - match: '/mcp_analytics/'
       owners: mcp-analytics
     - match: '/messaging/'

--- a/posthog/temporal/owners.yaml
+++ b/posthog/temporal/owners.yaml
@@ -16,7 +16,7 @@ rules:
     - match: '/logs_alerting/'
       owners: apm
     - match: '/mcp_analytics/'
-      owners: team-mcp-analytics
+      owners: mcp-analytics
     - match: '/messaging/'
       owners: team-workflows
     - match: '/product_analytics/'

--- a/products/apm/product.yaml
+++ b/products/apm/product.yaml
@@ -1,3 +1,3 @@
 name: APM
 owners:
-    - logs
+    - apm

--- a/products/apm/product.yaml
+++ b/products/apm/product.yaml
@@ -1,3 +1,3 @@
 name: APM
 owners:
-    - apm
+    - team-apm

--- a/products/logs/product.yaml
+++ b/products/logs/product.yaml
@@ -1,3 +1,3 @@
 name: Logs
 owners:
-    - apm
+    - team-apm

--- a/products/logs/product.yaml
+++ b/products/logs/product.yaml
@@ -1,3 +1,3 @@
 name: Logs
 owners:
-    - logs
+    - apm

--- a/products/mcp_analytics/product.yaml
+++ b/products/mcp_analytics/product.yaml
@@ -1,3 +1,3 @@
 name: MCP analytics
 owners:
-    - team-mcp-analytics
+    - mcp-analytics

--- a/products/metrics/product.yaml
+++ b/products/metrics/product.yaml
@@ -1,3 +1,3 @@
 name: Metrics
 owners:
-    - apm
+    - team-apm

--- a/products/metrics/product.yaml
+++ b/products/metrics/product.yaml
@@ -1,3 +1,3 @@
 name: Metrics
 owners:
-    - logs
+    - apm

--- a/products/tracing/product.yaml
+++ b/products/tracing/product.yaml
@@ -1,3 +1,3 @@
 name: Tracing
 owners:
-    - apm
+    - team-apm

--- a/products/tracing/product.yaml
+++ b/products/tracing/product.yaml
@@ -1,3 +1,3 @@
 name: Tracing
 owners:
-    - logs
+    - apm

--- a/services/mcp/src/owners.yaml
+++ b/services/mcp/src/owners.yaml
@@ -6,7 +6,7 @@ rules:
           - '/hono/analytics.ts'
           - '/lib/posthog/analytics.ts'
           - '/tools/generated/mcp_analytics.ts'
-      owners: team-mcp-analytics
+      owners: mcp-analytics
     - match:
           - '/generated/ai_observability/'
           - '/tools/aiObservability/'

--- a/services/mcp/tests/owners.yaml
+++ b/services/mcp/tests/owners.yaml
@@ -4,4 +4,4 @@ rules:
     - match:
           - '/hono/analytics.test.ts'
           - '/unit/posthog/analytics.test.ts'
-      owners: team-mcp-analytics
+      owners: mcp-analytics


### PR DESCRIPTION
## Problem

A pull request touching Logs, APM, Metrics, Tracing, or MCP analytics gets no team reviewer, and Stamphog denies it for an owning team its author cannot join.

- The `logs` and `team-mcp-analytics` GitHub teams no longer exist. As an org member, `gh api /orgs/PostHog/teams/logs` returns 404, and neither slug appears in the org team list.
- The live teams are `team-apm`, which carries the membership of the old logs team, and `mcp-analytics`.
- `assign-reviewers.js` takes a 422 on the whole batch, retries each reviewer alone, then skips the invalid team without failing the job.
- Stamphog reads the same ownership files, so its "author not on owning team" gate can never pass for these products. It denied [#91080](https://github.com/PostHog/posthog/pull/91080) on that basis while the author was on APM.

`hogli owners:lint --live` catches both slugs, but `ci-backend.yml` runs it only on changed files. A slug goes stale the moment a team is deleted upstream, and nothing revalidates the files that name it.

## Changes

- Stamphog now names `@PostHog/team-apm` and `@PostHog/mcp-analytics`, so its membership gate can resolve.
- Reviewer assignment on these five products now names a team that exists.
- Slack routing is unchanged. `team-apm` derives `#team-apm` on its own, so it needs no registry entry. `mcp-analytics` gains one for `#team-mcp-analytics`, which it would otherwise derive as `#mcp-analytics`.
- The whole diff is ownership config. No runtime code changes, and nothing a user sees changes.

The `mcp-analytics` rename rides along because `--live` validates every slug in each file it reads, and the dead slug sits in two files the APM fix has to touch. The commits stay separate.

`seed_engineering_analytics.py` still contains the string `team-mcp-analytics` as seed data. It is not an ownership source, so it stays as is.

> [!NOTE]
> This PR is necessary but not sufficient for reviewer assignment. A team can only be requested as a reviewer once it has access to this repository, and `team-apm` currently has access to no repositories. An org owner has to add it. About a third of the team slugs in our ownership files have the same gap, so `assign-reviewers.js` silently skips them today.

## How did you test this code?

- `hogli owners:lint --live` on the ten changed files reported `unknown team slug: logs` and `unknown team slug: team-mcp-analytics` before the change, and passes now.
- `hogli owners:who products/logs/backend/api.py` resolves to `team-apm` with slack `#team-apm`.
- `hogli owners:who products/mcp_analytics/backend/__init__.py` resolves to `mcp-analytics` with slack `#team-mcp-analytics`.
- `hogli ci:preflight --fix` reported no failures.
- No tests were added. The live lint already covers this class of error, and the fix is a data change to the files it reads.
- The Slack channels were not verified against Slack. The registry preserves the channel each slug resolved to before this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app, from a question about why `@PostHog/logs` appears in Stamphog output but not in the org team list. Comparing `apm` and `logs` lookups under an org member token confirmed the team is gone rather than secret.

The first version renamed only `logs`, to `apm`. CI then failed on `team-mcp-analytics`, because the live lint validates whole files rather than changed lines, so the second commit renames that slug too. The third commit moves APM onto the newly created `team-apm`, after review feedback asked for the `team-` prefix.

Skills invoked: `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S66N93FX/p1788190992198639)*
