### PR TITLE
feat(replay_vision): find goal-relevant events beyond the briefing sample

### DIFF
--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Literal, cast
 
 from django.conf import settings
+from django.db.models import Q
 
 import structlog
 import posthoganalytics
@@ -26,6 +27,7 @@ from pydantic import BaseModel, Field
 from posthog.schema import RecordingsQuery
 
 from posthog.llm.semantic_enrichment import get_team_business_context
+from posthog.models import EventDefinition
 from posthog.models.team import Team
 from posthog.models.user import User
 
@@ -84,6 +86,89 @@ _MAX_FILTER_PAGES = 5
 # Replaces a collapsed ":id" run when building the page regex. Matches one path segment, so the
 # literal segments on both sides of the id stay anchored to the real URL structure.
 _ID_WILDCARD = "[^/]+"
+# The goal-based briefing lists this many of the team's events as general context. A large product
+# has thousands of custom events, so this is a sample, not the catalogue.
+_MAX_BASELINE_EVENTS = 100
+# Events whose names match the goal's own words, added on top of the baseline. Ranking cannot
+# surface a rare-but-relevant event: on a large product "survey sent" is the 591st busiest event,
+# so no baseline length reaches it, while matching the word "survey" finds it at once.
+_MAX_GOAL_MATCHED_EVENTS = 30
+# Goal words shorter than this match too much of the catalogue to be a useful lookup.
+_MIN_GOAL_TERM_CHARS = 4
+# Only the first terms are looked up, so a long goal stays one bounded query.
+_MAX_GOAL_TERMS = 8
+# Words common to almost any goal. Matching them returns arbitrary events rather than the ones the
+# user means, and crowds out the terms that carry the intent.
+_GOAL_STOPWORDS = frozenset(
+    {
+        "about",
+        "after",
+        "also",
+        "before",
+        "being",
+        "does",
+        "doing",
+        "done",
+        "during",
+        "each",
+        "every",
+        "find",
+        "from",
+        "have",
+        "having",
+        "into",
+        "just",
+        "know",
+        "like",
+        "look",
+        "made",
+        "make",
+        "many",
+        "more",
+        "most",
+        "onto",
+        "over",
+        "page",
+        "pages",
+        "people",
+        "person",
+        "product",
+        "recording",
+        "recordings",
+        "scanner",
+        "scanners",
+        "session",
+        "sessions",
+        "show",
+        "site",
+        "some",
+        "someone",
+        "than",
+        "that",
+        "their",
+        "them",
+        "then",
+        "there",
+        "these",
+        "they",
+        "this",
+        "those",
+        "through",
+        "user",
+        "users",
+        "want",
+        "wants",
+        "watch",
+        "watching",
+        "what",
+        "when",
+        "where",
+        "which",
+        "will",
+        "with",
+        "would",
+    }
+)
 
 
 class DraftError(Exception):
