### PR TITLE
fix(desktop): stop re-serializing every completed turn per streamed chunk

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -85,7 +85,7 @@ import {
   type ThreadScrollResume,
   type TurnRow,
 } from "@posthog/ui/features/sessions/components/chat-thread/threadVirtualization";
-import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
+import { buildTurnCopyTextCached } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 import { usePromptRecallSource } from "@posthog/ui/features/sessions/components/chat-thread/usePromptRecallSource";
 import { VirtualThreadScrollBody } from "@posthog/ui/features/sessions/components/chat-thread/VirtualThreadScrollBody";
 import {
@@ -943,7 +943,7 @@ const ThreadRow = memo(function ThreadRow({
           <TurnFooter
             turnId={item.id}
             timestamp={completedTurnTimestamp(item)}
-            copyText={buildTurnCopyText(item.items) ?? undefined}
+            copyText={buildTurnCopyTextCached(item.items) ?? undefined}
           />
         </FooterRevealContext.Provider>
       </ChatMessageScrollerItem>

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -1,6 +1,6 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
-import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
+import { buildTurnCopyTextCached } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 
 /** A row is either a parsed conversation item or a synthesized group of tool calls. */
 export type ThreadItem = ConversationItem | ToolGroupItem;
@@ -164,7 +164,7 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
       const copyText =
         timestamp == null
           ? undefined
-          : (buildTurnCopyText(row.items) ?? undefined);
+          : (buildTurnCopyTextCached(row.items) ?? undefined);
       for (let i = 0; i < row.items.length; i++) {
         const item = row.items[i];
         const isTrailing = i === row.items.length - 1;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.test.ts
@@ -1,7 +1,7 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
 import { describe, expect, it } from "vitest";
-import { buildTurnCopyText } from "./turnCopyText";
+import { buildTurnCopyText, buildTurnCopyTextCached } from "./turnCopyText";
 
 function userMessage(id: string, content: string): ConversationItem {
   return { type: "user_message", id, content, timestamp: 0 };
@@ -74,5 +74,29 @@ describe("buildTurnCopyText", () => {
     ["blank agent prose", [userMessage("u1", "prompt"), agentText("a1", "\n")]],
   ])("returns null when there is nothing to copy: %s", (_label, items) => {
     expect(buildTurnCopyText(items)).toBeNull();
+  });
+});
+
+describe("buildTurnCopyTextCached", () => {
+  it("matches the uncached result across rebuilt container arrays", () => {
+    const items = [agentText("a1", "first"), agentText("a2", "second")];
+
+    expect(buildTurnCopyTextCached([...items])).toBe(
+      buildTurnCopyText([...items]),
+    );
+    expect(buildTurnCopyTextCached([...items])).toBe("first\n\nsecond");
+  });
+
+  it("recomputes when the turn gains an item", () => {
+    const first = agentText("a1", "first");
+    expect(buildTurnCopyTextCached([first])).toBe("first");
+
+    expect(buildTurnCopyTextCached([first, agentText("a2", "second")])).toBe(
+      "first\n\nsecond",
+    );
+  });
+
+  it("returns null for an empty turn without caching", () => {
+    expect(buildTurnCopyTextCached([])).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.ts
@@ -24,3 +24,39 @@ export function buildTurnCopyText(
   if (parts.length === 0) return null;
   return parts.join("\n\n");
 }
+
+interface TurnCopyTextCacheEntry {
+  itemCount: number;
+  lastItem: unknown;
+  text: string | null;
+}
+
+const turnCopyTextCache = new WeakMap<object, TurnCopyTextCacheEntry>();
+
+/**
+ * {@link buildTurnCopyText} with per-turn memoization. The thread re-derives
+ * its rows on every streamed chunk and rebuilds each turn's container array,
+ * so an uncached call re-serializes the prose of every completed turn several
+ * times a second for the length of a run. The cache keys on the turn's first
+ * item, which is identity-stable once a turn completes; the item count and
+ * last-item guards invalidate the entry when a turn still gains items. Keys
+ * are the item objects themselves, so entries release with the transcript.
+ */
+export function buildTurnCopyTextCached(
+  items: Array<ConversationItem | ToolGroupItem>,
+): string | null {
+  const first = items[0];
+  if (!first) return null;
+  const last = items[items.length - 1];
+  const hit = turnCopyTextCache.get(first);
+  if (hit && hit.itemCount === items.length && hit.lastItem === last) {
+    return hit.text;
+  }
+  const text = buildTurnCopyText(items);
+  turnCopyTextCache.set(first, {
+    itemCount: items.length,
+    lastItem: last,
+    text,
+  });
+  return text;
+}


### PR DESCRIPTION
## Problem

- On a long transcript, every streamed token makes the desktop chat thread stutter and drives allocation the GC has to absorb for the length of the run, feeding the renderer OOM crashes users report as random reloads.
- The thread re-derives its row list on every streamed chunk, and `flattenTurnRows` rebuilt the plain-text "Copy turn" transcript of **every completed turn** each time.
- Each rebuild allocates a fresh string of that turn's entire prose, so a long transcript re-serializes megabytes several times a second while a turn streams.

## Changes

- Streaming no longer re-serializes completed turns; the visible thread behaves the same and "Copy turn" still copies the same text.
- `buildTurnCopyTextCached` memoizes the copy text per turn in a `WeakMap` keyed on the turn's first item, which is identity-stable once a turn completes.
- Item-count and last-item guards invalidate an entry when a turn still gains items, so a growing turn never serves stale text.
- Both call sites switch to the cached variant: `flattenTurnRows` (windowed body) and the turn footer in `ChatThread` (non-virtualized body). Mechanical beyond the new function.

## How did you test this code?

- New cases in `turnCopyText.test.ts`: cached result equals the uncached result across rebuilt container arrays (guards a stale-cache regression when the thread rebuilds turn arrays per chunk), and recompute when a turn gains an item (guards the invalidation).
- Ran the `turnCopyText` and `threadVirtualization` vitest suites and Biome on the touched files; the desktop-wide turbo typecheck ran in the pre-commit hook.
- Not run: app E2E; the sandbox has no display.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code from a renderer OOM investigation of `products/desktop`; third-ranked fix of five (alongside #92037 and #92040).
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Decision: the cache keys on the first item object rather than the `items` array because `groupIntoTurns` rebuilds the container arrays on every pass; item objects are what the incremental parser keeps identity-stable for completed turns.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbcTvgKxjwLae4eT9zce6w)_