### PR TITLE
fix(signals): stop the inbox diff failure toast, keep the real reason

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -51,6 +51,7 @@ const ERROR_FILTER_ALLOW_LIST = [
     'loadSelfDrivingEvaluationReports', // The self-driving eval table renders its own retry state
     'loadToolDataEvents',
     'loadInstallRequests', // Polled in the background on Settings → Integrations; the banner just stays hidden
+    'loadReportDiff', // The Inbox report detail's diff panel renders its own error state
     'loadPrChecks', // Polled in the Inbox report detail; the CI checks section renders its own error state
     'loadPrComments', // The Inbox report detail's PR comments section renders its own error state
     'loadMonitoringSnapshot', // The managed warehouse Monitoring tab renders its own retry state

--- a/products/signals/frontend/inbox/logics/inboxReportDetailLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/inboxReportDetailLogic.test.ts
@@ -161,6 +161,42 @@ describe('inboxReportDetailLogic', () => {
         })
     })
 
+    describe('diff fetching', () => {
+        let logic: ReturnType<typeof inboxReportDetailLogic.build>
+
+        beforeEach(() => {
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/signals/reports/:id/artefacts/': { results: [] },
+                    '/api/projects/:team_id/signals/reports/:id/signals/': [],
+                    '/api/projects/:team_id/signals/reports/available_reviewers/': [],
+                    '/api/projects/:team_id/signals/reports/:id/artefacts/:artefact_id/diff/': () => [
+                        404,
+                        { error: "Branch 'fix-checkout' was not found on GitHub." },
+                    ],
+                },
+            })
+            initKeaTests()
+            silenceKeaLoadersErrors()
+            logic = inboxReportDetailLogic({ reportId: REPORT.id, report: REPORT })
+            logic.mount()
+        })
+
+        afterEach(() => {
+            logic.unmount()
+            resumeKeaLoadersErrors()
+        })
+
+        // The endpoint returns its reason under `error`, not DRF's `detail`, so a reducer that reads
+        // the wrong key falls back to guessing at a cause the response already stated.
+        it('surfaces what the endpoint says it could not find', async () => {
+            logic.actions.loadReportDiff({ artefactId: 'artefact-1' })
+            await expectLogic(logic).toFinishAllListeners()
+
+            expect(logic.values.reportDiffError).toBe("Branch 'fix-checkout' was not found on GitHub.")
+        })
+    })
+
     describe('report task polling', () => {
         let logic: ReturnType<typeof inboxReportDetailLogic.build>
         let artefactRequests: number

--- a/products/signals/frontend/inbox/logics/inboxReportDetailLogic.ts
+++ b/products/signals/frontend/inbox/logics/inboxReportDetailLogic.ts
@@ -851,15 +851,18 @@ export const inboxReportDetailLogic = kea<inboxReportDetailLogicType>([
                 setFeedbackNoteSubmitting: (_, { submitting }) => submitting,
             },
         ],
-        // Human-readable diff-load failure (kea-loaders only exposes a boolean loading flag). A failed
-        // compare usually means the branch was merged, deleted, or force-rewritten away.
+        // Human-readable diff-load failure (kea-loaders only exposes a boolean loading flag). The
+        // endpoint says which branch or repository GitHub could not find, so prefer its message and
+        // keep the guess for a failure that carried none (a network drop, a gateway error page).
         reportDiffError: [
             null as string | null,
             {
                 loadReportDiff: () => null,
                 loadReportDiffSuccess: () => null,
-                loadReportDiffFailure: () =>
-                    "Couldn't load the diff. The branch may have been merged, deleted, or rewritten.",
+                loadReportDiffFailure: (_state: string | null, { errorObject }: { errorObject?: any }) =>
+                    typeof errorObject?.data?.error === 'string' && errorObject.data.error
+                        ? errorObject.data.error
+                        : "Couldn't load the diff. The branch may have been merged, deleted, or rewritten.",
             },
         ],
         // The commit artefact the current `reportDiff` was loaded for, so the artefact poll re-fetches


### PR DESCRIPTION
## Problem

Anyone reading a report in the Self-driving inbox gets a red toast saying `Load report diff failed: URL not found` when the "Files changed" diff can't be fetched.

Two things are wrong with it:

- The diff panel already shows its own inline error, so the toast is a second copy of the same news.
- The wording is meaningless. The diff endpoint returns its reason under `error`, but the generic kea-loaders handler only reads DRF's `detail`, so a 404 falls back to "URL not found" — even though the response said the branch or repository was not found on GitHub.

A merged-and-deleted branch is normal, so this fires on healthy reports.

## Changes

- No toast on a failed diff load. `loadReportDiff` joins `loadPrChecks` and `loadPrComments` on the toast allowlist, since the same panel already surfaces the failure.
- The inline error now says what GitHub could not find (which branch, which repository) instead of always guessing "the branch may have been merged, deleted, or rewritten". That guess stays as the fallback for a failure with no server message, such as a network drop.

## How did you test this code?

Added one kea logic case in `inboxReportDetailLogic.test.ts`: a 404 whose body carries `error` must reach `reportDiffError`. It catches a reducer reading the wrong key — the exact bug here — and was confirmed to fail against the previous reducer before the fix. `products/signals/frontend/inbox/logics/inboxReportDetailLogic.test.ts` passes locally.

Not verified in a running app: the toast suppression is a one-line allowlist entry matching two neighbours that already work this way.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported from a Slack thread as a recurring toast in the inbox, then traced from the toast string back through `initKea`'s loader failure handler to the signals artefact diff endpoint. Left unassigned because no GitHub handle for the reporter was verified in the session — please assign the reporter on triage.

Tools: PostHog Slack app (Claude Code harness) with repo search, file edits, Jest. Repo skills consulted: `writing-tests` (gate for the added case).

The narrower fix — suppressing the toast only — would have left the inline message guessing at a cause the response already stated, so the reducer now prefers the endpoint's wording.

No customer data, thread contents, or internal material is present in the diff or this description.
