### PR TITLE
fix(replay): correct the person property rewrite behind its feature flag

### DIFF
--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -49,14 +49,6 @@ REPLAY_NEGATIVE_BLOCKLIST_TRUNCATED_COUNTER = Counter(
     "A replay exclusion blocklist hit its row cap, so some sessions were not excluded from the results",
 )
 
-# The mode that copies person properties onto the event row at ingest AND resolves person ids
-# through the overrides table. A property filter reads the frozen copy, so it misses sessions
-# recorded before an identify, while the person id follows the merge. That gap is what the
-# rewrite closes, and the override-aware person id is what lets it close it cheaply.
-# PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS freezes properties too but has no override-aware
-# person id, so it needs the more expensive distinct-id expansion and stays flag-gated.
-REWRITE_ON_BY_DEFAULT_MODES = frozenset({PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS})
-
 # Modes where events.person_id is resolved through person_distinct_id_overrides, so it follows
 # a person merge instead of reporting whoever the event was attributed to at ingest.
 PERSON_ID_OVERRIDE_MODES = frozenset(
@@ -198,18 +190,12 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
         This solves the "late identification problem" where filtering by person properties
         in standard PoE mode only finds sessions where those properties existed at event time.
 
-        Only REWRITE_ON_BY_DEFAULT_MODES has that problem in a form this can close cheaply,
-        so it gets the rewrite unconditionally. The flag still turns it on elsewhere, and is
-        evaluated locally: its distinct id is a team id, so a condition on person properties
-        can never resolve, and a remote round trip on the query path buys nothing.
+        The flag is the only switch. Turn it off and this path is dead, whatever mode the
+        project is in.
         """
-        if self._team.person_on_events_mode in REWRITE_ON_BY_DEFAULT_MODES:
-            return True
-
         return feature_enabled_or_false(
             "enable-hybrid-poe-replay-filtering",
             str(self._team.id),
-            only_evaluate_locally=True,
             send_feature_flag_events=False,
         )
 

--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -11,7 +11,6 @@ from posthog.schema import (
     EventPropertyFilter,
     EventsNode,
     HogQLQueryModifiers,
-    PersonsOnEventsMode,
     PropertyOperator,
     RecordingsQuery,
 )
@@ -47,18 +46,6 @@ NEGATIVE_BLOCKLIST_LIMIT = 1_000_000
 REPLAY_NEGATIVE_BLOCKLIST_TRUNCATED_COUNTER = Counter(
     "replay_negative_blocklist_truncated",
     "A replay exclusion blocklist hit its row cap, so some sessions were not excluded from the results",
-)
-
-# Modes that copy person properties onto the event row at ingest. A replay filter on a person
-# property then sees only the values the person had when each event was sent, so sessions
-# recorded before an identify never match. The other modes resolve person properties at query
-# time - PERSON_ID_OVERRIDE_PROPERTIES_JOINED joins `persons` live, DISABLED goes through
-# person_distinct_ids - and so already find those sessions without the hybrid rewrite.
-FROZEN_PERSON_PROPERTIES_MODES = frozenset(
-    {
-        PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
-        PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
-    }
 )
 
 # Person properties eligible for hybrid query optimization
@@ -192,19 +179,10 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
 
         This solves the "late identification problem" where filtering by person properties
         in standard PoE mode only finds sessions where those properties existed at event time.
-
-        Only the modes in FROZEN_PERSON_PROPERTIES_MODES have that problem, so they get the
-        rewrite unconditionally. The flag remains for turning it on elsewhere, and is evaluated
-        locally: its distinct id is a team id, so a condition on person properties can never
-        resolve, and a remote round trip on the query path buys nothing.
         """
-        if self._team.person_on_events_mode in FROZEN_PERSON_PROPERTIES_MODES:
-            return True
-
         return feature_enabled_or_false(
             "enable-hybrid-poe-replay-filtering",
             str(self._team.id),
-            only_evaluate_locally=True,
             send_feature_flag_events=False,
         )
 

--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -452,6 +452,11 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
             # follows a merge: an event sent under an anonymous distinct id reports the person it
             # was later merged into. Matching on it reaches pre-identification sessions directly,
             # the same way the person profile's replay tab does.
+            #
+            # This trusts person_distinct_id_overrides to hold the merge. A merge that reached
+            # person_distinct_ids but not the overrides table would be missed here and found by
+            # the distinct-id expansion below, which reads the other table. The two are written
+            # by the same merge path, so they only diverge while one lags.
             return self._build_sessions_query(
                 ast.CompareOperation(
                     op=ast.CompareOperationOp.In,

--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -11,6 +11,7 @@ from posthog.schema import (
     EventPropertyFilter,
     EventsNode,
     HogQLQueryModifiers,
+    PersonsOnEventsMode,
     PropertyOperator,
     RecordingsQuery,
 )
@@ -46,6 +47,18 @@ NEGATIVE_BLOCKLIST_LIMIT = 1_000_000
 REPLAY_NEGATIVE_BLOCKLIST_TRUNCATED_COUNTER = Counter(
     "replay_negative_blocklist_truncated",
     "A replay exclusion blocklist hit its row cap, so some sessions were not excluded from the results",
+)
+
+# Modes that copy person properties onto the event row at ingest. A replay filter on a person
+# property then sees only the values the person had when each event was sent, so sessions
+# recorded before an identify never match. The other modes resolve person properties at query
+# time - PERSON_ID_OVERRIDE_PROPERTIES_JOINED joins `persons` live, DISABLED goes through
+# person_distinct_ids - and so already find those sessions without the hybrid rewrite.
+FROZEN_PERSON_PROPERTIES_MODES = frozenset(
+    {
+        PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,
+        PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
+    }
 )
 
 # Person properties eligible for hybrid query optimization
@@ -179,10 +192,19 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
 
         This solves the "late identification problem" where filtering by person properties
         in standard PoE mode only finds sessions where those properties existed at event time.
+
+        Only the modes in FROZEN_PERSON_PROPERTIES_MODES have that problem, so they get the
+        rewrite unconditionally. The flag remains for turning it on elsewhere, and is evaluated
+        locally: its distinct id is a team id, so a condition on person properties can never
+        resolve, and a remote round trip on the query path buys nothing.
         """
+        if self._team.person_on_events_mode in FROZEN_PERSON_PROPERTIES_MODES:
+            return True
+
         return feature_enabled_or_false(
             "enable-hybrid-poe-replay-filtering",
             str(self._team.id),
+            only_evaluate_locally=True,
             send_feature_flag_events=False,
         )
 

--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -343,11 +343,11 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
                         left=ast.Field(chain=["timestamp"]),
                         right=ast.Constant(value=date_to_buffered),
                     ),
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.NotEq,
-                        left=ast.Call(name="empty", args=[_event_session_id_field()]),
-                        right=ast.Constant(value=1),
-                    ),
+                    # notEmpty, not `empty(...) != 1`: an absent session id reads as NULL, and
+                    # HogQL prints `!=` as ifNull(notEquals(...), 1), so the NULL would compare
+                    # true and reach the GROUP BY. The caller matches this against the replay
+                    # table's non-nullable session_id, which rejects a NULL in the set.
+                    ast.Call(name="notEmpty", args=[_event_session_id_field()]),
                 ]
             ),
             group_by=[_event_session_id_field()],  # DISTINCT session_id

--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -11,6 +11,7 @@ from posthog.schema import (
     EventPropertyFilter,
     EventsNode,
     HogQLQueryModifiers,
+    PersonsOnEventsMode,
     PropertyOperator,
     RecordingsQuery,
 )
@@ -46,6 +47,23 @@ NEGATIVE_BLOCKLIST_LIMIT = 1_000_000
 REPLAY_NEGATIVE_BLOCKLIST_TRUNCATED_COUNTER = Counter(
     "replay_negative_blocklist_truncated",
     "A replay exclusion blocklist hit its row cap, so some sessions were not excluded from the results",
+)
+
+# The mode that copies person properties onto the event row at ingest AND resolves person ids
+# through the overrides table. A property filter reads the frozen copy, so it misses sessions
+# recorded before an identify, while the person id follows the merge. That gap is what the
+# rewrite closes, and the override-aware person id is what lets it close it cheaply.
+# PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS freezes properties too but has no override-aware
+# person id, so it needs the more expensive distinct-id expansion and stays flag-gated.
+REWRITE_ON_BY_DEFAULT_MODES = frozenset({PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS})
+
+# Modes where events.person_id is resolved through person_distinct_id_overrides, so it follows
+# a person merge instead of reporting whoever the event was attributed to at ingest.
+PERSON_ID_OVERRIDE_MODES = frozenset(
+    {
+        PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,
+        PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,
+    }
 )
 
 # Person properties eligible for hybrid query optimization
@@ -179,10 +197,19 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
 
         This solves the "late identification problem" where filtering by person properties
         in standard PoE mode only finds sessions where those properties existed at event time.
+
+        Only REWRITE_ON_BY_DEFAULT_MODES has that problem in a form this can close cheaply,
+        so it gets the rewrite unconditionally. The flag still turns it on elsewhere, and is
+        evaluated locally: its distinct id is a team id, so a condition on person properties
+        can never resolve, and a remote round trip on the query path buys nothing.
         """
+        if self._team.person_on_events_mode in REWRITE_ON_BY_DEFAULT_MODES:
+            return True
+
         return feature_enabled_or_false(
             "enable-hybrid-poe-replay-filtering",
             str(self._team.id),
+            only_evaluate_locally=True,
             send_feature_flag_events=False,
         )
 
@@ -277,19 +304,18 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
 
     def _build_sessions_query(
         self,
-        distinct_ids_subquery: ast.SelectQuery,
+        person_match: ast.Expr,
     ) -> ast.SelectQuery:
         """
-        Stage 3: Build query to find all sessions for the distinct_ids from Stage 2.
-
-        This finds all session_ids from events where the distinct_id matches any of
-        the distinct_ids from Stage 2, within the query date range (with buffers).
+        Final stage: every session an event attributes to the matching persons, within the
+        query date range (with buffers).
 
         Args:
-            distinct_ids_subquery: The query from Stage 2 that returns distinct_ids
+            person_match: how an event is tied back to those persons, either by resolved
+                person id or by one of their distinct ids
 
         Returns:
-            SelectQuery that finds all session_ids for those distinct_ids
+            SelectQuery that finds all session_ids for those persons
         """
         # Calculate date range with ±1 day buffer to match events_subquery behavior
         # Events can arrive before session starts or after it ends
@@ -306,11 +332,7 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
                         left=ast.Field(chain=["team_id"]),
                         right=ast.Constant(value=self._team.pk),
                     ),
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.In,
-                        left=ast.Field(chain=["distinct_id"]),
-                        right=distinct_ids_subquery,
-                    ),
+                    person_match,
                     ast.CompareOperation(
                         op=ast.CompareOperationOp.GtEq,
                         left=ast.Field(chain=["timestamp"]),
@@ -422,17 +444,31 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
         except Exception as e:
             posthoganalytics.capture_exception(e, properties={"context": "hybrid_query_monitoring"})
 
-        # Build the three-stage query using Pure AST
-        # Stage 1: Find person_ids from persons table
+        # Stage 1: the persons whose properties match
         persons_query = self._build_persons_query(person_properties, person_id_limit)
 
-        # Stage 2: Find distinct_ids for those person_ids
-        distinct_ids_query = self._build_distinct_ids_query(persons_query)
+        if self._team.person_on_events_mode in PERSON_ID_OVERRIDE_MODES:
+            # events.person_id already resolves through the overrides table in these modes, so it
+            # follows a merge: an event sent under an anonymous distinct id reports the person it
+            # was later merged into. Matching on it reaches pre-identification sessions directly,
+            # the same way the person profile's replay tab does.
+            return self._build_sessions_query(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.In,
+                    left=ast.Field(chain=["person_id"]),
+                    right=persons_query,
+                )
+            )
 
-        # Stage 3: Find sessions for those distinct_ids
-        sessions_query = self._build_sessions_query(distinct_ids_query)
-
-        return sessions_query
+        # Otherwise events.person_id is the value frozen at ingest and does not follow a merge,
+        # so the persons have to be expanded to their distinct ids first.
+        return self._build_sessions_query(
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.In,
+                left=ast.Field(chain=["distinct_id"]),
+                right=self._build_distinct_ids_query(persons_query),
+            )
+        )
 
     def _get_queries_for_matching(
         self, select_expr: ast.Expr, group_by: list[ast.Expr], union_entities: bool = False

--- a/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
@@ -101,6 +101,10 @@ class TestPersonPropertyHybridQuery(ClickhouseTestMixin, APIBaseTest):
                 properties={"$session_id": session_id_after},
             )
 
