### PR TITLE
fix(managed-warehouse): restore registration feature flag

### DIFF
--- a/products/managed_warehouse/backend/README.md
+++ b/products/managed_warehouse/backend/README.md
@@ -102,15 +102,15 @@ This path currently supports Parquet only. Support for Azure Blob Storage, CSV, 
 
 ## Feature flag gating
 
-Each workflow evaluates a feature flag through `feature_enabled`. Create or update the appropriate flag locally. The copy flags target the project, while `data-warehouse-scene` targets the organization. Otherwise, the workflow will be skipped even if the rest of the configuration is correct.
+Each workflow evaluates its own project-scoped feature flag through `feature_enabled`. Create or update the appropriate flag locally. Otherwise, the workflow will be skipped even if the rest of the configuration is correct. The organization-scoped `data-warehouse-scene` flag controls the Data Ops UI and managed warehouse provisioning separately.
 
-| Workflow                 | Feature Flag                           |
-| ------------------------ | -------------------------------------- |
-| Data Modeling            | `ducklake-data-modeling-copy-workflow` |
-| Data Imports             | `ducklake-data-imports-copy-workflow`  |
-| Data Import Registration | `data-warehouse-scene`                 |
+| Workflow                 | Feature Flag                                  |
+| ------------------------ | --------------------------------------------- |
+| Data Modeling            | `ducklake-data-modeling-copy-workflow`        |
+| Data Imports             | `ducklake-data-imports-copy-workflow`         |
+| Data Import Registration | `ducklake-data-imports-registration-workflow` |
 
-The data-import copy and registration paths target the same stable DuckLake table. An organization with `data-warehouse-scene` enabled runs registration. Disable `ducklake-data-imports-copy-workflow` for its projects to avoid both paths applying the same import. If both run, the last atomic table swap wins.
+The two data-import flags are independent and target the same stable DuckLake table. During rollout, enable only the intended path for a project. If both run, the last atomic table swap wins.
 
 ## Data Ops workflow status
 
@@ -200,7 +200,7 @@ Follow these checklists to exercise the DuckLake copy workflows on a local check
 ### Testing Data Imports workflows
 
 1. **Start the dev stack**
-   Run `hogli start` (or `bin/start`) so Postgres, Duckgres, SeaweedFS, Temporal, and all DuckLake defaults are up. Enable `data-warehouse-scene` for the prepared-Parquet path. Enable `ducklake-data-imports-copy-workflow` only when testing the existing Delta-copy path; both paths run when both flags are enabled.
+   Run `hogli start` (or `bin/start`) so Postgres, Duckgres, SeaweedFS, Temporal, and all DuckLake defaults are up. Enable either `ducklake-data-imports-copy-workflow` for the existing Delta-copy path or `ducklake-data-imports-registration-workflow` for the prepared-Parquet path.
 
 2. **Trigger a data import sync from the app**
    In the PostHog UI, open Data Warehouse → Sources, connect a source (e.g., Stripe, Hubspot), select the schemas to sync, and click **Sync**. This schedules the `external-data-job` workflow.

--- a/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
@@ -47,7 +47,6 @@ from products.managed_warehouse.backend.facade.contracts import (
     ManagedWarehouseSourceJobUpdate,
     ManagedWarehouseSourceJobWorkflow,
 )
