### PR TITLE
fix(conversations): poll open support threads and scale cadence by view

### DIFF
--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
@@ -43,10 +43,23 @@ import type {
     SidePanelViewState,
 } from '../../types'
 
-const POLL_INTERVAL = 60 * 1000 // 60 seconds
+// Poll cadence scales with how actively the user is looking at support, so an open thread stays
+// fresh without every idle tab hammering the widget once a minute.
+const POLL_INTERVAL_BACKGROUND = 60 * 1000 // support surface not visible: only keep the unread badge fresh
+const POLL_INTERVAL_ACTIVE = 20 * 1000 // support surface open on the ticket list
+const POLL_INTERVAL_THREAD = 10 * 1000 // a ticket thread is open, so replies must land quickly
 
 // Panel options for a ticket deep link (#panel=support:ticket:<id>); supportRouterLogic skips this prefix
 const TICKET_OPTIONS_PREFIX = 'ticket:'
+
+// True when the person can actually see support: the side panel open on the Support tab, or the
+// full-screen tickets scene. Reads the live router so callers don't have to thread the pathname in.
+function isOnSupportSurface(sidePanelOpen: boolean, selectedTab: SidePanelTab | null): boolean {
+    return (
+        (sidePanelOpen && selectedTab === SidePanelTab.Support) ||
+        removeProjectIdIfPresent(router.values.location.pathname) === urls.myTickets()
+    )
+}
 
 function removeRestoreTokenFromUrl(): void {
     if ('ph_conv_restore' in router.values.searchParams) {
@@ -490,9 +503,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 // persistent error toast on surfaces that have nothing to do with support and block
                 // clicks on whatever sits under the toast container. Only warn while the person is
                 // actually on a support surface; opening one later re-runs loadTickets and warns then.
-                const onSupportSurface =
-                    (values.sidePanelOpen && values.selectedTab === SidePanelTab.Support) ||
-                    removeProjectIdIfPresent(router.values.location.pathname) === urls.myTickets()
+                const onSupportSurface = isOnSupportSurface(values.sidePanelOpen, values.selectedTab)
                 // Only warn people who could act on it. A free plan has no email fallback, and the
                 // panel already shows them the community and upgrade options, so a toast offering
                 // to email us would promise a channel they don't get. Warn while entitlement is
@@ -513,8 +524,12 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 const response = await posthog.conversations.getTickets({ limit: 50 })
                 if (response) {
                     actions.setTickets(response.results as ConversationTicket[])
+                    // With no tickets there's nothing to poll for; creating one re-runs loadTickets
+                    // and restarts polling. Otherwise (re)schedule at the cadence startPolling picks.
                     if (response.results.length > 0) {
                         actions.startPolling()
+                    } else {
+                        actions.stopPolling()
                     }
                 }
             } catch (e) {
@@ -537,13 +552,40 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
             if (document.visibilityState !== 'visible') {
                 return
             }
+            // Nothing to poll for until the user has at least one ticket. Creating one re-runs
+            // loadTickets, which restarts polling from there.
+            if (values.tickets.length === 0) {
+                actions.stopPolling()
+                return
+            }
             // Clear any existing poll timer
             if (cache.pollTimer) {
                 clearTimeout(cache.pollTimer)
             }
+            const onSupportSurface = isOnSupportSurface(values.sidePanelOpen, values.selectedTab)
+            // Only treat a thread as open when the surface showing it is actually visible — the logic
+            // stays mounted for the panel-bar unread badge, so `view` can still be 'ticket' for a
+            // panel the user has since closed.
+            const insideTicket = onSupportSurface && values.view === 'ticket' && !!values.currentTicket
+            const interval = insideTicket
+                ? POLL_INTERVAL_THREAD
+                : onSupportSurface
+                  ? POLL_INTERVAL_ACTIVE
+                  : POLL_INTERVAL_BACKGROUND
             cache.pollTimer = window.setTimeout(() => {
                 actions.loadTickets()
-            }, POLL_INTERVAL)
+                // loadTickets only refreshes the list, so a support reply wouldn't appear while the
+                // reader sits inside the thread. Re-check on fire in case they've since navigated away,
+                // and skip when a load is already running so a slow fetch can't overlap this one.
+                if (
+                    values.currentTicket &&
+                    values.view === 'ticket' &&
+                    !values.messagesLoading &&
+                    isOnSupportSurface(values.sidePanelOpen, values.selectedTab)
+                ) {
+                    actions.loadMessages(values.currentTicket.id)
+                }
+            }, interval)
         },
         stopPolling: () => {
             if (cache.pollTimer) {
@@ -698,6 +740,8 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
             if (values.sidePanelOpen && values.selectedTab === SidePanelTab.Support) {
                 actions.setSidePanelOptions(`${TICKET_OPTIONS_PREFIX}${ticket.id}`)
             }
+            // Cadence is bumped to the thread rate by the setView('ticket') dispatched above, so no
+            // startPolling here — it would just reschedule the same timer a second time.
         },
         setView: ({ view }) => {
             // Only clear our own format; other option strings belong to the support form
@@ -709,6 +753,8 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
             ) {
                 actions.setSidePanelOptions(null)
             }
+            // Leaving a thread (back to the list or composer) drops polling back to the slower cadence.
+            actions.startPolling()
         },
         openTicketById: ({ ticketId }) => {
             if (values.view === 'ticket' && values.currentTicket?.id === ticketId) {
@@ -906,10 +952,13 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
             }
         },
         sidePanelOpen: (open: boolean) => {
-            // Only on open — a close-triggered fetch is wasted (nothing renders the result), and the
-            // full-screen tickets scene closes the panel as it opens, which would double-fetch
             if (open) {
+                // A fresh fetch on open; loadTickets reschedules polling at the active cadence.
                 actions.loadTickets()
+            } else {
+                // Closing doesn't fetch (nothing renders the result), but polling drops to the slow
+                // background cadence — or stops if there are no tickets.
+                actions.startPolling()
             }
         },
         isEmailFormOpen: (open: boolean) => {

--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
@@ -961,6 +961,12 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 actions.startPolling()
             }
         },
