### PR TITLE
feat(signals): start a PR in one press, steer from the chevron

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6937,9 +6937,13 @@ snapshots:
     scenes-app-inbox-cards--skeleton--light:
         hash: v1.k794b7964.24c19ab5df1e4ccb843b1ad726752e3a98aeadaa08595e66cb4b41aff1a9e9a1.Y3z44tkU4jsAYUyXxfl72fTuZ0MKA6_S6TTNCKt5jSg
     scenes-app-inbox-createprbutton--default--dark:
-        hash: v1.k794b7964.48c126cb2fbf7e2ff90a961fec1dbe587726b4fe10346c933e7948f0c5722fc6.o3rRliF1DHQt7OSgtsMeThXxAYCAkiUcKqRxRRaqvMg
+        hash: v1.k794b7964.ed3dcef6d62105108f3ce66a23623a5ce7ab39405dfd5b58cfbdf4e48130accb.8ndY7EDwZWW7bkU8B31ICU2QZIK6Og4NxbVBPBeSn1c
     scenes-app-inbox-createprbutton--default--light:
-        hash: v1.k794b7964.afd9c8a70584e887de98dc27361817c64057c32da340ceb85f4584212bfb2dad.J1FNKAVCovRg8LIuY9uoXEFCuQ6MlUp1kFs6aJ33X5Y
+        hash: v1.k794b7964.451bf28e6745e87d652309ff7e700df19787f6a8eb1caea6511b3e167e267066.4wCG_I6-hdtHnB3OoYj3gV851OxePPZfWws6tpJ2mDk
+    scenes-app-inbox-createprbutton--steering--dark:
+        hash: v1.k794b7964.ed2c06f0785093b47269ea129ee4394971e399fe288dc9a394520a402456b260.moDVSzdoUZiJ8U-tm2T24s9NiTehnObGxIHlVOZOi24
+    scenes-app-inbox-createprbutton--steering--light:
+        hash: v1.k794b7964.90e380944266cf30b04a4066e14121297ea3b2a184face92194ec23350a384f1.As5SqMtAtiDIaP486BIfIfDUzkbg6xMi-ths87o8MeE
     scenes-app-inbox-detail--pull-request--dark:
         hash: v1.k794b7964.e3d35a1f32d39211cf8bd41914c83ec6e4ed9e0251e8b883a8fa62c048dc4165.na0HIQko2FwF9KTcKxD66kvttld6IbR_S0bejyK_1hs
     scenes-app-inbox-detail--pull-request--light:

--- a/products/signals/frontend/inbox/components/detail/CreatePrButton.stories.tsx
+++ b/products/signals/frontend/inbox/components/detail/CreatePrButton.stories.tsx
@@ -8,26 +8,31 @@ import { CreatePrButton } from './CreatePrButton'
 const meta: Meta<typeof CreatePrButton> = {
     title: 'Scenes-App/Inbox/CreatePrButton',
     component: CreatePrButton,
-    parameters: { layout: 'centered', testOptions: { snapshotTargetSelector: '.Popover' } },
+    parameters: { layout: 'centered' },
 }
 export default meta
 
 type Story = StoryObj<typeof CreatePrButton>
 
