### PR TITLE
feat(navigation): describe and link docs for every sidebar entry

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -8217,9 +8217,9 @@ snapshots:
     scenes-app-settings-user--settings-user-danger-zone--light:
         hash: v1.k794b7964.96846d7823357e89a9d91350f6f435373fe287f713250b59ccce2dbd31b6f69c.kl21kygOhH1SlNOJ6VekMMlGUuyNg5Ka7NXFoHcG6M0
     scenes-app-settings-user--settings-user-navigation--dark:
-        hash: v1.k794b7964.2d771e056c3ebc20c676cdfb0f8c36243ea14de2b3b26169a21a6291a8bea68e.gZiwcbMTy2UahK2xIHaX5rfPk7ZkHFFe8bupdJ6Lknk
+        hash: v1.k794b7964.87ca468f0949495f6fb53cc8b07900f724e8cecdcd38c3791d49c6683a83f379.nPpp4yuzr2RtTIvFvDjlxk835WS_N7K8qVWNNxPCxgQ
     scenes-app-settings-user--settings-user-navigation--light:
-        hash: v1.k794b7964.f5976853d33d90afdfc9ac22a09dc24c672a223766a99c22761ab894734794a7.prwUzPsNSfVh_U2_cCZ2N-ZMWg9fkhj0-xKRWx0gVRU
+        hash: v1.k794b7964.90007325cf24bd688266d36edca8206e11eb24d6aa98fc0208533ba74adb668b.Vjg6puokORg18-P-bIOttdR-X6L8hXOxoOklyUTlkiY
     scenes-app-settings-user--settings-user-notifications--dark:
         hash: v1.k794b7964.a09a57f1c0bbcebf82942edebeba7772b2f684ba235bcef3a816aec2beb4cbce.AtQZhdZeeMVvpcmyBhPvprSMZawliTZaIFE5G8M_MVg
     scenes-app-settings-user--settings-user-notifications--light:

--- a/frontend/src/layout/panel-layout/sidebarCustomization.tsx
+++ b/frontend/src/layout/panel-layout/sidebarCustomization.tsx
@@ -21,6 +21,8 @@ export interface SidebarCustomizableItem {
     label: string
     /** Very brief explanation of what the item opens, shown under the label in settings. */
     description: string
+    /** Link to this item's page on posthog.com/docs, when it has one. */
+    docsHref?: string
     icon: JSX.Element
     /** Mirrors the flag gating the item in the navbar, so the toggle is only offered when the item can render at all. */
     flag?: string
@@ -30,6 +32,7 @@ export interface SidebarCustomizableSection {
     key: SidebarSectionKey
     label: string
     description: string
+    docsHref?: string
     icon: JSX.Element
     items: SidebarCustomizableItem[]
 }
@@ -52,18 +55,21 @@ export const SIDEBAR_CUSTOMIZABLE_SECTIONS: SidebarCustomizableSection[] = [
                 key: 'inbox',
                 label: 'Self-driving',
                 description: 'Reports and signals that need your attention.',
+                docsHref: 'https://posthog.com/docs/self-driving',
                 icon: <IconNotification />,
                 flag: FEATURE_FLAGS.PRODUCT_AUTONOMY,
             },
             {
                 label: 'Activity',
                 description: 'A live stream of events coming into your project.',
+                docsHref: 'https://posthog.com/docs/activity',
                 icon: <IconClock />,
             },
             {
                 key: 'data',
                 label: 'Data',
                 description: 'Manage events, actions, properties, and people.',
+                docsHref: 'https://posthog.com/docs/data',
                 icon: <IconDatabase />,
             },
             {

--- a/frontend/src/layout/panel-layout/sidebarToolMeta.test.ts
+++ b/frontend/src/layout/panel-layout/sidebarToolMeta.test.ts
@@ -1,0 +1,25 @@
+import { SIDEBAR_TOOLS_WITHOUT_DOCS, sidebarToolMeta } from '~/layout/panel-layout/sidebarToolMeta'
+import { getTreeItemsProducts } from '~/products'
+
+describe('sidebarToolMeta', () => {
+    const products = getTreeItemsProducts()
+
+    it.each(products.map((product) => [product.path, product] as const))(
+        '%s explains itself in sidebar settings',
+        (path, product) => {
+            const { description, docsHref } = sidebarToolMeta(product)
+            expect(description).toBeTruthy()
+            if (!SIDEBAR_TOOLS_WITHOUT_DOCS.has(path)) {
+                expect(docsHref).toMatch(/^https:\/\/posthog\.com\/docs\//)
+            }
+        }
+    )
+
+    it('only exempts tools that are still missing a docs page', () => {
+        const stale = [...SIDEBAR_TOOLS_WITHOUT_DOCS].filter((path) => {
+            const product = products.find((candidate) => candidate.path === path)
+            return !product || sidebarToolMeta(product).docsHref
+        })
+        expect(stale).toEqual([])
+    })
+})

--- a/frontend/src/layout/panel-layout/sidebarToolMeta.ts
+++ b/frontend/src/layout/panel-layout/sidebarToolMeta.ts
@@ -1,0 +1,34 @@
+import { sceneConfigurations } from 'scenes/scenes'
+
+import { FileSystemImport } from '~/queries/schema/schema-general'
+
+/**
+ * Tree items whose product has no page on posthog.com/docs yet, so they show no docs link.
+ * Every other sidebar tool must have one — `sidebarToolMeta.test.ts` fails when a new tool has neither.
+ */
+export const SIDEBAR_TOOLS_WITHOUT_DOCS = new Set<string>([
+    'AI gateway',
+    'Apps',
+    'Business knowledge',
+    'Engineering analytics',
+    'Identity matching',
+    'Links',
+    'Live Debugger',
+    'Product tours',
+    'Pulse',
+    'User research',
+    'Visual review',
+])
+
+export interface SidebarToolMeta {
+    description?: string
+    docsHref?: string
+}
+
+/** Description and docs link for a sidebar tool, both read from the product's scene config. */
+export function sidebarToolMeta(product: FileSystemImport): SidebarToolMeta {
+    // Most tree items name their scene explicitly; the rest are generated with a single-scene list.
+    const sceneKey = product.sceneKey ?? (product.sceneKeys?.length === 1 ? product.sceneKeys[0] : undefined)
+    const sceneConfig = sceneKey ? sceneConfigurations[sceneKey] : undefined
+    return { description: sceneConfig?.description, docsHref: sceneConfig?.docsHref }
+}

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -466,6 +466,7 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-container',
         description: 'Analyze and understand your AI usage and performance.',
         iconType: 'llm_analytics',
+        docsHref: 'https://posthog.com/docs/ai-observability',
     },
     AIObservabilityTrace: { projectBased: true, name: 'AI observability trace', layout: 'app-container' },
     AIObservabilitySession: { projectBased: true, name: 'AI observability session', layout: 'app-container' },
@@ -476,6 +477,7 @@ export const productConfiguration: Record<string, any> = {
         description: 'Test and experiment with LLM prompts in a sandbox environment.',
         layout: 'app-full-scene-height',
         iconType: 'llm_playground',
+        docsHref: 'https://posthog.com/docs/ai-observability/playground',
     },
     AIObservabilityDatasets: {
         projectBased: true,
@@ -483,6 +485,7 @@ export const productConfiguration: Record<string, any> = {
         description: 'Manage datasets for testing and evaluation.',
         layout: 'app-container',
         iconType: 'llm_datasets',
+        docsHref: 'https://posthog.com/docs/ai-evals/datasets',
     },
     AIObservabilityDataset: { projectBased: true, name: 'Dataset', layout: 'app-container', iconType: 'llm_datasets' },
     AIObservabilityEvaluations: {
@@ -492,6 +495,7 @@ export const productConfiguration: Record<string, any> = {
         activityScope: 'AIObservability',
         layout: 'app-container',
         iconType: 'llm_evaluations',
+        docsHref: 'https://posthog.com/docs/ai-evals',
     },
     AIObservabilityEvaluation: {
         projectBased: true,
@@ -514,6 +518,7 @@ export const productConfiguration: Record<string, any> = {
         activityScope: 'AIObservability',
         layout: 'app-container',
         iconType: 'llm_tags',
+        docsHref: 'https://posthog.com/docs/ai-evals/taggers',
     },
     AIObservabilityTag: {
         projectBased: true,
@@ -528,6 +533,7 @@ export const productConfiguration: Record<string, any> = {
         description: 'Track and manage your LLM prompts.',
         layout: 'app-container',
         iconType: 'llm_prompts',
+        docsHref: 'https://posthog.com/docs/prompt-management',
     },
     AIObservabilityPrompt: { projectBased: true, name: 'Prompt', layout: 'app-container', iconType: 'llm_prompts' },
     AIObservabilityClusters: {
@@ -536,6 +542,7 @@ export const productConfiguration: Record<string, any> = {
         description: 'Discover patterns and clusters in your AI usage.',
         layout: 'app-container',
         iconType: 'llm_clusters',
+        docsHref: 'https://posthog.com/docs/ai-observability/clusters',
     },
     AIObservabilityCluster: {
         projectBased: true,
@@ -578,6 +585,7 @@ export const productConfiguration: Record<string, any> = {
         iconType: 'conversations',
         projectBased: true,
         layout: 'app-container',
+        docsHref: 'https://posthog.com/docs/support',
     },
     SupportTicketDetail: { name: 'Ticket detail', projectBased: true, layout: 'app-container' },
     SupportSettings: { name: 'Support settings', projectBased: true, layout: 'app-container' },
@@ -587,6 +595,7 @@ export const productConfiguration: Record<string, any> = {
         name: 'Customer analytics',
         description: 'Understand how your customers interact with your product ',
         iconType: 'cohort',
+        docsHref: 'https://posthog.com/docs/customer-analytics',
     },
     CustomerAnalyticsConfiguration: { projectBased: true, name: 'Customer analytics configuration' },
     CustomerJourneyBuilder: { projectBased: true, name: 'New journey' },
@@ -603,6 +612,7 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-container',
         iconType: 'data_warehouse',
         description: 'Review and manage governed metrics, certifications, and relationships for your data.',
+        docsHref: 'https://posthog.com/docs/semantic-layer',
     },
     DataCatalogMetric: { projectBased: true, name: 'Metric' },
     DataOps: {
@@ -611,6 +621,7 @@ export const productConfiguration: Record<string, any> = {
         activityScope: 'DataWarehouse',
         description: "Manage your organization's shared data warehouse.",
         iconType: 'data_warehouse',
+        docsHref: 'https://posthog.com/docs/data-warehouse',
     },
     Models: {
         name: 'Models',
@@ -625,6 +636,7 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-raw-no-header',
         hideProjectNotice: true,
         description: 'Write and execute SQL queries against your data warehouse',
+        docsHref: 'https://posthog.com/docs/sql',
     },
     Sources: {
         projectBased: true,
@@ -643,6 +655,7 @@ export const productConfiguration: Record<string, any> = {
         projectBased: true,
         description: 'Allow your users to individually enable or disable features that are in public beta.',
         iconType: 'early_access_feature',
+        docsHref: 'https://posthog.com/docs/feature-flags/early-access-feature-management',
     },
     EarlyAccessFeature: { name: 'Early access feature', projectBased: true },
     EndpointsScene: {
@@ -652,6 +665,7 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-container',
         iconType: 'endpoints',
         description: 'Define queries your application will use via the API and monitor their cost and usage.',
+        docsHref: 'https://posthog.com/docs/endpoints',
     },
     EndpointScene: { projectBased: true, name: 'Endpoint', activityScope: 'Endpoint' },
     EngineeringAnalytics: {
@@ -701,6 +715,7 @@ export const productConfiguration: Record<string, any> = {
         name: 'Error tracking',
         iconType: 'error_tracking',
         description: 'Track and analyze your error tracking data to understand and fix issues.',
+        docsHref: 'https://posthog.com/docs/error-tracking',
     },
     ErrorTrackingIssue: { projectBased: true, name: 'Error tracking issue', layout: 'app-raw' },
     ErrorTrackingIssueFingerprints: { projectBased: true, name: 'Error tracking issue fingerprints' },
@@ -712,6 +727,7 @@ export const productConfiguration: Record<string, any> = {
         description:
             'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or due to chance.',
         iconType: 'experiment',
+        docsHref: 'https://posthog.com/docs/experiments',
     },
     FeatureFlagTemplates: { projectBased: true, name: 'Feature flag templates' },
     FeatureFlagsStaffTools: { instanceLevel: true, name: 'Flags staff tools' },
@@ -741,7 +757,11 @@ export const productConfiguration: Record<string, any> = {
         iconType: 'link',
     },
     Link: { name: 'Link', projectBased: true, activityScope: 'Link' },
-    LiveDebugger: { name: 'Live Debugger', projectBased: true },
+    LiveDebugger: {
+        name: 'Live debugger',
+        projectBased: true,
+        description: 'Set breakpoints in your running code and inspect the state captured when they hit.',
+    },
     Logs: {
         projectBased: true,
         name: 'Logs',
@@ -749,6 +769,7 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-container',
         iconType: 'logs',
         description: 'Monitor and analyze your logs to understand and fix issues.',
+        docsHref: 'https://posthog.com/docs/logs',
     },
     LogsAlertDetail: { projectBased: true, name: 'Alert', activityScope: ActivityScope.LOG, layout: 'app-container' },
     LogsAlertNotificationDetail: {
@@ -793,6 +814,7 @@ export const productConfiguration: Record<string, any> = {
         layout: 'app-container',
         description: 'Capture user intent and behaviour patterns to understand what AI users need from your tools.',
         iconType: 'mcp_analytics',
+        docsHref: 'https://posthog.com/docs/mcp-analytics',
     },
     MCPAnalyticsToolDetail: {
         projectBased: true,
@@ -807,6 +829,7 @@ export const productConfiguration: Record<string, any> = {
             'Route every MCP server your team uses through one gateway: shared credentials, per-tool policies, agent identities, and an audit log.',
         layout: 'app-container',
         iconType: 'tools',
+        docsHref: 'https://posthog.com/docs/model-context-protocol',
     },
     McpGatewayServer: { projectBased: true, name: 'MCP server' },
     McpGatewayAgent: { projectBased: true, name: 'MCP agent' },
@@ -818,6 +841,7 @@ export const productConfiguration: Record<string, any> = {
         activityScope: 'Metrics',
         description: 'Monitor and analyze application metrics to understand system performance and health.',
         iconType: 'metrics',
+        docsHref: 'https://posthog.com/docs/metrics',
     },
     TaskTracker: {
         name: 'Tasks',
@@ -826,6 +850,7 @@ export const productConfiguration: Record<string, any> = {
         description: 'Tasks are work that agents can do for you, like creating a pull request or fixing an issue.',
         iconType: 'task',
         layout: 'app-full-scene-height',
+        docsHref: 'https://posthog.com/docs/posthog-desktop/tasks',
     },
     Pulse: {
         name: 'Pulse',
@@ -841,6 +866,7 @@ export const productConfiguration: Record<string, any> = {
             'Set up AI scanners that automatically analyze new session recordings as they come in. Each result emits a queryable event.',
         iconType: 'replay_vision',
         layout: 'app-container',
+        docsHref: 'https://posthog.com/docs/replay-vision',
     },
     ReplayVisionScanner: {
         name: 'Replay vision scanner',
@@ -883,11 +909,13 @@ export const productConfiguration: Record<string, any> = {
         projectBased: true,
         description: 'Automated code reviews of your pull requests, and your review agent settings.',
         iconType: 'code_review',
+        docsHref: 'https://posthog.com/docs/posthog-desktop/code-review',
     },
     Inbox: {
         name: 'Inbox',
         projectBased: true,
         description: 'Actionable reports automatically generated from user session analysis and other signals.',
+        docsHref: 'https://posthog.com/docs/self-driving/inbox',
     },
     Skills: {
         projectBased: true,
@@ -895,6 +923,7 @@ export const productConfiguration: Record<string, any> = {
         description: 'Manage versioned agent skills that any MCP-connected agent can discover and use.',
         layout: 'app-container',
         iconType: 'llm_prompts',
+        docsHref: 'https://posthog.com/docs/skills',
     },
     Skill: { projectBased: true, name: 'Skill', layout: 'app-container', iconType: 'llm_prompts' },
     CommunitySkills: {
@@ -932,6 +961,7 @@ export const productConfiguration: Record<string, any> = {
         projectBased: true,
         description: 'PostHog toolbar launches PostHog right in your app or website.',
         iconType: 'toolbar',
+        docsHref: 'https://posthog.com/docs/toolbar',
     },
     Tracing: {
         name: 'Tracing',
@@ -940,6 +970,7 @@ export const productConfiguration: Record<string, any> = {
         activityScope: 'Tracing',
         description: 'Monitor and analyze distributed traces to understand service performance and debug issues.',
         iconType: 'tracing',
+        docsHref: 'https://posthog.com/docs/distributed-tracing',
     },
     TracingOperation: {
         name: 'Operation',
@@ -980,6 +1011,7 @@ export const productConfiguration: Record<string, any> = {
         projectBased: true,
         iconType: 'heatmap',
         description: 'Heatmaps are a way to visualize user behavior on your website.',
+        docsHref: 'https://posthog.com/docs/toolbar/heatmaps',
     },
     Heatmap: { name: 'Heatmap', projectBased: true, iconType: 'heatmap' },
     HeatmapNew: { name: 'New heatmap', projectBased: true, iconType: 'heatmap' },
@@ -989,6 +1021,7 @@ export const productConfiguration: Record<string, any> = {
         iconType: 'workflows',
         projectBased: true,
         description: 'Automate user communication and internal processes',
+        docsHref: 'https://posthog.com/docs/workflows',
     },
     Workflow: { name: 'Workflows', iconType: 'workflows', projectBased: true },
     WorkflowsLibraryTemplate: { name: 'Workflows', iconType: 'workflows', projectBased: true },
@@ -2279,7 +2312,9 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
     },
     {
         path: 'Live Debugger',
+        displayLabel: 'Live debugger',
         intents: [ProductKey.LIVE_DEBUGGER],
+        sceneKey: 'LiveDebugger',
         category: ProductItemCategory.UNRELEASED,
         type: 'live_debugger',
         href: urls.liveDebugger(),

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -303,6 +303,8 @@ export interface SceneConfig {
     name?: string
     /** Optional static description of the scene or product. Used both in the UI and by Max AI as context on what the scene is for */
     description?: string
+    /** Link to this product's page on posthog.com/docs. Shown next to the product in sidebar settings */
+    docsHref?: string
     /** Route should only be accessed when logged out (N.B. should be added to posthog/urls.py too) */
     onlyUnauthenticated?: boolean
     /** Route **can** be accessed when logged out (i.e. can be accessed when logged in too; should be added to posthog/urls.py too) */

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -73,6 +73,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         description: 'Web scripts allow you to add custom tags and functionality to your website using PostHog.',
         activityScope: ActivityScope.HOG_FUNCTION,
         iconType: 'data_pipeline',
+        docsHref: 'https://posthog.com/docs/js-snippets',
     },
     [Scene.BatchExport]: {
         projectBased: true,
@@ -135,6 +136,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         activityScope: ActivityScope.DASHBOARD,
         description: 'Create and manage your dashboards',
         iconType: 'dashboard',
+        docsHref: 'https://posthog.com/docs/product-analytics/dashboards',
     },
     [Scene.DataManagement]: {
         projectBased: true,
@@ -231,6 +233,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         description:
             'Use feature flags to safely deploy and roll back new features in an easy-to-manage way. Roll variants out to certain groups, a percentage of users, or everyone all at once.',
         activityScope: ActivityScope.FEATURE_FLAG,
+        docsHref: 'https://posthog.com/docs/feature-flags',
     },
     [Scene.Game368]: { name: '368 Hedgehogs', projectBased: true },
     [Scene.Group]: {
@@ -299,6 +302,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         name: 'Notebooks',
         description: 'Notebooks are a way to organize your work and share it with others.',
         activityScope: ActivityScope.NOTEBOOK,
+        docsHref: 'https://posthog.com/docs/notebooks',
     },
     [Scene.OAuthAuthorize]: {
         name: 'Authorize',
@@ -409,6 +413,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         iconType: 'session_replay',
         description:
             'Replay recordings of user sessions to understand how users interact with your product or website.',
+        docsHref: 'https://posthog.com/docs/session-replay',
     },
     [Scene.ReplayKiosk]: {
         projectBased: true,
@@ -434,6 +439,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         description:
             'Analyze your marketing performance across integrations: spend, impressions, conversions, ROAS, and more metrics.',
         iconType: 'marketing_analytics',
+        docsHref: 'https://posthog.com/docs/web-analytics/marketing-analytics',
     },
     [Scene.MarketingAnalyticsSettings]: {
         projectBased: true,
@@ -447,6 +453,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         description: 'Track, analyze, and experiment with user behavior.',
         activityScope: ActivityScope.INSIGHT,
         iconType: 'product_analytics',
+        docsHref: 'https://posthog.com/docs/product-analytics',
     },
     [Scene.Health]: {
         projectBased: true,
@@ -511,6 +518,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         activityScope: ActivityScope.SURVEY,
         description: 'Create surveys to collect feedback from your users',
         iconType: 'survey',
+        docsHref: 'https://posthog.com/docs/surveys',
     },
     [Scene.ProductTours]: {
         projectBased: true,
@@ -569,6 +577,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         layout: 'app-container',
         description: 'Analyze your web analytics data to understand website performance and user behavior.',
         iconType: 'web_analytics',
+        docsHref: 'https://posthog.com/docs/web-analytics',
     },
     [Scene.WebAnalyticsRecap]: {
         projectBased: true,

--- a/frontend/src/scenes/settings/user/SidebarSettings.tsx
+++ b/frontend/src/scenes/settings/user/SidebarSettings.tsx
@@ -5,7 +5,6 @@ import { LemonLabel, LemonSegmentedButton, LemonSwitch } from '@posthog/lemon-ui
 import { Link } from 'lib/lemon-ui/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getProductAccessDisabledReason } from 'lib/utils/accessControlUtils'
-import { PRODUCT_BRANDING } from 'scenes/welcome/productBranding'
 
 import { customProductsLogic } from '~/layout/panel-layout/ProjectTree/customProductsLogic'
 import { getDefaultTreeProducts, iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
@@ -15,9 +14,9 @@ import {
     SIDEBAR_CUSTOMIZABLE_SECTIONS,
     SidebarCustomizableItem,
 } from '~/layout/panel-layout/sidebarCustomization'
+import { sidebarToolMeta } from '~/layout/panel-layout/sidebarToolMeta'
 import { HomepageConfiguration } from '~/layout/scenes/HomepageConfiguration'
 import { uiCustomizationLogic } from '~/layout/uiCustomizationLogic'
-import { productConfiguration } from '~/products'
 import { FileSystemImport, SidebarDensity } from '~/queries/schema/schema-general'
 
 export function HomepageSetting(): JSX.Element {
@@ -99,7 +98,14 @@ export function SidebarItemsSetting(): JSX.Element {
                     className="py-2"
                     checked={true}
                     disabledReason={`${item.label} always stays visible`}
-                    label={<ItemLabel icon={item.icon} label={item.label} description={item.description} />}
+                    label={
+                        <ItemLabel
+                            icon={item.icon}
+                            label={item.label}
+                            description={item.description}
+                            docsHref={item.docsHref}
+                        />
+                    }
                     bordered
                     fullWidth
                     data-attr={`sidebar-customization-item-${item.label.toLowerCase()}`}
@@ -113,7 +119,14 @@ export function SidebarItemsSetting(): JSX.Element {
                 checked={isSidebarItemShown(key)}
                 onChange={(checked) => setSidebarItemShown(key, checked)}
                 loading={userLoading}
-                label={<ItemLabel icon={item.icon} label={item.label} description={item.description} />}
+                label={
+                    <ItemLabel
+                        icon={item.icon}
+                        label={item.label}
+                        description={item.description}
+                        docsHref={item.docsHref}
+                    />
+                }
                 bordered
                 fullWidth
                 data-attr={`sidebar-customization-item-${key}`}
@@ -142,6 +155,7 @@ export function SidebarItemsSetting(): JSX.Element {
                                     icon={section.icon}
                                     label={section.label}
                                     description={section.description}
+                                    docsHref={section.docsHref}
                                 />
                             }
                             bordered
@@ -212,12 +226,7 @@ export function SidebarMyToolsSetting(): JSX.Element {
                     <div key={category} className="flex flex-col gap-2">
                         <LemonLabel>{category}</LemonLabel>
                         {[...categoryProducts].sort(sortProducts).map((product) => {
-                            const description: string | undefined = product.sceneKey
-                                ? productConfiguration[product.sceneKey]?.description
-                                : undefined
-                            const docsHref: string | undefined = product.intents?.length
-                                ? PRODUCT_BRANDING[product.intents[0]]?.docsHref
-                                : undefined
+                            const { description, docsHref } = sidebarToolMeta(product)
                             return (
                                 <LemonSwitch
                                     key={product.path}

--- a/products/ai_observability/manifest.tsx
+++ b/products/ai_observability/manifest.tsx
@@ -18,6 +18,7 @@ export const manifest: ProductManifest = {
             layout: 'app-container',
             description: 'Analyze and understand your AI usage and performance.',
             iconType: 'llm_analytics',
+            docsHref: 'https://posthog.com/docs/ai-observability',
         },
         AIObservabilityTrace: {
             import: () => import('./frontend/AIObservabilityTraceScene'),
@@ -44,6 +45,7 @@ export const manifest: ProductManifest = {
             description: 'Test and experiment with LLM prompts in a sandbox environment.',
             layout: 'app-full-scene-height',
             iconType: 'llm_playground',
+            docsHref: 'https://posthog.com/docs/ai-observability/playground',
         },
         AIObservabilityDatasets: {
             import: () => import('./frontend/datasets/AIObservabilityDatasetsScene'),
@@ -52,6 +54,7 @@ export const manifest: ProductManifest = {
             description: 'Manage datasets for testing and evaluation.',
             layout: 'app-container',
             iconType: 'llm_datasets',
+            docsHref: 'https://posthog.com/docs/ai-evals/datasets',
         },
         AIObservabilityDataset: {
             import: () => import('./frontend/datasets/AIObservabilityDatasetScene'),
@@ -68,6 +71,7 @@ export const manifest: ProductManifest = {
             activityScope: 'AIObservability',
             layout: 'app-container',
             iconType: 'llm_evaluations',
+            docsHref: 'https://posthog.com/docs/ai-evals',
         },
         AIObservabilityEvaluation: {
             import: () => import('./frontend/evaluations/AIObservabilityEvaluation'),
@@ -93,6 +97,7 @@ export const manifest: ProductManifest = {
             activityScope: 'AIObservability',
             layout: 'app-container',
             iconType: 'llm_tags',
+            docsHref: 'https://posthog.com/docs/ai-evals/taggers',
         },
         AIObservabilityTag: {
             import: () => import('./frontend/tags/AIObservabilityTag'),
@@ -109,6 +114,7 @@ export const manifest: ProductManifest = {
             description: 'Track and manage your LLM prompts.',
             layout: 'app-container',
             iconType: 'llm_prompts',
+            docsHref: 'https://posthog.com/docs/prompt-management',
         },
         AIObservabilityPrompt: {
             import: () => import('./frontend/prompts/LLMPromptScene'),
@@ -124,6 +130,7 @@ export const manifest: ProductManifest = {
             description: 'Discover patterns and clusters in your AI usage.',
             layout: 'app-container',
             iconType: 'llm_clusters',
+            docsHref: 'https://posthog.com/docs/ai-observability/clusters',
         },
         AIObservabilityCluster: {
             import: () => import('./frontend/clusters/AIObservabilityClusterScene'),

--- a/products/conversations/manifest.tsx
+++ b/products/conversations/manifest.tsx
@@ -15,6 +15,7 @@ export const manifest: ProductManifest = {
             import: () => import('./frontend/scenes/tickets/SupportTicketsScene'),
             projectBased: true,
             layout: 'app-container',
+            docsHref: 'https://posthog.com/docs/support',
         },
         SupportTicketDetail: {
             name: 'Ticket detail',

--- a/products/customer_analytics/manifest.tsx
+++ b/products/customer_analytics/manifest.tsx
@@ -18,6 +18,7 @@ export const manifest: ProductManifest = {
             name: 'Customer analytics',
             description: 'Understand how your customers interact with your product ',
             iconType: 'cohort',
+            docsHref: 'https://posthog.com/docs/customer-analytics',
         },
         CustomerAnalyticsConfiguration: {
             import: () =>

--- a/products/data_catalog/manifest.tsx
+++ b/products/data_catalog/manifest.tsx
@@ -13,6 +13,7 @@ export const manifest: ProductManifest = {
             layout: 'app-container',
             iconType: 'data_warehouse',
             description: 'Review and manage governed metrics, certifications, and relationships for your data.',
+            docsHref: 'https://posthog.com/docs/semantic-layer',
         },
         DataCatalogMetric: {
             import: () => import('./frontend/DataCatalogMetricScene'),

--- a/products/data_warehouse/manifest.tsx
+++ b/products/data_warehouse/manifest.tsx
@@ -19,6 +19,7 @@ export const manifest: ProductManifest = {
             activityScope: 'DataWarehouse',
             description: "Manage your organization's shared data warehouse.",
             iconType: 'data_warehouse',
+            docsHref: 'https://posthog.com/docs/data-warehouse',
         },
         Models: {
             name: 'Models',
@@ -38,6 +39,7 @@ export const manifest: ProductManifest = {
             layout: 'app-raw-no-header',
             hideProjectNotice: true,
             description: 'Write and execute SQL queries against your data warehouse',
+            docsHref: 'https://posthog.com/docs/sql',
         },
         Sources: {
             import: () => import('./frontend/scenes/SourcesScene/SourcesScene'),

--- a/products/early_access_features/manifest.tsx
+++ b/products/early_access_features/manifest.tsx
@@ -13,6 +13,7 @@ export const manifest: ProductManifest = {
             projectBased: true,
             description: 'Allow your users to individually enable or disable features that are in public beta.',
             iconType: 'early_access_feature',
+            docsHref: 'https://posthog.com/docs/feature-flags/early-access-feature-management',
         },
         EarlyAccessFeature: {
             name: 'Early access feature',

--- a/products/endpoints/manifest.tsx
+++ b/products/endpoints/manifest.tsx
@@ -17,6 +17,7 @@ export const manifest: ProductManifest = {
             layout: 'app-container',
             iconType: 'endpoints',
             description: 'Define queries your application will use via the API and monitor their cost and usage.',
+            docsHref: 'https://posthog.com/docs/endpoints',
         },
         EndpointScene: {
             import: () => import('./frontend/EndpointScene'),

--- a/products/error_tracking/manifest.tsx
+++ b/products/error_tracking/manifest.tsx
@@ -16,6 +16,7 @@ export const manifest: ProductManifest = {
             name: 'Error tracking',
             iconType: 'error_tracking',
             description: 'Track and analyze your error tracking data to understand and fix issues.',
+            docsHref: 'https://posthog.com/docs/error-tracking',
         },
         ErrorTrackingIssue: {
             import: () => import('./frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene'),

--- a/products/experiments/manifest.tsx
+++ b/products/experiments/manifest.tsx
@@ -15,6 +15,7 @@ export const manifest: ProductManifest = {
             description:
                 'Experiments help you test changes to your product to see which changes will lead to optimal results. Automatic statistical calculations let you see if the results are valid or due to chance.',
             iconType: 'experiment',
+            docsHref: 'https://posthog.com/docs/experiments',
         },
     },
     routes: { '/experiments': ['Experiments', 'experiments'] },

--- a/products/live_debugger/manifest.tsx
+++ b/products/live_debugger/manifest.tsx
@@ -9,9 +9,10 @@ export const manifest: ProductManifest = {
     name: 'Live Debugger',
     scenes: {
         LiveDebugger: {
-            name: 'Live Debugger',
+            name: 'Live debugger',
             import: () => import('./frontend/LiveDebugger'),
             projectBased: true,
+            description: 'Set breakpoints in your running code and inspect the state captured when they hit.',
         },
     },
     routes: {
@@ -35,7 +36,9 @@ export const manifest: ProductManifest = {
     treeItemsProducts: [
         {
             path: 'Live Debugger',
+            displayLabel: 'Live debugger',
             intents: [ProductKey.LIVE_DEBUGGER],
+            sceneKey: 'LiveDebugger',
             category: ProductItemCategory.UNRELEASED,
             type: 'live_debugger',
             href: urls.liveDebugger(),

--- a/products/logs/manifest.tsx
+++ b/products/logs/manifest.tsx
@@ -17,6 +17,7 @@ export const manifest: ProductManifest = {
             layout: 'app-container',
             iconType: 'logs',
             description: 'Monitor and analyze your logs to understand and fix issues.',
+            docsHref: 'https://posthog.com/docs/logs',
         },
         LogsAlertDetail: {
             import: () => import('./frontend/scenes/LogsAlertDetailScene/LogsAlertDetailScene'),

--- a/products/mcp_analytics/manifest.tsx
+++ b/products/mcp_analytics/manifest.tsx
@@ -24,6 +24,7 @@ export const manifest: ProductManifest = {
             layout: 'app-container',
             description: 'Capture user intent and behaviour patterns to understand what AI users need from your tools.',
             iconType: 'mcp_analytics',
+            docsHref: 'https://posthog.com/docs/mcp-analytics',
         },
         MCPAnalyticsToolDetail: {
             import: () => import('./frontend/MCPAnalyticsToolDetail'),

--- a/products/mcp_store/manifest.tsx
+++ b/products/mcp_store/manifest.tsx
@@ -15,6 +15,7 @@ export const manifest: ProductManifest = {
                 'Route every MCP server your team uses through one gateway: shared credentials, per-tool policies, agent identities, and an audit log.',
             layout: 'app-container',
             iconType: 'tools',
+            docsHref: 'https://posthog.com/docs/model-context-protocol',
         },
         McpGatewayServer: {
             import: () => import('./frontend/gateway/GatewayServerScene'),

--- a/products/metrics/manifest.tsx
+++ b/products/metrics/manifest.tsx
@@ -15,6 +15,7 @@ export const manifest: ProductManifest = {
             activityScope: 'Metrics',
             description: 'Monitor and analyze application metrics to understand system performance and health.',
             iconType: 'metrics',
+            docsHref: 'https://posthog.com/docs/metrics',
         },
     },
     routes: {

--- a/products/posthog_ai/manifest.tsx
+++ b/products/posthog_ai/manifest.tsx
@@ -17,6 +17,7 @@ export const manifest: ProductManifest = {
             iconType: 'task',
             // Master/detail with internally-scrolling columns — the scene fills the viewport height.
             layout: 'app-full-scene-height',
+            docsHref: 'https://posthog.com/docs/posthog-desktop/tasks',
         },
     },
     routes: {

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
+                  ([e__person.properties___fish] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,6 +44,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -111,7 +121,17 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -168,8 +188,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -178,6 +198,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -294,7 +324,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -326,7 +373,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/replay_vision/manifest.tsx
+++ b/products/replay_vision/manifest.tsx
@@ -15,6 +15,7 @@ export const manifest: ProductManifest = {
                 'Set up AI scanners that automatically analyze new session recordings as they come in. Each result emits a queryable event.',
             iconType: 'replay_vision',
             layout: 'app-container',
+            docsHref: 'https://posthog.com/docs/replay-vision',
         },
         ReplayVisionScanner: {
             name: 'Replay vision scanner',

--- a/products/review_hog/manifest.tsx
+++ b/products/review_hog/manifest.tsx
@@ -13,6 +13,7 @@ export const manifest: ProductManifest = {
             projectBased: true,
             description: 'Automated code reviews of your pull requests, and your review agent settings.',
             iconType: 'code_review',
+            docsHref: 'https://posthog.com/docs/posthog-desktop/code-review',
         },
     },
     routes: {

--- a/products/signals/manifest.tsx
+++ b/products/signals/manifest.tsx
@@ -31,6 +31,7 @@ export const manifest: ProductManifest = {
             import: () => import('./frontend/inbox/InboxScene'),
             projectBased: true,
             description: 'Actionable reports automatically generated from user session analysis and other signals.',
+            docsHref: 'https://posthog.com/docs/self-driving/inbox',
         },
     },
     routes: {

--- a/products/skills/manifest.tsx
+++ b/products/skills/manifest.tsx
@@ -16,6 +16,7 @@ export const manifest: ProductManifest = {
             description: 'Manage versioned agent skills that any MCP-connected agent can discover and use.',
             layout: 'app-container',
             iconType: 'llm_prompts',
+            docsHref: 'https://posthog.com/docs/skills',
         },
         Skill: {
             import: () => import('./frontend/LLMSkillScene'),

--- a/products/toolbar/manifest.tsx
+++ b/products/toolbar/manifest.tsx
@@ -12,6 +12,7 @@ export const manifest: ProductManifest = {
             projectBased: true,
             description: 'PostHog toolbar launches PostHog right in your app or website.',
             iconType: 'toolbar',
+            docsHref: 'https://posthog.com/docs/toolbar',
         },
     },
     urls: {

--- a/products/tracing/manifest.tsx
+++ b/products/tracing/manifest.tsx
@@ -17,6 +17,7 @@ export const manifest: ProductManifest = {
             activityScope: 'Tracing',
             description: 'Monitor and analyze distributed traces to understand service performance and debug issues.',
             iconType: 'tracing',
+            docsHref: 'https://posthog.com/docs/distributed-tracing',
         },
         TracingOperation: {
             name: 'Operation',

--- a/products/web_analytics/manifest.tsx
+++ b/products/web_analytics/manifest.tsx
@@ -29,6 +29,7 @@ export const manifest: ProductManifest = {
             projectBased: true,
             iconType: 'heatmap',
             description: 'Heatmaps are a way to visualize user behavior on your website.',
+            docsHref: 'https://posthog.com/docs/toolbar/heatmaps',
         },
         Heatmap: {
             name: 'Heatmap',

--- a/products/workflows/manifest.tsx
+++ b/products/workflows/manifest.tsx
@@ -14,6 +14,7 @@ export const manifest: ProductManifest = {
             iconType: 'workflows',
             projectBased: true,
             description: 'Automate user communication and internal processes',
+            docsHref: 'https://posthog.com/docs/workflows',
         },
         Workflow: {
             import: () => import('./frontend/Workflows/WorkflowScene'),


### PR DESCRIPTION
## Problem

Anyone customizing their sidebar in Settings → Navigation saw an inconsistent list. Six of the biggest products — Product analytics, Dashboards, Web analytics, Session replay, Surveys, Feature flags — showed a bare label with no explanation. Only nine tools out of 49 offered a docs link, and a few of those pointed at the wrong page: SQL editor linked to the data warehouse docs, Taggers to the AI observability overview.

The cause was in the lookups, not the content. Descriptions were read from product manifests only, so every product whose scene lives in the core app resolved to nothing. Docs links were read from the onboarding branding map, keyed by the product's first declared intent — a map with nine entries that was never meant for this.

## Changes

- Every tool in "My tools" now shows a description, including the six core products that showed none.
- Every tool that has a docs page now links to it, and the links point at that product's own page. 38 products gained one.
- The Self-driving, Activity, and Data nav items link to their docs too.
- Live debugger shows a description, and its label is now sentence case like the rest.
- Eleven alpha products have no docs page on posthog.com yet, so they show a description and no link: AI gateway, Apps, Business knowledge, Engineering analytics, Identity matching, Links, Live debugger, Product tours, Pulse, User research, Visual review.

Mechanical: descriptions and docs links both resolve from the product's scene config now, so `SceneConfig` gains a `docsHref` field and the resolver moved into `sidebarToolMeta.ts`. The per-manifest and `scenes.ts` edits are one added line each.

![My tools](https://raw.githubusercontent.com/PostHog/pr-assets/2c6957f8aad79c8c4a8abb27e5fc4a44368f185d/2026/08/02b49566-73cf-4d27-9ad0-9c7d35bed305.png)

![Navigation items](https://raw.githubusercontent.com/PostHog/pr-assets/708f4d0d2e71e1da4409bc07d243345f5fbdd06f/2026/08/0d5fe074-0daf-432d-b6a5-8ba6f8e5b87f.png)

## How did you test this code?

`frontend/src/layout/panel-layout/sidebarToolMeta.test.ts` walks the real product catalog and fails when a tool has no description, or has no docs link without being listed as still missing a docs page. A second case rejects a stale exemption, so a product keeps its link once its docs land. No existing test asserted anything about this metadata, which is how six products shipped with no description.

Every one of the 41 docs URLs in this diff was fetched and returned 200; several first guesses 404'd and were replaced with the page that exists. Rendered the settings section in Storybook at 1280px and 760px and read the resulting list — the screenshots above are those renders. Ran the panel-layout Jest suites and the frontend typecheck. Did not exercise the section in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — this links to existing docs pages and adds no documented behavior.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude in PostHog Desktop. No repo skills were loaded for this change; it followed the written conventions in `AGENTS.md` and `frontend/src/AGENTS.md` directly.

Two design points worth a reviewer's attention. First, the docs links live on `SceneConfig` rather than in a curated map beside the sidebar code; a map is a smaller diff, but it drifts from the products it describes, and the scene config already owns `description`. Second, the eleven products with no docs page are listed in the test rather than pointed at a plausible parent section, so nobody clicks "Docs" and lands somewhere that doesn't describe the product. That list is the honest gap this PR leaves: those products need docs written, not a link invented.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