+            # Carries no $session_id, so it reads as NULL. It must not reach the session id
+            # set the replay table is matched against, which rejects a NULL.
+            create_event(identified_id, self.an_hour_ago, team=self.team)
+
             self._assert_query_matches_session_ids(
                 {
                     "properties": [

--- a/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
@@ -6,8 +6,9 @@ from django.test import override_settings
 from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
+from parameterized import parameterized
 
-from posthog.schema import PersonPropertyFilter, PropertyOperator, RecordingsQuery
+from posthog.schema import PersonPropertyFilter, PersonsOnEventsMode, PropertyOperator, RecordingsQuery
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.log_entries import TRUNCATE_LOG_ENTRIES_TABLE_SQL
@@ -40,48 +41,26 @@ class TestPersonPropertyHybridQuery(ClickhouseTestMixin, APIBaseTest):
     def an_hour_ago(self):
         return (now() - relativedelta(hours=1)).replace(microsecond=0, second=0)
 
-    def test_hybrid_query_disabled_by_default(self) -> None:
-        with freeze_time("2021-08-21T20:00:00.000Z"):
-            anonymous_id = "anonymous_user_123"
-            identified_id = "identified_user_123"
-            session_id_after = "session_after_identification"
+    @parameterized.expand(
+        [
+            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS, True),
+            (PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS, True),
+            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED, False),
+            (PersonsOnEventsMode.DISABLED, False),
+        ]
+    )
+    @patch("posthoganalytics.feature_enabled", return_value=False)
+    def test_hybrid_query_gate_follows_person_on_events_mode(
+        self, mode: PersonsOnEventsMode, expected: bool, mock_feature_enabled
+    ) -> None:
+        self.team.modifiers = {"personsOnEventsMode": mode.value}
+        self.team.save()
 
-            create_person(
-                team=self.team,
-                distinct_ids=[anonymous_id, identified_id],
-                properties={"email": "user@example.com"},
-            )
+        subquery = ReplayFiltersEventsSubQuery(self.team, RecordingsQuery())
 
-            produce_replay_summary(
-                distinct_id=identified_id,
-                session_id=session_id_after,
-                first_timestamp=self.an_hour_ago,
-                team_id=self.team.id,
-            )
-            create_event(
-                identified_id,
-                self.an_hour_ago,
-                team=self.team,
-                event_name="$pageview",
-                properties={"$session_id": session_id_after},
-            )
+        assert subquery._is_hybrid_query_mode_enabled() is expected
 
-            self._assert_query_matches_session_ids(
-                {
-                    "properties": [
-                        {
-                            "key": "email",
-                            "value": "user@example.com",
-                            "type": "person",
-                            "operator": "exact",
-                        }
-                    ]
-                },
-                [session_id_after],
-            )
-
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_hybrid_query_enabled_finds_sessions(self, mock_feature_enabled) -> None:
+    def test_hybrid_query_finds_pre_identification_sessions_without_the_flag(self) -> None:
         with freeze_time("2021-08-21T20:00:00.000Z"):
             anonymous_id = "anonymous_user_456"
             identified_id = "identified_user_456"

--- a/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
@@ -6,9 +6,8 @@ from django.test import override_settings
 from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
-from parameterized import parameterized
 
-from posthog.schema import PersonPropertyFilter, PersonsOnEventsMode, PropertyOperator, RecordingsQuery
+from posthog.schema import PersonPropertyFilter, PropertyOperator, RecordingsQuery
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.log_entries import TRUNCATE_LOG_ENTRIES_TABLE_SQL
@@ -41,26 +40,48 @@ class TestPersonPropertyHybridQuery(ClickhouseTestMixin, APIBaseTest):
     def an_hour_ago(self):
         return (now() - relativedelta(hours=1)).replace(microsecond=0, second=0)
 
-    @parameterized.expand(
-        [
-            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS, True),
-            (PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS, True),
-            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED, False),
-            (PersonsOnEventsMode.DISABLED, False),
-        ]
-    )
-    @patch("posthoganalytics.feature_enabled", return_value=False)
-    def test_hybrid_query_gate_follows_person_on_events_mode(
-        self, mode: PersonsOnEventsMode, expected: bool, mock_feature_enabled
-    ) -> None:
-        self.team.modifiers = {"personsOnEventsMode": mode.value}
-        self.team.save()
+    def test_hybrid_query_disabled_by_default(self) -> None:
+        with freeze_time("2021-08-21T20:00:00.000Z"):
+            anonymous_id = "anonymous_user_123"
+            identified_id = "identified_user_123"
+            session_id_after = "session_after_identification"
 
