### PR TITLE
fix(replay_vision): draft the most specific page, not a parent too

### DIFF
--- a/products/replay_vision/backend/scanner_draft.py
+++ b/products/replay_vision/backend/scanner_draft.py
@@ -628,7 +628,12 @@ Pick the single type that best fits the goal, then draft the scanner:
   - filter_pages: the pages list is what the product actually calls things, so map the goal's words
     onto their closest real pages, including synonyms: someone saying "money" or "payments" means the
     billing pages. Pick up to 5, each copied EXACTLY from the briefing's pages list. They OR together:
-    a session that visited ANY of them is scanned, so cover the flow rather than picking one page.
+    a session that visited ANY of them is scanned. Pick the MOST SPECIFIC page that matches the goal.
+    Do NOT also add a parent of a page you already picked: "/experiments/new" is the creation page, so
+    adding "/experiments" as well widens the scan to everyone browsing the experiments section, which
+    a goal about creation does not want. Use several pages only when the goal genuinely spans distinct
+    pages (a checkout moving through cart, shipping, and payment), never to add a broader page around a
+    specific one.
   - filter_events: when a specific action is the sharpest signal for the goal, pick the one or two
     custom events that mark it, each copied EXACTLY from the briefing's events list. An event is often
     more precise than a page for "did the user DO X" (e.g. an event fired when a flow starts).


### PR DESCRIPTION
## Problem

A goal about the experiment creation flow drafted a page filter of **both** `/experiments/new` and `/experiments`. The overview showed both chips, and the scan matched everyone in the experiments section, not just the creation flow.

Two things compound:
- Page filters OR together, so adding the parent widens rather than narrows.
- The match is unanchored, so `/project/[^/]+/experiments` matches `/experiments/new` too. The broad page **subsumes** the specific one, and the pair collapses to "anyone in the experiments section" — list browsers and editors included.

The prompt caused it: it told the model to "cover the flow rather than picking one page", which pushed it to add the parent.

Stacked on [#92094](https://github.com/PostHog/posthog/pull/92094).

## Changes

- The prompt now tells the draft to pick the **most specific** page that matches the goal, and never to add a parent of a page it already chose (spelling out the `/experiments/new` vs `/experiments` case). Several pages are for goals that genuinely span distinct pages (a checkout moving through cart, shipping, payment), not for stacking a broad page around a specific one.

**Why the prompt and not code.** When the model picks both a page and its parent, the parent already dominates the OR, so the result is the same whichever we drop. Which one the goal wants is a judgment only the model can make, so a code rule would have to guess intent and could silently exclude a page someone did want. If dogfooding shows the model still stacks despite the guidance, a dedup can follow with evidence.

## What this does not change

- A goal that names an event still prefers the event when it is the sharper signal. For a goal that includes people who *abandon* a flow, pages stay the right primitive, because a success event never fires for the people who did not finish.

## How did you test this code?

Prompt-only change. No unit test: asserting the prompt contains a phrase is a change-detector, and the page-grounding mechanics are already covered by `TestV2Query` and `TestFinalizeV2`. Validated by the dogfooding case that surfaced it; the real check is the next live draft. Existing tests stay green.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by dogfooding an experiment-creation goal on prod. Written with Claude Code. No customer conversation, ticket, or log shaped this change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*