### PR TITLE
feat(tasks): use GLM-5.3 Flash for image builder

### DIFF
--- a/products/tasks/backend/logic/services/image_builder.py
+++ b/products/tasks/backend/logic/services/image_builder.py
@@ -24,7 +24,7 @@ def is_custom_images_enabled(*, distinct_id: str, organization_id: str) -> bool:
         return False
 
 
-IMAGE_BUILDER_MODEL = "@cf/zai-org/glm-5.2"
+IMAGE_BUILDER_MODEL = "zai-org/glm-5.3-flash"
 IMAGE_BUILDER_REASONING_EFFORT = "high"
 
 IMAGE_BUILDER_PROMPT = """You are an expert at building sandbox base images for PostHog cloud tasks.

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -12857,7 +12857,7 @@ class TestSandboxCustomImageAPI(BaseTaskAPITest):
         self.assertEqual(state["custom_image_builder_id"], data["id"])
         self.assertIs(state["use_modal_vm_sandbox"], True)
         self.assertEqual(state["runtime_adapter"], "claude")
-        self.assertEqual(state["model"], "@cf/zai-org/glm-5.2")
+        self.assertEqual(state["model"], "zai-org/glm-5.3-flash")
         self.assertEqual(state["reasoning_effort"], "high")
         self.assertIn("image-spec.yaml", state["pending_user_message"])
         self.assertIn("install pytorch and flox", state["pending_user_message"])


### PR DESCRIPTION
## Problem

Custom image builders currently use an older GLM model.

**Why:** Faster builder responses shorten image configuration loops.