-        subquery = ReplayFiltersEventsSubQuery(self.team, RecordingsQuery())
+            create_person(
+                team=self.team,
+                distinct_ids=[anonymous_id, identified_id],
+                properties={"email": "user@example.com"},
+            )
 
-        assert subquery._is_hybrid_query_mode_enabled() is expected
+            produce_replay_summary(
+                distinct_id=identified_id,
+                session_id=session_id_after,
+                first_timestamp=self.an_hour_ago,
+                team_id=self.team.id,
+            )
+            create_event(
+                identified_id,
+                self.an_hour_ago,
+                team=self.team,
+                event_name="$pageview",
+                properties={"$session_id": session_id_after},
+            )
 
-    def test_hybrid_query_finds_pre_identification_sessions_without_the_flag(self) -> None:
+            self._assert_query_matches_session_ids(
+                {
+                    "properties": [
+                        {
+                            "key": "email",
+                            "value": "user@example.com",
+                            "type": "person",
+                            "operator": "exact",
+                        }
+                    ]
+                },
+                [session_id_after],
+            )
+
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_hybrid_query_enabled_finds_sessions(self, mock_feature_enabled) -> None:
         with freeze_time("2021-08-21T20:00:00.000Z"):
             anonymous_id = "anonymous_user_456"
             identified_id = "identified_user_456"

