### PR TITLE
fix(customer-analytics): apply saved views before the first fetch

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTable.tsx
@@ -886,7 +886,7 @@ export function AccountsTable(): JSX.Element {
     const { responseLoading, response } = useValues(
         dataNodeLogic({
             key: ACCOUNTS_TABLE_DATA_NODE_KEY,
-            query: accountsQuerySource ?? accountsDataTableQuery.source,
+            query: accountsQuerySource,
         } as DataNodeLogicProps)
     )
     const { featureFlags } = useValues(featureFlagLogic)

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -175,6 +175,7 @@ export interface accountsLogicValues {
     allRolesUnassigned: boolean
     assignedToCurrentUser: boolean
     assignedToFilter: RoleFilterValue
+    awaitingSavedView: boolean
     canSortClientSide: boolean
     currentUserId: number | null
     customPropertyOverrides: Record<string, CustomPropertyValueWriteApi['value']>
@@ -402,6 +403,9 @@ export interface accountsLogicActions {
     }
     setAssignedToFilter: (value: RoleFilterValue) => {
         value: RoleFilterValue
+    }
+    setAwaitingSavedView: (awaiting: boolean) => {
+        awaiting: boolean
     }
     setCustomPropertyOverride: (
         accountId: string,
@@ -671,6 +675,10 @@ export const accountsLogic = kea<accountsLogicType>([
         // Restrict the list to a single account by id — drives the `/accounts/:accountId/:tab`
         // path route. null clears it (back to the full list).
         setAccountIdFilter: (accountId: string | null) => ({ accountId }),
+        // accountsViewsLogic holds this true from mount until the persisted view is applied,
+        // so the first fetch runs once with the view's inputs instead of once before and once
+        // after the view lands.
+        setAwaitingSavedView: (awaiting: boolean) => ({ awaiting }),
     }),
     reducers({
         searchInput: [
@@ -714,6 +722,12 @@ export const accountsLogic = kea<accountsLogicType>([
             null as string | null,
             {
                 setAccountIdFilter: (_, { accountId }) => accountId,
+            },
+        ],
+        awaitingSavedView: [
+            false,
+            {
+                setAwaitingSavedView: (_, { awaiting }) => awaiting,
             },
         ],
         sortOrder: [
@@ -991,11 +1005,13 @@ export const accountsLogic = kea<accountsLogicType>([
             (input: BuildAccountsTableQueryPlanInput): AccountsTableQueryPlan => buildAccountsTableQueryPlan(input),
         ],
         accountsQuerySource: [
-            (s) => [s.accountsTableQueryPlan, s.relationshipDefinitionsLoaded],
+            (s) => [s.accountsTableQueryPlan, s.relationshipDefinitionsLoaded, s.awaitingSavedView],
             (
                 accountsTableQueryPlan: AccountsTableQueryPlan,
-                relationshipDefinitionsLoaded: boolean
-            ): AccountsTableQuery | null => (relationshipDefinitionsLoaded ? accountsTableQueryPlan.query : null),
+                relationshipDefinitionsLoaded: boolean,
+                awaitingSavedView: boolean
+            ): AccountsTableQuery | null =>
+                relationshipDefinitionsLoaded && !awaitingSavedView ? accountsTableQueryPlan.query : null,
         ],
         accountsDataTableQuery: [
             (s) => [s.accountsTableQueryPlan, s.accountsQuerySource],
@@ -1011,13 +1027,14 @@ export const accountsLogic = kea<accountsLogicType>([
             }),
         ],
         metricsQuery: [
-            (s) => [s.overviewMetrics, s.accountsTableQueryPlan, s.relationshipDefinitionsLoaded],
+            (s) => [s.overviewMetrics, s.accountsTableQueryPlan, s.relationshipDefinitionsLoaded, s.awaitingSavedView],
             (
                 overviewMetrics: AccountsTableMetric[],
                 accountsTableQueryPlan: AccountsTableQueryPlan,
-                relationshipDefinitionsLoaded: boolean
+                relationshipDefinitionsLoaded: boolean,
+                awaitingSavedView: boolean
             ): AccountsTableQuery | null => {
-                if (overviewMetrics.length === 0 || !relationshipDefinitionsLoaded) {
+                if (overviewMetrics.length === 0 || !relationshipDefinitionsLoaded || awaitingSavedView) {
                     return null
                 }
                 return {

--- a/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsLogic.ts
@@ -539,7 +539,8 @@ export interface accountsLogicMeta {
         ) => AccountsTableQueryPlan
         accountsQuerySource: (
             accountsTableQueryPlan: AccountsTableQueryPlan,
-            relationshipDefinitionsLoaded: boolean
+            relationshipDefinitionsLoaded: boolean,
+            awaitingSavedView: boolean
         ) => AccountsTableQuery | null
         accountsDataTableQuery: (
             accountsTableQueryPlan: AccountsTableQueryPlan,
@@ -548,7 +549,8 @@ export interface accountsLogicMeta {
         metricsQuery: (
             overviewMetrics: AccountsTableMetric[],
             accountsTableQueryPlan: AccountsTableQueryPlan,
-            relationshipDefinitionsLoaded: boolean
+            relationshipDefinitionsLoaded: boolean,
+            awaitingSavedView: boolean
         ) => AccountsTableQuery | null
     }
 }
@@ -675,9 +677,6 @@ export const accountsLogic = kea<accountsLogicType>([
         // Restrict the list to a single account by id — drives the `/accounts/:accountId/:tab`
         // path route. null clears it (back to the full list).
         setAccountIdFilter: (accountId: string | null) => ({ accountId }),
-        // accountsViewsLogic holds this true from mount until the persisted view is applied,
-        // so the first fetch runs once with the view's inputs instead of once before and once
-        // after the view lands.
         setAwaitingSavedView: (awaiting: boolean) => ({ awaiting }),
     }),
     reducers({

--- a/products/customer_analytics/frontend/components/Accounts/accountsViewsLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsViewsLogic.test.ts
@@ -80,7 +80,6 @@ describe('accountsViewsLogic', () => {
         )
         mountAll()
 
-        // The gate closes synchronously on mount, before the views request resolves.
         expect(accountsLogic.values.awaitingSavedView).toBe(true)
         expect(accountsLogic.values.accountsQuerySource).toBeNull()
         expect(accountsLogic.values.metricsQuery).toBeNull()
@@ -88,7 +87,6 @@ describe('accountsViewsLogic', () => {
         await expectLogic(logic).toDispatchActions(['loadViewsSuccess', 'applyView']).toFinishAllListeners()
 
         expect(accountsLogic.values.awaitingSavedView).toBe(false)
-        // The first buildable query already carries the applied view's state.
         expect(accountsColumnConfigLogic.values.selectColumns).toEqual(['name', 'csm'])
         expect(accountsLogic.values.searchQuery).toEqual('acme')
     })

--- a/products/customer_analytics/frontend/components/Accounts/accountsViewsLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsViewsLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 
 import { userLogic } from 'scenes/userLogic'
 
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
 import type { AccountsTableQuery } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
@@ -69,6 +70,44 @@ describe('accountsViewsLogic', () => {
             .toMatchValues({
                 views: [expect.objectContaining({ id: 'view-1' })],
             })
+    })
+
+    it('holds the first accounts fetch until the persisted view is applied', async () => {
+        useMocks({ get: { '/api/environments/:team_id/column_configurations/': { count: 1, results: [buildView()] } } })
+        localStorage.setItem(
+            `customerAnalytics.accounts.accountsViewsLogic.${MOCK_DEFAULT_TEAM.id}.currentViewId`,
+            JSON.stringify('view-1')
+        )
+        mountAll()
+
+        // The gate closes synchronously on mount, before the views request resolves.
+        expect(accountsLogic.values.awaitingSavedView).toBe(true)
+        expect(accountsLogic.values.accountsQuerySource).toBeNull()
+        expect(accountsLogic.values.metricsQuery).toBeNull()
+
+        await expectLogic(logic).toDispatchActions(['loadViewsSuccess', 'applyView']).toFinishAllListeners()
+
+        expect(accountsLogic.values.awaitingSavedView).toBe(false)
+        // The first buildable query already carries the applied view's state.
+        expect(accountsColumnConfigLogic.values.selectColumns).toEqual(['name', 'csm'])
+        expect(accountsLogic.values.searchQuery).toEqual('acme')
+    })
+
+    it('opens the gate when loading views fails, so the list still fetches', async () => {
+        useMocks({ get: { '/api/environments/:team_id/column_configurations/': () => [500, {}] } })
+        localStorage.setItem(
+            `customerAnalytics.accounts.accountsViewsLogic.${MOCK_DEFAULT_TEAM.id}.currentViewId`,
+            JSON.stringify('view-1')
+        )
+        silenceKeaLoadersErrors()
+        try {
+            mountAll()
+            expect(accountsLogic.values.awaitingSavedView).toBe(true)
+            await expectLogic(logic).toDispatchActions(['loadViewsFailure'])
+            expect(accountsLogic.values.awaitingSavedView).toBe(false)
+        } finally {
+            resumeKeaLoadersErrors()
+        }
     })
 
     it('applyView hydrates columns, filters, sort, and tiles', async () => {

--- a/products/customer_analytics/frontend/components/Accounts/accountsViewsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsViewsLogic.ts
@@ -652,7 +652,6 @@ export const accountsViewsLogic = kea<accountsViewsLogicType>([
         loadViewsFailure: ({ error }) => {
             posthog.captureException(error)
             lemonToast.error('Failed to load views')
-            // The gate must never stick closed, or the accounts list never fetches.
             actions.setAwaitingSavedView(false)
         },
         submitNewViewFormFailure: ({ error }) => {
@@ -689,15 +688,10 @@ export const accountsViewsLogic = kea<accountsViewsLogicType>([
                     actions.applyView(view)
                 }
             }
-            // Opened after applyView so the view's state changes are already in when the first
-            // fetch builds its query. Unconditional so a deleted or missing view still opens it.
             actions.setAwaitingSavedView(false)
         },
     })),
     afterMount(({ actions, values }) => {
-        // A persisted view is about to be applied. Hold the first accounts fetch until it lands
-        // so the list does not fetch once with defaults and again with the view's inputs. A
-        // `#view=` hash restores synchronously through urlToAction instead, so it does not hold.
         if (values.currentViewId && !router.values.hashParams?.view) {
             actions.setAwaitingSavedView(true)
         }

--- a/products/customer_analytics/frontend/components/Accounts/accountsViewsLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsViewsLogic.ts
@@ -128,6 +128,9 @@ export interface accountsViewsLogicActions {
     setAssignedToFilter: (value: RoleFilterValue) => {
         value: RoleFilterValue
     } // accountsLogic
+    setAwaitingSavedView: (awaiting: boolean) => {
+        awaiting: boolean
+    } // accountsLogic
     setSearchQuery: (query: string) => {
         query: string
     } // accountsLogic
@@ -410,6 +413,7 @@ export const accountsViewsLogic = kea<accountsViewsLogicType>([
                 'setAssignedToFilter',
                 'setSortOrder',
                 'setAccountFilters',
+                'setAwaitingSavedView',
             ],
             accountsOverviewTilesLogic,
             ['setTiles', 'setTileFilter'],
@@ -648,6 +652,8 @@ export const accountsViewsLogic = kea<accountsViewsLogicType>([
         loadViewsFailure: ({ error }) => {
             posthog.captureException(error)
             lemonToast.error('Failed to load views')
+            // The gate must never stick closed, or the accounts list never fetches.
+            actions.setAwaitingSavedView(false)
         },
         submitNewViewFormFailure: ({ error }) => {
             posthog.captureException(error)
@@ -683,9 +689,18 @@ export const accountsViewsLogic = kea<accountsViewsLogicType>([
                     actions.applyView(view)
                 }
             }
+            // Opened after applyView so the view's state changes are already in when the first
+            // fetch builds its query. Unconditional so a deleted or missing view still opens it.
+            actions.setAwaitingSavedView(false)
         },
     })),
-    afterMount(({ actions }) => {
+    afterMount(({ actions, values }) => {
+        // A persisted view is about to be applied. Hold the first accounts fetch until it lands
+        // so the list does not fetch once with defaults and again with the view's inputs. A
+        // `#view=` hash restores synchronously through urlToAction instead, so it does not hold.
+        if (values.currentViewId && !router.values.hashParams?.view) {
+            actions.setAwaitingSavedView(true)
+        }
         actions.loadViews()
     }),
 ])


### PR DESCRIPTION
## Problem

- A user with a remembered saved view can pay for the Accounts list twice on open: the table fetches once with default columns, then again when the view lands, with a visible column swap in between.
- The saved-views request races the relationship-definitions request that gates the first fetch. Nothing sequences them, so whichever resolves last decides whether the fetch runs once or twice.
- Every accounts fetch recomputes in Postgres (the query kind never reads the cache), so the lost race doubles the tab's real load cost.

## Changes

- The first list and tiles fetch now waits for the remembered view to apply, so the table renders once with the view's columns, sort, and filters.
- `accountsViewsLogic` closes an `awaitingSavedView` gate on mount only when a persisted view id exists and no `#view=` hash overrides it, and opens the gate after `applyView`.
- A failed views request also opens the gate, so the list always fetches.
- Users without a remembered view see no change: the gate defaults open and never closes for them.

## How did you test this code?

- A new jest case holds the query source at `null` until the persisted view applies, then asserts the first buildable query carries the view's state. Removing the gate fails it.
- A second new case asserts a 500 from the views endpoint opens the gate. A stuck gate would mean the list never loads.
- The `accountsLogic` and `accountsViewsLogic` suites, frontend typecheck, and oxlint ran locally against current master and pass.
- Not run: `hogli ci:preflight` (stale Python venv in this sandbox). The diff is frontend-only and the frontend checks it wraps ran directly.
- Not done: manual browser verification; this environment has no running app stack.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The Accounts agent guide describes the saved-view lifecycle at a level this change does not alter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by an agent in a PostHog Desktop task; the driver has no verified GitHub handle in-session, so the PR is left unassigned.
- Skills invoked: `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`, `/security-review` (no findings; the gate is client-side fetch-ordering state).
- Sibling to [#92004](https://github.com/PostHog/posthog/pull/92004); both came out of the same investigation into slow Accounts tab loads. Independent changes, either can land first.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
