### PR TITLE
fix(growth): process each enrichment page in enumeration order

### DIFF
--- a/products/growth/backend/management/commands/enrichment_label_batch.py
+++ b/products/growth/backend/management/commands/enrichment_label_batch.py
@@ -282,9 +282,15 @@ class Command(BaseCommand):
             for page in _id_batches():
                 if circuit_open.is_set():
                     return
-                fetches = OrganizationEnrichmentFetch.objects.filter(
-                    id__in=[fetch_id for fetch_id, _ in page]
-                ).select_related("organization")
+                # The page arrives in keyset order, but `id__in` does not carry that order, so
+                # Postgres can return the rows of one page in any order. Sort again by
+                # organization_id. A mid-run consent revocation stops the orgs the run has not
+                # reached yet, and that set only means something under a defined order.
+                fetches = (
+                    OrganizationEnrichmentFetch.objects.filter(id__in=[fetch_id for fetch_id, _ in page])
+                    .select_related("organization")
+                    .order_by("organization_id")
+                )
                 for fetch in fetches:
                     if circuit_open.is_set():
                         return

--- a/products/growth/backend/tests/test_enrichment_label_commands.py
+++ b/products/growth/backend/tests/test_enrichment_label_commands.py
@@ -501,8 +501,12 @@ class TestAiProcessingConsent(_BatchCommandTestCase):
         self._config()
         first_org = self.organization
         second_org = Organization.objects.create(name="Second")
-        self._fetch(organization=first_org)
+        # Insert the fetches in reverse. Organization ids are time-ordered, so second_org sorts
+        # last by organization_id while its row is physically first. Any plan that returns a page
+        # in physical order then reaches second_org before the revocation, and the run makes two
+        # LLM calls instead of one. The order the command enumerates in is the one that must win.
         self._fetch(organization=second_org)
+        self._fetch(organization=first_org)
         client = _mock_llm_client()
 
         def _revoke_after_first(*args: Any, **kwargs: Any):


### PR DESCRIPTION
## Problem

- An admin who revokes AI data processing consent partway through an enrichment run can still have that org sent to the LLM.
- The revocation is defined as stopping the orgs the run has not reached yet, so "not reached yet" has to mean something. It does not: the run has no defined order.
- `_id_batches` keyset-paginates by `organization_id`, then `_attempt_targets` re-reads each page with `id__in`. That second query carries no `ORDER BY`, so Postgres returns the rows of a page in whatever order its plan produces.
- The same gap makes `test_revoking_mid_run_is_honored_for_orgs_still_queued` fail intermittently in CI, most recently on an unrelated PR: [run 33430333268](https://github.com/PostHog/posthog/actions/runs/33430333268/job/99615053683).

## Changes

- An org whose consent is revoked mid-run is now skipped, whichever page it sits in. The page read sorts by `organization_id`, which is the order enumeration already chose.
- The test creates its two fetches in reverse order, so the row that must be skipped is the physically first one. Under a plan that returns a page in physical order, the unfixed code makes two LLM calls and the test fails.

> [!NOTE]
> The processing order inside a page changes. Nothing depends on the old order: pagination advances from the ordered page query, and a resumed run skips completed orgs through `_result_exists`.

## How did you test this code?

- `products/growth/backend/tests/test_enrichment_label_commands.py` passes locally, 28 cases.
- The failure did not reproduce locally, with or without the fix. The local planner returns the page in `organization_id` order anyway, so the test cannot force the adverse order on this machine. The CI failure is attributable to order: it reported `attempted 2, succeeded 2, skipped_no_ai_consent 0`, and `ai_processing_approved` reads consent fresh from the database on the same connection, so a stale read cannot produce those counts.
- Not run: the rest of the backend suite. The change is one `order_by` on one query.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal management command with no documented surface.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Found while fixing CI on an unrelated PR, [#91382](https://github.com/PostHog/posthog/pull/91382), where this test failed in a shared product-test job. Opened separately because the two changes share nothing.
- Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.
- The first attempt tried to make the test deterministic by reversing the insertion order alone. It still passed against the unfixed command, so the reversal is kept as a stronger setup rather than as proof, and the section above states that limit instead of hiding it.
- Public artifact: nothing here comes from outside this repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
