### PR TITLE
fix(clickhouse): connect to the persons queue inside the sweep op

### DIFF
--- a/posthog/dags/clickhouse_cleanup.py
+++ b/posthog/dags/clickhouse_cleanup.py
@@ -20,8 +20,8 @@ from math import ceil
 from django.conf import settings
 
 import dagster
+import psycopg2
 import pydantic
-import psycopg2.extensions
 from clickhouse_driver.client import Client
 from prometheus_client import Counter
 from psycopg2.extras import execute_values
@@ -989,7 +989,7 @@ def delete_orphaned_distinct_ids(
 def persist_deleted_persons(
     context: dagster.OpExecutionContext,
     cluster: dagster.ResourceParam[ClickhouseCluster],
-    persons_database: dagster.ResourceParam[psycopg2.extensions.connection],
+    persons_database_url: dagster.ResourceParam[str],
     run: CleanupRun,
 ) -> CleanupRun:
     """Hand the swept persons to Postgres, before the step that makes them unrecoverable.
@@ -1002,6 +1002,12 @@ def persist_deleted_persons(
     if run.dry_run:
         context.log.info("dry run: skipping the write to %s", PG_CLEANUP_QUEUE_TABLE)
         return run
+
+    # Connected here rather than at resource init: a connect failure at init happens before the
+    # step exists, so no failure hook runs and the run's dictionaries are stranded. Failing
+    # inside the op is a step failure, which is what lets drop_assets_on_failure fire. It also
+    # keeps a dry run from dialing Postgres at all.
+    persons_database = psycopg2.connect(persons_database_url, connect_timeout=10)
 
     def read_page(client: Client, after: tuple[int, str] | None) -> list[tuple[int, str]]:
         # Reads the snapshot directly rather than the dictionary's query, so adding attributes to
@@ -1030,46 +1036,49 @@ def persist_deleted_persons(
     deleted_at = run.distinct_ids_deleted_at
     written = 0
     after: tuple[int, str] | None = None
-    with persons_database.cursor() as cursor:
-        cursor.execute("SET application_name = 'clickhouse_cleanup'")
-        # Bounded so a lock conflict on the queue fails the page instead of holding a transaction
-        # open on the persons writer; the per-page upsert is idempotent, so a retry is safe.
-        cursor.execute("SET statement_timeout = '120s'")
-        cursor.execute("SET lock_timeout = '10s'")
-        while True:
-            page = cluster.any_host_by_role(partial(read_page, after=after), NodeRole.DATA).result()
-            if not page:
-                break
-            # A person can be deleted, drained, re-created and deleted again under the same uuid,
-            # and the drain only looks at rows where cleaned_at is null. Leaving an already-cleaned
-            # row untouched would drop that second deletion on the floor and leak its Postgres rows
-            # for good, so the conflict re-arms the row instead of ignoring it. The WHERE keeps a
-            # retried op from rewriting rows that already hold these values: an unconditional
-            # DO UPDATE writes a new tuple version per row, so a retry over millions of rows would
-            # leave that many dead tuples for the persons writer to vacuum.
-            execute_values(
-                cursor,
-                f"""
-                INSERT INTO {PG_CLEANUP_QUEUE_TABLE} (team_id, person_uuid, deleted_at)
-                VALUES %s
-                ON CONFLICT (team_id, person_uuid) DO UPDATE
-                SET deleted_at = EXCLUDED.deleted_at, cleaned_at = NULL
-                WHERE {PG_CLEANUP_QUEUE_TABLE}.cleaned_at IS NOT NULL
-                   OR {PG_CLEANUP_QUEUE_TABLE}.deleted_at IS DISTINCT FROM EXCLUDED.deleted_at
-                """,
-                [(team_id, str(person_id), deleted_at) for team_id, person_id in page],
-                page_size=1000,
-            )
-            # The conflict guard makes rowcount "rows changed", not "rows queued"; the metric is
-            # the queued set, which is the page.
-            written += len(page)
-            # Commit per page: the upsert makes replays idempotent, and one transaction across
-            # millions of rows would hold WAL and xmin on the persons writer for the whole op.
-            persons_database.commit()
-            if len(page) < PERSIST_PAGE_SIZE:
-                break
-            last_team, last_person = page[-1]
-            after = (last_team, str(last_person))
+    try:
+        with persons_database.cursor() as cursor:
+            cursor.execute("SET application_name = 'clickhouse_cleanup'")
+            # Bounded so a lock conflict on the queue fails the page instead of holding a transaction
+            # open on the persons writer; the per-page upsert is idempotent, so a retry is safe.
+            cursor.execute("SET statement_timeout = '120s'")
+            cursor.execute("SET lock_timeout = '10s'")
+            while True:
+                page = cluster.any_host_by_role(partial(read_page, after=after), NodeRole.DATA).result()
+                if not page:
+                    break
+                # A person can be deleted, drained, re-created and deleted again under the same uuid,
+                # and the drain only looks at rows where cleaned_at is null. Leaving an already-cleaned
+                # row untouched would drop that second deletion on the floor and leak its Postgres rows
+                # for good, so the conflict re-arms the row instead of ignoring it. The WHERE keeps a
+                # retried op from rewriting rows that already hold these values: an unconditional
+                # DO UPDATE writes a new tuple version per row, so a retry over millions of rows would
+                # leave that many dead tuples for the persons writer to vacuum.
+                execute_values(
+                    cursor,
+                    f"""
+                    INSERT INTO {PG_CLEANUP_QUEUE_TABLE} (team_id, person_uuid, deleted_at)
+                    VALUES %s
+                    ON CONFLICT (team_id, person_uuid) DO UPDATE
+                    SET deleted_at = EXCLUDED.deleted_at, cleaned_at = NULL
+                    WHERE {PG_CLEANUP_QUEUE_TABLE}.cleaned_at IS NOT NULL
+                       OR {PG_CLEANUP_QUEUE_TABLE}.deleted_at IS DISTINCT FROM EXCLUDED.deleted_at
+                    """,
+                    [(team_id, str(person_id), deleted_at) for team_id, person_id in page],
+                    page_size=1000,
+                )
+                # The conflict guard makes rowcount "rows changed", not "rows queued"; the metric is
+                # the queued set, which is the page.
+                written += len(page)
+                # Commit per page: the upsert makes replays idempotent, and one transaction across
+                # millions of rows would hold WAL and xmin on the persons writer for the whole op.
+                persons_database.commit()
+                if len(page) < PERSIST_PAGE_SIZE:
+                    break
+                last_team, last_person = page[-1]
+                after = (last_team, str(last_person))
+    finally:
+        persons_database.close()
 
     context.add_output_metadata({"queued_for_postgres": dagster.MetadataValue.int(written)})
     return run

--- a/posthog/dags/common/resources.py
+++ b/posthog/dags/common/resources.py
@@ -223,6 +223,8 @@ class PostgresResource(dagster.ConfigurableResource):
     password: str
 
     def create_resource(self, context: dagster.InitResourceContext) -> psycopg2.extensions.connection:
+        # Without a timeout a blackholed route hangs this connect for the OS TCP timeout
+        # (about two minutes) and the step emits nothing while it waits.
         return psycopg2.connect(
             host=self.host,
             port=int(self.port),
@@ -230,6 +232,7 @@ class PostgresResource(dagster.ConfigurableResource):
             user=self.user,
             password=self.password,
             cursor_factory=psycopg2.extras.RealDictCursor,
+            connect_timeout=10,
         )
 
 
@@ -271,6 +274,20 @@ class PostgresURLResource(dagster.ConfigurableResource):
             password=parsed.password or "",
         )
         return pg.create_resource(context)
+
+
+class PostgresURL(dagster.ConfigurableResource):
+    """A Postgres connection URL handed to the op unopened.
+
+    An op that connects in its own body turns a connect failure into a step failure, which is
+    what lets failure hooks run; a connection opened at resource init fails before the step
+    exists and no hook fires. It also lets a dry run skip the connect entirely.
+    """
+
+    connection_url: str
+
+    def create_resource(self, context: dagster.InitResourceContext) -> str:
+        return self.connection_url
 
 
 @dagster.resource

--- a/posthog/dags/locations/__init__.py
+++ b/posthog/dags/locations/__init__.py
@@ -10,6 +10,7 @@ from posthog.dags.common.resources import (
     ClayWebhookResource,
     ClickhouseClusterResource,
     PostgresResource,
+    PostgresURL,
     PostgresURLResource,
     PostHogAnalyticsResource,
     RedisResource,
@@ -49,6 +50,9 @@ resources_by_env = {
         "persons_database": PostgresURLResource(
             connection_url=dagster.EnvVar("PERSONS_DB_WRITER_URL"),
         ),
+        "persons_database_url": PostgresURL(
+            connection_url=dagster.EnvVar("PERSONS_DB_WRITER_URL"),
+        ),
         # Kafka producer (auto-configured from Django settings)
         "kafka_producer": kafka_producer_resource,
         # Clay webhook for job switchers pipeline
@@ -83,6 +87,9 @@ resources_by_env = {
         "posthoganalytics": PostHogAnalyticsResource(personal_api_key=dagster.EnvVar("PERSONAL_API_KEY")),
         # Persons DB resource (parses connection URL)
         "persons_database": PostgresURLResource(
+            connection_url=dagster.EnvVar("PERSONS_DB_WRITER_URL"),
+        ),
+        "persons_database_url": PostgresURL(
             connection_url=dagster.EnvVar("PERSONS_DB_WRITER_URL"),
         ),
         # Kafka producer (auto-configured from Django settings)

--- a/posthog/dags/tests/test_clickhouse_cleanup.py
+++ b/posthog/dags/tests/test_clickhouse_cleanup.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import dagster
 import psycopg2
 from clickhouse_driver import Client
+from psycopg2 import OperationalError
 
 from posthog.clickhouse.cleanup_snapshots import (
     CLEANUP_DELETED_PERSONS_TABLE,
@@ -56,7 +57,7 @@ def persons_database() -> Iterator[psycopg2.extensions.connection]:
 def run_job(cluster: ClickhouseCluster, persons_database, run_config=RUN_FOR_REAL, raise_on_error=True):
     return clickhouse_deletion_sweep_job.execute_in_process(
         run_config=run_config,
-        resources={"cluster": cluster, "persons_database": persons_database},
+        resources={"cluster": cluster, "persons_database_url": persons_db_url(writer=True)},
         raise_on_error=raise_on_error,
     )
 
@@ -340,6 +341,42 @@ def test_requeues_a_person_the_drain_already_cleaned(cluster: ClickhouseCluster,
 
 
 @pytest.mark.django_db
+def test_a_dry_run_never_dials_postgres(cluster: ClickhouseCluster, persons_database):
+    # The EU dry run failed at Postgres resource init on a network path a dry run never needed.
+    # Connecting inside the op, after the dry-run return, keeps a dry run ClickHouse-only.
+    run = clickhouse_cleanup.CleanupRun.for_run("dry_run_no_pg", clickhouse_cleanup.CleanupConfig(dry_run=True))
+    with patch.object(clickhouse_cleanup.psycopg2, "connect", side_effect=AssertionError("dialed postgres")):
+        clickhouse_cleanup.persist_deleted_persons(dagster.build_op_context(), cluster, "postgres://unused", run)
+
+
+@pytest.mark.django_db
+def test_a_postgres_connect_failure_drops_the_dictionaries(cluster: ClickhouseCluster, persons_database):
+    # A connect failure at resource init happens before the step exists, so the failure hook
+    # never ran and the run's dictionaries survived on every host. Connecting inside the op
+    # makes it a step failure, and the hook must clean up.
+    create_person(team_id=TEAM_ID, version=0, is_deleted=True)
+
+    real_connect = psycopg2.connect
+
+    def refuse_dsn_connects(*args, **kwargs):
+
+        # Only the op passes a single DSN string; Django's own connections use kwargs and must
+
+        # keep working, or the cohort op fails first and the wrong step trips the hook.
+
+        if args and isinstance(args[0], str):
+            raise OperationalError("connection timed out")
+
+        return real_connect(*args, **kwargs)
+
+    with patch.object(clickhouse_cleanup.psycopg2, "connect", side_effect=refuse_dsn_connects):
+        result = run_job(cluster, persons_database, raise_on_error=False)
+
+    assert not result.success
+    assert cluster.any_host(dictionaries_for_run(result.run_id)).result() == 0
+
+
+@pytest.mark.django_db
 def test_a_capped_run_deletes_a_slice_and_the_next_run_drains_the_rest(cluster: ClickhouseCluster, persons_database):
     # max_persons bounds one run's blast radius; correctness across runs holds because whatever
     # the cap excludes keeps its tombstones. Dropping the cap plumbing or making the capped
@@ -401,10 +438,10 @@ def test_a_same_run_retry_rewrites_no_rows(cluster: ClickhouseCluster, persons_d
             [row] = cursor.fetchall()
             return row
 
-    clickhouse_cleanup.persist_deleted_persons(dagster.build_op_context(), cluster, persons_database, run)
+    clickhouse_cleanup.persist_deleted_persons(dagster.build_op_context(), cluster, persons_db_url(writer=True), run)
     first = queue_row()
 
-    clickhouse_cleanup.persist_deleted_persons(dagster.build_op_context(), cluster, persons_database, run)
+    clickhouse_cleanup.persist_deleted_persons(dagster.build_op_context(), cluster, persons_db_url(writer=True), run)
     assert queue_row() == first
 
     # A drained row must still be re-armed even when deleted_at matches, or the second deletion
@@ -412,7 +449,7 @@ def test_a_same_run_retry_rewrites_no_rows(cluster: ClickhouseCluster, persons_d
     with persons_database.cursor() as cursor:
         cursor.execute(f"UPDATE {PG_CLEANUP_QUEUE_TABLE} SET cleaned_at = now()")
     persons_database.commit()
-    clickhouse_cleanup.persist_deleted_persons(dagster.build_op_context(), cluster, persons_database, run)
+    clickhouse_cleanup.persist_deleted_persons(dagster.build_op_context(), cluster, persons_db_url(writer=True), run)
     rearmed = queue_row()
     assert rearmed[2] is None
     assert rearmed[0] != first[0]


### PR DESCRIPTION
## Problem

The first prod dry run of `clickhouse_deletion_sweep_job` failed on a Postgres connection a dry run never uses. The `persons_database` resource opens its connection at resource init, so `persist_deleted_persons` dialed the persons writer before its dry-run check ran, and the closed network path timed out after two silent minutes. A resource-init failure emits no `STEP_FAILURE`, so `drop_assets_on_failure` never fired and the run's two dictionaries (about 18 GiB on each of 24 hosts) survived until dropped by hand.

## Changes

- A dry run of the sweep no longer touches Postgres at all.
- A failed connect now fails the step, so the failure hook drops the run's dictionaries instead of stranding them.
- `persist_deleted_persons` receives the connection URL (new `PostgresURL` resource, `persons_database_url`) and connects inside the op body, after the dry-run return, closing the connection in a `finally`.
- The shared `PostgresResource` gains `connect_timeout=10`, so a blackholed route fails in seconds with a clear error instead of hanging for the OS TCP timeout. This is the one part of the diff that touches other jobs; the rest is confined to the sweep.
- No user-visible change; this is all Dagster job plumbing.

## How did you test this code?

- New test: a run whose Postgres connect fails ends with zero dictionaries left for that run, which is exactly the cleanup the prod failure skipped.
- New test: a dry-run invocation of the op with `psycopg2.connect` patched to raise never calls it.
- The existing handoff tests (queueing, paging, requeue, retry-idempotence) run through the new connect path unchanged.
- Not run: `hogli review` (the local Greptile CLI fails to install in this environment).

## 🤖 Agent context

Authored with Claude Code in an interactive session with Eli, from the failed prod-eu run's debug log (`RESOURCE_INIT_FAILURE` on `persons_database`, psycopg2 connection timeout to the persons writer). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`. Companion charts PR PostHog/charts#14920 attaches the persons client security group to the Dagster node class, which is the network half of the fix. Kept the existing eager `persons_database` resource for its other consumers; only the sweep op moved to the lazy URL resource.
