### PR TITLE
fix(desktop): thin superseded tool call snapshots in live transcripts

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionEvents.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionEvents.test.ts
@@ -19,6 +19,7 @@ import {
   promptReferencesAbsoluteFolder,
   selectEchoedOptimisticItemIds,
   selectUnseededPendingFollowups,
+  thinSupersededToolCallUpdates,
 } from "./sessionEvents";
 
 describe("isFatalSessionError", () => {
@@ -706,5 +707,136 @@ describe("collapseSupersededToolCallUpdates", () => {
     expect(sessionUpdate(last)).not.toHaveProperty("rawInput");
     expect(sessionUpdate(collapsed[0])).toHaveProperty("rawInput");
     expect(sessionUpdate(collapsed[0]).status).toBe("completed");
+  });
+});
+
+describe("thinSupersededToolCallUpdates", () => {
+  const toolUpdateFields = (
+    toolCallId: string,
+    fields: Record<string, unknown>,
+  ): AcpMessage =>
+    ({
+      type: "acp_message",
+      ts: 1,
+      message: {
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId,
+            ...fields,
+          },
+        },
+      },
+    }) as unknown as AcpMessage;
+
+  const other = (text: string): AcpMessage =>
+    ({
+      type: "acp_message",
+      ts: 1,
+      message: {
+        method: "session/update",
+        params: {
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text },
+          },
+        },
+      },
+    }) as unknown as AcpMessage;
+
+  // biome-ignore lint/suspicious/noExplicitAny: test introspection
+  const sessionUpdate = (e: AcpMessage) => (e.message as any).params.update;
+
+  it("deletes only the keys the incoming update re-sends", () => {
+    const previous = toolUpdateFields("a", {
+      rawInput: { command: "ls" },
+      content: "partial output",
+      status: "in_progress",
+    });
+    const incoming = toolUpdateFields("a", {
+      content: "full output",
+      status: "completed",
+    });
+
+    thinSupersededToolCallUpdates([other("hi"), previous], [incoming]);
+
+    expect(sessionUpdate(previous)).toEqual({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "a",
+      rawInput: { command: "ls" },
+    });
+    expect(sessionUpdate(incoming).content).toBe("full output");
+  });
+
+  it("preserves the previous event's wrapper identity and frozen-ness", () => {
+    const previous = Object.freeze(toolUpdateFields("a", { content: "old" }));
+    const existing = [previous];
+
+    thinSupersededToolCallUpdates(existing, [
+      toolUpdateFields("a", { content: "new" }),
+    ]);
+
+    expect(existing[0]).toBe(previous);
+    expect(Object.isFrozen(previous)).toBe(true);
+    expect(sessionUpdate(previous)).not.toHaveProperty("content");
+  });
+
+  it("replaying a thinned transcript merges to the same result", () => {
+    const makeRun = (): AcpMessage[] => [
+      toolUpdateFields("a", { rawInput: { command: "ls" } }),
+      toolUpdateFields("a", { title: "List files", content: "partial" }),
+      other("between"),
+      toolUpdateFields("a", { content: "done", status: "completed" }),
+    ];
+    const original = makeRun();
+
+    const thinned = makeRun();
+    thinSupersededToolCallUpdates(thinned.slice(0, 1), [thinned[1]]);
+    thinSupersededToolCallUpdates(thinned.slice(0, 3), [thinned[3]]);
+
+    const mergedOf = (events: AcpMessage[]) => {
+      const last = collapseSupersededToolCallUpdates(events).at(-1);
+      return last ? sessionUpdate(last) : undefined;
+    };
+    expect(mergedOf(thinned)).toBeDefined();
+    expect(mergedOf(thinned)).toEqual(mergedOf(original));
+  });
+
+  it("ignores tool calls of other ids and non-tool events", () => {
+    const otherTool = toolUpdateFields("b", { content: "b output" });
+    const prose = other("hi");
+
+    thinSupersededToolCallUpdates(
+      [otherTool, prose],
+      [toolUpdateFields("a", { content: "a output" })],
+    );
+
+    expect(sessionUpdate(otherTool).content).toBe("b output");
+    expect(sessionUpdate(prose).content).toEqual({ type: "text", text: "hi" });
+  });
+
+  it("does not thin snapshots beyond the bounded scan window", () => {
+    const previous = toolUpdateFields("a", { content: "far back" });
+    const filler = Array.from({ length: 400 }, (_, i) => other(`f${i}`));
+
+    thinSupersededToolCallUpdates(
+      [previous, ...filler],
+      [toolUpdateFields("a", { content: "new" })],
+    );
+
+    expect(sessionUpdate(previous).content).toBe("far back");
+  });
+
+  it("leaves a deep-frozen previous update untouched instead of throwing", () => {
+    const previous = toolUpdateFields("a", { content: "old" });
+    Object.freeze(sessionUpdate(previous));
+
+    thinSupersededToolCallUpdates(
+      [previous],
+      [toolUpdateFields("a", { content: "new" })],
+    );
+
+    expect(sessionUpdate(previous).content).toBe("old");
   });
 });

