### PR TITLE
fix(mysql): retry TiDB/TiProxy unavailability as a transient error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -660,17 +660,17 @@ def _is_transient_vitess_reparent(e: BaseException) -> bool:
     return _VITESS_REPARENT_TOKEN in " ".join(str(arg) for arg in e.args)
 
 
-# TiProxy (TiDB's connection proxy) surfaces this 1105 error when it can't reach a TiDB
-# node — a failover, a restart, or a momentary network blip. It arrives during the MySQL
-# auth handshake: TiProxy accepts the TCP connection but then can't route to a backend
-# TiDB node and sends back ER_UNKNOWN_ERROR (1105) with this fixed message. Like the
-# Vitess `code = Unavailable` case above (same error code, same proxy-layer pattern),
+# TiProxy (TiDB's connection proxy) surfaces this 1105 error when it cannot reach a TiDB
+# node due to a failover, a restart, or a momentary network blip. It arrives during the
+# MySQL auth handshake: TiProxy accepts the TCP connection but then cannot route to a
+# backend TiDB node and sends back ER_UNKNOWN_ERROR (1105) with this fixed message. Like
+# the Vitess `code = Unavailable` case above (same error code, same proxy-layer pattern),
 # a fresh attempt recovers once a healthy TiDB node is available.
 _TIPROXY_UNAVAILABLE_TOKEN = "TiProxy fails to connect to TiDB"
 
 
 def _is_transient_tiproxy_unavailable(e: BaseException) -> bool:
-    """Return True if TiProxy could not reach a TiDB backend — a transient blip."""
+    """Return True if TiProxy could not reach a TiDB backend due to a transient failure."""
     if not isinstance(e, pymysql.err.OperationalError):
         return False
     return _TIPROXY_UNAVAILABLE_TOKEN in " ".join(str(arg) for arg in e.args)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -606,6 +606,7 @@ def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
                 or _is_transient_connect_broken_pipe(e)
                 or _is_transient_packet_sequence_error(e)
                 or _is_transient_vitess_dial_timeout(e)
+                or _is_transient_tiproxy_unavailable(e)
                 or _is_transient_too_many_connections(e)
                 or _is_transient_cant_create_thread(e)
             ):
@@ -659,6 +660,22 @@ def _is_transient_vitess_reparent(e: BaseException) -> bool:
     return _VITESS_REPARENT_TOKEN in " ".join(str(arg) for arg in e.args)
 
 
