### PR TITLE
feat(workflows): wire the loops UI to hog_flows behind a flag

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -229,6 +229,11 @@ export interface TaskListOptions {
   commentedBy?: number;
   /** Filter to tasks whose thread mentions this user ID. */
   mentions?: number;
+  /**
+   * Filter to the runs one workflow's "Create AI task" action spawned. Hand-vendored ahead of
+   * https://github.com/PostHog/posthog/pull/91581 landing — see `@posthog/api-client/workflows`.
+   */
+  hogFlowId?: string;
   /** List only archived tasks; the server excludes them by default. */
   archived?: boolean;
   /** Caller-side cap for surfaces that only show the newest few. */
@@ -2657,6 +2662,10 @@ export class PostHogAPIClient {
 
     if (options?.mentions) {
       params.mentions = options.mentions;
+    }
+
+    if (options?.hogFlowId) {
+      params.hog_flow_id = options.hogFlowId;
     }
 
     if (options?.archived) {

--- a/products/desktop/packages/api-client/src/workflows.ts
+++ b/products/desktop/packages/api-client/src/workflows.ts
@@ -116,7 +116,9 @@ export namespace WorkflowSchemas {
     version: number;
     status: HogFlowStatus;
     created_at: string;
-    created_by: UserBasic;
+    /** Null once the creating user's row is gone (e.g. SCIM deprovisioning hard-deletes the
+     * user) — the backend FK is `on_delete=SET_NULL`. */
+    created_by: UserBasic | null;
     updated_at: string;
     trigger: HogFlowTrigger;
     edges: HogFlowEdge[];
@@ -134,7 +136,7 @@ export namespace WorkflowSchemas {
     version: number;
     status: HogFlowStatus;
     created_at: string;
-    created_by: UserBasic;
+    created_by: UserBasic | null;
     updated_at: string;
     trigger: HogFlowTrigger;
     edges: HogFlowEdge[];

--- a/products/desktop/packages/ui/src/features/loops/components/LoopDetailView.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopDetailView.tsx
@@ -21,6 +21,7 @@ import {
   Badge,
   Button,
 } from "@posthog/quill";
+import { LOOPS_HOG_FLOWS_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
 import { assertCloudUsageAvailable } from "@posthog/ui/features/billing/preflightCloudUsage";
@@ -28,6 +29,7 @@ import { useUsageLimitStore } from "@posthog/ui/features/billing/usageLimitStore
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { Button as ActionButton } from "@posthog/ui/primitives/Button";
 import { TimezoneTimestamp } from "@posthog/ui/primitives/TimezoneTimestamp";
@@ -59,6 +61,7 @@ import {
   buildLoopViewedProps,
 } from "../loopAnalytics";
 import {
+  deriveHogFlowRunHealth,
   describeTrigger,
   loopFireBlockedMessage,
   loopPausedDescription,
@@ -93,6 +96,7 @@ export function LoopDetailView({
   const hasLoopListOrigin = useLocation({
     select: (location) => location.state.loopListOrigin === true,
   });
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const { data: loop, isLoading, isError } = useLoop(loopId);
   const updateLoop = useUpdateLoop(loopId);
   const deleteLoop = useDeleteLoop();
@@ -360,6 +364,17 @@ export function LoopDetailView({
     return <LoopLoadError />;
   }
 
+  // hog_flows-backed loops carry no backend-computed run health (see `hogFlowToLoop`) — derive
+  // it from the run history already loaded above so the status badge isn't stuck on "Active".
+  const runHealth = hogFlowsEnabled ? deriveHogFlowRunHealth(runs) : null;
+  const displayLoop = runHealth
+    ? {
+        ...loop,
+        last_run_status: runHealth.lastRunStatus,
+        consecutive_failures: runHealth.consecutiveFailures,
+      }
+    : loop;
+
   return (
     <div className="h-full min-h-0 overflow-y-auto">
       <Flex
@@ -386,8 +401,8 @@ export function LoopDetailView({
               >
                 {loop.name}
               </Text>
-              <Badge variant={loopStatusBadgeVariant(loop)}>
-                {loopStatusLabel(loop)}
+              <Badge variant={loopStatusBadgeVariant(displayLoop)}>
+                {loopStatusLabel(displayLoop)}
               </Badge>
               <Badge>{formatVisibility(loop.visibility)}</Badge>
             </Flex>

--- a/products/desktop/packages/ui/src/features/loops/components/LoopDetailView.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopDetailView.tsx
@@ -146,7 +146,7 @@ export function LoopDetailView({
   const handleToggleEnabled = (enabled: boolean) => {
     if (!loop) return;
     updateLoop.mutate(
-      { enabled },
+      { kind: "toggleEnabled", enabled },
       {
         onSuccess: () => {
           track(

--- a/products/desktop/packages/ui/src/features/loops/components/LoopForm.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopForm.tsx
@@ -6,9 +6,10 @@ import {
 } from "@phosphor-icons/react";
 import { type LoopSchemas, LoopsApiError } from "@posthog/api-client/loops";
 import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
-import { ANALYTICS_EVENTS } from "@posthog/shared";
+import { ANALYTICS_EVENTS, LOOPS_HOG_FLOWS_FLAG } from "@posthog/shared";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useBluebirdFlag } from "@posthog/ui/features/feature-flags/useBluebirdFlag";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { SettingsOptionSelect } from "@posthog/ui/features/settings/SettingsOptionSelect";
 import { useSandboxEnvironments } from "@posthog/ui/features/settings/sections/environments/useSandboxEnvironments";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
@@ -23,6 +24,7 @@ import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex, Text, TextArea, TextField } from "@radix-ui/themes";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useAuthStateValue } from "../../auth/store";
+import { useHogFlow } from "../hooks/useHogFlow";
 import {
   useCreateLoop,
   useDeleteLoop,
@@ -37,7 +39,6 @@ import { summarizeTrigger } from "../loopDisplay";
 import { useLoopDraftStore } from "../loopDraftStore";
 import {
   emptyLoopFormValues,
-  formValuesToLoopWrite,
   isAutoFixEnabled,
   isLoopFormValid,
   isTriggerDraftValid,
@@ -46,6 +47,11 @@ import {
   loopToFormValues,
   normalizeLoopFormValues,
 } from "../loopFormTypes";
+import {
+  emptyHogFlowLoopFormValues,
+  hogFlowToFormValues,
+  isHogFlowLoopFormValid,
+} from "../loopHogFlowMapping";
 import { formatLoopModel } from "../loopModels";
 import { buildSkillInstructions, loopSkillBundles } from "../loopSkill";
 import { LoopBehaviorFields } from "./LoopBehaviorFields";
@@ -57,6 +63,7 @@ import { LoopNotificationsFields } from "./LoopNotificationsFields";
 import { LoopRepositoryPicker } from "./LoopRepositoryPicker";
 import { LoopInstructionsFields } from "./LoopSkillFields";
 import { LoopSpaceBreadcrumb } from "./LoopSpaceBreadcrumb";
+import { LoopTeamSkillsFields } from "./LoopTeamSkillsFields";
 import { LoopTriggerEditor } from "./LoopTriggerEditor";
 
 const VISIBILITY_OPTIONS: {
@@ -81,8 +88,12 @@ type LoopFormBaseline = {
   serialized: string;
 };
 
-function buildLoopFormBaseline(loop: LoopSchemas.Loop): LoopFormBaseline {
-  const values = normalizeLoopFormValues(loopToFormValues(loop));
+function buildLoopFormBaseline(
+  loop: LoopSchemas.Loop,
+  overrideValues?: LoopFormValues,
+): LoopFormBaseline {
+  const values =
+    overrideValues ?? normalizeLoopFormValues(loopToFormValues(loop));
   return {
     loopId: loop.id,
     updatedAt: loop.updated_at,
@@ -109,9 +120,21 @@ export function LoopForm({
 }: LoopFormProps) {
   const isEdit = !!loop;
   const isEmbedded = variant === "embedded";
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const projectId = useAuthStateValue((state) => state.currentProjectId);
+  // The raw HogFlow behind this loop, needed only because the `Loop` wire shape `loop` decompiles
+  // to has no field for `skillNames` — see `useHogFlow`. Not loaded yet on first render, so the
+  // initial state below still seeds from `loop` and gets corrected once this resolves.
+  const hogFlow = useHogFlow(loop?.id, hogFlowsEnabled && isEdit);
+  const hogFlowFormValues =
+    hogFlowsEnabled && hogFlow.data
+      ? normalizeLoopFormValues(
+          hogFlowToFormValues(hogFlow.data.flow, hogFlow.data.schedule),
+        )
+      : undefined;
   const [values, setValues] = useState<LoopFormValues>(() => {
     if (loop) return normalizeLoopFormValues(loopToFormValues(loop));
+    if (hogFlowsEnabled) return emptyHogFlowLoopFormValues();
     // One-shot prefill from the landing prompt or a template; merged over the
     // blank defaults. Read (not consumed) here, then cleared in the effect
     // below so the manual "New loop" button always opens a blank form.
@@ -139,8 +162,12 @@ export function LoopForm({
 
   useEffect(() => {
     if (!loop) return;
+    // Still waiting on the raw HogFlow (see `hogFlow` above) — don't seed the form from the
+    // lossy `Loop` facade in the meantime, or a freshly-loaded skillNames would get stomped by
+    // this effect re-running once the real values arrive right after.
+    if (hogFlowsEnabled && !hogFlowFormValues) return;
 
-    const nextBaseline = buildLoopFormBaseline(loop);
+    const nextBaseline = buildLoopFormBaseline(loop, hogFlowFormValues);
     if (!baseline || baseline.loopId !== loop.id) {
       setBaseline(nextBaseline);
       setValues(nextBaseline.values);
@@ -158,7 +185,7 @@ export function LoopForm({
     setBaseline(nextBaseline);
     setValues(nextBaseline.values);
     setHasRemoteUpdate(false);
-  }, [loop, baseline, isDirty]);
+  }, [loop, baseline, isDirty, hogFlowsEnabled, hogFlowFormValues]);
 
   useEffect(() => {
     onDirtyChange?.(isDirty);
@@ -205,8 +232,10 @@ export function LoopForm({
     bundleSkill.isPending ||
     replaceSkillBundles.isPending ||
     deleteLoop.isPending;
-  const canSubmit =
-    isLoopFormValid(values) && !isSubmitting && !hasRemoteUpdate;
+  const formIsValid = hogFlowsEnabled
+    ? isHogFlowLoopFormValid(values)
+    : isLoopFormValid(values);
+  const canSubmit = formIsValid && !isSubmitting && !hasRemoteUpdate;
 
   // Per-step gate for the Next button. The final Create button is gated on the
   // whole form being valid, so jumping between steps can't submit a bad loop.
@@ -215,7 +244,7 @@ export function LoopForm({
       (values.skill !== null || !!values.instructions.trim()),
     values.triggers.every(isTriggerDraftValid),
     true,
-    isLoopFormValid(values),
+    formIsValid,
   ];
   const isLastStep = step === STEPS.length - 1;
 
@@ -268,7 +297,32 @@ export function LoopForm({
       return;
     }
     if (!canSubmit) return;
-    const body = formValuesToLoopWrite(values);
+
+    if (hogFlowsEnabled) {
+      // No skill-bundle upload step: skills are already attached by name in `values.skillNames`,
+      // sent as part of the write itself (see `formValuesToHogFlowWrite`).
+      try {
+        const saved = isEdit
+          ? await updateLoop.mutateAsync({ kind: "save", values })
+          : await createLoop.mutateAsync(values);
+        track(
+          isEdit
+            ? ANALYTICS_EVENTS.LOOP_UPDATED
+            : ANALYTICS_EVENTS.LOOP_CREATED,
+          buildLoopSavedProps(saved),
+        );
+        if (onSaved) {
+          onSaved(saved);
+        } else {
+          navigateToLoopDetail(saved.id);
+        }
+      } catch (error) {
+        toast.error(isEdit ? "Failed to save loop" : "Failed to create loop", {
+          description: error instanceof Error ? error.message : undefined,
+        });
+      }
+      return;
+    }
 
     // Bundling runs before anything is persisted: a missing or broken local
     // skill fails here with no partial state, instead of leaving a saved loop
@@ -287,8 +341,8 @@ export function LoopForm({
 
     try {
       const saved = isEdit
-        ? await updateLoop.mutateAsync(body)
-        : await createLoop.mutateAsync(body);
+        ? await updateLoop.mutateAsync({ kind: "save", values })
+        : await createLoop.mutateAsync(values);
       track(
         isEdit ? ANALYTICS_EVENTS.LOOP_UPDATED : ANALYTICS_EVENTS.LOOP_CREATED,
         buildLoopSavedProps(saved),
@@ -390,11 +444,19 @@ export function LoopForm({
               onChange={(e) => patch({ description: e.target.value })}
             />
           </Field>
-          <LoopInstructionsFields
-            values={values}
-            disabled={isSubmitting}
-            onPatch={patch}
-          />
+          {hogFlowsEnabled ? (
+            <LoopTeamSkillsFields
+              values={values}
+              disabled={isSubmitting}
+              onPatch={patch}
+            />
+          ) : (
+            <LoopInstructionsFields
+              values={values}
+              disabled={isSubmitting}
+              onPatch={patch}
+            />
+          )}
         </Step>
 
         <Divider />
@@ -407,6 +469,7 @@ export function LoopForm({
             triggers={values.triggers}
             triggerEndpointPath={triggerEndpointPath}
             disabled={isSubmitting}
+            availableTriggerTypes={hogFlowsEnabled ? ["schedule"] : undefined}
             onChange={(triggers) => patch({ triggers })}
           />
         </Step>
@@ -610,11 +673,19 @@ export function LoopForm({
                   onChange={(e) => patch({ description: e.target.value })}
                 />
               </Field>
-              <LoopInstructionsFields
-                values={values}
-                disabled={isSubmitting}
-                onPatch={patch}
-              />
+              {hogFlowsEnabled ? (
+                <LoopTeamSkillsFields
+                  values={values}
+                  disabled={isSubmitting}
+                  onPatch={patch}
+                />
+              ) : (
+                <LoopInstructionsFields
+                  values={values}
+                  disabled={isSubmitting}
+                  onPatch={patch}
+                />
+              )}
             </Step>
           ) : null}
 
@@ -627,6 +698,9 @@ export function LoopForm({
                 triggers={values.triggers}
                 triggerEndpointPath={triggerEndpointPath}
                 disabled={isSubmitting}
+                availableTriggerTypes={
+                  hogFlowsEnabled ? ["schedule"] : undefined
+                }
                 onChange={(triggers) => patch({ triggers })}
               />
             </Step>

--- a/products/desktop/packages/ui/src/features/loops/components/LoopForm.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopForm.tsx
@@ -5,6 +5,7 @@ import {
   Check,
 } from "@phosphor-icons/react";
 import { type LoopSchemas, LoopsApiError } from "@posthog/api-client/loops";
+import { WorkflowsApiError } from "@posthog/api-client/workflows";
 import { channelDisplayLabel } from "@posthog/core/canvas/channelName";
 import { ANALYTICS_EVENTS, LOOPS_HOG_FLOWS_FLAG } from "@posthog/shared";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
@@ -86,6 +87,7 @@ type LoopFormBaseline = {
   updatedAt: string;
   values: LoopFormValues;
   serialized: string;
+  source: "loop" | "hogFlow";
 };
 
 function buildLoopFormBaseline(
@@ -99,6 +101,10 @@ function buildLoopFormBaseline(
     updatedAt: loop.updated_at,
     values,
     serialized: JSON.stringify(values),
+    // The `Loop` facade and the raw HogFlow report the same `updatedAt` for the same `loop`, so
+    // `updatedAt` equality alone can't distinguish "nothing changed" from "the hog_flows
+    // skillNames correction just arrived" — the sync effect needs this to tell them apart.
+    source: overrideValues ? "hogFlow" : "loop",
   };
 }
 
@@ -134,11 +140,30 @@ export function LoopForm({
       : undefined;
   const [values, setValues] = useState<LoopFormValues>(() => {
     if (loop) return normalizeLoopFormValues(loopToFormValues(loop));
-    if (hogFlowsEnabled) return emptyHogFlowLoopFormValues();
     // One-shot prefill from the landing prompt or a template; merged over the
     // blank defaults. Read (not consumed) here, then cleared in the effect
     // below so the manual "New loop" button always opens a blank form.
     const prefill = useLoopDraftStore.getState().prefill;
+    if (hogFlowsEnabled) {
+      const base = emptyHogFlowLoopFormValues();
+      if (!prefill) return base;
+      // Only the fields the hog_flows compiler round-trips: name/description/instructions and a
+      // schedule trigger (capped to one — see the trigger-cardinality fix above). Fields the
+      // prefill can carry that hogFlows has no counterpart for (skill, contextTarget, a
+      // github/api trigger) are dropped instead of producing an uneditable, unsavable draft.
+      const scheduleTrigger = prefill.triggers?.find(
+        (t) => t.type === "schedule",
+      );
+      return normalizeLoopFormValues({
+        ...base,
+        ...prefill,
+        skill: null,
+        skillContext: "",
+        skillNames: base.skillNames,
+        contextTarget: null,
+        triggers: scheduleTrigger ? [scheduleTrigger] : base.triggers,
+      });
+    }
     return normalizeLoopFormValues({
       ...emptyLoopFormValues(),
       ...(prefill ?? {}),
@@ -175,7 +200,15 @@ export function LoopForm({
       return;
     }
 
-    if (nextBaseline.updatedAt === baseline.updatedAt) return;
+    // The lossy `Loop` facade and the raw HogFlow report the same `updatedAt`, so this is not a
+    // genuine remote update — it's the hog_flows skillNames correction becoming available. Don't
+    // skip it just because `updatedAt` looks unchanged.
+    const isHogFlowCorrection =
+      baseline.source === "loop" && nextBaseline.source === "hogFlow";
+
+    if (nextBaseline.updatedAt === baseline.updatedAt && !isHogFlowCorrection) {
+      return;
+    }
 
     if (isDirty) {
       setHasRemoteUpdate(true);
@@ -235,7 +268,13 @@ export function LoopForm({
   const formIsValid = hogFlowsEnabled
     ? isHogFlowLoopFormValid(values)
     : isLoopFormValid(values);
-  const canSubmit = formIsValid && !isSubmitting && !hasRemoteUpdate;
+  // Blocks saving until the raw HogFlow (and its real skillNames) has loaded, or if it failed to
+  // load — otherwise a save would write back the still-uncorrected empty skillNames and silently
+  // strip the loop's attached skills. See `hogFlow` above and the sync effect below.
+  const hogFlowDataPending =
+    hogFlowsEnabled && isEdit && (hogFlow.isLoading || hogFlow.isError);
+  const canSubmit =
+    formIsValid && !isSubmitting && !hasRemoteUpdate && !hogFlowDataPending;
 
   // Per-step gate for the Next button. The final Create button is gated on the
   // whole form being valid, so jumping between steps can't submit a bad loop.
@@ -318,7 +357,12 @@ export function LoopForm({
         }
       } catch (error) {
         toast.error(isEdit ? "Failed to save loop" : "Failed to create loop", {
-          description: error instanceof Error ? error.message : undefined,
+          description:
+            error instanceof WorkflowsApiError
+              ? (error.detail ?? error.message)
+              : error instanceof Error
+                ? error.message
+                : undefined,
         });
       }
       return;
@@ -469,7 +513,14 @@ export function LoopForm({
             triggers={values.triggers}
             triggerEndpointPath={triggerEndpointPath}
             disabled={isSubmitting}
-            availableTriggerTypes={hogFlowsEnabled ? ["schedule"] : undefined}
+            availableTriggerTypes={
+              hogFlowsEnabled
+                ? values.triggers.length === 0
+                  ? ["schedule"]
+                  : []
+                : undefined
+            }
+            minTriggers={hogFlowsEnabled ? 1 : undefined}
             onChange={(triggers) => patch({ triggers })}
           />
         </Step>
@@ -478,30 +529,36 @@ export function LoopForm({
 
         <Step
           title="Options"
-          description="Visibility, working context, and notifications."
+          description={
+            hogFlowsEnabled
+              ? "Base repository."
+              : "Visibility, working context, and notifications."
+          }
         >
           <div className="grid gap-4 md:grid-cols-2">
-            <Field
-              label="Visibility"
-              hint={
-                values.contextTarget
-                  ? "Channel loops are team-visible."
-                  : undefined
-              }
-            >
-              <SettingsOptionSelect
-                value={values.visibility}
-                options={VISIBILITY_OPTIONS}
-                disabled={isSubmitting || !!values.contextTarget}
-                size="lg"
-                ariaLabel="Visibility"
-                onValueChange={(value) =>
-                  patch({
-                    visibility: value as LoopSchemas.LoopVisibilityEnum,
-                  })
+            {hogFlowsEnabled ? null : (
+              <Field
+                label="Visibility"
+                hint={
+                  values.contextTarget
+                    ? "Channel loops are team-visible."
+                    : undefined
                 }
-              />
-            </Field>
+              >
+                <SettingsOptionSelect
+                  value={values.visibility}
+                  options={VISIBILITY_OPTIONS}
+                  disabled={isSubmitting || !!values.contextTarget}
+                  size="lg"
+                  ariaLabel="Visibility"
+                  onValueChange={(value) =>
+                    patch({
+                      visibility: value as LoopSchemas.LoopVisibilityEnum,
+                    })
+                  }
+                />
+              </Field>
+            )}
 
             <Field
               label="Base repository"
@@ -525,27 +582,29 @@ export function LoopForm({
               />
             </Field>
 
-            <Field
-              label="Sandbox environment"
-              hint="Applies its environment variables, network access, and image to every run."
-            >
-              <SettingsOptionSelect
-                value={values.sandboxEnvironmentId ?? ""}
-                options={sandboxEnvironmentOptions}
-                disabled={isSubmitting || environmentsLoading}
-                size="lg"
-                ariaLabel="Sandbox environment"
-                placeholder={
-                  environmentsLoading ? "Loading environments…" : undefined
-                }
-                onValueChange={(value) =>
-                  patch({ sandboxEnvironmentId: value || null })
-                }
-              />
-            </Field>
+            {hogFlowsEnabled ? null : (
+              <Field
+                label="Sandbox environment"
+                hint="Applies its environment variables, network access, and image to every run."
+              >
+                <SettingsOptionSelect
+                  value={values.sandboxEnvironmentId ?? ""}
+                  options={sandboxEnvironmentOptions}
+                  disabled={isSubmitting || environmentsLoading}
+                  size="lg"
+                  ariaLabel="Sandbox environment"
+                  placeholder={
+                    environmentsLoading ? "Loading environments…" : undefined
+                  }
+                  onValueChange={(value) =>
+                    patch({ sandboxEnvironmentId: value || null })
+                  }
+                />
+              </Field>
+            )}
           </div>
 
-          {showContextField ? (
+          {showContextField && !hogFlowsEnabled ? (
             <Field label="Context" hint="Attach runs to a sidebar channel.">
               <LoopContextFields
                 value={values.contextTarget}
@@ -561,30 +620,42 @@ export function LoopForm({
             </Field>
           ) : null}
 
-          <Field label="Notifications">
-            <LoopNotificationsFields
-              notifications={values.notifications}
-              disabled={isSubmitting}
-              onChange={(notifications) => patch({ notifications })}
-            />
-          </Field>
+          {hogFlowsEnabled ? null : (
+            <Field label="Notifications">
+              <LoopNotificationsFields
+                notifications={values.notifications}
+                disabled={isSubmitting}
+                onChange={(notifications) => patch({ notifications })}
+              />
+            </Field>
+          )}
         </Step>
 
         <Divider />
 
-        <Step title="Advanced" description="Behavior, model, and reasoning.">
-          <Field label="Behavior">
-            <LoopBehaviorFields
-              behaviors={values.behaviors}
-              disabled={isSubmitting}
-              onChange={(behaviors) => patch({ behaviors })}
-            />
-          </Field>
+        <Step
+          title="Advanced"
+          description={
+            hogFlowsEnabled
+              ? "Model and reasoning."
+              : "Behavior, model, and reasoning."
+          }
+        >
+          {hogFlowsEnabled ? null : (
+            <Field label="Behavior">
+              <LoopBehaviorFields
+                behaviors={values.behaviors}
+                disabled={isSubmitting}
+                onChange={(behaviors) => patch({ behaviors })}
+              />
+            </Field>
+          )}
           <LoopModelFields
             adapter={values.runtimeAdapter}
             model={values.model}
             reasoningEffort={values.reasoningEffort}
             disabled={isSubmitting}
+            hideAdapter={hogFlowsEnabled}
             onAdapterChange={(runtimeAdapter) => patch({ runtimeAdapter })}
             onModelChange={(model) => patch({ model })}
             onReasoningEffortChange={(reasoningEffort) =>
@@ -692,15 +763,24 @@ export function LoopForm({
           {step === 1 ? (
             <Step
               title="When should it run?"
-              description="A loop can have several triggers, and any one of them starts a run. With no triggers, you run it yourself from the loop's page."
+              description={
+                hogFlowsEnabled
+                  ? "Set a schedule, or leave this manual-only."
+                  : "A loop can have several triggers, and any one of them starts a run. With no triggers, you run it yourself from the loop's page."
+              }
             >
               <LoopTriggerEditor
                 triggers={values.triggers}
                 triggerEndpointPath={triggerEndpointPath}
                 disabled={isSubmitting}
                 availableTriggerTypes={
-                  hogFlowsEnabled ? ["schedule"] : undefined
+                  hogFlowsEnabled
+                    ? values.triggers.length === 0
+                      ? ["schedule"]
+                      : []
+                    : undefined
                 }
+                minTriggers={hogFlowsEnabled ? 1 : undefined}
                 onChange={(triggers) => patch({ triggers })}
               />
             </Step>
@@ -709,34 +789,42 @@ export function LoopForm({
           {step === 2 ? (
             <Step
               title="Options"
-              description="Who can see it and how you hear about runs."
+              description={
+                hogFlowsEnabled
+                  ? "Base repository, model, and reasoning."
+                  : "Who can see it and how you hear about runs."
+              }
             >
-              <Field
-                label="Visibility"
-                className="max-w-[340px]"
-                hint={
-                  values.contextTarget
-                    ? "Loops attached to a channel post runs to its shared feed, so they're visible to everyone on the project."
-                    : undefined
-                }
-              >
-                <SettingsOptionSelect
-                  value={values.visibility}
-                  options={VISIBILITY_OPTIONS}
-                  disabled={isSubmitting || !!values.contextTarget}
-                  size="lg"
-                  ariaLabel="Visibility"
-                  onValueChange={(value) =>
-                    patch({
-                      visibility: value as LoopSchemas.LoopVisibilityEnum,
-                    })
-                  }
-                />
-              </Field>
+              {hogFlowsEnabled ? null : (
+                <>
+                  <Field
+                    label="Visibility"
+                    className="max-w-[340px]"
+                    hint={
+                      values.contextTarget
+                        ? "Loops attached to a channel post runs to its shared feed, so they're visible to everyone on the project."
+                        : undefined
+                    }
+                  >
+                    <SettingsOptionSelect
+                      value={values.visibility}
+                      options={VISIBILITY_OPTIONS}
+                      disabled={isSubmitting || !!values.contextTarget}
+                      size="lg"
+                      ariaLabel="Visibility"
+                      onValueChange={(value) =>
+                        patch({
+                          visibility: value as LoopSchemas.LoopVisibilityEnum,
+                        })
+                      }
+                    />
+                  </Field>
 
-              <Divider />
+                  <Divider />
+                </>
+              )}
 
-              {showContextField ? (
+              {showContextField && !hogFlowsEnabled ? (
                 <>
                   <Field
                     label="Context"
@@ -787,60 +875,79 @@ export function LoopForm({
 
               <Divider />
 
-              <Field label="Notifications">
-                <LoopNotificationsFields
-                  notifications={values.notifications}
+              {hogFlowsEnabled ? (
+                <LoopModelFields
+                  adapter={values.runtimeAdapter}
+                  model={values.model}
+                  reasoningEffort={values.reasoningEffort}
                   disabled={isSubmitting}
-                  onChange={(notifications) => patch({ notifications })}
+                  hideAdapter
+                  onAdapterChange={(runtimeAdapter) =>
+                    patch({ runtimeAdapter })
+                  }
+                  onModelChange={(model) => patch({ model })}
+                  onReasoningEffortChange={(reasoningEffort) =>
+                    patch({ reasoningEffort })
+                  }
                 />
-              </Field>
-
-              <Divider />
-
-              <Flex direction="column" gap="4">
-                <button
-                  type="button"
-                  onClick={() => setShowAdvanced((open) => !open)}
-                  className="flex items-center gap-1.5 text-left"
-                >
-                  <CaretRight
-                    size={12}
-                    className={`text-gray-10 transition-transform ${
-                      showAdvanced ? "rotate-90" : ""
-                    }`}
-                  />
-                  <Text className="font-medium text-[12.5px] text-gray-11">
-                    Advanced
-                  </Text>
-                  <Text className="text-[11.5px] text-gray-9">
-                    Behavior, model and reasoning
-                  </Text>
-                </button>
-                {showAdvanced ? (
-                  <Flex direction="column" gap="4">
-                    <Field label="Behavior">
-                      <LoopBehaviorFields
-                        behaviors={values.behaviors}
-                        disabled={isSubmitting}
-                        onChange={(behaviors) => patch({ behaviors })}
-                      />
-                    </Field>
-                    <LoopModelFields
-                      adapter={values.runtimeAdapter}
-                      model={values.model}
-                      reasoningEffort={values.reasoningEffort}
+              ) : (
+                <>
+                  <Field label="Notifications">
+                    <LoopNotificationsFields
+                      notifications={values.notifications}
                       disabled={isSubmitting}
-                      onAdapterChange={(runtimeAdapter) =>
-                        patch({ runtimeAdapter })
-                      }
-                      onModelChange={(model) => patch({ model })}
-                      onReasoningEffortChange={(reasoningEffort) =>
-                        patch({ reasoningEffort })
-                      }
+                      onChange={(notifications) => patch({ notifications })}
                     />
+                  </Field>
+
+                  <Divider />
+
+                  <Flex direction="column" gap="4">
+                    <button
+                      type="button"
+                      onClick={() => setShowAdvanced((open) => !open)}
+                      className="flex items-center gap-1.5 text-left"
+                    >
+                      <CaretRight
+                        size={12}
+                        className={`text-gray-10 transition-transform ${
+                          showAdvanced ? "rotate-90" : ""
+                        }`}
+                      />
+                      <Text className="font-medium text-[12.5px] text-gray-11">
+                        Advanced
+                      </Text>
+                      <Text className="text-[11.5px] text-gray-9">
+                        Behavior, model and reasoning
+                      </Text>
+                    </button>
+                    {showAdvanced ? (
+                      <Flex direction="column" gap="4">
+                        <Field label="Behavior">
+                          <LoopBehaviorFields
+                            behaviors={values.behaviors}
+                            disabled={isSubmitting}
+                            onChange={(behaviors) => patch({ behaviors })}
+                          />
+                        </Field>
+                        <LoopModelFields
+                          adapter={values.runtimeAdapter}
+                          model={values.model}
+                          reasoningEffort={values.reasoningEffort}
+                          disabled={isSubmitting}
+                          onAdapterChange={(runtimeAdapter) =>
+                            patch({ runtimeAdapter })
+                          }
+                          onModelChange={(model) => patch({ model })}
+                          onReasoningEffortChange={(reasoningEffort) =>
+                            patch({ reasoningEffort })
+                          }
+                        />
+                      </Flex>
+                    ) : null}
                   </Flex>
-                ) : null}
-              </Flex>
+                </>
+              )}
             </Step>
           ) : null}
 
@@ -849,7 +956,11 @@ export function LoopForm({
               title="Review"
               description="Check everything before you create the loop."
             >
-              <ReviewList values={values} showContext={showContextField} />
+              <ReviewList
+                values={values}
+                showContext={showContextField}
+                hogFlowsEnabled={hogFlowsEnabled}
+              />
             </Step>
           ) : null}
         </Box>
@@ -1000,9 +1111,11 @@ function Divider() {
 function ReviewList({
   values,
   showContext,
+  hogFlowsEnabled,
 }: {
   values: LoopFormValues;
   showContext: boolean;
+  hogFlowsEnabled: boolean;
 }) {
   const reasoning = values.reasoningEffort ?? "auto";
   const channels = (["push", "email", "slack"] as const).filter(
@@ -1015,10 +1128,12 @@ function ReviewList({
       className="divide-y divide-(--gray-4) rounded-(--radius-3) border border-border"
     >
       <ReviewRow label="Name" value={values.name || "Not set"} />
-      <ReviewRow
-        label="Visibility"
-        value={values.visibility === "team" ? "Team" : "Personal"}
-      />
+      {hogFlowsEnabled ? null : (
+        <ReviewRow
+          label="Visibility"
+          value={values.visibility === "team" ? "Team" : "Personal"}
+        />
+      )}
       <ReviewRow
         label="Prompt"
         value={
@@ -1030,12 +1145,16 @@ function ReviewList({
       />
       <ReviewRow
         label="Model"
-        value={`${ADAPTER_LABELS[values.runtimeAdapter]} · ${formatLoopModel(
-          values.runtimeAdapter,
-          values.model,
-        )} · ${reasoning} reasoning`}
+        value={
+          hogFlowsEnabled
+            ? `${formatLoopModel(values.runtimeAdapter, values.model)} · ${reasoning} reasoning`
+            : `${ADAPTER_LABELS[values.runtimeAdapter]} · ${formatLoopModel(
+                values.runtimeAdapter,
+                values.model,
+              )} · ${reasoning} reasoning`
+        }
       />
-      {showContext ? (
+      {showContext && !hogFlowsEnabled ? (
         <ReviewRow
           label="Context"
           value={describeContext(values.contextTarget)}
@@ -1057,14 +1176,18 @@ function ReviewList({
             : values.triggers.map(summarizeTrigger).join(", ")
         }
       />
-      <ReviewRow
-        label="Auto-fix PRs"
-        value={isAutoFixEnabled(values.behaviors) ? "On" : "Off"}
-      />
-      <ReviewRow
-        label="Notifications"
-        value={channels.length === 0 ? "None" : channels.join(", ")}
-      />
+      {hogFlowsEnabled ? null : (
+        <>
+          <ReviewRow
+            label="Auto-fix PRs"
+            value={isAutoFixEnabled(values.behaviors) ? "On" : "Off"}
+          />
+          <ReviewRow
+            label="Notifications"
+            value={channels.length === 0 ? "None" : channels.join(", ")}
+          />
+        </>
+      )}
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/loops/components/LoopModelFields.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopModelFields.tsx
@@ -38,6 +38,9 @@ interface LoopModelFieldsProps {
     effort: LoopSchemas.LoopReasoningEffortEnum | null,
   ) => void;
   disabled?: boolean;
+  /** Hides the adapter picker: the hog_flows-backed create-task action has no field for it, so
+   * every run uses Claude regardless of what's selected here — see `formValuesToHogFlowWrite`. */
+  hideAdapter?: boolean;
 }
 
 /**
@@ -58,6 +61,7 @@ export function LoopModelFields({
   onModelChange,
   onReasoningEffortChange,
   disabled,
+  hideAdapter,
 }: LoopModelFieldsProps) {
   const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
@@ -133,16 +137,18 @@ export function LoopModelFields({
       </Field>
 
       <Flex gap="4" wrap="wrap">
-        <Field label="Adapter" className="min-w-[180px] flex-1">
-          <SettingsOptionSelect
-            value={adapter}
-            options={ADAPTER_OPTIONS}
-            onValueChange={handleAdapterChange}
-            disabled={disabled}
-            size="lg"
-            ariaLabel="Adapter"
-          />
-        </Field>
+        {hideAdapter ? null : (
+          <Field label="Adapter" className="min-w-[180px] flex-1">
+            <SettingsOptionSelect
+              value={adapter}
+              options={ADAPTER_OPTIONS}
+              onValueChange={handleAdapterChange}
+              disabled={disabled}
+              size="lg"
+              ariaLabel="Adapter"
+            />
+          </Field>
+        )}
 
         <Field label="Reasoning effort" className="min-w-[180px] flex-1">
           <SettingsOptionSelect

--- a/products/desktop/packages/ui/src/features/loops/components/LoopTeamSkillsFields.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopTeamSkillsFields.tsx
@@ -1,5 +1,4 @@
-import { Text, ToggleGroup, ToggleGroupItem } from "@posthog/quill";
-import { TextArea } from "@radix-ui/themes";
+import { Text, Textarea, ToggleGroup, ToggleGroupItem } from "@posthog/quill";
 import { useTeamSkills } from "../../skills/useTeamSkills";
 import type { LoopFormValues } from "../loopFormTypes";
 import { Field } from "./LoopFormPrimitives";
@@ -19,7 +18,7 @@ export function LoopTeamSkillsFields({
   disabled: boolean;
   onPatch: (next: Partial<LoopFormValues>) => void;
 }) {
-  const { data, isLoading } = useTeamSkills([]);
+  const { data, isLoading, isError } = useTeamSkills([]);
   const skillNames = data?.skills.map((skill) => skill.name) ?? [];
   // A previously-attached skill that's since been archived still needs to render, so it can be
   // seen and removed.
@@ -28,7 +27,7 @@ export function LoopTeamSkillsFields({
   return (
     <div className="flex flex-col gap-3">
       <Field label="Instructions">
-        <TextArea
+        <Textarea
           value={values.instructions}
           placeholder="What should the agent do?"
           disabled={disabled}
@@ -40,6 +39,10 @@ export function LoopTeamSkillsFields({
       <Field label="Skills">
         {isLoading ? (
           <Text className="text-[12px] text-gray-10">Loading skills…</Text>
+        ) : isError ? (
+          <Text className="text-[12px] text-gray-10">
+            Couldn't load team skills. Try again later.
+          </Text>
         ) : options.length === 0 ? (
           <Text className="text-[12px] text-gray-10">No team skills yet.</Text>
         ) : (

--- a/products/desktop/packages/ui/src/features/loops/components/LoopTeamSkillsFields.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopTeamSkillsFields.tsx
@@ -1,0 +1,68 @@
+import { Text, ToggleGroup, ToggleGroupItem } from "@posthog/quill";
+import { TextArea } from "@radix-ui/themes";
+import { useTeamSkills } from "../../skills/useTeamSkills";
+import type { LoopFormValues } from "../loopFormTypes";
+import { Field } from "./LoopFormPrimitives";
+
+/**
+ * hog_flows-backed replacement for `LoopInstructionsFields`: plain instructions text plus a
+ * multi-select of the team's skills store (see `useTeamSkills`), matching the create-task
+ * action's `skills` input — a list of names, not the single uploaded-bundle skill the Loops API
+ * models. No local/repo/marketplace skill sources here; those only exist for Loop-backed forms.
+ */
+export function LoopTeamSkillsFields({
+  values,
+  disabled,
+  onPatch,
+}: {
+  values: LoopFormValues;
+  disabled: boolean;
+  onPatch: (next: Partial<LoopFormValues>) => void;
+}) {
+  const { data, isLoading } = useTeamSkills([]);
+  const skillNames = data?.skills.map((skill) => skill.name) ?? [];
+  // A previously-attached skill that's since been archived still needs to render, so it can be
+  // seen and removed.
+  const options = [...new Set([...skillNames, ...values.skillNames])];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Field label="Instructions">
+        <TextArea
+          value={values.instructions}
+          placeholder="What should the agent do?"
+          disabled={disabled}
+          rows={6}
+          className="text-[13px] leading-relaxed"
+          onChange={(e) => onPatch({ instructions: e.target.value })}
+        />
+      </Field>
+      <Field label="Skills">
+        {isLoading ? (
+          <Text className="text-[12px] text-gray-10">Loading skills…</Text>
+        ) : options.length === 0 ? (
+          <Text className="text-[12px] text-gray-10">No team skills yet.</Text>
+        ) : (
+          <ToggleGroup
+            multiple
+            disabled={disabled}
+            value={values.skillNames}
+            onValueChange={(skillNames: string[]) => onPatch({ skillNames })}
+            className="flex flex-wrap gap-1.5"
+          >
+            {options.map((name) => (
+              <ToggleGroupItem
+                key={name}
+                value={name}
+                size="sm"
+                variant="outline"
+              >
+                {name}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        )}
+      </Field>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/loops/components/LoopTriggerEditor.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopTriggerEditor.tsx
@@ -124,6 +124,11 @@ interface LoopTriggerEditorProps {
    * variant of this feature passes `["schedule"]` — HogFlow triggers other than schedule aren't
    * supported here yet. */
   availableTriggerTypes?: LoopSchemas.LoopTriggerTypeEnum[];
+  /** Floor below which "Remove trigger" is hidden. The hog_flows-backed variant of this feature
+   * always writes exactly one trigger — HogFlow has nowhere to store a manual-only loop's "no
+   * trigger" state — so removing the last one there would show a "Manual only" review row the
+   * form can never actually save. Defaults to 0 (Loop-backed forms genuinely support zero). */
+  minTriggers?: number;
 }
 
 export function LoopTriggerEditor({
@@ -132,6 +137,7 @@ export function LoopTriggerEditor({
   triggerEndpointPath,
   disabled,
   availableTriggerTypes = ALL_TRIGGER_TYPES,
+  minTriggers = 0,
 }: LoopTriggerEditorProps) {
   const updateTrigger = (key: string, patch: Partial<LoopTriggerDraft>) => {
     onChange(
@@ -148,6 +154,8 @@ export function LoopTriggerEditor({
   const addTrigger = (type: LoopSchemas.LoopTriggerTypeEnum) => {
     onChange([...triggers, defaultLoopTriggerOfType(type)]);
   };
+
+  const canRemove = triggers.length > minTriggers;
 
   return (
     <Flex direction="column" gap="3">
@@ -171,6 +179,7 @@ export function LoopTriggerEditor({
             trigger={trigger}
             triggerEndpointPath={triggerEndpointPath}
             disabled={disabled}
+            canRemove={canRemove}
             onChange={(patch) => updateTrigger(trigger.key, patch)}
             onRemove={() => removeTrigger(trigger.key)}
           />
@@ -250,12 +259,14 @@ function TriggerCard({
   trigger,
   triggerEndpointPath,
   disabled,
+  canRemove,
   onChange,
   onRemove,
 }: {
   trigger: LoopTriggerDraft;
   triggerEndpointPath: string | null;
   disabled?: boolean;
+  canRemove: boolean;
   onChange: (patch: Partial<LoopTriggerDraft>) => void;
   onRemove: () => void;
 }) {
@@ -296,37 +307,39 @@ function TriggerCard({
           disabled={disabled}
           aria-label={trigger.enabled ? "Disable trigger" : "Enable trigger"}
         />
-        <DropdownMenu>
-          <DropdownMenuTrigger
-            render={
-              <Button
-                type="button"
-                variant="link-muted"
-                size="sm"
-                disabled={disabled}
-                aria-label="Trigger actions"
-                className="text-gray-10"
-              >
-                <DotsThreeVertical size={16} weight="bold" />
-              </Button>
-            }
-          />
-          <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
-            <DropdownMenuItem
-              onClick={onRemove}
+        {canRemove ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger
               render={
-                <ItemMenuItem size="xs" className="w-full text-(--red-11)">
-                  <ItemMedia variant="icon" className="mt-2 ml-2">
-                    <Trash size={15} />
-                  </ItemMedia>
-                  <ItemContent variant="menuItem">
-                    <ItemTitle>Remove trigger</ItemTitle>
-                  </ItemContent>
-                </ItemMenuItem>
+                <Button
+                  type="button"
+                  variant="link-muted"
+                  size="sm"
+                  disabled={disabled}
+                  aria-label="Trigger actions"
+                  className="text-gray-10"
+                >
+                  <DotsThreeVertical size={16} weight="bold" />
+                </Button>
               }
             />
-          </DropdownMenuContent>
-        </DropdownMenu>
+            <DropdownMenuContent align="end" side="bottom" sideOffset={6}>
+              <DropdownMenuItem
+                onClick={onRemove}
+                render={
+                  <ItemMenuItem size="xs" className="w-full text-(--red-11)">
+                    <ItemMedia variant="icon" className="mt-2 ml-2">
+                      <Trash size={15} />
+                    </ItemMedia>
+                    <ItemContent variant="menuItem">
+                      <ItemTitle>Remove trigger</ItemTitle>
+                    </ItemContent>
+                  </ItemMenuItem>
+                }
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
       </Flex>
 
       <Box

--- a/products/desktop/packages/ui/src/features/loops/components/LoopTriggerEditor.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopTriggerEditor.tsx
@@ -108,12 +108,22 @@ function githubTriggerInvalidMessage(
   return "Fill in a path and a value for each payload condition, or remove the empty rows.";
 }
 
+const ALL_TRIGGER_TYPES: LoopSchemas.LoopTriggerTypeEnum[] = [
+  "schedule",
+  "github",
+  "api",
+];
+
 interface LoopTriggerEditorProps {
   triggers: LoopTriggerDraft[];
   onChange: (triggers: LoopTriggerDraft[]) => void;
   /** Rendered in the API trigger card. Absent for a not-yet-created loop. */
   triggerEndpointPath: string | null;
   disabled?: boolean;
+  /** Trigger types offerable from "Add trigger". Defaults to all three; the hog_flows-backed
+   * variant of this feature passes `["schedule"]` — HogFlow triggers other than schedule aren't
+   * supported here yet. */
+  availableTriggerTypes?: LoopSchemas.LoopTriggerTypeEnum[];
 }
 
 export function LoopTriggerEditor({
@@ -121,6 +131,7 @@ export function LoopTriggerEditor({
   onChange,
   triggerEndpointPath,
   disabled,
+  availableTriggerTypes = ALL_TRIGGER_TYPES,
 }: LoopTriggerEditorProps) {
   const updateTrigger = (key: string, patch: Partial<LoopTriggerDraft>) => {
     onChange(
@@ -166,7 +177,11 @@ export function LoopTriggerEditor({
         ))
       )}
 
-      <AddTriggerMenu disabled={disabled} onAdd={addTrigger} />
+      <AddTriggerMenu
+        disabled={disabled}
+        onAdd={addTrigger}
+        availableTypes={availableTriggerTypes}
+      />
     </Flex>
   );
 }
@@ -174,10 +189,17 @@ export function LoopTriggerEditor({
 function AddTriggerMenu({
   disabled,
   onAdd,
+  availableTypes,
 }: {
   disabled?: boolean;
   onAdd: (type: LoopSchemas.LoopTriggerTypeEnum) => void;
+  availableTypes: LoopSchemas.LoopTriggerTypeEnum[];
 }) {
+  const options = TRIGGER_TYPES.filter((option) =>
+    availableTypes.includes(option.type),
+  );
+  if (options.length === 0) return null;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -200,7 +222,7 @@ function AddTriggerMenu({
         sideOffset={6}
         className="w-auto min-w-[280px]"
       >
-        {TRIGGER_TYPES.map((option) => (
+        {options.map((option) => (
           <DropdownMenuItem
             key={option.type}
             onClick={() => onAdd(option.type)}

--- a/products/desktop/packages/ui/src/features/loops/hooks/useHogFlow.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useHogFlow.ts
@@ -4,6 +4,7 @@ import {
 } from "@posthog/api-client/workflows";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import { useQuery } from "@tanstack/react-query";
+import { isDecompilableLoopHogFlow } from "../loopHogFlowMapping";
 import { useWorkflowsClient } from "./useWorkflowsClient";
 
 /**
@@ -32,6 +33,9 @@ export function useHogFlow(loopId: string | undefined, enabled: boolean) {
         workflowsClient.projectId,
         loopId,
       );
+      if (!isDecompilableLoopHogFlow(flow, flow.schedules)) {
+        throw new Error("This workflow isn't editable as a loop.");
+      }
       return { flow, schedule: flow.schedules[0] ?? null };
     },
     enabled: enabled && !!workflowsClient && !!loopId,

--- a/products/desktop/packages/ui/src/features/loops/hooks/useHogFlow.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useHogFlow.ts
@@ -1,0 +1,41 @@
+import {
+  retrieveHogFlow,
+  type WorkflowSchemas,
+} from "@posthog/api-client/workflows";
+import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { useQuery } from "@tanstack/react-query";
+import { useWorkflowsClient } from "./useWorkflowsClient";
+
+/**
+ * The raw HogFlow behind a loop, only needed where `useLoop`'s `Loop`-shaped facade loses
+ * information the `Loop` wire type has no field for — `LoopForm` initializing its edit state
+ * needs `skillNames`, which only `hogFlowToFormValues` (fed by the raw flow) can produce. Every
+ * other read (list rows, the detail view's read-only summary) goes through `useLoop`.
+ */
+export function useHogFlow(loopId: string | undefined, enabled: boolean) {
+  const workflowsClient = useWorkflowsClient();
+
+  return useQuery<{
+    flow: WorkflowSchemas.HogFlow;
+    schedule: WorkflowSchemas.HogFlowSchedule | null;
+  }>({
+    queryKey: [
+      "workflows-loops",
+      "raw",
+      workflowsClient?.projectId ?? null,
+      loopId ?? "",
+    ],
+    queryFn: async () => {
+      if (!workflowsClient || !loopId) throw new Error("Not authenticated");
+      const flow = await retrieveHogFlow(
+        workflowsClient.client,
+        workflowsClient.projectId,
+        loopId,
+      );
+      return { flow, schedule: flow.schedules[0] ?? null };
+    },
+    enabled: enabled && !!workflowsClient && !!loopId,
+    staleTime: 15_000,
+    meta: AUTH_SCOPED_QUERY_META,
+  });
+}

--- a/products/desktop/packages/ui/src/features/loops/hooks/useLoop.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useLoop.ts
@@ -1,13 +1,20 @@
 import { type LoopSchemas, retrieveLoop } from "@posthog/api-client/loops";
+import { retrieveHogFlow } from "@posthog/api-client/workflows";
+import { LOOPS_HOG_FLOWS_FLAG } from "@posthog/shared";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useQuery } from "@tanstack/react-query";
+import { hogFlowToLoop } from "../loopHogFlowMapping";
 import { loopsKeys } from "./loopsKeys";
 import { useLoopsClient } from "./useLoopsClient";
+import { useWorkflowsClient } from "./useWorkflowsClient";
 
 export function useLoop(loopId: string | undefined) {
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const loopsClient = useLoopsClient();
+  const workflowsClient = useWorkflowsClient();
 
-  return useQuery<LoopSchemas.Loop>({
+  const legacy = useQuery<LoopSchemas.Loop>({
     queryKey: loopsKeys.detail(loopsClient?.projectId ?? null, loopId ?? ""),
     queryFn: async () => {
       if (!loopsClient || !loopId) throw new Error("Not authenticated");
@@ -17,8 +24,31 @@ export function useLoop(loopId: string | undefined) {
         loopId,
       );
     },
-    enabled: !!loopsClient && !!loopId,
+    enabled: !hogFlowsEnabled && !!loopsClient && !!loopId,
     staleTime: 15_000,
     meta: AUTH_SCOPED_QUERY_META,
   });
+
+  const hogFlow = useQuery<LoopSchemas.Loop>({
+    queryKey: [
+      "workflows-loops",
+      "detail",
+      workflowsClient?.projectId ?? null,
+      loopId ?? "",
+    ],
+    queryFn: async () => {
+      if (!workflowsClient || !loopId) throw new Error("Not authenticated");
+      const flow = await retrieveHogFlow(
+        workflowsClient.client,
+        workflowsClient.projectId,
+        loopId,
+      );
+      return hogFlowToLoop(flow, flow.schedules[0] ?? null);
+    },
+    enabled: hogFlowsEnabled && !!workflowsClient && !!loopId,
+    staleTime: 15_000,
+    meta: AUTH_SCOPED_QUERY_META,
+  });
+
+  return hogFlowsEnabled ? hogFlow : legacy;
 }

--- a/products/desktop/packages/ui/src/features/loops/hooks/useLoop.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useLoop.ts
@@ -4,7 +4,10 @@ import { LOOPS_HOG_FLOWS_FLAG } from "@posthog/shared";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useQuery } from "@tanstack/react-query";
-import { hogFlowToLoop } from "../loopHogFlowMapping";
+import {
+  hogFlowToLoop,
+  isDecompilableLoopHogFlow,
+} from "../loopHogFlowMapping";
 import { loopsKeys } from "./loopsKeys";
 import { useLoopsClient } from "./useLoopsClient";
 import { useWorkflowsClient } from "./useWorkflowsClient";
@@ -43,6 +46,12 @@ export function useLoop(loopId: string | undefined) {
         workflowsClient.projectId,
         loopId,
       );
+      // A workflow this feature didn't build (or hand-edited elsewhere since) isn't a loop this
+      // feature can show or edit safely — failing here keeps Save/Delete from acting on a
+      // resource whose real shape they'd silently destroy. See `isDecompilableLoopHogFlow`.
+      if (!isDecompilableLoopHogFlow(flow, flow.schedules)) {
+        throw new Error("This workflow isn't editable as a loop.");
+      }
       return hogFlowToLoop(flow, flow.schedules[0] ?? null);
     },
     enabled: hogFlowsEnabled && !!workflowsClient && !!loopId,

--- a/products/desktop/packages/ui/src/features/loops/hooks/useLoopMutations.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useLoopMutations.ts
@@ -5,34 +5,135 @@ import {
   partialUpdateLoop,
   runLoop,
 } from "@posthog/api-client/loops";
+import {
+  createHogFlow,
+  createHogFlowSchedule,
+  destroyHogFlow,
+  partialUpdateHogFlow,
+  partialUpdateHogFlowSchedule,
+  runHogFlow,
+  WorkflowsApiError,
+} from "@posthog/api-client/workflows";
+import { LOOPS_HOG_FLOWS_FLAG } from "@posthog/shared";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { formValuesToLoopWrite, type LoopFormValues } from "../loopFormTypes";
+import {
+  formValuesToHogFlowWrite,
+  formValuesToScheduleWrite,
+  hogFlowToLoop,
+} from "../loopHogFlowMapping";
 import { loopsKeys } from "./loopsKeys";
 import { useLoopsClient } from "./useLoopsClient";
+import { useWorkflowsClient } from "./useWorkflowsClient";
+
+/** A HogFlow write always needs a status; a freshly created loop starts active unless its
+ * (only) trigger was created disabled. */
+function statusFor(values: LoopFormValues): "active" | "draft" {
+  return values.triggers[0]?.enabled ? "active" : "draft";
+}
 
 export function useCreateLoop() {
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const loopsClient = useLoopsClient();
+  const workflowsClient = useWorkflowsClient();
   const queryClient = useQueryClient();
 
-  return useMutation<LoopSchemas.Loop, Error, LoopSchemas.LoopWrite>({
-    mutationFn: async (body) => {
+  return useMutation<LoopSchemas.Loop, Error, LoopFormValues>({
+    mutationFn: async (values) => {
+      if (hogFlowsEnabled) {
+        if (!workflowsClient) throw new Error("Not authenticated");
+        const flow = await createHogFlow(
+          workflowsClient.client,
+          workflowsClient.projectId,
+          formValuesToHogFlowWrite(values, statusFor(values)),
+        );
+        const scheduleWrite = formValuesToScheduleWrite(values);
+        const schedule = scheduleWrite
+          ? await createHogFlowSchedule(
+              workflowsClient.client,
+              workflowsClient.projectId,
+              flow.id,
+              scheduleWrite,
+            )
+          : null;
+        return hogFlowToLoop(flow, schedule);
+      }
       if (!loopsClient) throw new Error("Not authenticated");
-      return await createLoop(loopsClient.client, loopsClient.projectId, body);
+      return await createLoop(
+        loopsClient.client,
+        loopsClient.projectId,
+        formValuesToLoopWrite(values),
+      );
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: loopsKeys.list(loopsClient?.projectId ?? null),
+        queryKey: hogFlowsEnabled
+          ? ["workflows-loops", "list"]
+          : loopsKeys.list(loopsClient?.projectId ?? null),
       });
     },
   });
 }
 
+/** Either a full form save, or the detail view's isolated "toggle enabled" switch — the latter
+ * touches only the loop's status, never the rest of its config. */
+export type UpdateLoopPayload =
+  | { kind: "toggleEnabled"; enabled: boolean }
+  | { kind: "save"; values: LoopFormValues };
+
 export function useUpdateLoop(loopId: string) {
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const loopsClient = useLoopsClient();
+  const workflowsClient = useWorkflowsClient();
   const queryClient = useQueryClient();
 
-  return useMutation<LoopSchemas.Loop, Error, LoopSchemas.PatchedLoop>({
-    mutationFn: async (body) => {
+  return useMutation<LoopSchemas.Loop, Error, UpdateLoopPayload>({
+    mutationFn: async (payload) => {
+      if (hogFlowsEnabled) {
+        if (!workflowsClient) throw new Error("Not authenticated");
+        if (payload.kind === "toggleEnabled") {
+          const flow = await partialUpdateHogFlow(
+            workflowsClient.client,
+            workflowsClient.projectId,
+            loopId,
+            { status: payload.enabled ? "active" : "draft" },
+          );
+          return hogFlowToLoop(flow, flow.schedules[0] ?? null);
+        }
+
+        const flow = await partialUpdateHogFlow(
+          workflowsClient.client,
+          workflowsClient.projectId,
+          loopId,
+          formValuesToHogFlowWrite(payload.values, statusFor(payload.values)),
+        );
+        const scheduleWrite = formValuesToScheduleWrite(payload.values);
+        const existingSchedule = flow.schedules[0] ?? null;
+        const schedule = scheduleWrite
+          ? existingSchedule
+            ? await partialUpdateHogFlowSchedule(
+                workflowsClient.client,
+                workflowsClient.projectId,
+                loopId,
+                existingSchedule.id,
+                scheduleWrite,
+              )
+            : await createHogFlowSchedule(
+                workflowsClient.client,
+                workflowsClient.projectId,
+                loopId,
+                scheduleWrite,
+              )
+          : existingSchedule;
+        return hogFlowToLoop(flow, schedule);
+      }
+
       if (!loopsClient) throw new Error("Not authenticated");
+      const body: LoopSchemas.PatchedLoop =
+        payload.kind === "toggleEnabled"
+          ? { enabled: payload.enabled }
+          : formValuesToLoopWrite(payload.values);
       return await partialUpdateLoop(
         loopsClient.client,
         loopsClient.projectId,
@@ -42,48 +143,109 @@ export function useUpdateLoop(loopId: string) {
     },
     onSuccess: (loop) => {
       queryClient.setQueryData(
-        loopsKeys.detail(loopsClient?.projectId ?? null, loopId),
+        hogFlowsEnabled
+          ? [
+              "workflows-loops",
+              "detail",
+              workflowsClient?.projectId ?? null,
+              loopId,
+            ]
+          : loopsKeys.detail(loopsClient?.projectId ?? null, loopId),
         loop,
       );
       void queryClient.invalidateQueries({
-        queryKey: loopsKeys.list(loopsClient?.projectId ?? null),
+        queryKey: hogFlowsEnabled
+          ? ["workflows-loops", "list"]
+          : loopsKeys.list(loopsClient?.projectId ?? null),
       });
     },
   });
 }
 
 export function useDeleteLoop() {
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const loopsClient = useLoopsClient();
+  const workflowsClient = useWorkflowsClient();
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, string>({
     mutationFn: async (loopId) => {
+      if (hogFlowsEnabled) {
+        if (!workflowsClient) throw new Error("Not authenticated");
+        await destroyHogFlow(
+          workflowsClient.client,
+          workflowsClient.projectId,
+          loopId,
+        );
+        return;
+      }
       if (!loopsClient) throw new Error("Not authenticated");
       await destroyLoop(loopsClient.client, loopsClient.projectId, loopId);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: loopsKeys.list(loopsClient?.projectId ?? null),
+        queryKey: hogFlowsEnabled
+          ? ["workflows-loops", "list"]
+          : loopsKeys.list(loopsClient?.projectId ?? null),
       });
     },
   });
 }
 
 export function useRunLoop(loopId: string) {
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const loopsClient = useLoopsClient();
+  const workflowsClient = useWorkflowsClient();
   const queryClient = useQueryClient();
 
   return useMutation<LoopSchemas.LoopFireRun, Error, void>({
     mutationFn: async () => {
+      if (hogFlowsEnabled) {
+        if (!workflowsClient) throw new Error("Not authenticated");
+        try {
+          await runHogFlow(
+            workflowsClient.client,
+            workflowsClient.projectId,
+            loopId,
+          );
+        } catch (error) {
+          // Unlike Loops' own dedup/rate-cap system, a hog_flows run either queues or fails
+          // outright (e.g. "must be active") — there's no soft-reject reason to report, so this
+          // surfaces as a thrown error for the caller's generic catch block instead of a
+          // `LoopFireRun.reason`.
+          throw new Error(
+            error instanceof WorkflowsApiError
+              ? (error.detail ?? error.message)
+              : (error as Error).message,
+          );
+        }
+        // The run is only queued at this point; the task it spawns doesn't exist yet, so there's
+        // no task_id/task_run_id to report (unlike Loops' own synchronous fire).
+        return {
+          created: true,
+          reason: "created",
+          task_id: null,
+          task_run_id: null,
+        };
+      }
       if (!loopsClient) throw new Error("Not authenticated");
       return await runLoop(loopsClient.client, loopsClient.projectId, loopId);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: loopsKeys.runs(loopsClient?.projectId ?? null, loopId),
+        queryKey: hogFlowsEnabled
+          ? ["workflows-loops", "runs", loopId]
+          : loopsKeys.runs(loopsClient?.projectId ?? null, loopId),
       });
       void queryClient.invalidateQueries({
-        queryKey: loopsKeys.detail(loopsClient?.projectId ?? null, loopId),
+        queryKey: hogFlowsEnabled
+          ? [
+              "workflows-loops",
+              "detail",
+              workflowsClient?.projectId ?? null,
+              loopId,
+            ]
+          : loopsKeys.detail(loopsClient?.projectId ?? null, loopId),
       });
     },
   });

--- a/products/desktop/packages/ui/src/features/loops/hooks/useLoopMutations.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useLoopMutations.ts
@@ -23,9 +23,29 @@ import {
   formValuesToScheduleWrite,
   hogFlowToLoop,
 } from "../loopHogFlowMapping";
+import { isOnceOffSchedule } from "../loopScheduleRRule";
 import { loopsKeys } from "./loopsKeys";
 import { useLoopsClient } from "./useLoopsClient";
 import { useWorkflowsClient } from "./useWorkflowsClient";
+
+/** hog_flows-loops query keys that don't live in `loopsKeys` (which is Loops-API-specific).
+ * Kept in one place so every mutation invalidates the same set. */
+const workflowsLoopsKeys = {
+  list: (projectId: string | null) => ["workflows-loops", "list", projectId],
+  detail: (projectId: string | null, loopId: string) => [
+    "workflows-loops",
+    "detail",
+    projectId,
+    loopId,
+  ],
+  raw: (projectId: string | null, loopId: string) => [
+    "workflows-loops",
+    "raw",
+    projectId,
+    loopId,
+  ],
+  runs: (loopId: string) => ["workflows-loops", "runs", loopId],
+};
 
 /** A HogFlow write always needs a status; a freshly created loop starts active unless its
  * (only) trigger was created disabled. */
@@ -49,15 +69,30 @@ export function useCreateLoop() {
           formValuesToHogFlowWrite(values, statusFor(values)),
         );
         const scheduleWrite = formValuesToScheduleWrite(values);
-        const schedule = scheduleWrite
-          ? await createHogFlowSchedule(
+        if (!scheduleWrite) return hogFlowToLoop(flow, null);
+        try {
+          const schedule = await createHogFlowSchedule(
+            workflowsClient.client,
+            workflowsClient.projectId,
+            flow.id,
+            scheduleWrite,
+          );
+          return hogFlowToLoop(flow, schedule);
+        } catch (error) {
+          // The flow already exists without a schedule at this point — an enabled loop that can
+          // never fire, and every retry would create another. Roll it back rather than leave it.
+          try {
+            await destroyHogFlow(
               workflowsClient.client,
               workflowsClient.projectId,
               flow.id,
-              scheduleWrite,
-            )
-          : null;
-        return hogFlowToLoop(flow, schedule);
+            );
+          } catch {
+            // The flow is orphaned; surfacing the original schedule error still tells the user
+            // the create failed, which is the actionable half of this.
+          }
+          throw error;
+        }
       }
       if (!loopsClient) throw new Error("Not authenticated");
       return await createLoop(
@@ -69,7 +104,7 @@ export function useCreateLoop() {
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: hogFlowsEnabled
-          ? ["workflows-loops", "list"]
+          ? workflowsLoopsKeys.list(workflowsClient?.projectId ?? null)
           : loopsKeys.list(loopsClient?.projectId ?? null),
       });
     },
@@ -110,22 +145,35 @@ export function useUpdateLoop(loopId: string) {
         );
         const scheduleWrite = formValuesToScheduleWrite(payload.values);
         const existingSchedule = flow.schedules[0] ?? null;
-        const schedule = scheduleWrite
+        // Re-anchoring an unchanged schedule to "now" can clear a due-but-unfired occurrence on
+        // the backend (it recomputes next_run_at from the new starts_at) — so skip the write
+        // entirely when the timing hasn't actually changed, rather than resending it every save.
+        const scheduleUnchanged =
+          !!scheduleWrite &&
+          !!existingSchedule &&
+          scheduleWrite.rrule === existingSchedule.rrule &&
+          scheduleWrite.timezone === existingSchedule.timezone &&
+          (isOnceOffSchedule(scheduleWrite.rrule)
+            ? scheduleWrite.starts_at === existingSchedule.starts_at
+            : true);
+        const schedule = scheduleUnchanged
           ? existingSchedule
-            ? await partialUpdateHogFlowSchedule(
-                workflowsClient.client,
-                workflowsClient.projectId,
-                loopId,
-                existingSchedule.id,
-                scheduleWrite,
-              )
-            : await createHogFlowSchedule(
-                workflowsClient.client,
-                workflowsClient.projectId,
-                loopId,
-                scheduleWrite,
-              )
-          : existingSchedule;
+          : scheduleWrite
+            ? existingSchedule
+              ? await partialUpdateHogFlowSchedule(
+                  workflowsClient.client,
+                  workflowsClient.projectId,
+                  loopId,
+                  existingSchedule.id,
+                  scheduleWrite,
+                )
+              : await createHogFlowSchedule(
+                  workflowsClient.client,
+                  workflowsClient.projectId,
+                  loopId,
+                  scheduleWrite,
+                )
+            : existingSchedule;
         return hogFlowToLoop(flow, schedule);
       }
 
@@ -144,20 +192,31 @@ export function useUpdateLoop(loopId: string) {
     onSuccess: (loop) => {
       queryClient.setQueryData(
         hogFlowsEnabled
-          ? [
-              "workflows-loops",
-              "detail",
+          ? workflowsLoopsKeys.detail(
               workflowsClient?.projectId ?? null,
               loopId,
-            ]
+            )
           : loopsKeys.detail(loopsClient?.projectId ?? null, loopId),
         loop,
       );
+    },
+    onSettled: () => {
+      // Runs on both success and failure: the flow PATCH can commit even when the follow-up
+      // schedule write fails (see the mutationFn above), so the caches need refreshing either
+      // way rather than only on a clean success.
       void queryClient.invalidateQueries({
         queryKey: hogFlowsEnabled
-          ? ["workflows-loops", "list"]
+          ? workflowsLoopsKeys.list(workflowsClient?.projectId ?? null)
           : loopsKeys.list(loopsClient?.projectId ?? null),
       });
+      if (hogFlowsEnabled) {
+        void queryClient.invalidateQueries({
+          queryKey: workflowsLoopsKeys.raw(
+            workflowsClient?.projectId ?? null,
+            loopId,
+          ),
+        });
+      }
     },
   });
 }
@@ -182,12 +241,20 @@ export function useDeleteLoop() {
       if (!loopsClient) throw new Error("Not authenticated");
       await destroyLoop(loopsClient.client, loopsClient.projectId, loopId);
     },
-    onSuccess: () => {
+    onSuccess: (_data, loopId) => {
       void queryClient.invalidateQueries({
         queryKey: hogFlowsEnabled
-          ? ["workflows-loops", "list"]
+          ? workflowsLoopsKeys.list(workflowsClient?.projectId ?? null)
           : loopsKeys.list(loopsClient?.projectId ?? null),
       });
+      if (hogFlowsEnabled) {
+        void queryClient.invalidateQueries({
+          queryKey: workflowsLoopsKeys.raw(
+            workflowsClient?.projectId ?? null,
+            loopId,
+          ),
+        });
+      }
     },
   });
 }
@@ -234,17 +301,15 @@ export function useRunLoop(loopId: string) {
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: hogFlowsEnabled
-          ? ["workflows-loops", "runs", loopId]
+          ? workflowsLoopsKeys.runs(loopId)
           : loopsKeys.runs(loopsClient?.projectId ?? null, loopId),
       });
       void queryClient.invalidateQueries({
         queryKey: hogFlowsEnabled
-          ? [
-              "workflows-loops",
-              "detail",
+          ? workflowsLoopsKeys.detail(
               workflowsClient?.projectId ?? null,
               loopId,
-            ]
+            )
           : loopsKeys.detail(loopsClient?.projectId ?? null, loopId),
       });
     },

--- a/products/desktop/packages/ui/src/features/loops/hooks/useLoopRuns.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useLoopRuns.ts
@@ -1,6 +1,10 @@
 import { type LoopSchemas, listLoopRuns } from "@posthog/api-client/loops";
+import { LOOPS_HOG_FLOWS_FLAG } from "@posthog/shared";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useAuthenticatedQuery } from "@posthog/ui/hooks/useAuthenticatedQuery";
 import { useQuery } from "@tanstack/react-query";
+import { taskToLoopRun } from "../loopHogFlowMapping";
 import { loopsKeys } from "./loopsKeys";
 import { useLoopsClient } from "./useLoopsClient";
 
@@ -8,9 +12,14 @@ export const RECENT_RUNS_LIMIT = 10;
 
 /** The most recent runs for a loop, polled so the detail view stays live. */
 export function useLoopRuns(loopId: string | undefined) {
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const loopsClient = useLoopsClient();
 
-  return useQuery<LoopSchemas.LoopRunPage, Error, LoopSchemas.LoopRun[]>({
+  const legacy = useQuery<
+    LoopSchemas.LoopRunPage,
+    Error,
+    LoopSchemas.LoopRun[]
+  >({
     queryKey: loopsKeys.runs(loopsClient?.projectId ?? null, loopId ?? ""),
     queryFn: async () => {
       if (!loopsClient || !loopId) throw new Error("Not authenticated");
@@ -22,9 +31,30 @@ export function useLoopRuns(loopId: string | undefined) {
       );
     },
     select: (page) => page.results.slice(0, RECENT_RUNS_LIMIT),
-    enabled: !!loopsClient && !!loopId,
+    enabled: !hogFlowsEnabled && !!loopsClient && !!loopId,
     staleTime: 10_000,
     refetchInterval: 15_000,
     meta: AUTH_SCOPED_QUERY_META,
   });
+
+  const hogFlow = useAuthenticatedQuery<LoopSchemas.LoopRun[]>(
+    ["workflows-loops", "runs", loopId ?? ""],
+    async (client) => {
+      if (!loopId) throw new Error("Not authenticated");
+      const { tasks } = await client.getTasksPage({
+        hogFlowId: loopId,
+        limit: RECENT_RUNS_LIMIT,
+      });
+      return tasks
+        .map(taskToLoopRun)
+        .filter((run): run is LoopSchemas.LoopRun => run !== null);
+    },
+    {
+      enabled: hogFlowsEnabled && !!loopId,
+      staleTime: 10_000,
+      refetchInterval: 15_000,
+    },
+  );
+
+  return hogFlowsEnabled ? hogFlow : legacy;
 }

--- a/products/desktop/packages/ui/src/features/loops/hooks/useLoops.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useLoops.ts
@@ -1,15 +1,29 @@
 import { type LoopSchemas, listLoops } from "@posthog/api-client/loops";
+import {
+  isLoopShapedHogFlow,
+  listHogFlows,
+} from "@posthog/api-client/workflows";
+import { LOOPS_HOG_FLOWS_FLAG } from "@posthog/shared";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useQuery } from "@tanstack/react-query";
+import { hogFlowMinimalToLoop } from "../loopHogFlowMapping";
 import { loopsKeys } from "./loopsKeys";
 import { type LoopsApiClient, useLoopsClient } from "./useLoopsClient";
+import {
+  useWorkflowsClient,
+  type WorkflowsApiClient,
+} from "./useWorkflowsClient";
 
 const LOOPS_LIST_LIMIT = 100;
 
 /** Shared query for the loops list page. Both `useLoops` (the loop rows) and `useLoopLimits`
  * (the per-project cap) read from this single fetch via `select`, so the cap the backend serves
  * stays in lockstep with the list and there's no second request. */
-function loopsPageQueryOptions(loopsClient: LoopsApiClient | null) {
+function loopsPageQueryOptions(
+  loopsClient: LoopsApiClient | null,
+  enabled: boolean,
+) {
   return {
     queryKey: loopsKeys.list(loopsClient?.projectId ?? null),
     queryFn: async (): Promise<LoopSchemas.PaginatedLoopList> => {
@@ -18,18 +32,56 @@ function loopsPageQueryOptions(loopsClient: LoopsApiClient | null) {
         limit: LOOPS_LIST_LIMIT,
       });
     },
-    enabled: !!loopsClient,
+    enabled: enabled && !!loopsClient,
+    staleTime: 30_000,
+    meta: AUTH_SCOPED_QUERY_META,
+  };
+}
+
+/** hog_flows-backed equivalent of `loopsPageQueryOptions`: lists every workflow and keeps only
+ * the ones this feature would recognize as a loop (see `isLoopShapedHogFlow`) — a workflow built
+ * or edited in the real Workflows editor isn't a loop this feature can show here. */
+function hogFlowLoopsQueryOptions(
+  workflowsClient: WorkflowsApiClient | null,
+  enabled: boolean,
+) {
+  return {
+    queryKey: [
+      "workflows-loops",
+      "list",
+      workflowsClient?.projectId ?? null,
+    ] as const,
+    queryFn: async (): Promise<LoopSchemas.Loop[]> => {
+      if (!workflowsClient) throw new Error("Not authenticated");
+      const page = await listHogFlows(
+        workflowsClient.client,
+        workflowsClient.projectId,
+        {
+          limit: LOOPS_LIST_LIMIT,
+        },
+      );
+      return page.results.filter(isLoopShapedHogFlow).map(hogFlowMinimalToLoop);
+    },
+    enabled: enabled && !!workflowsClient,
     staleTime: 30_000,
     meta: AUTH_SCOPED_QUERY_META,
   };
 }
 
 export function useLoops() {
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const loopsClient = useLoopsClient();
-  return useQuery({
-    ...loopsPageQueryOptions(loopsClient),
+  const workflowsClient = useWorkflowsClient();
+
+  const legacy = useQuery({
+    ...loopsPageQueryOptions(loopsClient, !hogFlowsEnabled),
     select: (page: LoopSchemas.PaginatedLoopList) => page.results,
   });
+  const hogFlows = useQuery(
+    hogFlowLoopsQueryOptions(workflowsClient, hogFlowsEnabled),
+  );
+
+  return hogFlowsEnabled ? hogFlows : legacy;
 }
 
 /** The per-project loop cap, straight from the backend so the frontend never hardcodes it. */
@@ -43,14 +95,16 @@ export interface LoopLimits {
 }
 
 export function useLoopLimits(): LoopLimits | null {
+  const hogFlowsEnabled = useFeatureFlag(LOOPS_HOG_FLOWS_FLAG);
   const loopsClient = useLoopsClient();
   const { data } = useQuery({
-    ...loopsPageQueryOptions(loopsClient),
+    ...loopsPageQueryOptions(loopsClient, !hogFlowsEnabled),
     select: (page: LoopSchemas.PaginatedLoopList): LoopLimits => ({
       max: page.max_loops_per_team,
       used: page.total_loop_count,
       atLimit: page.total_loop_count >= page.max_loops_per_team,
     }),
   });
-  return data ?? null;
+  // HogFlows have no per-project loop cap yet.
+  return hogFlowsEnabled ? null : (data ?? null);
 }

--- a/products/desktop/packages/ui/src/features/loops/hooks/useLoops.ts
+++ b/products/desktop/packages/ui/src/features/loops/hooks/useLoops.ts
@@ -60,7 +60,11 @@ function hogFlowLoopsQueryOptions(
           limit: LOOPS_LIST_LIMIT,
         },
       );
-      return page.results.filter(isLoopShapedHogFlow).map(hogFlowMinimalToLoop);
+      return page.results
+        .filter(
+          (flow) => isLoopShapedHogFlow(flow) && flow.status !== "archived",
+        )
+        .map(hogFlowMinimalToLoop);
     },
     enabled: enabled && !!workflowsClient,
     staleTime: 30_000,

--- a/products/desktop/packages/ui/src/features/loops/loopDisplay.test.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopDisplay.test.ts
@@ -1,5 +1,7 @@
+import type { LoopSchemas } from "@posthog/api-client/loops";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  deriveHogFlowRunHealth,
   describeTrigger,
   loopFireBlockedMessage,
   loopPausedDescription,
@@ -9,6 +11,22 @@ import {
   summarizeNotificationDestinations,
   summarizeTrigger,
 } from "./loopDisplay";
+
+const run = (
+  status: LoopSchemas.LoopRunStatusEnum,
+  created_at: string,
+): LoopSchemas.LoopRun => ({
+  id: created_at,
+  task_id: "task-1",
+  loop_trigger_id: null,
+  status,
+  environment: "cloud",
+  branch: null,
+  error_message: null,
+  output: null,
+  created_at,
+  completed_at: null,
+});
 
 const statusFields = (
   overrides: Partial<{
@@ -213,6 +231,40 @@ describe("nextScheduleRun", () => {
         new Date("2026-07-24T10:00:00.000Z"),
       )?.toISOString(),
     ).toBe("2026-07-27T09:00:00.000Z");
+  });
+});
+
+describe("deriveHogFlowRunHealth", () => {
+  it("returns no status and zero failures with no run history", () => {
+    expect(deriveHogFlowRunHealth([])).toEqual({
+      lastRunStatus: null,
+      consecutiveFailures: 0,
+    });
+  });
+
+  it("reads the latest run regardless of input order", () => {
+    const runs = [
+      run("failed", "2026-01-01T00:00:00.000Z"),
+      run("completed", "2026-01-03T00:00:00.000Z"),
+      run("failed", "2026-01-02T00:00:00.000Z"),
+    ];
+    expect(deriveHogFlowRunHealth(runs)).toEqual({
+      lastRunStatus: "completed",
+      consecutiveFailures: 0,
+    });
+  });
+
+  it("counts only the unbroken streak of failures since the latest run", () => {
+    const runs = [
+      run("completed", "2026-01-01T00:00:00.000Z"),
+      run("failed", "2026-01-04T00:00:00.000Z"),
+      run("failed", "2026-01-03T00:00:00.000Z"),
+      run("completed", "2026-01-02T00:00:00.000Z"),
+    ];
+    expect(deriveHogFlowRunHealth(runs)).toEqual({
+      lastRunStatus: "failed",
+      consecutiveFailures: 2,
+    });
   });
 });
 

--- a/products/desktop/packages/ui/src/features/loops/loopDisplay.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopDisplay.ts
@@ -90,6 +90,25 @@ export function loopStatusLabel(loop: LoopStatusFields): string {
   return "Active";
 }
 
+/** hog_flows-backed loops carry no backend-computed `last_run_status`/`consecutive_failures`
+ * (see `hogFlowToLoop`) — this derives the same fields from the run history the detail view
+ * already loads, so the status badge reflects real failures instead of always reading "Active". */
+export function deriveHogFlowRunHealth(runs: LoopSchemas.LoopRun[]): {
+  lastRunStatus: LoopSchemas.LoopRun["status"] | null;
+  consecutiveFailures: number;
+} {
+  const sorted = [...runs].sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+  let consecutiveFailures = 0;
+  for (const run of sorted) {
+    if (run.status !== "failed") break;
+    consecutiveFailures++;
+  }
+  return { lastRunStatus: sorted[0]?.status ?? null, consecutiveFailures };
+}
+
 const PAUSED_DESCRIPTIONS: Record<string, string> = {
   usage_limited:
     "Paused automatically: your organization reached its usage limit. Upgrade or wait for the limit to reset, then re-enable the loop.",

--- a/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.test.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.test.ts
@@ -5,7 +5,9 @@ import {
   emptyHogFlowLoopFormValues,
   formValuesToHogFlowWrite,
   formValuesToScheduleWrite,
+  hogFlowMinimalToLoop,
   hogFlowToFormValues,
+  hogFlowToLoop,
   isDecompilableLoopHogFlow,
   isHogFlowLoopFormValid,
   taskToLoopRun,
@@ -329,5 +331,70 @@ describe("taskToLoopRun", () => {
         origin_product: "workflow",
       }),
     ).toBeNull();
+  });
+});
+
+describe("hogFlowMinimalToLoop", () => {
+  it("maps list-row fields LoopRow renders, defaulting fields the minimal response omits", () => {
+    const minimal: WorkflowSchemas.HogFlowMinimal = {
+      id: "flow-1",
+      name: "My loop",
+      description: "Runs nightly",
+      version: 1,
+      status: "active",
+      created_at: "2026-01-01T00:00:00.000Z",
+      created_by: { id: 42, email: "a@example.com" },
+      updated_at: "2026-01-01T00:00:00.000Z",
+      trigger: { type: "schedule" },
+      edges: [LOOP_EDGE],
+      actions: [TRIGGER_ACTION, taskAction()],
+    };
+
+    const loop = hogFlowMinimalToLoop(minimal);
+
+    expect(loop.name).toBe("My loop");
+    expect(loop.description).toBe("Runs nightly");
+    expect(loop.created_by_id).toBe(42);
+    expect(loop.enabled).toBe(true);
+    expect(loop.instructions).toBe("Investigate failing CI runs");
+    expect(loop.consecutive_failures).toBe(0);
+    expect(loop.disabled_reason).toBeNull();
+    expect(loop.triggers).toEqual([]);
+  });
+
+  it("reads enabled off status, not a separate flag", () => {
+    const minimal: WorkflowSchemas.HogFlowMinimal = {
+      id: "flow-1",
+      name: "My loop",
+      description: "",
+      version: 1,
+      status: "draft",
+      created_at: "2026-01-01T00:00:00.000Z",
+      created_by: { id: 1, email: "a@example.com" },
+      updated_at: "2026-01-01T00:00:00.000Z",
+      trigger: { type: "schedule" },
+      edges: [LOOP_EDGE],
+      actions: [TRIGGER_ACTION, taskAction()],
+    };
+
+    expect(hogFlowMinimalToLoop(minimal).enabled).toBe(false);
+  });
+});
+
+describe("hogFlowToLoop", () => {
+  it("carries a real trigger, unlike hogFlowMinimalToLoop", () => {
+    const loop = hogFlowToLoop(flow(), DAILY_SCHEDULE);
+
+    expect(loop.triggers).toHaveLength(1);
+    expect(loop.triggers[0]).toMatchObject({
+      type: "schedule",
+      enabled: true,
+      config: { cron_expression: "30 9 * * *", timezone: "UTC" },
+    });
+  });
+
+  it("carries an empty trigger config with no schedule", () => {
+    const loop = hogFlowToLoop(flow(), null);
+    expect(loop.triggers[0].config).toEqual({});
   });
 });

--- a/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.test.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.test.ts
@@ -210,23 +210,42 @@ describe("hogFlowToFormValues", () => {
     );
     expect(values.triggers[0].enabled).toBe(false);
   });
+
+  it("decompiles a once-off schedule to run_at instead of dropping its timing", () => {
+    const values = hogFlowToFormValues(flow(), {
+      ...DAILY_SCHEDULE,
+      rrule: "FREQ=DAILY;COUNT=1",
+      starts_at: "2026-02-01T09:00:00.000Z",
+    });
+    expect(values.triggers[0].config).toEqual({
+      run_at: "2026-02-01T09:00:00.000Z",
+    });
+  });
 });
 
 describe("isDecompilableLoopHogFlow", () => {
-  it("is true for a canonical loop shape with a recognized schedule", () => {
-    expect(isDecompilableLoopHogFlow(flow(), DAILY_SCHEDULE)).toBe(true);
+  it("is true for a canonical loop shape with exactly one recognized schedule", () => {
+    expect(isDecompilableLoopHogFlow(flow(), [DAILY_SCHEDULE])).toBe(true);
   });
 
   it("is false with no schedule", () => {
-    expect(isDecompilableLoopHogFlow(flow(), null)).toBe(false);
+    expect(isDecompilableLoopHogFlow(flow(), [])).toBe(false);
+  });
+
+  it("is false with more than one schedule (this feature never writes a second; picking one would silently mistarget edits)", () => {
+    expect(
+      isDecompilableLoopHogFlow(flow(), [
+        DAILY_SCHEDULE,
+        { ...DAILY_SCHEDULE, id: "sched-2" },
+      ]),
+    ).toBe(false);
   });
 
   it("is false for an rrule this feature didn't author", () => {
     expect(
-      isDecompilableLoopHogFlow(flow(), {
-        ...DAILY_SCHEDULE,
-        rrule: "FREQ=MONTHLY;BYMONTHDAY=1",
-      }),
+      isDecompilableLoopHogFlow(flow(), [
+        { ...DAILY_SCHEDULE, rrule: "FREQ=MONTHLY;BYMONTHDAY=1" },
+      ]),
     ).toBe(false);
   });
 
@@ -240,8 +259,14 @@ describe("isDecompilableLoopHogFlow", () => {
     expect(
       isDecompilableLoopHogFlow(
         flow({ actions: [TRIGGER_ACTION, taskAction(), extraAction] }),
-        DAILY_SCHEDULE,
+        [DAILY_SCHEDULE],
       ),
+    ).toBe(false);
+  });
+
+  it("is false for an archived flow (Save/Resume must not resurrect it)", () => {
+    expect(
+      isDecompilableLoopHogFlow(flow({ status: "archived" }), [DAILY_SCHEDULE]),
     ).toBe(false);
   });
 });

--- a/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.ts
@@ -124,18 +124,150 @@ export function emptyHogFlowLoopFormValues(): LoopFormValues {
         config: { cron_expression: "0 9 * * 1", timezone: "UTC" },
       },
     ],
-    behaviors: {
-      create_prs: true,
-      watch_ci: false,
-      fix_review_comments: false,
-      max_fix_iterations: 3,
-    },
-    notifications: {
-      push: { enabled: false, events: [], params: {} },
-      email: { enabled: false, events: [], params: {} },
-      slack: { enabled: false, events: [], params: {} },
-    },
+    behaviors: HOG_FLOW_LOOP_BEHAVIORS,
+    notifications: emptyLoopNotifications(),
     contextTarget: null,
+  };
+}
+
+const HOG_FLOW_LOOP_BEHAVIORS: LoopSchemas.LoopBehaviors = {
+  create_prs: true,
+  watch_ci: false,
+  fix_review_comments: false,
+  max_fix_iterations: 3,
+};
+
+function emptyLoopNotifications(): LoopSchemas.LoopNotifications {
+  return {
+    push: { enabled: false, events: [], params: {} },
+    email: { enabled: false, events: [], params: {} },
+    slack: { enabled: false, events: [], params: {} },
+  };
+}
+
+/** Reads the create-task action's inputs shared by every read direction (form values, list
+ * row, detail view) — one action shape, three renderings. */
+function deriveCreateTaskFields(actions: WorkflowSchemas.HogFlowAction[]): {
+  instructions: string;
+  model: string;
+  reasoningEffort: LoopSchemas.LoopReasoningEffortEnum | null;
+  repositories: LoopSchemas.LoopRepositoryEntry[];
+  skillNames: string[];
+} {
+  const inputs = findCreateTaskAction(actions)?.config.inputs;
+  return {
+    instructions: inputs?.prompt.value ?? "",
+    model: inputs?.model?.value.model ?? "",
+    reasoningEffort:
+      (inputs?.model?.value
+        .reasoning_effort as LoopSchemas.LoopReasoningEffortEnum | null) ??
+      null,
+    // The create-task action's `repository` input is a plain "org/repo" string with no
+    // integration id — `github_integration_id: 0` is a display-only placeholder for
+    // `LoopRepositoryPicker`, never sent back on write (see `buildCreateTaskAction`).
+    repositories: inputs?.repository?.value
+      ? [{ github_integration_id: 0, full_name: inputs.repository.value }]
+      : [],
+    skillNames: inputs?.skills?.value ?? [],
+  };
+}
+
+/** Decompiles a HogFlow list row onto the `Loop` shape `LoopRow`/`LoopsListView` already
+ * render, so those components don't need a hog_flows-specific variant. Fields the minimal
+ * list response doesn't carry (last run status, consecutive failures, disabled reason) default
+ * to their "healthy, no history yet" values rather than being guessed at — the detail view
+ * (`hogFlowToLoop`) is where a caller gets the real ones. */
+export function hogFlowMinimalToLoop(
+  flow: WorkflowSchemas.HogFlowMinimal,
+): LoopSchemas.Loop {
+  const fields = deriveCreateTaskFields(flow.actions);
+  return {
+    id: flow.id,
+    team_id: 0,
+    created_by_id: flow.created_by.id,
+    name: flow.name ?? "",
+    description: flow.description,
+    visibility: "team",
+    instructions: fields.instructions,
+    runtime_adapter: "claude",
+    model: fields.model,
+    reasoning_effort: fields.reasoningEffort,
+    repositories: fields.repositories,
+    sandbox_environment_id: null,
+    enabled: flow.status === "active",
+    disabled_reason: null,
+    overlap_policy: "skip",
+    behaviors: HOG_FLOW_LOOP_BEHAVIORS,
+    connectors: { mcp_installation_ids: [], posthog_mcp_scopes: "read_only" },
+    notifications: emptyLoopNotifications(),
+    context_target: null,
+    internal: false,
+    origin_product: "user_created",
+    last_run_at: null,
+    last_run_status: null,
+    last_error: null,
+    consecutive_failures: 0,
+    created_at: flow.created_at,
+    updated_at: flow.updated_at,
+    // The minimal list response carries no schedule — a list row never reads triggers
+    // (see `LoopRow`), so this stays empty rather than faking one.
+    triggers: [],
+  };
+}
+
+/** Decompiles a full HogFlow (plus its schedule) onto the `Loop` shape `LoopDetailView` already
+ * renders. Unlike `hogFlowMinimalToLoop`, this carries a real trigger — the detail view reads
+ * it for its read-only "configuration summary" section. */
+export function hogFlowToLoop(
+  flow: WorkflowSchemas.HogFlow,
+  schedule: WorkflowSchemas.HogFlowSchedule | null,
+): LoopSchemas.Loop {
+  const fields = deriveCreateTaskFields(flow.actions);
+  const scheduleConfig = schedule
+    ? rruleScheduleToLoopTriggerConfig(schedule)
+    : null;
+
+  return {
+    id: flow.id,
+    team_id: 0,
+    created_by_id: flow.created_by.id,
+    name: flow.name ?? "",
+    description: flow.description,
+    visibility: "team",
+    instructions: fields.instructions,
+    runtime_adapter: "claude",
+    model: fields.model,
+    reasoning_effort: fields.reasoningEffort,
+    repositories: fields.repositories,
+    sandbox_environment_id: null,
+    enabled: flow.status === "active",
+    disabled_reason: null,
+    overlap_policy: "skip",
+    behaviors: HOG_FLOW_LOOP_BEHAVIORS,
+    connectors: { mcp_installation_ids: [], posthog_mcp_scopes: "read_only" },
+    notifications: emptyLoopNotifications(),
+    context_target: null,
+    internal: false,
+    origin_product: "user_created",
+    last_run_at: null,
+    last_run_status: null,
+    last_error: null,
+    consecutive_failures: 0,
+    created_at: flow.created_at,
+    updated_at: flow.updated_at,
+    triggers: [
+      {
+        id: TRIGGER_ACTION_ID,
+        loop_id: flow.id,
+        type: "schedule",
+        enabled: flow.status === "active",
+        config: scheduleConfig ?? {},
+        schedule_sync_status: null,
+        last_fired_at: null,
+        created_at: flow.created_at,
+        updated_at: flow.updated_at,
+      },
+    ],
   };
 }
 
@@ -159,8 +291,7 @@ export function hogFlowToFormValues(
   flow: WorkflowSchemas.HogFlow,
   schedule: WorkflowSchemas.HogFlowSchedule | null,
 ): LoopFormValues {
-  const task = findCreateTaskAction(flow.actions);
-  const inputs = task?.config.inputs;
+  const fields = deriveCreateTaskFields(flow.actions);
   const scheduleConfig = schedule
     ? rruleScheduleToLoopTriggerConfig(schedule)
     : null;
@@ -177,35 +308,18 @@ export function hogFlowToFormValues(
     name: flow.name ?? "",
     description: flow.description,
     visibility: "team",
-    instructions: inputs?.prompt.value ?? "",
+    instructions: fields.instructions,
     skill: null,
     skillContext: "",
-    skillNames: inputs?.skills?.value ?? [],
+    skillNames: fields.skillNames,
     runtimeAdapter: "claude",
-    model: inputs?.model?.value.model ?? "",
-    reasoningEffort:
-      (inputs?.model?.value
-        .reasoning_effort as LoopSchemas.LoopReasoningEffortEnum | null) ??
-      null,
-    // The create-task action's `repository` input is a plain "org/repo" string with no
-    // integration id — `github_integration_id: 0` is a display-only placeholder for
-    // `LoopRepositoryPicker`, never sent back on write (see `buildCreateTaskAction`).
-    repositories: inputs?.repository?.value
-      ? [{ github_integration_id: 0, full_name: inputs.repository.value }]
-      : [],
+    model: fields.model,
+    reasoningEffort: fields.reasoningEffort,
+    repositories: fields.repositories,
     sandboxEnvironmentId: null,
     triggers: [trigger],
-    behaviors: {
-      create_prs: true,
-      watch_ci: false,
-      fix_review_comments: false,
-      max_fix_iterations: 3,
-    },
-    notifications: {
-      push: { enabled: false, events: [], params: {} },
-      email: { enabled: false, events: [], params: {} },
-      slack: { enabled: false, events: [], params: {} },
-    },
+    behaviors: HOG_FLOW_LOOP_BEHAVIORS,
+    notifications: emptyLoopNotifications(),
     contextTarget: null,
   };
 }

--- a/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopHogFlowMapping.ts
@@ -156,7 +156,7 @@ function deriveCreateTaskFields(actions: WorkflowSchemas.HogFlowAction[]): {
 } {
   const inputs = findCreateTaskAction(actions)?.config.inputs;
   return {
-    instructions: inputs?.prompt.value ?? "",
+    instructions: inputs?.prompt?.value ?? "",
     model: inputs?.model?.value.model ?? "",
     reasoningEffort:
       (inputs?.model?.value
@@ -184,7 +184,7 @@ export function hogFlowMinimalToLoop(
   return {
     id: flow.id,
     team_id: 0,
-    created_by_id: flow.created_by.id,
+    created_by_id: flow.created_by?.id ?? null,
     name: flow.name ?? "",
     description: flow.description,
     visibility: "team",
@@ -230,7 +230,7 @@ export function hogFlowToLoop(
   return {
     id: flow.id,
     team_id: 0,
-    created_by_id: flow.created_by.id,
+    created_by_id: flow.created_by?.id ?? null,
     name: flow.name ?? "",
     description: flow.description,
     visibility: "team",
@@ -271,20 +271,23 @@ export function hogFlowToLoop(
   };
 }
 
-/** True once every part of the flow this feature didn't explicitly write has been checked:
- * the action/edge shape (see `isLoopShapedHogFlow`) and, separately, whether its schedule's
- * RRULE is one the form's picker would have produced. A flow failing either check was built or
- * edited outside this feature and should render read-only — see `LoopDetailView`. */
+/** True once every part of the flow this feature didn't explicitly write has been checked: the
+ * action/edge shape (see `isLoopShapedHogFlow`), that the flow isn't archived, that it carries
+ * exactly one schedule (HogFlows support several; this feature only ever writes one, and picking
+ * an arbitrary one of several would silently mistarget edits), and that the schedule's RRULE is
+ * one the form's picker would have produced. A flow failing any check was built or edited outside
+ * this feature — callers should treat it as not-a-loop rather than force-fit it into the form. */
 export function isDecompilableLoopHogFlow(
-  flow: Pick<WorkflowSchemas.HogFlow, "actions" | "edges">,
-  schedule: Pick<
+  flow: Pick<WorkflowSchemas.HogFlow, "actions" | "edges" | "status">,
+  schedules: Pick<
     WorkflowSchemas.HogFlowSchedule,
     "rrule" | "starts_at" | "timezone"
-  > | null,
+  >[],
 ): boolean {
   if (!isLoopShapedHogFlow(flow)) return false;
-  if (!schedule) return false;
-  return rruleScheduleToLoopTriggerConfig(schedule) !== null;
+  if (flow.status === "archived") return false;
+  if (schedules.length !== 1) return false;
+  return rruleScheduleToLoopTriggerConfig(schedules[0]) !== null;
 }
 
 export function hogFlowToFormValues(

--- a/products/desktop/packages/ui/src/features/loops/loopScheduleRRule.test.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopScheduleRRule.test.ts
@@ -100,14 +100,14 @@ describe("rruleScheduleToLoopTriggerConfig / loopScheduleTriggerConfigToRRuleWri
     ).toBeNull();
   });
 
-  it("returns null for the once-off marker rrule (callers should read timing off starts_at)", () => {
+  it("maps the once-off marker rrule back to a run_at, not a recurring cron", () => {
     expect(
       rruleScheduleToLoopTriggerConfig({
         rrule: "FREQ=DAILY;COUNT=1",
         starts_at: NOW.toISOString(),
         timezone: "UTC",
       }),
-    ).toBeNull();
+    ).toEqual({ run_at: NOW.toISOString() });
   });
 });
 

--- a/products/desktop/packages/ui/src/features/loops/loopScheduleRRule.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopScheduleRRule.ts
@@ -70,15 +70,17 @@ const RRULE_TO_RECURRING: Record<
 };
 
 /** Reverses `loopScheduleTriggerConfigToRRuleWrite` for exactly the RRULE shapes it writes.
- * Returns null for a "once" schedule (`rrule` is a marker, not real recurrence — the caller
- * should read `run_at`-style timing off `starts_at` directly instead) or an RRULE this feature
- * didn't author, e.g. one edited through the main-app workflow schedule UI. */
+ * Returns null for an RRULE this feature didn't author, e.g. one edited through the main-app
+ * workflow schedule UI. */
 export function rruleScheduleToLoopTriggerConfig(
   schedule: Pick<
     WorkflowSchemas.HogFlowSchedule,
     "rrule" | "starts_at" | "timezone"
   >,
-): { cron_expression: string; timezone: string } | null {
+): { cron_expression: string; timezone: string } | { run_at: string } | null {
+  if (isOnceOffSchedule(schedule.rrule)) {
+    return { run_at: schedule.starts_at };
+  }
   const recurring = RRULE_TO_RECURRING[schedule.rrule];
   if (recurring) {
     const time = isoTimeInZone(schedule.starts_at, schedule.timezone);


### PR DESCRIPTION
## Problem

The Loops UI only knows how to talk to the Loops API. [#91716](https://github.com/PostHog/posthog/pull/91716) added a HogFlow client and a form-to-HogFlow compiler, but nothing calls them yet.

## Changes

- `useLoops`, `useLoop`, `useLoopRuns`, `useCreateLoop`, `useUpdateLoop`, `useDeleteLoop`, `useRunLoop` each branch on `LOOPS_HOG_FLOWS_FLAG`, calling hog_flows instead of the Loops API when it's on. Every hook keeps its existing return shape (`Loop`, `LoopRun[]`), so `LoopsListView`, `LoopForm`, `LoopDetailView`, and `LoopRunRow` need no changes to read them.
- New `useHogFlow` hook: `LoopForm`'s edit-mode init needs the raw HogFlow (for `skillNames`, which the `Loop`-shaped facade has no field for).
- `LoopTriggerEditor` takes an `availableTriggerTypes` prop; hog_flows mode passes `["schedule"]` since GitHub/API triggers aren't supported on HogFlow yet.
- New `LoopTeamSkillsFields` replaces the skill picker when hog_flows-backed: a multi-select over the team's skills store, matching the create-task action's `skills` input, instead of the single uploaded-bundle skill the Loops API models.
- `getTasksPage` takes a `hogFlowId` filter (hand-vendored ahead of #91581), used by `useLoopRuns`'s run-history query.

With the flag off, every branch resolves to the exact code that ran before this PR - no behavior change.

## How did you test this code?

Extended `loopHogFlowMapping.test.ts` with the two new `Loop`-shaped adapters (list row, detail view). Ran the full `packages/ui/src/features/loops` suite (217 passed) and `packages/api-client` (236 passed), and `tsc --noEmit` on both touched packages - clean, no regressions.

Not run: no dev stack or Electron app in this sandbox, so the actual UI (list rendering, the trigger editor, the skill picker, run-now) is typechecked and unit-tested at the data layer but not visually verified.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, continuing the loops-as-workflows plan on top of #91716. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. No verified GitHub handle was available this session - the PR stays unassigned.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*