### PR TITLE
fix(session-replay): stop the scoring sweep exhausting ClickHouse query slots

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -95,6 +95,8 @@ class ClickHouseUser(StrEnum):
     ENDPOINTS = "endpoints"
     BILLING = "billing"
     REPLAY_VISION = "replay_vision"
+    # Session replay surfacing scoring sweep, which fans a feature SELECT out over hash buckets every 5 minutes
+    SURFACING_SCORING = "surfacing_scoring"
 
     # Backups - used by Dagster backup jobs
     BACKUPS = "backups"

--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -95,7 +95,7 @@ class ClickHouseUser(StrEnum):
     ENDPOINTS = "endpoints"
     BILLING = "billing"
     REPLAY_VISION = "replay_vision"
-    # Session replay surfacing scoring sweep, which fans a feature SELECT out over hash buckets every 5 minutes
+    # Session replay surfacing scoring sweep
     SURFACING_SCORING = "surfacing_scoring"
 
     # Backups - used by Dagster backup jobs

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/activities.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/activities.py
@@ -40,6 +40,7 @@ from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
 from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import ClickHouseUser
 from posthog.kafka_client.routing import get_producer
 from posthog.kafka_client.topics import KAFKA_CLICKHOUSE_SESSION_REPLAY_EVENTS
 from posthog.models.event.util import format_clickhouse_timestamp
