### PR TITLE
feat(mcp-store): add Magic Hour to the MCP server catalog

### DIFF
--- a/products/mcp_store/backend/catalog.py
+++ b/products/mcp_store/backend/catalog.py
@@ -214,6 +214,15 @@ MCP_SERVER_CATALOG: list[CatalogEntry] = [
         icon_domain="linear.app",
     ),
     CatalogEntry(
+        name="Magic Hour",
+        url="https://mcp.magichour.ai/",
+        description="Create and edit images, videos, GIFs, and audio with Magic Hour.",
+        auth_type="oauth",
+        category="design",
+        icon_domain="magichour.ai",
+        docs_url="https://magichour.ai/mcp",
+    ),
+    CatalogEntry(
         name="Mem0",
         url="https://mcp.mem0.ai/mcp/",
         description="Save, search, and update AI agent memories with Mem0.",


### PR DESCRIPTION
## Summary

- add Magic Hour as a hosted design/media MCP server
- use the vendor-owned MCP endpoint, brand domain, and MCP docs page

## Verification

**Tier 2: probe only; no PostHog install completed.**

- `POST https://mcp.magichour.ai/` completed MCP `initialize` with HTTP 200 and server identity `magic-hour` v0.1.0
- RFC 9728/8414 metadata resolves from the vendor-owned host
- the authorization endpoint, token endpoint, and DCR endpoint are live
- a PostHog-style DCR request with the US callback was rejected as `invalid_redirect_uri`, so this is `oauth_shared` and must ship inactive
- Python compilation and a focused catalog validation passed (41 unique, case-insensitively alphabetized entries)
- `git diff --check` passed
- `hogli` is not installed in this sparse checkout, so `hogli test products/mcp_store/backend/test/test_catalog_sync.py` was not runnable locally

## Operator checklist

This server does not currently accept PostHog callback URIs through Dynamic Client Registration, so it ships inactive. To activate (per environment, US and EU):

- [ ] Register an OAuth app with Magic Hour
- [ ] Redirect URI: `https://us.posthog.com/api/mcp_store/oauth_redirect/` (and the EU equivalent)
- [ ] Paste client ID + secret into Django admin → MCP server templates → Magic Hour
- [ ] OAuth metadata was auto-discovered by the sync; run the “Discover metadata” admin action only if it is empty
- [ ] Tick `is_active`