### PR TITLE
fix(rokt-ads): classify HTTP 400 from the report endpoint as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/source.py
@@ -62,6 +62,15 @@ class RoktAdsSource(ResumableSource[RoktAdsSourceConfig, RoktAdsResumeConfig]):
         return {
             "401 Client Error: Unauthorized for url": "Rokt rejected these credentials. Please regenerate the app ID and app secret in One Platform and reconnect.",
             "403 Client Error: Forbidden for url": "These Rokt credentials cannot read this account. Please check the account ID and the app's permissions.",
+            # The same request body is sent on every retry, so a 400 from the report endpoint will
+            # never become data. Likely causes: the account type does not support advertiser
+            # campaigns, a time zone or currency code setting is unrecognised, or the account is
+            # not fully configured in One Platform.
+            "400 Client Error: Bad Request for url": (
+                "Rokt rejected the report request as invalid. This can happen if the account type does not support "
+                "advertiser campaigns, if the time zone or currency code setting is unrecognised, or if the account "
+                "is not fully configured in One Platform. Check your account settings, or contact Rokt support."
+            ),
         }
 
     def get_canonical_descriptions(self) -> CanonicalDescriptions:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/tests/test_rokt_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/rokt_ads/tests/test_rokt_ads_source.py
@@ -197,6 +197,7 @@ class TestNonRetryableErrors:
         errors = RoktAdsSource().get_non_retryable_errors()
         assert any("401" in key for key in errors)
         assert any("403" in key for key in errors)
+        assert any("400" in key for key in errors)
 
 
 class TestCanonicalDescriptions:


### PR DESCRIPTION
## Problem

When a Rokt Ads sync encounters an HTTP 400 from the `POST /v1/query/accounts/{id}/campaigns/` endpoint, Temporal retries the activity up to its maximum budget — logging an error on every attempt — because 400 is not listed in the source's non-retryable error set. The request body is deterministic (same account, same date range, same dimensions/metrics), so retrying never changes the outcome.

Observed via error tracking: all schemas for the affected source failed within a 21-second window, consistent with a single sync run hitting the same 400 across parallel schema jobs. Likely causes include the Rokt account type not supporting advertiser campaigns, an unrecognised time zone or currency code setting, or an incomplete account configuration in One Platform.

## Changes

- Rokt Ads syncs that receive HTTP 400 now stop after the first failed attempt instead of exhausting the Temporal retry budget, and the user sees an actionable message pointing them toward their Rokt One Platform account settings.
- Mechanical: test extended to assert 400 is covered alongside the existing 401/403 assertions.

## How did you test this code?

Extended `TestNonRetryableErrors.test_auth_and_permission_failures_stop_retrying` with `assert any("400" in key for key in errors)`. This assertion would fail if the 400 entry were removed, catching the regression of "400 errors retry indefinitely with no user-facing guidance." All 73 tests in the Rokt Ads test module pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None required.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated the error via error tracking (issue `01a05929-b125-7230-b982-36faa54f9cf9`): 18 occurrences in a 21-second window for one source, all schemas, incremental sync. Stack trace confirmed the `HTTPError` originates in `RoktAdsClient.post` and propagates through `_handle_import_error` without matching any non-retryable rule. Confirmed PR [#91906](https://github.com/PostHog/posthog/pull/91906) (open) covers `RoktAdsError` capability exceptions but not `HTTPError` 400 — the two fixes are independent. Classified as user/upstream rather than a code bug: the request body is built correctly (capabilities are checked, metrics are intersected), so the 400 reflects account-level configuration the user needs to resolve. Skills invoked: `/writing-tests`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*