### PR TITLE
fix(flags): sort evaluation contexts in the Rust cache builder

### DIFF
--- a/products/feature_flags/backend/test/test_flags_cache.py
+++ b/products/feature_flags/backend/test/test_flags_cache.py
@@ -2437,14 +2437,19 @@ class TestManagementCommands(BaseTest):
             created_by=self.user,
             filters={"groups": [{"properties": [], "rollout_percentage": 100}]},
         )
-        ctx = EvaluationContext.objects.create(team=self.team, name="original-context-name")
+        # Out of alphabetical order on purpose. The assertions below also cover the sort that
+        # ArrayAgg(distinct=True) applies, which the Rust builder matches with
+        # ARRAY_AGG(DISTINCT ...). Remove distinct=True and the two write different arrays.
+        ctx = EvaluationContext.objects.create(team=self.team, name="zulu-context")
+        other_ctx = EvaluationContext.objects.create(team=self.team, name="alpha-context")
         FeatureFlagEvaluationContext.objects.create(feature_flag=flag, evaluation_context=ctx)
+        FeatureFlagEvaluationContext.objects.create(feature_flag=flag, evaluation_context=other_ctx)
 
         # Warm the cache
         update_flags_cache(self.team)
 
         # Rename the context directly in DB (bypassing signals to simulate stale cache)
-        EvaluationContext.objects.filter(id=ctx.id).update(name="renamed-context-name")
+        EvaluationContext.objects.filter(id=ctx.id).update(name="mike-context")
 
         # Verify should detect the mismatch
         result = verify_team_flags(self.team, verbose=True)
@@ -2456,8 +2461,8 @@ class TestManagementCommands(BaseTest):
 
         field_diffs = result["diffs"][0]["field_diffs"]
         eval_tag_diff = next(d for d in field_diffs if d["field"] == "evaluation_contexts")
-        self.assertEqual(eval_tag_diff["cached_value"], ["original-context-name"])
-        self.assertEqual(eval_tag_diff["db_value"], ["renamed-context-name"])
+        self.assertEqual(eval_tag_diff["cached_value"], ["alpha-context", "zulu-context"])
+        self.assertEqual(eval_tag_diff["db_value"], ["alpha-context", "mike-context"])
 
         # Mismatch result should include db_data for cache fix optimization
         self.assertIn("db_data", result)

--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -146,8 +146,15 @@ impl FeatureFlagList {
                   f.ensure_experience_continuity,
                   f.version,
                   f.evaluation_runtime,
+                  -- DISTINCT makes Postgres sort the names before it aggregates them, which
+                  -- matches ArrayAgg(..., distinct=True) on the two Python paths that write
+                  -- this cache entry: products/feature_flags/backend/flags_cache.py (batch) and
+                  -- products/feature_flags/backend/models/feature_flag.py (single team, which is
+                  -- also what the cache verifier compares against). Without DISTINCT the array
+                  -- order follows the join, so the sides disagree for a flag with two or more
+                  -- contexts. Keep all three in lockstep.
                   COALESCE(
-                      ARRAY_AGG(ctx.name) FILTER (WHERE ctx.name IS NOT NULL),
+                      ARRAY_AGG(DISTINCT ctx.name) FILTER (WHERE ctx.name IS NOT NULL),
                       '{}'::text[]
                   ) AS evaluation_tags,
                   bucketing_identifier,
@@ -504,15 +511,13 @@ mod tests {
         assert_eq!(flag.key, "flag1");
         assert_eq!(flag.team_id, team.id);
 
-        // Check that evaluation tags were properly fetched
+        // ARRAY_AGG(DISTINCT ...) sorts, so this is not the insertion order.
         let tags = flag
             .evaluation_tags
             .as_ref()
             .expect("Should have evaluation tags");
-        assert_eq!(tags.len(), 3);
-        assert!(tags.contains(&"docs-page".to_string()));
-        assert!(tags.contains(&"marketing-site".to_string()));
-        assert!(tags.contains(&"app".to_string()));
+        let tag_names: Vec<&str> = tags.iter().map(String::as_str).collect();
+        assert_eq!(tag_names, ["app", "docs-page", "marketing-site"]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

- A flag with two or more evaluation contexts gets a different array from each of the two cache builders, so the shadow comparison between them reports an `evaluation_contexts` field mismatch.
- Python aggregates the names with `ArrayAgg(..., distinct=True)`, which Postgres renders as `array_agg(DISTINCT ...)`. That sorts them.
- Rust used a bare `ARRAY_AGG` with neither `DISTINCT` nor `ORDER BY`. Postgres guarantees no row order without one, so Rust returned join order, and could return a different order between runs.

## Changes

- The Rust builder emits `ARRAY_AGG(DISTINCT ctx.name)`, so both builders produce the same sorted array (`rust/feature-flags/src/flags/feature_flag_list.rs`).
- Rust changed, not Python. Python is the incumbent writer, so every live cache entry already holds Python's ordering. Moving Python to Rust's order would rewrite every team's cache instead.
- `DISTINCT` rather than `ORDER BY ctx.name`, so both sides run the identical construct and match by construction. The explicit sort looks stricter, but it would only go on the Rust side: four Python sites use the bare `ArrayAgg(..., distinct=True)`. If Postgres ever stopped sorting for aggregate `DISTINCT`, identical constructs break together and both tests go red, whereas a one-sided `ORDER BY` would leave Rust sorted and Python not.
- No user-visible change. The Rust builder does not write the cache that serves flags.
- The rest of the diff is comments and test assertions.

## How did you test this code?

- Rust: `test_fetch_flags_with_evaluation_tags_from_pg` now asserts the exact array. It already inserted three contexts out of alphabetical order, but asserted membership with `contains`, so no ordering bug could fail it. On the old aggregate it fails with left `["docs-page", "marketing-site", "app"]` against right `["app", "docs-page", "marketing-site"]`.
- Python: `test_verify_cache_detects_evaluation_context_rename` moves from one evaluation context to two, created out of alphabetical order. The single-element array it used could not vary in order. This case passes before and after, because the Python aggregate is unchanged. It catches a later removal of `distinct=True`, which would split the two builders again.
- Not checked: 16 tests in `cargo test -p feature-flags` fail locally before this change as well. They need a GeoIP database file and a `cohort_membership` table the local database does not have. None reach this code path.
- No manual testing against a running app. The change is a background cache builder with no UI surface.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code worked from a written brief that fixed the scope, the direction of the fix, and the build and test commands.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, `/review-code --fix`.

Two decisions are worth a reviewer's attention. The brief called for extending the Python test at `test_flags_cache.py`, but that test cannot fail before the change, because it never runs the Rust query. The failing test is therefore the Rust one, and the Python case is widened only to pin the reference ordering. Separately, the review pass proposed an explicit `ORDER BY` inside the aggregate; the Changes section records why that was declined.

The review pass also corrected a comment that named one Python builder when there are two. `flags_hypercache` registers both a `load_fn` and a `batch_load_fn`, and the single-team path in `products/feature_flags/backend/models/feature_flag.py` carries a second copy of the same `ArrayAgg`. That copy is the one the cache verifier compares against.

Follow-up not taken here: the same `ArrayAgg(..., distinct=True)` is hand-rolled at four Python sites. A shared helper would give the Rust comment one symbol to point at, but it touches files this change does not otherwise edit.
