### PR TITLE
fix(desktop): pass personalization to pi tasks

### DIFF
--- a/products/desktop/packages/core/src/task-detail/taskInput.test.ts
+++ b/products/desktop/packages/core/src/task-detail/taskInput.test.ts
@@ -2,19 +2,40 @@ import { describe, expect, it } from "vitest";
 import { buildWorktreeAdoptionInput, prepareTaskInput } from "./taskInput";
 
 describe("prepareTaskInput", () => {
-  // The isCloud guard on customInstructions is the only thing preventing
-  // double-injection: local tasks already receive personalization via the
-  // workspace-server system prompt, so the field must be dropped for them and
-  // only passed through for cloud.
+  // Local ACP reads personalization through its workspace-server prompt. Pi
+  // bypasses that path, so it needs the task input to carry the instructions.
   it.each([
-    { workspaceMode: "cloud" as const, expected: "Always use tabs." },
-    { workspaceMode: "local" as const, expected: undefined },
-    { workspaceMode: "worktree" as const, expected: undefined },
+    {
+      workspaceMode: "cloud" as const,
+      runtime: "acp" as const,
+      expected: "Always use tabs.",
+    },
+    {
+      workspaceMode: "local" as const,
+      runtime: "acp" as const,
+      expected: undefined,
+    },
+    {
+      workspaceMode: "worktree" as const,
+      runtime: "acp" as const,
+      expected: undefined,
+    },
+    {
+      workspaceMode: "local" as const,
+      runtime: "pi" as const,
+      expected: "Always use tabs.",
+    },
+    {
+      workspaceMode: "worktree" as const,
+      runtime: "pi" as const,
+      expected: "Always use tabs.",
+    },
   ])(
-    "passes customInstructions through only for cloud (%s)",
-    ({ workspaceMode, expected }) => {
+    "passes customInstructions through for cloud and Pi tasks",
+    ({ workspaceMode, runtime, expected }) => {
       const input = prepareTaskInput("do the thing", [], {
         workspaceMode,
+        runtime,
         customInstructions: "Always use tabs.",
       });
       expect(input.customInstructions).toBe(expected);

--- a/products/desktop/packages/core/src/task-detail/taskInput.ts
+++ b/products/desktop/packages/core/src/task-detail/taskInput.ts
@@ -52,6 +52,9 @@ export function prepareTaskInput(
   options: PrepareTaskInputOptions,
 ): TaskCreationInput {
   const isCloud = options.workspaceMode === "cloud";
+  const runtime = options.runtime ?? "acp";
+  const includesCustomInstructions = isCloud || runtime === "pi";
+
   return {
     content: serializedContent,
     taskDescription: isCloud
@@ -70,7 +73,7 @@ export function prepareTaskInput(
     executionMode: options.executionMode,
     adapter: options.adapter,
     codexModelAccess: options.codexModelAccess,
-    runtime: options.runtime ?? "acp",
+    runtime,
     model: options.model,
     reasoningLevel: options.reasoningLevel,
     contextWindow: options.contextWindow,
@@ -91,7 +94,9 @@ export function prepareTaskInput(
     channelName: options.channelName,
     channelId: options.channelId,
     channelContextId: options.channelContextId,
-    customInstructions: isCloud ? options.customInstructions : undefined,
+    customInstructions: includesCustomInstructions
+      ? options.customInstructions
+      : undefined,
     allowNoRepo: options.allowNoRepo,
     importedMcpServers: isCloud ? options.importedMcpServers : undefined,
     relayedMcpServers: isCloud ? options.relayedMcpServers : undefined,

--- a/products/desktop/packages/shared/src/task-creation-domain.ts
+++ b/products/desktop/packages/shared/src/task-creation-domain.ts
@@ -89,9 +89,8 @@ export interface TaskCreationInput {
   channelContextId?: string;
   /**
    * The user's saved personalization (Settings → Personalization custom
-   * instructions). Cloud-only: local tasks already receive these through the
-   * workspace-server system prompt, so the saga folds this into the cloud run's
-   * first message instead, to avoid double-injecting.
+   * instructions). Cloud tasks include these in their first message. Local Pi
+   * tasks need them here because they bypass the workspace-server prompt.
    */
   customInstructions?: string;
   /**


### PR DESCRIPTION
## Problem

- People who start local or worktree Pi tasks do not receive their saved Personalization custom instructions.

## Changes

- Pi now receives saved Personalization custom instructions when people start local or worktree tasks.