--- a/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
@@ -49,17 +49,17 @@ class TestPersonPropertyHybridQuery(ClickhouseTestMixin, APIBaseTest):
 
     @parameterized.expand(
         [
-            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS, True),
-            (PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS, False),
-            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED, False),
-            (PersonsOnEventsMode.DISABLED, False),
+            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS,),
+            (PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS,),
+            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED,),
+            (PersonsOnEventsMode.DISABLED,),
         ]
     )
     @patch("posthoganalytics.feature_enabled", return_value=False)
-    def test_hybrid_query_gate_follows_person_on_events_mode(
-        self, mode: PersonsOnEventsMode, expected: bool, mock_feature_enabled
+    def test_hybrid_query_stays_off_in_every_mode_while_the_flag_is_off(
+        self, mode: PersonsOnEventsMode, mock_feature_enabled
     ) -> None:
-        assert self._subquery_for_mode(mode)._is_hybrid_query_mode_enabled() is expected
+        assert self._subquery_for_mode(mode)._is_hybrid_query_mode_enabled() is False
 
     @parameterized.expand(
         [
@@ -95,7 +95,8 @@ class TestPersonPropertyHybridQuery(ClickhouseTestMixin, APIBaseTest):
         assert expected_column in matched
         assert unusable_column not in matched
 
-    def test_hybrid_query_finds_pre_identification_sessions_without_the_flag(self) -> None:
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_hybrid_query_finds_pre_identification_sessions(self, mock_feature_enabled) -> None:
         with freeze_time("2021-08-21T20:00:00.000Z"):
             anonymous_id = "anonymous_user_456"
             identified_id = "identified_user_456"

--- a/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
@@ -6,8 +6,11 @@ from django.test import override_settings
 from django.utils.timezone import now
 
 from dateutil.relativedelta import relativedelta
+from parameterized import parameterized
 
-from posthog.schema import PersonPropertyFilter, PropertyOperator, RecordingsQuery
+from posthog.schema import PersonPropertyFilter, PersonsOnEventsMode, PropertyOperator, RecordingsQuery
+
+from posthog.hogql import ast
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.log_entries import TRUNCATE_LOG_ENTRIES_TABLE_SQL
@@ -40,48 +43,59 @@ class TestPersonPropertyHybridQuery(ClickhouseTestMixin, APIBaseTest):
     def an_hour_ago(self):
         return (now() - relativedelta(hours=1)).replace(microsecond=0, second=0)
 
-    def test_hybrid_query_disabled_by_default(self) -> None:
-        with freeze_time("2021-08-21T20:00:00.000Z"):
-            anonymous_id = "anonymous_user_123"
-            identified_id = "identified_user_123"
-            session_id_after = "session_after_identification"
+    def _subquery_for_mode(self, mode: PersonsOnEventsMode) -> ReplayFiltersEventsSubQuery:
+        self.team.modifiers = {"personsOnEventsMode": mode.value}
+        return ReplayFiltersEventsSubQuery(team=self.team, query=RecordingsQuery())
 
-            create_person(
-                team=self.team,
-                distinct_ids=[anonymous_id, identified_id],
-                properties={"email": "user@example.com"},
-            )
+    @parameterized.expand(
+        [
+            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS, True),
+            (PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS, False),
+            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED, False),
+            (PersonsOnEventsMode.DISABLED, False),
+        ]
+    )
+    @patch("posthoganalytics.feature_enabled", return_value=False)
+    def test_hybrid_query_gate_follows_person_on_events_mode(
+        self, mode: PersonsOnEventsMode, expected: bool, mock_feature_enabled
+    ) -> None:
+        assert self._subquery_for_mode(mode)._is_hybrid_query_mode_enabled() is expected
 
-            produce_replay_summary(
-                distinct_id=identified_id,
-                session_id=session_id_after,
-                first_timestamp=self.an_hour_ago,
-                team_id=self.team.id,
-            )
-            create_event(
-                identified_id,
-                self.an_hour_ago,
-                team=self.team,
-                event_name="$pageview",
-                properties={"$session_id": session_id_after},
-            )
+    @parameterized.expand(
+        [
+            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS, "person_id"),
+            (PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED, "person_id"),
+            (PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS, "distinct_id"),
+            (PersonsOnEventsMode.DISABLED, "distinct_id"),
+        ]
+    )
+    def test_hybrid_query_matches_on_person_id_only_when_overrides_apply(
+        self, mode: PersonsOnEventsMode, expected_column: str
+    ) -> None:
+        subquery = self._subquery_for_mode(mode)
 
