### PR TITLE
fix(desktop): keep session replay off the streaming transcript hot path

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatMarkdown.tsx
@@ -291,8 +291,13 @@ export const ChatStreamingMarkdown = memo(function ChatStreamingMarkdown({
   const blocks = useMemo(() => splitMarkdownBlocks(content), [content]);
   const lastIndex = blocks.length - 1;
 
+  // ph-no-capture: session replay records a DOM mutation per streamed token,
+  // and this subtree mutates every animation frame for the length of a turn.
+  // Blocking it keeps rrweb's mutation buffer off the streaming hot path; the
+  // completed message re-renders through ChatMarkdown outside this component,
+  // so the final content still reaches the replay.
   return (
-    <div className="flex flex-col gap-3 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+    <div className="ph-no-capture flex flex-col gap-3 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
       {blocks.map((block, index) => {
         const key = `b${index}`;
         const openFence = index === lastIndex ? parseOpenFence(block) : null;

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/AgentMessage.tsx
@@ -72,11 +72,17 @@ export const AgentMessage = memo(function AgentMessage({
   return (
     <Box className="group/msg relative pl-3 text-[13px] [&>*:last-child]:mb-0 [&_p]:leading-[1.9]">
       {isStreaming ? (
-        <StreamingMarkdown
-          content={smoothed}
-          renderObjectTags
-          componentsOverride={agentComponents}
-        />
+        // ph-no-capture: this subtree mutates every animation frame while the
+        // turn streams, which floods session replay's mutation buffer. The
+        // completed message renders through MarkdownRenderer below, so the
+        // final content still reaches the replay.
+        <div className="ph-no-capture">
+          <StreamingMarkdown
+            content={smoothed}
+            renderObjectTags
+            componentsOverride={agentComponents}
+          />
+        </div>
       ) : (
         <MarkdownRenderer
           content={content}

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -137,9 +137,16 @@ export function initializePostHog(sessionId?: string) {
     // canvases are xterm terminals (secrets show up as pixels, bypassing text
     // masking) and decorative WebGL (hedgehog, confetti). Capturing them costs
     // an image encode per canvas at canvasFps for the whole app lifetime.
+    // Network and console capture are pinned off for the same reason: this
+    // renderer lives for a whole workday and streams agent output, so any
+    // recorder feature the shared project turns on remotely accumulates in
+    // this process until the V8 heap limit, not for one page view.
     session_recording: {
       captureCanvas: { recordCanvas: false },
+      recordHeaders: false,
+      recordBody: false,
     },
+    enable_recording_console_log: false,
     // The shared analytics project runs many popover surveys aimed at the
     // PostHog web app; any one without URL/event conditions would render here
     // too. This app only submits survey responses through its own UI


### PR DESCRIPTION
## Problem

- Desktop users on long agent runs see the renderer's memory climb toward V8's 4 GB heap limit, then a crash and an automatic reload.
- The renderer records its own PostHog session replay, force-started at boot and never stopped, with a 10 hour idle timeout.
- rrweb buffers a mutation record per DOM change, and a streaming turn mutates the transcript every animation frame, so one recording accumulates token-cadence mutations for a whole workday.
- Nothing pinned the recorder's remote-config surface, so the shared analytics project could also switch on console log and network payload capture in this long-lived process.

## Changes

- Replays of the desktop app no longer show the in-flight typing animation of a streaming turn; the completed message still appears, because it re-renders through the non-streaming markdown path on turn end.
- `ChatStreamingMarkdown`'s container and the `StreamingMarkdown` branch of `AgentMessage` are now `ph-no-capture`, the same mechanism that already excludes parked terminal canvases.
- Console log recording (`enable_recording_console_log`) and network header/body capture (`recordHeaders`, `recordBody`) are pinned off client-side, so remote config cannot re-enable them here.
- The deliberate 10 hour `session_idle_timeout_seconds` and canvas exclusion are unchanged.

## How did you test this code?

- Ran the `ChatMarkdown` and `posthogAnalyticsImpl` vitest suites and Biome on the touched files; the desktop-wide turbo typecheck ran in the pre-commit hook.
- No new tests: the change is two class names and three config literals; a test would only restate them.
- Not run: a live replay capture check; the sandbox has no display. Worth one manual dogfood pass: open a streaming task and confirm the recording stays small and the finished message appears.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code from a renderer OOM investigation of `products/desktop`; second-ranked fix of five (transcript retention lands in #92037).
- Skills invoked: `/posthog-desktop`, `/writing-code-comments`, `/writing-pr-descriptions`, `/writing-tests`.
- Decision: excluding only the streaming subtrees was chosen over `ph-no-capture` on the whole transcript, which would blind replay dogfooding of the transcript UI, and over lowering the idle timeout, which would change session analytics semantics.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbcTvgKxjwLae4eT9zce6w)_