### PR TITLE
chore(ci): run master coverage hourly, narrow Python and Node.js on PRs

### DIFF
--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -63,7 +63,9 @@ env:
     # evaluated on its own, so a green master-push run can't mask a red scheduled run. Backend CI is
     # split this way: master push runs only the per-commit checks (migrations, OpenAPI types, repo
     # checks), and the test matrices run hourly.
-    SCHEDULED_GATING_WORKFLOWS: 'ci-backend.yml'
+    # Frontend CI is split the same way — jest runs hourly, while typecheck, format and bundle size
+    # stay on every push.
+    SCHEDULED_GATING_WORKFLOWS: 'ci-backend.yml,ci-frontend.yml'
     # A scheduled lane produces one run an hour, so it needs its own arms: the push streak of 5
     # would take 5 hours to trip, while the push wall-clock arm of 60 minutes pages on a single
     # flaky run held for one tick. Two red ticks in a row, or red across two ticks, is the honest

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -64,8 +64,9 @@ env:
     # split this way: master push runs only the per-commit checks (migrations, OpenAPI types, repo
     # checks), and the test matrices run hourly.
     # Frontend CI is split the same way — jest runs hourly, while typecheck, format and bundle size
-    # stay on every push.
-    SCHEDULED_GATING_WORKFLOWS: 'ci-backend.yml,ci-frontend.yml'
+    # stay on every push. Node.js, Dagster, Python and MCP moved their whole suite to the cron, so
+    # their push lane now only proves the run dispatched; the scheduled lane carries the coverage.
+    SCHEDULED_GATING_WORKFLOWS: 'ci-backend.yml,ci-frontend.yml,ci-nodejs.yml,ci-dagster.yml,ci-python.yml,ci-mcp.yml'
     # A scheduled lane produces one run an hour, so it needs its own arms: the push streak of 5
     # would take 5 hours to trip, while the push wall-clock arm of 60 minutes pages on a single
     # flaky run held for one tick. Two red ticks in a row, or red across two ticks, is the honest

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -113,8 +113,10 @@ jobs:
             - uses: ./.github/actions/paths-filter
               id: filter
               # Skipped on master push and on the hourly schedule: every output then
-              # defaults to true. On schedule the action would otherwise diff only the
-              # last commit and could turn the full suite into a no-op.
+              # defaults to true. On a cron the action has nothing to diff against — it gets
+              # no `base` input, so base resolves to the default branch and equals head, and
+              # `before` is set only on push events — so it falls back to the last commit
+              # alone, and one docs-only commit would narrow the hourly run to nothing.
               if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -5,6 +5,12 @@ on:
         branches:
             - master
     pull_request:
+    schedule:
+        # Hourly run against the newest master state. Master pushes no longer run the
+        # dagster suite per commit — the merge queue's trunk-merge/** run already gated
+        # every commit before it landed — so this is where master's coverage comes from.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '33 * * * *'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -106,7 +112,10 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: every output then
+              # defaults to true. On schedule the action would otherwise diff only the
+              # last commit and could turn the full suite into a no-op.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
@@ -233,7 +242,9 @@ jobs:
 
             - name: Read ClickHouse versions from JSON
               id: read-versions
-              if: github.event_name == 'push' || steps.filter.outputs.dagster == 'true'
+              # `schedule` has to be listed explicitly for the same reason as build-matrix
+              # below, which consumes this step's oldest_supported output.
+              if: github.event_name == 'push' || github.event_name == 'schedule' || steps.filter.outputs.dagster == 'true'
               run: |
                   oldest_supported=$(jq -r '.oldest_supported' .github/clickhouse-versions.json)
                   if [ -z "$oldest_supported" ] || [ "$oldest_supported" = "null" ]; then
@@ -244,7 +255,10 @@ jobs:
 
             - name: Build sharded test matrix
               id: build-matrix
-              if: github.event_name == 'push' || steps.filter.outputs.dagster == 'true'
+              # `schedule` has to be listed explicitly: the paths filter is skipped there,
+              # so steps.filter.outputs.dagster is empty. Without this the matrix would be
+              # [] and the hourly run would report green having run no tests at all.
+              if: github.event_name == 'push' || github.event_name == 'schedule' || steps.filter.outputs.dagster == 'true'
               env:
                   OLDEST_SUPPORTED: ${{ steps.read-versions.outputs.oldest_supported }}
               run: |
@@ -450,12 +464,15 @@ jobs:
             fail-fast: false
             matrix:
                 include: ${{ fromJson(needs.select-tests.outputs.matrix_include || needs.changes.outputs.matrix_include || '[]') }}
-        # !cancelled() lets this run when select-tests is skipped (master,
+        # !cancelled() lets this run when select-tests is skipped (schedule,
         # merge queue) or failed (fall back to the full matrix); mode 'none'
         # means the diff cannot affect any dagster test, so nothing runs and
         # the merge-queue full suite remains the gate.
