### PR TITLE
fix(inbox): swap the retired replay source for Replay Vision

### DIFF
--- a/products/desktop/apps/mobile/src/features/inbox/sourceFilterOptions.test.ts
+++ b/products/desktop/apps/mobile/src/features/inbox/sourceFilterOptions.test.ts
@@ -16,7 +16,7 @@ describe("SOURCE_PRODUCT_OPTIONS", () => {
 
   it("keeps the native products", () => {
     const values = SOURCE_PRODUCT_OPTIONS.map((o) => o.value);
-    expect(values).toContain("session_replay");
+    expect(values).toContain("replay_vision");
     expect(values).toContain("signals_scout");
   });
 });
@@ -51,7 +51,7 @@ describe("narrowSourceProductOptions", () => {
 
   it("always keeps PostHog's own products", () => {
     const result = values([]);
-    expect(result).toContain("session_replay");
+    expect(result).toContain("replay_vision");
     expect(result).toContain("signals_scout");
     expect(result).not.toContain("github");
   });

--- a/products/desktop/apps/mobile/src/features/inbox/sourceFilterOptions.ts
+++ b/products/desktop/apps/mobile/src/features/inbox/sourceFilterOptions.ts
@@ -7,7 +7,7 @@ import {
 
 export const SOURCE_PRODUCT_OPTIONS: { value: SourceProduct; label: string }[] =
   [
-    { value: "session_replay", label: "Session replay" },
+    { value: "replay_vision", label: "Replay Vision" },
     { value: "error_tracking", label: "Error tracking" },
     { value: "llm_analytics", label: "AI observability" },
     { value: "conversations", label: "Conversations" },

--- a/products/desktop/packages/core/src/inbox/signalSourceService.test.ts
+++ b/products/desktop/packages/core/src/inbox/signalSourceService.test.ts
@@ -104,7 +104,7 @@ describe("SignalSourceService.toggleSource", () => {
     const result = await service.toggleSource(
       client,
       1,
-      "session_replay",
+      "health_checks",
       true,
       [],
       [],

--- a/products/desktop/packages/core/src/inbox/signalSourceService.ts
+++ b/products/desktop/packages/core/src/inbox/signalSourceService.ts
@@ -36,7 +36,6 @@ type SourceType = SignalSourceConfig["source_type"];
 const SOURCE_TYPE_MAP: Partial<Record<SignalSourceProduct, SourceType>> = {
   conversations: "ticket",
   health_checks: "health_issue",
-  session_replay: "session_analysis_cluster",
   // AI observability signals are always emitted per evaluation report.
   llm_analytics: "evaluation_report",
   ...Object.fromEntries(
@@ -68,7 +67,6 @@ const ALL_SOURCE_PRODUCTS: SignalSourceProduct[] = [
   "conversations",
   "error_tracking",
   "health_checks",
-  "session_replay",
   "llm_analytics",
   ...EXTERNAL_INBOX_SOURCES.map((s) => s.product),
 ];

--- a/products/desktop/packages/shared/src/inbox-types.test.ts
+++ b/products/desktop/packages/shared/src/inbox-types.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { SourceProduct } from "./inbox-types";
 import { filterInboxSourceOptions } from "./inbox-types";
 
-// A minimal mix of native products (session_replay, signals_scout) and
+// A minimal mix of native products (replay_vision, signals_scout) and
 // warehouse-backed products (github, sentry) from the shared registry.
 const OPTIONS: { value: SourceProduct }[] = [
-  { value: "session_replay" },
+  { value: "replay_vision" },
   { value: "signals_scout" },
   { value: "github" },
   { value: "sentry" },
@@ -23,25 +23,25 @@ describe("filterInboxSourceOptions", () => {
       name: "shows an enabled warehouse source and hides a disabled one",
       enabled: new Set(["github"]),
       selected: [] as SourceProduct[],
-      expected: ["session_replay", "signals_scout", "github"],
+      expected: ["replay_vision", "signals_scout", "github"],
     },
     {
       name: "keeps PostHog's own products when nothing is enabled",
       enabled: new Set<string>(),
       selected: [] as SourceProduct[],
-      expected: ["session_replay", "signals_scout"],
+      expected: ["replay_vision", "signals_scout"],
     },
     {
       name: "keeps a disabled source while it is selected",
       enabled: new Set<string>(),
       selected: ["sentry"] as SourceProduct[],
-      expected: ["session_replay", "signals_scout", "sentry"],
+      expected: ["replay_vision", "signals_scout", "sentry"],
     },
     {
       name: "hides nothing while the enabled set is unknown",
       enabled: undefined,
       selected: [] as SourceProduct[],
-      expected: ["session_replay", "signals_scout", "github", "sentry"],
+      expected: ["replay_vision", "signals_scout", "github", "sentry"],
     },
   ])("$name", ({ enabled, selected, expected }) => {
     expect(values(enabled, selected)).toEqual(expected);

--- a/products/desktop/packages/shared/src/inbox-types.ts
+++ b/products/desktop/packages/shared/src/inbox-types.ts
@@ -419,15 +419,23 @@ export type SourceProduct =
   | "error_tracking"
   | "health_checks"
   | "llm_analytics"
+  | "replay_vision"
   | "session_replay"
   | "signals_scout"
   | ExternalInboxSourceProduct;
 
 /**
- * Products that render as a toggle in the Self-driving sources modal. Excludes `signals_scout`,
- * which appears only as a signal origin and is always on rather than user-toggled.
+ * Products that render as a toggle in the Self-driving sources modal.
+ *
+ * `signals_scout` appears only as a signal origin and is always on. `replay_vision` authorizes
+ * itself through each scanner's own `emits_signals` flag, so there is no config row to toggle.
+ * `session_replay` is retired: the session summarization behind it is gone, and it survives here
+ * only so reports emitted before that still render their source.
  */
-export type ToggleableSourceProduct = Exclude<SourceProduct, "signals_scout">;
+export type ToggleableSourceProduct = Exclude<
+  SourceProduct,
+  "signals_scout" | "replay_vision" | "session_replay"
+>;
 
 /**
  * Every backend signal `source_type`: the PostHog-native types (alphabetical) plus the

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportCard.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportCard.stories.tsx
@@ -17,7 +17,7 @@ const report = (overrides: Partial<SignalReport> = {}): SignalReport => ({
   priority: "P2",
   actionability: "immediately_actionable",
   is_suggested_reviewer: true,
-  source_products: ["session_replay"],
+  source_products: ["replay_vision"],
   ...overrides,
 });
 

--- a/products/desktop/packages/ui/src/features/inbox/components/ResponderAgentRoster.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ResponderAgentRoster.tsx
@@ -1,8 +1,4 @@
-import {
-  ArrowSquareOutIcon,
-  CircleNotchIcon,
-  type IconProps,
-} from "@phosphor-icons/react";
+import { ArrowSquareOutIcon, type IconProps } from "@phosphor-icons/react";
 import type { SignalSourceConfig } from "@posthog/api-client/posthog-client";
 import { Button } from "@posthog/quill";
 import {
@@ -14,7 +10,6 @@ import type { SignalSourceValues } from "@posthog/ui/features/inbox/components/S
 import { InboxBadge } from "@posthog/ui/features/inbox/components/utils/InboxBadge";
 import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
 import { Badge } from "@posthog/ui/primitives/Badge";
-import { Spin } from "@posthog/ui/primitives/Spinner";
 import { Box, Flex, Spinner, Switch, Text } from "@radix-ui/themes";
 import { type ComponentType, memo, useCallback } from "react";
 
@@ -223,17 +218,6 @@ const ResponderAgentCard = memo(function ResponderAgentCard({
           )}
         </Flex>
       </Flex>
-
-      {armed && agent.source === "session_replay" && status === "syncing" ? (
-        <Flex align="center" gap="2" className="mt-2 ml-8">
-          <Spin className="text-(--accent-11)">
-            <CircleNotchIcon size={14} />
-          </Spin>
-          <Text className="text-(--accent-11) text-[13px]">
-            Session analysis run in progress…
-          </Text>
-        </Flex>
-      ) : null}
     </Box>
   );
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -3,10 +3,8 @@ import {
   BrainIcon,
   BugIcon,
   ChatsIcon,
-  CircleNotchIcon,
   FirstAidIcon,
   PlugIcon,
-  VideoIcon,
 } from "@phosphor-icons/react";
 import type {
   ExternalDataSource,
@@ -20,8 +18,6 @@ import {
 } from "@posthog/shared";
 import { GitHubSourceRepositoriesDialog } from "@posthog/ui/features/inbox/components/GitHubSourceRepositoriesDialog";
 import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
-import { Badge } from "@posthog/ui/primitives/Badge";
-import { Spin } from "@posthog/ui/primitives/Spinner";
 import { memo, useCallback, useState } from "react";
 
 export type SignalSourceValues = Record<ToggleableSourceProduct, boolean>;
@@ -306,26 +302,6 @@ const ExternalSourceCard = memo(function ExternalSourceCard({
   );
 });
 
-function SourceRunningIndicator({
-  status,
-  message,
-}: {
-  status: SignalSourceConfig["status"];
-  message: string;
-}) {
-  if (status !== "running") {
-    return null;
-  }
-  return (
-    <div className="mt-2 flex items-center gap-2">
-      <Spin className="text-(--accent-11)">
-        <CircleNotchIcon size={14} />
-      </Spin>
-      <span className="text-(--accent-11) text-[13px]">{message}</span>
-    </div>
-  );
-}
-
 interface SignalSourceTogglesProps {
   value: SignalSourceValues;
   onToggle: (source: ToggleableSourceProduct, enabled: boolean) => void;
@@ -341,10 +317,6 @@ export function SignalSourceToggles({
   sourceStates,
   onSetup,
 }: SignalSourceTogglesProps) {
-  const toggleSessionReplay = useCallback(
-    (checked: boolean) => onToggle("session_replay", checked),
-    [onToggle],
-  );
   const toggleErrorTracking = useCallback(
     (checked: boolean) => onToggle("error_tracking", checked),
     [onToggle],
@@ -401,25 +373,6 @@ export function SignalSourceToggles({
             disabled={disabled}
             docsUrl="https://posthog.com/docs/support"
             docsLabel="Support"
-          />
-          <SignalSourceToggleCard
-            icon={<VideoIcon size={20} />}
-            label="Session Replay"
-            labelSuffix={<Badge color="orange">Alpha</Badge>}
-            description="Analyze recordings for UX issues"
-            checked={value.session_replay}
-            onCheckedChange={toggleSessionReplay}
-            disabled={disabled}
-            docsUrl="https://posthog.com/docs/session-replay"
-            docsLabel="Session Replay"
-            statusSection={
-              value.session_replay ? (
-                <SourceRunningIndicator
-                  status={sourceStates?.session_replay?.syncStatus ?? null}
-                  message="Session analysis run in progress now..."
-                />
-              ) : undefined
-            }
           />
           <SignalSourceToggleCard
             icon={<BrainIcon size={20} />}

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -71,6 +71,9 @@ export function signalCardSourceLine(signal: {
   ) {
     return "Session replay · Session analysis cluster";
   }
+  if (source_product === "replay_vision" && source_type === "scanner_finding") {
+    return "Replay Vision · Scanner finding";
+  }
   if (source_product === "llm_analytics" && source_type === "evaluation") {
     return "AI observability · Evaluation";
   }

--- a/products/desktop/packages/ui/src/features/inbox/components/responderAgentMeta.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/responderAgentMeta.ts
@@ -48,15 +48,6 @@ export const RESPONDER_AGENT_GROUPS: ResponderAgentGroup[] = [
         docsLabel: "Health checks",
       },
       {
-        source: "session_replay",
-        sourceProduct: "session_replay",
-        label: "Session Replay",
-        description: "UX problems found in session recordings.",
-        docsUrl: "https://posthog.com/docs/session-replay",
-        docsLabel: "Session Replay",
-        alpha: true,
-      },
-      {
         source: "llm_analytics",
         sourceProduct: "llm_analytics",
         label: "AI observability",

--- a/products/desktop/packages/ui/src/features/inbox/components/utils/source-product-icons.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/utils/source-product-icons.tsx
@@ -57,6 +57,12 @@ export function hasKnownSourceProduct(
 }
 
 const SOURCE_PRODUCT_META: Partial<Record<SourceProduct, SourceProductMeta>> = {
+  replay_vision: {
+    Icon: VideoIcon,
+    color: "var(--amber-9)",
+    label: "Replay Vision",
+  },
+  // Retired source: kept so reports emitted before it was removed still show where they came from.
   session_replay: {
     Icon: VideoIcon,
     color: "var(--amber-9)",

--- a/products/desktop/packages/ui/src/features/inbox/filterOptions.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/filterOptions.test.ts
@@ -71,7 +71,7 @@ describe("filterInboxSourceOptions", () => {
 
   it("keeps only the warehouse sources that are switched on", () => {
     expect(values(new Set(["github", "zendesk"]))).toEqual([
-      "session_replay",
+      "replay_vision",
       "error_tracking",
       "llm_analytics",
       "conversations",
@@ -84,7 +84,7 @@ describe("filterInboxSourceOptions", () => {
 
   it("keeps PostHog's own products when nothing is switched on", () => {
     expect(values(new Set())).toEqual([
-      "session_replay",
+      "replay_vision",
       "error_tracking",
       "llm_analytics",
       "conversations",

--- a/products/desktop/packages/ui/src/features/inbox/filterOptions.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/filterOptions.tsx
@@ -79,8 +79,8 @@ export type InboxSourceOption = {
 
 export const INBOX_SOURCE_OPTIONS: InboxSourceOption[] = [
   {
-    value: "session_replay",
-    label: "Session replay",
+    value: "replay_vision",
+    label: "Replay Vision",
     icon: <VideoIcon size={14} />,
   },
   {

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useSignalSourceToggles.ts
@@ -27,7 +27,6 @@ type SourceKey = keyof SignalSourceValues;
 const SOURCE_TYPE_MAP: Partial<Record<SourceKey, SourceType>> = {
   conversations: "ticket",
   health_checks: "health_issue",
-  session_replay: "session_analysis_cluster",
   // AI observability signals are always emitted per evaluation report.
   llm_analytics: "evaluation_report",
   ...Object.fromEntries(
@@ -45,7 +44,6 @@ const SOURCE_LABELS: Partial<Record<SourceKey, string>> = {
   conversations: "PostHog Support",
   error_tracking: "Error tracking",
   health_checks: "Health checks",
-  session_replay: "Session replay",
   llm_analytics: "AI observability",
   ...Object.fromEntries(
     EXTERNAL_INBOX_SOURCES.map((s) => [s.product, s.label]),
@@ -70,7 +68,6 @@ const ALL_SOURCE_PRODUCTS: SourceKey[] = [
   "conversations",
   "error_tracking",
   "health_checks",
-  "session_replay",
   "llm_analytics",
   ...EXTERNAL_INBOX_SOURCES.map((s) => s.product),
 ];
@@ -113,6 +110,9 @@ function computeValues(
  *  - Optimistic per-source toggle overrides so a click reflects without waiting for the API.
  *  - Triggering the warehouse setup wizard when a source requires it (`github`, `linear`, `zendesk`, `pganalyze`).
  *  - Forcing `issues` (`should_sync=true`, `sync_type=full_refresh` for GitHub/Linear) when a source is turned on.
+ *
+ * Replay Vision is absent by design: each scanner's `emits_signals` flag is its own per-source
+ * config, so there is no row here to switch. Scanners are set up in PostHog or by the Wizard.
  */
 export function useSignalSourceToggles() {
   const client = useAuthenticatedClient();


### PR DESCRIPTION
## Problem

Anyone configuring Self-driving sources in the desktop app can switch on "Session Replay" and get nothing back. The card lights up, the switch stays on, and no finding ever arrives.

- The toggle writes `session_replay` / `session_analysis_cluster`. That source was retired with session summarization in #83019.
- [Migration `0094`](https://github.com/PostHog/posthog/blob/master/products/signals/backend/migrations/0094_delete_session_analysis_source_configs.py) deleted the existing rows, and `has_enabled_source` now excludes the pair. The app writes back what the server deleted.
- The card shows no status either, because the serializer returns `null` for a source with no warehouse schema behind it.

Replay Vision took over that surface, and the app never learned the product. A scanner finding reaches the inbox with no source name, no icon, and no way to filter to it: `replay_vision` is absent from the `SourceProduct` union, so `hasKnownSourceProduct` returns false and the card hides its source row.

## Changes

- The sources grid and the Responders list no longer offer Session Replay. The dead switch is gone rather than fixed, because there is no config row to fix.
- Replay Vision findings now carry a source. Report cards and detail headers show the name and icon, and the source filter offers "Replay Vision" on desktop and mobile.
- A Replay Vision finding's detail row reads "Replay Vision · Scanner finding" instead of falling back to "replay vision · scanner finding".

Replay Vision has no toggle, and that is deliberate: each scanner's own `emits_signals` flag is the per-source config, so there is no row for a switch to write. Scanners are set up in PostHog or by `npx @posthog/wizard self-driving`. A read-only card showing scanner state would need a new client method and query hook; it is worth doing, and it is not this PR.

`session_replay` stays in the union and the icon map. Reports emitted before the retirement still render their source.

Mechanical: the source-product maps in `useSignalSourceToggles`, `signalSourceService`, and the shared types, plus the test updates that follow them.

The diff is confined to `products/desktop/`. #91851 carries the matching label for Slack inbox notifications, whose map mirrors `signalCardSourceLine` here. The two are independent and can land in either order.

> [!NOTE]
> No screenshots. The change is visible — one card disappears from the "PostHog data" grid, one row from the Responders list, and a source chip appears on Replay Vision reports — but the sources grid has no story, and rendering it needs the Electron app signed in to a project. The app was not run.

## How did you test this code?

Automated only. `pnpm typecheck` passes across all 27 desktop packages, and the touched suites pass: `packages/shared`, `packages/ui` inbox, `packages/core` `signalSourceService`, and `apps/mobile` inbox.

No new tests. Existing ones were updated to name a live source instead of the retired one, and they already cover what matters here: `filterInboxSourceOptions` keeping PostHog's own products, and the source-line label table. The type system caught the real risk — narrowing `ToggleableSourceProduct` failed the build on `packages/core/src/inbox/signalSourceService.ts`, a second copy of the same maps for the mobile host that a grep over the UI feature had missed.

Not checked: the app was not run, so the grid and the Responders list are unverified by eye.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by @skoob13, who asked whether a planned move from the session recording source to Replay Vision scanners had shipped, and then to fix it.

Skills invoked: `/posthog-desktop` for the nested workspace toolchain, and `/writing-pr-descriptions`.

Two companion PRs cover the wizard side of the same item, where the setup run still created the retired row: PostHog/context-mill#370 (the skill, and the one that changes what a run does) and PostHog/wizard#1174 (the prompt and architecture doc).

Scope was a decision point. Three options were on the table for this app: remove the dead toggle and teach the renderer the product; add a read-only card backed by a new scanner-list call; or a full toggle over `emits_signals`. The first was chosen, so this PR adds no API surface.
