### PR TITLE
fix(desktop): bound tool output, image, and highlighter memory in thread

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -1482,6 +1482,11 @@ function ChatThreadRenderer({
     () => ({
       workerFactory: () => diffWorkerFactory(),
       totalASTLRUCacheSize: 200,
+      // Each pooled highlighter worker is a full V8 isolate with shiki
+      // grammars loaded (~40MB RSS); the library default of 8 costs hundreds
+      // of MB for parallelism thread diffs don't need. Matches
+      // ConversationView and ReviewShell.
+      poolSize: 2,
     }),
     [diffWorkerFactory],
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/toolCallUtils.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/toolCallUtils.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ContentPre } from "./toolCallUtils";
+
+describe("ContentPre", () => {
+  it("renders output under the cap in full, with no reveal button", () => {
+    render(<ContentPre>{"short output"}</ContentPre>);
+
+    expect(screen.getByText("short output")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("caps oversized output and reveals the rest on request", async () => {
+    const text = `${"a".repeat(60_000)}END`;
+    const { container } = render(<ContentPre>{text}</ContentPre>);
+
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent?.length).toBeLessThan(51_000);
+    expect(pre?.textContent?.includes("END")).toBe(false);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Show full output" }),
+    );
+
+    expect(container.querySelector("pre")?.textContent?.endsWith("END")).toBe(
+      true,
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/toolCallUtils.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/toolCallUtils.tsx
@@ -15,9 +15,10 @@ import {
   Trash,
   Wrench,
 } from "@phosphor-icons/react";
-import { cn } from "@posthog/quill";
+import { Button, cn } from "@posthog/quill";
 import { DotsCircleSpinner } from "@posthog/ui/primitives/DotsCircleSpinner";
 import { Box, Text } from "@radix-ui/themes";
+import { useState } from "react";
 import type { CodeToolKind, ToolCall, ToolCallContent } from "../../types";
 import { useChatThreadChrome } from "../chat-thread/chatThreadChrome";
 
@@ -295,28 +296,60 @@ export function ExpandableIcon({
   );
 }
 
+/**
+ * Character cap on tool output committed to the DOM. The scroll box clips the
+ * output visually either way, but the full string still became a DOM text
+ * node: one large file read or command output puts megabytes into the
+ * document, and every re-render of the row re-commits it. Past the cap the
+ * rest renders only when the reader asks for it.
+ */
+const CONTENT_PRE_COLLAPSE_CHARS = 50_000;
+
 export function ContentPre({ children }: { children: React.ReactNode }) {
   // New thread wraps output in a bordered, muted box (it sits inside a ChatMarker panel); the legacy
   // thread keeps the original borderless scroll box so ConversationView is unchanged when toggled off.
   const chatChrome = useChatThreadChrome();
+  const [showFull, setShowFull] = useState(false);
+  const text = typeof children === "string" ? children : null;
+  const capped =
+    text !== null && !showFull && text.length > CONTENT_PRE_COLLAPSE_CHARS;
+  const shown = capped
+    ? `${text.slice(0, CONTENT_PRE_COLLAPSE_CHARS)}…`
+    : children;
+  const showFullButton = capped ? (
+    <Button
+      variant="outline"
+      size="xs"
+      className="mt-1 self-start"
+      onClick={() => setShowFull(true)}
+    >
+      Show full output
+    </Button>
+  ) : null;
   if (chatChrome) {
     return (
-      <Box className="max-h-64 rounded-sm border border-border">
-        <Box className="scroll-mask-2 max-h-64 overflow-auto bg-muted/50 p-3">
-          <pre className="m-0 whitespace-pre-wrap break-all font-mono text-xs">
-            {children}
-          </pre>
+      <>
+        <Box className="max-h-64 rounded-sm border border-border">
+          <Box className="scroll-mask-2 max-h-64 overflow-auto bg-muted/50 p-3">
+            <pre className="m-0 whitespace-pre-wrap break-all font-mono text-xs">
+              {shown}
+            </pre>
+          </Box>
         </Box>
-      </Box>
+        {showFullButton}
+      </>
     );
   }
   return (
-    <Box className="scroll-mask-2 max-h-64 overflow-auto px-3 py-2">
-      <Text asChild className="text-[13px] text-gray-11">
-        <pre className="m-0 whitespace-pre-wrap break-all font-mono">
-          {children}
-        </pre>
-      </Text>
-    </Box>
+    <>
+      <Box className="scroll-mask-2 max-h-64 overflow-auto px-3 py-2">
+        <Text asChild className="text-[13px] text-gray-11">
+          <pre className="m-0 whitespace-pre-wrap break-all font-mono">
+            {shown}
+          </pre>
+        </Text>
+      </Box>
+      {showFullButton}
+    </>
   );
 }

--- a/products/desktop/packages/ui/src/primitives/SafeImagePreview.tsx
+++ b/products/desktop/packages/ui/src/primitives/SafeImagePreview.tsx
@@ -9,7 +9,7 @@ import {
   MAX_IMAGE_BASE64_LENGTH,
 } from "@posthog/shared";
 import { Flex, Text } from "@radix-ui/themes";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
 
 const MIN_SCALE = 0.1;
@@ -171,13 +171,21 @@ export function SafeImagePreview({
     base64.length <= MAX_IMAGE_BASE64_LENGTH &&
     isAllowedImageMimeType(mimeType);
 
-  if (!isPayloadValid || hasError) {
+  // Memoized because the data URL can be megabytes of string: an unmemoized
+  // build allocates it again on every re-render of the row, only for React to
+  // discard it as an unchanged prop.
+  const src = useMemo(
+    () => (isPayloadValid ? buildImageDataUrl(mimeType, base64) : null),
+    [isPayloadValid, mimeType, base64],
+  );
+
+  if (!src || hasError) {
     return <>{fallback ?? <DefaultFallback />}</>;
   }
 
   return (
     <ZoomableImage
-      src={buildImageDataUrl(mimeType, base64)}
+      src={src}
       alt={alt ?? "image preview"}
       className={className}
       style={style}


### PR DESCRIPTION
## Problem

- A transcript holding one large file read or command output makes the desktop renderer hold megabytes of DOM text per tool row, re-committed on every row render, feeding the OOM crashes users see as random reloads.
- Nothing in the tool-output path caps content size: `ContentPre` clips visually with `max-h-64` but renders the full string.
- Image previews rebuilt their data URL (up to the 15 MB base64 cap) on every render, only for React to discard it as an unchanged prop.
- The chat thread's diff highlighter pool omitted the `poolSize` cap its two sibling call sites apply, so it spawned the library default of 8 worker isolates at ~40 MB each.

## Changes

- Tool output longer than 50,000 characters now renders capped, with a "Show full output" button below the box; shorter output is unchanged. This is the one visible change.
- `SafeImagePreview` memoizes the data URL, so image rows stop re-allocating multi-megabyte strings per render. No visual change.
- The thread's diff worker pool sets `poolSize: 2`, matching `ConversationView` and `ReviewShell` and their in-code justification. Roughly 240 MB of process footprint saved; mechanical.

## How did you test this code?

- New `toolCallUtils.test.tsx`: output under the cap renders in full with no button (guards the cap misfiring on normal output), and oversized output truncates then reveals in full on click (guards the cap or the reveal being dropped).
- Ran that suite and Biome on the touched files; the desktop-wide turbo typecheck ran in the pre-commit hook.
- Not run: app E2E and a visual pass of the capped state; the sandbox has no display. No screenshot for the same reason: worth one manual look at a capped output box before merge.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with Claude Code from a renderer OOM investigation of `products/desktop`; fifth-ranked fix of five (with #92037, #92040, #92041, #92044).
- Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Decision: the cap lives inside `ContentPre` so every tool view inherits it; `ReadToolView`'s CodeMirror file preview is deliberately untouched because capping an editor document changes its UX and deserves its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbcTvgKxjwLae4eT9zce6w)_