### PR TITLE
feat(experiments): set experiment exposure event cutoff to 2026-09-01

### DIFF
--- a/products/experiments/backend/hogql_queries/exposure_query_logic.py
+++ b/products/experiments/backend/hogql_queries/exposure_query_logic.py
@@ -45,7 +45,7 @@ EXPERIMENT_EXPOSURE_EVENT_FLAG = "experiment-exposure-event"
 # (at least partly) without the new event, so they must keep counting exposures via
 # $feature_flag_called even where the two overlap. Only experiments whose start_date is at or
 # after the cutoff can rely on $experiment_exposure covering their whole exposure window.
-EXPERIMENT_EXPOSURE_EVENT_CUTOFF = datetime(2026, 8, 5, tzinfo=UTC)
+EXPERIMENT_EXPOSURE_EVENT_CUTOFF = datetime(2026, 9, 1, tzinfo=UTC)
 
 
 def resolve_default_exposure_event(team: Team, start_date: Optional[datetime]) -> str:


### PR DESCRIPTION
## Problem

- New experiments on teams flagged into the `$experiment_exposure` rollout still count exposures on `$feature_flag_called`, because the cutoff constant held a placeholder date in the past that predates the event.
- Ingestion now duplicates multivariate `$feature_flag_called` events into `$experiment_exposure` for all teams, live since 2026-08-31 (PostHog/charts#14873).

## Changes

- `EXPERIMENT_EXPOSURE_EVENT_CUTOFF` moves from the placeholder 2026-08-05 to 2026-09-01, the first full UTC day with duplication live for all teams.
- Experiments that start on or after 2026-09-01 UTC, on teams flagged into `experiment-exposure-event`, now count exposures on `$experiment_exposure`. All other experiments stay on `$feature_flag_called`.
- Nothing changes for teams outside the rollout flag.

## How did you test this code?

- Existing tests derive all dates from the constant, so current coverage applies to the new value unchanged. `test_exposure_query_logic.py` passes locally.
- Event data confirms duplication was live in production before 2026-09-01 00:00 UTC, so experiments starting at or after the cutoff have full exposure coverage (checked manually).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The user changed the constant, committed it, and verified the rollout timing against production event data; Claude Code verified the change, ran the exposure logic tests, and wrote this description.
- Skills invoked: /writing-pr-descriptions.
