### PR TITLE
chore(admin): add managed proxy records to django admin

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -26,6 +26,7 @@ from posthog.admin.inlines.organization_domain_inline import OrganizationDomainI
 from posthog.admin.inlines.organization_invite_inline import OrganizationInviteInline
 from posthog.admin.inlines.organization_member_inline import OrganizationMemberInline
 from posthog.admin.inlines.project_inline import ProjectInline
+from posthog.admin.inlines.proxy_record_inline import ProxyRecordInline
 from posthog.admin.inlines.team_inline import TeamInline
 from posthog.admin.paginators.no_count_paginator import NoCountPaginator
 from posthog.models.organization import Organization
@@ -265,6 +266,7 @@ class OrganizationAdmin(admin.ModelAdmin):
         OrganizationMemberInline,
         OrganizationInviteInline,
         OrganizationDomainInline,
+        ProxyRecordInline,
     ]
     readonly_fields = [
         "id",

--- a/posthog/admin/admins/proxy_record_admin.py
+++ b/posthog/admin/admins/proxy_record_admin.py
@@ -1,0 +1,55 @@
+from django.contrib import admin
+from django.http import HttpRequest
+from django.urls import reverse
+from django.utils.html import format_html
+
+from posthog.models import ProxyRecord
+
+
+@admin.register(ProxyRecord)
+class ProxyRecordAdmin(admin.ModelAdmin):
+    list_display = ("domain", "organization_link", "status", "target_cname", "created_at")
+    list_filter = ("status",)
+    search_fields = ("domain", "organization__name")
+    list_select_related = ("organization", "created_by")
+    readonly_fields = (
+        "id",
+        "domain",
+        "organization_link",
+        "status",
+        "target_cname",
+        "message",
+        "created_by_link",
+        "created_at",
+        "updated_at",
+    )
+    fields = (
+        "id",
+        "domain",
+        "organization_link",
+        "status",
+        "target_cname",
+        "message",
+        "created_by_link",
+        "created_at",
+        "updated_at",
+    )
+    ordering = ("-created_at",)
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        return False
+
+    def has_delete_permission(self, request: HttpRequest, obj: ProxyRecord | None = None) -> bool:
+        return False
+
+    @admin.display(description="Organization", ordering="organization__name")
+    def organization_link(self, obj: ProxyRecord) -> str:
+        url = reverse("admin:posthog_organization_change", args=[obj.organization_id])
+        return format_html('<a href="{}">{}</a>', url, obj.organization.name)
+
+    @admin.display(description="Created By", ordering="created_by__email")
+    def created_by_link(self, obj: ProxyRecord) -> str:
+        if not obj.created_by:
+            return "-"
+        url = reverse("admin:posthog_user_change", args=[obj.created_by_id])
+        return format_html('<a href="{}">{}</a>', url, obj.created_by.email)

--- a/posthog/admin/admins/proxy_record_admin.py
+++ b/posthog/admin/admins/proxy_record_admin.py
@@ -47,7 +47,7 @@ class ProxyRecordAdmin(admin.ModelAdmin):
         url = reverse("admin:posthog_organization_change", args=[obj.organization_id])
         return format_html('<a href="{}">{}</a>', url, obj.organization.name)
 
-    @admin.display(description="Created By", ordering="created_by__email")
+    @admin.display(description="Created by", ordering="created_by__email")
     def created_by_link(self, obj: ProxyRecord) -> str:
         if not obj.created_by:
             return "-"

--- a/posthog/admin/inlines/proxy_record_inline.py
+++ b/posthog/admin/inlines/proxy_record_inline.py
@@ -1,5 +1,8 @@
+from django.http import HttpRequest
+
 from django_admin_inline_paginator.admin import TabularInlinePaginated
 
+from posthog.models.organization import Organization
 from posthog.models.proxy_record import ProxyRecord
 
 
@@ -24,9 +27,9 @@ class ProxyRecordInline(TabularInlinePaginated):
 
     ordering = ("-created_at",)
 
-    def has_add_permission(self, request, obj=None):
+    def has_add_permission(self, request: HttpRequest, obj: Organization | None = None) -> bool:
         # Proxy records are created via the app, not the admin
         return False
 
-    def has_delete_permission(self, request, obj=None):
+    def has_delete_permission(self, request: HttpRequest, obj: Organization | None = None) -> bool:
         return False

--- a/posthog/admin/inlines/proxy_record_inline.py
+++ b/posthog/admin/inlines/proxy_record_inline.py
@@ -1,0 +1,32 @@
+from django_admin_inline_paginator.admin import TabularInlinePaginated
+
+from posthog.models.proxy_record import ProxyRecord
+
+
+class ProxyRecordInline(TabularInlinePaginated):
+    extra = 0
+    model = ProxyRecord
+    per_page = 20
+    pagination_key = "page-proxy-record"
+    show_change_link = True
+    verbose_name = "reverse proxy"
+    verbose_name_plural = "Reverse proxies"
+
+    fields = (
+        "domain",
+        "status",
+        "target_cname",
+        "message",
+        "created_at",
+    )
+
+    readonly_fields = fields
+
+    ordering = ("-created_at",)
+
+    def has_add_permission(self, request, obj=None):
+        # Proxy records are created via the app, not the admin
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False


### PR DESCRIPTION
## Problem

Staff had no way to inspect a customer's managed reverse proxy (`ProxyRecord`) instances, or see which reverse proxies belong to an organization, without querying Postgres directly.

## Changes

- Registers `ProxyRecord` in Django admin as a read-only list and detail view: staff can search by domain or organization name and filter by status.
- Adds a "Reverse proxies" table to the organization admin page, directly below "Domains".
- Every field is read-only and add/delete are disabled on both surfaces, since proxy records should only change through the app's DNS and certificate lifecycle, not admin edits.
- Organization and user links render from the related row rather than a select widget, so the pages never load the full organizations or users table.

## How did you test this code?

Verified against a running local dev stack with Django's test client, force-logged in as a staff user:
- Changelist and detail pages for `ProxyRecord`, and the organization change page, return 200 and show the expected fields, including the organization link.
- `GET /admin/posthog/proxyrecord/add/` and the delete endpoint both return 403.
- `POST` to the change view is a no-op: the domain stays unchanged.
- `ruff check`, `ruff format --check`, and repo-wide `uv run mypy --cache-fine-grained .` are clean.

Not run: Playwright/browser E2E, since the Django test client against the live backend already exercises the real view and permission logic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal staff tooling, not a documented user-facing workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built in Claude Code at the user's direction, across two increments: the standalone `ProxyRecordAdmin`, then the `ProxyRecordInline` on the organization page. Skills invoked: `/writing-pr-descriptions`.

Followed the existing `OrganizationDomainAdmin` / `OrganizationDomainInline` pattern (same read-only, no-add inline shape) for consistency. Chose full read-only over a partially editable admin, and disabled delete, so the admin cannot mutate proxy state or leave a `ProxyRecord` orphaned from its DNS/certificate lifecycle.