+        # Skipped on master push: the merge queue already ran the suite for every
+        # landed commit, and the hourly scheduled run keeps master coverage.
         if: >-
             ${{ !cancelled()
+            && github.event_name != 'push'
             && needs.select-tests.outputs.mode != 'none'
             && (needs.changes.outputs.dagster_direct == 'true'
                 || (needs.changes.outputs.merge_queue == 'true'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -14,8 +14,18 @@ on:
     push:
         branches:
             - master
+    schedule:
+        # Hourly jest run against the newest master state. Master pushes no longer run
+        # jest per commit — the merge queue's trunk-merge/** run already gated every
+        # commit before it landed — so this is where master's jest coverage and its
+        # Trunk flaky-test baseline come from. Typecheck, format and bundle size stay
+        # on every push, because they are cheap and per-commit meaningful.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '7 * * * *'
 
 concurrency:
+    # Scheduled runs share the ref group with master pushes and do not cancel, so a
+    # slow hourly run queues the next one instead of stacking runs.
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -80,7 +90,10 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: every output then
+              # defaults to true. On schedule the action would otherwise diff only the
+              # last commit and could turn the full jest run into a no-op.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
@@ -183,11 +196,11 @@ jobs:
             # above is inline YAML — paths-filter takes one or the other. The exclude-only
             # filter is true only when some changed file lives OUTSIDE every excluded dir.
             - name: Derive Node-only product workspace exclusions
-              if: github.event_name != 'push'
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               run: bin/frontend-exclude-filter > "$RUNNER_TEMP/frontend-exclude.yml"
             - uses: ./.github/actions/paths-filter
               id: exclude
-              if: github.event_name != 'push'
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: ${{ runner.temp }}/frontend-exclude.yml
@@ -730,9 +743,13 @@ jobs:
         # A status function is required because select-jest-tests is skipped on ready
         # PRs and master pushes, and a skipped need would otherwise cascade a skip here.
         # !cancelled() rather than always() so a superseded run's shards stop promptly.
+        # Skipped on master push: the merge queue already ran the full matrix for every
+        # landed commit, and the hourly scheduled run keeps master's jest coverage and
+        # its Trunk flaky baseline.
         if: |
             !cancelled() && needs.changes.outputs.frontend_code == 'true'
             && needs.select-jest-tests.outputs.should_run != 'false'
+            && github.event_name != 'push'
         name: Jest test (${{ matrix.segment }} - ${{ matrix.chunk }})
         strategy:
             # If one test fails, still run the others
@@ -740,8 +757,8 @@ jobs:
             # On draft PRs, select-jest-tests may narrow this to two EE jobs
             # running only the tests reachable from changed frontend source files,
             # or skip jest entirely (should_run=false) when selection can't be
-            # trusted. On ready PRs and master pushes it's skipped, so
-            # we fall back to the full FOSS×EE × chunk fanout (the merge gate).
+            # trusted. On ready PRs and on the hourly scheduled run it's skipped, so
+            # we fall back to the full FOSS×EE × chunk fanout.
             matrix: ${{ fromJson(needs.select-jest-tests.outputs.matrix || '{"segment":["FOSS","EE"],"chunk":[1,2,3,4]}') }}
 
         steps:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -91,8 +91,10 @@ jobs:
             - uses: ./.github/actions/paths-filter
               id: filter
               # Skipped on master push and on the hourly schedule: every output then
-              # defaults to true. On schedule the action would otherwise diff only the
-              # last commit and could turn the full jest run into a no-op.
+              # defaults to true. On a cron the action has nothing to diff against — it gets
+              # no `base` input, so base resolves to the default branch and equals head, and
+              # `before` is set only on push events — so it falls back to the last commit
+              # alone, and one docs-only commit would narrow the hourly run to nothing.
               if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -10,6 +10,13 @@ on:
         # The `no-ci` label silences this workflow on a draft entirely (prototypes).
         # No labeled/unlabeled triggers here, so it takes effect from the next push.
         types: [opened, synchronize, reopened, ready_for_review]
+    schedule:
+        # Hourly run against the newest master state. Master pushes no longer run the
+        # build, unit or integration tests per commit — the merge queue's trunk-merge/**
+        # run already gated every commit before it landed — so this is where master's
+        # coverage comes from.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '53 * * * *'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -56,7 +63,10 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: every output then
+              # defaults to true. On schedule the action would otherwise diff only the
+              # last commit and could turn the full run into a no-op.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
@@ -142,7 +152,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         needs: changes
-        if: needs.changes.outputs.mcp == 'true'
+        # Skipped on master push: the merge queue already ran this for every landed
+        # commit, and the hourly scheduled run keeps master coverage.
+        if: needs.changes.outputs.mcp == 'true' && github.event_name != 'push'
 
         steps:
             - name: Checkout code
@@ -223,7 +235,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         needs: changes
-        if: needs.changes.outputs.mcp == 'true'
+        # Skipped on master push: the merge queue already ran this for every landed
+        # commit, and the hourly scheduled run keeps master coverage.
+        if: needs.changes.outputs.mcp == 'true' && github.event_name != 'push'
         steps:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -307,7 +321,11 @@ jobs:
         # non-pytest Python change, so they're the expensive half of this workflow.
         # Build and unit tests still run on drafts; the `MCP Tests Pass` aggregator
         # treats skipped as success, and the ready-for-review run is the merge gate.
-        if: needs.changes.outputs.mcp == 'true' && (github.event.pull_request.draft != true || startsWith(github.head_ref, 'trunk-merge/'))
+        # Skipped on master push too: the merge queue already ran them for every
+        # landed commit, and the hourly scheduled run keeps master coverage.
+        if: >-
+            needs.changes.outputs.mcp == 'true' && github.event_name != 'push'
+            && (github.event.pull_request.draft != true || startsWith(github.head_ref, 'trunk-merge/'))
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -64,8 +64,10 @@ jobs:
             - uses: ./.github/actions/paths-filter
               id: filter
               # Skipped on master push and on the hourly schedule: every output then
-              # defaults to true. On schedule the action would otherwise diff only the
-              # last commit and could turn the full run into a no-op.
+              # defaults to true. On a cron the action has nothing to diff against — it gets
+              # no `base` input, so base resolves to the default branch and equals head, and
+              # `before` is set only on push events — so it falls back to the last commit
+              # alone, and one docs-only commit would narrow the hourly run to nothing.
               if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -4,6 +4,12 @@ on:
     push:
         branches:
             - master
+    schedule:
+        # Hourly run against the newest master state. Master pushes no longer run the
+        # Node.js checks per commit — the merge queue's trunk-merge/** run already gated
+        # every commit before it landed — so this is where master's coverage comes from.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '13 * * * *'
 
 env:
     OBJECT_STORAGE_ENABLED: true
@@ -49,7 +55,10 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: the decision step below
+              # treats both as "run everything". On schedule the action would otherwise
+              # diff only the last commit and could turn the full run into a no-op.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
@@ -92,14 +101,18 @@ jobs:
                         - '.github/actions/rust-compute-affected/**'
 
             - name: Install rust for affected-crate detection
-              if: github.event_name != 'push' && steps.filter.outputs.rust == 'true'
+              # Not needed on schedule either: the decision step below already returns
+              # nodejs=true there without consulting the affected-crate set.
+              if: github.event_name != 'push' && github.event_name != 'schedule' && steps.filter.outputs.rust == 'true'
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
 
             - name: Compute affected Rust crates
               id: rust-affected
-              if: github.event_name != 'push' && steps.filter.outputs.rust == 'true'
+              # Not needed on schedule either: the decision step below already returns
+              # nodejs=true there without consulting the affected-crate set.
+              if: github.event_name != 'push' && github.event_name != 'schedule' && steps.filter.outputs.rust == 'true'
               uses: ./.github/actions/rust-compute-affected
               with:
                   event-name: ${{ github.event_name }}
@@ -115,7 +128,10 @@ jobs:
                   RUST_AFFECTED_CRATES: ${{ steps.rust-affected.outputs.crates }}
                   RUST_NODE_E2E_CRATES: '["ingestion-consumer"]'
               run: |
-                  if [ "${{ github.event_name }}" = "push" ]; then
+                  # `schedule` alongside `push`: the paths filter is skipped on both, so
+                  # NODEJS_CHANGED is empty there. Without this the hourly run would decide
+                  # nodejs=false and report green having run no tests at all.
+                  if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "schedule" ]; then
                     echo "nodejs=true" >> "$GITHUB_OUTPUT"
                     exit 0
                   fi
@@ -140,7 +156,9 @@ jobs:
                   echo "nodejs=false" >> "$GITHUB_OUTPUT"
 
     lint:
-        if: needs.changes.outputs.nodejs == 'true'
+        # Skipped on master push: the merge queue already ran this for every landed
+        # commit, and the hourly scheduled run keeps master coverage.
+        if: needs.changes.outputs.nodejs == 'true' && github.event_name != 'push'
         name: Node.js Code quality (depot-ubuntu-24.04)
         needs: changes
         runs-on: depot-ubuntu-24.04
@@ -205,7 +223,9 @@ jobs:
                         fi
 
     build:
-        if: needs.changes.outputs.nodejs == 'true'
+        # Skipped on master push: the merge queue already ran this for every landed
+        # commit, and the hourly scheduled run keeps master coverage.
+        if: needs.changes.outputs.nodejs == 'true' && github.event_name != 'push'
         name: Node.js Build (depot-ubuntu-24.04)
         needs: changes
         runs-on: depot-ubuntu-24.04
@@ -267,7 +287,9 @@ jobs:
                   fi
 
     tests:
-        if: needs.changes.outputs.nodejs == 'true'
+        # Skipped on master push: the merge queue already ran this for every landed
+        # commit, and the hourly scheduled run keeps master coverage.
+        if: needs.changes.outputs.nodejs == 'true' && github.event_name != 'push'
         name: Node.js ${{ matrix.lane }} Tests ${{ matrix.shard }}/${{ matrix.shard_count }} (depot-ubuntu-24.04-4)
         needs: changes
         runs-on: depot-ubuntu-24.04-4
@@ -586,7 +608,9 @@ jobs:
                   docker compose -f docker-compose.dev.yml exec clickhouse cat /var/log/clickhouse-server/clickhouse-server.err.log
 
     rust_ingestion_e2e:
-        if: needs.changes.outputs.nodejs == 'true'
+        # Skipped on master push: the merge queue already ran this for every landed
+        # commit, and the hourly scheduled run keeps master coverage.
+        if: needs.changes.outputs.nodejs == 'true' && github.event_name != 'push'
         name: Rust ingestion consumer Node API e2e (depot-ubuntu-24.04-4)
         needs: changes
         runs-on: depot-ubuntu-24.04-4

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -38,6 +38,10 @@ jobs:
             pull-requests: read
         outputs:
             nodejs: ${{ steps.nodejs-changes.outputs.nodejs || 'true' }}
+            # Jest selection for the tests job. `mode` is 'selective' only when the diff is
+            # confined to Node source files jest can resolve; anything else is 'full'.
+            test_mode: ${{ steps.select-tests.outputs.mode || 'full' }}
+            test_files: ${{ steps.select-tests.outputs.files }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -63,6 +67,8 @@ jobs:
               if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
+                  # node_src_files feeds jest --findRelatedTests in the select step below.
+                  list-files: 'escape'
                   filters: |
                       nodejs:
                         - .github/workflows/ci-nodejs.yml
@@ -101,6 +107,21 @@ jobs:
                         - 'proto/**'
                         - '.github/rust-images.yml'
                         - '.github/actions/rust-compute-affected/**'
+                      # Node sources jest can resolve. Their paths feed --findRelatedTests.
+                      node_src:
+                        - 'nodejs/**/*.ts'
+                        - 'nodejs/**/*.js'
+                        - '!nodejs/**/*.d.ts'
+                      # Anything here invalidates jest's view of the module graph, or changes
+                      # the native addons every suite links, so no narrowed run can be trusted.
+                      node_full:
+                        - 'nodejs/jest*.config.js'
+                        - 'nodejs/package.json'
+                        - 'nodejs/tsconfig*.json'
+                        - 'pnpm-lock.yaml'
+                        - 'rust/**'
+                        - 'proto/**'
+                        - '.github/workflows/ci-nodejs.yml'
 
             - name: Install rust for affected-crate detection
               # Not needed on schedule either: the decision step below already returns
@@ -156,6 +177,50 @@ jobs:
                   fi
 
                   echo "nodejs=false" >> "$GITHUB_OUTPUT"
+
+            # Narrow the jest run to the tests reachable from the changed Node sources.
+            # Verified locally that jest applies --findRelatedTests before --shard, so the
+            # shards still partition the selected set exactly rather than a subset of it.
+            # Fail-open is always FULL, never skip: this workflow has no draft/ready split
+            # and no later run on the PR would cover a miss.
+            - name: Select jest tests
+              id: select-tests
+              env:
+                  NODE_FULL: ${{ steps.filter.outputs.node_full }}
+                  NODE_SRC: ${{ steps.filter.outputs.node_src }}
+                  NODE_SRC_FILES: ${{ steps.filter.outputs.node_src_files }}
+              run: |
+                  set -uo pipefail
+
+                  full() {
+                      echo "::notice::$1; running the full jest suite"
+                      {
+                          echo "mode=full"
+                          echo "files="
+                      } >> "$GITHUB_OUTPUT"
+                      exit 0
+                  }
+
+                  # Master push and the cron skip the paths filter, so every output is empty.
+                  [ "${{ github.event_name }}" = "pull_request" ] || full "not a pull request"
+                  [ "$NODE_FULL" != "true" ] || full "config, lockfile or Rust change"
+                  [ "$NODE_SRC" = "true" ] || full "no resolvable Node source changes"
+
+                  # Paths arrive repo-relative; jest runs from nodejs/, so strip the prefix.
+                  # `list-files: escape` returns one shell-escaped, space-separated list, so
+                  # the splitting shellcheck warns about is exactly what turns it into paths.
+                  # shellcheck disable=SC2086
+                  files=$(printf '%s\n' $NODE_SRC_FILES | sed 's|^nodejs/||' | tr '\n' ' ')
+                  # shellcheck disable=SC2086
+                  count=$(printf '%s\n' $NODE_SRC_FILES | grep -c . || true)
+                  [ "$count" -le 200 ] || full "diff touches $count Node sources (>200)"
+                  [ -n "${files// /}" ] || full "changed-file list came back empty"
+
+                  echo "::notice::selective jest over $count changed Node source file(s)"
+                  {
+                      echo "mode=selective"
+                      echo "files=$files"
+                  } >> "$GITHUB_OUTPUT"
 
     lint:
         # Skipped on master push: the merge queue already ran this for every landed
@@ -529,9 +594,21 @@ jobs:
                   JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
                   # New compileHog callers must generate and commit their source-addressed fixture.
                   HOG_BYTECODE_CACHE_REQUIRED: 'true'
+                  TEST_MODE: ${{ needs.changes.outputs.test_mode }}
+                  TEST_FILES: ${{ needs.changes.outputs.test_files }}
               run: |
                   if [ -f nodejs/jest.serial.config.js ]; then
-                    cd nodejs && pnpm run test:${{ matrix.lane }}
+                    # In selective mode append --findRelatedTests to the package script, which
+                    # already carries --shard and --testPathIgnorePatterns. jest resolves the
+                    # related set first and shards that, so the shards stay disjoint.
+                    # --passWithNoTests because a shard can legitimately receive nothing once
+                    # the set is narrowed; the serial script does not set it itself.
+                    if [ "$TEST_MODE" = "selective" ]; then
+                      # shellcheck disable=SC2086
+                      cd nodejs && pnpm run test:${{ matrix.lane }} -- --passWithNoTests --findRelatedTests $TEST_FILES
+                    else
+                      cd nodejs && pnpm run test:${{ matrix.lane }}
+                    fi
                   elif [ "${{ matrix.lane }}" = 'serial' ]; then
                     bin/turbo run test --filter=@posthog/nodejs
                   else

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -189,6 +189,8 @@ jobs:
                   NODE_FULL: ${{ steps.filter.outputs.node_full }}
                   NODE_SRC: ${{ steps.filter.outputs.node_src }}
                   NODE_SRC_FILES: ${{ steps.filter.outputs.node_src_files }}
+                  # Through env, not inline: a branch name is author-controlled.
+                  HEAD_REF: ${{ github.head_ref }}
               run: |
                   set -uo pipefail
 
@@ -203,6 +205,12 @@ jobs:
 
                   # Master push and the cron skip the paths filter, so every output is empty.
                   [ "${{ github.event_name }}" = "pull_request" ] || full "not a pull request"
+                  # Trunk's merge-queue branches raise a pull_request event like any other, so
+                  # they need excluding by name. That run is the gate for master and must never
+                  # be narrowed.
+                  case "$HEAD_REF" in
+                      trunk-merge/*) full "merge queue run" ;;
+                  esac
                   [ "$NODE_FULL" != "true" ] || full "config, lockfile or Rust change"
                   [ "$NODE_SRC" = "true" ] || full "no resolvable Node source changes"
 

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -56,8 +56,10 @@ jobs:
             - uses: ./.github/actions/paths-filter
               id: filter
               # Skipped on master push and on the hourly schedule: the decision step below
-              # treats both as "run everything". On schedule the action would otherwise
-              # diff only the last commit and could turn the full run into a no-op.
+              # treats both as "run everything". On a cron the action has nothing to diff
+              # against — it gets no `base` input, so base resolves to the default branch and
+              # equals head, and `before` is set only on push events — so it falls back to the
+              # last commit alone, and one docs-only commit would narrow the run to nothing.
               if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -30,6 +30,14 @@ jobs:
         # Set job outputs to values from filter step
         outputs:
             python: ${{ steps.filter.outputs.python || 'true' }}
+            # Per-tool outputs gating the self-contained pytest steps in code-quality.
+            # Each defaults to true, so master push and the hourly cron — where the filter
+            # is skipped — still run every suite.
+            hogli: ${{ steps.filter.outputs.hogli || 'true' }}
+            owners: ${{ steps.filter.outputs.owners || 'true' }}
+            query_perf: ${{ steps.filter.outputs.query_perf || 'true' }}
+            stamphog: ${{ steps.filter.outputs.stamphog || 'true' }}
+            bin_scripts: ${{ steps.filter.outputs.bin_scripts || 'true' }}
         steps:
             # For pull requests it's not necessary to checkout the code, but we
             # also want this to run on master so we need to checkout
@@ -93,6 +101,43 @@ jobs:
                         # Stamphog policy files validated by the pr-approval-agent suite
                         - '.stamphog/**'
                         - '**/AGENT_APPROVALS.md'
+                      # Per-tool groups below gate the pytest steps in code-quality. Each of
+                      # these trees imports only stdlib and its own package — none of them
+                      # imports posthog — so a change under posthog/ cannot affect them and
+                      # they do not need to run on every Python PR. Verify that before adding
+                      # a tree here: a path filter that skips tests is a claim about the
+                      # import graph (see ci-things-already-tried.md, #50137).
+                      # Dependency and workflow changes run all of them.
+                      hogli:
+                        - 'tools/hogli/**'
+                        - 'tools/hogli-commands/**'
+                        - 'hogli.yaml'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
+                      owners:
+                        - 'tools/owners/**'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
+                      query_perf:
+                        - 'tools/query-performance-ai/**'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
+                      stamphog:
+                        - 'tools/pr-approval-agent/**'
+                        - 'products/stamphog/packages/pr-approval-agent/**'
+                        - '.stamphog/**'
+                        - '**/AGENT_APPROVALS.md'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
+                      bin_scripts:
+                        - 'bin/**'
+                        - 'pyproject.toml'
+                        - 'uv.lock'
+                        - .github/workflows/ci-python.yml
 
     code-quality:
         needs: changes
@@ -103,6 +148,16 @@ jobs:
 
         name: Python code quality (depot-ubuntu-24.04)
         runs-on: depot-ubuntu-24.04
+        # Read by the per-tool guards on the pytest steps below. These sit inside a
+        # `parallel:` block, where step-level `if:` has no exercised precedent in this
+        # repo — the one existing case can never be false — so the guard is a shell test
+        # on a job-level env var, which behaves the same either way.
+        env:
+            RUN_HOGLI: ${{ needs.changes.outputs.hogli }}
+            RUN_OWNERS: ${{ needs.changes.outputs.owners }}
+            RUN_QUERY_PERF: ${{ needs.changes.outputs.query_perf }}
+            RUN_STAMPHOG: ${{ needs.changes.outputs.stamphog }}
+            RUN_BIN_SCRIPTS: ${{ needs.changes.outputs.bin_scripts }}
 
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -222,19 +277,27 @@ jobs:
 
                   - name: Run hogli framework tests
                     shell: bash
-                    run: pytest tools/hogli/tests -v --junitxml=junit-hogli.xml
+                    run: |
+                        [ "$RUN_HOGLI" = "true" ] || { echo "hogli unchanged — skipping"; exit 0; }
+                        pytest tools/hogli/tests -v --junitxml=junit-hogli.xml
 
                   - name: Run hogli extension tests
                     shell: bash
-                    run: pytest tools/hogli-commands/hogli_commands/tests -v --junitxml=junit-hogli-commands.xml
+                    run: |
+                        [ "$RUN_HOGLI" = "true" ] || { echo "hogli unchanged — skipping"; exit 0; }
+                        pytest tools/hogli-commands/hogli_commands/tests -v --junitxml=junit-hogli-commands.xml
 
                   - name: Run owners resolver tests
                     shell: bash
-                    run: pytest tools/owners/tests -v --junitxml=junit-owners.xml
+                    run: |
+                        [ "$RUN_OWNERS" = "true" ] || { echo "tools/owners unchanged — skipping"; exit 0; }
+                        pytest tools/owners/tests -v --junitxml=junit-owners.xml
 
                   - name: Run query-performance-ai tests
                     shell: bash
-                    run: pytest tools/query-performance-ai/query_performance_ai -v --junitxml=junit-query-performance-ai.xml
+                    run: |
+                        [ "$RUN_QUERY_PERF" = "true" ] || { echo "query-performance-ai unchanged — skipping"; exit 0; }
+                        pytest tools/query-performance-ai/query_performance_ai -v --junitxml=junit-query-performance-ai.xml
 
                   - name: Run pr-approval-agent (stamphog) tests
                     shell: bash
@@ -244,6 +307,7 @@ jobs:
                     # both exist, because that merge can add a file at the old path next to the new
                     # tree.
                     run: |
+                        [ "$RUN_STAMPHOG" = "true" ] || { echo "pr-approval-agent unchanged — skipping"; exit 0; }
                         found=0
                         for dir in products/stamphog/packages/pr-approval-agent tools/pr-approval-agent; do
                           [ -d "$dir" ] || continue
@@ -257,13 +321,17 @@ jobs:
 
                   - name: Run dependency detection script tests
                     shell: bash
-                    run: pytest bin/test/test_find_python_dependencies.py -v --junitxml=junit-dependency-detection.xml
+                    run: |
+                        [ "$RUN_BIN_SCRIPTS" = "true" ] || { echo "bin/ unchanged — skipping"; exit 0; }
+                        pytest bin/test/test_find_python_dependencies.py -v --junitxml=junit-dependency-detection.xml
 
             - name: Upload test results
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               if: always()
               with:
                   name: junit-results-hogli
+                  # A gated-off suite writes no junit file, which is now the common case.
+                  if-no-files-found: ignore
                   path: |
                       junit-hogli.xml
                       junit-hogli-commands.xml
@@ -276,6 +344,7 @@ jobs:
               if: always()
               with:
                   name: junit-results-dependency-detection
+                  if-no-files-found: ignore
                   path: junit-dependency-detection.xml
 
             # - name: Check if "taxonomy.json/taxonomy.tsx" is up to date

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -51,8 +51,10 @@ jobs:
                   # request, so one wiring covers every shape the comparison needs to see.
                   PATHS_FILTER_SHADOW_POSTHOG_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
               # Skipped on master push and on the hourly schedule: every output then
-              # defaults to true. On schedule the action would otherwise diff only the
-              # last commit and could turn the full run into a no-op.
+              # defaults to true. On a cron the action has nothing to diff against — it gets
+              # no `base` input, so base resolves to the default branch and equals head, and
+              # `before` is set only on push events — so it falls back to the last commit
+              # alone, and one docs-only commit would narrow the hourly run to nothing.
               if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -5,6 +5,12 @@ on:
         branches:
             - master
     pull_request:
+    schedule:
+        # Hourly run against the newest master state. Master pushes no longer run the
+        # checks per commit — the merge queue's trunk-merge/** run already gated every
+        # commit before it landed — so this is where master's coverage comes from.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '43 * * * *'
 
 permissions:
     contents: read
@@ -44,7 +50,10 @@ jobs:
                   # This workflow opts in for the whole repository. It runs on every pull
                   # request, so one wiring covers every shape the comparison needs to see.
                   PATHS_FILTER_SHADOW_POSTHOG_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: every output then
+              # defaults to true. On schedule the action would otherwise diff only the
+              # last commit and could turn the full run into a no-op.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
@@ -85,7 +94,9 @@ jobs:
 
     code-quality:
         needs: changes
-        if: needs.changes.outputs.python == 'true'
+        # Skipped on master push: the merge queue already ran this for every landed
+        # commit, and the hourly scheduled run keeps master coverage.
+        if: needs.changes.outputs.python == 'true' && github.event_name != 'push'
         timeout-minutes: 30
 
         name: Python code quality (depot-ubuntu-24.04)


### PR DESCRIPTION
## Problem

CI re-runs work that something else already covered.

On master, every landed commit re-runs suites the merge queue just ran on a `trunk-merge/` branch. Backend CI stopped paying for that in [#90195](https://github.com/PostHog/posthog/pull/90195); five workflows still do.

On pull requests, two suites run more than the diff can affect. Python CI runs six pytest suites for self-contained dev tools on every Python PR, and Node.js CI runs its whole jest suite whenever it runs at all.

The master-side saving is smaller than push volume suggests, and worth stating plainly. Master push runs share one concurrency group per workflow, and GitHub keeps at most one pending run per group, so a burst collapses to the newest. Sampling ci-frontend over 2.7 hours: 50 master-push runs, **12 executed, 38 cancelled while pending**. Size it off the executed rate, roughly 4.4 runs an hour.

## Changes

**Master coverage moves to hourly crons.** Jest, Node.js, Dagster, Python and MCP now run against master hourly and skip on push. Typecheck, format and bundle size stay per push, because they are cheap and per-commit meaningful. Crons are staggered so the six hourly runs do not fan out into one dispatch window: backend `:23`, frontend `:07`, Node.js `:13`, Dagster `:33`, Python `:43`, MCP `:53`. All five join `SCHEDULED_GATING_WORKFLOWS`, or the master-red alerter would stop paging for them.

**Python CI stops running dev-tool tests on unrelated PRs.** The code-quality job runs six pytest suites for hogli, `tools/owners`, query-performance-ai, the stamphog pr-approval agent and a `bin/` script. None was gated, so a PR touching only `posthog/` ran all of them — about 133s of the job's 595s of step time, on the 44% of PRs that reach this job. Each now runs only when its own tree changes.

**Node.js CI runs only the tests the diff reaches.** Jest now takes `--findRelatedTests` over the changed Node sources, from the file list the paths filter already produces.

Where every suite lands once this and #91749 are in. Rows without a "changed by" note are unaffected:

![ci-stage-matrix](https://raw.githubusercontent.com/PostHog/pr-assets/8093ce72e98784d836880fd4390e9d598d89e129/2026/08/ffc59c17-f5f3-45cb-86c5-0f0d4806cd7b.png)

Read each cell as "given the workflow runs at all" — a paths filter gates every row on all three PR stages, and is skipped on master push and the crons. `selected` versus `full` says whether a selector narrows the suite to the diff once it does run.

Measured job-minutes per *executed* master-push run, which is what each cron replaces:

| Workflow | Job-min | Jobs |
| --- | --- | --- |
| Frontend (jest) | 59 | 16 |
| Dagster | 82 | 6 |
| MCP | 41 | 5 |
| Node.js | 35 | 10 |
| Python | 7 | 3 |

Nothing a PostHog user sees changes.

> [!WARNING]
> Three silent failure modes came up, and none would have failed loudly.
> **Dagster** builds its shard matrix in a step gated on `push` or the paths filter, and reads ClickHouse versions the same way. On `schedule` both would skip, leaving an empty matrix and a green run with no tests behind it. **Node.js** decides `nodejs=true` from the same kind of push-only branch and would have answered false on the cron. Both now name `schedule` explicitly.
> The third is the paths filter itself: it is skipped on `schedule` in all five, so outputs fall back to `true`. Left as-is the action has nothing to diff against on a cron — no `base` input, so base resolves to the default branch and equals head, and `before` is push-only — so it falls back to the last commit alone, and a docs-only commit at the head of master would narrow the hourly run to nothing.

### Two claims that were checked rather than assumed

**Path-gating the Python suites is a claim about the import graph.** Each of those trees imports only stdlib and its own package; none imports `posthog`. That check is the point: [#50137](https://github.com/PostHog/posthog/pull/50137) was reverted for making the same kind of claim without it.

**jest applies `--findRelatedTests` before `--shard`.** Verified locally: for one changed source with 3 related serial tests, shards 1/3, 2/3 and 3/3 returned 1, 1 and 1 — a partition, not a subset of a subset. `--findRelatedTests` also composes with the `--testPathIgnorePatterns` the package scripts pass, unlike `--testPathPatterns`, which is mutually exclusive with it.

### What is deliberately not changed

- **Storybook** — its master push sets `VR_PURPOSE: observe`, recording Visual Review baseline drift per commit. An hourly run would attribute drift to a batch of commits.
- **Playwright E2E** — same baseline role, already excluded from #90195 for it.
- **Rust** — master builds are incremental and already deduplicated; an hourly rebuild-all would be a wash.
- **Hog** — `release-hogvm` publishes a new HogVM TypeScript version from the master push, keyed off `hog-tests` outputs. Gating that off push would stop those releases, and at 5 job-min per executed run it is the cheapest of the set.
- **Security** — already the best-optimized of the group: nine per-language filters plus `semgrep --baseline-commit`, so it only reports on changed lines.
- **mypy** — cannot be narrowed. It follows imports, so a file subset misses reverse-dependency breakage, which is why AGENTS.md requires the repo-wide invocation.

## How did you test this code?

No new automated tests. The change is workflow triggers, job conditions and shell guards, which this repo covers with linters rather than unit tests.

- `bin/hogli lint:workflows` passes, 8 checks across 128 workflows.
- `actionlint` reports the same finding count as `master` for all six touched files.
- `bin/hogli ci:preflight` passes with no failures.
- Wrote three checkers for the failure modes above. Each failed first and caught something real:
  - Cron/filter wiring — caught the Dagster `read-versions` step, which feeds the matrix builder and would have skipped on the cron.
  - Guard wiring in Python CI — asserts every `RUN_*` guard resolves to a declared env var backed by a filter output that keeps its `|| 'true'` default. A typo would read empty, skip the suite on every run, and lose coverage silently.
  - Node.js selection — simulated the select step over all seven branches, extracting the step body from the workflow so the harness tracks the real script. Every fallback returns `full`, and selective correctly strips the `nodejs/` prefix.

Not checked, and worth knowing before merge:

- No cron has fired. The first hourly run after merge is the real test, and the scheduled alert lanes have no baseline until then.
- The Python gates cannot be exercised by this PR: its own diff touches `.github/workflows/ci-python.yml`, which every per-tool group matches, so all six suites run. A later Python-only PR should show them skipped.
- The Node.js selective path has not run on GitHub. This PR touches `ci-nodejs.yml`, which forces full.

> [!NOTE]
> Cron fires are not guaranteed here. Measured 31 Aug: backend's hourly fired at 11:27, 12:40, 13:30, 15:29 and 16:29 UTC — about five of six due hours, one two-hour gap, and times drifting well off the `:23` in its schedule. The scheduled alert lane already accounts for this with its own streak and wall-clock arms.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code. Skills invoked: `/authoring-ci-workflows`, `/stacking-prs`, `/writing-pr-descriptions`.

Candidates came from measuring per-workflow cost through the GitHub Actions API rather than reading the YAML. That is what produced the concurrency-dedup finding, which cut the estimated master-side saving by about 4x and is why the Problem section leads with it.

Several candidates came off the list under measurement. Storybook looked identical to jest in a summary table until `VR_PURPOSE` turned up; Hog came off after finding `release-hogvm`. Node.js selection was nearly dropped too — jest is only 40% of that job's step time, the rest being the compose stack, database setup and turbo prepare across four jobs, and the workflow fired on none of the last 18 pull requests. It stayed because the flag interaction checked out and the saving is real for anyone working in `nodejs/`.

The Python guards use a shell test rather than a step-level `if:`. Those steps sit in a `parallel:` block, and the repo's only `if:` inside one has a condition that cannot be false when its job runs, so nothing demonstrates the skip path works there.

A stack on top of #91749 was considered and dropped: `docs/internal/ci-things-already-tried.md` records that layers touching the same lines cost more review effort than one PR, and both PRs touch `ci-frontend.yml`. They are independent, so whichever lands second resolves one small conflict there.