+        selectedTab: () => {
+            // Switching tabs inside an already-open panel changes the support surface without
+            // touching sidePanelOpen, so re-evaluate the cadence — otherwise the timer keeps its
+            // previous interval until it next fires (e.g. entering Support still polls at 60s).
+            actions.startPolling()
+        },
         isEmailFormOpen: (open: boolean) => {
             if (open) {
                 actions.startTicketFromSupportForm()


### PR DESCRIPTION
## Problem

- A customer waiting in an open support thread never sees a new reply until they leave and reopen the ticket, or hard-refresh.
- The side panel only polled the ticket list, on a fixed 60s timer, and never refreshed messages for the open thread.

## Changes

- An open thread now also refreshes its messages, so support replies appear without leaving the ticket.
- Polling scales by how actively the person is looking at support:

| State | Interval | What refreshes |
| --- | --- | --- |
| No tickets | off | nothing |
| Support surface closed | 60s | ticket list (unread badge) |
| Support surface open on the list | 20s | ticket list |
| Inside a ticket thread | 10s | ticket list + open thread messages |

- Empty lists stop polling. Creating a ticket restarts it via the next list load.
- Cadence switches immediately when the panel opens or closes, or when the person enters or leaves a thread.
- Mechanical: shared `isOnSupportSurface` helper, skip overlapping message fetches while one is already loading.
- Nothing looks different in the UI beyond replies landing while a thread stays open. No screenshots.

```mermaid
flowchart LR
  A{{Has tickets?}} -->|no| B[Stop polling]
  A -->|yes| C{{On support surface?}}
  C -->|no| D[60s list poll]
  C -->|yes| E{{Inside ticket?}}
  E -->|no| F[20s list poll]
  E -->|yes| G[10s list + messages]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  class A phYellow;
  class B,D,F,G phBlue;
  class C,E phGray;
```

## How did you test this code?

- Ran `sidepanelTicketsLogic.test.ts` (existing suite). No new tests added.