### PR TITLE
fix(rokt-ads): stop retrying when the account lacks required dimensions or metrics

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/source.py
@@ -71,6 +71,19 @@ class RoktAdsSource(ResumableSource[RoktAdsSourceConfig, RoktAdsResumeConfig]):
                 "advertiser campaigns, if the time zone or currency code setting is unrecognised, or if the account "
                 "is not fully configured in One Platform. Check your account settings, or contact Rokt support."
             ),
+            # Raised by build_report_body when the account lacks a dimension that sets the row grain.
+            # Dropping the dimension would silently collapse rows, so the only safe options are to
+            # deselect the table or ask Rokt to enable the dimension — both require user action.
+            "Deselect this table or ask Rokt to enable those dimensions": (
+                "This Rokt account cannot report on one or more dimensions this table needs to identify rows. "
+                "Deselect this table in the sync settings, or contact Rokt to enable the missing dimensions "
+                "for your account, then re-enable the sync."
+            ),
+            # Raised when the account grants none of the metrics the endpoint declares.
+            "Rokt account grants none of the metrics": (
+                "This Rokt account has no metrics enabled for this table. Deselect this table in the sync "
+                "settings, or contact Rokt to enable metrics for your account, then re-enable the sync."
+            ),
         }
 
     def get_canonical_descriptions(self) -> CanonicalDescriptions:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/tests/test_rokt_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/tests/test_rokt_ads_source.py
@@ -199,6 +199,11 @@ class TestNonRetryableErrors:
         assert any("403" in key for key in errors)
         assert any("400" in key for key in errors)
 
+    def test_account_capability_errors_stop_retrying(self):
+        errors = RoktAdsSource().get_non_retryable_errors()
+        assert "Deselect this table or ask Rokt to enable those dimensions" in errors
+        assert "Rokt account grants none of the metrics" in errors
+
 
 class TestCanonicalDescriptions:
     def test_every_table_is_documented(self):


### PR DESCRIPTION
## Problem

A Rokt Ads sync that targets a table the account cannot report on (missing required dimensions or metrics) keeps retrying until the activity budget exhausts, then fails noisily. The table can never succeed without an account-side change, so every retry is wasted.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/01a05929-ae87-7880-bf5c-31953f44c4f6

## Changes

- A sync whose Rokt account lacks required dimensions or metrics now stops immediately with a user-readable message instead of retrying. The message tells the user to deselect the table or contact Rokt to enable access.
- Two new entries in `RoktAdsSource.get_non_retryable_errors()` match the stable suffixes of the errors raised by `build_report_body`.
- Mechanical: one test added to `TestNonRetryableErrors`.

## How did you test this code?

- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/tests/` locally — 74 passed.
- The new `test_account_capability_errors_stop_retrying` guards the regression: if either entry is removed from `get_non_retryable_errors`, the sync resumes retrying instead of pausing.
- Not checked: end-to-end with a live Rokt account.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error tracking issue linked above. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The error is raised in `build_report_body` when the Rokt account's capabilities (fetched from `/v1/query/accounts/{id}/{kind}/help`) do not include all dimensions declared for a table. Dropping a dimension would silently merge rows onto the wrong primary key, so the code raises rather than narrows — the right fix is to surface this to the user and stop, not retry. Both the dimension-missing and no-metrics paths share the same root cause and the same fix.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*