### PR TITLE
fix(metrics): don't flash the empty state while a superseded query refetches

### DIFF
--- a/products/metrics/frontend/components/MetricsSamplesPanel.tsx
+++ b/products/metrics/frontend/components/MetricsSamplesPanel.tsx
@@ -119,12 +119,12 @@ function SamplesTab(): JSX.Element {
 
 function AggregatesTab(): JSX.Element {
     const { aggregateRows } = useValues(metricsSamplesLogic)
-    const { queryResultsLoading, hasMetricName } = useValues(metricsViewerLogic)
+    const { queryLoading, hasMetricName } = useValues(metricsViewerLogic)
 
     return (
         <LemonTable
             dataSource={aggregateRows}
-            loading={queryResultsLoading}
+            loading={queryLoading}
             size="small"
             rowKey={(row: MetricsAggregateRow) => row.name}
             emptyState={

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -127,7 +127,7 @@ export const MetricsViewer = (): JSX.Element => {
         chartSeries,
         anomalyBadge,
         liveRefresh,
-        queryResultsLoading,
+        queryLoading,
         queryError,
         savedInsightLoading,
         savedInsight,
@@ -393,12 +393,12 @@ export const MetricsViewer = (): JSX.Element => {
                                 fallbackName={metricName}
                                 exemplars={chartMarkers}
                             />
-                        ) : !queryResultsLoading ? (
+                        ) : !queryLoading ? (
                             <div className="h-full flex items-center justify-center text-secondary text-sm">
                                 No data for this metric in the selected range.
                             </div>
                         ) : null}
-                        {queryResultsLoading && <SpinnerOverlay />}
+                        {queryLoading && <SpinnerOverlay />}
                     </div>
                 </div>
                 {hasMetricName && (

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -253,6 +253,24 @@ describe('metricsViewerLogic', () => {
         expect(logic.values.queryError).toBeNull()
     })
 
+    // A superseded query's abort lands as a failure while the replacement query is still in
+    // flight. kea-loaders' auto `queryResultsLoading` drops to false then, which flashed the
+    // "No data" empty state between the spinner and the chart — `queryLoading` must ride out
+    // the abort, while still clearing on a real failure.
+    it.each([
+        [
+            'a superseded (aborted) query',
+            NEW_QUERY_STARTED_ERROR_MESSAGE,
+            new DOMException(NEW_QUERY_STARTED_ERROR_MESSAGE, 'AbortError'),
+            true,
+        ],
+        ['a real query failure', 'Invalid regex pattern', new Error('Invalid regex pattern'), false],
+    ])('queryLoading after %s', (_name, message, errorObject, expected) => {
+        logic.actions.fetchQueryResults({})
+        logic.actions.fetchQueryResultsFailure(message, errorObject)
+        expect(logic.values.queryLoading).toBe(expected)
+    })
+
     // The filter bar's property filters must translate into the backend's Prometheus-style
     // matchers: operator mapping, multi-value alternation (with regex escaping), and skipping
     // chips that are still being edited. A bad mapping silently filters the chart wrong.

--- a/products/metrics/frontend/components/metricsViewerLogic.test.ts
+++ b/products/metrics/frontend/components/metricsViewerLogic.test.ts
@@ -255,8 +255,8 @@ describe('metricsViewerLogic', () => {
 
     // A superseded query's abort lands as a failure while the replacement query is still in
     // flight. kea-loaders' auto `queryResultsLoading` drops to false then, which flashed the
-    // "No data" empty state between the spinner and the chart — `queryLoading` must ride out
-    // the abort, while still clearing on a real failure.
+    // "No data" empty state between the spinner and the chart, so `queryLoading` must ride
+    // out the abort, while still clearing on a real failure.
     it.each([
         [
             'a superseded (aborted) query',

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -507,8 +507,8 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         ],
         // kea-loaders' auto `queryResultsLoading` drops to false when a superseded query's
         // abort lands as a failure, flashing the empty state while the replacement query is
-        // still in flight. This flag only clears on success or a real failure — the UI must
-        // read it instead of `queryResultsLoading`.
+        // still in flight. This flag only clears on success or a real failure, so the UI
+        // must read it instead of `queryResultsLoading`.
         queryLoading: [
             false as boolean,
             {

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -208,6 +208,7 @@ export interface metricsViewerLogicValues {
     queryAbortController: AbortController | null
     queryError: string | null
     queryFilters: _MetricFilterApi[]
+    queryLoading: boolean
     queryResults: MetricsViewerSeries[]
     queryResultsLoading: boolean
     savedInsight: QueryBasedInsightModel | null
@@ -502,6 +503,18 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                 fetchQueryResultsSuccess: () => null,
                 fetchQueryResultsFailure: (state, { error }) =>
                     isUserInitiatedError(error) ? state : error || 'Something went wrong running this query.',
+            },
+        ],
+        // kea-loaders' auto `queryResultsLoading` drops to false when a superseded query's
+        // abort lands as a failure, flashing the empty state while the replacement query is
+        // still in flight. This flag only clears on success or a real failure — the UI must
+        // read it instead of `queryResultsLoading`.
+        queryLoading: [
+            false as boolean,
+            {
+                fetchQueryResults: () => true,
+                fetchQueryResultsSuccess: () => false,
+                fetchQueryResultsFailure: (state, { error }) => (isUserInitiatedError(error) ? state : false),
             },
         ],
     }),


### PR DESCRIPTION
## Problem

- Anyone opening the metrics viewer from a deep link (for example a trace's metric link) sees the spinner, then a false "No data for this metric in the selected range", then the chart.
- The same flash appears when a filter, date, or aggregation change supersedes an in-flight chart query.
- The viewer aborts the superseded request. The abort lands as `fetchQueryResultsFailure`, which resets kea-loaders' auto `queryResultsLoading` while the replacement query still runs.
- With no results and no loading flag, the chart region renders the empty state until the replacement query returns.

Surfaced by the test-plan clips for [#91888](https://github.com/PostHog/posthog/pull/91888), but the bug predates that PR: its deep links always refetch once, because the recommended aggregation arrives after the first query starts.

## Changes

- The chart and the samples panel now hold their loading state until a query succeeds or fails for real. The mid-refetch "No data" flash is gone; nothing else looks different.
- `metricsViewerLogic` gains a `queryLoading` reducer that ignores superseded-abort failures, the same treatment `queryError` already had and the same pattern as `logsViewerDataLogic`'s `logsLoading`.
- `MetricsViewer` and `MetricsSamplesPanel` read `queryLoading` instead of the auto flag (mechanical swap).

### Before

The first query is superseded ~1s in; the empty state shows until the replacement query returns:

![Before: spinner, then a false 'No data' flash, then the chart](https://raw.githubusercontent.com/PostHog/pr-assets/19dcf058c93af7701ab87017b201245afc395602/2026/08/4c786ebf-5b88-476f-afea-4ec325d3580e.gif)

### After

Same timeline, same supersede; the spinner holds until the chart renders:

![After: spinner holds until the chart renders](https://raw.githubusercontent.com/PostHog/pr-assets/03383b93203b1367f87ec0d4a26f35967be0fd3e/2026/08/e23a4d59-3676-43ee-bf4f-83cceab66309.gif)

Both clips come from a throwaway Storybook story (not committed) that mounts `MetricsViewer` with mocked, delay-tuned metrics endpoints and replays the deep-link sequence: metric name and type set without an aggregation, the picker's arrival applying the recommended aggregation, and the second query aborting the first mid-flight. The "before" clip runs the same story with the components reverted to the auto flag. All data in the clips is invented.

## How did you test this code?

- Added two parameterized cases to `metricsViewerLogic.test.ts`: a superseded-abort failure keeps `queryLoading` true (catches the flash regression, which no existing test covered), and a real failure clears it (catches a stuck spinner on the samples table). Extends the existing abort-handling tests for `queryError`.
- Ran the file's jest suite and the frontend typecheck; the typecheck reports the same pre-existing, unrelated errors with and without this change.
- Recorded the before/after behavior in Storybook against mocked endpoints (clips above) — the flash reproduces with the auto flag and is gone with `queryLoading`.
- Not run: verification in the full app against a real backend.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated after a report that the metrics viewer in the #91888 test-plan clips cycled spinner → "No data" → chart. Traced the flash to the abort-on-supersede path in `metricsViewerLogic` and confirmed the handling is identical on master, so the fix ships standalone rather than in that stack. Skills invoked: /writing-tests, /writing-pr-descriptions, /simplify, /code-review. Recordings made with a temporary Storybook story driven by Playwright.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*

