### PR TITLE
fix(desktop): recover messages after stale cloud sends

### DIFF
--- a/products/desktop/packages/core/src/pi-runtime/piSessionController.test.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionController.test.ts
@@ -1099,45 +1099,51 @@ describe("PiSessionController", () => {
     );
   });
 
-  it("resumes and retries a message when the prior sandbox is gone", async () => {
-    const staleSession = {
-      ...createSession(),
-      taskRunId: "run-1",
-      sendUserMessage: vi.fn(async () => {
-        throw new Error("No active sandbox for this task run");
-      }),
-    };
-    const resumedSession = {
-      ...createSession(),
-      sendUserMessage: vi.fn(async () => {}),
-    };
-    const provider = {
-      get: vi
-        .fn()
-        .mockResolvedValueOnce(staleSession)
-        .mockResolvedValue(resumedSession),
-    } as PiSessionProvider;
-    const resumeCloudPiRun = vi.fn(async () => ({ id: "run-2" }));
-    const taskService = {
-      prepareCloudPiMessage: vi.fn(async () => ({
-        content: "continue",
-        artifactIds: [],
-      })),
-      resumeCloudPiRun,
-    } as unknown as TaskService;
-    const controller = new PiSessionController(provider, taskService);
+  it.each([
+    ["the prior sandbox is gone", "No active sandbox for this task run"],
+    ["the prior workflow has ended", "Task run workflow has ended"],
+  ])(
+    "resumes and retries a message when %s",
+    async (_condition, errorMessage) => {
+      const staleSession = {
+        ...createSession(),
+        taskRunId: "run-1",
+        sendUserMessage: vi.fn(async () => {
+          throw new Error(errorMessage);
+        }),
+      };
+      const resumedSession = {
+        ...createSession(),
+        sendUserMessage: vi.fn(async () => {}),
+      };
+      const provider = {
+        get: vi
+          .fn()
+          .mockResolvedValueOnce(staleSession)
+          .mockResolvedValue(resumedSession),
+      } as PiSessionProvider;
+      const resumeCloudPiRun = vi.fn(async () => ({ id: "run-2" }));
+      const taskService = {
+        prepareCloudPiMessage: vi.fn(async () => ({
+          content: "continue",
+          artifactIds: [],
+        })),
+        resumeCloudPiRun,
+      } as unknown as TaskService;
+      const controller = new PiSessionController(provider, taskService);
 
-    await controller.connect("task-1");
-    await controller.submit("task-1", "continue", false, "steer");
+      await controller.connect("task-1");
+      await controller.submit("task-1", "continue", false, "steer");
 
-    expect(resumeCloudPiRun).toHaveBeenCalledWith("task-1", "run-1");
-    expect(resumedSession.sendUserMessage).toHaveBeenCalledWith(
-      "prompt",
-      "continue",
-      [],
-      expect.any(String),
-    );
-  });
+      expect(resumeCloudPiRun).toHaveBeenCalledWith("task-1", "run-1");
+      expect(resumedSession.sendUserMessage).toHaveBeenCalledWith(
+        "prompt",
+        "continue",
+        [],
+        expect.any(String),
+      );
+    },
+  );
 
   it("keeps a connected transcript usable when a command fails", async () => {
     const initialEvent: AgentConversationEvent = {
@@ -1165,6 +1171,7 @@ describe("PiSessionController", () => {
         scope: "operation",
         title: "Failed to send message",
         message: "temporary command failure",
+        recoveryPrompt: "retry me",
       },
     });
   });

--- a/products/desktop/packages/core/src/pi-runtime/piSessionController.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piSessionController.ts
@@ -153,6 +153,14 @@ function normalizeSessionError(error: unknown): {
   };
 }
 
+function isResumableCloudSendError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("No active sandbox") ||
+    message.includes("Task run workflow has ended")
+  );
+}
+
 @injectable()
 export class PiSessionController {
   readonly store: PiSessionStore = createPiSessionStore();
@@ -516,7 +524,13 @@ export class PiSessionController {
         }
         this.setTurnStreaming(taskId, wasStreaming);
         const operation = queuesMessage ? "queue" : "prompt";
-        throw this.recordOperationFailure(taskId, operation, error);
+        throw this.recordOperationFailure(
+          taskId,
+          operation,
+          error,
+          undefined,
+          message,
+        );
       }
     }
 
@@ -1372,9 +1386,8 @@ export class PiSessionController {
       await session.sendUserMessage(type, content, artifactIds, messageId);
       return;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
       const taskRunId = this.taskRunIds.get(taskId) ?? session.taskRunId;
-      if (!taskRunId || !message.includes("No active sandbox")) {
+      if (!taskRunId || !isResumableCloudSendError(error)) {
         throw error;
       }
 


### PR DESCRIPTION
## Problem

A follow-up message can fail and disappear when a cloud agent workflow ends before Desktop observes the terminal run state.

**Why:** People should be able to continue finished cloud tasks without retyping messages, even when run state changes race with a send.

## Changes

- Desktop resumes a stale cloud run and retries the message when the workflow-ended response arrives.
- If the send still fails, the composer restores the original prompt instead of dropping it.