--- a/products/desktop/packages/core/src/sessions/sessionEvents.ts
+++ b/products/desktop/packages/core/src/sessions/sessionEvents.ts
@@ -347,6 +347,64 @@ export function collapseSupersededToolCallUpdates(
   return collapsed;
 }
 
+/**
+ * How far back {@link thinSupersededToolCallUpdates} scans for a tool call's
+ * previous snapshot. The active call's last snapshot sits at or near the end of
+ * the log, so a bounded scan finds it without an index; a snapshot further back
+ * stays unthinned, which only costs memory, never correctness.
+ */
+const SUPERSEDED_SCAN_WINDOW = 400;
+
+/** Keys that make an update recognizable as a tool_call_update. Never thinned. */
+const STRUCTURAL_UPDATE_KEYS = new Set(["sessionUpdate", "toolCallId"]);
+
+/**
+ * Reclaim the bulk of superseded live snapshots before `incoming` is appended
+ * after `existing`. Agents re-send the full accumulated tool output on every
+ * update (see {@link collapseSupersededToolCallUpdates}), so a resident live
+ * transcript otherwise retains every growing snapshot for the length of the
+ * run, which is quadratic in the tool's output.
+ *
+ * For each incoming tool_call_update, the previous snapshot for the same
+ * toolCallId is thinned in place: a key is deleted only when the incoming
+ * update carries that key, because the reducer's shallow merge (later fields
+ * win) then never reads the deleted value again, on the live fold and on a
+ * full replay alike. Keys the incoming update does not re-send are kept, for
+ * the same reason the collapse merges instead of dropping.
+ *
+ * Mutation happens inside the event's (shallowly frozen) wrapper on purpose:
+ * `createAppendOnlyTracker` detects history rewrites by wrapper identity, so
+ * replacing the event object would force a full transcript refold on every
+ * streamed update.
+ */
+export function thinSupersededToolCallUpdates(
+  existing: readonly AcpMessage[],
+  incoming: readonly AcpMessage[],
+): void {
+  for (const event of incoming) {
+    const update = toolCallUpdateOf(event);
+    if (!update) continue;
+    const previous = findLatestToolCallUpdate(existing, update.toolCallId);
+    if (!previous || previous === update || Object.isFrozen(previous)) continue;
+    for (const key of Object.keys(previous)) {
+      if (STRUCTURAL_UPDATE_KEYS.has(key)) continue;
+      if (key in update) delete previous[key];
+    }
+  }
+}
+
+function findLatestToolCallUpdate(
+  events: readonly AcpMessage[],
+  toolCallId: string,
+): (Record<string, unknown> & { toolCallId: string }) | undefined {
+  const floor = Math.max(0, events.length - SUPERSEDED_SCAN_WINDOW);
+  for (let i = events.length - 1; i >= floor; i--) {
+    const update = toolCallUpdateOf(events[i]);
+    if (update?.toolCallId === toolCallId) return update;
+  }
+  return undefined;
+}
+
 export function convertStoredEntriesToEvents(
   entries: StoredLogEntry[],
   taskDescription?: string,

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -126,6 +126,7 @@ import {
   selectEchoedOptimisticItemIds,
   selectUnseededPendingFollowups,
   shellExecutesToContextBlocks,
+  thinSupersededToolCallUpdates,
 } from "./sessionEvents";
 import { selectSessionsToEvict } from "./sessionEviction";
 import { createBaseSession } from "./sessionFactory";
@@ -8905,6 +8906,7 @@ export class SessionService {
       ? dropEventsCoveredByTail(existingEvents, taskRunId, startEntryIndex)
       : undefined;
     if (keptEvents) {
+      thinSupersededToolCallUpdates(keptEvents, events);
       this.d.store.updateSession(taskRunId, {
         events: [...keptEvents, ...events],
         ...(options.processedLineCount !== undefined

--- a/products/desktop/packages/core/src/sessions/sessionStore.ts
+++ b/products/desktop/packages/core/src/sessions/sessionStore.ts
@@ -12,6 +12,7 @@ import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { setAutoFreeze } from "immer";
 import { immer } from "zustand/middleware/immer";
 import { createStore } from "zustand/vanilla";
+import { thinSupersededToolCallUpdates } from "./sessionEvents";
 
 // immer autofreeze deep-walks produced state on every commit. For the
 // append-only `events` array that re-walks the whole (growing) array on every
@@ -137,6 +138,11 @@ export const sessionStoreSetters = {
     events: AcpMessage[],
     newLineCount?: number,
   ) => {
+    // Thin against the committed state BEFORE entering the immer draft: a
+    // draft read copies the event on write, which swaps the stored wrapper
+    // and makes the appendOnlyTracker refold the whole transcript.
+    const committed = sessionStore.getState().sessions[taskRunId];
+    if (committed) thinSupersededToolCallUpdates(committed.events, events);
     sessionStore.setState((state) => {
       const session = state.sessions[taskRunId];
       if (session) {

--- a/products/desktop/packages/core/src/sessions/sessionStoreThinning.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionStoreThinning.test.ts
@@ -1,0 +1,60 @@
+import type { AcpMessage, AgentSession } from "@posthog/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import { sessionStore, sessionStoreSetters } from "./sessionStore";
+
+const RUN = "run-thin";
+const TASK = "task-thin";
+
+function toolUpdate(fields: Record<string, unknown>): AcpMessage {
+  return {
+    type: "acp_message",
+    ts: 1,
+    message: {
+      method: "session/update",
+      params: {
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tool-1",
+          ...fields,
+        },
+      },
+    },
+  } as unknown as AcpMessage;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test introspection
+const sessionUpdate = (e: AcpMessage) => (e.message as any).params.update;
+
+afterEach(() => sessionStoreSetters.removeSession(RUN));
+
+describe("appendEvents — superseded snapshot thinning", () => {
+  it("thins the resident previous snapshot when a newer one is appended", () => {
+    sessionStoreSetters.setSession({
+      taskRunId: RUN,
+      taskId: TASK,
+      events: [],
+      messageQueue: [],
+      pendingPermissions: new Map(),
+      status: "connected",
+    } as unknown as AgentSession);
+
+    const first = toolUpdate({
+      rawInput: { command: "ls" },
+      content: "partial",
+    });
+    sessionStoreSetters.appendEvents(RUN, [first]);
+    sessionStoreSetters.appendEvents(RUN, [
+      toolUpdate({ content: "full", status: "completed" }),
+    ]);
+
+    const events = sessionStore.getState().sessions[RUN].events;
+    expect(events).toHaveLength(2);
+    expect(events[0]).toBe(first);
+    expect(sessionUpdate(events[0])).toEqual({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "tool-1",
+      rawInput: { command: "ls" },
+    });
+    expect(sessionUpdate(events[1]).content).toBe("full");
+  });
+});


### PR DESCRIPTION
## Problem

- A long tool-heavy agent run makes the desktop renderer's memory grow until Chromium kills the process near V8's 4 GB heap limit, and the app reloads mid-task.
- Agents re-send the full accumulated tool output on every `tool_call_update`, so the resident transcript keeps every growing snapshot for the length of the run. Retained memory is quadratic in one tool's output.
- Loading a transcript from disk already collapses superseded snapshots (the collapse comment documents one 9k-update run carrying ~312 MB of tool content that merges to ~3 MB). The live path collapsed only within one 16 ms flush batch, so a running session kept every cross-batch snapshot.

## Changes

- Long tool-heavy runs no longer grow renderer memory quadratically. Nothing else changes for the user.
- On append, `thinSupersededToolCallUpdates` thins the previous resident snapshot for the same tool call in place. A key is deleted only when the incoming update re-sends that key.
- The conversation reducer merges updates shallowly with later fields winning, so a deleted value is never read again, on the live fold and on a full replay alike.
- Thinning mutates inside the shallowly frozen event wrapper on purpose. The append-only transcript fold detects history rewrites by wrapper identity, so replacing the event object would force a full refold on every streamed update.
- Thinning runs against committed store state before the immer draft opens. A draft read copies on write, which would swap the stored wrapper.
- Wired into `sessionStore.appendEvents` (local live appends and the cloud tail fast path) and the cloud tail merge path in `sessionService`.

## How did you test this code?

- New cases in `sessionEvents.test.ts`: deleting only re-sent keys (guards replay data loss if thinning over-deletes), wrapper identity and frozen-ness preservation (guards the per-update full-refold regression), replay equivalence against `collapseSupersededToolCallUpdates`, the bounded scan window, and the deep-frozen no-throw guard.
- New `sessionStoreThinning.test.ts` wiring test: `appendEvents` thins the resident predecessor. It catches the store call being dropped, which no pure-helper test can.
- Ran the `packages/core` sessions suite (52 files) and `tsc` for `@posthog/core`, both clean.
- Not run: app E2E; the sandbox has no display. Seven pre-existing core test files outside sessions fail in this sandbox because `@posthog/agent` dist is unbuilt there; they fail identically on master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code from a renderer OOM investigation of `products/desktop`; this PR is the top-ranked fix of five.
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Decision: the first draft thinned inside the immer recipe; an immer draft read copies on write and swaps the stored wrapper, which the append-only fold treats as a history rewrite. The shipped version thins committed state before `setState`, mirroring `drainQueueHead`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbcTvgKxjwLae4eT9zce6w)_