### PR TITLE
fix(signals): collapse stack traces in inbox error evidence cards

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7096,6 +7096,10 @@ snapshots:
         hash: v1.k794b7964.8220c14a1dc6de9d9aa2fa2fa829bff1d19230cf7cdb947906b3fee3ead37d98.BBzXUXAId7C0u5sasTEYZBdaqZjXRU20paQFY6thp3s
     scenes-app-inbox-signal-cards--all-sources--light:
         hash: v1.k794b7964.0934851297243b7d23bdd81a483207f45c9d2c3d1610ef6e110f7caff8bdd827.7VHcEHSf7WtelKnEDOy6Rr2-Bu9t6I3J3f4-OuLUQAA
+    scenes-app-inbox-signal-cards--error-tracking-stack-trace--dark:
+        hash: v1.k794b7964.1079c33189e18745b6948c8d893f67cc548ab1d97d91726856404d6fffe2144f.nN2u5Dah5xh1s43vMIoK393U45xSnh0a__0Fj8IZiQs
+    scenes-app-inbox-signal-cards--error-tracking-stack-trace--light:
+        hash: v1.k794b7964.aa21988170efa24558a07df517a8d8fd27b9708c6f1228d7c1ffd08572e5a8ce.Y5gzV-7m1I3ViQfpe3ek_QMq0YgPZuIXGPaaQXKkJr4
     scenes-app-inbox-signal-cards--generic-fallbacks--dark:
         hash: v1.k794b7964.0675fbd7acca5320139d134150e70d3cd9e763580b0eb4cbaa93d5756669ae15.pKrX03LXxk8_E-bezOswMJafPsVaFWft7GbSeImpQDQ
     scenes-app-inbox-signal-cards--generic-fallbacks--light:

--- a/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
@@ -74,6 +74,12 @@ export interface LemonMarkdownProps {
     disableImages?: boolean
     className?: string
     wrapCode?: boolean
+    /**
+     * If set, block code longer than this many lines collapses to it, with a control to expand.
+     * Copy still copies the full block. Use where content can carry an unboundedly long code block
+     * (e.g. a stack trace) that would otherwise dominate the surrounding UI.
+     */
+    codeMaxLinesWithoutExpansion?: number
     /** Whether to generate id attributes on heading elements for anchor linking. */
     generateHeadingIds?: boolean
     /**
@@ -127,6 +133,7 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
     disableDocsRedirect = false,
     disableImages = false,
     wrapCode = false,
+    codeMaxLinesWithoutExpansion,
     generateHeadingIds = false,
     renderMermaid,
     renderChartRef,
@@ -158,7 +165,12 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
                     }
                     const language = languageMatch ? getLanguage(languageMatch[1]) : Language.Text
                     return (
-                        <CodeSnippet language={language} wrap={wrapCode} compact>
+                        <CodeSnippet
+                            language={language}
+                            wrap={wrapCode}
+                            maxLinesWithoutExpansion={codeMaxLinesWithoutExpansion}
+                            compact
+                        >
                             {value}
                         </CodeSnippet>
                     )
@@ -274,6 +286,7 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
             disableImages,
             lowKeyHeadings,
             wrapCode,
+            codeMaxLinesWithoutExpansion,
             generateHeadingIds,
             renderMermaid,
             renderChartRef,
@@ -316,6 +329,7 @@ function LemonMarkdownComponent({
     disableDocsRedirect = false,
     disableImages = false,
     wrapCode = false,
+    codeMaxLinesWithoutExpansion,
     generateHeadingIds = false,
     renderMermaid,
     renderChartRef,
@@ -328,6 +342,7 @@ function LemonMarkdownComponent({
                 disableDocsRedirect={disableDocsRedirect}
                 disableImages={disableImages}
                 wrapCode={wrapCode}
+                codeMaxLinesWithoutExpansion={codeMaxLinesWithoutExpansion}
                 generateHeadingIds={generateHeadingIds}
                 renderMermaid={renderMermaid}
                 renderChartRef={renderChartRef}

--- a/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonMarkdown/LemonMarkdown.tsx
@@ -75,11 +75,11 @@ export interface LemonMarkdownProps {
     className?: string
     wrapCode?: boolean
     /**
-     * If set, block code longer than this many lines collapses to it, with a control to expand.
-     * Copy still copies the full block. Use where content can carry an unboundedly long code block
+     * If set, block code renders at most this many lines and the rest is cut. The copy button
+     * copies the visible lines only. Use where content can carry an unboundedly long code block
      * (e.g. a stack trace) that would otherwise dominate the surrounding UI.
      */
-    codeMaxLinesWithoutExpansion?: number
+    codeMaxLines?: number
     /** Whether to generate id attributes on heading elements for anchor linking. */
     generateHeadingIds?: boolean
     /**
@@ -133,7 +133,7 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
     disableDocsRedirect = false,
     disableImages = false,
     wrapCode = false,
-    codeMaxLinesWithoutExpansion,
+    codeMaxLines,
     generateHeadingIds = false,
     renderMermaid,
     renderChartRef,
@@ -164,14 +164,12 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
                         return <>{renderMermaid(value)}</>
                     }
                     const language = languageMatch ? getLanguage(languageMatch[1]) : Language.Text
+                    const lines = value.split('\n')
+                    const displayedValue =
+                        codeMaxLines && lines.length > codeMaxLines ? lines.slice(0, codeMaxLines).join('\n') : value
                     return (
-                        <CodeSnippet
-                            language={language}
-                            wrap={wrapCode}
-                            maxLinesWithoutExpansion={codeMaxLinesWithoutExpansion}
-                            compact
-                        >
-                            {value}
+                        <CodeSnippet language={language} wrap={wrapCode} compact>
+                            {displayedValue}
                         </CodeSnippet>
                     )
                 }
@@ -286,7 +284,7 @@ const LemonMarkdownRenderer = memo(function LemonMarkdownRenderer({
             disableImages,
             lowKeyHeadings,
             wrapCode,
-            codeMaxLinesWithoutExpansion,
+            codeMaxLines,
             generateHeadingIds,
             renderMermaid,
             renderChartRef,
@@ -329,7 +327,7 @@ function LemonMarkdownComponent({
     disableDocsRedirect = false,
     disableImages = false,
     wrapCode = false,
-    codeMaxLinesWithoutExpansion,
+    codeMaxLines,
     generateHeadingIds = false,
     renderMermaid,
     renderChartRef,
@@ -342,7 +340,7 @@ function LemonMarkdownComponent({
                 disableDocsRedirect={disableDocsRedirect}
                 disableImages={disableImages}
                 wrapCode={wrapCode}
-                codeMaxLinesWithoutExpansion={codeMaxLinesWithoutExpansion}
+                codeMaxLines={codeMaxLines}
                 generateHeadingIds={generateHeadingIds}
                 renderMermaid={renderMermaid}
                 renderChartRef={renderChartRef}

--- a/products/signals/frontend/inbox/components/signalCards/ErrorTrackingSignalCard.tsx
+++ b/products/signals/frontend/inbox/components/signalCards/ErrorTrackingSignalCard.tsx
@@ -94,9 +94,9 @@ export function ErrorTrackingSignalCard({ signal }: SignalCardProps): JSX.Elemen
         <SignalCardShell signal={signal}>
             {signal.content && (
                 // The signal content ends with the issue's full stack trace in a code fence, which
-                // is written for the report LLM rather than for display, so collapse it to keep it
-                // from swallowing the evidence rail.
-                <LemonMarkdown className="text-sm text-secondary mb-2" disableImages codeMaxLinesWithoutExpansion={3}>
+                // is written for the report LLM rather than for display, so cap it to keep it from
+                // swallowing the evidence rail. The View issue link carries the full trace.
+                <LemonMarkdown className="text-sm text-secondary mb-2" disableImages codeMaxLines={3}>
                     {signal.content}
                 </LemonMarkdown>
             )}

--- a/products/signals/frontend/inbox/components/signalCards/ErrorTrackingSignalCard.tsx
+++ b/products/signals/frontend/inbox/components/signalCards/ErrorTrackingSignalCard.tsx
@@ -93,7 +93,10 @@ export function ErrorTrackingSignalCard({ signal }: SignalCardProps): JSX.Elemen
     return (
         <SignalCardShell signal={signal}>
             {signal.content && (
-                <LemonMarkdown className="text-sm text-secondary mb-2" disableImages>
+                // The signal content ends with the issue's full stack trace in a code fence, which
+                // is written for the report LLM rather than for display, so collapse it to keep it
+                // from swallowing the evidence rail.
+                <LemonMarkdown className="text-sm text-secondary mb-2" disableImages codeMaxLinesWithoutExpansion={3}>
                     {signal.content}
                 </LemonMarkdown>
             )}

--- a/products/signals/frontend/inbox/components/signalCards/SignalCards.stories.tsx
+++ b/products/signals/frontend/inbox/components/signalCards/SignalCards.stories.tsx
@@ -186,6 +186,41 @@ const errorTrackingIssue = makeSignal({
     extra: { fingerprint: 'fp-upload-413' },
 })
 
+// The real signal content carries the issue's full stack trace as a code fence (it is written for
+// the report LLM, see `emit_issue_lifecycle_signal`), so a fixture with a long one pins the
+// three-line collapse the card applies to it.
+const STACK_TRACE = [
+    'RequestEntityTooLarge: upload chunk exceeds 10 MB',
+    'handle_upload in app/api/uploads.py line 214',
+    'validate_request in app/api/middleware.py line 61',
+    'process_chunks in app/uploads/chunking.py line 88',
+    'next_chunk in app/uploads/chunking.py line 47',
+    'write_chunk in app/uploads/storage.py line 132',
+    'put_object in app/clients/object_store.py line 55',
+    'with_retries in app/clients/retry.py line 29',
+    'inner in contextlib.py line 85',
+    'request in httpclient/session.py line 402',
+    'send in httpclient/adapters.py line 318',
+    'raise_for_status in httpclient/models.py line 761',
+    'handle_error in app/clients/object_store.py line 71',
+    'to_upload_error in app/uploads/errors.py line 18',
+    'log_failure in app/uploads/telemetry.py line 33',
+    'capture in analytics/client.py line 96',
+    'enqueue in analytics/queue.py line 54',
+    'flush in analytics/queue.py line 78',
+    'run in concurrent/futures/thread.py line 58',
+    '_bootstrap_inner in threading.py line 1038',
+    '_bootstrap in threading.py line 995',
+].join('\n')
+
+const errorTrackingIssueWithStackTrace = makeSignal({
+    source_product: 'error_tracking',
+    source_type: 'issue_created',
+    source_id: 'issue-3',
+    content: `New error tracking issue created - this particular exception was observed for the first time:\nRequestEntityTooLarge: upload chunk exceeds 10 MB\n\n\`\`\`\n${STACK_TRACE}\n\`\`\``,
+    extra: { fingerprint: 'fp-upload-413-created' },
+})
+
 const healthCheck = makeSignal({
     source_product: 'health_checks',
     source_type: 'health_issue',
@@ -396,6 +431,52 @@ export const TicketAttachments: Story = {
 
 export const GenericFallbacks: Story = {
     render: () => <Rail signals={[genericWithEntityLink, genericWithExternalLink, genericWithoutLink]} />,
+}
+
+/** The stack trace fence in the signal content collapses to three lines instead of filling the rail. */
+export const ErrorTrackingStackTrace: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/environments/:team_id/error_tracking/issues/:issue_id/': () => [
+                    200,
+                    {
+                        id: 'issue-3',
+                        name: 'RequestEntityTooLarge',
+                        description: 'upload chunk exceeds 10 MB',
+                        assignee: null,
+                        status: 'active',
+                        first_seen: '2026-06-08T09:30:00Z',
+                        external_issues: [],
+                    },
+                ],
+            },
+            post: {
+                '/api/environments/:team_id/query/ErrorTrackingQuery/': () => [
+                    200,
+                    {
+                        results: [
+                            {
+                                first_seen: '2026-06-08T09:30:00Z',
+                                last_seen: BASE_DATE,
+                                aggregations: {
+                                    occurrences: 12,
+                                    sessions: 8,
+                                    users: 6,
+                                    volume_buckets: [
+                                        { label: '2026-06-08T00:00:00Z', value: 2 },
+                                        { label: '2026-06-09T00:00:00Z', value: 4 },
+                                        { label: '2026-06-10T00:00:00Z', value: 6 },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                ],
+            },
+        }),
+    ],
+    render: () => <Rail signals={[errorTrackingIssueWithStackTrace]} />,
 }
 
 /** One card per source with a dedicated renderer, so a layout change to any of them shows up here. */

--- a/products/signals/frontend/inbox/components/signalCards/SignalCards.stories.tsx
+++ b/products/signals/frontend/inbox/components/signalCards/SignalCards.stories.tsx
@@ -188,7 +188,7 @@ const errorTrackingIssue = makeSignal({
 
 // The real signal content carries the issue's full stack trace as a code fence (it is written for
 // the report LLM, see `emit_issue_lifecycle_signal`), so a fixture with a long one pins the
-// three-line collapse the card applies to it.
+// three-line cap the card applies to it.
 const STACK_TRACE = [
     'RequestEntityTooLarge: upload chunk exceeds 10 MB',
     'handle_upload in app/api/uploads.py line 214',
@@ -433,7 +433,7 @@ export const GenericFallbacks: Story = {
     render: () => <Rail signals={[genericWithEntityLink, genericWithExternalLink, genericWithoutLink]} />,
 }
 
-/** The stack trace fence in the signal content collapses to three lines instead of filling the rail. */
+/** The stack trace fence in the signal content is cut to three lines instead of filling the rail. */
 export const ErrorTrackingStackTrace: Story = {
     decorators: [
         mswDecorator({


### PR DESCRIPTION
## Problem

A single error tracking evidence card can fill an Inbox report's whole evidence rail with a stack trace. The other evidence gets buried below it.

- The signal content ends with the issue's full stack trace in a code fence. The backend writes that fence for the report LLM, not for display.
- The card rendered the whole fence with no height limit.

## Changes

- The stack trace in an error tracking evidence card now shows its first three lines. The rest is cut, with no expand control. The View issue link carries the full trace.
- `LemonMarkdown` gets a `codeMaxLines` prop that cuts block code to that many lines. Every other markdown surface leaves it unset, so nothing else changes.
- Mechanical: a new `ErrorTrackingStackTrace` story renders the card from an invented 22-line trace.

| Before | After |
| --- | --- |
| ![inbox-error-card-before](https://raw.githubusercontent.com/PostHog/pr-assets/40d99645730248b50cde6235aed1ded032838438/2026/08/33e415c8-ca89-4579-ae3c-d75ceede3bbc.png) | ![inbox-error-card-after-capped](https://raw.githubusercontent.com/PostHog/pr-assets/1c212b82aae063a72ba78478097df493e46da2d2/2026/08/54ff7d72-f68e-4f1a-b028-2f0f3aaaf5be.png) |

## How did you test this code?

- The new story mocks the issue endpoints and pins the capped card as a visual snapshot. It catches the prop no longer reaching the code block renderer.
- The screenshots above come from that story in a local Storybook.
- No unit test added: the cut is a pure line slice with no branching beyond the prop being set.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: an in-app display detail with no documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5), [session](https://claude.ai/code/session_01LYrLTX1As5g8phTjxfjxT6). Skills invoked: /writing-ui-components, /writing-code-comments, /writing-pr-descriptions.
- Prompted by an internal inbox report whose error evidence card carried a screen-filling stack trace. The story's stack trace and issue data are invented, not taken from that report.
- The first revision capped the trace with CodeSnippet's "Show more" expansion; a follow-up request removed the button, so the prop became a plain cut.