@@ -723,6 +808,58 @@ def _build_user_content_v2(
     return "\n".join(lines)
 
 
+def _goal_terms(goal: str) -> list[str]:
+    """The words in a goal worth looking up as event names, longest first.
+
+    Longest first because a specific word ("checkout") is a better lookup than a vague one
+    ("flow"), and only the first few terms are searched.
+    """
+    words = {w for w in re.findall(r"[a-z0-9]+", goal.lower()) if len(w) >= _MIN_GOAL_TERM_CHARS}
+    ranked = sorted(words - _GOAL_STOPWORDS, key=lambda w: (-len(w), w))
+    return ranked[:_MAX_GOAL_TERMS]
+
+
+def _events_for_goal(team: Team, goal: str) -> list[str]:
+    """Custom event names to show the model: a baseline sample, widened by the goal's own words.
+
+    The baseline alone cannot cover a large product. Ranking does not rescue it either, because the
+    event a goal needs is often rare: "survey sent" is the 591st busiest event on a product with
+    2,332 of them, so it sits outside any baseline worth putting in a prompt, while its name matches
+    the word "survey" immediately.
+
+    Matching only widens what the model can see. The model still chooses, and `_grounded` still
+    drops anything it invents, so a term that matches the wrong events costs prompt space rather
+    than correctness.
+    """
+    base_qs = EventDefinition.objects.filter(team_id=team.id, last_seen_at__isnull=False).exclude(name__startswith="$")
+    baseline: list[str] = []
+    try:
+        baseline = list(base_qs.order_by("-last_seen_at").values_list("name", flat=True)[:_MAX_BASELINE_EVENTS])
+    except Exception:
+        logger.warning("replay_vision.scanner_draft.baseline_events_failed", team_id=team.id, exc_info=True)
+
+    terms = _goal_terms(goal)
+    if not terms:
+        return baseline
+
+    matched: list[str] = []
+    try:
+        name_matches = Q()
+        for term in terms:
+            name_matches |= Q(name__icontains=term)
+        matched = list(
+            base_qs.filter(name_matches)
+            .order_by("-last_seen_at")
+            .values_list("name", flat=True)[:_MAX_GOAL_MATCHED_EVENTS]
+        )
+    except Exception:
+        # A failed lookup costs the goal-matched events, not the draft.
+        logger.warning("replay_vision.scanner_draft.goal_events_failed", team_id=team.id, exc_info=True)
+
+    # Matched first: they are the ones the goal actually points at, and the briefing is read in order.
+    return list(dict.fromkeys([*matched, *baseline]))
+
+
 def _page_filter_regex(pathname: str) -> str | None:
     """A ClickHouse regex matching real URLs for a collapsed grounding path, or None when the path
     cannot narrow.
@@ -923,7 +1060,7 @@ def draft_scanner_from_goal_v2(
         # A draft grounded only in events still beats no draft; the filter just cannot name pages.
         logger.warning("replay_vision.scanner_draft.visited_paths_failed", team_id=team.id, exc_info=True)
         pages = ()
-    events = _product_taxonomy(team).events
+    events = _events_for_goal(team, goal)
     company = (
         " / ".join(part for part in [team.organization.name, team.project.name if team.project else ""] if part)
         if include_business_context

--- a/products/replay_vision/backend/tests/test_scanner_draft.py
+++ b/products/replay_vision/backend/tests/test_scanner_draft.py
@@ -1,11 +1,13 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.utils import timezone
+
 from rest_framework import status
 
 from posthog.schema import RecordingsQuery
 
-from posthog.models import PersonalAPIKey
+from posthog.models import EventDefinition, PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.rate_limit import AIBurstRateThrottle
 
@@ -15,15 +17,18 @@ from products.replay_vision.backend.queries.scanner_candidate_query import MIN_S
 from products.replay_vision.backend.queries.scanner_volume_estimate import ScannerVolumeEstimate
 from products.replay_vision.backend.queries.visited_paths import VisitedPath
 from products.replay_vision.backend.scanner_draft import (
+    _MAX_BASELINE_EVENTS,
     DraftError,
     ScannerDraft,
     _build_user_content,
     _business_context,
+    _events_for_goal,
     _existing_scanners,
     _ExistingScanner,
     _finalize,
     _finalize_v2,
     _generate,
+    _goal_terms,
     _LlmDraft,
     _LlmDraftV2,
     _solve_budget,
@@ -585,6 +590,61 @@ class TestDraftScannerEndpoint(_VisionAPITestCase):
             resp = self.client.post(self.draft_url, data={"goal": "find rage clicks"}, format="json")
 
         assert resp.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+
+class TestGoalTerms:
+    def test_keeps_the_words_that_carry_intent_longest_first(self):
+        # Longest first because only the first terms are looked up, and a specific word is a better
+        # event-name lookup than a vague one.
+        assert _goal_terms("watch users who answered the Onboarding feedback survey") == [
+            "onboarding",
+            "answered",
+            "feedback",
+            "survey",
+        ]
+
+    @pytest.mark.parametrize(
+        "goal",
+        [
+            "what do users want to see",  # all stopwords
+            "who is on it",  # all below the length floor
+            "",
+        ],
+    )
+    def test_a_goal_with_no_usable_words_looks_nothing_up(self, goal):
+        # No terms means the baseline alone, not an unfiltered scan of every event name.
+        assert _goal_terms(goal) == []
+
+
+class TestEventsForGoal(_VisionAPITestCase):
+    def _event(self, name: str):
+        return EventDefinition.objects.create(team=self.team, name=name, last_seen_at=timezone.now())
+
+    def test_a_rare_event_named_in_the_goal_is_surfaced_ahead_of_the_baseline(self):
+        # The regression this exists for: a relevant event too rare to sit in any baseline. The old
+        # briefing showed a fixed recency slice, so a goal naming this event saw nothing to filter on.
+        self._event("survey sent")
+        for i in range(_MAX_BASELINE_EVENTS + 10):
+            self._event(f"filler_event_{i:03d}")
+
+        events = _events_for_goal(self.team, "watch people who answered the pricing survey")
+
+        assert "survey sent" in events
+        # Matched events lead, so the one the goal points at is not buried under the sample.
+        assert events[0] == "survey sent"
+
+    def test_internal_events_stay_excluded_even_when_the_goal_names_them(self):
+        # `$`-prefixed events are PostHog internals, not product categories, on both paths.
+        self._event("$pageview")
+
+        assert _events_for_goal(self.team, "watch the pageview funnel") == []
+
+    def test_a_goal_matching_nothing_still_returns_the_baseline(self):
+        self._event("checkout_started")
+
+        events = _events_for_goal(self.team, "understand the zzzz nonexistent flow")
+
+        assert events == ["checkout_started"]
 
 
 class TestV2Query:


### PR DESCRIPTION
## Problem

The goal-based draft shows the model the team's custom events so it can filter on one. It shows **25**, ordered by which fired most recently.

On PostHog's own project that is 25 of **2,332** custom events (1.1%), and recency ordering makes the sample near-arbitrary and unstable: draft twice, get a different 25. An event the goal names is usually absent, so the draft filters on nothing.

A goal about people answering a survey is the clearest case. Survey responses fire `survey sent`, which the model never sees.

## Changes

- The briefing now lists 100 events as general context, and adds up to 30 whose names match the goal's own words.
- Goal words are filtered to the ones carrying intent: at least 4 characters, common words like "users" and "sessions" dropped, longest first, capped at 8 lookups so a long goal stays one bounded query.
- Matched events are listed before the sample, so the ones the goal points at are not buried.
- The legacy AI box is untouched. `_product_taxonomy` still serves it; only the goal-based path changed.

**Why a longer list alone would not fix this.** Ranking cannot surface a rare but relevant event. Measured on project 2 over 30 days:

| event | rank by volume |
|---|---|
| `survey shown` | #174 |
| `survey dismissed` | #250 |
| **`survey sent`** | **#591** |

The top 25 events cover 82% of volume and the top 200 cover 99%, but `survey sent` sits at #591. No sample length worth putting in a prompt reaches it. Matching the word "survey" finds it immediately.

**Why matching does not decide anything.** An earlier design used lexical matching to pick the filter and failed, because "money" never matches "billing". Here matching only widens what the model can see; the model still chooses, and grounding still drops anything it invents. A term that matches the wrong events costs prompt space, not correctness.

## How did you test this code?

- `TestGoalTerms`: intent words survive and rank longest first; a goal of only stopwords or short words looks nothing up, so it falls back to the sample rather than scanning every event name. 4 tests pass locally.
- `TestEventsForGoal`: a rare event named in the goal is surfaced ahead of a sample larger than the cap; `$`-prefixed internals stay excluded; a goal matching nothing still returns the sample. These need Postgres, which was unavailable in this environment, so they ran in CI rather than locally.
- mypy repo-wide and `hogli lint:tach` are clean.

## What this pull request does not do

| Not here | Where |
|---|---|
| Property filters, so a draft can say `survey sent` where `$survey_id` is X | Next PR |
| Semantic matching, so "money" reaches "billing" beyond the sample | Not attempted |

Finding `survey sent` is necessary but not sufficient for the survey case: `filter_events` holds event names only, so there is still nowhere to put the survey's identity. That is the next PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sized with the PostHog MCP against project 2 (event counts and volume ranks above). Written with Claude Code. No customer conversation, ticket, or log shaped this change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
