### PR TITLE
fix(mcp): restore write-implies-read for server-mint scopes

### DIFF
--- a/services/mcp/src/lib/api.ts
+++ b/services/mcp/src/lib/api.ts
@@ -9,11 +9,12 @@ const SERVER_MINT_ONLY_SCOPE_OBJECTS = new Set([
 
 export const hasScope = (scopes: string[], requiredScope: string): boolean => {
     const scopeObject = requiredScope.split(':', 1)[0]
-    if (scopeObject && SERVER_MINT_ONLY_SCOPE_OBJECTS.has(scopeObject)) {
-        return scopes.includes(requiredScope)
-    }
+    const isServerMintOnly = scopeObject !== undefined && SERVER_MINT_ONLY_SCOPE_OBJECTS.has(scopeObject)
 
-    if (scopes.includes('*')) {
+    // A user-consented `*` must never reach a server-minted scope object. Only the wildcard is
+    // withheld — the read/write rule below still applies, so this stays in step with the Django
+    // permission layer (`posthog/permissions.py`), which authorizes the same tokens server-side.
+    if (!isServerMintOnly && scopes.includes('*')) {
         return true
     }
 

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -498,6 +498,37 @@ describe('server-minted scope matching', () => {
         expect(hasScope(['*'], 'signal_scratchpad_internal:write')).toBe(false)
         expect(hasScope(['signal_scratchpad_internal:write'], 'signal_scratchpad_internal:write')).toBe(true)
     })
+
+    // Withholding the wildcard from these objects must not also withhold write-implies-read.
+    // Scout sandbox tokens carry `signal_scout_internal:write` and never the `:read` form, so
+    // dropping that rule hid `scout-members-list` from every scout's toolset and left reports
+    // with nobody to route to. Django authorizes the same tokens with the rule applied.
+    it.each([
+        'internal_run',
+        'loop_context_internal',
+        'mcp_builtin_agent',
+        'signal_scout_internal',
+        'signal_scout_report',
+        'signal_scratchpad_internal',
+    ])('lets a %s:write token satisfy the matching :read scope', (scopeObject) => {
+        expect(hasScope([`${scopeObject}:write`], `${scopeObject}:read`)).toBe(true)
+        // The implication runs one way only.
+        expect(hasScope([`${scopeObject}:read`], `${scopeObject}:write`)).toBe(false)
+        // A wildcard still reaches neither form.
+        expect(hasScope(['*'], `${scopeObject}:read`)).toBe(false)
+        expect(hasScope(['*'], `${scopeObject}:write`)).toBe(false)
+    })
+
+    it('does not let a write on one internal object reach another', () => {
+        expect(hasScope(['signal_scout_report:write'], 'signal_scout_internal:read')).toBe(false)
+    })
+
+    it('leaves wildcard and write-implies-read intact for user-grantable scopes', () => {
+        expect(hasScope(['*'], 'insight:read')).toBe(true)
+        expect(hasScope(['*'], 'insight:write')).toBe(true)
+        expect(hasScope(['insight:write'], 'insight:read')).toBe(true)
+        expect(hasScope(['insight:read'], 'insight:write')).toBe(false)
+    })
 })
 
 describe('getAdvertisedOAuthScopes', () => {


### PR DESCRIPTION
## Problem

Since 23 August, scouts on every project cannot look up project members. Reports reach the inbox with no suggested reviewer, so nobody is routed to act on them.

`hasScope` gained an early return for server-mint-only scope objects. Withholding a user-consented `*` wildcard from an internal scope is correct, but the branch returned an exact scope match, so it also skipped the write-implies-read rule below it.

- Scout sandbox tokens carry `signal_scout_internal:write`, never the `:read` form.
- `scout-members-list` declares `signal_scout_internal:read`.
- The MCP server dropped the tool from the toolset before a scout could call it.

Django applies write-implies-read to the same tokens, so the two authorization layers disagreed. The endpoint would authorize the call. The MCP server never let it be made.

`scout-members-list` is the only tool declaring a `:read` scope on any of the six affected objects. That is why report emission kept working and only reviewer routing broke.

Closes #91907
Closes #91817
Closes #91324

## Changes

- Scouts resolve report owners again, so reports arrive routed instead of unowned.
- `hasScope` withholds only the wildcard from server-mint-only objects, and applies write-implies-read to all of them.
- Narrowing the branch to the wildcard, rather than repeating the read/write rule inside it, keeps one copy of the rule and matches `posthog/permissions.py`.
- The fix targets the rule, not the one tool. Five other objects sit in the same set and carry the same latent failure.

Nothing visual changes. This is server-side scope matching.

## How did you test this code?

Regression tests extend the existing `server-minted scope matching` block in `services/mcp/tests/unit/tool-filtering.test.ts`.

- `:write` satisfies the matching `:read`, parameterized across all six server-mint-only objects. This is the defect. Reverting the fix fails exactly these six cases and leaves the rest green.
- `:read` does not satisfy `:write`, and a wildcard reaches neither form. This guards against reopening the wildcard hole the branch was added to close.
- A write on one internal object does not reach another.
- Wildcard and write-implies-read still hold for user-grantable scopes. No existing test covered `hasScope` for ordinary scope objects, and this change moved that path.

The pre-existing wildcard-block cases pass unchanged.

No live scout run verified this. Only the unit suite exercised the change.

`pnpm --filter=@posthog/mcp run typecheck` reports errors only under `src/ui-apps/`, all of them missing `@posthog/quill` modules from the unbuilt nested workspace. None fall outside that directory.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app, which was asked whether an inbox report existed for #91907 and then to fix it.

Skills invoked: `/inbox-exploration`, `/writing-tests`, `/writing-pr-descriptions`.

The originating report proposed repeating the read/write rule inside the server-mint branch. This version narrows the branch to the wildcard instead, so the rule stays in one place.

Two adjacent defects named in #91907 were investigated and left out on purpose:

- The commit-author lookup failure in `resolve_reviewers.py`. `resolve_suggested_reviewers_with_diagnostics` and `GitHubIntegration.get_commit_author_info` both read correctly, and the lookups return `None` at runtime. Root-causing that needs live request data, so a code change here would be speculative. It is the larger cause of empty reviewers and deserves its own issue.
- The missing scope leg in `_emit_eligibility`. The profile builder has no access to the run's token scopes, so adding one means plumbing them through, which is a design change rather than a small fix.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1788212947593459)*