@@ -82,6 +83,7 @@ def _count_unscored_in_one_bucket(lookback_days: int, of_chunks: int) -> int:
         sync_execute(
             surfacing_scoring_sweep_sql.count_unscored_sql(),
             {"lookback_days": lookback_days, "of_chunks": of_chunks},
+            ch_user=ClickHouseUser.SURFACING_SCORING,
             settings={
                 "max_execution_time": CH_FEATURE_QUERY_TIMEOUT_S,
                 "max_memory_usage": CH_FEATURE_QUERY_MAX_MEMORY_BYTES,
@@ -145,6 +147,7 @@ def _fetch_features_dataframe(spec: ChunkSpec) -> pd.DataFrame:
                 "chunk_id": spec.chunk_id,
                 "chunk_size": spec.chunk_size,
             },
+            ch_user=ClickHouseUser.SURFACING_SCORING,
             settings={
                 "max_execution_time": CH_FEATURE_QUERY_TIMEOUT_S,
                 "max_memory_usage": CH_FEATURE_QUERY_MAX_MEMORY_BYTES,

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/constants.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/constants.py
@@ -29,6 +29,13 @@ TARGET_SESSIONS_PER_TICK = 200_000
 DEFAULT_OF_CHUNKS = 20
 TARGET_CHUNK_SIZE = TARGET_SESSIONS_PER_TICK // DEFAULT_OF_CHUNKS
 
+# Chunks run concurrently, and each one holds a ClickHouse query slot for its whole feature
+# SELECT. Dispatching all DEFAULT_OF_CHUNKS at once exceeds the per-user concurrent query
+# limit, and ClickHouse rejects the excess outright, so those chunks score nothing and wait
+# for the next tick. A chunk takes well under a minute, so a few bounded waves still fit the
+# tick budget and every chunk gets to run.
+MAX_CONCURRENT_SCORE_CHUNKS = 8
+
 # Window for "score eligible" rows. Older sessions are intentionally left
 # unscored — if a session hasn't been scored within this window its features
 # are no longer useful for downstream summarization.

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/constants.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/constants.py
@@ -29,11 +29,9 @@ TARGET_SESSIONS_PER_TICK = 200_000
 DEFAULT_OF_CHUNKS = 20
 TARGET_CHUNK_SIZE = TARGET_SESSIONS_PER_TICK // DEFAULT_OF_CHUNKS
 
-# Chunks run concurrently, and each one holds a ClickHouse query slot for its whole feature
-# SELECT. Dispatching all DEFAULT_OF_CHUNKS at once exceeds the per-user concurrent query
-# limit, and ClickHouse rejects the excess outright, so those chunks score nothing and wait
-# for the next tick. A chunk takes well under a minute, so a few bounded waves still fit the
-# tick budget and every chunk gets to run.
+# Fanning all DEFAULT_OF_CHUNKS out at once exceeds ClickHouse's per-user concurrent query
+# limit (max_concurrent_queries_for_user, set per user in posthog-cloud-infra), and ClickHouse
+# rejects the excess outright, so those chunks score nothing until the next tick.
 MAX_CONCURRENT_SCORE_CHUNKS = 8
 
 # Window for "score eligible" rows. Older sessions are intentionally left
@@ -65,6 +63,9 @@ SCORE_CHUNK_ACTIVITY_TIMEOUT = timedelta(minutes=4)
 SCORE_CHUNK_HEARTBEAT_TIMEOUT = timedelta(seconds=90)
 LIST_CHUNKS_ACTIVITY_TIMEOUT = timedelta(seconds=30)
 
-# Parent workflow has to outlive its longest in-flight chunk activity, but
-# must not stretch into the next 5-min tick.
+# Parent workflow has to outlive its longest in-flight chunk activity, but must not stretch
+# into the next 5-min tick. MAX_CONCURRENT_SCORE_CHUNKS makes this a throughput bound as well:
+# the tick fits while the mean chunk stays under
+# WORKFLOW_EXECUTION_TIMEOUT * MAX_CONCURRENT_SCORE_CHUNKS / DEFAULT_OF_CHUNKS. Past that the
+# workflow expires with chunks undispatched, and those sessions wait for the next tick.
 WORKFLOW_EXECUTION_TIMEOUT = timedelta(minutes=4, seconds=30)

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
@@ -27,6 +27,7 @@ from temporalio.exceptions import ActivityError
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.session_replay.surfacing_scoring_sweep.constants import (
     LIST_CHUNKS_ACTIVITY_TIMEOUT,
+    MAX_CONCURRENT_SCORE_CHUNKS,
     SCORE_CHUNK_ACTIVITY_TIMEOUT,
     SCORE_CHUNK_HEARTBEAT_TIMEOUT,
     WORKFLOW_NAME,
@@ -46,6 +47,9 @@ with workflow.unsafe.imports_passed_through():
         score_chunk_activity,
     )
     from posthog.temporal.session_replay.surfacing_scoring_sweep.metrics import record_tick_summary
+
+
+_PATCH_BOUNDED_CHUNK_FANOUT = "surfacing-scoring-bounded-chunk-fanout"
 
 
 @workflow.defn(name=WORKFLOW_NAME)
@@ -73,8 +77,20 @@ class ScoreSessionsBatchWorkflow(PostHogWorkflow):
             )
             return ScoreSessionsBatchResult()
 
+        # Activity dispatch order is recorded in Temporal history, so gate the bound for
+        # deterministic replay of runs that started before it.
+        concurrency = len(plan.chunks)
+        if workflow.patched(_PATCH_BOUNDED_CHUNK_FANOUT):
+            concurrency = min(MAX_CONCURRENT_SCORE_CHUNKS, concurrency)
+
+        semaphore = asyncio.Semaphore(concurrency)
+
+        async def _score_with_semaphore(spec: ChunkSpec) -> ChunkResult:
+            async with semaphore:
+                return await self._score_chunk(spec)
+
         results = await asyncio.gather(
-            *(self._score_chunk(spec) for spec in plan.chunks),
+            *(_score_with_semaphore(spec) for spec in plan.chunks),
             return_exceptions=True,
         )
 

--- a/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
+++ b/posthog/temporal/session_replay/surfacing_scoring_sweep/workflow.py
@@ -3,9 +3,10 @@
 Per tick (driven by `schedule.py`):
     1. `list_chunks_activity` plans the fan-out — N deterministic hash-partitioned
        chunks, each carrying a `(chunk_id, of_chunks, chunk_size)` spec only.
-    2. All chunks are dispatched via `asyncio.gather` so they run in parallel
-       across the worker pool. Each `score_chunk_activity` is fully self-
-       contained (fetch + predict + write happen inside one activity).
+    2. Chunks are dispatched via `asyncio.gather` behind a semaphore, so at most
+       `MAX_CONCURRENT_SCORE_CHUNKS` run at once and the rest start as slots free.
+       Each `score_chunk_activity` is fully self-contained (fetch + predict +
+       write happen inside one activity).
 
 The workflow stays tiny on purpose:
     * No per-session work in the workflow code path (workflow CPU is precious).
@@ -79,11 +80,9 @@ class ScoreSessionsBatchWorkflow(PostHogWorkflow):
 
         # Activity dispatch order is recorded in Temporal history, so gate the bound for
         # deterministic replay of runs that started before it.
-        concurrency = len(plan.chunks)
-        if workflow.patched(_PATCH_BOUNDED_CHUNK_FANOUT):
-            concurrency = min(MAX_CONCURRENT_SCORE_CHUNKS, concurrency)
-
-        semaphore = asyncio.Semaphore(concurrency)
+        semaphore = asyncio.Semaphore(
+            MAX_CONCURRENT_SCORE_CHUNKS if workflow.patched(_PATCH_BOUNDED_CHUNK_FANOUT) else len(plan.chunks)
+        )
 
         async def _score_with_semaphore(spec: ChunkSpec) -> ChunkResult:
             async with semaphore:

--- a/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
@@ -225,9 +225,11 @@ async def test_workflow_survives_empty_chunk_results() -> None:
 
 
 @pytest.mark.asyncio
-async def test_bounds_concurrent_score_chunk_activities() -> None:
+@pytest.mark.parametrize("patched", [True, False])
+async def test_bounds_concurrent_score_chunk_activities(patched: bool) -> None:
     # ClickHouse rejects queries past the per-user concurrency limit outright, and a rejected
     # chunk scores nothing until the next tick, so the sweep must not dispatch every chunk at once.
+    # Unpatched runs keep dispatching everything, which is what makes replay deterministic.
     chunk_count = MAX_CONCURRENT_SCORE_CHUNKS + 3
     chunks = [_chunk(chunk_id, of_chunks=chunk_count) for chunk_id in range(chunk_count)]
     active = 0
@@ -251,11 +253,11 @@ async def test_bounds_concurrent_score_chunk_activities() -> None:
 
     with (
         mock.patch("temporalio.workflow.execute_activity", side_effect=execute_activity),
-        mock.patch("temporalio.workflow.patched", return_value=True),
+        mock.patch("temporalio.workflow.patched", return_value=patched),
         mock.patch("temporalio.workflow.logger", mock.MagicMock()),
         mock.patch("posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.record_tick_summary"),
     ):
         result = await ScoreSessionsBatchWorkflow().run(ScoreSessionsBatchInputs())
 
-    assert peak_active == MAX_CONCURRENT_SCORE_CHUNKS
+    assert peak_active == (MAX_CONCURRENT_SCORE_CHUNKS if patched else chunk_count)
     assert _as_batch_result(result).chunks_dispatched == chunk_count

--- a/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/surfacing_scoring_sweep/test_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+import asyncio
 from datetime import timedelta
 
 import pytest
@@ -11,7 +12,11 @@ from temporalio import activity
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import Worker
 
-from posthog.temporal.session_replay.surfacing_scoring_sweep.constants import WORKFLOW_NAME
+from posthog.temporal.session_replay.surfacing_scoring_sweep.activities import (
+    list_chunks_activity,
+    score_chunk_activity,
+)
+from posthog.temporal.session_replay.surfacing_scoring_sweep.constants import MAX_CONCURRENT_SCORE_CHUNKS, WORKFLOW_NAME
 from posthog.temporal.session_replay.surfacing_scoring_sweep.types import (
     ChunkResult,
     ChunkSpec,
@@ -217,3 +222,40 @@ async def test_workflow_survives_empty_chunk_results() -> None:
     assert parsed.total_scored == 0
     assert parsed.chunks_failed == 0
     assert parsed.chunks_dispatched == 2
+
+
+@pytest.mark.asyncio
+async def test_bounds_concurrent_score_chunk_activities() -> None:
+    # ClickHouse rejects queries past the per-user concurrency limit outright, and a rejected
+    # chunk scores nothing until the next tick, so the sweep must not dispatch every chunk at once.
+    chunk_count = MAX_CONCURRENT_SCORE_CHUNKS + 3
+    chunks = [_chunk(chunk_id, of_chunks=chunk_count) for chunk_id in range(chunk_count)]
+    active = 0
+    peak_active = 0
+
+    async def execute_activity(activity_fn: object, activity_input: object, **_: object) -> object:
+        nonlocal active, peak_active
+
+        if activity_fn is list_chunks_activity:
+            return _plan(chunks)
+
+        assert activity_fn is score_chunk_activity
+        assert isinstance(activity_input, ChunkSpec)
+        active += 1
+        peak_active = max(peak_active, active)
+        try:
+            await asyncio.sleep(0)
+            return ChunkResult(chunk_id=activity_input.chunk_id, scored=1, fetched=1)
+        finally:
+            active -= 1
+
+    with (
+        mock.patch("temporalio.workflow.execute_activity", side_effect=execute_activity),
+        mock.patch("temporalio.workflow.patched", return_value=True),
+        mock.patch("temporalio.workflow.logger", mock.MagicMock()),
+        mock.patch("posthog.temporal.session_replay.surfacing_scoring_sweep.workflow.record_tick_summary"),
+    ):
+        result = await ScoreSessionsBatchWorkflow().run(ScoreSessionsBatchInputs())
+
+    assert peak_active == MAX_CONCURRENT_SCORE_CHUNKS
+    assert _as_batch_result(result).chunks_dispatched == chunk_count


### PR DESCRIPTION
## Problem

The session replay scoring sweep scores about half the sessions it should, every tick.

Each tick dispatches all 20 hash-bucket chunks at once, and each chunk holds a ClickHouse query slot for its whole feature SELECT. That runs as the `default` user, whose concurrent query limit is shared with every other unannotated consumer. ClickHouse rejects the excess outright:

```
Code: 202. DB::Exception: Too many simultaneous queries for user default. Current: 30, maximum: 30
```

In the 17:45 UTC tick on prod-US, 11 of 21 activities failed that way. A rejection is instant, so those chunks do no work and wait for the next tick, which hits the same wall. The sweep still reports success, because failed chunks are counted rather than raised.

It also cuts both ways: 20 concurrent queries twelve times an hour is a large share of a limit other consumers depend on.

## Changes

- More sessions get scored per tick. The fan-out is bounded to 8 chunks, so chunks queue instead of being thrown away. The semaphore is a sliding window, so a tick takes about `max(slowest chunk, total / 8)`: roughly 40s at the measured p50 of 16s, against a 270s budget.
- The sweep stops competing with unrelated queries. Both of its ClickHouse calls move to a dedicated `surfacing_scoring` user, whose concurrency is its own budget.
- The bound sits behind `workflow.patched("surfacing-scoring-bounded-chunk-fanout")`. Activity dispatch order is recorded in history, so an unguarded change would fail replay on the tick that is in flight at deploy time.

`ClickHouseUser` falls back to `default` when a user is not configured, so this is inert until the credential exists. It does not need to land in step with the infra change.

> [!NOTE]
> The `surfacing_scoring` ClickHouse user and its quota do not exist yet. Until they are provisioned in posthog-cloud-infra and the password is wired into the worker, the queries keep running as `default` and only the fan-out bound is active.

## How did you test this code?

- `test_bounds_concurrent_score_chunk_activities` asserts peak concurrency for both the patched and unpatched branch. Removing the bound fails the patched case in 0.29s.
- 149 tests pass across the sweep's suite.
- Chunk latency is measured, not assumed: p50 16.0s and p95 28.6s from `surfacing_scoring_score_chunk_activity_execution_latency` over 30 minutes in prod-US. The tick budget holds while the mean chunk stays under about 108s.
- The rejection counts come from reading the event history of the 17:45 UTC execution in prod-US Temporal.
- Not tested: behavior against a real `surfacing_scoring` user, which does not exist yet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Investigated and written by an agent, directed by a human.

- Found while confirming the recovery from #91586. The sweep completed again but the backlog did not fall, which led to the rejected chunks.
- The bound is 8 rather than a larger number so the sweep takes a modest share of the shared limit while the dedicated user does not exist.
- Bounding concurrency turns the tick budget into a throughput bound. A tick where the mean chunk runs long now expires with chunks undispatched, where before they were rejected by ClickHouse instead. Both leave the sessions for the next tick, and the constant carries the arithmetic.
- `MAX_CONCURRENT_EXPORT_PARTITIONS` in the sibling export sweep is the precedent for both the semaphore and the patch gate.
- Skills invoked: `/temporal-query`, `/prometheus-query`, `/writing-tests`, `/writing-pr-descriptions`.
