### PR TITLE
fix(tasks): reuse a repo warm across the default branch

### DIFF
--- a/posthog/models/github_integration_base.py
+++ b/posthog/models/github_integration_base.py
@@ -2106,6 +2106,20 @@ class GitHubIntegrationBase:
             "updated_at": updated_at,
         }
 
+    def cached_default_branch(self, repo: str) -> str | None:
+        """The repository's default branch as the branch cache already knows it, else ``None``.
+
+        Cache-only, so a caller on a request path can ask: it never calls GitHub, never writes, and
+        never raises. It reads the same entry that serves the branch pickers, so it answers with the
+        branch name a client picked its default from. Use ``get_default_branch`` when the answer has
+        to be authoritative.
+        """
+        cached = self._get_branch_cache(repo)
+        if cached is None:
+            return None
+        default_branch = cached.get("default_branch")
+        return default_branch if isinstance(default_branch, str) else None
+
     def branch_cache_is_stale(self, repo: str) -> bool:
         cached = self._get_branch_cache(repo)
         if cached is None:

--- a/posthog/models/test/integration/test_github.py
+++ b/posthog/models/test/integration/test_github.py
@@ -1597,6 +1597,32 @@ class TestGitHubIntegrationModel(BaseTest):
         mock_default_branch.assert_not_called()
         assert REGISTRY.get_sample_value("github_integration_cache_accesses_total", labels) == previous_count + 1
 
