### PR TITLE
fix(warehouse-sources): stop retrying sources whose hostname is gone

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -66,6 +66,9 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
     ResumableSource,
     error_message_matches,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http.proxy_errors import (
+    UNRESOLVABLE_SOURCE_HOST_ERROR,
+)
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.acquire_v3_lock import (
     AcquireV3LockActivityInputs,
     CheckPipelineVersionActivityInputs,
@@ -134,6 +137,15 @@ Any_Source_Errors: dict[str, str | None] = {
         "table replication, then re-enable the sync."
     ),
     "Integration matching query does not exist": "The connected account for this source is no longer available — it may have been disconnected. Please reconnect the source's account.",
+    # Raised by `_handle_import_error` when the egress proxy could not reach the source and the
+    # hostname returns NXDOMAIN. The name is fixed config, so every retry resolves the same dead
+    # host. See sources/common/http/proxy_errors.py for why the proxy hides this from the sources
+    # that already classify a resolver failure themselves.
+    UNRESOLVABLE_SOURCE_HOST_ERROR: (
+        "We couldn't find the server for this source. Its address no longer exists, which usually "
+        "means the service was deleted or renamed. Check the connection settings, update the host "
+        "if it changed, then re-enable the sync."
+    ),
     # A fatal TLS alert from the remote host (raised in the shared HTTP transport for every
     # REST-based source). The server refused the handshake, which is deterministic for a given
     # host/TLS config — retrying replays the identical failure, so it's not transient. Usually a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/proxy_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/proxy_errors.py
@@ -25,12 +25,30 @@ from urllib.parse import urlparse
 # customer-facing message and disable the schema, so the two must stay in step.
 UNRESOLVABLE_SOURCE_HOST_ERROR = "The source's hostname does not exist in DNS"
 
+# Recorded on a run that found the hostname missing while the condition is still inside its grace
+# window. `_handle_import_error` counts these across runs to decide when the condition has lasted
+# long enough to act on. It must not contain `UNRESOLVABLE_SOURCE_HOST_ERROR` or any other
+# `Any_Source_Errors` key, because the finalization activity matches that dict against the recorded
+# error text and would disable the schema on the first occurrence, which is what the grace prevents.
+UNRESOLVABLE_SOURCE_HOST_PENDING = "The source's hostname did not resolve on this run"
+
 _PROXY_CONNECT_FAILURE_MARKERS = ("cannot connect to proxy", "tunnel connection failed")
 
 # urllib3 names the destination in its pool repr, e.g. `HTTPSConnectionPool(host='x.com', port=443)`.
 # Used only when the exception carries no request to read the URL from, which is the case for vendor
-# SDKs that re-wrap the failure in their own error type.
-_POOL_HOST = re.compile(r"host='([^']+)'")
+# SDKs that re-wrap the failure in their own error type. The pool prefix is part of the pattern
+# because an error message can also carry a response body, and a bare `host='...'` search would take
+# whatever the source echoed back instead of the destination we connected to.
+_POOL_HOST = re.compile(r"HTTPS?ConnectionPool\(host='([^']+)'")
+
+# A hostname we are willing to resolve. The candidate comes out of an error message or a URL, so it
+# can be arbitrary text; resolving something that is not a hostname would return NXDOMAIN and
+# disable a schema whose real host is alive.
+_PLAUSIBLE_HOSTNAME = re.compile(r"^(?=.{1,253}$)[A-Za-z0-9_-]{1,63}(\.[A-Za-z0-9_-]{1,63})*\.?$")
+
+# How long to wait for the resolver. `getaddrinfo` has no timeout of its own, so a wedged resolver
+# would otherwise hold this failure path until the activity's own start-to-close timeout.
+_RESOLVE_TIMEOUT_SECONDS = 5
 
 # Only a definitive "this name does not exist" is permanent. EAI_AGAIN (a temporary resolver
 # failure) and every other socket error stay retryable, so a resolver problem on our side cannot
@@ -57,12 +75,17 @@ def _destination_host(error: BaseException) -> str | None:
     request = getattr(error, "request", None)
     url = getattr(request, "url", None)
     if url:
-        host = urlparse(url).hostname
-        if host:
+        try:
+            host = urlparse(url).hostname
+        except ValueError:
+            host = None
+        if host and _PLAUSIBLE_HOSTNAME.match(host):
             return host
 
     match = _POOL_HOST.search(str(error))
-    return match.group(1) if match else None
+    if match and _PLAUSIBLE_HOSTNAME.match(match.group(1)):
+        return match.group(1)
+    return None
 
 
 def _resolves(host: str) -> bool:
@@ -70,7 +93,11 @@ def _resolves(host: str) -> bool:
         socket.getaddrinfo(host, None)
     except socket.gaierror as e:
         return e.errno not in _PERMANENT_DNS_ERRNOS
-    except OSError:
+    except Exception:
+        # Anything the resolver raises that is not a name-resolution verdict leaves the question
+        # unanswered, so the sync stays retryable. `getaddrinfo` raises `UnicodeError` (not an
+        # `OSError`) for a label over 63 characters, and letting that escape would replace the
+        # source's real error with a spurious one and lose the actual cause.
         return True
     return True
 
@@ -81,6 +108,10 @@ async def unresolvable_host_behind_proxy(error: BaseException) -> str | None:
     Returns ``None`` for any other error, and for a CONNECT failure whose host still resolves,
     because the proxy or the destination can still recover. ``getaddrinfo`` blocks for as long as
     the resolver takes, so it runs off the event loop to keep activity heartbeats on time.
+
+    Every uncertain outcome returns ``None``: an unreadable host, a resolver that does not answer
+    in time, and any resolver error short of "this name does not exist". The caller disables the
+    customer's schema on a hit, so the cost of a wrong "dead" is much higher than another retry.
     """
     if not _is_proxy_connect_failure(error):
         return None
@@ -89,4 +120,9 @@ async def unresolvable_host_behind_proxy(error: BaseException) -> str | None:
     if host is None:
         return None
 
-    return None if await asyncio.to_thread(_resolves, host) else host
+    try:
+        resolves = await asyncio.wait_for(asyncio.to_thread(_resolves, host), _RESOLVE_TIMEOUT_SECONDS)
+    except TimeoutError:
+        return None
+
+    return None if resolves else host

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/proxy_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/proxy_errors.py
@@ -1,0 +1,92 @@
+"""Classification of CONNECT failures against the egress proxy.
+
+Outbound source traffic goes through the Smokescreen egress proxy, which resolves the
+destination host for us. When that resolution fails, Smokescreen answers the CONNECT with
+``502 Bad gateway``, and the connector sees
+``ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 502 Bad gateway'))``.
+
+That text is the same whether the hostname no longer exists or the proxy could not reach a
+host that does, so the message cannot separate a permanent failure from a transient one.
+Sources that resolve DNS themselves already treat an unresolvable host as non-retryable (the
+``Name or service not known`` entries in clickhouse/source.py and databricks/source.py). The
+proxy hop hides the resolver error behind a gateway status, and several sources list that
+status as retryable, so a deleted source host is retried on every scheduled run instead.
+Resolving the host once restores the existing classification for proxied traffic.
+"""
+
+from __future__ import annotations
+
+import re
+import socket
+import asyncio
+from urllib.parse import urlparse
+
+# Stable prefix of `UnresolvableSourceHostError`. `Any_Source_Errors` matches it to pick the
+# customer-facing message and disable the schema, so the two must stay in step.
+UNRESOLVABLE_SOURCE_HOST_ERROR = "The source's hostname does not exist in DNS"
+
+_PROXY_CONNECT_FAILURE_MARKERS = ("cannot connect to proxy", "tunnel connection failed")
+
+# urllib3 names the destination in its pool repr, e.g. `HTTPSConnectionPool(host='x.com', port=443)`.
+# Used only when the exception carries no request to read the URL from, which is the case for vendor
+# SDKs that re-wrap the failure in their own error type.
+_POOL_HOST = re.compile(r"host='([^']+)'")
+
+# Only a definitive "this name does not exist" is permanent. EAI_AGAIN (a temporary resolver
+# failure) and every other socket error stay retryable, so a resolver problem on our side cannot
+# disable a source whose host is fine. EAI_NODATA is absent on some platforms.
+_PERMANENT_DNS_ERRNOS = frozenset(
+    code for code in (getattr(socket, name, None) for name in ("EAI_NONAME", "EAI_NODATA")) if code is not None
+)
+
+
+class UnresolvableSourceHostError(Exception):
+    """A source's hostname returned NXDOMAIN, so no retry can reach it."""
+
+    def __init__(self, host: str) -> None:
+        super().__init__(f"{UNRESOLVABLE_SOURCE_HOST_ERROR}: {host}")
+        self.host = host
+
+
+def _is_proxy_connect_failure(error: BaseException) -> bool:
+    error_msg = str(error).lower()
+    return any(marker in error_msg for marker in _PROXY_CONNECT_FAILURE_MARKERS)
+
+
+def _destination_host(error: BaseException) -> str | None:
+    request = getattr(error, "request", None)
+    url = getattr(request, "url", None)
+    if url:
+        host = urlparse(url).hostname
+        if host:
+            return host
+
+    match = _POOL_HOST.search(str(error))
+    return match.group(1) if match else None
+
+
+def _resolves(host: str) -> bool:
+    try:
+        socket.getaddrinfo(host, None)
+    except socket.gaierror as e:
+        return e.errno not in _PERMANENT_DNS_ERRNOS
+    except OSError:
+        return True
+    return True
+
+
+async def unresolvable_host_behind_proxy(error: BaseException) -> str | None:
+    """Return the destination host when ``error`` is a proxy CONNECT failure for a dead hostname.
+
+    Returns ``None`` for any other error, and for a CONNECT failure whose host still resolves,
+    because the proxy or the destination can still recover. ``getaddrinfo`` blocks for as long as
+    the resolver takes, so it runs off the event loop to keep activity heartbeats on time.
+    """
+    if not _is_proxy_connect_failure(error):
+        return None
+
+    host = _destination_host(error)
+    if host is None:
+        return None
+
+    return None if await asyncio.to_thread(_resolves, host) else host

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/tests/test_proxy_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/tests/test_proxy_errors.py
@@ -1,3 +1,4 @@
+import time
 import socket
 
 import pytest
@@ -36,6 +37,49 @@ async def test_only_a_definitive_nxdomain_is_treated_as_permanent(
 ):
     with mock.patch.object(socket, "getaddrinfo", side_effect=resolver_error):
         assert await proxy_errors.unresolvable_host_behind_proxy(ProxyError(PROXY_502)) == expected
+
+
+@pytest.mark.asyncio
+async def test_a_resolver_error_that_is_not_a_name_verdict_does_not_escape():
+    # `getaddrinfo` raises UnicodeError (not OSError) for a DNS label over 63 characters. Letting it
+    # escape replaces the source's real error with a spurious one inside the shared error handler,
+    # which loses the actual cause and burns the retry budget.
+    long_label = "a" * 64
+    error = ProxyError(
+        f"HTTPSConnectionPool(host='{long_label}.example.com', port=443): Max retries exceeded "
+        "(Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 502 Bad gateway')))"
+    )
+
+    assert await proxy_errors.unresolvable_host_behind_proxy(error) is None
+
+
+@pytest.mark.asyncio
+async def test_host_comes_from_the_pool_repr_not_from_echoed_response_text():
+    # A source can echo `host='...'` back in a response body. Taking the first match in the message
+    # would resolve that text, get NXDOMAIN, and disable a schema whose real host is alive.
+    error = ProxyError(
+        'Source responded: {"detail": "host=\'wat is this\' Cannot connect to proxy."} '
+        "HTTPSConnectionPool(host='real-and-alive.example.com', port=443)"
+    )
+
+    with mock.patch.object(socket, "getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]) as resolve:
+        assert await proxy_errors.unresolvable_host_behind_proxy(error) is None
+
+    assert resolve.call_args.args[0] == "real-and-alive.example.com"
+
+
+@pytest.mark.asyncio
+async def test_a_resolver_that_does_not_answer_in_time_stays_retryable():
+    # `getaddrinfo` has no timeout of its own, so a wedged resolver would otherwise hold this path
+    # until the activity's own start-to-close timeout.
+    def _hang(*_args: object, **_kwargs: object) -> None:
+        time.sleep(30)
+
+    with (
+        mock.patch.object(proxy_errors, "_RESOLVE_TIMEOUT_SECONDS", 0.05),
+        mock.patch.object(socket, "getaddrinfo", side_effect=_hang),
+    ):
+        assert await proxy_errors.unresolvable_host_behind_proxy(ProxyError(PROXY_502)) is None
 
 
 @pytest.mark.asyncio

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/tests/test_proxy_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/tests/test_proxy_errors.py
@@ -1,0 +1,73 @@
+import socket
+
+import pytest
+from unittest import mock
+
+from parameterized import parameterized
+from requests.exceptions import ProxyError
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import proxy_errors
+
+PROXY_502 = (
+    "HTTPSConnectionPool(host='gone.my.salesforce.com', port=443): Max retries exceeded with url: "
+    "/services/oauth2/token (Caused by ProxyError('Cannot connect to proxy.', "
+    "OSError('Tunnel connection failed: 502 Bad gateway')))"
+)
+
+
+def _gaierror(errno: int) -> socket.gaierror:
+    return socket.gaierror(errno, "resolver said so")
+
+
+@parameterized.expand(
+    [
+        # The bug this module exists for: a hostname that no longer exists is replayed on every
+        # scheduled run because the proxy reports it as a gateway status.
+        ("nxdomain", _gaierror(socket.EAI_NONAME), "gone.my.salesforce.com"),
+        # A resolver outage on our side must never disable a customer's working source, so
+        # anything short of "this name does not exist" stays retryable.
+        ("temporary_resolver_failure", _gaierror(socket.EAI_AGAIN), None),
+        ("resolver_socket_error", OSError("resolver socket blew up"), None),
+    ]
+)
+@pytest.mark.asyncio
+async def test_only_a_definitive_nxdomain_is_treated_as_permanent(
+    _name: str, resolver_error: Exception, expected: str | None
+):
+    with mock.patch.object(socket, "getaddrinfo", side_effect=resolver_error):
+        assert await proxy_errors.unresolvable_host_behind_proxy(ProxyError(PROXY_502)) == expected
+
+
+@pytest.mark.asyncio
+async def test_proxy_failure_against_a_live_host_stays_retryable():
+    with mock.patch.object(socket, "getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]):
+        assert await proxy_errors.unresolvable_host_behind_proxy(ProxyError(PROXY_502)) is None
+
+
+@parameterized.expand(
+    [
+        ("connection_reset", ProxyError("Connection reset by peer")),
+        ("unrelated", ValueError("nothing to do with the proxy")),
+    ]
+)
+@pytest.mark.asyncio
+async def test_errors_that_are_not_proxy_connect_failures_are_ignored(_name: str, error: Exception):
+    # No resolver patch: a non-CONNECT error must be rejected before any DNS lookup happens.
+    assert await proxy_errors.unresolvable_host_behind_proxy(error) is None
+
+
+@pytest.mark.asyncio
+async def test_host_is_read_from_the_request_url_when_the_message_has_no_pool_repr():
+    error = ProxyError("Cannot connect to proxy.")
+    error.request = mock.MagicMock(url="https://gone.example.com/v1/records?token=x")
+
+    with mock.patch.object(socket, "getaddrinfo", side_effect=_gaierror(socket.EAI_NONAME)):
+        assert await proxy_errors.unresolvable_host_behind_proxy(error) == "gone.example.com"
+
+
+@pytest.mark.asyncio
+async def test_proxy_failure_with_no_discoverable_host_is_ignored():
+    with mock.patch.object(socket, "getaddrinfo", side_effect=_gaierror(socket.EAI_NONAME)) as resolve:
+        assert await proxy_errors.unresolvable_host_behind_proxy(ProxyError("Cannot connect to proxy.")) is None
+
+    resolve.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -69,6 +69,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.his
     history_start_for_schema,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http.proxy_errors import (
+    UNRESOLVABLE_SOURCE_HOST_PENDING,
     UnresolvableSourceHostError,
     unresolvable_host_behind_proxy,
 )
@@ -555,6 +556,43 @@ POSTHOG_DATABASE_UNAVAILABLE_MESSAGE = (
 )
 
 
+# How long the source's hostname must stay missing before the sync is disabled. A wall-clock span
+# rather than a run count, so a schema on a fast cadence gets the same protection from a short DNS
+# outage as one that syncs daily. The hosts this targets have been unreachable for weeks, so the
+# wait costs nothing against the retrying it prevents.
+_UNRESOLVABLE_HOST_GRACE = dt.timedelta(hours=6)
+
+# Bound on how far back the streak scan reads. A schema on a five-minute cadence produces about 72
+# runs inside the grace window, so this leaves room for that plus a wide margin.
+_UNRESOLVABLE_HOST_SCAN_LIMIT = 250
+
+
+@database_sync_to_async_pool
+def _unresolvable_host_streak_started_at(team_id: int, schema_id: uuid.UUID, run_id: str) -> Optional[dt.datetime]:
+    """When the unbroken run of unresolvable-hostname failures began, or None if this run is the first.
+
+    The schema's own job history is the record, so no extra state is stored: each run inside the
+    grace window records `UNRESOLVABLE_SOURCE_HOST_PENDING`, and any other terminal outcome ends the
+    streak. A successful run therefore clears it without anything having to reset a counter.
+    """
+    recent_runs = (
+        ExternalDataJob.objects.filter(team_id=team_id, schema_id=schema_id, status__in=TERMINAL_JOB_STATUSES)
+        .exclude(pk=run_id)
+        .order_by("-created_at")
+        .values_list("created_at", "status", "latest_error")[:_UNRESOLVABLE_HOST_SCAN_LIMIT]
+    )
+
+    streak_started_at: Optional[dt.datetime] = None
+    for created_at, status, latest_error in recent_runs:
+        if status != ExternalDataJob.Status.FAILED:
+            break
+        if UNRESOLVABLE_SOURCE_HOST_PENDING not in (latest_error or ""):
+            break
+        streak_started_at = created_at
+
+    return streak_started_at
+
+
 async def _handle_import_error(
     job_inputs: PipelineInputs,
     logger: FilteringBoundLogger,
@@ -669,22 +707,6 @@ async def _handle_import_error(
             job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
         )
 
-    # The egress proxy resolves the destination for us, so a hostname that no longer exists comes
-    # back as a CONNECT failure rather than a resolver error. Sources list that gateway status in
-    # get_retryable_errors, which is right for a proxy that is briefly unwell and wrong for a host
-    # that is gone. Classify it here, ahead of those lists, so a deleted source host stops the sync
-    # instead of being retried on every scheduled run.
-    dead_host = await unresolvable_host_behind_proxy(error)
-    if dead_host is not None:
-        # The job's internal error is `str(cause.cause)`, so the stable message has to sit on the
-        # exception handed to handle_non_retryable_error for Any_Source_Errors to match it and
-        # disable the schema. Keep the original as __cause__ so the proxy detail stays debuggable.
-        dns_error = UnresolvableSourceHostError(dead_host)
-        dns_error.__cause__ = error
-        await handle_non_retryable_error(
-            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, str(dns_error), logger, dns_error
-        )
-
     # RESTClientRetryableError only escapes the shared REST engine's own tenacity retry loop once
     # that budget (rate limits, transient 5xx, connection resets/timeouts) is exhausted — the same
     # "reaches us only after internal retries exhaust" contract as get_retryable_errors below.
@@ -726,6 +748,40 @@ async def _handle_import_error(
         await logger.awarning(error_msg)
         await logger.adebug("Transient app-DB error - re-raising for Temporal retry")
         raise NonReportableError(POSTHOG_DATABASE_UNAVAILABLE_MESSAGE) from error
+
+    # The egress proxy resolves the destination for us, so a hostname that no longer exists comes
+    # back as a CONNECT failure rather than a resolver error. Sources list that gateway status in
+    # get_retryable_errors, which is right for a proxy that is briefly unwell and wrong for a host
+    # that is gone. Classify it ahead of those lists so a deleted source host stops the sync instead
+    # of being retried on every scheduled run.
+    #
+    # This sits below every check that identifies PostHog's own infrastructure, because the
+    # warehouse's own S3 traffic also egresses through that proxy unless the bypass flag is on
+    # (products/data_warehouse/backend/s3_proxy.py). Those checks must claim their errors first, or
+    # a failure of ours could be reported to the customer as their dead hostname.
+    dead_host = await unresolvable_host_behind_proxy(error)
+    if dead_host is not None:
+        # A hostname can go missing for minutes without the source being gone: a zone edit, a DNS
+        # provider hiccup, or a cached negative answer. Disabling the schema makes the customer
+        # re-enable it by hand, so wait for the condition to hold across separate scheduled runs
+        # before acting. handle_non_retryable_error's own cushion cannot serve here because its
+        # counter is keyed on the run, so all of its attempts sit inside this one run.
+        unresolvable_since = await _unresolvable_host_streak_started_at(
+            job_inputs.team_id, job_inputs.schema_id, job_inputs.run_id
+        )
+        if unresolvable_since is None or dt.datetime.now(dt.UTC) - unresolvable_since < _UNRESOLVABLE_HOST_GRACE:
+            await logger.awarning(f"{UNRESOLVABLE_SOURCE_HOST_PENDING}: {dead_host}")
+            await logger.adebug("Source hostname did not resolve - retrying until the grace window passes")
+            raise NonReportableError(f"{UNRESOLVABLE_SOURCE_HOST_PENDING}: {dead_host}") from error
+
+        # The job's internal error is `str(cause.cause)`, so the stable message has to sit on the
+        # exception handed to handle_non_retryable_error for Any_Source_Errors to match it and
+        # disable the schema. Keep the original as __cause__ so the proxy detail stays debuggable.
+        dns_error = UnresolvableSourceHostError(dead_host)
+        dns_error.__cause__ = error
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, str(dns_error), logger, dns_error
+        )
 
     # Cross-source non-retryable errors (missing primary key on an incremental table, bad SSH tunnel
     # auth, a widened column type) are raised from shared pipeline code, not any one source. The

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -68,6 +68,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.fan
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.history_window import (
     history_start_for_schema,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http.proxy_errors import (
+    UnresolvableSourceHostError,
+    unresolvable_host_behind_proxy,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.job_context import bind_job_context
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
     RESTClientNonRetryableError,
@@ -663,6 +667,22 @@ async def _handle_import_error(
     if isinstance(error, UndecryptedIntegrationSecretError):
         await handle_non_retryable_error(
             job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
+
+    # The egress proxy resolves the destination for us, so a hostname that no longer exists comes
+    # back as a CONNECT failure rather than a resolver error. Sources list that gateway status in
+    # get_retryable_errors, which is right for a proxy that is briefly unwell and wrong for a host
+    # that is gone. Classify it here, ahead of those lists, so a deleted source host stops the sync
+    # instead of being retried on every scheduled run.
+    dead_host = await unresolvable_host_behind_proxy(error)
+    if dead_host is not None:
+        # The job's internal error is `str(cause.cause)`, so the stable message has to sit on the
+        # exception handed to handle_non_retryable_error for Any_Source_Errors to match it and
+        # disable the schema. Keep the original as __cause__ so the proxy detail stays debuggable.
+        dns_error = UnresolvableSourceHostError(dead_host)
+        dns_error.__cause__ = error
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, str(dns_error), logger, dns_error
         )
 
     # RESTClientRetryableError only escapes the shared REST engine's own tenacity retry loop once

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -1,7 +1,7 @@
 import uuid
 import socket
 import contextlib
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 import pytest
@@ -31,6 +31,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import SimpleSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http.proxy_errors import (
     UNRESOLVABLE_SOURCE_HOST_ERROR,
+    UNRESOLVABLE_SOURCE_HOST_PENDING,
     UnresolvableSourceHostError,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
@@ -137,6 +138,73 @@ class TestGetModelsPrefetchesSource(BaseTest):
 
         with self.assertNumQueries(0):
             models.job.folder_path()
+
+
+class TestUnresolvableHostStreak(BaseTest):
+    def _schema(self) -> tuple[ExternalDataSource, ExternalDataSchema]:
+        source = ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()), connection_id=str(uuid.uuid4()), team=self.team, source_type="Salesforce"
+        )
+        schema = ExternalDataSchema.objects.create(name="Account", team=self.team, source=source, sync_type_config={})
+        return source, schema
+
+    def _job(
+        self,
+        source: ExternalDataSource,
+        schema: ExternalDataSchema,
+        status: str,
+        minutes_ago: int,
+        latest_error: str | None = None,
+    ) -> ExternalDataJob:
+        job = ExternalDataJob.objects.create(
+            team=self.team, pipeline=source, schema=schema, status=status, latest_error=latest_error
+        )
+        ExternalDataJob.objects.filter(pk=job.pk).update(created_at=datetime.now(UTC) - timedelta(minutes=minutes_ago))
+        job.refresh_from_db()
+        return job
+
+    def _streak_started_at(self, schema: ExternalDataSchema, run_id: str) -> datetime | None:
+        return cast(Any, module._unresolvable_host_streak_started_at).func(self.team.pk, schema.pk, run_id)
+
+    def test_streak_spans_consecutive_unresolvable_failures(self) -> None:
+        source, schema = self._schema()
+        pending = f"{UNRESOLVABLE_SOURCE_HOST_PENDING}: gone.example.com"
+        oldest = self._job(source, schema, ExternalDataJob.Status.FAILED, 400, pending)
+        self._job(source, schema, ExternalDataJob.Status.FAILED, 200, pending)
+        current = self._job(source, schema, ExternalDataJob.Status.RUNNING, 0)
+
+        started_at = self._streak_started_at(schema, str(current.pk))
+
+        assert started_at is not None
+        assert int(started_at.timestamp()) == int(oldest.created_at.timestamp())
+
+    def test_a_successful_run_ends_the_streak(self) -> None:
+        # Without this the streak reaches back past a recovery, so a source that broke, worked
+        # again, and broke a minute ago would be disabled on that minute-old failure.
+        source, schema = self._schema()
+        pending = f"{UNRESOLVABLE_SOURCE_HOST_PENDING}: gone.example.com"
+        self._job(source, schema, ExternalDataJob.Status.FAILED, 400, pending)
+        self._job(source, schema, ExternalDataJob.Status.COMPLETED, 300)
+        recent = self._job(source, schema, ExternalDataJob.Status.FAILED, 10, pending)
+        current = self._job(source, schema, ExternalDataJob.Status.RUNNING, 0)
+
+        started_at = self._streak_started_at(schema, str(current.pk))
+
+        assert started_at is not None
+        assert int(started_at.timestamp()) == int(recent.created_at.timestamp())
+
+    def test_a_different_failure_ends_the_streak(self) -> None:
+        source, schema = self._schema()
+        self._job(source, schema, ExternalDataJob.Status.FAILED, 400, "Something else entirely")
+        current = self._job(source, schema, ExternalDataJob.Status.RUNNING, 0)
+
+        assert self._streak_started_at(schema, str(current.pk)) is None
+
+    def test_no_prior_runs_means_no_streak(self) -> None:
+        source, schema = self._schema()
+        current = self._job(source, schema, ExternalDataJob.Status.RUNNING, 0)
+
+        assert self._streak_started_at(schema, str(current.pk)) is None
 
 
 @pytest.mark.asyncio
@@ -590,8 +658,11 @@ async def test_proxy_failure_for_a_dead_host_beats_the_sources_retryable_gateway
     logger.aexception = mock.AsyncMock()
     logger.adebug = mock.AsyncMock()
 
+    stale = datetime.now(UTC) - module._UNRESOLVABLE_HOST_GRACE - timedelta(minutes=1)
+
     with (
         mock.patch.object(socket, "getaddrinfo", side_effect=socket.gaierror(socket.EAI_NONAME, "not known")),
+        mock.patch.object(module, "_unresolvable_host_streak_started_at", new=mock.AsyncMock(return_value=stale)),
         mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
         mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
     ):
@@ -607,6 +678,51 @@ async def test_proxy_failure_for_a_dead_host_beats_the_sources_retryable_gateway
     assert isinstance(routed, UnresolvableSourceHostError)
     assert UNRESOLVABLE_SOURCE_HOST_ERROR in str(routed)
     assert routed.__cause__ is error
+    logger.aexception.assert_not_awaited()
+
+
+@parameterized.expand(
+    [
+        # Nothing before this run: a single missing lookup must never disable a sync on its own.
+        ("first_occurrence", None),
+        # Seen before, but not for long enough that a short DNS outage is ruled out.
+        ("inside_grace", timedelta(minutes=30)),
+    ]
+)
+@pytest.mark.asyncio
+async def test_a_recently_unresolvable_host_keeps_retrying_instead_of_disabling(_name: str, age: timedelta | None):
+    # A hostname can go missing for minutes without the source being gone (a zone edit, a DNS
+    # provider hiccup, a cached negative answer). Disabling on that costs the customer a manual
+    # re-enable, so the condition has to outlast the grace window first.
+    error = ProxyError(
+        "HTTPSConnectionPool(host='gone.example.com', port=443): Max retries exceeded with url: /? "
+        "(Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 502 Bad gateway')))"
+    )
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    started_at = None if age is None else datetime.now(UTC) - age
+
+    with (
+        mock.patch.object(socket, "getaddrinfo", side_effect=socket.gaierror(socket.EAI_NONAME, "not known")),
+        mock.patch.object(module, "_unresolvable_host_streak_started_at", new=mock.AsyncMock(return_value=started_at)),
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
+    ):
+        with pytest.raises(NonReportableError) as raised:
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_not_awaited()
+    # The recorded text is what the next run counts, and it must not carry the permanent marker or
+    # the finalization activity would disable the schema on this very run.
+    assert UNRESOLVABLE_SOURCE_HOST_PENDING in str(raised.value)
+    assert UNRESOLVABLE_SOURCE_HOST_ERROR not in str(raised.value)
     logger.aexception.assert_not_awaited()
 
 
@@ -1016,6 +1132,10 @@ async def test_integration_failure_is_classified_before_the_bare_404_rule():
     [
         ("integration_credential", "INTEGRATION_CREDENTIAL_UNAVAILABLE_MESSAGE"),
         ("posthog_database", "POSTHOG_DATABASE_UNAVAILABLE_MESSAGE"),
+        # Recorded on every run inside the unresolvable-host grace window. A pattern matching it
+        # would disable the schema on the first missing lookup, which is the whole thing the grace
+        # window exists to prevent.
+        ("unresolvable_host_pending", "UNRESOLVABLE_SOURCE_HOST_PENDING"),
     ]
 )
 def test_the_customer_facing_message_matches_no_non_retryable_pattern(_name: str, message_attr: str):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -1,4 +1,5 @@
 import uuid
+import socket
 import contextlib
 from datetime import datetime
 from typing import Any, cast
@@ -11,7 +12,7 @@ from django.db import InterfaceError, InternalError, OperationalError
 
 from jsonpath_ng.exceptions import JsonPathParserError
 from parameterized import parameterized
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ProxyError
 
 from posthog.integration_secrets.errors import (
     IntegrationServiceMisconfiguredError,
@@ -28,6 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
     SchemaColumnTypeChangedException,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http.proxy_errors import (
+    UNRESOLVABLE_SOURCE_HOST_ERROR,
+    UnresolvableSourceHostError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
     RESTClientNonRetryableError,
     RESTClientRetryableError,
@@ -566,10 +571,82 @@ async def test_jsonpath_error_routes_through_handler_without_source_opt_in():
     logger.aexception.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_proxy_failure_for_a_dead_host_beats_the_sources_retryable_gateway_pattern():
+    # The egress proxy resolves the destination, so a hostname that no longer exists arrives as the
+    # same gateway status a briefly unwell proxy produces. Sources list that status in
+    # get_retryable_errors (clickhouse/source.py does), so without the DNS check the run is retried
+    # on every scheduled sync forever. The dead host has to win over the source's own pattern.
+    error = ProxyError(
+        "HTTPSConnectionPool(host='gone.example.com', port=443): Max retries exceeded with url: /? "
+        "(Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 502 Bad gateway')))"
+    )
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = {"Tunnel connection failed: 502"}
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with (
+        mock.patch.object(socket, "getaddrinfo", side_effect=socket.gaierror(socket.EAI_NONAME, "not known")),
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
+    ):
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args is not None
+    # The finalization activity reads `str(cause.cause)` to pick the customer-facing message and
+    # disable the schema, so the stable text has to reach it on this exception.
+    routed = handle_mock.await_args.args[5]
+    assert isinstance(routed, UnresolvableSourceHostError)
+    assert UNRESOLVABLE_SOURCE_HOST_ERROR in str(routed)
+    assert routed.__cause__ is error
+    logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_proxy_failure_for_a_live_host_stays_retryable():
+    # The counterpart guard: a proxy that is briefly unwell talking to a host that still resolves
+    # must keep retrying, or a transient gateway blip would disable a working source.
+    error = ProxyError(
+        "HTTPSConnectionPool(host='live.example.com', port=443): Max retries exceeded with url: /? "
+        "(Caused by ProxyError('Cannot connect to proxy.', OSError('Tunnel connection failed: 502 Bad gateway')))"
+    )
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = {"Tunnel connection failed: 502"}
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with (
+        mock.patch.object(socket, "getaddrinfo", return_value=[(2, 1, 6, "", ("93.184.216.34", 443))]),
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
+    ):
+        with pytest.raises(NonReportableError):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_not_awaited()
+    logger.awarning.assert_awaited_once()
+    logger.aexception.assert_not_awaited()
+
+
 @parameterized.expand(
     [
         # Raised in shared pipeline code (delta merge) when a keyless table syncs incrementally.
         ("primary_key", "Primary key required for incremental syncs"),
+        # Raised by _handle_import_error when the egress proxy could not reach a source whose
+        # hostname returns NXDOMAIN.
+        ("unresolvable_host", f"{UNRESOLVABLE_SOURCE_HOST_ERROR}: gone.example.com"),
         # Raised by botocore when the object storage endpoint hostname is one it rejects (e.g. an
         # underscore in a self-hosted OBJECT_STORAGE_ENDPOINT). Deterministic for the deployment, so
         # it must stop retrying instead of looping the activity's budget and reporting every attempt.


### PR DESCRIPTION
## Problem

- A data warehouse sync whose source hostname no longer exists retries on every scheduled run indefinitely, and never stops on its own.
- The customer reads "Cannot connect to proxy", which sounds like a PostHog outage, so the change they actually need to make never surfaces.
- Outbound source traffic goes through the Smokescreen egress proxy, which resolves the destination host for us and answers a dead name with `502 Bad gateway` on the CONNECT.
- Sources that resolve DNS themselves already classify an unresolvable host as non-retryable.
- Several sources also list that gateway status in `get_retryable_errors`, because a proxy can be briefly unwell.
- The proxy hop therefore turns a permanent failure into a retryable one, and the message alone cannot separate the two cases.

## Changes

- A sync whose hostname stays unresolvable now stops and tells the customer the address no longer exists and to check the connection settings.
- The hostname must stay unresolvable for six hours across separate scheduled runs before that happens. Disabling costs the customer a manual re-enable, and a name can go missing for minutes without the source being gone: a zone edit, a provider hiccup, a cached negative answer.
- Runs inside that window record a distinct message and keep retrying. The schema's own job history is the record, so there is no new state and no migration, and a successful run ends the streak without anything resetting a counter.
- The grace window is a wall-clock span, not a run count, so a schema on a fast cadence gets the same protection as one that syncs daily. A count of three on a five-minute cadence is ten minutes, shorter than typical negative-DNS caching.
- `handle_non_retryable_error` cannot bound this on its own: its counter is keyed on the run, so all of its attempts sit inside a single run, minutes apart.
- A proxy failure against a host that still resolves keeps retrying, unchanged.
- `unresolvable_host_behind_proxy` resolves the host once on a proxy CONNECT failure, in the new `sources/common/http/proxy_errors.py`.
- Every uncertain outcome stays retryable: an unreadable host, a resolver that does not answer within five seconds, and any resolver error short of "this name does not exist".
- Matching the proxy message alone cannot work, because one `502` covers both a dead name and a transient proxy fault. The lookup is what separates them.
- The classification runs below every check that identifies PostHog's own infrastructure, including the object store and the app DB. The warehouse's own S3 traffic egresses through the same proxy unless `data-warehouse-s3-proxy-bypass` is on, so those checks claim their errors first.
- No UI changes. The only visible difference is the error text on an affected sync.

> [!NOTE]
> This changes what an affected customer sees. A sync that used to retry forever now stops after the grace window, marks the schema disabled, and shows the new message. Syncs whose host resolves are unaffected.

## How did you test this code?

- `test_proxy_errors.py` covers the resolver matrix. It catches an inverted fail-open: if a temporary resolver failure were treated as permanent, a DNS wobble on our side would disable working customer sources.
- Two cases cover defects found in review of the first commit. `getaddrinfo` raises `UnicodeError`, not `OSError`, for a DNS label over 63 characters, and letting it escape replaced the source's real error with a spurious one inside the shared handler. The host pattern also matched a bare `host='...'` anywhere in the message, so a source echoing that text in a response body could stand in for the real destination.
- `TestUnresolvableHostStreak` covers the grace window against the database. Without the successful-run case, a source that broke, recovered, and broke again a minute ago would be disabled on that minute-old failure.
- Two wiring guards in `test_import_data_sync.py`. No existing test covered a classification that has to override a source's own `get_retryable_errors`, which is exactly the defect here.
- The pending message is added to the existing guard test that proves no non-retryable pattern matches it. If one ever did, the schema would be disabled on the first missing lookup and the grace window would be silently defeated.
- The classifier was checked against a real resolver, using a hostname that no longer exists and one that does, to confirm the permanent case is distinguishable.
- Not run: no manual end-to-end sync against a live source, and no verification in a deployed environment. The grace window is what bounds that gap: if the worker's resolver ever disagreed with the proxy's, the condition would have to persist for six hours before anything is disabled.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/investigating-warehouse-sources-load`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`, and `dc-review-pr` from the PostHog skill store.

The session started as triage of a recurring assessment that asked for a circuit breaker on repeated source failure. The investigation did not support that: run rates tracked each schema's configured `sync_frequency_interval` before, during, and after the failures, so there was no runaway retry loop to break. The defect found instead was narrower, and is what this PR fixes.

An earlier shape matched proxy error text against a pattern list. That was dropped because no string can distinguish a dead hostname from a transient proxy fault, which is the whole problem.

The second commit is the result of an independent review pass, run in a separate agent so the code was not reviewed by its author. It found the `UnicodeError` escape, the unanchored host pattern, and the ordering against PostHog's own infrastructure checks, and it argued that a brief false NXDOMAIN should not be able to disable a sync. The six-hour grace window is the response to that last point, chosen over a feature flag because a flag defers the risk to whoever remembers to flip it.

**Public artifact:** the production data that motivated this stayed out of the diff. No customer identifiers, hostnames, team IDs, or operational figures appear in the code, fixtures, comments, commit messages, or this description. Test fixtures use `example.com` hostnames.
