### PR TITLE
feat(self-driving): Add a flagged github-first onboarding option to self-driving

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -182,6 +182,7 @@ export const FEATURE_FLAGS = {
 
     // UX flags, used to control the UX of the app
     CREATE_BUTTON_NAV_EXPERIMENT: 'create-button-nav-experiment', // owner: #team-platform-ux multivariate=control,test — adds a Create dropdown to the top of the Browse tab in the left nav
+    GITHUB_FIRST_SELF_DRIVING_ONBOARDING: 'github-first-self-driving-onboarding', // owner: #team-self-driving
     INBOX_SELF_DRIVING_EMPTY_STATE: 'inbox-self-driving-empty-state',
     STARRED_REORDER: 'starred-reorder', // owner: #team-platform-ux, drag-and-drop reorder of starred shortcuts in the side panel
     UX_HIDE_PROJECT_NOTICE: 'ux-hide-project-notice', // owner: #team-platform-ux, hides the project notice banner across all scenes

--- a/frontend/src/lib/integrations/GitHubInstallRequestsBanner.tsx
+++ b/frontend/src/lib/integrations/GitHubInstallRequestsBanner.tsx
@@ -1,10 +1,9 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, Link } from '@posthog/lemon-ui'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { githubInstallRequestsLogic } from 'lib/integrations/githubInstallRequestsLogic'
-import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import type { GitHubInstallRequestItemApi } from '~/generated/core/api.schemas'
 