+    @parameterized.expand(
+        [
+            ("cached", True, "main"),
+            ("not_cached", False, None),
+        ]
+    )
+    @patch("posthog.models.integration.github.GitHubIntegration.list_branches")
+    @patch("posthog.models.integration.github.GitHubIntegration.get_default_branch")
+    def test_cached_default_branch_answers_without_calling_github(
+        self, _name, is_cached, expected, mock_default_branch, mock_list_branches
+    ):
+        integration = self.create_integration(
+            {"installation_id": "INSTALL", "account": {"name": "PostHog"}},
+            {"access_token": "ACCESS_TOKEN"},
+        )
+        repo = "posthog/posthog"
+        if is_cached:
+            cache.set(
+                GitHubIntegration(integration)._get_branch_cache_key(repo),
+                {"branches": ["main"], "default_branch": "main", "updated_at": time.time()},
+            )
+
+        assert GitHubIntegration(integration).cached_default_branch(repo) == expected
+        mock_list_branches.assert_not_called()
+        mock_default_branch.assert_not_called()
+
     @patch("posthog.models.integration.github.GitHubIntegration.list_branches")
     @patch("posthog.models.integration.github.GitHubIntegration.get_default_branch")
     def test_list_cached_branches_filters_search_before_pagination(self, mock_default_branch, mock_list_branches):

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
@@ -1,6 +1,7 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
+import { githubBranchSearchLogic } from 'lib/integrations/githubBranchSearchLogic'
 import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -10,6 +11,7 @@ import { RuntimeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
 
 import { attachedContextLogic } from '../../api/logics'
 import { composerSeedLogic } from '../../logics/composerSeedLogic'
+import { taskWarmLogic } from '../../logics/taskWarmLogic'
 import { toolStreamEventsLogic } from '../../logics/toolStreamEventsLogic'
 import { OriginProduct, Task, TaskRunEnvironment, TaskRunStatus } from '../../types/taskTypes'
 import { taskTrackerSceneLogic } from './taskTrackerSceneLogic'
@@ -201,6 +203,36 @@ describe('taskTrackerSceneLogic', () => {
         blockedLogic.unmount()
         consent.unmount()
         jest.restoreAllMocks()
+    })
+
+    // The composer gets one warm per selection: a changed selection cancels the sandbox that is still
+    // booting and starts another. So a repo-scoped draft warms on the first keystroke, before the branch
+    // picker has resolved the repo's default, and the default landing afterwards must read as the same
+    // selection — it is the branch that warm already boots on.
+    it.each([
+        ['before the branch picker has resolved', undefined, null],
+        ['once the picker settles on the default branch', 'main', null],
+        ['on a branch the user picked', 'feature/x', 'feature/x'],
+    ])('warms a repo-scoped draft %s', async (_name, branch, warmedBranch) => {
+        const branches = githubBranchSearchLogic({ integrationId: 7, repo: 'acme/widgets' })
+        branches.mount()
+        branches.actions.loadPageSuccess(['main'], 'main', false, 0)
+        logic.mount()
+
+        await expectLogic(logic, () => {
+            logic.actions.setNewTaskData({
+                description: 'do the thing',
+                repositoryConfig: { integrationId: 7, repository: 'acme/widgets', branch },
+            })
+        }).toDispatchActions([
+            (action: any) =>
+                action.type === taskWarmLogic({ panelId: undefined }).actionTypes.noteDraft &&
+                action.payload.hasText &&
+                action.payload.request.repository === 'acme/widgets' &&
+                action.payload.request.branch === warmedBranch,
+        ])
+
+        branches.unmount()
     })
 
     // The repo picker only renders once `repositoryConfig.integrationId` is set (auto-selected from the

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -4,6 +4,7 @@ import { router, urlToAction } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
+import { githubBranchSearchLogic } from 'lib/integrations/githubBranchSearchLogic'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { uuid } from 'lib/utils/dom'
 import { projectLogic } from 'scenes/projectLogic'
@@ -72,24 +73,33 @@ export interface TaskTrackerSceneLogicProps {
 const LAST_REPOSITORY_CONFIG_STORAGE_KEY = 'posthog_ai.tasks.lastRepositoryConfig'
 
 /**
- * The warm request for the current composer selection, or `null` when this selection can't be warmed.
+ * The branch a warm sandbox boots on, or `null` to leave it on the repo's default branch.
  *
- * A repo-scoped warm must already know its branch: the backend matches branch as a `None`-normalized
- * exact value, so warming while `GitHubBranchCombobox` is still resolving the repo's default would
- * book a sandbox on `null` and then miss on submit. Repo-less drafts carry `null` on both sides and
- * warm immediately.
+ * A draft on the default branch warms as `null`, which is both what the sandbox checks out anyway and
+ * what the backend matches such a warm on. That holds the selection steady while `GitHubBranchCombobox`
+ * resolves the default: warming on the resolved name instead would change the selection mid-draft, and
+ * the composer answers a changed selection by cancelling the sandbox that is already booting and
+ * starting a second one. A branch the user picked is sent as-is.
+ */
+function warmBranch({ integrationId, repository, branch }: RepositoryConfig): string | null {
+    if (!repository || !branch || integrationId === undefined) {
+        return null
+    }
+    const defaultBranch = githubBranchSearchLogic.findMounted({ integrationId, repo: repository })?.values.defaultBranch
+    return branch === defaultBranch ? null : branch
+}
+
+/**
+ * The warm request for the current composer selection, or `null` when this selection can't be warmed.
  */
 function buildWarmRequest(form: TaskCreateForm, catalogue: ModelChoiceApi[]): WarmTaskRequestApi | null {
     const { repositoryConfig, model, reasoningEffort, permissionMode } = form
-    if (repositoryConfig.repository && !repositoryConfig.branch) {
-        return null
-    }
     const runRequest = buildRunCreateRequest(
         catalogue,
         model,
         resolveEffortForModel(catalogue, reasoningEffort, model),
         permissionMode,
-        { branch: repositoryConfig.branch ?? null }
+        { branch: warmBranch(repositoryConfig) }
     )
     if (!('runtime_adapter' in runRequest)) {
         return null

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -6176,6 +6176,48 @@ def can_mint_readonly_github_token(team_id: int) -> bool:
     return _can_mint(team_id)
 
 
+def _warm_branch_predicate(
+    branch: str | None, *, team_id: int, repository: str | None, github_integration_id: int | None
+) -> Q:
+    """Branch predicate for warm reuse, where "no branch" and "the repository's default branch" name the
+    same checkout.
+
+    A repository-scoped warm booted without a branch clones the repository's default branch, so a submit
+    that names that branch explicitly is asking for the sandbox that is already up. The composer sends no
+    branch until its branch picker has resolved the default, which lands after the first keystroke — an
+    exact match would miss that pair and cold-boot a second sandbox.
+
+    Best-effort in both directions: the default branch is read from the branch cache the pickers are
+    served from, and an unknown default falls back to an exact match, which costs the warm and nothing
+    else. A branch the user picked never widens to anything.
+    """
+    wanted = branch or None
+    if repository is None or github_integration_id is None:
+        return Q(branch=wanted)
+    default_branch = _cached_default_branch(team_id, github_integration_id, repository)
+    if default_branch is None or wanted not in (None, default_branch):
+        return Q(branch=wanted)
+    return Q(branch__isnull=True) | Q(branch=default_branch)
+
+
+def _cached_default_branch(team_id: int, github_integration_id: int, repository: str) -> str | None:
+    """This team's cached default branch for ``repository``, or ``None`` when nothing has cached one."""
+    from posthog.models.integration import (  # noqa: PLC0415 — keep the GitHub client off the api import path
+        GitHubIntegration,
+    )
+
+    # Deferred columns on purpose: the cache read needs the integration id alone, and `repository_cache`
+    # holds every repository the installation can see.
+    integration = (
+        Integration.objects.filter(id=github_integration_id, team_id=team_id, kind="github")
+        .only("id", "kind", "team_id")
+        .first()
+    )
+    if integration is None:
+        return None
+    return GitHubIntegration(integration).cached_default_branch(repository)
+
+
 def _find_idling_warm_run(
     team_id: int,
     user_id: int | None,
@@ -6198,7 +6240,9 @@ def _find_idling_warm_run(
     awaiting its first user message (the ``await_user_message`` state marker). This is the backend's single
     source of truth for the warm pool: it dedupes warm provisioning (so a repeated ``warm`` call reuses the
     live Run instead of spawning a second) and lets the normal create+run path transparently reuse a
-    warm Run on submit. Team + user scoped; branch compared as ``None``-normalized exact match.
+    warm Run on submit. Team + user scoped; branch compared as a ``None``-normalized exact match, except
+    that a single-repository lookup also treats "no branch" and that repository's default branch as the
+    same target (see :func:`_warm_branch_predicate`).
 
     ``origin_product`` is required and never defaulted: it selects the OAuth app, the warm quota gate, the
     pool caps, and PR authorship, all of which are fixed when the warm boots and cannot be changed at
@@ -6216,15 +6260,20 @@ def _find_idling_warm_run(
         return None
     normalized_repositories = [repo.lower() for repo in (repositories or ([repository] if repository else []))]
     repository_filter = {"task__repository__iexact": repository} if repository else {"task__repository__isnull": True}
+    # Only a single-repository sandbox checks out a branch, so only that lookup has a default branch to
+    # widen to.
+    branch_repository = repository if len(normalized_repositories) == 1 else None
     candidates = (
         TaskRun.objects.filter(  # nosemgrep: idor-lookup-without-team — team_id filter applied via the task FK below
+            _warm_branch_predicate(
+                branch, team_id=team_id, repository=branch_repository, github_integration_id=github_integration_id
+            ),
             task__team_id=team_id,
             task__created_by_id=user_id,
             task__origin_product=origin_product,
             task__deleted=False,
             task__github_integration_id=github_integration_id,
             state__await_user_message=True,
-            branch=branch or None,
             **repository_filter,
         )
         .exclude(status__in=_TERMINAL_TASK_RUN_STATUSES)

--- a/products/tasks/backend/tests/test_warm_facade.py
+++ b/products/tasks/backend/tests/test_warm_facade.py
@@ -708,6 +708,27 @@ class TestCreateTaskWarmReuse(APIBaseTest):
         run.refresh_from_db()
         assert "await_user_message" not in run.state
 
+    @parameterized.expand(
+        [
+            # The PostHog AI composer warms without a branch while its picker resolves the default, then
+            # submits on the resolved name. Both name the branch the sandbox already checked out.
+            ("warm_before_the_picker_resolved", None, "main", True),
+            ("submit_leaves_the_branch_to_the_default", "main", None, True),
+            ("branch_the_user_picked", None, "feature/x", False),
+        ]
+    )
+    def test_reuses_a_repo_warm_across_the_default_branch(self, _name, warm_branch, submit_branch, expect_reuse):
+        warm_task, _ = self._warm_run(branch=warm_branch)
+
+        with (
+            patch("posthog.models.integration.GitHubIntegration.cached_default_branch", return_value="main"),
+            patch(f"{FACADE}.signal_task_run_user_message", return_value=True),
+            patch(f"{TITLE_SRC}.generate_task_title", return_value="T"),
+        ):
+            dto = self._create(branch=submit_branch)
+
+        assert (str(dto.id) == str(warm_task.id)) is expect_reuse
+
     def test_create_endpoint_returns_structured_compute_quota_denial_before_warm_activation(self):
         warm_task, run = self._warm_run()
 


### PR DESCRIPTION
## Problem

A PostHog AI chat with a repository selected gets no prewarmed sandbox until the branch picker resolves the repository's default branch, so the first reply waits out the full cold boot. Follow-up to [#91163](https://github.com/PostHog/posthog/pull/91163), which fixed the repo-less case.

- The composer refuses to warm a repo-scoped draft that has no branch yet ([`taskTrackerSceneLogic.ts:84`](https://github.com/PostHog/posthog/blob/0a782dc9/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts#L84)).
- That guard is there because the warm endpoint compares the branch as a `None`-normalized exact value, so a warm booked on `null` misses a submit sent on `main`.
- A repo-scoped sandbox with no branch clones the repository's default branch anyway, so the two name the same checkout.

## Changes

- A repo-scoped draft now warms on the first keystroke, so the submit lands on a sandbox that is already booting.
- The warm reuse lookup accepts a warm booted with no branch when the submit names that repository's default branch, and the reverse. A single-repository lookup only, since only that sandbox checks out a branch.
- A branch the user picked still matches exactly, so a `feature/x` submit never lands on a sandbox booted on trunk.
- The default branch comes from the branch cache that serves the pickers, so no request calls GitHub. An unknown default falls back to the exact match and costs the warm, nothing else.
- The composer sends `null` for a draft on the default branch. The picker resolving that default then reads as the same selection, instead of cancelling the sandbox that is booting and starting a second one.
- Rejected: fixing the client alone. The desktop and mobile composers warm the same repo-plus-no-branch shape and ship on their own cadence, so the rule belongs in the endpoint.
- Mechanical: `cached_default_branch`, a cache-only reader on the GitHub integration.

Nothing looks different: the composer renders the same controls, and the change is which sandbox a submit lands on.

## How did you test this code?

- `test_reuses_a_repo_warm_across_the_default_branch` covers the pair the composer sends (warm without a branch, submit on the default), the reverse, and a picked branch that must still cold-create. The first two cases fail on master.
- Two of the three new `taskTrackerSceneLogic` cases fail on master: a repo-scoped draft warms before the picker resolves, and the resolved default does not change the warm request.
- `test_cached_default_branch_answers_without_calling_github` pins the reader to the cache, so a changed cache shape fails here rather than silently dropping warm reuse.
- Not run: the sandbox itself. This sandbox has no GitHub installation, so no warm actually booted and cloned a repository; the branch equivalence rests on `provision_sandbox` cloning with `branch=None` when no branch is set.
- Not run: repo-wide jest and Playwright.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A PostHog engineer raised the repo-plus-no-branch case in the linked Slack thread as a follow-up to their own fix in #91163 and scoped this work to the warm endpoint and `products/posthog_ai`. Claude Code (Opus 5) traced the warm and submit paths, wrote the change and the tests, and confirmed each new case fails on master.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The first plan resolved the default branch at warm time and stored it on the run. That was dropped because it would make the sandbox check out a cached branch name explicitly, where today git resolves the real default during the clone. Matching at lookup time leaves sandbox behavior untouched.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788190868326419)*