-            self._assert_query_matches_session_ids(
-                {
-                    "properties": [
-                        {
-                            "key": "email",
-                            "value": "user@example.com",
-                            "type": "person",
-                            "operator": "exact",
-                        }
-                    ]
-                },
-                [session_id_after],
-            )
+        query = subquery._get_person_id_based_sessions_query(
+            [
+                PersonPropertyFilter(
+                    key="email",
+                    value="user@example.com",
+                    operator=PropertyOperator.EXACT,
+                    type="person",
+                )
+            ]
+        )
 
-    @patch("posthoganalytics.feature_enabled", return_value=True)
-    def test_hybrid_query_enabled_finds_sessions(self, mock_feature_enabled) -> None:
+        assert isinstance(query.where, ast.And)
+        matched = {
+            expr.left.chain[-1]
+            for expr in query.where.exprs
+            if isinstance(expr, ast.CompareOperation) and isinstance(expr.left, ast.Field)
+        }
+        unusable_column = "distinct_id" if expected_column == "person_id" else "person_id"
+        assert expected_column in matched
+        assert unusable_column not in matched
+
+    def test_hybrid_query_finds_pre_identification_sessions_without_the_flag(self) -> None:
         with freeze_time("2021-08-21T20:00:00.000Z"):
             anonymous_id = "anonymous_user_456"
             identified_id = "identified_user_456"