@@ -25,9 +24,8 @@ export function GitHubInstallRequestsBanner({
     /** Alternative to `onFinishConnecting` for surfaces whose connect is a plain link. */
     finishConnectingUrl?: string
 }): JSX.Element | null {
-    const { pendingInstallRequests, approvedInstallRequests, installUrl, dismissingRequestIds } =
-        useValues(githubInstallRequestsLogic)
-    const { startPolling, stopPolling, dismissInstallRequest } = useActions(githubInstallRequestsLogic)
+    const { pendingInstallRequests, approvedInstallRequests, installUrl } = useValues(githubInstallRequestsLogic)
+    const { startPolling, stopPolling } = useActions(githubInstallRequestsLogic)
 
     useOnMountEffect(() => {
         startPolling()
@@ -48,72 +46,40 @@ export function GitHubInstallRequestsBanner({
                             <strong>{request.account_login || request.github_login || 'your organization'}</strong>.
                             Finish connecting to start using it.
                         </span>
-                        <div className="flex gap-2 shrink-0">
-                            <LemonButton
-                                type="primary"
-                                size="small"
-                                to={finishConnectingUrl}
-                                disableClientSideRouting={!!finishConnectingUrl}
-                                onClick={onFinishConnecting}
-                            >
-                                Finish connecting
-                            </LemonButton>
-                            <LemonButton
-                                type="tertiary"
-                                size="small"
-                                loading={dismissingRequestIds.includes(request.id)}
-                                onClick={() => dismissInstallRequest(request.id)}
-                            >
-                                Dismiss
-                            </LemonButton>
-                        </div>
+                        <LemonButton
+                            type="primary"
+                            size="small"
+                            to={finishConnectingUrl}
+                            disableClientSideRouting={!!finishConnectingUrl}
+                            onClick={onFinishConnecting}
+                        >
+                            Finish connecting
+                        </LemonButton>
                     </div>
                 </LemonBanner>
             ))}
             {pendingInstallRequests.map((request: GitHubInstallRequestItemApi) => (
                 <LemonBanner key={request.id} type="info" hideIcon>
-                    <div className="flex flex-col gap-2">
-                        <span className="text-sm font-normal">
-                            GitHub sent your request
-                            {request.github_login ? (
-                                <>
-                                    {' '}
-                                    (as <strong>{request.github_login}</strong>)
-                                </>
-                            ) : null}{' '}
-                            to your organization owners. Once an owner approves the PostHog app, we'll finish connecting
-                            here.
-                        </span>
+                    <span className="text-sm font-normal">
+                        GitHub sent your request
+                        {request.github_login ? (
+                            <>
+                                {' '}
+                                (as <strong>{request.github_login}</strong>)
+                            </>
+                        ) : null}{' '}
+                        to your organization owners. Once an owner approves the PostHog app, we'll finish connecting
+                        here.
                         {installUrl ? (
-                            <code className="text-xs whitespace-normal break-words">
-                                {buildOrgOwnerMessage(installUrl)}
-                            </code>
+                            <>
+                                {' '}
+                                <Link to={installUrl} target="_blank">
+                                    Open the approval page
+                                </Link>
+                                .
+                            </>
                         ) : null}
-                        <div className="flex flex-wrap gap-2">
-                            {installUrl ? (
-                                <LemonButton
-                                    type="secondary"
-                                    size="small"
-                                    onClick={() =>
-                                        void copyToClipboard(
-                                            buildOrgOwnerMessage(installUrl),
-                                            'message for your org owner'
-                                        )
-                                    }
-                                >
-                                    Copy message for your org owner
-                                </LemonButton>
-                            ) : null}
-                            <LemonButton
-                                type="tertiary"
-                                size="small"
-                                loading={dismissingRequestIds.includes(request.id)}
-                                onClick={() => dismissInstallRequest(request.id)}
-                            >
-                                Dismiss
-                            </LemonButton>
-                        </div>
-                    </div>
+                    </span>
                 </LemonBanner>
             ))}
         </div>

--- a/frontend/src/lib/integrations/GitHubInstallRequestsBanner.tsx
+++ b/frontend/src/lib/integrations/GitHubInstallRequestsBanner.tsx
@@ -4,6 +4,7 @@ import { LemonBanner, LemonButton, Link } from '@posthog/lemon-ui'
 
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { githubInstallRequestsLogic } from 'lib/integrations/githubInstallRequestsLogic'
+import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 import type { GitHubInstallRequestItemApi } from '~/generated/core/api.schemas'
 
@@ -18,14 +19,17 @@ export function buildOrgOwnerMessage(installUrl: string): string {
 export function GitHubInstallRequestsBanner({
     onFinishConnecting,
     finishConnectingUrl,
+    variant = 'default',
 }: {
     /** Runs the surface's own connect flow once an owner has approved the install. */
     onFinishConnecting?: () => void
     /** Alternative to `onFinishConnecting` for surfaces whose connect is a plain link. */
     finishConnectingUrl?: string
+    variant?: 'default' | 'onboarding'
 }): JSX.Element | null {
-    const { pendingInstallRequests, approvedInstallRequests, installUrl } = useValues(githubInstallRequestsLogic)
-    const { startPolling, stopPolling } = useActions(githubInstallRequestsLogic)
+    const { pendingInstallRequests, approvedInstallRequests, installUrl, dismissingRequestIds } =
+        useValues(githubInstallRequestsLogic)
+    const { startPolling, stopPolling, dismissInstallRequest } = useActions(githubInstallRequestsLogic)
 
     useOnMountEffect(() => {
         startPolling()
@@ -46,40 +50,85 @@ export function GitHubInstallRequestsBanner({
                             <strong>{request.account_login || request.github_login || 'your organization'}</strong>.
                             Finish connecting to start using it.
                         </span>
-                        <LemonButton
-                            type="primary"
-                            size="small"
-                            to={finishConnectingUrl}
-                            disableClientSideRouting={!!finishConnectingUrl}
-                            onClick={onFinishConnecting}
-                        >
-                            Finish connecting
-                        </LemonButton>
+                        <div className="flex gap-2 shrink-0">
+                            <LemonButton
+                                type="primary"
+                                size="small"
+                                to={finishConnectingUrl}
+                                disableClientSideRouting={!!finishConnectingUrl}
+                                onClick={onFinishConnecting}
+                            >
+                                Finish connecting
+                            </LemonButton>
+                            {variant === 'default' ? (
+                                <LemonButton
+                                    type="tertiary"
+                                    size="small"
+                                    loading={dismissingRequestIds.includes(request.id)}
+                                    onClick={() => dismissInstallRequest(request.id)}
+                                >
+                                    Dismiss
+                                </LemonButton>
+                            ) : null}
+                        </div>
                     </div>
                 </LemonBanner>
             ))}
             {pendingInstallRequests.map((request: GitHubInstallRequestItemApi) => (
                 <LemonBanner key={request.id} type="info" hideIcon>
-                    <span className="text-sm font-normal">
-                        GitHub sent your request
-                        {request.github_login ? (
-                            <>
-                                {' '}
-                                (as <strong>{request.github_login}</strong>)
-                            </>
-                        ) : null}{' '}
-                        to your organization owners. Once an owner approves the PostHog app, we'll finish connecting
-                        here.
-                        {installUrl ? (
-                            <>
-                                {' '}
-                                <Link to={installUrl} target="_blank">
-                                    Open the approval page
-                                </Link>
-                                .
-                            </>
+                    <div className="flex flex-col gap-2">
+                        <span className="text-sm font-normal">
+                            GitHub sent your request
+                            {request.github_login ? (
+                                <>
+                                    {' '}
+                                    (as <strong>{request.github_login}</strong>)
+                                </>
+                            ) : null}{' '}
+                            to your organization owners. Once an owner approves the PostHog app, we'll finish connecting
+                            here.
+                            {variant === 'onboarding' && installUrl ? (
+                                <>
+                                    {' '}
+                                    <Link to={installUrl} target="_blank">
+                                        Open the approval page
+                                    </Link>
+                                    .
+                                </>
+                            ) : null}
+                        </span>
+                        {variant === 'default' && installUrl ? (
+                            <code className="text-xs whitespace-normal break-words">
+                                {buildOrgOwnerMessage(installUrl)}
+                            </code>
                         ) : null}
-                    </span>
+                        {variant === 'default' ? (
+                            <div className="flex flex-wrap gap-2">
+                                {installUrl ? (
+                                    <LemonButton
+                                        type="secondary"
+                                        size="small"
+                                        onClick={() =>
+                                            void copyToClipboard(
+                                                buildOrgOwnerMessage(installUrl),
+                                                'message for your org owner'
+                                            )
+                                        }
+                                    >
+                                        Copy message for your org owner
+                                    </LemonButton>
+                                ) : null}
+                                <LemonButton
+                                    type="tertiary"
+                                    size="small"
+                                    loading={dismissingRequestIds.includes(request.id)}
+                                    onClick={() => dismissInstallRequest(request.id)}
+                                >
+                                    Dismiss
+                                </LemonButton>
+                            </div>
+                        ) : null}
+                    </div>
                 </LemonBanner>
             ))}
         </div>

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -932,6 +932,8 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 // When the org has more than one installation the caller passes the chosen
                 // installationId, since the backend can't auto-resolve between them.
                 linkExistingGithubInstallation: async (installationId?: string) => {
+                    // The global kea-loaders failure handler shows the API detail. Do not add a
+                    // local toast here because the rejected loader would then show both messages.
                     const integration = await api.integrations.githubLinkExisting(
                         installationId ? { installation_id: installationId } : {}
                     )

--- a/frontend/src/lib/integrations/integrationsLogic.ts
+++ b/frontend/src/lib/integrations/integrationsLogic.ts
@@ -932,17 +932,12 @@ export const integrationsLogic = kea<integrationsLogicType>([
                 // When the org has more than one installation the caller passes the chosen
                 // installationId, since the backend can't auto-resolve between them.
                 linkExistingGithubInstallation: async (installationId?: string) => {
-                    try {
-                        const integration = await api.integrations.githubLinkExisting(
-                            installationId ? { installation_id: installationId } : {}
-                        )
-                        lemonToast.success('Linked the existing GitHub installation to this project.')
-                        actions.loadIntegrations()
-                        return integration
-                    } catch (e) {
-                        toastApiError(e)
-                        throw e
-                    }
+                    const integration = await api.integrations.githubLinkExisting(
+                        installationId ? { installation_id: installationId } : {}
+                    )
+                    lemonToast.success('Linked the existing GitHub installation to this project.')
+                    actions.loadIntegrations()
+                    return integration
                 },
             },
         ],

--- a/frontend/src/lib/integrations/utils.ts
+++ b/frontend/src/lib/integrations/utils.ts
@@ -61,6 +61,7 @@ export type IntegrationConnectSurface =
     | 'missing_scopes_reconnect'
     | 'warehouse_source_reconnect'
     | 'onboarding_wizard'
+    | 'inbox_welcome'
     | 'signals_agent_setup'
     | 'task_composer'
     | 'visual_review_settings'

--- a/frontend/src/scenes/integrations/components/GithubIntegration.tsx
+++ b/frontend/src/scenes/integrations/components/GithubIntegration.tsx
@@ -1,11 +1,12 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronDown } from '@posthog/icons'
+import { IconChevronDown, IconGithub } from '@posthog/icons'
 import { LemonBanner, LemonButton, Link } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { GitHubInstallRequestsBanner } from 'lib/integrations/GitHubInstallRequestsBanner'
+import { githubInstallRequestsLogic } from 'lib/integrations/githubInstallRequestsLogic'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import type { IntegrationConnectSurface } from 'lib/integrations/utils'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
@@ -20,8 +21,14 @@ import { Integration, useIntegrations } from './Integration'
 export function GithubIntegration({
     next,
     connectSurface,
+    connectText = 'Connect account',
+    emphasizeConnect = false,
+    showPersonalConnectionHelp = true,
 }: {
     next?: string
+    connectText?: string
+    emphasizeConnect?: boolean
+    showPersonalConnectionHelp?: boolean
     /**
      * Where this card is rendered, reported as the `surface` on `integration_connect_clicked`.
      * Omit it only on the OAuth landing page, which reports every kind's connect click itself —
@@ -35,6 +42,7 @@ export function GithubIntegration({
     const { linkExistingGithubInstallation, loadGithubAvailableInstallations, startPolling, stopPolling } =
         useActions(integrationsLogic)
     const { reportIntegrationConnectClicked } = useActions(eventUsageLogic)
+    const { hasPendingInstallRequests } = useValues(githubInstallRequestsLogic)
     const githubIntegrations = useIntegrations('github')
 
     // integrationsLogic is a singleton mounted from dozens of unrelated surfaces, so this fetch
@@ -56,6 +64,7 @@ export function GithubIntegration({
     const isConnected = githubIntegrations.length > 0
     const canLinkExisting = !isConnected && installations.length > 0
     const multipleInstallations = installations.length > 1
+    const installRequestInProgress = hasPendingInstallRequests
 
     // Silent without `connectSurface`, because the only card rendered without one sits on the OAuth
     // landing page, which already reports every kind's connect click for itself.
@@ -93,6 +102,7 @@ export function GithubIntegration({
                             <GitHubInstallationLink
                                 installations={installations}
                                 loading={linkedGithubInstallationLoading}
+                                emphasizeInstallation={emphasizeConnect}
                                 onLink={(installationId) => {
                                     // Reusing an existing install never leaves PostHog, so it's a
                                     // connect that skips GitHub entirely — worth separating from the
@@ -105,32 +115,55 @@ export function GithubIntegration({
                         </div>
                     </LemonBanner>
                 )}
-                <div className="flex flex-wrap gap-2">
-                    {/* This leaves PostHog entirely, and a GitHub App installs at most once per
-                        account, so GitHub offers install where it's missing and configure where it
-                        isn't. "Connect account" matches the Linear and Jira cards, which name the
-                        third party's container. */}
-                    <LemonButton
-                        type="secondary"
-                        disableClientSideRouting
-                        to={authorizationUrl}
-                        onClick={() => reportConnect(isConnected ? 'settings_manage' : undefined)}
-                    >
-                        {isConnected ? 'Manage on GitHub' : 'Connect account'}
-                    </LemonButton>
-                </div>
+                {installRequestInProgress ? null : emphasizeConnect && !isConnected ? (
+                    <div className="flex w-full flex-col items-center gap-4">
+                        <div className="flex flex-wrap justify-center gap-2">
+                            <LemonButton
+                                type={canLinkExisting ? 'secondary' : 'primary'}
+                                icon={<IconGithub />}
+                                disableClientSideRouting
+                                to={authorizationUrl}
+                                onClick={() => reportConnect()}
+                            >
+                                {canLinkExisting ? 'Connect a different organization or repository' : connectText}
+                            </LemonButton>
+                        </div>
+                        <p className="m-0 max-w-[520px] text-center text-[13px] text-tertiary">
+                            PostHog uses GitHub to create reports and pull requests based on your code. After connecting
+                            GitHub, you can run Wizard in the background to complete setup.
+                        </p>
+                    </div>
+                ) : (
+                    <div className="flex flex-wrap gap-2">
+                        {/* This leaves PostHog entirely, and a GitHub App installs at most once per
+                            account, so GitHub offers install where it's missing and configure where it
+                            isn't. "Connect account" matches the Linear and Jira cards, which name the
+                            third party's container. */}
+                        <LemonButton
+                            type="secondary"
+                            disableClientSideRouting
+                            to={authorizationUrl}
+                            onClick={() => reportConnect(isConnected ? 'settings_manage' : undefined)}
+                        >
+                            {isConnected ? 'Manage on GitHub' : connectText}
+                        </LemonButton>
+                    </div>
+                )}
                 {isConnected && (
                     <p className="text-secondary text-xs mb-0">
                         Add the PostHog app to another GitHub account, or change which repositories it can see.
                     </p>
                 )}
-                {!isConnected && installations.length === 0 && githubPersonalConnected === false && (
-                    <p className="text-secondary text-xs mb-0">
-                        Already installed the PostHog GitHub App but don't see it here? Connect your GitHub account
-                        under <Link to={urls.settings('user-personal-integrations')}>Personal integrations</Link> so
-                        PostHog can find it.
-                    </p>
-                )}
+                {showPersonalConnectionHelp &&
+                    !isConnected &&
+                    installations.length === 0 &&
+                    githubPersonalConnected === false && (
+                        <p className="text-secondary text-xs mb-0">
+                            Already installed the PostHog GitHub App but don't see it here? Connect your GitHub account
+                            under <Link to={urls.settings('user-personal-integrations')}>Personal integrations</Link> so
+                            PostHog can find it.
+                        </p>
+                    )}
             </div>
         </Integration>
     )
@@ -147,12 +180,14 @@ export function GitHubInstallationLink({
     loading,
     onLink,
     projectName,
+    emphasizeInstallation = false,
 }: {
     installations: GitHubAvailableInstallationApi[]
     loading: boolean
     onLink: (installationId?: string) => void
     /** Named on the button, so it's clear which project the install lands in. */
     projectName?: string
+    emphasizeInstallation?: boolean
 }): JSX.Element | null {
     if (installations.length === 0) {
         return null
@@ -163,12 +198,14 @@ export function GitHubInstallationLink({
         // backend to auto-resolve from a sibling project, which an orphan installation has none of.
         return (
             <LemonButton
-                type="secondary"
+                type={emphasizeInstallation ? 'primary' : 'secondary'}
                 size="small"
                 loading={loading}
                 onClick={() => onLink(installations[0].installation_id)}
             >
-                Connect to {projectName ?? 'this project'}
+                {emphasizeInstallation
+                    ? `Connect ${accountLabel(installations[0])}`
+                    : `Connect to ${projectName ?? 'this project'}`}
             </LemonButton>
         )
     }
@@ -182,8 +219,13 @@ export function GitHubInstallationLink({
                 onClick: () => onLink(installation.installation_id),
             }))}
         >
-            <LemonButton type="secondary" size="small" loading={loading} sideIcon={<IconChevronDown />}>
-                Choose an account
+            <LemonButton
+                type={emphasizeInstallation ? 'primary' : 'secondary'}
+                size="small"
+                loading={loading}
+                sideIcon={<IconChevronDown />}
+            >
+                {emphasizeInstallation ? 'Choose an existing installation' : 'Choose an account'}
             </LemonButton>
         </LemonMenu>
     )

--- a/frontend/src/scenes/integrations/components/GithubIntegration.tsx
+++ b/frontend/src/scenes/integrations/components/GithubIntegration.tsx
@@ -82,6 +82,7 @@ export function GithubIntegration({
                 <GitHubInstallRequestsBanner
                     finishConnectingUrl={authorizationUrl}
                     onFinishConnecting={() => reportConnect('install_approved_banner')}
+                    variant={emphasizeConnect ? 'onboarding' : 'default'}
                 />
                 {/* An install GitHub already has is the exception, not a second way to connect, so it
                     reads as an aside with its own action rather than a button competing with the one

--- a/products/signals/frontend/inbox/components/onboarding/InboxWelcome.tsx
+++ b/products/signals/frontend/inbox/components/onboarding/InboxWelcome.tsx
@@ -1,14 +1,20 @@
 import './InboxWelcome.scss'
 
-import { useActions } from 'kea'
+import { useActions, useMountedLogic, useValues } from 'kea'
+import { combineUrl } from 'kea-router'
 import { useEffect, useRef, useState } from 'react'
 
-import { IconRewindPlay, IconWarning } from '@posthog/icons'
-import { LemonButton, LemonCard, LemonTag } from '@posthog/lemon-ui'
+import { IconCheck, IconRewindPlay, IconWarning } from '@posthog/icons'
+import { LemonButton, LemonCard, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
 
 import { Logomark } from 'lib/brand'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { IconSlack } from 'lib/lemon-ui/icons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
+import { GithubIntegration } from 'scenes/integrations/components/GithubIntegration'
+import { urls } from 'scenes/urls'
 
 import { captureInboxWelcomeCommandCopied, captureInboxWelcomeViewed } from '../../inboxAnalytics'
 import { inboxOnboardingLogic } from '../../logics/inboxOnboardingLogic'
@@ -59,6 +65,48 @@ function CommandCta(): JSX.Element {
             >
                 {copied ? 'Copied' : 'Copy'}
             </button>
+        </div>
+    )
+}
+
+function GithubFirstCta(): JSX.Element {
+    useMountedLogic(integrationsLogic)
+    const { githubIntegrations, integrationsLoading } = useValues(integrationsLogic)
+    const hasGithubIntegration = githubIntegrations.some(
+        (integration) => integration.installation_status !== 'unavailable'
+    )
+
+    if (integrationsLoading) {
+        return <LemonSkeleton className="h-10 w-64 rounded" />
+    }
+
+    if (hasGithubIntegration) {
+        return (
+            <>
+                <div className="mb-4">
+                    <LemonTag type="success" icon={<IconCheck />}>
+                        GitHub connected
+                    </LemonTag>
+                </div>
+                <h2 className="mb-4 text-lg font-semibold">Almost there</h2>
+                <CommandCta />
+                <p className="mt-3.5 max-w-[520px] text-[13px] text-tertiary">
+                    Run the setup agent in your repo to pick the signal sources and scouts to watch. PRs start landing
+                    in this inbox.
+                </p>
+            </>
+        )
+    }
+
+    return (
+        <div className="w-full max-w-[560px] text-left">
+            <GithubIntegration
+                next={combineUrl(urls.inbox(), { setup: 'github-first' }).url}
+                connectSurface="inbox_welcome"
+                connectText="Connect GitHub"
+                emphasizeConnect
+                showPersonalConnectionHelp={false}
+            />
         </div>
     )
 }
@@ -195,6 +243,9 @@ function LoopDiagram(): JSX.Element {
  * Rendered in place of the report list and without the tab bar: a full-pane welcome, not a tab.
  */
 export function InboxWelcome(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const githubFirst = !!featureFlags[FEATURE_FLAGS.GITHUB_FIRST_SELF_DRIVING_ONBOARDING]
+
     useEffect(() => {
         captureInboxWelcomeViewed()
     }, [])
@@ -213,11 +264,17 @@ export function InboxWelcome(): JSX.Element {
                         PostHog watches your session replays, errors, and Slack. When it finds something worth fixing,
                         it writes the pull request. You review and merge.
                     </p>
-                    <CommandCta />
-                    <p className="mt-3.5 max-w-[520px] text-[13px] text-tertiary">
-                        Run it in your repo. That's the whole setup: it connects GitHub and picks the signal sources and
-                        scouts to watch. PRs start landing in this inbox.
-                    </p>
+                    {githubFirst ? (
+                        <GithubFirstCta />
+                    ) : (
+                        <>
+                            <CommandCta />
+                            <p className="mt-3.5 max-w-[520px] text-[13px] text-tertiary">
+                                Run it in your repo. That's the whole setup: it connects GitHub and picks the signal
+                                sources and scouts to watch. PRs start landing in this inbox.
+                            </p>
+                        </>
+                    )}
                     <ManualSetupAction />
                 </div>
             </div>

--- a/products/signals/frontend/inbox/logics/inboxOnboardingLogic.ts
+++ b/products/signals/frontend/inbox/logics/inboxOnboardingLogic.ts
@@ -266,6 +266,7 @@ export interface inboxOnboardingLogicValues {
     pullsCountLoading: boolean // reportListLogic
     reportsCount: number | null // reportListLogic
     reportsCountLoading: boolean // reportListLogic
+    searchParams: Record<string, any> // router
     enabledScoutsCount: number // scoutFleetLogic
     scoutConfigs: SignalScoutConfig[] | null // scoutFleetLogic
     scoutConfigsLoading: boolean // scoutFleetLogic
@@ -379,7 +380,10 @@ export interface inboxOnboardingLogicMeta {
         ) => InboxSettledUiState | null
         onboardingMode: (
             resolvedOnboardingMode: InboxOnboardingMode,
-            lastSettledUiState: InboxSettledUiState | null
+            lastSettledUiState: InboxSettledUiState | null,
+            searchParams: Record<string, any>,
+            isSelfDrivingSetUp: boolean,
+            isWizardRunning: boolean
         ) => InboxOnboardingMode
     }
 }
@@ -432,6 +436,8 @@ export const inboxOnboardingLogic = kea<inboxOnboardingLogicType>([
             ['receivedFeatureFlags'],
             teamLogic,
             ['currentTeamId'],
+            router,
+            ['searchParams'],
         ],
         actions: [
             wizardActiveSessionDetectorLogic,
@@ -639,11 +645,25 @@ export const inboxOnboardingLogic = kea<inboxOnboardingLogicType>([
         // What the scene renders: while the verdict is settling, fall back to what this team saw
         // last visit instead of a skeleton, so the loading state only ever shows on a first visit.
         onboardingMode: [
-            (s) => [s.resolvedOnboardingMode, s.lastSettledUiState],
+            (s) => [
+                s.resolvedOnboardingMode,
+                s.lastSettledUiState,
+                s.searchParams,
+                s.isSelfDrivingSetUp,
+                s.isWizardRunning,
+            ],
             (
                 resolvedOnboardingMode: InboxOnboardingMode,
-                lastSettledUiState: InboxSettledUiState | null
-            ): InboxOnboardingMode => resolveDisplayMode(resolvedOnboardingMode, lastSettledUiState),
+                lastSettledUiState: InboxSettledUiState | null,
+                searchParams: Record<string, unknown>,
+                isSelfDrivingSetUp: boolean,
+                isWizardRunning: boolean
+            ): InboxOnboardingMode => {
+                if (searchParams.setup === 'github-first' && !isSelfDrivingSetUp && !isWizardRunning) {
+                    return 'takeover'
+                }
+                return resolveDisplayMode(resolvedOnboardingMode, lastSettledUiState)
+            },
         ],
     }),
 


### PR DESCRIPTION
Currently, onboarding to self-driving starts with running a `Wizard` command, which blocks at some point on establishing a GitHub connection.

This PR creates an experimental path that _starts_ with the GitHub connection, and the moves to the Wizard step, which should now be able to complete cleanly without waiting for a user.

## Problem


## Changes

Users subject to the feature flag will now see a "Connect to GitHub" button instead of the Wizard prompt. After GitHub is successfully connected, they'll see the wizard step.

Feature flag is here: https://us.posthog.com/project/2/feature_flags/856846

![Screenshot 2026-08-31 at 5.04.22 PM](https://raw.githubusercontent.com/PostHog/pr-assets/4cab9d407cb93a9fb15014374c25538f665fd407/2026/08/0bd8a23c-5283-4936-ac06-46ad169eac64.png)

![Screenshot 2026-08-31 at 5.13.24 PM](https://raw.githubusercontent.com/PostHog/pr-assets/09df867dcdfaed29e207b8e150e861ac0591fa2d/2026/08/917e1756-ed76-4f57-8358-3370d15752a0.png)

## How did you test this code?

There are a number of potential edge cases here and I attempted to force data states to check each of these. I'm likely missing some more subtle ones.

![Screenshot 2026-08-31 at 5.41.17 PM](https://raw.githubusercontent.com/PostHog/pr-assets/c5781026c620a783f4db4bd3dd63fb6d1af811ac/2026/08/844313f5-dfeb-4b83-9d36-c23887c577fc.png)

![Screenshot 2026-08-31 at 5.29.43 PM](https://raw.githubusercontent.com/PostHog/pr-assets/e30fe74dec593cd10553739053d5d029f1489232/2026/08/95458fb9-cee0-4586-9523-e6dc6c1d4003.png)

![Screenshot 2026-08-31 at 5.33.18 PM](https://raw.githubusercontent.com/PostHog/pr-assets/2e2dd7f9b78f166b6cfafe084bf1ba4771591911/2026/08/7e55d03f-d94e-49eb-b55d-f9cbb31eff90.png)

![Screenshot 2026-08-31 at 5.24.01 PM](https://raw.githubusercontent.com/PostHog/pr-assets/38eba972ab3188e5e6752d072ae2734ee22e76af/2026/08/e732af6a-04af-4f69-b84d-0085df6fea3b.png)

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