+# TiProxy (TiDB's connection proxy) surfaces this 1105 error when it can't reach a TiDB
+# node — a failover, a restart, or a momentary network blip. It arrives during the MySQL
+# auth handshake: TiProxy accepts the TCP connection but then can't route to a backend
+# TiDB node and sends back ER_UNKNOWN_ERROR (1105) with this fixed message. Like the
+# Vitess `code = Unavailable` case above (same error code, same proxy-layer pattern),
+# a fresh attempt recovers once a healthy TiDB node is available.
+_TIPROXY_UNAVAILABLE_TOKEN = "TiProxy fails to connect to TiDB"
+
+
+def _is_transient_tiproxy_unavailable(e: BaseException) -> bool:
+    """Return True if TiProxy could not reach a TiDB backend — a transient blip."""
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    return _TIPROXY_UNAVAILABLE_TOKEN in " ".join(str(arg) for arg in e.args)
+
+
 def _is_transient_metadata_query_reset(e: BaseException) -> bool:
     """Return True if a metadata query's connection was reset mid-query — a transient blip.
 
@@ -706,6 +723,7 @@ def _retry_on_transient_tablet_unavailable(
             if attempt >= max_attempts or not (
                 _is_transient_tablet_unavailable(e)
                 or _is_transient_vitess_reparent(e)
+                or _is_transient_tiproxy_unavailable(e)
                 or _is_transient_metadata_query_reset(e)
             ):
                 raise

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -403,11 +403,11 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             "Too many connections",
             "Can't create a new thread",
             "reparent operation in progress",
-            # TiProxy can't reach a TiDB backend — a failover, restart, or momentary network
-            # blip. `_connect_with_transient_retry` already retries it in-process (see
-            # `_is_transient_tiproxy_unavailable` in mysql.py); this entry is the backstop for
-            # the rare case where it exhausts that budget and Temporal's own activity retry
-            # should recover it, rather than surfacing it as error-tracking noise.
+            # TiProxy cannot reach a TiDB backend due to a failover, restart, or momentary
+            # network blip. `_connect_with_transient_retry` already retries it in-process (see
+            # `_is_transient_tiproxy_unavailable` in mysql.py). This entry is the backstop for
+            # the rare case where it exhausts that budget so Temporal's own activity retry
+            # can recover it rather than surfacing it as error-tracking noise.
             "TiProxy fails to connect to TiDB",
         }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -403,6 +403,12 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             "Too many connections",
             "Can't create a new thread",
             "reparent operation in progress",
+            # TiProxy can't reach a TiDB backend — a failover, restart, or momentary network
+            # blip. `_connect_with_transient_retry` already retries it in-process (see
+            # `_is_transient_tiproxy_unavailable` in mysql.py); this entry is the backstop for
+            # the rare case where it exhausts that budget and Temporal's own activity retry
+            # should recover it, rather than surfacing it as error-tracking noise.
+            "TiProxy fails to connect to TiDB",
         }
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -35,6 +35,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     _is_transient_metadata_query_reset,
     _is_transient_packet_sequence_error,
     _is_transient_tablet_unavailable,
+    _is_transient_tiproxy_unavailable,
     _is_transient_too_many_connections,
     _is_transient_vitess_dial_timeout,
     _is_transient_vitess_reparent,
@@ -1493,6 +1494,26 @@ class TestConnectTransientRetry:
         assert mock_connect.call_count == 2
         sleep.assert_called_once_with(2)
 
+    def test_retries_tiproxy_unavailable_then_succeeds(self, mocker):
+        sleep = mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        conn = MagicMock()
+        conn.__enter__.return_value = conn
+        mock_connect = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            side_effect=[
+                pymysql.err.OperationalError(
+                    1105, "TiProxy fails to connect to TiDB, please make sure TiDB is available"
+                ),
+                conn,
+            ],
+        )
+
+        with MySQLImplementation().connect(_make_config()) as yielded:
+            assert yielded is conn
+
+        assert mock_connect.call_count == 2
+        sleep.assert_called_once_with(2)
+
     def test_does_not_retry_connection_refused(self, mocker):
         sleep = mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
         mock_connect = mocker.patch(
@@ -1625,6 +1646,35 @@ class TestIsTransientVitessReparent:
 
     def test_does_not_match_non_operational_error(self):
         assert not _is_transient_vitess_reparent(ValueError("reparent operation in progress"))
+
+
+class TestIsTransientTiproxyUnavailable:
+    def test_matches_tiproxy_unavailable(self):
+        # TiProxy accepts the TCP connection but can't reach a TiDB backend and sends back
+        # ER_UNKNOWN_ERROR (1105) with this fixed message during the MySQL auth handshake —
+        # a failover, restart, or momentary network blip that a fresh attempt recovers from.
+        assert _is_transient_tiproxy_unavailable(
+            pymysql.err.OperationalError(1105, "TiProxy fails to connect to TiDB, please make sure TiDB is available")
+        )
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            # Other 1105 payloads (Vitess cases, unrelated TiDB errors) are not this class.
+            (1105, "vttablet: rpc error: code = Unavailable desc = node is shutting down"),
+            (1105, "vttablet: rpc error: code = InvalidArgument desc = some bad request"),
+            (1045, "Access denied for user"),
+            (2003, "Can't connect to MySQL server on 'db.example.com'"),
+        ],
+    )
+    def test_does_not_match_other_errors(self, code, message):
+        assert not _is_transient_tiproxy_unavailable(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_tiproxy_unavailable(pymysql.err.OperationalError())
+
+    def test_does_not_match_non_operational_error(self):
+        assert not _is_transient_tiproxy_unavailable(ValueError("TiProxy fails to connect to TiDB"))
 
 
 class TestIsTransientMetadataQueryReset:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1650,9 +1650,6 @@ class TestIsTransientVitessReparent:
 
 class TestIsTransientTiproxyUnavailable:
     def test_matches_tiproxy_unavailable(self):
-        # TiProxy accepts the TCP connection but can't reach a TiDB backend and sends back
-        # ER_UNKNOWN_ERROR (1105) with this fixed message during the MySQL auth handshake —
-        # a failover, restart, or momentary network blip that a fresh attempt recovers from.
         assert _is_transient_tiproxy_unavailable(
             pymysql.err.OperationalError(1105, "TiProxy fails to connect to TiDB, please make sure TiDB is available")
         )


### PR DESCRIPTION
## Problem

MySQL syncs connecting to a TiDB cluster surface an unhandled `OperationalError(1105)` and the sync fails without retry when TiProxy — TiDB's connection proxy — temporarily can't reach a TiDB node during the MySQL authentication handshake.

The error occurs on the streaming connection open inside \`_connect_with_transient_retry\`. That function catches \`DatabaseError\` but none of its transient predicates matched error 1105 with this message, so the error re-raised immediately (no in-process retry) and propagated to error tracking.

Related error tracking issue: https://us.posthog.com/project/2/error_tracking/01a05c10-c283-7ba3-a933-44c52cdfc01a

## Changes

- TiProxy unavailability is now recognised as a transient connect error and retried in-process (up to 5 attempts with backoff), the same as Vitess's \`code = Unavailable\` (also 1105).
- The token \`"TiProxy fails to connect to TiDB"\` is added to \`get_retryable_errors\` as a Temporal-level backstop, so if the in-process budget is exhausted, Temporal retries the activity rather than surfacing it as error-tracking noise.
- Mechanical: new \`_TIPROXY_UNAVAILABLE_TOKEN\` constant and \`_is_transient_tiproxy_unavailable\` predicate in \`mysql.py\`; predicate wired into \`_connect_with_transient_retry\` and \`_retry_on_transient_tablet_unavailable\`.

## How did you test this code?

8 new unit tests:
- \`TestIsTransientTiproxyUnavailable\`: verifies the predicate matches the exact TiProxy message and rejects other 1105 payloads (Vitess, auth errors, unrelated 1105s).
- \`TestConnectTransientRetry.test_retries_tiproxy_unavailable_then_succeeds\`: verifies that \`connect()\` retries a TiProxy unavailability error rather than raising on the first attempt.

All 290 tests in \`test_mysql.py\` pass. Not run: the database-backed test suites (no database in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No doc change needed — no user-facing behaviour changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error tracking webhook. The stack trace showed the error firing at \`_connect_with_transient_retry\` during the streaming connection open — TiProxy accepts the TCP connection and then fails to reach a TiDB backend during the MySQL auth handshake (same proxy-layer pattern as Vitess's \`code = Unavailable\`, also error 1105). Skills invoked: \`/writing-tests\`, \`/writing-pr-descriptions\`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*