### PR TITLE
feat(desktop): pick the model first and auto-select its harness

### DIFF
--- a/products/desktop/apps/code/.storybook/main.ts
+++ b/products/desktop/apps/code/.storybook/main.ts
@@ -97,6 +97,20 @@ const config: StorybookConfig = {
             ),
           },
           {
+            find: "@posthog/agent/adapters/reasoning-effort",
+            replacement: path.resolve(
+              __dirname,
+              "../../../packages/agent/dist/adapters/reasoning-effort.js",
+            ),
+          },
+          {
+            find: "@posthog/agent/gateway-models",
+            replacement: path.resolve(
+              __dirname,
+              "../../../packages/agent/dist/gateway-models.js",
+            ),
+          },
+          {
             find: "@posthog/electron-trpc/renderer",
             replacement: path.resolve(__dirname, "./mocks/electron-trpc.ts"),
           },
@@ -111,6 +125,10 @@ const config: StorybookConfig = {
           {
             find: /^(node:)?fs$/,
             replacement: path.resolve(__dirname, "./mocks/node-fs.ts"),
+          },
+          {
+            find: /^(node:)?url$/,
+            replacement: path.resolve(__dirname, "./mocks/node-url.ts"),
           },
           { find: /^(node:)?path$/, replacement: "pathe" },
           // Resolve the remaining @posthog/* workspace packages to source, exactly

--- a/products/desktop/apps/code/.storybook/mocks/node-url.ts
+++ b/products/desktop/apps/code/.storybook/mocks/node-url.ts
@@ -1,0 +1,8 @@
+// Benign url stub for @posthog/agent dist bundles loaded in Storybook. The
+// tsup banner only derives __filename/__dirname from it, which nothing a
+// story renders ever reads.
+export function fileURLToPath(url: string | URL): string {
+  return String(url).replace(/^file:\/\//, "");
+}
+
+export default { fileURLToPath };

--- a/products/desktop/apps/web/src/web-agent-config.ts
+++ b/products/desktop/apps/web/src/web-agent-config.ts
@@ -5,6 +5,7 @@ import {
   getAvailableModes,
 } from "@posthog/agent/execution-mode";
 import {
+  buildHarnessModelGroups,
   DEFAULT_CODEX_MODEL,
   DEFAULT_GATEWAY_MODEL,
   fetchGatewayModels,
@@ -26,6 +27,7 @@ import type { Adapter } from "@posthog/shared";
 export async function getWebPreviewConfigOptions(
   apiHost: string,
   adapter: Adapter = "claude",
+  allHarnessModels = false,
 ): Promise<SessionConfigOption[]> {
   const gatewayUrl = getLlmGatewayUrl(apiHost);
   const gatewayModels = await fetchGatewayModels({ gatewayUrl });
@@ -93,7 +95,9 @@ export async function getWebPreviewConfigOptions(
       name: "Model",
       type: "select",
       currentValue: resolvedModelId,
-      options: modelOptions,
+      options: allHarnessModels
+        ? buildHarnessModelGroups(gatewayModels, adapter, resolvedModelId)
+        : modelOptions,
       category: "model",
       description: "Choose which model Claude should use",
     },

--- a/products/desktop/apps/web/src/web-agent-config.ts
+++ b/products/desktop/apps/web/src/web-agent-config.ts
@@ -5,7 +5,7 @@ import {
   getAvailableModes,
 } from "@posthog/agent/execution-mode";
 import {
-  buildHarnessModelGroups,
+  buildProviderModelGroups,
   DEFAULT_CODEX_MODEL,
   DEFAULT_GATEWAY_MODEL,
   fetchGatewayModels,
@@ -96,7 +96,7 @@ export async function getWebPreviewConfigOptions(
       type: "select",
       currentValue: resolvedModelId,
       options: allHarnessModels
-        ? buildHarnessModelGroups(gatewayModels, adapter, resolvedModelId)
+        ? buildProviderModelGroups(gatewayModels, adapter, resolvedModelId)
         : modelOptions,
       category: "model",
       description: "Choose which model Claude should use",

--- a/products/desktop/apps/web/src/web-host-router.ts
+++ b/products/desktop/apps/web/src/web-host-router.ts
@@ -168,10 +168,15 @@ const agentStubRouter = router({
       z.object({
         apiHost: z.string(),
         adapter: z.enum(["claude", "codex"]).default("claude"),
+        allHarnessModels: z.boolean().optional(),
       }),
     )
     .query(({ input }) =>
-      getWebPreviewConfigOptions(input.apiHost, input.adapter),
+      getWebPreviewConfigOptions(
+        input.apiHost,
+        input.adapter,
+        input.allHarnessModels,
+      ),
     ),
 });
 

--- a/products/desktop/packages/agent/src/gateway-models.ts
+++ b/products/desktop/packages/agent/src/gateway-models.ts
@@ -8,7 +8,7 @@ export {
   adapterForModelId,
   BLOCKED_GATEWAY_MODEL_IDS,
   buildCloudTaskConfigOptions,
-  buildHarnessModelGroups,
+  buildProviderModelGroups,
   type CloudTaskConfigOption,
   type CloudTaskConfigSelectGroup,
   type CloudTaskConfigSelectOption,

--- a/products/desktop/packages/agent/src/gateway-models.ts
+++ b/products/desktop/packages/agent/src/gateway-models.ts
@@ -5,9 +5,12 @@ import {
 import { buildPosthogProjectHeaderRecord } from "@posthog/shared/posthog-property-headers";
 
 export {
+  adapterForModelId,
   BLOCKED_GATEWAY_MODEL_IDS,
   buildCloudTaskConfigOptions,
+  buildHarnessModelGroups,
   type CloudTaskConfigOption,
+  type CloudTaskConfigSelectGroup,
   type CloudTaskConfigSelectOption,
   compareModelsForPicker,
   DEFAULT_CODEX_MODEL,

--- a/products/desktop/packages/core/src/task-detail/configOptions.test.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.test.ts
@@ -1,7 +1,11 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { modelHarnessMeta } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
-import { harnessForModelValue } from "./configOptions";
+import {
+  flattenConfigValues,
+  harnessForModelValue,
+  modelOptionForHarness,
+} from "./configOptions";
 
 const groupedModelOption = {
   id: "model",
@@ -54,12 +58,6 @@ describe("harnessForModelValue", () => {
       expected: "codex",
     },
     {
-      label: "reads the current harness's own group too",
-      option: groupedModelOption,
-      value: "claude-opus-5",
-      expected: "claude",
-    },
-    {
       label: "falls back to the id shape when nothing is stamped",
       option: flatUnstampedOption,
       value: "gpt-5.5",
@@ -77,5 +75,26 @@ describe("harnessForModelValue", () => {
 
   it("returns undefined without an option", () => {
     expect(harnessForModelValue(undefined, "gpt-5.5")).toBeUndefined();
+  });
+});
+
+describe("modelOptionForHarness", () => {
+  it.each([
+    { adapter: "claude" as const, expected: ["claude-opus-5"] },
+    { adapter: "codex" as const, expected: ["gpt-5.5"] },
+  ])(
+    "keeps only $adapter models from a grouped list",
+    ({ adapter, expected }) => {
+      const narrowed = modelOptionForHarness(groupedModelOption, adapter);
+      expect(flattenConfigValues(narrowed as SessionConfigOption)).toEqual(
+        expected,
+      );
+    },
+  );
+
+  it("leaves a single-harness list alone", () => {
+    expect(modelOptionForHarness(flatUnstampedOption, "claude")).toBe(
+      flatUnstampedOption,
+    );
   });
 });

--- a/products/desktop/packages/core/src/task-detail/configOptions.test.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.test.ts
@@ -5,7 +5,7 @@ import {
   flattenConfigValues,
   harnessForModelValue,
   modelOptionForHarness,
-  resolvePiModelPick,
+  syntheticPiModelSelection,
 } from "./configOptions";
 
 const groupedModelOption = {
@@ -79,29 +79,25 @@ describe("harnessForModelValue", () => {
   });
 });
 
-describe("resolvePiModelPick", () => {
-  const piModelIds = ["claude-opus-5", "gpt-5.6-terra"];
-
+describe("syntheticPiModelSelection", () => {
   it.each([
     {
-      label: "keeps Pi for a model in its catalog",
-      value: "claude-opus-5",
-      expected: "pi",
-    },
-    {
-      label: "falls to the stamped harness for a model Pi cannot run",
+      label: "takes the display name from the option",
       value: "gpt-5.5",
-      expected: "codex",
+      expected: "GPT-5.5",
     },
     {
-      label: "falls back to the id shape for a model the option lacks",
-      value: "gpt-4o",
-      expected: "codex",
+      label: "falls back to a formatted id for a model the option lacks",
+      value: "claude-opus-4-8",
+      expected: "Claude Opus 4.8",
     },
   ])("$label", ({ value, expected }) => {
-    expect(resolvePiModelPick(piModelIds, groupedModelOption, value)).toBe(
-      expected,
-    );
+    expect(syntheticPiModelSelection(groupedModelOption, value)).toMatchObject({
+      provider: "posthog",
+      id: value,
+      name: expected,
+      thinkingLevels: [],
+    });
   });
 });
 

--- a/products/desktop/packages/core/src/task-detail/configOptions.test.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.test.ts
@@ -5,6 +5,7 @@ import {
   flattenConfigValues,
   harnessForModelValue,
   modelOptionForHarness,
+  resolvePiModelPick,
 } from "./configOptions";
 
 const groupedModelOption = {
@@ -16,8 +17,8 @@ const groupedModelOption = {
   description: "",
   options: [
     {
-      group: "claude",
-      name: "Claude Code",
+      group: "anthropic",
+      name: "Anthropic",
       options: [
         {
           value: "claude-opus-5",
@@ -27,8 +28,8 @@ const groupedModelOption = {
       ],
     },
     {
-      group: "codex",
-      name: "Codex",
+      group: "openai",
+      name: "OpenAI",
       options: [
         { value: "gpt-5.5", name: "GPT-5.5", _meta: modelHarnessMeta("codex") },
       ],
@@ -75,6 +76,32 @@ describe("harnessForModelValue", () => {
 
   it("returns undefined without an option", () => {
     expect(harnessForModelValue(undefined, "gpt-5.5")).toBeUndefined();
+  });
+});
+
+describe("resolvePiModelPick", () => {
+  const piModelIds = ["claude-opus-5", "gpt-5.6-terra"];
+
+  it.each([
+    {
+      label: "keeps Pi for a model in its catalog",
+      value: "claude-opus-5",
+      expected: "pi",
+    },
+    {
+      label: "falls to the stamped harness for a model Pi cannot run",
+      value: "gpt-5.5",
+      expected: "codex",
+    },
+    {
+      label: "falls back to the id shape for a model the option lacks",
+      value: "gpt-4o",
+      expected: "codex",
+    },
+  ])("$label", ({ value, expected }) => {
+    expect(resolvePiModelPick(piModelIds, groupedModelOption, value)).toBe(
+      expected,
+    );
   });
 });
 

--- a/products/desktop/packages/core/src/task-detail/configOptions.test.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.test.ts
@@ -1,0 +1,81 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { modelHarnessMeta } from "@posthog/shared";
+import { describe, expect, it } from "vitest";
+import { harnessForModelValue } from "./configOptions";
+
+const groupedModelOption = {
+  id: "model",
+  name: "Model",
+  type: "select",
+  category: "model",
+  currentValue: "claude-opus-5",
+  description: "",
+  options: [
+    {
+      group: "claude",
+      name: "Claude Code",
+      options: [
+        {
+          value: "claude-opus-5",
+          name: "Opus 5",
+          _meta: modelHarnessMeta("claude"),
+        },
+      ],
+    },
+    {
+      group: "codex",
+      name: "Codex",
+      options: [
+        { value: "gpt-5.5", name: "GPT-5.5", _meta: modelHarnessMeta("codex") },
+      ],
+    },
+  ],
+} as SessionConfigOption;
+
+const flatUnstampedOption = {
+  id: "model",
+  name: "Model",
+  type: "select",
+  category: "model",
+  currentValue: "claude-opus-5",
+  description: "",
+  options: [
+    { value: "claude-opus-5", name: "Opus 5" },
+    { value: "gpt-5.5", name: "GPT-5.5" },
+  ],
+} as SessionConfigOption;
+
+describe("harnessForModelValue", () => {
+  it.each([
+    {
+      label: "reads the harness stamped on a grouped option",
+      option: groupedModelOption,
+      value: "gpt-5.5",
+      expected: "codex",
+    },
+    {
+      label: "reads the current harness's own group too",
+      option: groupedModelOption,
+      value: "claude-opus-5",
+      expected: "claude",
+    },
+    {
+      label: "falls back to the id shape when nothing is stamped",
+      option: flatUnstampedOption,
+      value: "gpt-5.5",
+      expected: "codex",
+    },
+    {
+      label: "returns undefined for a model the option does not offer",
+      option: groupedModelOption,
+      value: "gpt-4o",
+      expected: undefined,
+    },
+  ])("$label", ({ option, value, expected }) => {
+    expect(harnessForModelValue(option, value)).toBe(expected);
+  });
+
+  it("returns undefined without an option", () => {
+    expect(harnessForModelValue(undefined, "gpt-5.5")).toBeUndefined();
+  });
+});

--- a/products/desktop/packages/core/src/task-detail/configOptions.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.ts
@@ -3,6 +3,7 @@ import {
   type Adapter,
   adapterForModelId,
   flattenSelectOptions,
+  isSelectGroup,
   selectOptionHarness,
 } from "@posthog/shared";
 
@@ -41,4 +42,24 @@ export function harnessForModelValue(
   );
   if (!entry) return undefined;
   return selectOptionHarness(entry._meta) ?? adapterForModelId(value);
+}
+
+/**
+ * Narrows a model option that spans harnesses down to one harness. A picker
+ * that cannot switch harness with the pick must not offer the other's models,
+ * or the task runs a model its harness cannot serve. A list for a single
+ * harness passes through untouched.
+ */
+export function modelOptionForHarness(
+  option: SessionConfigOption | undefined,
+  adapter: Adapter,
+): SessionConfigOption | undefined {
+  if (option?.type !== "select" || !isSelectGroup(option.options))
+    return option;
+  return {
+    ...option,
+    options: flattenSelectOptions(option.options).filter(
+      (entry) => selectOptionHarness(entry._meta) === adapter,
+    ),
+  };
 }

--- a/products/desktop/packages/core/src/task-detail/configOptions.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.ts
@@ -3,9 +3,11 @@ import {
   type Adapter,
   adapterForModelId,
   flattenSelectOptions,
+  formatModelId,
   isSelectGroup,
   selectOptionHarness,
 } from "@posthog/shared";
+import type { PiThinkingLevel } from "../pi-runtime/piSessionController";
 
 type RawOptionItem = {
   value?: string;
@@ -45,17 +47,35 @@ export function harnessForModelValue(
 }
 
 /**
- * The harness a model pick lands on while Pi is the current harness. Pi keeps
- * the pick when its catalog runs the model; otherwise the pick falls to the
- * model's own harness.
+ * A session-only Pi selection for a pick outside Pi's curated catalog. Pi
+ * runs any gateway model, so the pick keeps its id; the thinking levels are
+ * unknown, so the composer hides the thinking control.
  */
-export function resolvePiModelPick(
-  piModelIds: readonly string[],
+export function syntheticPiModelSelection(
   option: SessionConfigOption | undefined,
   value: string,
-): "pi" | Adapter {
-  if (piModelIds.includes(value)) return "pi";
-  return harnessForModelValue(option, value) ?? adapterForModelId(value);
+): {
+  provider: "posthog";
+  id: string;
+  name: string;
+  isDefault: boolean;
+  contextWindow: number;
+  thinkingLevels: PiThinkingLevel[];
+} {
+  const name =
+    option?.type === "select"
+      ? flattenSelectOptions(option.options).find(
+          (entry) => entry.value === value,
+        )?.name
+      : undefined;
+  return {
+    provider: "posthog",
+    id: value,
+    name: name ?? formatModelId(value),
+    isDefault: false,
+    contextWindow: 0,
+    thinkingLevels: [],
+  };
 }
 
 /**

--- a/products/desktop/packages/core/src/task-detail/configOptions.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.ts
@@ -45,6 +45,20 @@ export function harnessForModelValue(
 }
 
 /**
+ * The harness a model pick lands on while Pi is the current harness. Pi keeps
+ * the pick when its catalog runs the model; otherwise the pick falls to the
+ * model's own harness.
+ */
+export function resolvePiModelPick(
+  piModelIds: readonly string[],
+  option: SessionConfigOption | undefined,
+  value: string,
+): "pi" | Adapter {
+  if (piModelIds.includes(value)) return "pi";
+  return harnessForModelValue(option, value) ?? adapterForModelId(value);
+}
+
+/**
  * Narrows a model option that spans harnesses down to one harness. A picker
  * that cannot switch harness with the pick must not offer the other's models,
  * or the task runs a model its harness cannot serve. A list for a single

--- a/products/desktop/packages/core/src/task-detail/configOptions.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.ts
@@ -1,4 +1,10 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import {
+  type Adapter,
+  adapterForModelId,
+  flattenSelectOptions,
+  selectOptionHarness,
+} from "@posthog/shared";
 
 type RawOptionItem = {
   value?: string;
@@ -18,4 +24,21 @@ export function isValidConfigValue(
 ): option is Extract<SessionConfigOption, { type: "select" }> {
   if (!option || option.type !== "select") return false;
   return flattenConfigValues(option).includes(value);
+}
+
+/**
+ * Names the harness a model in a select option runs on. A model list that spans
+ * harnesses stamps the harness on each option; the id shape is the fallback for
+ * lists built before the stamp existed.
+ */
+export function harnessForModelValue(
+  option: SessionConfigOption | undefined,
+  value: string,
+): Adapter | undefined {
+  if (!option || option.type !== "select") return undefined;
+  const entry = flattenSelectOptions(option.options).find(
+    (candidate) => candidate.value === value,
+  );
+  if (!entry) return undefined;
+  return selectOptionHarness(entry._meta) ?? adapterForModelId(value);
 }

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.test.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.test.ts
@@ -90,6 +90,7 @@ describe("resolvePosthogPiModelCatalog", () => {
     ["gpt-5.6-luna", "GPT-5.6 Luna"],
     ["@cf/zai-org/glm-5.2", "GLM-5.2"],
     ["moonshotai/kimi-k3", "Kimi K3"],
+    ["deepseek-ai/deepseek-v4-flash-0731", "DeepSeek V4 Flash"],
   ])("formats %s for Pi", (id, name) => {
     const models = resolvePosthogPiModelCatalog(
       [
@@ -120,7 +121,7 @@ describe("resolvePosthogPiModelCatalog", () => {
     );
 
     expect(models).toEqual([
-      expect.objectContaining({ id: "new-model", name: "new-model" }),
+      expect.objectContaining({ id: "new-model", name: "New Model" }),
     ]);
   });
 

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.test.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.test.ts
@@ -88,7 +88,7 @@ describe("resolvePosthogPiModelCatalog", () => {
     ["gpt-5.6-sol", "GPT-5.6 Sol"],
     ["gpt-5.6-terra", "GPT-5.6 Terra"],
     ["gpt-5.6-luna", "GPT-5.6 Luna"],
-    ["@cf/zai-org/glm-5.2", "GLM-5.2"],
+    ["zai-org/glm-5.3", "GLM-5.3"],
     ["moonshotai/kimi-k3", "Kimi K3"],
     ["deepseek-ai/deepseek-v4-flash-0731", "DeepSeek V4 Flash"],
   ])("formats %s for Pi", (id, name) => {
@@ -139,6 +139,7 @@ describe("resolvePosthogPiModelCatalog", () => {
     "gpt-5.4",
     "gpt-5.5",
     "gpt-5-mini",
+    "@cf/zai-org/glm-5.2",
   ])("excludes %s from the Pi catalog", (id) => {
     const models = resolvePosthogPiModelCatalog(
       [

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
@@ -3,7 +3,7 @@ import {
   type ModelThinkingLevel,
 } from "@earendil-works/pi-ai";
 import type { ModelInfo } from "@earendil-works/pi-coding-agent";
-import type { CloudRegion } from "@posthog/shared";
+import { type CloudRegion, formatGatewayModelName } from "@posthog/shared";
 import {
   fetchPosthogGatewayModels,
   type GatewayModel,
@@ -52,6 +52,20 @@ export type PiModelCatalogEntry = Omit<
   thinkingLevels: ModelThinkingLevel[];
 };
 
+// The provider config loses owned_by, so the shared formatter falls back to
+// id-based detection. Keeps Pi's names identical to the shared model picker.
+function piModelDisplayName(model: { id: string; name: string }): string {
+  if (model.name !== model.id) return model.name;
+  return formatGatewayModelName({
+    id: model.id,
+    owned_by: "",
+    context_window: 0,
+    supports_streaming: false,
+    supports_vision: false,
+    allowed: true,
+  });
+}
+
 export function resolvePosthogPiModelCatalog(
   gatewayModels: GatewayModel[],
   region: CloudRegion,
@@ -61,7 +75,7 @@ export function resolvePosthogPiModelCatalog(
     .map((model) => ({
       provider: "posthog",
       id: model.id,
-      name: PI_MODEL_LABELS[model.id] ?? model.name,
+      name: PI_MODEL_LABELS[model.id] ?? piModelDisplayName(model),
       isDefault: model.id === DEFAULT_PI_MODEL_ID,
       contextWindow: model.contextWindow,
       thinkingLevels: getSupportedThinkingLevels({

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/model-catalog.ts
@@ -40,6 +40,7 @@ const HIDDEN_PI_MODEL_IDS = new Set([
   "gpt-5.4",
   "gpt-5.5",
   "gpt-5-mini",
+  "@cf/zai-org/glm-5.2",
 ]);
 
 export type PiModelCatalogEntry = Omit<

--- a/products/desktop/packages/host-router/src/routers/agent.router.ts
+++ b/products/desktop/packages/host-router/src/routers/agent.router.ts
@@ -277,6 +277,10 @@ export const agentRouter = router({
     .query(({ ctx, input }) =>
       ctx.container
         .get<AgentService>(AGENT_SERVICE)
-        .getPreviewConfigOptions(input.apiHost, input.adapter),
+        .getPreviewConfigOptions(
+          input.apiHost,
+          input.adapter,
+          input.allHarnessModels,
+        ),
     ),
 });

--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   adapterForModelId,
   buildCloudTaskConfigOptions,
-  buildHarnessModelGroups,
+  buildProviderModelGroups,
   compareModelsForPicker,
   formatGatewayModelName,
   type GatewayModel,
@@ -292,7 +292,7 @@ describe("adapterForModelId", () => {
   });
 });
 
-describe("buildHarnessModelGroups", () => {
+describe("buildProviderModelGroups", () => {
   const catalog = [
     model("gpt-5.6-sol", "openai"),
     model("claude-opus-5", "anthropic"),
@@ -300,22 +300,27 @@ describe("buildHarnessModelGroups", () => {
     model("moonshotai/kimi-k3", "modal"),
   ];
 
-  it.each([
-    ["claude", ["claude", "codex"]],
-    ["codex", ["codex", "claude"]],
-  ] as const)("puts the %s harness's group first", (adapter, expectedOrder) => {
-    const groups = buildHarnessModelGroups(catalog, adapter);
-    expect(groups.map((group) => group.group)).toEqual(expectedOrder);
-  });
+  it.each(["claude", "codex"] as const)(
+    "keeps the same groups in the same order on the %s harness",
+    (adapter) => {
+      const groups = buildProviderModelGroups(catalog, adapter);
+      expect(groups.map((group) => group.group)).toEqual([
+        "anthropic",
+        "openai",
+        "moonshotai",
+      ]);
+    },
+  );
 
-  it("splits models by harness and stamps each option with its harness", () => {
-    const groups = buildHarnessModelGroups(catalog, "claude");
+  it("groups models by vendor and stamps each option with its harness", () => {
+    const groups = buildProviderModelGroups(catalog, "claude");
 
     expect(groups).toMatchObject([
       {
-        group: "claude",
-        name: "Claude Code",
+        group: "anthropic",
+        name: "Anthropic",
         options: [
+          { value: "claude-opus-5" },
           {
             value: "claude-opus-4-8",
             _meta: {
@@ -323,13 +328,11 @@ describe("buildHarnessModelGroups", () => {
               "posthog.code/restrictedModel": true,
             },
           },
-          { value: "claude-opus-5" },
-          { value: "moonshotai/kimi-k3" },
         ],
       },
       {
-        group: "codex",
-        name: "Codex",
+        group: "openai",
+        name: "OpenAI",
         options: [
           {
             value: "gpt-5.6-sol",
@@ -337,34 +340,53 @@ describe("buildHarnessModelGroups", () => {
           },
         ],
       },
+      {
+        group: "moonshotai",
+        name: "Moonshot AI",
+        options: [
+          {
+            value: "moonshotai/kimi-k3",
+            _meta: { "posthog.code/modelHarness": "claude" },
+          },
+        ],
+      },
     ]);
   });
 
   it("keeps a current model missing from the catalog as a custom entry", () => {
-    const groups = buildHarnessModelGroups(catalog, "claude", "my-custom");
-    expect(groups[0].options[0]).toMatchObject({
-      value: "my-custom",
-      description: "Custom model",
+    const groups = buildProviderModelGroups(catalog, "claude", "my-custom");
+    expect(groups.at(-1)).toMatchObject({
+      options: [{ value: "my-custom", description: "Custom model" }],
     });
   });
 
   // A gateway blip answers with an empty or one-sided catalog. The picker must
-  // still offer the model the task will run on, under its own harness.
+  // still offer the model the task will run on, under its own vendor.
   it.each([
     { label: "an empty catalog", models: [] },
     {
-      label: "a catalog holding only the other harness",
+      label: "a catalog holding only another vendor",
       models: [model("gpt-5.6-sol", "openai")],
     },
   ])(
-    "keeps the current model under its own harness with $label",
+    "keeps the current model under its own vendor with $label",
     ({ models }) => {
-      const groups = buildHarnessModelGroups(models, "claude", "claude-opus-5");
+      const groups = buildProviderModelGroups(
+        models,
+        "claude",
+        "claude-opus-5",
+      );
 
       expect(groups[0]).toMatchObject({
-        group: "claude",
-        name: "Claude Code",
-        options: [{ value: "claude-opus-5", description: "Custom model" }],
+        group: "anthropic",
+        name: "Anthropic",
+        options: [
+          {
+            value: "claude-opus-5",
+            description: "Custom model",
+            _meta: { "posthog.code/modelHarness": "claude" },
+          },
+        ],
       });
     },
   );

--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -54,9 +54,9 @@ describe("formatGatewayModelName", () => {
 });
 
 describe("normalizeGatewayModelsResponse", () => {
-  it("passes through the gateway's advertised context window for GLM 5.2 unmodified", () => {
+  it("passes through the gateway's advertised context window unmodified", () => {
     const models = normalizeGatewayModelsResponse([
-      model("@cf/zai-org/glm-5.2", "cloudflare"),
+      model("zai-org/glm-5.3", "baseten"),
     ]);
 
     expect(models[0]?.context_window).toBe(128000);
@@ -64,7 +64,7 @@ describe("normalizeGatewayModelsResponse", () => {
 
   it("does not override any model's context window", () => {
     const models = normalizeGatewayModelsResponse([
-      { ...model("@cf/zai-org/glm-5.2", "cloudflare"), context_window: 256000 },
+      { ...model("zai-org/glm-5.3", "baseten"), context_window: 256000 },
     ]);
 
     expect(models[0]?.context_window).toBe(256000);
@@ -75,12 +75,16 @@ describe("isBlockedModelId", () => {
   it.each([
     "claude-opus-4-5",
     "claude-opus-4-6",
+    "claude-opus-4-7",
     "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
     "ANTHROPIC/CLAUDE-HAIKU-4-5",
     "gpt-5.2",
     "gpt-5.3",
     "gpt-5.3-codex",
     "OPENAI/GPT-5.3-CODEX",
+    "gpt-5.4",
+    "@cf/zai-org/glm-5.2",
   ])("blocks %s", (modelId) => {
     expect(isBlockedModelId(modelId)).toBe(true);
   });

--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  adapterForModelId,
   buildCloudTaskConfigOptions,
+  buildHarnessModelGroups,
   compareModelsForPicker,
   formatGatewayModelName,
   type GatewayModel,
@@ -274,5 +276,75 @@ describe("buildCloudTaskConfigOptions", () => {
     expect(codexModelOptions).not.toContainEqual(
       expect.objectContaining({ value: "deepseek-ai/deepseek-v4-flash-0731" }),
     );
+  });
+});
+
+describe("adapterForModelId", () => {
+  it.each([
+    ["gpt-5.6-sol", "codex"],
+    ["openai/gpt-5.5", "codex"],
+    ["claude-opus-5", "claude"],
+    ["@cf/zai-org/glm-5.2", "claude"],
+    ["moonshotai/kimi-k3", "claude"],
+    ["deepseek-ai/deepseek-v4-flash-0731", "claude"],
+  ])("maps %s to the %s harness", (modelId, adapter) => {
+    expect(adapterForModelId(modelId)).toBe(adapter);
+  });
+});
+
+describe("buildHarnessModelGroups", () => {
+  const catalog = [
+    model("gpt-5.6-sol", "openai"),
+    model("claude-opus-5", "anthropic"),
+    model("claude-opus-4-8", "anthropic", false),
+    model("moonshotai/kimi-k3", "modal"),
+  ];
+
+  it.each([
+    ["claude", ["claude", "codex"]],
+    ["codex", ["codex", "claude"]],
+  ] as const)("puts the %s harness's group first", (adapter, expectedOrder) => {
+    const groups = buildHarnessModelGroups(catalog, adapter);
+    expect(groups.map((group) => group.group)).toEqual(expectedOrder);
+  });
+
+  it("splits models by harness and stamps each option with its harness", () => {
+    const groups = buildHarnessModelGroups(catalog, "claude");
+
+    expect(groups).toMatchObject([
+      {
+        group: "claude",
+        name: "Claude Code",
+        options: [
+          {
+            value: "claude-opus-4-8",
+            _meta: {
+              "posthog.code/modelHarness": "claude",
+              "posthog.code/restrictedModel": true,
+            },
+          },
+          { value: "claude-opus-5" },
+          { value: "moonshotai/kimi-k3" },
+        ],
+      },
+      {
+        group: "codex",
+        name: "Codex",
+        options: [
+          {
+            value: "gpt-5.6-sol",
+            _meta: { "posthog.code/modelHarness": "codex" },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("keeps a current model missing from the catalog as a custom entry", () => {
+    const groups = buildHarnessModelGroups(catalog, "claude", "my-custom");
+    expect(groups[0].options[0]).toMatchObject({
+      value: "my-custom",
+      description: "Custom model",
+    });
   });
 });

--- a/products/desktop/packages/shared/src/cloud-task-models.test.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.test.ts
@@ -347,4 +347,25 @@ describe("buildHarnessModelGroups", () => {
       description: "Custom model",
     });
   });
+
+  // A gateway blip answers with an empty or one-sided catalog. The picker must
+  // still offer the model the task will run on, under its own harness.
+  it.each([
+    { label: "an empty catalog", models: [] },
+    {
+      label: "a catalog holding only the other harness",
+      models: [model("gpt-5.6-sol", "openai")],
+    },
+  ])(
+    "keeps the current model under its own harness with $label",
+    ({ models }) => {
+      const groups = buildHarnessModelGroups(models, "claude", "claude-opus-5");
+
+      expect(groups[0]).toMatchObject({
+        group: "claude",
+        name: "Claude Code",
+        options: [{ value: "claude-opus-5", description: "Custom model" }],
+      });
+    },
+  );
 });

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -1,6 +1,6 @@
 import type { Adapter } from "./adapter";
 import { CODEX_MODE_PRESETS } from "./execution-modes";
-import { restrictedModelMeta } from "./models";
+import { modelHarnessMeta, restrictedModelMeta } from "./models";
 import { getReasoningEffortOptions } from "./reasoning-effort";
 
 export interface GatewayModel {
@@ -23,6 +23,12 @@ export interface CloudTaskConfigSelectOption {
   name: string;
   description?: string;
   _meta?: Record<string, unknown>;
+}
+
+export interface CloudTaskConfigSelectGroup {
+  group: Adapter;
+  name: string;
+  options: CloudTaskConfigSelectOption[];
 }
 
 export interface CloudTaskConfigOption {
@@ -323,6 +329,74 @@ function getAdapterModels(
   );
 }
 
+export function adapterForModelId(modelId: string): Adapter {
+  const normalized = modelId.toLowerCase();
+  return normalized.startsWith("gpt-") || normalized.startsWith("openai/")
+    ? "codex"
+    : "claude";
+}
+
+export const HARNESS_DISPLAY_NAMES: Record<Adapter, string> = {
+  claude: "Claude Code",
+  codex: "Codex",
+};
+
+function buildModelSelectOptions(
+  models: readonly GatewayModel[],
+  adapter: Adapter,
+): CloudTaskConfigSelectOption[] {
+  const options = getAdapterModels(models, adapter).map((model) => ({
+    value: model.id,
+    name: formatGatewayModelName(model),
+    description: `Context: ${model.context_window.toLocaleString()} tokens`,
+    _meta: {
+      ...modelHarnessMeta(adapter),
+      ...(model.allowed ? {} : restrictedModelMeta()),
+    },
+  }));
+  if (adapter === "claude") {
+    options.sort(
+      (a, b) => getClaudeModelRecency(a.value) - getClaudeModelRecency(b.value),
+    );
+  }
+  return options;
+}
+
+/**
+ * Model options for every harness, the current harness's group first, so a
+ * picker can offer the full catalog and switch harness on a cross-harness
+ * pick. A currentValue missing from the catalog is kept as a custom entry.
+ */
+export function buildHarnessModelGroups(
+  models: readonly GatewayModel[],
+  adapter: Adapter,
+  currentValue?: string,
+): CloudTaskConfigSelectGroup[] {
+  const harnesses: Adapter[] =
+    adapter === "codex" ? ["codex", "claude"] : ["claude", "codex"];
+  const groups = harnesses
+    .map((harness) => ({
+      group: harness,
+      name: HARNESS_DISPLAY_NAMES[harness],
+      options: buildModelSelectOptions(models, harness),
+    }))
+    .filter((group) => group.options.length > 0);
+  const hasCurrent =
+    !currentValue ||
+    groups.some((group) =>
+      group.options.some((option) => option.value === currentValue),
+    );
+  if (!hasCurrent && currentValue && groups.length > 0) {
+    groups[0].options.unshift({
+      value: currentValue,
+      name: currentValue,
+      description: "Custom model",
+      _meta: modelHarnessMeta(adapter),
+    });
+  }
+  return groups;
+}
+
 function getModeOptions(
   adapter: Adapter,
   modePresets?: readonly CloudTaskModePreset[],
@@ -343,20 +417,7 @@ export function buildCloudTaskConfigOptions(
   modePresets?: readonly CloudTaskModePreset[],
 ): CloudTaskConfigOption[] {
   const adapterModels = getAdapterModels(models, adapter);
-  const modelOptions: CloudTaskConfigSelectOption[] = adapterModels.map(
-    (model) => ({
-      value: model.id,
-      name: formatGatewayModelName(model),
-      description: `Context: ${model.context_window.toLocaleString()} tokens`,
-      ...(model.allowed ? {} : { _meta: restrictedModelMeta() }),
-    }),
-  );
-
-  if (adapter === "claude") {
-    modelOptions.sort(
-      (a, b) => getClaudeModelRecency(a.value) - getClaudeModelRecency(b.value),
-    );
-  }
+  const modelOptions = buildModelSelectOptions(models, adapter);
 
   const defaultModel =
     adapter === "codex"

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -60,14 +60,21 @@ export const BLOCKED_GATEWAY_MODEL_IDS = [
   "openai/gpt-5.3",
   "gpt-5.3-codex",
   "openai/gpt-5.3-codex",
+  "gpt-5.4",
+  "openai/gpt-5.4",
   "claude-opus-4-5",
   "anthropic/claude-opus-4-5",
   "claude-opus-4-6",
   "anthropic/claude-opus-4-6",
+  "claude-opus-4-7",
+  "anthropic/claude-opus-4-7",
   "claude-sonnet-4-5",
   "anthropic/claude-sonnet-4-5",
+  "claude-sonnet-4-6",
+  "anthropic/claude-sonnet-4-6",
   "claude-haiku-4-5",
   "anthropic/claude-haiku-4-5",
+  "@cf/zai-org/glm-5.2",
 ] as const;
 
 const BLOCKED_GATEWAY_MODELS = new Set<string>(BLOCKED_GATEWAY_MODEL_IDS);

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -386,13 +386,27 @@ export function buildHarnessModelGroups(
     groups.some((group) =>
       group.options.some((option) => option.value === currentValue),
     );
-  if (!hasCurrent && currentValue && groups.length > 0) {
-    groups[0].options.unshift({
+  if (!hasCurrent && currentValue) {
+    const custom = {
       value: currentValue,
       name: currentValue,
       description: "Custom model",
       _meta: modelHarnessMeta(adapter),
-    });
+    };
+    // The model belongs to the current harness, so it goes in that harness's
+    // group. An empty or one-sided catalog (a gateway blip returns no models)
+    // leaves no group to put it in, so open one — otherwise the picker offers
+    // nothing at all, or files the model under the other harness's heading.
+    const own = groups.find((group) => group.group === adapter);
+    if (own) {
+      own.options.unshift(custom);
+    } else {
+      groups.unshift({
+        group: adapter,
+        name: HARNESS_DISPLAY_NAMES[adapter],
+        options: [custom],
+      });
+    }
   }
   return groups;
 }

--- a/products/desktop/packages/shared/src/cloud-task-models.ts
+++ b/products/desktop/packages/shared/src/cloud-task-models.ts
@@ -26,7 +26,7 @@ export interface CloudTaskConfigSelectOption {
 }
 
 export interface CloudTaskConfigSelectGroup {
-  group: Adapter;
+  group: string;
   name: string;
   options: CloudTaskConfigSelectOption[];
 }
@@ -362,53 +362,86 @@ function buildModelSelectOptions(
   return options;
 }
 
+const MODEL_VENDOR_NAMES: Record<string, string> = {
+  "zai-org": "Z.ai",
+  moonshotai: "Moonshot AI",
+  "deepseek-ai": "DeepSeek",
+  "google-vertex": "Gemini",
+  meta: "Meta",
+};
+
+const VENDOR_GROUP_ORDER = ["anthropic", "openai"];
+
+function modelVendor(modelId: string): { key: string; name: string } {
+  const normalized = modelId.toLowerCase().replace(/^@cf\//, "");
+  if (normalized.startsWith("claude-") || normalized.startsWith("anthropic/")) {
+    return { key: "anthropic", name: "Anthropic" };
+  }
+  if (normalized.startsWith("gpt-") || normalized.startsWith("openai/")) {
+    return { key: "openai", name: "OpenAI" };
+  }
+  const org = normalized.split("/")[0];
+  const name = MODEL_VENDOR_NAMES[org];
+  if (name) return { key: org, name };
+  return { key: "other", name: "Other" };
+}
+
 /**
- * Model options for every harness, the current harness's group first, so a
- * picker can offer the full catalog and switch harness on a cross-harness
- * pick. A currentValue missing from the catalog is kept as a custom entry.
+ * Model options for every harness, grouped by the model's vendor, so every
+ * picker offers one identical catalog and the harness is derived from the
+ * pick. Each option keeps its harness stamp in _meta; a currentValue missing
+ * from the catalog is kept as a custom entry under its own vendor.
  */
-export function buildHarnessModelGroups(
+export function buildProviderModelGroups(
   models: readonly GatewayModel[],
   adapter: Adapter,
   currentValue?: string,
 ): CloudTaskConfigSelectGroup[] {
-  const harnesses: Adapter[] =
-    adapter === "codex" ? ["codex", "claude"] : ["claude", "codex"];
-  const groups = harnesses
-    .map((harness) => ({
-      group: harness,
-      name: HARNESS_DISPLAY_NAMES[harness],
-      options: buildModelSelectOptions(models, harness),
-    }))
-    .filter((group) => group.options.length > 0);
+  const groups: CloudTaskConfigSelectGroup[] = [];
+  const groupsByVendor = new Map<string, CloudTaskConfigSelectGroup>();
+  const groupFor = (modelId: string): CloudTaskConfigSelectGroup => {
+    const vendor = modelVendor(modelId);
+    let group = groupsByVendor.get(vendor.key);
+    if (!group) {
+      group = { group: vendor.key, name: vendor.name, options: [] };
+      groupsByVendor.set(vendor.key, group);
+      groups.push(group);
+    }
+    return group;
+  };
+
+  const harnesses: Adapter[] = ["claude", "codex"];
+  for (const option of harnesses.flatMap((harness) =>
+    buildModelSelectOptions(models, harness),
+  )) {
+    groupFor(option.value).options.push(option);
+  }
+  for (const group of groups) {
+    group.options.sort((a, b) => compareModelsForPicker(a.value, b.value));
+  }
+
   const hasCurrent =
     !currentValue ||
     groups.some((group) =>
       group.options.some((option) => option.value === currentValue),
     );
   if (!hasCurrent && currentValue) {
-    const custom = {
+    // The current selection has to stay offered even when a gateway blip
+    // answers with an empty or partial catalog, so keep it as a custom entry
+    // stamped with the harness it is running on.
+    groupFor(currentValue).options.unshift({
       value: currentValue,
       name: currentValue,
       description: "Custom model",
       _meta: modelHarnessMeta(adapter),
-    };
-    // The model belongs to the current harness, so it goes in that harness's
-    // group. An empty or one-sided catalog (a gateway blip returns no models)
-    // leaves no group to put it in, so open one — otherwise the picker offers
-    // nothing at all, or files the model under the other harness's heading.
-    const own = groups.find((group) => group.group === adapter);
-    if (own) {
-      own.options.unshift(custom);
-    } else {
-      groups.unshift({
-        group: adapter,
-        name: HARNESS_DISPLAY_NAMES[adapter],
-        options: [custom],
-      });
-    }
+    });
   }
-  return groups;
+
+  const vendorRank = (key: string): number => {
+    const index = VENDOR_GROUP_ORDER.indexOf(key);
+    return index === -1 ? VENDOR_GROUP_ORDER.length : index;
+  };
+  return groups.sort((a, b) => vendorRank(a.group) - vendorRank(b.group));
 }
 
 function getModeOptions(

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -63,7 +63,7 @@ export {
   adapterForModelId,
   BLOCKED_GATEWAY_MODEL_IDS,
   buildCloudTaskConfigOptions,
-  buildHarnessModelGroups,
+  buildProviderModelGroups,
   type CloudTaskConfigOption,
   type CloudTaskConfigSelectGroup,
   type CloudTaskConfigSelectOption,

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -60,9 +60,12 @@ export {
   serializeCloudPrompt,
 } from "./cloud-prompt";
 export {
+  adapterForModelId,
   BLOCKED_GATEWAY_MODEL_IDS,
   buildCloudTaskConfigOptions,
+  buildHarnessModelGroups,
   type CloudTaskConfigOption,
+  type CloudTaskConfigSelectGroup,
   type CloudTaskConfigSelectOption,
   compareModelsForPicker,
   DEFAULT_CODEX_MODEL,
@@ -73,6 +76,7 @@ export {
   getClaudeModelRecency,
   getCloudTaskGatewayUrl,
   getProviderName,
+  HARNESS_DISPLAY_NAMES,
   isAnthropicModel,
   isAnthropicModelId,
   isBasetenModel,
@@ -205,9 +209,11 @@ export {
   defaultEligibleModel,
   isDefaultSelectOption,
   isRestrictedModelOption,
+  modelHarnessMeta,
   OPTION_DOCS_URL_META_KEY,
   restrictedModelMeta,
   selectOptionDocsUrl,
+  selectOptionHarness,
 } from "./models";
 export {
   getOauthClientIdFromRegion,

--- a/products/desktop/packages/shared/src/models.ts
+++ b/products/desktop/packages/shared/src/models.ts
@@ -1,3 +1,5 @@
+import type { Adapter } from "./adapter";
+
 /**
  * Returns the id unless it's a premium family (currently Fable) that must be
  * an explicit per-task pick and never the implicit default for a new task.
@@ -50,4 +52,22 @@ export function selectOptionDocsUrl(
 ): string | undefined {
   const url = meta?.[OPTION_DOCS_URL_META_KEY];
   return typeof url === "string" ? url : undefined;
+}
+
+/**
+ * ACP SessionConfigSelectOption `_meta` key naming the harness a model runs
+ * on, so a picker offering models across harnesses can switch to the right
+ * one when a cross-harness model is chosen.
+ */
+const MODEL_HARNESS_META_KEY = "posthog.code/modelHarness";
+
+export function modelHarnessMeta(adapter: Adapter): Record<string, unknown> {
+  return { [MODEL_HARNESS_META_KEY]: adapter };
+}
+
+export function selectOptionHarness(
+  meta: Record<string, unknown> | null | undefined,
+): Adapter | undefined {
+  const harness = meta?.[MODEL_HARNESS_META_KEY];
+  return harness === "claude" || harness === "codex" ? harness : undefined;
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -3,7 +3,7 @@ import type {
   PiThinkingLevel,
 } from "@posthog/core/pi-runtime/piSessionController";
 import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
-import type { AgentRuntime } from "@posthog/shared";
+import { type AgentRuntime, adapterForModelId } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   subscriptionModelAccess,
@@ -340,17 +340,44 @@ export const ChannelHomeComposer = forwardRef<
     },
     [setLastUsedAgentRuntime],
   );
+  // A manual harness switch keeps the selected model when the target harness
+  // runs it; otherwise the target falls back to its default.
   const handleHarnessChange = useCallback(
     (harness: AgentHarness) => {
       if (harness === "pi") {
+        if (runtime !== "pi" && currentModel) {
+          // Session-only: the Pi resolver falls back to Pi's own default when
+          // its catalog lacks the model, without clobbering the saved Pi pick.
+          setSelectedPiModelId(currentModel);
+        }
         handleRuntimeChange("pi");
         return;
       }
 
+      if (runtime === "pi") {
+        const carried = currentPiModel?.id;
+        if (carried && adapterForModelId(carried) === harness) {
+          setLastUsedModel(carried);
+          if (harness === adapter && isValidConfigValue(modelOption, carried)) {
+            // Same adapter means no config refetch, so apply the pick directly.
+            setConfigOption(modelOption.id, carried);
+          }
+        }
+      }
       handleRuntimeChange("acp");
       setAdapter(harness);
     },
-    [handleRuntimeChange, setAdapter],
+    [
+      adapter,
+      currentModel,
+      currentPiModel,
+      handleRuntimeChange,
+      modelOption,
+      runtime,
+      setAdapter,
+      setConfigOption,
+      setLastUsedModel,
+    ],
   );
   // Saving the model before the switch lets the new harness's config restore
   // it instead of resetting to that harness's default.

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -4,7 +4,7 @@ import type {
 } from "@posthog/core/pi-runtime/piSessionController";
 import {
   isValidConfigValue,
-  resolvePiModelPick,
+  syntheticPiModelSelection,
 } from "@posthog/core/task-detail/configOptions";
 import { type AgentRuntime, adapterForModelId } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
@@ -217,6 +217,11 @@ export const ChannelHomeComposer = forwardRef<
       : undefined;
   const currentPiModel =
     piModelCatalog.find((model) => model.id === selectedPiModelId) ??
+    // Pi runs any gateway model, so a session pick outside Pi's curated
+    // catalog sticks instead of falling back to Pi's default.
+    (selectedPiModelId
+      ? syntheticPiModelSelection(modelOption, selectedPiModelId)
+      : undefined) ??
     piModelCatalog.find((model) => model.id === lastUsedPiModel) ??
     piModelCatalog.find((model) => model.isDefault) ??
     piModelCatalog[0];
@@ -349,8 +354,7 @@ export const ChannelHomeComposer = forwardRef<
     (harness: AgentHarness) => {
       if (harness === "pi") {
         if (runtime !== "pi" && currentModel) {
-          // Session-only: the Pi resolver falls back to Pi's own default when
-          // its catalog lacks the model, without clobbering the saved Pi pick.
+          // Session-only, so the saved Pi pick is not clobbered.
           setSelectedPiModelId(currentModel);
         }
         handleRuntimeChange("pi");
@@ -387,30 +391,9 @@ export const ChannelHomeComposer = forwardRef<
   const handleHarnessModelChange = useCallback(
     (harness: AgentAdapter, model: string) => {
       setLastUsedModel(model);
-      if (runtime !== "pi") {
-        handleHarnessChange(harness);
-        return;
-      }
-      handleRuntimeChange("acp");
-      if (harness === adapter) {
-        // Same adapter means no config refetch, so apply the pick directly.
-        if (isValidConfigValue(modelOption, model)) {
-          setConfigOption(modelOption.id, model);
-        }
-        return;
-      }
-      setAdapter(harness);
+      handleHarnessChange(harness);
     },
-    [
-      adapter,
-      handleHarnessChange,
-      handleRuntimeChange,
-      modelOption,
-      runtime,
-      setAdapter,
-      setConfigOption,
-      setLastUsedModel,
-    ],
+    [handleHarnessChange, setLastUsedModel],
   );
   const handlePiModelChange = useCallback(
     (model: PiModelSelection) => {
@@ -419,32 +402,18 @@ export const ChannelHomeComposer = forwardRef<
     },
     [setLastUsedPiModel],
   );
-  // The Pi menu offers the same full catalog; a pick stays on Pi when its
-  // catalog runs the model, otherwise it falls to the model's own harness.
+  // Pi runs any gateway model, so a pick in the Pi menu never leaves Pi. A
+  // pick outside Pi's curated catalog applies session-only.
   const handlePiGatewayModelSelect = useCallback(
     (model: string) => {
-      const target = resolvePiModelPick(
-        piModelCatalog.map((entry) => entry.id),
-        modelOption,
-        model,
-      );
-      if (target === "pi") {
-        const entry = piModelCatalog.find(
-          (candidate) => candidate.id === model,
-        );
-        if (entry) {
-          handlePiModelChange(entry);
-        }
+      const entry = piModelCatalog.find((candidate) => candidate.id === model);
+      if (entry) {
+        handlePiModelChange(entry);
         return;
       }
-      handleHarnessModelChange(target, model);
+      setSelectedPiModelId(model);
     },
-    [
-      handleHarnessModelChange,
-      handlePiModelChange,
-      modelOption,
-      piModelCatalog,
-    ],
+    [handlePiModelChange, piModelCatalog],
   );
   const handlePiThinkingLevelChange = useCallback((level: PiThinkingLevel) => {
     setSelectedPiThinkingLevel(level);

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -131,7 +131,7 @@ export const ChannelHomeComposer = forwardRef<
   );
   const [selectedPiThinkingLevel, setSelectedPiThinkingLevel] =
     useState<PiThinkingLevel | null>(null);
-  const piHarnessEnabled = useFeatureFlag("pi-harness");
+  const piHarnessEnabled = useFeatureFlag("pi-harness", import.meta.env.DEV);
   const flagsLoaded = useFeatureFlagsLoaded();
   const { data: piModelCatalog = [], isPending: isPiConfigLoading } =
     usePiModelCatalog(runtime === "pi");

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -186,7 +186,7 @@ export const ChannelHomeComposer = forwardRef<
     fastModeOption,
     isLoading,
     setConfigOption,
-  } = usePreviewConfig(adapter);
+  } = usePreviewConfig(adapter, { allHarnessModels: true });
 
   const currentModel =
     modelOption?.type === "select" ? modelOption.currentValue : undefined;
@@ -352,6 +352,15 @@ export const ChannelHomeComposer = forwardRef<
     },
     [handleRuntimeChange, setAdapter],
   );
+  // Saving the model before the switch lets the new harness's config restore
+  // it instead of resetting to that harness's default.
+  const handleHarnessModelChange = useCallback(
+    (harness: AgentAdapter, model: string) => {
+      setLastUsedModel(model);
+      handleHarnessChange(harness);
+    },
+    [handleHarnessChange, setLastUsedModel],
+  );
   const handlePiModelChange = useCallback(
     (model: PiModelSelection) => {
       setSelectedPiModelId(model.id);
@@ -495,6 +504,7 @@ export const ChannelHomeComposer = forwardRef<
               onHarnessChange={
                 piHarnessEnabled ? handleHarnessChange : undefined
               }
+              onHarnessModelChange={handleHarnessModelChange}
               includePiHarness={piHarnessEnabled}
               onConfigOptionChange={setConfigOption}
               menuOpen={modelMenuOpen}

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -2,7 +2,10 @@ import type {
   PiModelSelection,
   PiThinkingLevel,
 } from "@posthog/core/pi-runtime/piSessionController";
-import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
+import {
+  isValidConfigValue,
+  resolvePiModelPick,
+} from "@posthog/core/task-detail/configOptions";
 import { type AgentRuntime, adapterForModelId } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
@@ -384,9 +387,30 @@ export const ChannelHomeComposer = forwardRef<
   const handleHarnessModelChange = useCallback(
     (harness: AgentAdapter, model: string) => {
       setLastUsedModel(model);
-      handleHarnessChange(harness);
+      if (runtime !== "pi") {
+        handleHarnessChange(harness);
+        return;
+      }
+      handleRuntimeChange("acp");
+      if (harness === adapter) {
+        // Same adapter means no config refetch, so apply the pick directly.
+        if (isValidConfigValue(modelOption, model)) {
+          setConfigOption(modelOption.id, model);
+        }
+        return;
+      }
+      setAdapter(harness);
     },
-    [handleHarnessChange, setLastUsedModel],
+    [
+      adapter,
+      handleHarnessChange,
+      handleRuntimeChange,
+      modelOption,
+      runtime,
+      setAdapter,
+      setConfigOption,
+      setLastUsedModel,
+    ],
   );
   const handlePiModelChange = useCallback(
     (model: PiModelSelection) => {
@@ -394,6 +418,33 @@ export const ChannelHomeComposer = forwardRef<
       setLastUsedPiModel(model.id);
     },
     [setLastUsedPiModel],
+  );
+  // The Pi menu offers the same full catalog; a pick stays on Pi when its
+  // catalog runs the model, otherwise it falls to the model's own harness.
+  const handlePiGatewayModelSelect = useCallback(
+    (model: string) => {
+      const target = resolvePiModelPick(
+        piModelCatalog.map((entry) => entry.id),
+        modelOption,
+        model,
+      );
+      if (target === "pi") {
+        const entry = piModelCatalog.find(
+          (candidate) => candidate.id === model,
+        );
+        if (entry) {
+          handlePiModelChange(entry);
+        }
+        return;
+      }
+      handleHarnessModelChange(target, model);
+    },
+    [
+      handleHarnessModelChange,
+      handlePiModelChange,
+      modelOption,
+      piModelCatalog,
+    ],
   );
   const handlePiThinkingLevelChange = useCallback((level: PiThinkingLevel) => {
     setSelectedPiThinkingLevel(level);
@@ -512,6 +563,8 @@ export const ChannelHomeComposer = forwardRef<
               onChange={handlePiModelChange}
               onThinkingLevelChange={handlePiThinkingLevelChange}
               onHarnessChange={handleHarnessChange}
+              modelOption={modelOption}
+              onGatewayModelSelect={handlePiGatewayModelSelect}
               menuOpen={modelMenuOpen}
               onMenuOpenChange={setModelMenuOpen}
             />

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -324,9 +324,12 @@ export const ChannelHomeComposer = forwardRef<
   );
   const handleModelChange = useCallback(
     (value: string) => {
+      // A harness switch clears the options while the new config loads, and
+      // the menu stays open through that window. Recording the pick first
+      // lets the reload restore it instead of dropping it silently.
+      setLastUsedModel(value);
       if (modelOption) {
         setConfigOption(modelOption.id, value);
-        setLastUsedModel(value);
       }
     },
     [modelOption, setConfigOption, setLastUsedModel],

--- a/products/desktop/packages/ui/src/features/loops/components/LoopModelFields.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopModelFields.tsx
@@ -64,6 +64,7 @@ export function LoopModelFields({
         glm53Enabled: modelFlags.glm53,
         glm53FlashEnabled: modelFlags.glm53Flash,
         kimiEnabled: modelFlags.kimi,
+        deepseekEnabled: modelFlags.deepseek,
         pinnedModel: model,
       }),
     ],

--- a/products/desktop/packages/ui/src/features/loops/components/LoopModelFields.tsx
+++ b/products/desktop/packages/ui/src/features/loops/components/LoopModelFields.tsx
@@ -1,11 +1,5 @@
 import type { LoopSchemas } from "@posthog/api-client/loops";
-import {
-  GLM_MODEL_FLAG,
-  GLM53_FLASH_MODEL_FLAG,
-  GLM53_MODEL_FLAG,
-  KIMI_MODEL_FLAG,
-} from "@posthog/shared";
-import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useModelRolloutFlags } from "@posthog/ui/features/sessions/useModelRolloutFlags";
 import { SettingsOptionSelect } from "@posthog/ui/features/settings/SettingsOptionSelect";
 import { Flex } from "@radix-ui/themes";
 import { useMemo } from "react";
@@ -59,32 +53,21 @@ export function LoopModelFields({
   onReasoningEffortChange,
   disabled,
 }: LoopModelFieldsProps) {
-  const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
-  const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
-  const glm53FlashEnabled = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
-  const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
+  const modelFlags = useModelRolloutFlags();
   const configOptions = useLoopModelConfigOptions(adapter);
 
   const modelOptions = useMemo(
     () => [
       { value: DEFAULT_MODEL_VALUE, label: "Default (recommended)" },
       ...loopModelOptions(adapter, configOptions, {
-        glmEnabled,
-        glm53Enabled,
-        glm53FlashEnabled,
-        kimiEnabled,
+        glmEnabled: modelFlags.glm,
+        glm53Enabled: modelFlags.glm53,
+        glm53FlashEnabled: modelFlags.glm53Flash,
+        kimiEnabled: modelFlags.kimi,
         pinnedModel: model,
       }),
     ],
-    [
-      adapter,
-      configOptions,
-      glmEnabled,
-      glm53Enabled,
-      glm53FlashEnabled,
-      kimiEnabled,
-      model,
-    ],
+    [adapter, configOptions, modelFlags, model],
   );
 
   const reasoningOptions = useMemo(

--- a/products/desktop/packages/ui/src/features/loops/loopModels.test.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopModels.test.ts
@@ -142,27 +142,22 @@ describe("loopModelOptions", () => {
   it.each<{
     name: string;
     adapter: LoopSchemas.LoopRuntimeAdapterEnum;
-    glmEnabled: boolean;
+    glm53Enabled?: boolean;
     expectedValues: string[];
   }>([
     {
       name: "falls back to the known claude models when the config has no model select",
       adapter: "claude",
-      glmEnabled: true,
       expectedValues: [
-        "claude-sonnet-4-6",
-        "claude-opus-4-7",
         "claude-opus-4-8",
         "claude-opus-5",
         "claude-sonnet-5",
         "claude-fable-5",
-        "@cf/zai-org/glm-5.2",
       ],
     },
     {
       name: "falls back to the known codex models when the config has no model select",
       adapter: "codex",
-      glmEnabled: true,
       expectedValues: [
         "gpt-5",
         "gpt-5.5",
@@ -172,21 +167,21 @@ describe("loopModelOptions", () => {
       ],
     },
     {
-      name: "applies the GLM flag to the fallback list",
+      name: "applies the GLM 5.3 flag to the fallback list",
       adapter: "claude",
-      glmEnabled: false,
+      glm53Enabled: true,
       expectedValues: [
-        "claude-sonnet-4-6",
-        "claude-opus-4-7",
         "claude-opus-4-8",
         "claude-opus-5",
         "claude-sonnet-5",
         "claude-fable-5",
+        "zai-org/glm-5.3",
       ],
     },
-  ])("$name", ({ adapter, glmEnabled, expectedValues }) => {
+  ])("$name", ({ adapter, glm53Enabled, expectedValues }) => {
     const values = loopModelOptions(adapter, [], {
-      glmEnabled,
+      glmEnabled: true,
+      glm53Enabled,
       pinnedModel: "",
     }).map((option) => option.value);
     expect(values).toEqual(expectedValues);

--- a/products/desktop/packages/ui/src/features/loops/loopModels.test.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopModels.test.ts
@@ -139,6 +139,42 @@ describe("loopModelOptions", () => {
     ).toEqual(expected);
   });
 
+  it.each([
+    {
+      name: "hides a served DeepSeek model when the flag is off",
+      deepseekEnabled: false,
+      pinnedModel: "",
+      expectedValues: ["claude-sonnet-5"],
+    },
+    {
+      name: "shows a served DeepSeek model when the flag is on",
+      deepseekEnabled: true,
+      pinnedModel: "",
+      expectedValues: ["claude-sonnet-5", "deepseek-ai/deepseek-v4-flash-0731"],
+    },
+    {
+      name: "keeps a pinned DeepSeek model visible with the flag off",
+      deepseekEnabled: false,
+      pinnedModel: "deepseek-ai/deepseek-v4-flash-0731",
+      expectedValues: ["claude-sonnet-5", "deepseek-ai/deepseek-v4-flash-0731"],
+    },
+  ])("$name", ({ deepseekEnabled, pinnedModel, expectedValues }) => {
+    const options = modelConfigOption([
+      { value: "claude-sonnet-5", name: "Claude Sonnet 5" },
+      {
+        value: "deepseek-ai/deepseek-v4-flash-0731",
+        name: "DeepSeek V4 Flash",
+      },
+    ]);
+
+    const values = loopModelOptions("claude", options, {
+      glmEnabled: true,
+      deepseekEnabled,
+      pinnedModel,
+    }).map((option) => option.value);
+    expect(values).toEqual(expectedValues);
+  });
+
   it.each<{
     name: string;
     adapter: LoopSchemas.LoopRuntimeAdapterEnum;

--- a/products/desktop/packages/ui/src/features/loops/loopModels.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopModels.ts
@@ -41,13 +41,10 @@ const FALLBACK_MODEL_OPTIONS: Record<
   LoopModelOption[]
 > = {
   claude: [
-    { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-    { value: "claude-opus-4-7", label: "Claude Opus 4.7" },
     { value: "claude-opus-4-8", label: "Claude Opus 4.8" },
     { value: "claude-opus-5", label: "Claude Opus 5" },
     { value: "claude-sonnet-5", label: "Claude Sonnet 5" },
     { value: "claude-fable-5", label: "Claude Fable 5" },
-    { value: "@cf/zai-org/glm-5.2", label: "GLM-5.2" },
     { value: "zai-org/glm-5.3", label: "GLM-5.3" },
     { value: "zai-org/glm-5.3-flash", label: "GLM-5.3 Flash" },
     { value: "moonshotai/kimi-k3", label: "Kimi K3" },

--- a/products/desktop/packages/ui/src/features/loops/loopModels.ts
+++ b/products/desktop/packages/ui/src/features/loops/loopModels.ts
@@ -3,6 +3,7 @@ import { getReasoningEffortOptions } from "@posthog/agent/adapters/reasoning-eff
 import type { LoopSchemas } from "@posthog/api-client/loops";
 import {
   flattenSelectOptions,
+  isDeepseekModelId,
   isDefaultSelectOption,
   isGlm53FlashModelId,
   isGlm53ModelId,
@@ -72,7 +73,8 @@ export function formatLoopModel(
  * Pinnable models for a loop, derived from the same per-adapter preview
  * config that feeds the main create-task picker, so the loops picker offers
  * exactly the ids the loops API accepts. Restricted (plan-locked) models are
- * dropped, GLM is flag-gated like the main picker, and the currently pinned
+ * dropped, staged models carry the same rollout flags as the main picker
+ * (`useModelRolloutFlags`), and the currently pinned
  * model always stays selectable so an existing loop's model never drops out.
  */
 export function loopModelOptions(
@@ -83,12 +85,14 @@ export function loopModelOptions(
     glm53Enabled,
     glm53FlashEnabled,
     kimiEnabled,
+    deepseekEnabled,
     pinnedModel,
   }: {
     glmEnabled: boolean;
     glm53Enabled?: boolean;
     glm53FlashEnabled?: boolean;
     kimiEnabled?: boolean;
+    deepseekEnabled?: boolean;
     pinnedModel: string;
   },
 ): LoopModelOption[] {
@@ -120,6 +124,12 @@ export function loopModelOptions(
         kimiEnabled ||
         option.value === pinnedModel ||
         !isKimiModelId(option.value),
+    )
+    .filter(
+      (option) =>
+        deepseekEnabled ||
+        option.value === pinnedModel ||
+        !isDeepseekModelId(option.value),
     );
   if (pinnedModel && !options.some((option) => option.value === pinnedModel)) {
     options.push({ value: pinnedModel, label: pinnedModel });

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.stories.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.stories.tsx
@@ -1,0 +1,98 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ReactElement, useState } from "react";
+import { within } from "storybook/test";
+import { PiModelSelector } from "./PiSessionControls";
+
+const option = (
+  harness: "claude" | "codex",
+  value: string,
+  name: string,
+): { value: string; name: string; _meta: Record<string, unknown> } => ({
+  value,
+  name,
+  _meta: { "posthog.code/modelHarness": harness },
+});
+
+function groupedModelOption(currentValue: string): SessionConfigOption {
+  return {
+    type: "select",
+    id: "model",
+    name: "Model",
+    category: "model",
+    currentValue,
+    options: [
+      {
+        group: "anthropic",
+        name: "Anthropic",
+        options: [
+          option("claude", "claude-fable-5", "Claude Fable 5"),
+          option("claude", "claude-opus-5", "Claude Opus 5"),
+          option("claude", "claude-sonnet-5", "Claude Sonnet 5"),
+        ],
+      },
+      {
+        group: "openai",
+        name: "OpenAI",
+        options: [
+          option("codex", "gpt-5.6-sol", "GPT-5.6 Sol"),
+          option("codex", "gpt-5.6-terra", "GPT-5.6 Terra"),
+          option("codex", "gpt-5.5", "GPT-5.5"),
+        ],
+      },
+      {
+        group: "zai-org",
+        name: "Z.ai",
+        options: [option("claude", "zai-org/glm-5.3", "GLM-5.3")],
+      },
+    ],
+  } as unknown as SessionConfigOption;
+}
+
+const piModels = [
+  { provider: "posthog" as const, id: "claude-opus-5", name: "Claude Opus 5" },
+  { provider: "posthog" as const, id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
+  { provider: "posthog" as const, id: "zai-org/glm-5.3", name: "GLM-5.3" },
+];
+
+function Harness(): ReactElement {
+  const [modelId, setModelId] = useState("gpt-5.6-terra");
+  const currentModel = piModels.find((model) => model.id === modelId);
+
+  return (
+    <div className="flex h-[480px] items-end p-2">
+      <PiModelSelector
+        models={piModels}
+        currentModel={currentModel}
+        thinkingLevel="high"
+        thinkingLevels={["off", "low", "medium", "high"]}
+        onChange={(model) => setModelId(model.id)}
+        onThinkingLevelChange={() => {}}
+        onHarnessChange={() => {}}
+        modelOption={groupedModelOption(modelId)}
+        onGatewayModelSelect={setModelId}
+      />
+    </div>
+  );
+}
+
+const meta: Meta<typeof Harness> = {
+  title: "Pi Sessions/PiModelSelector",
+  component: Harness,
+};
+
+export default meta;
+type Story = StoryObj<typeof Harness>;
+
+export const Default: Story = {};
+
+export const FullCatalogSubmenu: Story = {
+  play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      canvas.getByRole("button", { name: /Model and reasoning/ }),
+    );
+    await userEvent.hover(await body.findByText("Model"));
+    await body.findByText("GPT-5.6 Sol");
+  },
+};

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
@@ -1,117 +1,89 @@
-import { Theme } from "@radix-ui/themes";
-import { fireEvent, render, screen } from "@testing-library/react";
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { configure, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { PiModelSelector } from "./PiSessionControls";
 
+// Menu open/close and submenu reveals ride animations that starve under
+// parallel suite load; the default 1s async timeout flakes.
+configure({ asyncUtilTimeout: 5000 });
+
+const piModels = [
+  { provider: "posthog" as const, id: "claude-opus-5", name: "Claude Opus 5" },
+  { provider: "posthog" as const, id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },
+];
+
+function groupedModelOption(): SessionConfigOption {
+  return {
+    type: "select",
+    id: "model",
+    name: "Model",
+    category: "model",
+    currentValue: "claude-opus-5",
+    options: [
+      {
+        group: "anthropic",
+        name: "Anthropic",
+        options: [
+          {
+            name: "Claude Opus 5",
+            value: "claude-opus-5",
+            _meta: { "posthog.code/modelHarness": "claude" },
+          },
+        ],
+      },
+      {
+        group: "openai",
+        name: "OpenAI",
+        options: [
+          {
+            name: "GPT-5.5",
+            value: "gpt-5.5",
+            _meta: { "posthog.code/modelHarness": "codex" },
+          },
+        ],
+      },
+    ],
+  } as unknown as SessionConfigOption;
+}
+
+async function openSub(user: ReturnType<typeof userEvent.setup>, name: RegExp) {
+  const trigger = await screen.findByRole("menuitem", { name });
+  await user.click(trigger);
+  // The submenu opens on a Base UI timer that RTL's act-wrapped waitFor never
+  // flushes in jsdom, so poll with plain sleeps instead of findByRole.
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (screen.queryAllByRole("menuitemradio").length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error("submenu did not open");
+}
+
 describe("PiModelSelector", () => {
-  it("keeps Pi configuration open while changing the model", async () => {
-    const user = userEvent.setup({ pointerEventsCheck: 0 });
+  it("offers the full catalog and reports picks by gateway model id", async () => {
     const onChange = vi.fn();
-    const onThinkingLevelChange = vi.fn();
-    const onHarnessChange = vi.fn();
+    const onGatewayModelSelect = vi.fn();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
-      <Theme>
-        <PiModelSelector
-          models={[
-            {
-              provider: "posthog",
-              id: "gpt-5.6-sol",
-              name: "GPT-5.6 Sol",
-            },
-            {
-              provider: "posthog",
-              id: "gpt-5.6-terra",
-              name: "GPT-5.6 Terra",
-            },
-          ]}
-          currentModel={{
-            provider: "posthog",
-            id: "gpt-5.6-sol",
-            name: "GPT-5.6 Sol",
-          }}
-          thinkingLevel="medium"
-          thinkingLevels={["low", "medium", "high"]}
-          onChange={onChange}
-          onThinkingLevelChange={onThinkingLevelChange}
-          onHarnessChange={onHarnessChange}
-        />
-      </Theme>,
+      <PiModelSelector
+        models={piModels}
+        currentModel={piModels[0]}
+        onChange={onChange}
+        modelOption={groupedModelOption()}
+        onGatewayModelSelect={onGatewayModelSelect}
+      />,
     );
 
     await user.click(
-      screen.getByRole("button", {
-        name: "Model and reasoning: GPT-5.6 Sol Medium",
-      }),
+      screen.getByRole("button", { name: "Model: Claude Opus 5" }),
     );
-
-    expect(
-      await screen.findByRole("menuitem", { name: /^Harness Pi/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /^Model/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("menuitem", { name: /^Reasoning/ }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("menuitemradio", { name: "GPT-5.6 Terra" }),
-    ).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("menuitem", { name: /^Model/ }));
-
-    const terra = await screen.findByRole("menuitemradio", {
-      name: "GPT-5.6 Terra",
-    });
-    expect(terra).toBeInTheDocument();
-
-    fireEvent.click(terra);
-
-    expect(onChange).toHaveBeenCalledWith({
-      provider: "posthog",
-      id: "gpt-5.6-terra",
-      name: "GPT-5.6 Terra",
-    });
-    expect(
-      screen.getByRole("menuitem", { name: /^Model/ }),
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("menuitem", { name: /^Reasoning/ }));
-    fireEvent.click(await screen.findByRole("menuitemradio", { name: "High" }));
-
-    expect(onThinkingLevelChange).toHaveBeenCalledWith("high");
-    expect(
-      screen.getByRole("menuitem", { name: /^Reasoning/ }),
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("menuitem", { name: /^Harness/ }));
+    await openSub(user, /^Model/);
     fireEvent.click(
-      await screen.findByRole("menuitemradio", { name: "Codex" }),
+      await screen.findByRole("menuitemradio", { name: "GPT-5.5" }),
     );
 
-    expect(onHarnessChange).toHaveBeenCalledWith("codex");
-    expect(
-      screen.getByRole("menuitem", { name: /^Harness/ }),
-    ).toBeInTheDocument();
-  });
-
-  it("keeps an open menu mounted while the Pi catalog loads", async () => {
-    render(
-      <Theme>
-        <PiModelSelector
-          models={[]}
-          isLoading
-          onChange={vi.fn()}
-          onHarnessChange={vi.fn()}
-          menuOpen
-          onMenuOpenChange={vi.fn()}
-        />
-      </Theme>,
-    );
-
-    expect(screen.getByRole("button", { name: /Loading/ })).toBeInTheDocument();
-    expect(
-      await screen.findByRole("menuitem", { name: /^Harness/ }),
-    ).toBeInTheDocument();
+    expect(onGatewayModelSelect).toHaveBeenCalledWith("gpt-5.5");
+    expect(onGatewayModelSelect).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
@@ -86,4 +86,29 @@ describe("PiModelSelector", () => {
     expect(onGatewayModelSelect).toHaveBeenCalledTimes(1);
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("lists the running model when the curated catalog omits it", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const running = { provider: "posthog" as const, id: "gpt-5.5" };
+    render(
+      <PiModelSelector
+        models={piModels}
+        currentModel={running}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Model: gpt-5.5" }));
+    await openSub(user, /^Model/);
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: /Claude Opus 5/ }),
+    );
+    expect(onChange).toHaveBeenCalledWith(piModels[0]);
+
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: /gpt-5\.5/ }),
+    );
+    expect(onChange).toHaveBeenLastCalledWith(running);
+  });
 });

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.test.tsx
@@ -86,29 +86,4 @@ describe("PiModelSelector", () => {
     expect(onGatewayModelSelect).toHaveBeenCalledTimes(1);
     expect(onChange).not.toHaveBeenCalled();
   });
-
-  it("lists the running model when the curated catalog omits it", async () => {
-    const onChange = vi.fn();
-    const user = userEvent.setup({ pointerEventsCheck: 0 });
-    const running = { provider: "posthog" as const, id: "gpt-5.5" };
-    render(
-      <PiModelSelector
-        models={piModels}
-        currentModel={running}
-        onChange={onChange}
-      />,
-    );
-
-    await user.click(screen.getByRole("button", { name: "Model: gpt-5.5" }));
-    await openSub(user, /^Model/);
-    fireEvent.click(
-      await screen.findByRole("menuitemradio", { name: /Claude Opus 5/ }),
-    );
-    expect(onChange).toHaveBeenCalledWith(piModels[0]);
-
-    fireEvent.click(
-      await screen.findByRole("menuitemradio", { name: /gpt-5\.5/ }),
-    );
-    expect(onChange).toHaveBeenLastCalledWith(running);
-  });
 });

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
@@ -1,3 +1,4 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { CaretDown, Lightning, PiIcon, Stack } from "@phosphor-icons/react";
 import type {
   PiModelSelection,
@@ -24,6 +25,7 @@ import {
   ModelCostChip,
   ModelCostFooter,
 } from "@posthog/ui/features/sessions/components/ModelCostChip";
+import { ModelSelectList } from "@posthog/ui/features/sessions/components/ModelSelectList";
 import type { MessagingMode } from "@posthog/ui/features/sessions/messagingModeStore";
 import { Spinner } from "@posthog/ui/primitives/Spinner";
 import { useState } from "react";
@@ -40,6 +42,13 @@ interface PiModelSelectorProps {
   onChange: (model: PiModelSelection) => void;
   onThinkingLevelChange?: (level: PiThinkingLevel) => void;
   onHarnessChange?: (harness: AgentHarness) => void;
+  /**
+   * The full provider-grouped catalog, so the Pi menu offers the same model
+   * list as the other harnesses. Picks report the gateway model id and the
+   * caller decides whether the pick stays on Pi.
+   */
+  modelOption?: SessionConfigOption;
+  onGatewayModelSelect?: (modelId: string) => void;
   menuOpen?: boolean;
   onMenuOpenChange?: (open: boolean) => void;
 }
@@ -72,12 +81,18 @@ export function PiModelSelector({
   onChange,
   onThinkingLevelChange,
   onHarnessChange,
+  modelOption,
+  onGatewayModelSelect,
   menuOpen,
   onMenuOpenChange,
 }: PiModelSelectorProps) {
   const [internalMenuOpen, setInternalMenuOpen] = useState(false);
   const open = menuOpen ?? internalMenuOpen;
   const setOpen = onMenuOpenChange ?? setInternalMenuOpen;
+  const gatewayModelSelect =
+    modelOption?.type === "select" && onGatewayModelSelect
+      ? modelOption
+      : undefined;
 
   if (models.length === 0) {
     if (isLoading) {
@@ -103,6 +118,10 @@ export function PiModelSelector({
             sideOffset={6}
             className="min-w-[230px]"
           >
+            <DropdownMenuItem disabled>
+              <Spinner size={12} />
+              Loading models...
+            </DropdownMenuItem>
             {onHarnessChange && (
               <HarnessSubmenu
                 value="pi"
@@ -115,10 +134,6 @@ export function PiModelSelector({
                 }}
               />
             )}
-            <DropdownMenuItem disabled>
-              <Spinner size={12} />
-              Loading models...
-            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       );
@@ -172,6 +187,52 @@ export function PiModelSelector({
         sideOffset={6}
         className="min-w-[230px]"
       >
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span>Model</span>
+            <span className="flex-1 text-right text-muted-foreground">
+              {currentLabel}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="min-w-[220px]">
+            {gatewayModelSelect ? (
+              <ModelSelectList
+                options={gatewayModelSelect.options}
+                currentValue={selectedModel?.id}
+                onGated={() => setOpen(false)}
+                onSelect={(value) => onGatewayModelSelect?.(value)}
+              />
+            ) : (
+              <>
+                <DropdownMenuRadioGroup
+                  value={currentValue}
+                  onValueChange={(value) => {
+                    const model = models.find(
+                      (candidate) => modelKey(candidate) === value,
+                    );
+                    if (model) {
+                      onChange(model);
+                    }
+                  }}
+                >
+                  {models.map((model) => (
+                    <DropdownMenuRadioItem
+                      key={modelKey(model)}
+                      value={modelKey(model)}
+                      closeOnClick={false}
+                    >
+                      <span className="whitespace-nowrap">
+                        {modelLabel(model)}
+                      </span>
+                      <ModelCostChip modelId={model.id} />
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+                <ModelCostFooter />
+              </>
+            )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
         {onHarnessChange && (
           <HarnessSubmenu
             value="pi"
@@ -184,39 +245,6 @@ export function PiModelSelector({
             }}
           />
         )}
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
-            <span>Model</span>
-            <span className="flex-1 text-right text-muted-foreground">
-              {currentLabel}
-            </span>
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="min-w-[220px]">
-            <DropdownMenuRadioGroup
-              value={currentValue}
-              onValueChange={(value) => {
-                const model = models.find(
-                  (candidate) => modelKey(candidate) === value,
-                );
-                if (model) {
-                  onChange(model);
-                }
-              }}
-            >
-              {models.map((model) => (
-                <DropdownMenuRadioItem
-                  key={modelKey(model)}
-                  value={modelKey(model)}
-                  closeOnClick={false}
-                >
-                  <span className="whitespace-nowrap">{modelLabel(model)}</span>
-                  <ModelCostChip modelId={model.id} />
-                </DropdownMenuRadioItem>
-              ))}
-            </DropdownMenuRadioGroup>
-            <ModelCostFooter />
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
         {thinkingLevel &&
           onThinkingLevelChange &&
           thinkingLevels.length > 0 && (

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
@@ -142,13 +142,8 @@ export function PiModelSelector({
   }
 
   const currentValue = currentModel ? modelKey(currentModel) : "";
-  const catalogModel = models.find((model) => modelKey(model) === currentValue);
-  const selectedModel = catalogModel ?? currentModel;
-  // The composer offers every gateway model, so a session can run one the
-  // curated Pi catalog hides. Listing it keeps the running model reachable
-  // after the user tries another.
-  const menuModels =
-    catalogModel || !selectedModel ? models : [selectedModel, ...models];
+  const selectedModel =
+    models.find((model) => modelKey(model) === currentValue) ?? currentModel;
   const currentLabel = modelLabel(selectedModel);
   const thinkingLabel = thinkingLevel
     ? (thinkingLevelLabels[thinkingLevel] ?? thinkingLevel)
@@ -212,7 +207,7 @@ export function PiModelSelector({
                 <DropdownMenuRadioGroup
                   value={currentValue}
                   onValueChange={(value) => {
-                    const model = menuModels.find(
+                    const model = models.find(
                       (candidate) => modelKey(candidate) === value,
                     );
                     if (model) {
@@ -220,7 +215,7 @@ export function PiModelSelector({
                     }
                   }}
                 >
-                  {menuModels.map((model) => (
+                  {models.map((model) => (
                     <DropdownMenuRadioItem
                       key={modelKey(model)}
                       value={modelKey(model)}

--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionControls.tsx
@@ -142,8 +142,13 @@ export function PiModelSelector({
   }
 
   const currentValue = currentModel ? modelKey(currentModel) : "";
-  const selectedModel =
-    models.find((model) => modelKey(model) === currentValue) ?? currentModel;
+  const catalogModel = models.find((model) => modelKey(model) === currentValue);
+  const selectedModel = catalogModel ?? currentModel;
+  // The composer offers every gateway model, so a session can run one the
+  // curated Pi catalog hides. Listing it keeps the running model reachable
+  // after the user tries another.
+  const menuModels =
+    catalogModel || !selectedModel ? models : [selectedModel, ...models];
   const currentLabel = modelLabel(selectedModel);
   const thinkingLabel = thinkingLevel
     ? (thinkingLevelLabels[thinkingLevel] ?? thinkingLevel)
@@ -207,7 +212,7 @@ export function PiModelSelector({
                 <DropdownMenuRadioGroup
                   value={currentValue}
                   onValueChange={(value) => {
-                    const model = models.find(
+                    const model = menuModels.find(
                       (candidate) => modelKey(candidate) === value,
                     );
                     if (model) {
@@ -215,7 +220,7 @@ export function PiModelSelector({
                     }
                   }}
                 >
-                  {models.map((model) => (
+                  {menuModels.map((model) => (
                     <DropdownMenuRadioItem
                       key={modelKey(model)}
                       value={modelKey(model)}

--- a/products/desktop/packages/ui/src/features/pi-sessions/usePiModelCatalog.ts
+++ b/products/desktop/packages/ui/src/features/pi-sessions/usePiModelCatalog.ts
@@ -1,26 +1,15 @@
 import { useHostTRPC } from "@posthog/host-router/react";
-import {
-  DEEPSEEK_MODEL_FLAG,
-  GLM_MODEL_FLAG,
-  GLM53_FLASH_MODEL_FLAG,
-  GLM53_MODEL_FLAG,
-  getCloudUrlFromRegion,
-  KIMI_MODEL_FLAG,
-} from "@posthog/shared";
+import { getCloudUrlFromRegion } from "@posthog/shared";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
-import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { stripDisabledModels } from "@posthog/ui/features/sessions/modelOptionFilters";
+import { useModelRolloutFlags } from "@posthog/ui/features/sessions/useModelRolloutFlags";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 export function usePiModelCatalog(enabled: boolean) {
   const trpc = useHostTRPC();
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
-  const deepseek = useFeatureFlag(DEEPSEEK_MODEL_FLAG);
-  const glm = useFeatureFlag(GLM_MODEL_FLAG);
-  const glm53 = useFeatureFlag(GLM53_MODEL_FLAG);
-  const glm53Flash = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
-  const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
+  const modelFlags = useModelRolloutFlags();
   const apiHost = useMemo(
     () => (cloudRegion ? getCloudUrlFromRegion(cloudRegion) : null),
     [cloudRegion],
@@ -32,13 +21,6 @@ export function usePiModelCatalog(enabled: boolean) {
       region: cloudRegion ?? "us",
     }),
     enabled: enabled && apiHost !== null,
-    select: (models) =>
-      stripDisabledModels(models, {
-        deepseek,
-        glm,
-        glm53,
-        glm53Flash,
-        kimi: kimiEnabled,
-      }),
+    select: (models) => stripDisabledModels(models, modelFlags),
   });
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/HarnessSubmenu.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/HarnessSubmenu.tsx
@@ -5,13 +5,13 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from "@posthog/quill";
+import { HARNESS_DISPLAY_NAMES } from "@posthog/shared";
 import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
 
 export type AgentHarness = AgentAdapter | "pi";
 
 const harnessLabels: Record<AgentHarness, string> = {
-  claude: "Claude Code",
-  codex: "Codex",
+  ...HARNESS_DISPLAY_NAMES,
   pi: "Pi",
 };
 

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSelectList.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSelectList.tsx
@@ -26,6 +26,21 @@ interface ModelSelectListProps {
   unavailableReason?: (modelId: string) => string | undefined;
 }
 
+const renderEntries = (
+  list: SessionConfigSelectOption[],
+  unavailableReason?: (modelId: string) => string | undefined,
+) =>
+  list
+    .toSorted((a, b) => compareModelsForPicker(a.value, b.value))
+    .map((model) => (
+      <ModelRadioItem
+        key={model.value}
+        model={model}
+        closeOnClick={false}
+        unavailableReason={unavailableReason?.(model.value)}
+      />
+    ));
+
 /**
  * The model radio list every picker shares: one identical catalog, grouped by
  * provider, so the menu looks the same whichever harness is active. The
@@ -40,17 +55,6 @@ export function ModelSelectList({
 }: ModelSelectListProps) {
   const entries = flattenSelectOptions(options);
   const groups = isSelectGroup(options) ? options : [];
-  const renderEntries = (list: SessionConfigSelectOption[]) =>
-    list
-      .toSorted((a, b) => compareModelsForPicker(a.value, b.value))
-      .map((model) => (
-        <ModelRadioItem
-          key={model.value}
-          model={model}
-          closeOnClick={false}
-          unavailableReason={unavailableReason?.(model.value)}
-        />
-      ));
 
   return (
     <>
@@ -75,11 +79,11 @@ export function ModelSelectList({
                   {groups.length > 1 && group.name && (
                     <DropdownMenuLabel>{group.name}</DropdownMenuLabel>
                   )}
-                  {renderEntries(group.options)}
+                  {renderEntries(group.options, unavailableReason)}
                 </DropdownMenuGroup>
               </Fragment>
             ))
-          : renderEntries(entries)}
+          : renderEntries(entries, unavailableReason)}
       </DropdownMenuRadioGroup>
       <ModelCostFooter />
     </>

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSelectList.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSelectList.tsx
@@ -1,0 +1,87 @@
+import type {
+  SessionConfigSelectOption,
+  SessionConfigSelectOptions,
+} from "@agentclientprotocol/sdk";
+import { compareModelsForPicker } from "@posthog/agent/gateway-models";
+import {
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuSeparator,
+} from "@posthog/quill";
+import { isSelectGroup } from "@posthog/shared";
+import { gateRestrictedModelPick } from "@posthog/ui/features/billing/modelGate";
+import { ModelCostFooter } from "@posthog/ui/features/sessions/components/ModelCostChip";
+import { ModelRadioItem } from "@posthog/ui/features/sessions/components/ModelRadioItem";
+import { Fragment } from "react";
+import { flattenSelectOptions } from "../sessionStore";
+
+interface ModelSelectListProps {
+  options: SessionConfigSelectOptions;
+  currentValue?: string;
+  onSelect: (value: string) => void;
+  /** A plan-restricted pick opened the upgrade gate instead; close the menu. */
+  onGated?: () => void;
+  /** Names why the current billing source cannot run a model, if it cannot. */
+  unavailableReason?: (modelId: string) => string | undefined;
+}
+
+/**
+ * The model radio list every picker shares: one identical catalog, grouped by
+ * provider, so the menu looks the same whichever harness is active. The
+ * harness consequence of a pick is the caller's decision.
+ */
+export function ModelSelectList({
+  options,
+  currentValue,
+  onSelect,
+  onGated,
+  unavailableReason,
+}: ModelSelectListProps) {
+  const entries = flattenSelectOptions(options);
+  const groups = isSelectGroup(options) ? options : [];
+  const renderEntries = (list: SessionConfigSelectOption[]) =>
+    list
+      .toSorted((a, b) => compareModelsForPicker(a.value, b.value))
+      .map((model) => (
+        <ModelRadioItem
+          key={model.value}
+          model={model}
+          closeOnClick={false}
+          unavailableReason={unavailableReason?.(model.value)}
+        />
+      ));
+
+  return (
+    <>
+      <DropdownMenuRadioGroup
+        value={currentValue ?? ""}
+        onValueChange={(value) => {
+          if (unavailableReason?.(value)) return;
+          // A plan-restricted model opens the upgrade gate instead of
+          // becoming the selection.
+          if (gateRestrictedModelPick(entries, value)) {
+            onGated?.();
+            return;
+          }
+          onSelect(value);
+        }}
+      >
+        {groups.length > 0
+          ? groups.map((group, index) => (
+              <Fragment key={group.group}>
+                {index > 0 && <DropdownMenuSeparator />}
+                <DropdownMenuGroup>
+                  {groups.length > 1 && group.name && (
+                    <DropdownMenuLabel>{group.name}</DropdownMenuLabel>
+                  )}
+                  {renderEntries(group.options)}
+                </DropdownMenuGroup>
+              </Fragment>
+            ))
+          : renderEntries(entries)}
+      </DropdownMenuRadioGroup>
+      <ModelCostFooter />
+    </>
+  );
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/ModelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ModelSelector.tsx
@@ -12,16 +12,8 @@ import {
   DropdownMenuTrigger,
   MenuLabel,
 } from "@posthog/quill";
-import {
-  type Adapter,
-  DEEPSEEK_MODEL_FLAG,
-  GLM_MODEL_FLAG,
-  GLM53_FLASH_MODEL_FLAG,
-  GLM53_MODEL_FLAG,
-  KIMI_MODEL_FLAG,
-} from "@posthog/shared";
+import type { Adapter } from "@posthog/shared";
 import { gateRestrictedModelPick } from "@posthog/ui/features/billing/modelGate";
-import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { ModelCostFooter } from "@posthog/ui/features/sessions/components/ModelCostChip";
 import { ModelRadioItem } from "@posthog/ui/features/sessions/components/ModelRadioItem";
 import { stripDisabledModelOption } from "@posthog/ui/features/sessions/modelOptionFilters";
@@ -31,6 +23,7 @@ import {
   useSessionIsCloud,
   useSessionSelector,
 } from "@posthog/ui/features/sessions/sessionStore";
+import { useModelRolloutFlags } from "@posthog/ui/features/sessions/useModelRolloutFlags";
 import { Fragment, useMemo } from "react";
 
 interface ModelSelectorProps {
@@ -51,19 +44,9 @@ export function ModelSelector({
   const sessionStatus = useSessionSelector(taskId, (s) => s?.status);
   const sessionIsCloud = useSessionIsCloud(taskId);
   const rawModelOption = useModelConfigOptionForTask(taskId);
-  const deepseek = useFeatureFlag(DEEPSEEK_MODEL_FLAG);
-  const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
-  const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
-  const glm53FlashEnabled = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
-  const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
+  const modelFlags = useModelRolloutFlags();
   const modelOption = rawModelOption
-    ? stripDisabledModelOption(rawModelOption, {
-        deepseek,
-        glm: glmEnabled,
-        glm53: glm53Enabled,
-        glm53Flash: glm53FlashEnabled,
-        kimi: kimiEnabled,
-      })
+    ? stripDisabledModelOption(rawModelOption, modelFlags)
     : rawModelOption;
 
   const selectOption = modelOption?.type === "select" ? modelOption : undefined;

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
@@ -15,28 +15,37 @@ const harnessOption = (
   _meta: { "posthog.code/modelHarness": harness },
 });
 
-const CLAUDE_MODELS = [
+const ANTHROPIC_MODELS = [
   harnessOption("claude", "claude-fable-5", "Claude Fable 5"),
   harnessOption("claude", "claude-opus-5", "Claude Opus 5"),
   harnessOption("claude", "claude-opus-4-8", "Claude Opus 4.8"),
   harnessOption("claude", "claude-opus-4-7", "Claude Opus 4.7"),
   harnessOption("claude", "claude-sonnet-5", "Claude Sonnet 5"),
   harnessOption("claude", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
-  harnessOption("claude", "moonshotai/kimi-k3", "Kimi K3"),
-  harnessOption(
-    "claude",
-    "deepseek-ai/deepseek-v4-flash-0731",
-    "DeepSeek V4 Flash",
-  ),
+];
+
+const OPENAI_MODELS = [
+  harnessOption("codex", "gpt-5.6-sol", "GPT-5.6 Sol"),
+  harnessOption("codex", "gpt-5.6-terra", "GPT-5.6 Terra"),
+  harnessOption("codex", "gpt-5.5", "GPT-5.5"),
+];
+
+const ZAI_MODELS = [
   harnessOption("claude", "zai-org/glm-5.3-flash", "GLM-5.3 Flash"),
   harnessOption("claude", "zai-org/glm-5.3", "GLM-5.3"),
   harnessOption("claude", "@cf/zai-org/glm-5.2", "GLM-5.2"),
 ];
 
-const CODEX_MODELS = [
-  harnessOption("codex", "gpt-5.6-sol", "GPT-5.6 Sol"),
-  harnessOption("codex", "gpt-5.6-terra", "GPT-5.6 Terra"),
-  harnessOption("codex", "gpt-5.5", "GPT-5.5"),
+const MOONSHOT_MODELS = [
+  harnessOption("claude", "moonshotai/kimi-k3", "Kimi K3"),
+];
+
+const DEEPSEEK_MODELS = [
+  harnessOption(
+    "claude",
+    "deepseek-ai/deepseek-v4-flash-0731",
+    "DeepSeek V4 Flash",
+  ),
 ];
 
 function groupedModelOption(currentValue: string): SessionConfigOption {
@@ -47,8 +56,11 @@ function groupedModelOption(currentValue: string): SessionConfigOption {
     category: "model",
     currentValue,
     options: [
-      { group: "claude", name: "Claude Code", options: CLAUDE_MODELS },
-      { group: "codex", name: "Codex", options: CODEX_MODELS },
+      { group: "anthropic", name: "Anthropic", options: ANTHROPIC_MODELS },
+      { group: "openai", name: "OpenAI", options: OPENAI_MODELS },
+      { group: "zai-org", name: "Z.ai", options: ZAI_MODELS },
+      { group: "moonshotai", name: "Moonshot AI", options: MOONSHOT_MODELS },
+      { group: "deepseek-ai", name: "DeepSeek", options: DEEPSEEK_MODELS },
     ],
   } as unknown as SessionConfigOption;
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
@@ -1,0 +1,142 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { type ReactElement, useState } from "react";
+import { within } from "storybook/test";
+import { ReasoningLevelSelector } from "./ReasoningLevelSelector";
+
+const harnessOption = (
+  harness: AgentAdapter,
+  value: string,
+  name: string,
+): { value: string; name: string; _meta: Record<string, unknown> } => ({
+  value,
+  name,
+  _meta: { "posthog.code/modelHarness": harness },
+});
+
+const CLAUDE_MODELS = [
+  harnessOption("claude", "claude-fable-5", "Claude Fable 5"),
+  harnessOption("claude", "claude-opus-5", "Claude Opus 5"),
+  harnessOption("claude", "claude-opus-4-8", "Claude Opus 4.8"),
+  harnessOption("claude", "claude-opus-4-7", "Claude Opus 4.7"),
+  harnessOption("claude", "claude-sonnet-5", "Claude Sonnet 5"),
+  harnessOption("claude", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
+  harnessOption("claude", "moonshotai/kimi-k3", "Kimi K3"),
+  harnessOption(
+    "claude",
+    "deepseek-ai/deepseek-v4-flash-0731",
+    "DeepSeek V4 Flash",
+  ),
+  harnessOption("claude", "zai-org/glm-5.3-flash", "GLM-5.3 Flash"),
+  harnessOption("claude", "zai-org/glm-5.3", "GLM-5.3"),
+  harnessOption("claude", "@cf/zai-org/glm-5.2", "GLM-5.2"),
+];
+
+const CODEX_MODELS = [
+  harnessOption("codex", "gpt-5.6-sol", "GPT-5.6 Sol"),
+  harnessOption("codex", "gpt-5.6-terra", "GPT-5.6 Terra"),
+  harnessOption("codex", "gpt-5.5", "GPT-5.5"),
+];
+
+function groupedModelOption(currentValue: string): SessionConfigOption {
+  return {
+    type: "select",
+    id: "model",
+    name: "Model",
+    category: "model",
+    currentValue,
+    options: [
+      { group: "claude", name: "Claude Code", options: CLAUDE_MODELS },
+      { group: "codex", name: "Codex", options: CODEX_MODELS },
+    ],
+  } as unknown as SessionConfigOption;
+}
+
+function effortOption(currentValue: string): SessionConfigOption {
+  return {
+    type: "select",
+    id: "effort",
+    name: "Effort",
+    category: "thought_level",
+    currentValue,
+    options: [
+      { name: "Low", value: "low" },
+      { name: "Medium", value: "medium" },
+      {
+        name: "High",
+        value: "high",
+        _meta: { "posthog.code/defaultOption": true },
+      },
+      { name: "Extra High", value: "xhigh" },
+      { name: "Max", value: "max" },
+    ],
+  } as unknown as SessionConfigOption;
+}
+
+function contextWindowOption(): SessionConfigOption {
+  return {
+    type: "select",
+    id: "context_window",
+    name: "Context Window",
+    category: "_context_window",
+    currentValue: "1m",
+    options: [
+      { name: "200k", value: "200k" },
+      {
+        name: "1M",
+        value: "1m",
+        _meta: { "posthog.code/defaultOption": true },
+      },
+    ],
+  } as unknown as SessionConfigOption;
+}
+
+function Harness(): ReactElement {
+  const [adapter, setAdapter] = useState<AgentAdapter>("claude");
+  const [model, setModel] = useState("claude-opus-5");
+  const [effort, setEffort] = useState("medium");
+
+  return (
+    <div className="flex h-[520px] items-end p-2">
+      <ReasoningLevelSelector
+        thoughtOption={effortOption(effort)}
+        modelOption={groupedModelOption(model)}
+        adapter={adapter}
+        contextWindowOption={contextWindowOption()}
+        onChange={setEffort}
+        onModelChange={setModel}
+        onAdapterChange={setAdapter}
+        onHarnessModelChange={(harness, nextModel) => {
+          setAdapter(harness);
+          setModel(nextModel);
+        }}
+        onConfigOptionChange={() => {}}
+      />
+    </div>
+  );
+}
+
+const meta: Meta<typeof Harness> = {
+  title: "Sessions/ReasoningLevelSelector",
+  component: Harness,
+};
+
+export default meta;
+type Story = StoryObj<typeof Harness>;
+
+export const Default: Story = {};
+
+export const GroupedModelSubmenu: Story = {
+  play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(
+      canvas.getByRole("button", { name: /Model and reasoning/ }),
+    );
+    await userEvent.click(
+      await body.findByRole("button", { name: "Advanced" }),
+    );
+    await userEvent.hover(await body.findByText("Model"));
+    await body.findByText("GPT-5.6 Sol");
+  },
+};

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
@@ -19,9 +19,7 @@ const ANTHROPIC_MODELS = [
   harnessOption("claude", "claude-fable-5", "Claude Fable 5"),
   harnessOption("claude", "claude-opus-5", "Claude Opus 5"),
   harnessOption("claude", "claude-opus-4-8", "Claude Opus 4.8"),
-  harnessOption("claude", "claude-opus-4-7", "Claude Opus 4.7"),
   harnessOption("claude", "claude-sonnet-5", "Claude Sonnet 5"),
-  harnessOption("claude", "claude-sonnet-4-6", "Claude Sonnet 4.6"),
 ];
 
 const OPENAI_MODELS = [
@@ -33,7 +31,6 @@ const OPENAI_MODELS = [
 const ZAI_MODELS = [
   harnessOption("claude", "zai-org/glm-5.3-flash", "GLM-5.3 Flash"),
   harnessOption("claude", "zai-org/glm-5.3", "GLM-5.3"),
-  harnessOption("claude", "@cf/zai-org/glm-5.2", "GLM-5.2"),
 ];
 
 const MOONSHOT_MODELS = [

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -548,8 +548,10 @@ describe("ReasoningLevelSelector", () => {
       screen.getByRole("button", { name: /Model and reasoning/ }),
     );
     await user.click(await screen.findByRole("button", { name: "Advanced" }));
-    // The grouped model list replaces the Harness row.
-    expect(screen.queryByRole("menuitem", { name: /^Harness/ })).toBeNull();
+    // The Harness row stays as the visible, overridable result of the pick.
+    expect(
+      screen.getByRole("menuitem", { name: /^Harness/ }),
+    ).toBeInTheDocument();
     await openSub(user, /^Model/);
     fireEvent.click(
       await screen.findByRole("menuitemradio", { name: "GPT-5.6 Sol" }),

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -79,6 +79,47 @@ function mixedModelOption(currentValue = "claude-opus-5"): SessionConfigOption {
   } as unknown as SessionConfigOption;
 }
 
+function groupedModelOption(
+  currentValue = "claude-sonnet-5",
+): SessionConfigOption {
+  return {
+    type: "select",
+    id: "model",
+    name: "Model",
+    category: "model",
+    currentValue,
+    options: [
+      {
+        group: "claude",
+        name: "Claude Code",
+        options: [
+          {
+            name: "Claude Sonnet 5",
+            value: "claude-sonnet-5",
+            _meta: { "posthog.code/modelHarness": "claude" },
+          },
+          {
+            name: "Claude Opus 5",
+            value: "claude-opus-5",
+            _meta: { "posthog.code/modelHarness": "claude" },
+          },
+        ],
+      },
+      {
+        group: "codex",
+        name: "Codex",
+        options: [
+          {
+            name: "GPT-5.6 Sol",
+            value: "gpt-5.6-sol",
+            _meta: { "posthog.code/modelHarness": "codex" },
+          },
+        ],
+      },
+    ],
+  } as unknown as SessionConfigOption;
+}
+
 function effortlessModelOption(): SessionConfigOption {
   return {
     type: "select",
@@ -484,6 +525,41 @@ describe("ReasoningLevelSelector", () => {
     expect(
       screen.getByRole("menuitem", { name: /^Model/ }),
     ).toBeInTheDocument();
+  });
+
+  it("switches the harness when picking a model from the other harness's group", async () => {
+    const onModelChange = vi.fn();
+    const onHarnessModelChange = vi.fn();
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption()}
+          modelOption={groupedModelOption("claude-sonnet-5")}
+          adapter="claude"
+          onModelChange={onModelChange}
+          onHarnessModelChange={onHarnessModelChange}
+        />
+      </Theme>,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Model and reasoning/ }),
+    );
+    await user.click(await screen.findByRole("button", { name: "Advanced" }));
+    await openSub(user, /^Model/);
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "GPT-5.6 Sol" }),
+    );
+
+    expect(onHarnessModelChange).toHaveBeenCalledWith("codex", "gpt-5.6-sol");
+    expect(onModelChange).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      await screen.findByRole("menuitemradio", { name: "Claude Opus 5" }),
+    );
+    expect(onModelChange).toHaveBeenCalledWith("claude-opus-5");
+    expect(onHarnessModelChange).toHaveBeenCalledTimes(1);
   });
 
   it("moves the model and effort together on a ladder notch that changes both", async () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -537,6 +537,7 @@ describe("ReasoningLevelSelector", () => {
           thoughtOption={thoughtOption()}
           modelOption={groupedModelOption("claude-sonnet-5")}
           adapter="claude"
+          onAdapterChange={() => {}}
           onModelChange={onModelChange}
           onHarnessModelChange={onHarnessModelChange}
         />
@@ -547,6 +548,8 @@ describe("ReasoningLevelSelector", () => {
       screen.getByRole("button", { name: /Model and reasoning/ }),
     );
     await user.click(await screen.findByRole("button", { name: "Advanced" }));
+    // The grouped model list replaces the Harness row.
+    expect(screen.queryByRole("menuitem", { name: /^Harness/ })).toBeNull();
     await openSub(user, /^Model/);
     fireEvent.click(
       await screen.findByRole("menuitemradio", { name: "GPT-5.6 Sol" }),

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -90,8 +90,8 @@ function groupedModelOption(
     currentValue,
     options: [
       {
-        group: "claude",
-        name: "Claude Code",
+        group: "anthropic",
+        name: "Anthropic",
         options: [
           {
             name: "Claude Sonnet 5",
@@ -106,8 +106,8 @@ function groupedModelOption(
         ],
       },
       {
-        group: "codex",
-        name: "Codex",
+        group: "openai",
+        name: "OpenAI",
         options: [
           {
             name: "GPT-5.6 Sol",
@@ -527,7 +527,7 @@ describe("ReasoningLevelSelector", () => {
     ).toBeInTheDocument();
   });
 
-  it("switches the harness when picking a model from the other harness's group", async () => {
+  it("switches the harness when picking a model the current harness cannot run", async () => {
     const onModelChange = vi.fn();
     const onHarnessModelChange = vi.fn();
     const user = userEvent.setup({ pointerEventsCheck: 0 });

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -12,7 +12,9 @@ import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuSeparator,
   DropdownMenuSub,
@@ -21,12 +23,14 @@ import {
   DropdownMenuTrigger,
 } from "@posthog/quill";
 import {
+  adapterForModelId,
   FAST_MODE_FLAG,
   isAnthropicModelId,
   isDefaultSelectOption,
   isRestrictedModelOption,
   type ModelAccess,
   selectOptionDocsUrl,
+  selectOptionHarness,
 } from "@posthog/shared";
 import {
   EFFORT_LEVEL_LABELS,
@@ -68,6 +72,11 @@ interface ReasoningLevelSelectorProps {
   onModelChange?: (value: string) => void;
   onAdapterChange?: (adapter: AgentAdapter) => void;
   onHarnessChange?: (harness: AgentHarness) => void;
+  /**
+   * Called instead of onModelChange when the picked model runs on a
+   * different harness, so the caller can switch harness and keep the pick.
+   */
+  onHarnessModelChange?: (harness: AgentAdapter, model: string) => void;
   includePiHarness?: boolean;
   onConfigOptionChange?: (configId: string, value: string) => void;
   menuOpen?: boolean;
@@ -105,6 +114,7 @@ export function ReasoningLevelSelector({
   onModelChange,
   onAdapterChange,
   onHarnessChange,
+  onHarnessModelChange,
   includePiHarness,
   onConfigOptionChange,
   menuOpen,
@@ -474,6 +484,20 @@ export function ReasoningLevelSelector({
                             setOpen(false);
                             return;
                           }
+                          // A model from another harness's group switches the
+                          // harness and keeps the pick.
+                          if (adapter && onHarnessModelChange) {
+                            const entry = modelEntries.find(
+                              (candidate) => candidate.value === value,
+                            );
+                            const harness =
+                              selectOptionHarness(entry?._meta) ??
+                              adapterForModelId(value);
+                            if (harness !== adapter) {
+                              onHarnessModelChange(harness, value);
+                              return;
+                            }
+                          }
                           changeModel(value);
                         }}
                       >
@@ -481,20 +505,27 @@ export function ReasoningLevelSelector({
                           ? modelGroups.map((group, index) => (
                               <Fragment key={group.group}>
                                 {index > 0 && <DropdownMenuSeparator />}
-                                {group.options
-                                  .toSorted((a, b) =>
-                                    compareModelsForPicker(a.value, b.value),
-                                  )
-                                  .map((model) => (
-                                    <ModelRadioItem
-                                      key={model.value}
-                                      model={model}
-                                      closeOnClick={false}
-                                      unavailableReason={unavailableReason(
-                                        model.value,
-                                      )}
-                                    />
-                                  ))}
+                                <DropdownMenuGroup>
+                                  {modelGroups.length > 1 && group.name && (
+                                    <DropdownMenuLabel>
+                                      {group.name}
+                                    </DropdownMenuLabel>
+                                  )}
+                                  {group.options
+                                    .toSorted((a, b) =>
+                                      compareModelsForPicker(a.value, b.value),
+                                    )
+                                    .map((model) => (
+                                      <ModelRadioItem
+                                        key={model.value}
+                                        model={model}
+                                        closeOnClick={false}
+                                        unavailableReason={unavailableReason(
+                                          model.value,
+                                        )}
+                                      />
+                                    ))}
+                                </DropdownMenuGroup>
                               </Fragment>
                             ))
                           : modelEntries

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -175,12 +175,11 @@ export function ReasoningLevelSelector({
     onAdapterChange?.(harness);
   };
 
-  // With model-first wiring the grouped model list already carries the
-  // harness, so the row only remains as the path to Pi.
+  // The row stays visible even with model-first wiring: a model pick
+  // auto-selects its harness, and the row shows the result and allows a
+  // manual override (Pi can run models from both groups).
   const showHarnessSubmenu =
-    !!adapter &&
-    !!(onAdapterChange || onHarnessChange) &&
-    (!onHarnessModelChange || (includePiHarness && !!onHarnessChange));
+    !!adapter && !!(onAdapterChange || onHarnessChange);
 
   if (!hasEffort && !modelSelect) {
     if (isLoading) {

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -1,20 +1,14 @@
-import type {
-  SessionConfigOption,
-  SessionConfigSelectGroup,
-} from "@agentclientprotocol/sdk";
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import { ArrowCounterClockwise, Lightning } from "@phosphor-icons/react";
 import {
   getCapabilityLadder,
   getReasoningEffortOptions,
 } from "@posthog/agent/adapters/reasoning-effort";
-import { compareModelsForPicker } from "@posthog/agent/gateway-models";
 import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuSeparator,
   DropdownMenuSub,
@@ -36,20 +30,18 @@ import {
   EFFORT_LEVEL_LABELS,
   FAST_MODE_DOCS_URLS,
 } from "@posthog/shared/domain-types";
-import { gateRestrictedModelPick } from "@posthog/ui/features/billing/modelGate";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import {
   type AgentHarness,
   HarnessSubmenu,
 } from "@posthog/ui/features/sessions/components/HarnessSubmenu";
-import { ModelCostFooter } from "@posthog/ui/features/sessions/components/ModelCostChip";
-import { ModelRadioItem } from "@posthog/ui/features/sessions/components/ModelRadioItem";
+import { ModelSelectList } from "@posthog/ui/features/sessions/components/ModelSelectList";
 import { SubscriptionSubmenu } from "@posthog/ui/features/sessions/components/SubscriptionSubmenu";
 import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
 import { AnimatedHeight } from "@posthog/ui/primitives/AnimatedHeight";
 import { Spinner } from "@posthog/ui/primitives/Spinner";
 import { AnimatePresence, motion } from "framer-motion";
-import { Fragment, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { flattenSelectOptions } from "../sessionStore";
 import { useRetainedConfigOption } from "../useRetainedConfigOption";
 import {
@@ -201,6 +193,10 @@ export function ReasoningLevelSelector({
             sideOffset={6}
             className="min-w-[230px]"
           >
+            <DropdownMenuItem disabled>
+              <Spinner size={12} />
+              Loading models...
+            </DropdownMenuItem>
             {showHarnessSubmenu && adapter && (
               <HarnessSubmenu
                 value={adapter}
@@ -209,10 +205,6 @@ export function ReasoningLevelSelector({
                 onChange={handleHarnessSelect}
               />
             )}
-            <DropdownMenuItem disabled>
-              <Spinner size={12} />
-              Loading models...
-            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       );
@@ -231,12 +223,6 @@ export function ReasoningLevelSelector({
   const modelEntries = modelSelect
     ? flattenSelectOptions(modelSelect.options)
     : [];
-  const modelGroups =
-    modelSelect &&
-    modelSelect.options.length > 0 &&
-    "group" in modelSelect.options[0]
-      ? (modelSelect.options as SessionConfigSelectGroup[])
-      : [];
   const currentModel =
     typeof modelSelect?.currentValue === "string"
       ? modelSelect.currentValue
@@ -460,17 +446,6 @@ export function ReasoningLevelSelector({
                 transition={{ duration: 0.12, ease: "easeOut" }}
               >
                 {showBack && <BackRow onClick={() => setAdvanced(false)} />}
-                {showHarnessSubmenu && adapter && (
-                  <HarnessSubmenu
-                    value={adapter}
-                    includePi={includePiHarness && !!onHarnessChange}
-                    closeOnChange={false}
-                    onChange={handleHarnessSelect}
-                  />
-                )}
-                {showBillingMenu && adapter && (
-                  <SubscriptionSubmenu adapter={adapter} />
-                )}
                 {modelSelect && (
                   <DropdownMenuSub>
                     <DropdownMenuSubTrigger>
@@ -480,18 +455,14 @@ export function ReasoningLevelSelector({
                       </span>
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent>
-                      <DropdownMenuRadioGroup
-                        value={currentModel ?? ""}
-                        onValueChange={(value) => {
-                          if (unavailableReason(value)) return;
-                          // A plan-restricted model opens the upgrade gate
-                          // instead of becoming the selection.
-                          if (gateRestrictedModelPick(modelEntries, value)) {
-                            setOpen(false);
-                            return;
-                          }
-                          // A model from another harness's group switches the
-                          // harness and keeps the pick.
+                      <ModelSelectList
+                        options={modelSelect.options}
+                        currentValue={currentModel}
+                        onGated={() => setOpen(false)}
+                        unavailableReason={unavailableReason}
+                        onSelect={(value) => {
+                          // A model the current harness cannot run switches
+                          // the harness and keeps the pick.
                           if (adapter && onHarnessModelChange) {
                             const entry = modelEntries.find(
                               (candidate) => candidate.value === value,
@@ -506,52 +477,20 @@ export function ReasoningLevelSelector({
                           }
                           changeModel(value);
                         }}
-                      >
-                        {modelGroups.length > 0
-                          ? modelGroups.map((group, index) => (
-                              <Fragment key={group.group}>
-                                {index > 0 && <DropdownMenuSeparator />}
-                                <DropdownMenuGroup>
-                                  {modelGroups.length > 1 && group.name && (
-                                    <DropdownMenuLabel>
-                                      {group.name}
-                                    </DropdownMenuLabel>
-                                  )}
-                                  {group.options
-                                    .toSorted((a, b) =>
-                                      compareModelsForPicker(a.value, b.value),
-                                    )
-                                    .map((model) => (
-                                      <ModelRadioItem
-                                        key={model.value}
-                                        model={model}
-                                        closeOnClick={false}
-                                        unavailableReason={unavailableReason(
-                                          model.value,
-                                        )}
-                                      />
-                                    ))}
-                                </DropdownMenuGroup>
-                              </Fragment>
-                            ))
-                          : modelEntries
-                              .toSorted((a, b) =>
-                                compareModelsForPicker(a.value, b.value),
-                              )
-                              .map((model) => (
-                                <ModelRadioItem
-                                  key={model.value}
-                                  model={model}
-                                  closeOnClick={false}
-                                  unavailableReason={unavailableReason(
-                                    model.value,
-                                  )}
-                                />
-                              ))}
-                      </DropdownMenuRadioGroup>
-                      <ModelCostFooter />
+                      />
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
+                )}
+                {showHarnessSubmenu && adapter && (
+                  <HarnessSubmenu
+                    value={adapter}
+                    includePi={includePiHarness && !!onHarnessChange}
+                    closeOnChange={false}
+                    onChange={handleHarnessSelect}
+                  />
+                )}
+                {showBillingMenu && adapter && (
+                  <SubscriptionSubmenu adapter={adapter} />
                 )}
                 {hasEffort && (
                   <DropdownMenuSub>

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -175,6 +175,13 @@ export function ReasoningLevelSelector({
     onAdapterChange?.(harness);
   };
 
+  // With model-first wiring the grouped model list already carries the
+  // harness, so the row only remains as the path to Pi.
+  const showHarnessSubmenu =
+    !!adapter &&
+    !!(onAdapterChange || onHarnessChange) &&
+    (!onHarnessModelChange || (includePiHarness && !!onHarnessChange));
+
   if (!hasEffort && !modelSelect) {
     if (isLoading) {
       // Keep the dropdown mounted while a harness switch reloads the config:
@@ -195,7 +202,7 @@ export function ReasoningLevelSelector({
             sideOffset={6}
             className="min-w-[230px]"
           >
-            {adapter && (onAdapterChange || onHarnessChange) && (
+            {showHarnessSubmenu && adapter && (
               <HarnessSubmenu
                 value={adapter}
                 includePi={includePiHarness && !!onHarnessChange}
@@ -454,7 +461,7 @@ export function ReasoningLevelSelector({
                 transition={{ duration: 0.12, ease: "easeOut" }}
               >
                 {showBack && <BackRow onClick={() => setAdvanced(false)} />}
-                {adapter && (onAdapterChange || onHarnessChange) && (
+                {showHarnessSubmenu && adapter && (
                   <HarnessSubmenu
                     value={adapter}
                     includePi={includePiHarness && !!onHarnessChange}

--- a/products/desktop/packages/ui/src/features/sessions/modelOptionFilters.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/modelOptionFilters.test.ts
@@ -52,6 +52,34 @@ describe("modelOptionFilters", () => {
     },
   );
 
+  it("drops a group emptied by a disabled flag, heading and all", () => {
+    const option: SessionConfigOption = {
+      type: "select",
+      id: "model",
+      name: "Model",
+      currentValue: "claude-opus-5",
+      options: [
+        {
+          group: "anthropic",
+          name: "Anthropic",
+          options: [{ value: "claude-opus-5", name: "Claude Opus 5" }],
+        },
+        {
+          group: "moonshotai",
+          name: "Moonshot AI",
+          options: [{ value: "moonshotai/kimi-k3", name: "Kimi K3" }],
+        },
+      ],
+    };
+
+    expect(
+      stripDisabledModelOption(option, { ...enabledFlags, kimi: false }),
+    ).toMatchObject({
+      currentValue: "claude-opus-5",
+      options: [{ group: "anthropic" }],
+    });
+  });
+
   it.each(rolloutModels)(
     "removes only $flag models when its flag is disabled",
     ({ flag, id }) => {

--- a/products/desktop/packages/ui/src/features/sessions/modelOptionFilters.ts
+++ b/products/desktop/packages/ui/src/features/sessions/modelOptionFilters.ts
@@ -38,10 +38,14 @@ function stripModelOptions(
   if (option.type !== "select") return option;
 
   if (isSelectGroup(option.options)) {
-    const options = option.options.map((group) => ({
-      ...group,
-      options: group.options.filter((model) => !isStripped(model.value)),
-    }));
+    // A group emptied by the filter must go with its models, or the picker
+    // renders a heading with no rows under it.
+    const options = option.options
+      .map((group) => ({
+        ...group,
+        options: group.options.filter((model) => !isStripped(model.value)),
+      }))
+      .filter((group) => group.options.length > 0);
     return {
       ...option,
       options,

--- a/products/desktop/packages/ui/src/features/sessions/useModelRolloutFlags.ts
+++ b/products/desktop/packages/ui/src/features/sessions/useModelRolloutFlags.ts
@@ -1,0 +1,28 @@
+import {
+  DEEPSEEK_MODEL_FLAG,
+  GLM_MODEL_FLAG,
+  GLM53_FLASH_MODEL_FLAG,
+  GLM53_MODEL_FLAG,
+  KIMI_MODEL_FLAG,
+} from "@posthog/shared";
+import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useMemo } from "react";
+import type { ModelRolloutFlags } from "./modelOptionFilters";
+
+/**
+ * The rollout flags gating individual models, read in one place. Dev builds
+ * default them on, like pi-harness, so the full catalog shows without a
+ * posthog override. Memoized so the object can sit in dependency arrays.
+ */
+export function useModelRolloutFlags(): ModelRolloutFlags {
+  const dev = import.meta.env.DEV;
+  const deepseek = useFeatureFlag(DEEPSEEK_MODEL_FLAG, dev);
+  const glm = useFeatureFlag(GLM_MODEL_FLAG, dev);
+  const glm53 = useFeatureFlag(GLM53_MODEL_FLAG, dev);
+  const glm53Flash = useFeatureFlag(GLM53_FLASH_MODEL_FLAG, dev);
+  const kimi = useFeatureFlag(KIMI_MODEL_FLAG, dev);
+  return useMemo(
+    () => ({ deepseek, glm, glm53, glm53Flash, kimi }),
+    [deepseek, glm, glm53, glm53Flash, kimi],
+  );
+}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -13,7 +13,7 @@ import {
   harnessForModelValue,
   isValidConfigValue,
   modelOptionForHarness,
-  resolvePiModelPick,
+  syntheticPiModelSelection,
 } from "@posthog/core/task-detail/configOptions";
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
@@ -858,6 +858,11 @@ export function TaskInput({
     thoughtOption?.type === "select" ? thoughtOption.currentValue : undefined;
   const currentPiModel =
     piModelCatalog.find((model) => model.id === selectedPiModelId) ??
+    // Pi runs any gateway model, so a session pick outside Pi's curated
+    // catalog sticks instead of falling back to Pi's default.
+    (selectedPiModelId
+      ? syntheticPiModelSelection(modelOption, selectedPiModelId)
+      : undefined) ??
     piModelCatalog.find((model) => model.id === lastUsedPiModel) ??
     piModelCatalog.find((model) => model.isDefault) ??
     piModelCatalog[0];
@@ -1187,8 +1192,7 @@ export function TaskInput({
     (harness: AgentHarness) => {
       if (harness === "pi") {
         if (runtime !== "pi" && currentModel) {
-          // Session-only: the Pi resolver falls back to Pi's own default when
-          // its catalog lacks the model, without clobbering the saved Pi pick.
+          // Session-only, so the saved Pi pick is not clobbered.
           setSelectedPiModelId(currentModel);
         }
         handleRuntimeChange("pi");
@@ -1226,30 +1230,9 @@ export function TaskInput({
   const handleHarnessModelChange = useCallback(
     (harness: AgentAdapter, model: string) => {
       setLastUsedModel(model);
-      if (runtime !== "pi") {
-        handleHarnessChange(harness);
-        return;
-      }
-      handleRuntimeChange("acp");
-      if (harness === adapter) {
-        // Same adapter means no config refetch, so apply the pick directly.
-        if (isValidConfigValue(modelOption, model)) {
-          setConfigOption(modelOption.id, model);
-        }
-        return;
-      }
-      setAdapter(harness);
+      handleHarnessChange(harness);
     },
-    [
-      adapter,
-      handleHarnessChange,
-      handleRuntimeChange,
-      modelOption,
-      runtime,
-      setAdapter,
-      setConfigOption,
-      setLastUsedModel,
-    ],
+    [handleHarnessChange, setLastUsedModel],
   );
 
   const handlePiModelChange = useCallback(
@@ -1260,32 +1243,18 @@ export function TaskInput({
     [setLastUsedPiModel],
   );
 
-  // The Pi menu offers the same full catalog; a pick stays on Pi when its
-  // catalog runs the model, otherwise it falls to the model's own harness.
+  // Pi runs any gateway model, so a pick in the Pi menu never leaves Pi. A
+  // pick outside Pi's curated catalog applies session-only.
   const handlePiGatewayModelSelect = useCallback(
     (model: string) => {
-      const target = resolvePiModelPick(
-        piModelCatalog.map((entry) => entry.id),
-        modelOption,
-        model,
-      );
-      if (target === "pi") {
-        const entry = piModelCatalog.find(
-          (candidate) => candidate.id === model,
-        );
-        if (entry) {
-          handlePiModelChange(entry);
-        }
+      const entry = piModelCatalog.find((candidate) => candidate.id === model);
+      if (entry) {
+        handlePiModelChange(entry);
         return;
       }
-      handleHarnessModelChange(target, model);
+      setSelectedPiModelId(model);
     },
-    [
-      handleHarnessModelChange,
-      handlePiModelChange,
-      modelOption,
-      piModelCatalog,
-    ],
+    [handlePiModelChange, piModelCatalog],
   );
 
   const handlePiThinkingLevelChange = useCallback((level: PiThinkingLevel) => {

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -9,7 +9,10 @@ import type {
   PiModelSelection,
   PiThinkingLevel,
 } from "@posthog/core/pi-runtime/piSessionController";
-import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
+import {
+  harnessForModelValue,
+  isValidConfigValue,
+} from "@posthog/core/task-detail/configOptions";
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { ButtonGroup } from "@posthog/quill";
@@ -716,6 +719,15 @@ export function TaskInput({
     if (!initialModel && !initialMode) return;
 
     if (initialModel && isValidConfigValue(modelOption, initialModel)) {
+      // The list spans both harnesses, so a deep-linked model can belong to the
+      // other one. Switch harness first and leave the key unmarked: the reloaded
+      // config comes back around and applies the pick on the right harness.
+      const harness = harnessForModelValue(modelOption, initialModel);
+      if (harness && harness !== adapter) {
+        setLastUsedModel(initialModel);
+        setAdapter(harness);
+        return;
+      }
       setConfigOption(modelOption.id, initialModel);
     }
     if (initialMode && isValidConfigValue(modeOption, initialMode)) {
@@ -723,13 +735,16 @@ export function TaskInput({
     }
     lastAppliedDeepLinkConfigKey.current = initialPromptKey;
   }, [
+    adapter,
     isPreviewLoading,
     initialPromptKey,
     initialModel,
     initialMode,
     modelOption,
     modeOption,
+    setAdapter,
     setConfigOption,
+    setLastUsedModel,
   ]);
 
   const { folders, isLoaded: foldersLoaded } = useFolders();

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -705,7 +705,7 @@ export function TaskInput({
     fastModeOption,
     isLoading: isPreviewLoading,
     setConfigOption,
-  } = usePreviewConfig(adapter);
+  } = usePreviewConfig(adapter, { allHarnessModels: true });
 
   const lastAppliedDeepLinkConfigKey = useRef<string | undefined>(undefined);
 
@@ -1171,6 +1171,16 @@ export function TaskInput({
     [handleRuntimeChange, setAdapter],
   );
 
+  // Saving the model before the switch lets the new harness's config restore
+  // it instead of resetting to that harness's default.
+  const handleHarnessModelChange = useCallback(
+    (harness: AgentAdapter, model: string) => {
+      setLastUsedModel(model);
+      handleHarnessChange(harness);
+    },
+    [handleHarnessChange, setLastUsedModel],
+  );
+
   const handlePiModelChange = useCallback(
     (model: PiModelSelection) => {
       setSelectedPiModelId(model.id);
@@ -1585,6 +1595,7 @@ export function TaskInput({
                         onHarnessChange={
                           piHarnessEnabled ? handleHarnessChange : undefined
                         }
+                        onHarnessModelChange={handleHarnessModelChange}
                         includePiHarness={piHarnessEnabled}
                         onConfigOptionChange={setConfigOption}
                         menuOpen={modelMenuOpen}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -13,6 +13,7 @@ import {
   harnessForModelValue,
   isValidConfigValue,
   modelOptionForHarness,
+  resolvePiModelPick,
 } from "@posthog/core/task-detail/configOptions";
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
@@ -1225,9 +1226,30 @@ export function TaskInput({
   const handleHarnessModelChange = useCallback(
     (harness: AgentAdapter, model: string) => {
       setLastUsedModel(model);
-      handleHarnessChange(harness);
+      if (runtime !== "pi") {
+        handleHarnessChange(harness);
+        return;
+      }
+      handleRuntimeChange("acp");
+      if (harness === adapter) {
+        // Same adapter means no config refetch, so apply the pick directly.
+        if (isValidConfigValue(modelOption, model)) {
+          setConfigOption(modelOption.id, model);
+        }
+        return;
+      }
+      setAdapter(harness);
     },
-    [handleHarnessChange, setLastUsedModel],
+    [
+      adapter,
+      handleHarnessChange,
+      handleRuntimeChange,
+      modelOption,
+      runtime,
+      setAdapter,
+      setConfigOption,
+      setLastUsedModel,
+    ],
   );
 
   const handlePiModelChange = useCallback(
@@ -1236,6 +1258,34 @@ export function TaskInput({
       setLastUsedPiModel(model.id);
     },
     [setLastUsedPiModel],
+  );
+
+  // The Pi menu offers the same full catalog; a pick stays on Pi when its
+  // catalog runs the model, otherwise it falls to the model's own harness.
+  const handlePiGatewayModelSelect = useCallback(
+    (model: string) => {
+      const target = resolvePiModelPick(
+        piModelCatalog.map((entry) => entry.id),
+        modelOption,
+        model,
+      );
+      if (target === "pi") {
+        const entry = piModelCatalog.find(
+          (candidate) => candidate.id === model,
+        );
+        if (entry) {
+          handlePiModelChange(entry);
+        }
+        return;
+      }
+      handleHarnessModelChange(target, model);
+    },
+    [
+      handleHarnessModelChange,
+      handlePiModelChange,
+      modelOption,
+      piModelCatalog,
+    ],
   );
 
   const handlePiThinkingLevelChange = useCallback((level: PiThinkingLevel) => {
@@ -1618,6 +1668,8 @@ export function TaskInput({
                         onChange={handlePiModelChange}
                         onThinkingLevelChange={handlePiThinkingLevelChange}
                         onHarnessChange={handleHarnessChange}
+                        modelOption={modelOption}
+                        onGatewayModelSelect={handlePiGatewayModelSelect}
                         menuOpen={modelMenuOpen}
                         onMenuOpenChange={setModelMenuOpen}
                       />

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1156,9 +1156,12 @@ export function TaskInput({
 
   const handleModelChange = useCallback(
     (value: string) => {
+      // A harness switch clears the options while the new config loads, and
+      // the menu stays open through that window. Recording the pick first
+      // lets the reload restore it instead of dropping it silently.
+      setLastUsedModel(value);
       if (modelOption) {
         setConfigOption(modelOption.id, value);
-        setLastUsedModel(value);
       }
     },
     [modelOption, setConfigOption, setLastUsedModel],

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -483,7 +483,7 @@ export function TaskInput({
     hasGithubIntegration,
   } = useUserRepositoryIntegration();
 
-  const piHarnessEnabled = useFeatureFlag("pi-harness");
+  const piHarnessEnabled = useFeatureFlag("pi-harness", import.meta.env.DEV);
   const flagsLoaded = useFeatureFlagsLoaded();
   const reposReady = areReposReady({
     isLoadingRepos,

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -17,7 +17,11 @@ import {
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { ButtonGroup } from "@posthog/quill";
-import { type AgentRuntime, ANALYTICS_EVENTS } from "@posthog/shared";
+import {
+  type AgentRuntime,
+  ANALYTICS_EVENTS,
+  adapterForModelId,
+} from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   spendStopMessage,
@@ -1176,17 +1180,44 @@ export function TaskInput({
     [sessionId, setLastUsedAgentRuntime],
   );
 
+  // A manual harness switch keeps the selected model when the target harness
+  // runs it; otherwise the target falls back to its default.
   const handleHarnessChange = useCallback(
     (harness: AgentHarness) => {
       if (harness === "pi") {
+        if (runtime !== "pi" && currentModel) {
+          // Session-only: the Pi resolver falls back to Pi's own default when
+          // its catalog lacks the model, without clobbering the saved Pi pick.
+          setSelectedPiModelId(currentModel);
+        }
         handleRuntimeChange("pi");
         return;
       }
 
+      if (runtime === "pi") {
+        const carried = currentPiModel?.id;
+        if (carried && adapterForModelId(carried) === harness) {
+          setLastUsedModel(carried);
+          if (harness === adapter && isValidConfigValue(modelOption, carried)) {
+            // Same adapter means no config refetch, so apply the pick directly.
+            setConfigOption(modelOption.id, carried);
+          }
+        }
+      }
       handleRuntimeChange("acp");
       setAdapter(harness);
     },
-    [handleRuntimeChange, setAdapter],
+    [
+      adapter,
+      currentModel,
+      currentPiModel,
+      handleRuntimeChange,
+      modelOption,
+      runtime,
+      setAdapter,
+      setConfigOption,
+      setLastUsedModel,
+    ],
   );
 
   // Saving the model before the switch lets the new harness's config restore

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -12,6 +12,7 @@ import type {
 import {
   harnessForModelValue,
   isValidConfigValue,
+  modelOptionForHarness,
 } from "@posthog/core/task-detail/configOptions";
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
@@ -922,9 +923,11 @@ export function TaskInput({
 
   const autoresearchService =
     useServiceOptional<AutoresearchService>(AUTORESEARCH_SERVICE);
+  // The composer's picker spans both harnesses, but a stage model rides on the
+  // task's own harness with no way to switch, so the stages see only its models.
   const autoresearchModelOptions = useMemo(
-    () => toStageSelectOptions(modelOption),
-    [modelOption],
+    () => toStageSelectOptions(modelOptionForHarness(modelOption, adapter)),
+    [modelOption, adapter],
   );
   const autoresearchEffortOptions = useMemo(
     () => toStageSelectOptions(thoughtOption),

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -5,7 +5,10 @@ import {
   getFastModeOptions,
   getReasoningEffortOptions,
 } from "@posthog/agent/adapters/reasoning-effort";
-import { flattenConfigValues } from "@posthog/core/task-detail/configOptions";
+import {
+  flattenConfigValues,
+  harnessForModelValue,
+} from "@posthog/core/task-detail/configOptions";
 import {
   applyConfigChange,
   CONTEXT_WINDOW_OPTION_CATEGORY,
@@ -178,7 +181,13 @@ export function usePreviewConfig(
         const modelOpt = getOptionByCategory(initial, "model");
         // The user's explicit last pick always restores, premium families
         // included — a fresh launch must not silently downgrade the model.
-        const restorableModel = lastUsedModel ?? undefined;
+        // A grouped list also holds the other harness's models, so the pick has
+        // to belong to this harness or it would run on the wrong one.
+        const restorableModel =
+          lastUsedModel &&
+          harnessForModelValue(modelOpt, lastUsedModel) === adapter
+            ? lastUsedModel
+            : undefined;
         if (
           restorableModel &&
           modelOpt?.type === "select" &&

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -19,15 +19,11 @@ import { useHostTRPCClient } from "@posthog/host-router/react";
 import {
   type Adapter,
   adapterForModelId,
-  DEEPSEEK_MODEL_FLAG,
   FAST_MODE_FLAG,
-  GLM_MODEL_FLAG,
-  GLM53_FLASH_MODEL_FLAG,
-  GLM53_MODEL_FLAG,
   getCloudUrlFromRegion,
-  KIMI_MODEL_FLAG,
 } from "@posthog/shared";
 import { stripDisabledModelOption } from "@posthog/ui/features/sessions/modelOptionFilters";
+import { useModelRolloutFlags } from "@posthog/ui/features/sessions/useModelRolloutFlags";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { logger } from "../../../shell/logger";
 import { useAuthStateValue } from "../../auth/store";
@@ -76,11 +72,7 @@ export function usePreviewConfig(
 ): PreviewConfigResult {
   const allHarnessModels = opts?.allHarnessModels ?? false;
   const hostClient = useHostTRPCClient();
-  const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
-  const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
-  const glm53FlashEnabled = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
-  const deepseekEnabled = useFeatureFlag(DEEPSEEK_MODEL_FLAG);
-  const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
+  const modelFlags = useModelRolloutFlags();
   const fastModeFlagEnabled = useFeatureFlag(FAST_MODE_FLAG);
   const cloudRegion = useAuthStateValue((state) => state.cloudRegion);
   const apiHost = useMemo(
@@ -140,15 +132,7 @@ export function usePreviewConfig(
         if (abort.signal.aborted) return;
 
         const options = serverOptions
-          .map((option) =>
-            stripDisabledModelOption(option, {
-              deepseek: deepseekEnabled,
-              glm: glmEnabled,
-              glm53: glm53Enabled,
-              glm53Flash: glm53FlashEnabled,
-              kimi: kimiEnabled,
-            }),
-          )
+          .map((option) => stripDisabledModelOption(option, modelFlags))
           .filter((option) => fastModeFlagEnabled || option.id !== "fast");
 
         const {
@@ -279,11 +263,7 @@ export function usePreviewConfig(
     apiHost,
     hostClient,
     hasHydrated,
-    glmEnabled,
-    glm53Enabled,
-    glm53FlashEnabled,
-    deepseekEnabled,
-    kimiEnabled,
+    modelFlags,
     fastModeFlagEnabled,
   ]);
 

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/usePreviewConfig.ts
@@ -15,6 +15,7 @@ import {
 import { useHostTRPCClient } from "@posthog/host-router/react";
 import {
   type Adapter,
+  adapterForModelId,
   DEEPSEEK_MODEL_FLAG,
   FAST_MODE_FLAG,
   GLM_MODEL_FLAG,
@@ -52,13 +53,25 @@ function getOptionByCategory(
   );
 }
 
+interface PreviewConfigOpts {
+  /**
+   * Also list the other harness's models in the model option (as a second
+   * group), so the picker can switch harness from a model pick.
+   */
+  allHarnessModels?: boolean;
+}
+
 /**
  * Fetches config options (models, modes, effort levels) for the task input
  * page via a lightweight tRPC query. No agent session is created.
  *
  * Returns config options as local state with a setter for local updates.
  */
-export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
+export function usePreviewConfig(
+  adapter: Adapter,
+  opts?: PreviewConfigOpts,
+): PreviewConfigResult {
+  const allHarnessModels = opts?.allHarnessModels ?? false;
   const hostClient = useHostTRPCClient();
   const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
@@ -89,10 +102,16 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
     if (!hasHydrated) return;
 
     // A harness switch resets the saved selections so the new harness starts
-    // on its default preset notch (and the slider face shows).
+    // on its default preset notch (and the slider face shows). A saved model
+    // that already belongs to the new harness survives: that is the
+    // cross-harness model pick, where the model choice drives the switch.
     if (prevAdapterRef.current !== null && prevAdapterRef.current !== adapter) {
+      const { lastUsedModel } = useSettingsStore.getState();
       useSettingsStore.setState({
-        lastUsedModel: null,
+        lastUsedModel:
+          lastUsedModel && adapterForModelId(lastUsedModel) === adapter
+            ? lastUsedModel
+            : null,
         lastUsedReasoningEffort: null,
         lastUsedContextWindow: null,
         lastUsedFastMode: null,
@@ -110,7 +129,10 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
     setConfigOptions([]);
 
     hostClient.agent.getPreviewConfigOptions
-      .query({ apiHost, adapter }, { signal: abort.signal })
+      .query(
+        { apiHost, adapter, allHarnessModels: allHarnessModels || undefined },
+        { signal: abort.signal },
+      )
       .then((serverOptions) => {
         if (abort.signal.aborted) return;
 
@@ -244,6 +266,7 @@ export function usePreviewConfig(adapter: Adapter): PreviewConfigResult {
     };
   }, [
     adapter,
+    allHarnessModels,
     apiHost,
     hostClient,
     hasHydrated,

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -489,6 +489,48 @@ describe("AgentService", () => {
     });
   });
 
+  it("groups models by harness when allHarnessModels is set", async () => {
+    vi.mocked(fetchGatewayModels).mockResolvedValueOnce([
+      {
+        id: "claude-opus-4-8",
+        owned_by: "anthropic",
+        context_window: 1_000_000,
+        supports_streaming: true,
+        supports_vision: true,
+        allowed: true,
+      },
+      {
+        id: "gpt-5.6-sol",
+        owned_by: "openai",
+        context_window: 400_000,
+        supports_streaming: true,
+        supports_vision: true,
+        allowed: true,
+      },
+    ]);
+
+    const options = await service.getPreviewConfigOptions(
+      "https://us.posthog.com",
+      "claude",
+      true,
+    );
+
+    const modelOption = options.find((option) => option.id === "model");
+    expect(modelOption).toMatchObject({
+      type: "select",
+      options: [
+        {
+          group: "claude",
+          options: [expect.objectContaining({ value: "claude-opus-4-8" })],
+        },
+        {
+          group: "codex",
+          options: [expect.objectContaining({ value: "gpt-5.6-sol" })],
+        },
+      ],
+    });
+  });
+
   describe("mcp-apps config resolver", () => {
     function registeredResolver(): (serverName: string) => Promise<void> {
       const call = deps.mcpAppsService.setConfigResolver.mock.calls[0];

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -489,7 +489,7 @@ describe("AgentService", () => {
     });
   });
 
-  it("groups models by harness when allHarnessModels is set", async () => {
+  it("groups models by provider when allHarnessModels is set", async () => {
     vi.mocked(fetchGatewayModels).mockResolvedValueOnce([
       {
         id: "claude-opus-4-8",
@@ -520,11 +520,11 @@ describe("AgentService", () => {
       type: "select",
       options: [
         {
-          group: "claude",
+          group: "anthropic",
           options: [expect.objectContaining({ value: "claude-opus-4-8" })],
         },
         {
-          group: "codex",
+          group: "openai",
           options: [expect.objectContaining({ value: "gpt-5.6-sol" })],
         },
       ],

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -81,6 +81,7 @@ import {
   type Adapter,
   type BedrockGatewayVariant,
   buildCloudTaskConfigOptions,
+  buildHarnessModelGroups,
   type CloudRegion,
   type ExecutionMode,
   isAuthError,
@@ -2574,6 +2575,7 @@ For git operations while detached:
   async getPreviewConfigOptions(
     apiHost: string,
     adapter: Adapter = "claude",
+    allHarnessModels = false,
   ): Promise<SessionConfigOption[]> {
     const gatewayUrl = getLlmGatewayUrl(apiHost);
     const gatewayModels = await fetchGatewayModels({
@@ -2592,6 +2594,14 @@ For git operations while detached:
     );
     const resolvedModelId =
       modelOption?.type === "select" ? modelOption.currentValue : "";
+
+    if (allHarnessModels && modelOption?.type === "select") {
+      modelOption.options = buildHarnessModelGroups(
+        gatewayModels,
+        adapter,
+        resolvedModelId,
+      );
+    }
 
     // The adapter-level effort options carry _meta (default notch, docs links)
     // that the shared cloud builder omits; the desktop picker needs them.

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -81,7 +81,7 @@ import {
   type Adapter,
   type BedrockGatewayVariant,
   buildCloudTaskConfigOptions,
-  buildHarnessModelGroups,
+  buildProviderModelGroups,
   type CloudRegion,
   type ExecutionMode,
   isAuthError,
@@ -2596,7 +2596,7 @@ For git operations while detached:
       modelOption?.type === "select" ? modelOption.currentValue : "";
 
     if (allHarnessModels && modelOption?.type === "select") {
-      modelOption.options = buildHarnessModelGroups(
+      modelOption.options = buildProviderModelGroups(
         gatewayModels,
         adapter,
         resolvedModelId,

--- a/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
@@ -393,6 +393,9 @@ export const getPiModelCatalogOutput = z.array(piModelCatalogEntrySchema);
 export const getPreviewConfigOptionsInput = z.object({
   apiHost: z.string(),
   adapter: z.enum(["claude", "codex"]),
+  // Opt-in: the model option also lists the other harness's models as a
+  // second group, so a picker can switch harness from a model pick.
+  allHarnessModels: z.boolean().optional(),
 });
 
 export const getPreviewConfigOptionsOutput = z.array(sessionConfigOptionSchema);


### PR DESCRIPTION
## Problem

Using a Codex model means switching the harness first, then picking the model. It should be the other way around: pick a model and the harness follows. Each harness also shows a different model list today.

## Changes

- One model menu on every harness, Pi included, grouped by provider instead of by harness.
- A pick switches harness only when the current one can't run the model. Pi runs everything, so a pick on Pi never leaves it.
- The Harness row moved below the Model row. It stays as a manual override and keeps the model when the target harness runs it.
- Sonnet 4.6, Opus 4.7, GLM-5.2 and GPT-5.4 are gone from the picker. [Rarely used.](https://posthog.slack.com/archives/C0AD22ZD31Q/p1788232749761249?thread_ts=1788232285.164069&cid=C0AD22ZD31Q)
- Pi's trigger now names models like the picker does (DeepSeek showed its raw id).
- Dev builds default `pi-harness` and the per-model rollout flags on.
- Mechanical: a shared model list component, plus an opt-in `allHarnessModels` flag on the preview-config endpoint, mirrored in the web host.

https://screen.studio/share/9jw8E1pC

## How did you test this code?

- Manually
- Unit tests in shared, core, ui and workspace-server cover the provider grouping, the Pi pick rules, the hidden models and the endpoint flag.