### PR TITLE
fix(desktop): release hedgehog mode's actors and timers on teardown

### DIFF
--- a/products/desktop/apps/code/src/renderer/platform-adapters/hedgehog-mode-host.ts
+++ b/products/desktop/apps/code/src/renderer/platform-adapters/hedgehog-mode-host.ts
@@ -37,6 +37,20 @@ export class RendererHedgehogModeHost implements HedgehogModeHost {
     return {
       destroy: () => {
         canvas.removeEventListener("webglcontextlost", notifyContextLost);
+        // HedgeHogMode.destroy() tears down the Pixi app but never visits
+        // `elements`, so actor AI timers, per-actor input listeners and
+        // module-level spawn counters survive it and pin the dead game in
+        // memory. Drain the elements first: removeElement runs each
+        // element's beforeUnload, and destroying the sprite releases its
+        // shared-ticker registration, which stage removal alone does not.
+        for (const element of [...game.elements]) {
+          try {
+            game.removeElement(element);
+            element.sprite?.destroy({ children: true });
+          } catch {
+            // One broken element must not stop the rest of the drain.
+          }
+        }
         game.destroy();
       },
       isContextLost: () => {

--- a/products/desktop/packages/ui/src/shell/HedgehogMode.test.tsx
+++ b/products/desktop/packages/ui/src/shell/HedgehogMode.test.tsx
@@ -18,8 +18,10 @@ vi.mock("@posthog/di/react", () => ({
   useService: () => ({ mount: mocks.mount }),
 }));
 
+const meState = vi.hoisted(() => ({ data: undefined as unknown }));
+
 vi.mock("../features/auth/useMeQuery", () => ({
-  useMeQuery: () => ({ data: undefined }),
+  useMeQuery: () => meState,
 }));
 
 vi.mock("../features/settings/settingsStore", () => ({
@@ -84,6 +86,7 @@ beforeEach(() => {
   mocks.mount.mockImplementation(mountGameInto);
   mocks.contextLost = false;
   settingsState.hedgehogMode = true;
+  meState.data = undefined;
 });
 
 afterEach(() => {
@@ -169,6 +172,29 @@ describe("HedgehogMode", () => {
       vi.advanceTimersByTime(10_000);
     });
     expect(mocks.mount).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps the remount cap across mount-effect re-runs", async () => {
+    const { view, overlay } = await renderHedgehogMode();
+
+    for (let loss = 0; loss < 3; loss += 1) {
+      await loseContext();
+      await remountAfterDelay();
+    }
+    expect(mocks.mount).toHaveBeenCalledTimes(4);
+
+    // The user's hedgehog config settling re-runs the mount effect. That must
+    // not reset the loss count and re-arm more remount attempts.
+    meState.data = { hedgehog_config: { actor_options: {} } };
+    view.rerender(<HedgehogMode />);
+    await act(async () => {});
+    expect(mocks.mount).toHaveBeenCalledTimes(5);
+
+    await loseContext();
+    await remountAfterDelay();
+
+    expect(mocks.mount).toHaveBeenCalledTimes(5);
+    expect(overlay.style.visibility).toBe("hidden");
   });
 
   it("destroys the game on toggle off and remounts armed on re-enable", async () => {

--- a/products/desktop/packages/ui/src/shell/HedgehogMode.tsx
+++ b/products/desktop/packages/ui/src/shell/HedgehogMode.tsx
@@ -24,17 +24,23 @@ export function HedgehogMode() {
   const containerRef = useRef<HTMLDivElement>(null);
   const handleRef = useRef<HedgehogModeHandle | null>(null);
   const [gameDead, setGameDead] = useState(false);
+  // Counts context losses across effect re-runs. An effect-local counter
+  // resets whenever a dependency changes (user config settling at boot, a
+  // settings write), which re-arms three more remount attempts per re-run
+  // and lets a crashing GPU cycle the game indefinitely. Reset only when
+  // the user turns the mode off.
+  const contextLossesRef = useRef(0);
 
   useEffect(() => {
     if (hedgehogMode) return;
     setGameDead(false);
+    contextLossesRef.current = 0;
   }, [hedgehogMode]);
 
   useEffect(() => {
     if (!hedgehogMode || gameDead || !containerRef.current || !host) return;
 
     let cancelled = false;
-    let losses = 0;
     let remountTimer: ReturnType<typeof setTimeout> | null = null;
     const container = containerRef.current;
 
@@ -59,7 +65,8 @@ export function HedgehogMode() {
     // immediately.
     const handleContextLost = () => {
       if (!handleRef.current) return;
-      losses += 1;
+      contextLossesRef.current += 1;
+      const losses = contextLossesRef.current;
       log.error("Hedgehog mode WebGL context lost", { losses });
       captureException(new Error("Hedgehog mode WebGL context lost"), {
         source: "hedgehog-mode",


### PR DESCRIPTION
## Problem

- Users with hedgehog mode on accumulate renderer memory on every game teardown, and crash logs before renderer OOMs show hedgehog/Pixi animation errors.
- `@posthog/hedgehog-mode@0.0.53`'s `destroy()` tears down the Pixi `Application` but never visits `elements`, so each teardown permanently leaks: actor AI `setTimeout` chains that keep firing, per-actor input listeners, `AnimatedSprite`s still registered on Pixi's shared ticker, and module-level spawn counters that drift toward their caps.
- Leaked keyboard listeners then attempt spawns against the destroyed app; the spawn registers another leaked sprite before throwing on the nulled stage, which is the logged animation-error signature.
- The context-loss remount cap (3) lived in an effect closure, so any dependency re-run (the user's config settling at boot, a settings write) reset it and re-armed three more teardown-leak cycles for a crashing GPU.

## Changes

- Users see no visual difference; teardown now releases the game's memory instead of pinning it.
- The desktop adapter drains `game.elements` before `game.destroy()`: `removeElement` runs each element's `beforeUnload` (stops AI timers and per-actor listeners, decrements spawn counters), and `sprite.destroy({ children: true })` releases the shared-ticker registration that stage removal alone leaves behind. Shared spritesheet textures are not destroyed.
- The remount cap moves to a ref that only resets when the user turns the mode off, so effect re-runs cannot re-arm it.
- Not fixed here, needs a `@posthog/hedgehog-mode` release: the game's own window/document listeners (resize, mousemove, pointerdown, two keyboard systems whose disposers are discarded) and its permanent `gsap.ticker.remove(gsap.updateRoot)` global mutation survive `destroy()` and still retain the game object itself.

## How did you test this code?

- New test in `HedgehogMode.test.tsx`: three context losses, then a user-config re-run, then a fourth loss must not remount. It fails against the previous code (verified by stashing the fix) and passes with it.
- Ran the `HedgehogMode` vitest suite and Biome on the touched files; the desktop-wide turbo typecheck ran in the pre-commit hook.
- Not run: a real WebGL context-loss cycle in the app; the sandbox has no GPU or display.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code from a renderer OOM investigation of `products/desktop`; fourth-ranked fix of five (with #92037, #92040, #92041). The package-internal leak audit came from reading `@posthog/hedgehog-mode@0.0.53`'s published sources via its sourcemaps.
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Decision: draining elements from the adapter was chosen over patching the package's `dist` bundle (fragile) and over waiting for an upstream release, because `elements`, `removeElement`, and `sprite` are all public API.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbcTvgKxjwLae4eT9zce6w)_