### PR TITLE
fix(tasks): expire run streams shortly after completion

### DIFF
--- a/products/tasks/backend/logic/stream/redis_stream.py
+++ b/products/tasks/backend/logic/stream/redis_stream.py
@@ -19,10 +19,6 @@ logger = structlog.get_logger(__name__)
 TASK_RUN_STREAM_MAX_LENGTH = 5_000
 TASK_RUN_STREAM_TIMEOUT = SANDBOX_TTL_SECONDS
 TASK_RUN_STREAM_SEQUENCE_TIMEOUT = int(SANDBOX_EVENT_INGEST_TOKEN_TTL.total_seconds())
-# Completed runs render from persisted logs (S3 + Postgres), and a restart deletes the
-# stream before reading anything, so after the completion sentinel the stream only serves
-# viewers who opened the run just before it finished. Keep it for a short grace window
-# instead of the full sandbox TTL.
 TASK_RUN_STREAM_COMPLETED_TTL_SECONDS = 30 * 60
 TASK_RUN_STREAM_PREFIX = "task-run-stream:"
 TASK_RUN_STREAM_READ_COUNT = 16
@@ -648,13 +644,7 @@ def publish_task_run_stream_event(run_id: str, event: dict, use_dedicated: bool 
 
 
 def publish_task_run_stream_complete(run_id: str, use_dedicated: bool = False) -> bool:
-    """Synchronously publish a completion sentinel for a task-run stream.
-
-    Also drops the stream key's TTL to the completion grace window, including
-    when the sentinel was already written by another path (the agent-proxy or
-    the ingest handler), so completed streams never linger for the full
-    sandbox TTL.
-    """
+    """Synchronously publish a completion sentinel for a task-run stream."""
     stream_key = get_task_run_stream_key(run_id)
     completed_key = get_task_run_stream_completed_key(stream_key)
     client = get_tasks_stream_redis_sync(use_dedicated)

--- a/products/tasks/backend/logic/stream/redis_stream.py
+++ b/products/tasks/backend/logic/stream/redis_stream.py
@@ -19,6 +19,11 @@ logger = structlog.get_logger(__name__)
 TASK_RUN_STREAM_MAX_LENGTH = 5_000
 TASK_RUN_STREAM_TIMEOUT = SANDBOX_TTL_SECONDS
 TASK_RUN_STREAM_SEQUENCE_TIMEOUT = int(SANDBOX_EVENT_INGEST_TOKEN_TTL.total_seconds())
+# Completed runs render from persisted logs (S3 + Postgres), and a restart deletes the
+# stream before reading anything, so after the completion sentinel the stream only serves
+# viewers who opened the run just before it finished. Keep it for a short grace window
+# instead of the full sandbox TTL.
+TASK_RUN_STREAM_COMPLETED_TTL_SECONDS = 30 * 60
 TASK_RUN_STREAM_PREFIX = "task-run-stream:"
 TASK_RUN_STREAM_READ_COUNT = 16
 # XREAD BLOCK is push-based (XADD wakes the blocked client immediately), so a
@@ -643,7 +648,13 @@ def publish_task_run_stream_event(run_id: str, event: dict, use_dedicated: bool 
 
 
 def publish_task_run_stream_complete(run_id: str, use_dedicated: bool = False) -> bool:
-    """Synchronously publish a completion sentinel for a task-run stream."""
+    """Synchronously publish a completion sentinel for a task-run stream.
+
+    Also drops the stream key's TTL to the completion grace window, including
+    when the sentinel was already written by another path (the agent-proxy or
+    the ingest handler), so completed streams never linger for the full
+    sandbox TTL.
+    """
     stream_key = get_task_run_stream_key(run_id)
     completed_key = get_task_run_stream_completed_key(stream_key)
     client = get_tasks_stream_redis_sync(use_dedicated)
@@ -654,9 +665,10 @@ def publish_task_run_stream_complete(run_id: str, use_dedicated: bool = False) -
             # fakeredis doesn't support WATCH/MULTI; the sequencing race the
             # transaction guards against can't happen under the test harness.
             if client.exists(completed_key):
+                client.expire(stream_key, TASK_RUN_STREAM_COMPLETED_TTL_SECONDS)
                 return True
             client.xadd(stream_key, {DATA_KEY: raw}, maxlen=TASK_RUN_STREAM_MAX_LENGTH, approximate=True)
-            client.expire(stream_key, TASK_RUN_STREAM_TIMEOUT)
+            client.expire(stream_key, TASK_RUN_STREAM_COMPLETED_TTL_SECONDS)
             client.set(completed_key, "1", ex=TASK_RUN_STREAM_SEQUENCE_TIMEOUT)
             return True
 
@@ -666,10 +678,11 @@ def publish_task_run_stream_complete(run_id: str, use_dedicated: bool = False) -
                     pipe.watch(completed_key)
                     if pipe.exists(completed_key):
                         pipe.reset()
+                        client.expire(stream_key, TASK_RUN_STREAM_COMPLETED_TTL_SECONDS)
                         return True
                     pipe.multi()
                     pipe.xadd(stream_key, {DATA_KEY: raw}, maxlen=TASK_RUN_STREAM_MAX_LENGTH, approximate=True)
-                    pipe.expire(stream_key, TASK_RUN_STREAM_TIMEOUT)
+                    pipe.expire(stream_key, TASK_RUN_STREAM_COMPLETED_TTL_SECONDS)
                     pipe.set(completed_key, "1", ex=TASK_RUN_STREAM_SEQUENCE_TIMEOUT)
                     pipe.execute()
                     return True

--- a/products/tasks/backend/logic/stream/tests/test_redis_stream.py
+++ b/products/tasks/backend/logic/stream/tests/test_redis_stream.py
@@ -5,12 +5,20 @@ import pytest
 
 from products.tasks.backend.logic.stream.redis_stream import (
     DATA_KEY,
+    TASK_RUN_STREAM_COMPLETED_TTL_SECONDS,
+    TASK_RUN_STREAM_SEQUENCE_TIMEOUT,
+    TASK_RUN_STREAM_TIMEOUT,
     TaskRunRedisStream,
     TaskRunStreamAlreadyCompleted,
     TaskRunStreamCompletionSequenceMismatch,
     TaskRunStreamSequenceGap,
     _stream_id_sort_key,
+    get_task_run_stream_completed_key,
+    get_task_run_stream_key,
+    publish_task_run_stream_complete,
+    reset_task_run_stream,
 )
+from products.tasks.backend.redis import get_tasks_stream_redis_sync
 
 
 def _new_stream() -> TaskRunRedisStream:
@@ -107,6 +115,25 @@ async def test_mark_complete_is_idempotent() -> None:
         assert await _read_stream_events(redis_stream) == [{"type": "STREAM_STATUS", "status": "complete"}]
     finally:
         await redis_stream.delete_stream()
+
+
+@pytest.mark.parametrize("already_completed", [False, True])
+def test_publish_task_run_stream_complete_shortens_stream_ttl(already_completed: bool) -> None:
+    run_id = str(uuid4())
+    stream_key = get_task_run_stream_key(run_id)
+    client = get_tasks_stream_redis_sync()
+    try:
+        client.xadd(stream_key, {DATA_KEY: json.dumps({"type": "message"})})
+        client.expire(stream_key, TASK_RUN_STREAM_TIMEOUT)
+        if already_completed:
+            client.set(get_task_run_stream_completed_key(stream_key), "1", ex=TASK_RUN_STREAM_SEQUENCE_TIMEOUT)
+
+        assert publish_task_run_stream_complete(run_id)
+
+        ttl = client.ttl(stream_key)
+        assert 0 < ttl <= TASK_RUN_STREAM_COMPLETED_TTL_SECONDS
+    finally:
+        reset_task_run_stream(run_id)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Finished runs keep their full event stream in Redis for 6 more hours: the completion sentinel refreshes the sliding 6h TTL and nothing ever deletes the stream. Finished runs render from S3 and Postgres, so that copy serves nobody, and it dominates the tasks Redis working set.

## Changes

- On completion the stream key's TTL drops to a 30-minute grace window instead of 6 hours.
- Also applies when the agent-proxy wrote the sentinel first, since the cleanup activity always runs this path.
- Restarts already delete the stream before reading anything. The live-write contract is untouched, so no agent-proxy change is needed.

## How did you test this code?

Added a parameterized case in `test_redis_stream.py`: the completion publish shortens the TTL, both fresh and already-completed. Ran the stream and cleanup activity tests locally.