### PR TITLE
fix(signals): label Replay Vision findings in Slack notifications

### DIFF
--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -399,6 +399,7 @@ _SIGNAL_SOURCE_LINES: dict[tuple[str, str], str] = {
     ("session_replay", "session_problem"): "Session replay · Session problem",
     ("session_replay", "session_segment_cluster"): "Session replay · Session segment cluster",
     ("session_replay", "session_analysis_cluster"): "Session replay · Session analysis cluster",
+    ("replay_vision", "scanner_finding"): "Replay Vision · Scanner finding",
     ("llm_analytics", "evaluation"): "AI observability · Evaluation",
     ("llm_analytics", "evaluation_report"): "AI observability · Evaluation report",
     ("zendesk", "ticket"): "Zendesk · Ticket",

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -767,6 +767,7 @@ def test_dispatch_sends_once_per_channel_when_reviewers_share_channel(org_and_te
         ("error_tracking", "issue_spiking", "Error tracking · Volume spike"),
         ("session_replay", "session_problem", "Session replay · Session problem"),
         ("session_replay", "session_analysis_cluster", "Session replay · Session analysis cluster"),
+        ("replay_vision", "scanner_finding", "Replay Vision · Scanner finding"),
         ("llm_analytics", "evaluation", "AI observability · Evaluation"),
         ("llm_analytics", "evaluation_report", "AI observability · Evaluation report"),
         ("github", "issue", "GitHub · Issue"),


### PR DESCRIPTION
## Problem

A Slack inbox notification for a Replay Vision scanner finding names its source as "replay vision · scanner finding". Every other source product reads as a proper label: "Error tracking · New issue", "Zendesk · Ticket".

`_SIGNAL_SOURCE_LINES` has no entry for the pair, so `_signal_source_line` falls through to the humanizing fallback, which just swaps underscores for spaces.

## Changes

- A Replay Vision finding now reads "Replay Vision · Scanner finding" in the Slack notification header.
- One entry in `_SIGNAL_SOURCE_LINES`, plus its case in the existing parameterized test.

Nothing else changes. The map mirrors `signalCardSourceLine` in the desktop inbox and carries a comment saying to keep the two in sync, so the matching renderer change ships in #91846.

## How did you test this code?

`products/signals/backend/test/test_slack_inbox_notifications.py` passes. The new case extends `test_signal_source_line`, which already covers the explicit labels and the fallback; it catches the pair regressing back to the fallback.

Repo-wide mypy was not run. The change is one entry in an existing `dict[tuple[str, str], str]`.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code, directed by @skoob13. Split out of #91846 at their request, to keep the desktop app change and the backend change in separate PRs.

Skills invoked: `/writing-pr-descriptions`.

The two are independent and can land in either order.