-from products.managed_warehouse.backend.facade.feature_flags import DATA_WAREHOUSE_SCENE_FLAG
 from products.managed_warehouse.backend.models import ManagedWarehouseSourceJob
 from products.managed_warehouse.backend.storage import connect_to_duckgres, setup_duckgres_session
 from products.managed_warehouse.backend.temporal.metrics import (
@@ -65,6 +64,7 @@ from products.managed_warehouse.backend.temporal.source_job_state import record_
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
 LOGGER = get_logger(__name__)
+DUCKLAKE_DATA_IMPORTS_REGISTRATION_WORKFLOW_FLAG = "ducklake-data-imports-registration-workflow"
 DATA_IMPORTS_GENERATIONS_PREFIX = "_imports"
 DUCKLAKE_REGISTER_STAGE_DURATION_METRIC = "ducklake_register_data_imports_stage_duration"
 S3_COPY_BATCH_SIZE = 16
@@ -237,18 +237,23 @@ async def ducklake_register_data_imports_gate_activity(inputs: DuckLakeRegisterD
     logger = LOGGER.bind()
 
     try:
-        team = await database_sync_to_async(Team.objects.only("organization_id").get)(id=inputs.team_id)
+        team = await database_sync_to_async(Team.objects.only("uuid", "organization_id").get)(id=inputs.team_id)
     except Team.DoesNotExist:
         await logger.aerror("Team does not exist when evaluating DuckLake data imports registration gate")
         return False
 
-    organization_id = str(team.organization_id)
     try:
         flag_enabled = feature_enabled_or_false(
-            DATA_WAREHOUSE_SCENE_FLAG,
-            organization_id,
-            groups={"organization": organization_id},
-            group_properties={"organization": {"id": organization_id}},
+            DUCKLAKE_DATA_IMPORTS_REGISTRATION_WORKFLOW_FLAG,
+            str(team.uuid),
+            groups={
+                "organization": str(team.organization_id),
+                "project": str(team.id),
+            },
+            group_properties={
+                "organization": {"id": str(team.organization_id)},
+                "project": {"id": str(team.id)},
+            },
             only_evaluate_locally=True,
             send_feature_flag_events=False,
         )

--- a/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
@@ -15,6 +15,7 @@ from posthog.sync import database_sync_to_async
 from products.managed_warehouse.backend.facade.contracts import ManagedWarehouseSourceJobStatus
 from products.managed_warehouse.backend.temporal import ducklake_register_data_imports_workflow as registration_module
 from products.managed_warehouse.backend.temporal.ducklake_register_data_imports_workflow import (
+    DUCKLAKE_DATA_IMPORTS_REGISTRATION_WORKFLOW_FLAG,
     S3_COPY_BATCH_SIZE,
     DuckLakeRegisterDataImportsActivityInputs,
     DuckLakeRegisterDataImportsGateInputs,
@@ -52,7 +53,7 @@ def _cp_no_rows():
 @pytest.mark.asyncio
 @pytest.mark.django_db
 @pytest.mark.parametrize("flag_enabled", [True, False])
-async def test_registration_gate_uses_data_warehouse_scene_flag(monkeypatch, ateam, flag_enabled):
+async def test_registration_gate_uses_independent_feature_flag(monkeypatch, ateam, flag_enabled):
     captured: dict[str, object] = {}
 
     def fake_feature_enabled(key, distinct_id, **kwargs):
@@ -64,10 +65,16 @@ async def test_registration_gate_uses_data_warehouse_scene_flag(monkeypatch, ate
     result = await ducklake_register_data_imports_gate_activity(DuckLakeRegisterDataImportsGateInputs(team_id=ateam.id))
 
     assert result is flag_enabled
-    assert captured["key"] == "data-warehouse-scene"
-    assert captured["distinct_id"] == str(ateam.organization_id)
-    assert captured["groups"] == {"organization": str(ateam.organization_id)}
-    assert captured["group_properties"] == {"organization": {"id": str(ateam.organization_id)}}
+    assert captured["key"] == DUCKLAKE_DATA_IMPORTS_REGISTRATION_WORKFLOW_FLAG
+    assert captured["distinct_id"] == str(ateam.uuid)
+    assert captured["groups"] == {
+        "organization": str(ateam.organization_id),
+        "project": str(ateam.id),
+    }
+    assert captured["group_properties"] == {
+        "organization": {"id": str(ateam.organization_id)},
+        "project": {"id": str(ateam.id)},
+    }
     assert captured["only_evaluate_locally"] is True
     assert captured["send_feature_flag_events"] is False
 


### PR DESCRIPTION
## Problem

Data Ops beta access currently enables prepared-file registration for every project in that organization.

The UI and Temporal workflow need independent rollout controls with different scopes.

## Changes

- Data Ops access and imported-source registration can now roll out independently.
- `data-warehouse-scene` remains organization scoped for the UI and provisioning.
- `ducklake-data-imports-registration-workflow` returns as the project-scoped Temporal gate.
- The regression test verifies the flag key, project identity, and group properties.
- The backend guide documents the restored split.
- No UI rendering changes; no screenshot is needed.

Before:

```mermaid
flowchart LR
    SceneFlag[data-warehouse-scene] --> DataOps[Data Ops UI]
    SceneFlag --> Provisioning[Warehouse provisioning]
    SceneFlag --> Registration[Import registration]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class SceneFlag phYellow;
    class DataOps,Provisioning,Registration phBlue;
```

After:

```mermaid
flowchart LR
    SceneFlag[data-warehouse-scene] --> DataOps[Data Ops UI]
    SceneFlag --> Provisioning[Warehouse provisioning]
    RegistrationFlag[registration workflow flag] --> Registration[Import registration]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class SceneFlag,RegistrationFlag phYellow;
    class DataOps,Provisioning,Registration phBlue;
```

## How did you test this code?

- Local verification ran the focused registration gate test, Ruff checks, and `hogli ci:preflight --fix`.
- No manual end-to-end workflow run was performed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The backend guide is updated. [Runbooks PR #637](https://github.com/PostHog/runbooks/pull/637) restores the operational rollout instructions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex prepared the change with the writing-pr-descriptions and signed-git-publish skills. It restores the boundary removed in PR #84629 while preserving later workflow changes.

The PR contains no customer or private operational data.