-// The popover is closed until the trigger is pressed, so the story opens it — otherwise the
-// snapshot is of the same small button and the note box under review never renders. `findByText`
-// rather than `getByText`: the trigger mounts a kea logic chain reaching organization and user
-// state, so on a slow runner the play function can reach an empty canvas and fail the story.
-const openPopover: Story['play'] = async ({ canvasElement }) => {
-    await userEvent.click(await within(canvasElement).findByText('Create PR'))
-    await waitFor(() => {
-        if (!document.querySelector('.Popover')) {
-            throw new Error('popover not open yet')
-        }
-    })
+const report = makeReport({ title: 'Exceptions spiked after the 18 June deploy' })
+
+/** The resting split button. The divider is the only cue that the chevron does something else. */
+export const Default: Story = {
+    render: () => <CreatePrButton report={report} />,
 }
 
-export const Default: Story = {
-    render: () => <CreatePrButton report={makeReport({ title: 'Exceptions spiked after the 18 June deploy' })} />,
-    play: openPopover,
+// The note box is closed until the chevron is pressed, so the story opens it. `findByLabelText`
+// rather than `getByLabelText`: the button mounts a kea logic chain reaching organization and user
+// state, so on a slow runner the play function can reach an empty canvas and fail the story.
+export const Steering: Story = {
+    parameters: { testOptions: { snapshotTargetSelector: '.Popover' } },
+    render: () => <CreatePrButton report={report} />,
+    play: async ({ canvasElement }) => {
+        await userEvent.click(await within(canvasElement).findByLabelText('Add direction for the agent'))
+        await waitFor(() => {
+            if (!document.querySelector('.Popover')) {
+                throw new Error('note box not open yet')
+            }
+        })
+    },
 }

--- a/products/signals/frontend/inbox/components/detail/CreatePrButton.test.tsx
+++ b/products/signals/frontend/inbox/components/detail/CreatePrButton.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { initKeaTests } from '~/test/init'
@@ -47,17 +47,31 @@ describe('CreatePrButton', () => {
         jest.restoreAllMocks()
     })
 
-    async function openPopover(): Promise<ReturnType<typeof userEvent.setup>> {
+    async function openNoteBox(): Promise<ReturnType<typeof userEvent.setup>> {
         const user = userEvent.setup()
         render(<CreatePrButton report={makeReport()} />)
-        await user.click(screen.getByText('Create PR'))
+        await user.click(screen.getByTestId('inbox-report-create-pr-steer'))
+        await waitFor(() => expect(screen.getByRole('textbox')).toHaveFocus())
         return user
     }
+
+    it('starts an unsteered run from the main half, with no note box in the way', async () => {
+        // The point of the split: the common case is one press. A regression that routes the main
+        // half back into the popover shows up here as a missing call.
+        const user = userEvent.setup()
+        render(<CreatePrButton report={makeReport()} />)
+
+        await user.click(screen.getByTestId('inbox-report-create-pr'))
+
+        expect(createPrFromReport).toHaveBeenCalledWith(expect.objectContaining({ id: 'report-1' }), undefined)
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+        expect(jest.mocked(captureInboxReportAction).mock.calls[0][0].extra).toEqual({ has_feedback: false })
+    })
 
     it('passes a typed note to the agent and marks the action as steered', async () => {
         // The whole feature: a note in the box has to reach the prompt, or steering does nothing. The
         // `has_feedback` flag is how we compare steered runs against unsteered ones.
-        const user = await openPopover()
+        const user = await openNoteBox()
 
         await user.type(screen.getByRole('textbox'), '  Put the fix behind a flag.  ')
         await user.click(screen.getByTestId('inbox-report-create-pr-submit'))
@@ -69,13 +83,13 @@ describe('CreatePrButton', () => {
         expect(jest.mocked(captureInboxReportAction).mock.calls[0][0].extra).toEqual({ has_feedback: true })
     })
 
-    it('fires with no note when the box is empty, exactly as the old button did', async () => {
-        // Empty is the common case and must stay a one-press action, with no feedback appended.
-        const user = await openPopover()
+    it('submits the note on Enter without moving focus first', async () => {
+        // Guards the two halves of the shortcut at once: the box takes focus when it opens, and plain
+        // Enter submits. `onPressCmdEnter` would leave both typing and Enter with nothing to act on.
+        const user = await openNoteBox()
 
-        await user.click(screen.getByTestId('inbox-report-create-pr-submit'))
+        await user.keyboard('Backend only.{Enter}')
 
-        expect(createPrFromReport).toHaveBeenCalledWith(expect.objectContaining({ id: 'report-1' }), undefined)
-        expect(jest.mocked(captureInboxReportAction).mock.calls[0][0].extra).toEqual({ has_feedback: false })
+        expect(createPrFromReport).toHaveBeenCalledWith(expect.objectContaining({ id: 'report-1' }), 'Backend only.')
     })
 })

--- a/products/signals/frontend/inbox/components/detail/CreatePrButton.tsx
+++ b/products/signals/frontend/inbox/components/detail/CreatePrButton.tsx
@@ -1,11 +1,10 @@
 import { useActions, useValues } from 'kea'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
-import { IconChevronDown, IconPullRequest } from '@posthog/icons'
+import { IconPullRequest } from '@posthog/icons'
 import { LemonButton, lemonToast } from '@posthog/lemon-ui'
 
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
-import { Popover } from 'lib/lemon-ui/Popover'
 
 import { captureInboxReportAction } from '../../inboxAnalytics'
 import { inboxTaskKickoffLogic } from '../../inboxTaskKickoffLogic'
@@ -16,20 +15,22 @@ import { SignalReport } from '../../types'
 const PLACEHOLDER = 'Add direction for the agent (optional)…'
 
 /**
- * The detail-pane "Create PR" action. It opens a popover with an optional note instead of firing on
- * click, so the reader can steer the agent (behind a flag, backend only, skip the migration) at the
- * moment they have the most context. An empty note behaves exactly as the old fire-on-click button.
+ * The detail-pane "Create PR" action, as a split button.
+ *
+ * The main half starts the run immediately, because an unsteered run is the common case. The
+ * chevron half opens a note box, so the reader can steer the agent (behind a flag, backend only,
+ * skip the migration) at the moment they have the most context. A note is optional, so both halves
+ * reach the same action and only the note differs.
  *
  * A component, not a `ReportDetailAction`, because actions collapse into a `LemonMenu` on narrow
- * layouts and a menu item can't own a popover — this mirrors `DiscussReportButton` for the same reason.
+ * layouts and a menu item cannot own a popover. `DiscussReportButton` is a component for the same
+ * reason.
  */
 export function CreatePrButton({ report }: { report: SignalReport }): JSX.Element {
     const { isCreatingPr, aiConsentDisabledReason } = useValues(inboxTaskKickoffLogic)
     // Already mounted by `ReportDetail`, so this reads the loaded value rather than starting a fetch.
     const { hasLiveImplementationTask } = useValues(inboxReportDetailLogic({ reportId: report.id, report }))
     const { createPrFromReport } = useActions(inboxTaskKickoffLogic)
-    const buttonRef = useRef<HTMLButtonElement>(null)
-    const [isOpen, setIsOpen] = useState(false)
     const [feedback, setFeedback] = useState('')
 
     const disabledReason =
@@ -38,9 +39,9 @@ export function CreatePrButton({ report }: { report: SignalReport }): JSX.Elemen
             ? 'A PR task already exists for this report. Open it in the task log to continue.'
             : undefined)
 
-    const submit = (): void => {
-        // Cmd/Ctrl + Enter submits straight from the textarea, so it never sees the trigger's
-        // `disabledReason` — each guard has to hold here too, or a press fires a paid run anyway.
+    const submit = (note: string): void => {
+        // Enter submits straight from the textarea, so it never sees the button's `disabledReason`.
+        // Each guard has to hold here too, or a keypress starts a paid run anyway.
         if (isCreatingPr || hasLiveImplementationTask) {
             return
         }
@@ -48,74 +49,73 @@ export function CreatePrButton({ report }: { report: SignalReport }): JSX.Elemen
             lemonToast.error(aiConsentDisabledReason)
             return
         }
-        const trimmed = feedback.trim()
+        const trimmed = note.trim()
         captureInboxReportAction({
             report,
             actionType: 'create_pr',
             surface: 'detail_pane',
             extra: { has_feedback: trimmed.length > 0 },
         })
-        // The popover stays open on its spinner until the run is created and we navigate to it, so a
-        // failure leaves the note to retry with.
         createPrFromReport(report, trimmed || undefined)
     }
 
     return (
-        <Popover
-            visible={isOpen}
-            onClickOutside={(event) => {
-                if (event.target instanceof Node && buttonRef.current?.contains(event.target)) {
-                    return
-                }
-                setIsOpen(false)
+        <LemonButton
+            type="primary"
+            size="small"
+            icon={<IconPullRequest />}
+            onClick={() => submit('')}
+            loading={isCreatingPr}
+            disabledReason={disabledReason}
+            tooltip="Have Self-driving open a pull request for this report"
+            data-attr="inbox-report-create-pr"
+            sideAction={{
+                tooltip: 'Add direction before the agent starts',
+                'aria-label': 'Add direction for the agent',
+                'data-attr': 'inbox-report-create-pr-steer',
+                dropdown: {
+                    placement: 'bottom-end',
+                    // The box holds a textarea, so a click inside it must not close the popover. The
+                    // popover also stays open on its spinner until the run is created and we navigate
+                    // to it, which leaves the note to retry with after a failure.
+                    closeOnClickInside: false,
+                    overlay: (
+                        <div className="flex flex-col gap-2 p-2 w-96">
+                            <LemonTextArea
+                                value={feedback}
+                                onChange={setFeedback}
+                                onPressEnter={submit}
+                                placeholder={PLACEHOLDER}
+                                maxLength={4000}
+                                rows={4}
+                                autoFocus
+                                // The hint goes in the left slot so the character counter, which
+                                // `maxLength` puts in the right one, has room of its own.
+                                actions={[
+                                    <span key="shortcut" className="text-xs text-tertiary">
+                                        Enter to create PR, Shift + Enter for a new line
+                                    </span>,
+                                ]}
+                            />
+                            <div className="flex justify-end">
+                                <LemonButton
+                                    type="primary"
+                                    size="small"
+                                    icon={<IconPullRequest />}
+                                    onClick={() => submit(feedback)}
+                                    loading={isCreatingPr}
+                                    disabledReason={disabledReason}
+                                    data-attr="inbox-report-create-pr-submit"
+                                >
+                                    Create PR
+                                </LemonButton>
+                            </div>
+                        </div>
+                    ),
+                },
             }}
-            placement="bottom-end"
-            overlay={
-                <div className="flex flex-col gap-2 p-2 w-[22rem]">
-                    <LemonTextArea
-                        value={feedback}
-                        onChange={setFeedback}
-                        onPressCmdEnter={submit}
-                        placeholder={PLACEHOLDER}
-                        maxLength={4000}
-                        rows={4}
-                        autoFocus
-                        rightFooter={<span className="text-xs text-tertiary">Cmd/Ctrl + Enter to create PR</span>}
-                    />
-                    <div className="flex justify-end">
-                        <LemonButton
-                            type="primary"
-                            size="small"
-                            icon={<IconPullRequest />}
-                            onClick={submit}
-                            loading={isCreatingPr}
-                            disabledReason={disabledReason}
-                            data-attr="inbox-report-create-pr-submit"
-                        >
-                            Create PR
-                        </LemonButton>
-                    </div>
-                </div>
-            }
         >
-            <LemonButton
-                ref={buttonRef}
-                type="primary"
-                size="small"
-                icon={<IconPullRequest />}
-                // Keeps the chevron the plain button never had, so a returning reader sees it now
-                // opens a note box before it fires.
-                sideIcon={<IconChevronDown />}
-                active={isOpen}
-                loading={isCreatingPr}
-                // The trigger always opens, even when consent is missing or a PR task already exists;
-                // the reason sits on the submit inside, next to the thing it blocks.
-                tooltip="Have Self-driving open a pull request for this report"
-                onClick={() => setIsOpen((open) => !open)}
-                data-attr="inbox-report-create-pr"
-            >
-                Create PR
-            </LemonButton>
-        </Popover>
+            Create PR
+        </LemonButton>
     )
 }


### PR DESCRIPTION
## Problem

- An inbox reader who wants a PR with no direction presses Create PR, gets a note box, ignores it, then presses a second button.
- One trigger served both actions, so the common case paid the cost of the rare one.
- Enter in the note box made a new line. Only Cmd/Ctrl + Enter started the run.

## Changes

- The main half of Create PR starts the run at once. No note box opens.
- The chevron half opens the note box. A thin vertical line separates the two halves.
- The note box takes focus when it opens, so the reader types straight away.
- Enter in the note box starts the run. Shift + Enter makes a new line.
- The shortcut hint sits left of the character counter, which gives both room in the footer.
- `LemonButton` supplies the split and the divider through its `sideAction` prop. This part is mechanical.

> [!NOTE]
> `data-attr="inbox-report-create-pr"` now marks the button that starts the run. It marked the button that opened the note box. The chevron gets a new `inbox-report-create-pr-steer`. Autocapture dashboards that count the first value will read presses, not opens.

The `create_pr` analytics event and its `has_feedback` property do not change. A direct press reports `has_feedback: false`, as an empty note box did.

|            | Before                                                                                                                                                   | After                                                                                                                                                   |
| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Button     | ![before-closed](https://raw.githubusercontent.com/PostHog/pr-assets/0f389ca9b69bf76268de2538931d09e24d1f9fd6/2026/08/96bf4834-447c-407e-8544-c8ae667ec330.png) | ![after-closed](https://raw.githubusercontent.com/PostHog/pr-assets/528f3fc8a43f163fc635e344fb35adef0f3f2d20/2026/08/9f336f49-af72-496a-a0ba-0678782dca14.png) |
| Note box   | ![before-open](https://raw.githubusercontent.com/PostHog/pr-assets/e62cc63e025117a8a5148270e181dfbc7672a078/2026/08/4f648b9a-483e-43c5-97a1-c81ed933f1bb.png)   | ![after-open](https://raw.githubusercontent.com/PostHog/pr-assets/a2e7c17f1d9f3e8d722030102aa70c8df2ffd51a/2026/08/29062624-ebea-43ec-88b8-cf5c0ae209f7.png)   |

## How did you test this code?

Jest, in `CreatePrButton.test.tsx`. Each case guards one regression that no existing case caught:

- A press on the main half starts the run and opens no note box. This catches a change that routes the main half back into the note box.
- A typed note reaches the agent, and the event reports `has_feedback: true`. This case already existed and now opens the note box from the chevron.
- A keystroke plus Enter starts the run with the typed note. This catches a lost `autoFocus` and a return to `onPressCmdEnter`, because either one leaves the keystroke or the Enter with no effect.

Screenshots above come from the two Storybook stories, captured with Playwright against a local Storybook.

Not run: the app itself. This session booted no dev stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow covers this button.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`.

Decisions across the session:

- The split uses `LemonButton`'s `sideAction`, which `InsightSaveButton` already uses for the same shape. A hand-rolled divider would have duplicated the design system.
- The first draft left the shortcut hint in the `rightFooter` slot. A screenshot showed it touching the character counter, so the hint moved to the left slot and the note box widened from `w-[22rem]` to `w-96`.
- The chevron stays open to a reader whose run is blocked, and the reason stays on the submit inside. The main half now carries that reason too, because it starts the run.

https://claude.ai/code/session_013c7d3L6F36Ep3qAZUHpGZe
