### PR TITLE
fix(mixpanel): stop retrying 402 Payment Required on cohorts endpoint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/source.py
@@ -171,6 +171,12 @@ Authenticate with a [Mixpanel Service Account](https://developer.mixpanel.com/re
                 "The Mixpanel service account does not have access to this project or resource. Grant it "
                 "access to the project and reconnect."
             ),
+            # Mixpanel returns 402 when the project's plan does not include the data export API or the
+            # account is in a payment-overdue state. Retrying cannot resolve a billing issue.
+            "402 Client Error: Payment Required": (
+                "Mixpanel requires a paid plan that includes the data export API. Check your Mixpanel "
+                "plan and billing status, then try again."
+            ),
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel_source.py
@@ -132,3 +132,26 @@ class TestSourceForPipeline:
                 ),
             )
         assert mock_source.call_args.kwargs["db_incremental_field_last_value"] is None
+
+
+class TestNonRetryableErrors:
+    source = MixpanelSource()
+
+    @parameterized.expand(
+        [
+            ("401", "401 Client Error: Unauthorized for url: https://mixpanel.com/api/query/cohorts/list"),
+            ("403", "403 Client Error: Forbidden for url: https://mixpanel.com/api/query/engage"),
+            ("402", "402 Client Error: Payment Required for url: https://mixpanel.com/api/query/cohorts/list"),
+        ]
+    )
+    def test_billing_and_auth_failures_are_non_retryable(self, _name: str, observed_error: str) -> None:
+        assert any(key in observed_error for key in self.source.get_non_retryable_errors())
+
+    @parameterized.expand(
+        [
+            ("429", "429 Client Error: Too Many Requests for url: https://mixpanel.com/api/query/engage"),
+            ("500", "500 Server Error: Internal Server Error for url: https://mixpanel.com/api/query/engage"),
+        ]
+    )
+    def test_transient_failures_stay_retryable(self, _name: str, other_error: str) -> None:
+        assert not any(key in other_error for key in self.source.get_non_retryable_errors())


### PR DESCRIPTION
## Problem

A Mixpanel data warehouse sync that includes the cohorts endpoint fails permanently when the Mixpanel project's plan does not include the data export API, or when the account is in a billing-overdue state. Mixpanel returns 402 Payment Required in both cases. The sync retried this request repeatedly — 6 events across 49 seconds on a single affected source — burning resources with no chance of recovery.

Related error tracking issue: https://us.posthog.com/project/2/error_tracking/01a05b7b-a195-75e3-a0ff-c4d51704a78c

## Changes

- `MixpanelSource.get_non_retryable_errors` now includes `"402 Client Error: Payment Required"`. Syncs that hit this error stop retrying and surface an actionable message: "Mixpanel requires a paid plan that includes the data export API. Check your Mixpanel plan and billing status, then try again."
- Mechanical: adds `TestNonRetryableErrors` to the Mixpanel source test file with parametrized cases for 401, 402, 403 (non-retryable) and 429, 500 (retryable), matching the pattern used in other warehouse sources.

## How did you test this code?

Added parametrized cases in `TestNonRetryableErrors` that assert the exact substring `requests.raise_for_status()` emits for a 402 is recognized by `get_non_retryable_errors()`, and that 429/5xx are not matched. Each guards a distinct regression: the 402 case would fail if the match key is misspelled or the phrase format changes; the transient cases guard against over-broad matching. All 20 tests in `test_mixpanel_source.py` pass locally.

Not run: the full backend test suite (no database in this sandbox). CI covers that.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-visible API or configuration change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated the 402 error via the error tracking MCP, confirmed 6 occurrences from a single Mixpanel project within 49 seconds (tenacity retries + parallel activity runs). Root cause: `_check_response` in `mixpanel.py` falls through to `raise_for_status()` for any non-429/5xx error, so 402 surfaces as an unhandled `HTTPError`. The `validate_credentials` path already handled 402 with a billing message; `get_non_retryable_errors` was missing it. Searched open PRs from multiple angles and found no duplicate.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*