--- a/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_person_property_hybrid_query.py
@@ -1,5 +1,5 @@
 from freezegun import freeze_time
-from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, create_person_id_override_by_distinct_id
 from unittest.mock import patch
 
 from django.test import override_settings
@@ -140,6 +140,12 @@ class TestPersonPropertyHybridQuery(ClickhouseTestMixin, APIBaseTest):
             # Carries no $session_id, so it reads as NULL. It must not reach the session id
             # set the replay table is matched against, which rejects a NULL.
             create_event(identified_id, self.an_hour_ago, team=self.team)
+
+            # The merge itself. The anonymous event was written before the person existed, so it
+            # still carries a pre-merge person_id, and only this override row ties it to the
+            # person the identify produced. That is the shape a real merge leaves behind, and it
+            # is what makes events.person_id resolve to the merged person in an override mode.
+            create_person_id_override_by_distinct_id(anonymous_id, identified_id, self.team.pk)
 
             self._assert_query_matches_session_ids(
                 {


### PR DESCRIPTION
## Problem

A person property filter in session replay does not find sessions that a person recorded before they were identified. Type a person's email into Replay home. Their early sessions are absent. The same sessions are on that person's Recordings tab. Replay disagrees with itself about who owns a session.

This occurs in projects that read person properties from the event row. These modes copy person properties onto each event at ingest. A property filter then reads only the values the person had when the event was sent. A later merge corrects the event's `person_id` through the overrides table. Nothing corrects the copied properties.

A rewrite for this problem exists behind the `enable-hybrid-poe-replay-filtering` flag. It does not work. Turn the flag on and the recordings list fails with `Cannot convert NULL value to non-Nullable type`. Its distinct-id stage also runs out of memory on a large project.

This PR repairs the rewrite. It does not enable it.

## Changes

- The flag stays the only switch. With the flag off, nothing changes for anyone. This is safe to merge while the flag is off.
- Turn the flag on and the recordings list no longer fails. The final stage guarded absent session ids with `empty($session_id) != 1`. HogQL prints `!=` as `ifNull(notEquals(...), 1)`, so a NULL passed the guard and reached the `GROUP BY`. It then entered the set matched against `session_replay_events.session_id`, which is not nullable. The guard is now `notEmpty`, which the standard events path already uses.
- Turn the flag on and the rewrite finds pre-identification sessions. It matches `events.person_id` where that column resolves through the overrides table, so it follows a merge. An event sent under an anonymous distinct id reports the person it was merged into. The person profile's replay tab uses this same mechanism, which is why that tab finds these sessions today.
- That also removes the distinct-id stage for those modes. The stage filtered the argmax view by `person_id`, which is not the group key, so the whole distinct-id table was aggregated before the filter could prune anything. It ran out of memory against a large project. The stage remains only for the mode that has no override-aware person id.

## How did you test this code?

Automated tests only, run by CI. This environment has no Django, Postgres, or ClickHouse, so nothing ran locally. `ruff check` and `ruff format` pass.

The null behaviour was measured against ClickHouse, not reasoned about. For the values `'a'`, `''` and `NULL`:

| predicate | rows kept |
|---|---|
| `empty(x) != 1` | `'a'` and `NULL` |
| `notEmpty(x)` | `'a'` only |

Tests, and the regression each one catches:

- `test_hybrid_query_finds_pre_identification_sessions` — the reported bug, end to end. It now also creates the override row a merge leaves behind, so the anonymous event carries a pre-merge `person_id` that only the override ties to the identified person. That is the production shape, and it is what makes `events.person_id` resolve to the merged person. Without the override the test passed for an unrelated reason: `person_distinct_ids` alone tied the event to the person, which was enough for the old distinct-id match and is not enough for this one. CI caught exactly that.
- `test_hybrid_query_stays_off_in_every_mode_while_the_flag_is_off` — parameterized over all four modes. It catches any change that makes a mode turn the rewrite on by itself. An earlier revision of this PR did that, which would have enabled the rewrite everywhere on merge and removed the flag's control.
- `test_hybrid_query_matches_on_person_id_only_when_overrides_apply` — parameterized over the same modes. It catches a change that matches on `person_id` in a mode without override-aware person ids, which would silently lose pre-merge sessions. It asserts on the built query, because in a mode with override-aware person ids both shapes return the same sessions once the fixture is correct, so a result-based test cannot separate them.
- The pre-identification test also writes an event with no `$session_id`. No test in the file wrote one before, so every test passed while the query failed in production. The failure is the query raising, so the existing assertion catches it. It did not need a new test function.

Not verified. A reviewer should weigh these:

- That the null test fails if the `notEmpty` change is reverted. The fixture now contains an event with no `$session_id`, but whether that NULL reaches the matched set in the test topology was not confirmed against ClickHouse.
- The cost of `person_id IN (<persons>)` on a large project. It removes a full-table aggregation, so it should cost less, but this is an argument and not a measurement.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus) while debugging a report that a session on a person's Recordings tab returned nothing when the same person was filtered by email on Replay home.

The reported theory was a distinct-id or pre-identification problem. It was not. The identity data was correct, every distinct id mapped to the right person, and the merge override had applied. Reading `person_id` and the event-row person properties side by side on the affected event separated the two. The id followed the merge. The property copy did not. The fix rests on that observation: if `person_id` is already correct, the rewrite does not need distinct ids at all.

Four corrections shaped this PR, and each is worth recording. An early revision claimed the flag was already on for the affected project; that came from reading `is_not`-on-absent semantics off the Rust evaluator when the caller is the Python SDK, which raises before the operator. A later revision moved the gate onto person-on-events mode; enabling the flag to test that surfaced the null failure, and the memory problem was reproduced separately, so that revision would have traded a wrong-results bug for a failed-query bug across many projects. A third revision kept that mode gate after fixing both; it still ran before the flag was read, so it removed the flag's ability to switch the rewrite off. The gate is now the flag alone. The fourth came from CI rather than from review: the end-to-end test had never modelled a merge, so it could not tell the two match strategies apart, and it failed the moment the rewrite started depending on the overrides table.

Repo skills invoked: `/writing-tests` was required by `.claude/rules/writing-tests.md` and resolved for part of this work but not all of it, so its gate was applied by hand for the later test changes. That is why each test above is justified by the regression it catches rather than assumed.

Public artifact check: the report behind this PR came from a customer project. No identifiers, addresses, project or team ids, session ids, or query output from that investigation appear in the diff, the tests, the commit messages, or this description. The tests reuse the fixture file's existing invented `@example.com` data.
