### PR TITLE
fix(ci): publish agent skills releases with the job's own token

### DIFF
--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -515,13 +515,6 @@ jobs:
                   DEBUG: 1
               run: ./bin/hogli build:skills
 
-            - name: Mint release GitHub token
-              id: release-token
-              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-              with:
-                  client-id: ${{ vars.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}
-                  private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
-
             - name: Determine next version
               id: version
               run: |
@@ -532,8 +525,11 @@ jobs:
                   echo "tag=agent-skills-v0.$((MINOR + 1)).0" >> "$GITHUB_OUTPUT"
 
             - name: Create versioned release
+              # The job's own contents:write GITHUB_TOKEN, like build-phrocs.yml and
+              # build-livestream-tui.yml. No workflow triggers off these releases, so the
+              # app token bought nothing and only added a permission that can drift away.
               env:
-                  GH_TOKEN: ${{ steps.release-token.outputs.token }}
+                  GH_TOKEN: ${{ github.token }}
                   RELEASE_TAG: ${{ steps.version.outputs.tag }}
               run: |
                   gh release create "$RELEASE_TAG" \
@@ -545,7 +541,7 @@ jobs:
 
             - name: Update latest release
               env:
-                  GH_TOKEN: ${{ steps.release-token.outputs.token }}
+                  GH_TOKEN: ${{ github.token }}
                   RELEASE_TAG: ${{ steps.version.outputs.tag }}
               run: |
                   if gh release view agent-skills-latest &>/dev/null; then


### PR DESCRIPTION
## Problem

Anyone using the PostHog plugin for Claude Code, Codex, Cursor, or Gemini has been getting a skills catalog frozen at the 3 August build. Every skill written or edited in the four weeks since then never reached them.

- The `Release agent skills` job publishes `skills.zip` to the `agent-skills-latest` release on each master push. The plugin's daily sync downloads that asset.
- The release steps minted a token from the paths-filter GitHub App. That app grants read access for change detection and cannot write releases.
- Since 3 August the release API answers `HTTP 403: Resource not accessible by integration` ([failing job](https://github.com/PostHog/posthog/actions/runs/33421439696/job/99585909198)). The last published tag is [`agent-skills-v0.715.0`](https://github.com/PostHog/posthog/releases/tag/agent-skills-v0.715.0).
- The job also turned master red on every push it reached, so this cost a red check per merge as well.

## Changes

- Skill edits reach plugin users again: the release job publishes a new `agent-skills-v0.*` tag and refreshes `agent-skills-latest` on each master push.
- Both release steps read `github.token`. The job already declares `contents: write`, which is what `build-phrocs.yml` and `build-livestream-tui.yml` do for the same job.
- Deletes the app-token mint step. Mechanical.

Nothing user-visible changes in the product, and nothing triggers off these releases, so dropping the app token costs no downstream workflow run.

> [!NOTE]
> This unblocks the producer only. On the consumer side, [PostHog/ai-plugin#203](https://github.com/PostHog/ai-plugin/pull/203) still needs to land: the plugin's sync workflow requests review from a renamed team, so `gh pr create` exits 1 and `gh pr merge --auto` never runs. Until then a fresh `skills.zip` opens a sync PR that waits for a manual merge.

## How did you test this code?

- `bin/hogli lint:workflows`: 8 checks pass across 128 workflows.
- The change cannot be exercised before merge. The release job runs only on master pushes where the pushed SHA is still the branch tip, so a PR run never reaches it.
- Not checked: whether org policy allows `contents: write` on `GITHUB_TOKEN` for release creation. [build-phrocs](https://github.com/PostHog/posthog/actions/runs/31029770968) publishes releases that way and last succeeded on 5 August, after the app token started failing, which is the evidence this works.
- `actionlint` was not run; it is not installed in this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a Slack thread about the PostHog AI plugin shipping a stale and oversized skills catalog. The thread named the frozen sync job as a known but undiagnosed problem.

Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`.

The investigation started from the plugin repo, where the daily sync workflow also fails, and traced the frozen catalog one step upstream to this job. Two independent breaks sit on the same path; this PR fixes the producer, and the linked plugin PR fixes the consumer.

The alternative was minting a token from a write-capable app such as `GH_APP_POSTHOG_RELEASER`. `github.token` was chosen because the job already holds the permission, it removes a step, and it matches the two sibling release workflows in this repo.

No PR assignee is set: the requester's GitHub handle was not verifiable from the Slack thread, and guessing one tags an unrelated account.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788189196906069?thread_ts=1788189196.906069&cid=C09SK2PAGKF)*
