### PR TITLE
fix(oauth): skip empty client application lookups

### DIFF
--- a/posthog/api/oauth/test_client_auth.py
+++ b/posthog/api/oauth/test_client_auth.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from django.contrib.auth.hashers import make_password
 from django.test import SimpleTestCase
 
@@ -32,6 +34,10 @@ class TestVerifyClientSecret(SimpleTestCase):
         # a credential-less request and every confidential app that holds no secret.
         assert OAuthValidator()._check_secret("", make_password("")) is False
         assert OAuthValidator()._check_secret("s3cret", make_password("s3cret")) is True
+
+    @parameterized.expand([("missing", None), ("blank", "")])
+    def test_validator_skips_application_lookup_without_client_id(self, _name, client_id):
+        assert OAuthValidator()._load_application(client_id, SimpleNamespace(client=None)) is None
 
 
 class TestCredentialRepr(SimpleTestCase):

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -388,6 +388,9 @@ class OAuthValidator(OAuth2Validator):
         if request.client:
             return request.client
 
+        if not client_id:
+            return None
+
         app = OAuthApplication.objects.filter(client_id=client_id).first()
 
         if app is None or not app.is_usable(request):


### PR DESCRIPTION
## Problem

OAuth requests without a client ID run a database query that cannot match an application.

## Change

Return before the query when the client ID is empty. Preserve the existing cached client behavior.

## Test

- `uv run pytest posthog/api/oauth/test_client_auth.py -q`
- `ruff check posthog/api/oauth/views.py posthog/api/oauth/test_client_auth.py`
- `ruff format --check posthog/api/oauth/views.py posthog/api/oauth/test_client_auth.py`

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
