### PR TITLE
fix(posthog-ai): reopen the turn on a user message from the wire

### DIFF
--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -1625,8 +1625,9 @@ describe('runStreamLogic', () => {
         })
 
         // A follow-up on the same run starts a new turn with no second run_started frame. It reaches
-        // the thread as this composer's optimistic echo, or, when it was sent from Slack or another
-        // tab, as a wire user turn in one of its two forms.
+        // the thread as this composer's optimistic echo, as a wire user turn in one of its two forms,
+        // or — for a follow-up sent from Slack, where the live stream carries no user turn at all —
+        // only as the agent's first output.
         it.each([
             ['this composer', (): void => logic.actions.pushHumanMessage('and the mobile funnel?')],
             [
@@ -1643,6 +1644,17 @@ describe('runStreamLogic', () => {
                         sessionUpdate({ sessionUpdate: 'user_message', content: { text: 'and the mobile funnel?' } })
                     ),
             ],
+            [
+                'the agent producing output',
+                (): void =>
+                    logic.actions.ingestAcpFrame(
+                        sessionUpdate({
+                            sessionUpdate: 'agent_message_chunk',
+                            messageId: 'm2',
+                            content: { text: 'On' },
+                        })
+                    ),
+            ],
         ])('re-raises on a follow-up turn opened by %s, with no new run_started', (_case, sendFollowUp) => {
             logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
             logic.actions.ingestAcpFrame(notification('_posthog/turn_complete', {}))
@@ -1650,6 +1662,28 @@ describe('runStreamLogic', () => {
 
             sendFollowUp()
             expect(logic.values.isThinking).toEqual(true)
+        })
+
+        it('re-raises for a queued follow-up whose user turn precedes the prior turn_complete', () => {
+            logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
+            // A follow-up sent while the first turn is still running is persisted when it is received,
+            // so the replayed log carries it before that turn's completion.
+            logic.actions.ingestAcpFrame(notification('_posthog/user_message', { content: 'and mobile?' }))
+            logic.actions.ingestAcpFrame(notification('_posthog/turn_complete', {}))
+            expect(logic.values.isThinking).toEqual(false)
+
+            logic.actions.ingestAcpFrame(
+                sessionUpdate({ sessionUpdate: 'agent_message_chunk', messageId: 'm2', content: { text: 'On' } })
+            )
+            expect(logic.values.isThinking).toEqual(true)
+        })
+
+        it('stays off after turn_complete on an update that does not mean the agent is generating', () => {
+            logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
+            logic.actions.ingestAcpFrame(notification('_posthog/turn_complete', {}))
+
+            logic.actions.ingestAcpFrame(sessionUpdate({ sessionUpdate: 'current_mode_update', currentModeId: 'auto' }))
+            expect(logic.values.isThinking).toEqual(false)
         })
 
         it('is on during the cold-boot queued window before the first run_started', async () => {

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -1624,13 +1624,31 @@ describe('runStreamLogic', () => {
             expect(logic.values.isThinking).toEqual(false)
         })
 
-        it('re-raises on a follow-up turn opened by a human message, with no new run_started', () => {
+        // A follow-up on the same run starts a new turn with no second run_started frame. It reaches
+        // the thread as this composer's optimistic echo, or, when it was sent from Slack or another
+        // tab, as a wire user turn in one of its two forms.
+        it.each([
+            ['this composer', (): void => logic.actions.pushHumanMessage('and the mobile funnel?')],
+            [
+                'a wire _posthog/user_message',
+                (): void =>
+                    logic.actions.ingestAcpFrame(
+                        notification('_posthog/user_message', { content: 'and the mobile funnel?' })
+                    ),
+            ],
+            [
+                'a wire session/update user_message',
+                (): void =>
+                    logic.actions.ingestAcpFrame(
+                        sessionUpdate({ sessionUpdate: 'user_message', content: { text: 'and the mobile funnel?' } })
+                    ),
+            ],
+        ])('re-raises on a follow-up turn opened by %s, with no new run_started', (_case, sendFollowUp) => {
             logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
             logic.actions.ingestAcpFrame(notification('_posthog/turn_complete', {}))
             expect(logic.values.isThinking).toEqual(false)
 
-            // A follow-up on the same run starts a new turn — no second run_started frame arrives.
-            logic.actions.pushHumanMessage('and the mobile funnel?')
+            sendFollowUp()
             expect(logic.values.isThinking).toEqual(true)
         })
 

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -154,6 +154,20 @@ export const INITIAL_PERMISSION_MODE: TaskRunBootstrapCreateRequestInitialPermis
 const AGENT_CRASH_PREFIX = 'Agent server crashed'
 
 /**
+ * `session/update` sub-types that mean the agent is producing output for a turn, and so that a turn is
+ * open. An allowlist, so an unknown or malformed sub-type fails safe to "not generating" rather than
+ * reopening a turn that finished. `tool_call_update` is deliberately absent: it updates a call the turn
+ * already started, and can trail the end of that turn.
+ */
+const AGENT_GENERATING_SESSION_UPDATES: ReadonlySet<string> = new Set([
+    'agent_message',
+    'agent_message_chunk',
+    'agent_thought_chunk',
+    'tool_call',
+    'plan',
+])
+
+/**
  * In-band durable end-of-run sentinel emitted by both the Django stream view and the agent-proxy
  * (`event: stream-end`, `data: {"status":"complete"}`). Distinct from the rotation `end` event (a
  * 15-min connection recycle that means "reconnect"): the sentinel means the run is finished, so the
@@ -1811,8 +1825,9 @@ export const runStreamLogic = kea<runStreamLogicType>([
         setConversationClearSupported: (supported: boolean) => ({ supported }),
         markTurnComplete: true,
         /**
-         * Reopens the turn on a user message that reaches the run over the wire instead of from this
-         * composer, such as a follow-up sent from Slack, sent from another tab, or replayed from history.
+         * Reopens the turn for a follow-up that started outside this composer, such as one sent from Slack
+         * or from another tab. Dispatched from a user turn seen on the wire, and from the agent's first
+         * output of a turn, which is the only marker the live stream carries.
          */
         markTurnStarted: true,
         /** Echoes the user's own message into the thread as a `client`-sourced log entry (the wire never replays a live turn). */
@@ -2110,8 +2125,8 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 // A run emits `_posthog/run_started` once; a follow-up message on the same run starts
                 // a fresh turn with no new run_started frame, so a human message also reopens the
                 // turn — otherwise the thinking indicator would stay off for the whole follow-up.
-                // `pushHumanMessage` covers a send from this composer, `markTurnStarted` a user turn
-                // that reaches the run some other way (Slack, another tab, a replayed history tail).
+                // `pushHumanMessage` covers a send from this composer, `markTurnStarted` a turn that
+                // started some other way (Slack, another tab, a replayed history tail).
                 markRunStarted: () => false,
                 pushHumanMessage: () => false,
                 markTurnStarted: () => false,
@@ -3317,6 +3332,15 @@ export const runStreamLogic = kea<runStreamLogicType>([
             }
             if (!isKnownSessionUpdate(update)) {
                 return
+            }
+            // The agent producing output is the only marker of a new turn this client can rely on when the
+            // turn was started from outside its own composer. Such a follow-up is queued on the run, which
+            // emits no second `run_started`, and neither wire form of the user turn fills the gap: the live
+            // stream never carries one, and the persisted one is written when the message is received, so a
+            // message sent mid-turn is replayed *before* the previous turn's `turn_complete`. Guarded on
+            // `turnComplete` so this costs one dispatch per turn rather than one per streamed chunk.
+            if (values.turnComplete && AGENT_GENERATING_SESSION_UPDATES.has(update.sessionUpdate)) {
+                actions.markTurnStarted()
             }
             if (update.sessionUpdate === 'current_mode_update') {
                 actions.setCurrentMode(String(update.currentModeId ?? update.mode ?? ''))

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -1504,6 +1504,9 @@ export interface runStreamLogicActions {
     markTurnComplete: () => {
         value: true
     }
+    markTurnStarted: () => {
+        value: true
+    }
     mergeResourcesUsed: (
         products: {
             id?: string
@@ -1807,6 +1810,11 @@ export const runStreamLogic = kea<runStreamLogicType>([
         /** Records the agent's `/clear` capability, read off each `_posthog/run_started` frame. */
         setConversationClearSupported: (supported: boolean) => ({ supported }),
         markTurnComplete: true,
+        /**
+         * Reopens the turn on a user message that reaches the run over the wire instead of from this
+         * composer, such as a follow-up sent from Slack, sent from another tab, or replayed from history.
+         */
+        markTurnStarted: true,
         /** Echoes the user's own message into the thread as a `client`-sourced log entry (the wire never replays a live turn). */
         pushHumanMessage: (content: string) => ({ content }),
         /**
@@ -2102,8 +2110,11 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 // A run emits `_posthog/run_started` once; a follow-up message on the same run starts
                 // a fresh turn with no new run_started frame, so a human message also reopens the
                 // turn — otherwise the thinking indicator would stay off for the whole follow-up.
+                // `pushHumanMessage` covers a send from this composer, `markTurnStarted` a user turn
+                // that reaches the run some other way (Slack, another tab, a replayed history tail).
                 markRunStarted: () => false,
                 pushHumanMessage: () => false,
+                markTurnStarted: () => false,
                 reset: () => false,
             },
         ],
@@ -3251,6 +3262,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
             // unattached optimistic stream has no task id and records nothing — its send path marks
             // sent keys directly.
             if (isPosthogNotification(notification, '_posthog/user_message')) {
+                actions.markTurnStarted()
                 if (values.bootstrappedTaskId) {
                     const lines = contextBlockLinesFromUserMessage(extractUserMessageText(notification.params?.content))
                     if (lines.length > 0) {
@@ -3294,6 +3306,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
             // chains persist a turn in both wire forms, and the seen-lines reducer dedupes the overlap.
             // Chunked frames are skipped: a partial text could truncate a block mid-line.
             if (isSessionUpdateUserMessage(update)) {
+                actions.markTurnStarted()
                 if (values.bootstrappedTaskId && update.sessionUpdate === 'user_message') {
                     const lines = contextBlockLinesFromUserMessage(String(update.content?.text ?? update.text ?? ''))
                     if (lines.length > 0) {


### PR DESCRIPTION
## Problem

- Someone watching an agent run in PostHog sees a still, silent thread while the agent is actively working, if the turn was started from Slack rather than the in-app composer.
- The thread's thinking indicator is gated on `isThinking`, which is `runInFlight && !turnComplete`.
- `turnComplete` latches on `_posthog/turn_complete` and only three things cleared it: `markRunStarted`, `pushHumanMessage` (this composer's optimistic echo), and `reset`.
- A follow-up on an in-progress run is queued on the run and emits no second `run_started`, so none of the three fire and the latch stays set for the rest of the run's life.
- The user's message does not fill the gap either. The live stream carries no user turn at all, and the persisted one is written when the message is received, so a message sent mid-turn is replayed *before* the previous turn's `turn_complete`.
- A page reload does not recover it, because the replayed history ends on the same stale `turn_complete`.

## Changes

- The thinking indicator now appears for a follow-up turn started from Slack, from another tab, or replayed from a history tail.
- A new `markTurnStarted` action clears `turnComplete`, dispatched from the agent's first output of a turn. That is the only marker of a new turn the live stream carries.
- Which frames count comes from an allowlist of session update sub-types that mean the agent is generating, so an unknown or malformed sub-type leaves a finished turn closed rather than reopening it.
- Both wire forms of the user turn dispatch it too, which raises the indicator a little earlier on a replay.

Nothing looks different for a run driven from the in-app composer, so there is no before-and-after screenshot. The one visible change is an indicator that used to be missing.

## How did you test this code?

- `products/posthog_ai/frontend/logics/runStreamLogic.test.ts` grew a `test.each` over the four ways a follow-up turn opens, replacing a single case that covered only the composer echo.
- Two standalone cases cover what the parameterized one cannot: a queued follow-up whose user turn is replayed before the prior `turn_complete`, and a non-generating update that must leave a finished turn closed.
- The regression they catch: a follow-up turn leaving `turnComplete` set, so `isThinking` stays false while the agent works.
- The agent-output case and the queued-ordering case were both confirmed to fail against the previous commit on this branch and pass after it.
- Not run: the repo-wide Jest suite and any browser test. The change is confined to one kea reducer and one ingest branch, and CI covers the rest.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing doc describes the indicator.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The work started as a question about why an in-progress run showed no thinking indicator. Reading `runStreamLogic` located the latch, and a reproduction in the existing test file confirmed it.

The first commit reopened the turn on the user's message alone. Automated review flagged that a follow-up sent mid-turn would be re-latched by the prior turn's completion, and checking the backend showed the trigger was weaker still: the user turn is persisted to the run log, which the live stream does not read, so it never reaches a connected client. Reopening on the agent's first output covers both orderings and both transports, which is why the allowlist replaced the user-turn trigger as the load-bearing one.

Known trade-off: if a late frame from a finished turn arrives after that turn's completion, the indicator will re-appear until the next completion or a terminal status. That is preferred over never showing it for a whole turn.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1788192232001759)*
