### PR TITLE
feat(tasks): let the hogland flag win over the Modal VM-sandbox and allowlist flags

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -794,15 +794,18 @@ def _resolve_sandbox_backend(
     run_id: str,
     state: dict | None,
     task_runtime: str,
-    use_modal_vm_sandbox: bool,
-    use_modal_network_allowlist: bool,
     custom_image_name: str | None,
 ) -> str:
     """Pick the sandbox provider for this run.
 
-    Hogland only takes plain default-template ACP runs; anything needing a
-    Modal-only feature (VM runtime, custom image, Pi runtime, Modal-level network
-    allowlist) stays on Modal even with the flag on. Fails closed to Modal.
+    Hogland only takes plain default-template ACP runs. A custom image (hogland has
+    only the default golden template) or the Pi runtime are hard incapabilities —
+    hogland cannot run them, so they force Modal even with the flag on. The Modal
+    VM-sandbox and network-allowlist flags are runtime *preferences*, not
+    incapabilities: a run the hogland flag (or override) selects wins hogland over
+    them. The caller then forces both off so the run provisions as a plain hogland
+    box; egress stays enforced in-box by agentsh via the run's allowed_domains.
+    Fails closed to Modal.
     """
     raw_override = (state or {}).get("sandbox_backend")
     override = raw_override if isinstance(raw_override, str) and raw_override in ("modal", "hogland") else None
@@ -812,21 +815,21 @@ def _resolve_sandbox_backend(
         log_with_activity_context("sandbox_backend_state_override", run_id=run_id, sandbox_backend="modal")
         return "modal"
 
-    # Hard gates: a "hogland" result (override OR flag) is only allowed when hogland can
-    # actually run this run. These sit ahead of the override so a stale or forged `hogland`
-    # carried across a cloud resume can't defeat the EU guard or the Modal-only
-    # fallbacks and leave the run with unenforced egress.
+    # Hard gates: a "hogland" result (override OR flag) is only allowed when hogland is
+    # available (US region + configured URL/token) and can actually run this run (no
+    # custom image, no Pi runtime). These sit ahead of the override so a stale or forged
+    # `hogland` carried across a cloud resume can't defeat the EU guard or route an
+    # incapable run to hogland.
     if not settings.HOGLAND_API_URL or not (settings.HOGLAND_API_TOKEN_FILE or settings.HOGLAND_API_TOKEN):
         return "modal"
     # Hogland runs in the US only; EU runs stay on Modal regardless of flag/override state.
     if getattr(settings, "CLOUD_DEPLOYMENT", None) == "EU":
         return "modal"
-    if (
-        use_modal_vm_sandbox
-        or custom_image_name is not None
-        or task_runtime == Task.Runtime.PI
-        or use_modal_network_allowlist
-    ):
+    # Hard hogland incapabilities: a custom image or the Pi runtime cannot run on the
+    # default golden template, so keep those on Modal even when the flag is on. The
+    # Modal VM-sandbox / network-allowlist flags are deliberately NOT gated here — a
+    # flagged run wins hogland over them (the caller forces both off for hogland runs).
+    if custom_image_name is not None or task_runtime == Task.Runtime.PI:
         return "modal"
 
     # Past the gates, a "hogland" override pins the run (the canary lever), no flag eval.
@@ -1290,10 +1293,16 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         run_id=run_id,
         state=state,
         task_runtime=task.runtime,
-        use_modal_vm_sandbox=use_modal_vm_sandbox,
-        use_modal_network_allowlist=use_modal_network_allowlist,
         custom_image_name=custom_image_name,
     )
+    if sandbox_backend == "hogland":
+        # Hogland runs are plain default-template runs, so the Modal VM-runtime and
+        # network-allowlist preferences don't apply. Force both off so provisioning
+        # builds a DEFAULT_BASE hogland box (not a Modal VM_BASE config) and skips the
+        # Modal provider-layer allowlist. Egress stays enforced in-box by agentsh, which
+        # keys on the run's allowed_domains independently of use_modal_network_allowlist.
+        use_modal_vm_sandbox = False
+        use_modal_network_allowlist = False
     emit_agent_log(
         run_id,
         "debug",

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -1353,6 +1353,30 @@ class TestGetTaskProcessingContextActivity:
         assert result.custom_image_name == "posthog-dev-stack"
 
     @pytest.mark.django_db(transaction=True)
+    @override_settings(HOGLAND_API_URL="https://hogland.example", HOGLAND_API_TOKEN="hog-tok")
+    def test_hogland_run_forces_off_modal_vm_and_network_allowlist(self, activity_environment, test_task):
+        # A run that resolves to hogland must carry use_modal_vm_sandbox and
+        # use_modal_network_allowlist as False, so provisioning builds a plain hogland
+        # box instead of a Modal VM_BASE config with the Modal provider allowlist. The
+        # VM payload and the flag below would each set their value True; the force-off
+        # must still land both at False for a hogland run.
+        task_run = test_task.create_run()
+        input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
+
+        with (
+            patch(VM_FLAG_PAYLOAD_TARGET, return_value='{"default_base_origin_products": ["user_created"]}'),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+                return_value=True,
+            ),
+        ):
+            result = async_to_sync(activity_environment.run)(get_task_processing_context, input_data)
+
+        assert result.sandbox_backend == "hogland"
+        assert result.use_modal_vm_sandbox is False
+        assert result.use_modal_network_allowlist is False
+
+    @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_exposes_ci_prompt(self, activity_environment, test_task):
         custom_prompt = "Re-run the failed mypy checks and push a fix."
         test_task.ci_prompt = custom_prompt
@@ -1396,8 +1420,6 @@ class TestResolveSandboxBackend:
             "run_id": "run-1",
             "state": None,
             "task_runtime": "acp",
-            "use_modal_vm_sandbox": False,
-            "use_modal_network_allowlist": False,
             "custom_image_name": None,
         }
         kwargs.update(overrides)
@@ -1418,15 +1440,17 @@ class TestResolveSandboxBackend:
     @pytest.mark.parametrize(
         "overrides",
         [
-            {"use_modal_vm_sandbox": True},
             {"custom_image_name": "posthog-sandbox-custom-x"},
             {"task_runtime": "pi"},
-            {"use_modal_network_allowlist": True},
         ],
-        ids=["vm_runtime", "custom_image", "pi_runtime", "modal_network_allowlist"],
+        ids=["custom_image", "pi_runtime"],
     )
     @override_settings(**_HOGLAND_SETTINGS)
-    def test_modal_only_features_fall_back_to_modal_even_with_the_flag_on(self, overrides):
+    def test_hard_incapabilities_fall_back_to_modal_even_with_the_flag_on(self, overrides):
+        # A custom image or the Pi runtime cannot run on hogland's default template, so
+        # they force Modal even with the flag on. The Modal VM-sandbox and
+        # network-allowlist preferences are deliberately not gated here — a flagged run
+        # wins hogland over them (covered by the caller force-off test).
         assert self._resolve_with_flag(True, **overrides) == "modal"
 
     @override_settings(**_HOGLAND_SETTINGS, CLOUD_DEPLOYMENT="EU")
@@ -1478,14 +1502,15 @@ class TestResolveSandboxBackend:
     @pytest.mark.parametrize(
         "overrides",
         [
-            {"use_modal_vm_sandbox": True},
             {"custom_image_name": "img"},
-            {"use_modal_network_allowlist": True},
+            {"task_runtime": "pi"},
         ],
-        ids=["vm", "custom_image", "network_allowlist"],
+        ids=["custom_image", "pi_runtime"],
     )
     @override_settings(**_HOGLAND_SETTINGS)
-    def test_hogland_override_cannot_defeat_modal_only_fallbacks(self, overrides):
+    def test_hogland_override_cannot_defeat_hard_incapabilities(self, overrides):
+        # A stale or forged hogland override surviving a cloud resume must not route a
+        # custom-image or Pi run to hogland — the capability gates sit ahead of the override.
         assert self._resolve_with_flag(True, state={"sandbox_backend": "hogland"}, **overrides) == "modal"
 
     @override_settings(**_HOGLAND_SETTINGS)


### PR DESCRIPTION
## Problem

A PostHog Code task never runs on hogland, even for a user the `tasks-hogland-sandbox` flag targets. The sandbox resolver forces Modal whenever `use_modal_vm_sandbox` or `use_modal_network_allowlist` is set, and both are broadly on for `user_created` tasks (the VM-sandbox payload lists `user_created`; the network-allowlist flag is on for everyone). So the resolver returns `modal` before it ever evaluates the hogland flag — the flag can never win.

## Changes

- The `tasks-hogland-sandbox` flag (and a `hogland` state override) now win over the Modal VM-sandbox and network-allowlist flags. A flag-targeted user's plain run routes to hogland instead of Modal.
- Only true hogland incapabilities still force Modal ahead of the flag: a custom image (hogland has only the default golden template), the Pi runtime, the EU region, or a missing hogland URL/token.
- When a run resolves to hogland, the activity forces `use_modal_vm_sandbox` and `use_modal_network_allowlist` off, so provisioning builds a plain hogland box (`DEFAULT_BASE`) rather than a Modal `VM_BASE` config with the provider allowlist.
- Mechanical: `_resolve_sandbox_backend` no longer takes the two Modal-preference flags; they were only used for the gate that moved.

The behavior change is flag-gated, so only `tasks-hogland-sandbox`-targeted users move off Modal; every other run is unchanged.

### Egress — the point to review

Egress stays enforced for hogland runs. In-box `agentsh` keys on the run's `allowed_domains` independently of `use_modal_network_allowlist` (`_agentsh_domains_for` returns `agentsh_domain_allowlist or allowed_domains`), and its setup runs on any backend. Forcing `use_modal_network_allowlist` off for a hogland run drops only Modal's provider-layer allowlist — the Modal-specific belt on top of the in-box layer. Please confirm the tasks/egress owners are comfortable relying on the in-box `agentsh` layer for hogland runs without Modal's provider layer.

## How did you test this code?

I am an agent (Claude Code). Automated tests I ran:

- Updated the resolver unit tests in `TestResolveSandboxBackend` and ran them: 13 pass. They now assert that a custom image and the Pi runtime stay hard gates, and drop the VM-sandbox / network-allowlist cases (no longer resolver inputs). The regression guarded: someone re-adding those two flags to the modal-forcing gate, or dropping the custom-image / Pi gate.
- Added `test_hogland_run_forces_off_modal_vm_and_network_allowlist`: a full-context run that resolves to hogland must carry `use_modal_vm_sandbox=False` and `use_modal_network_allowlist=False`, even when the VM payload and the flag would each set them True. The regression guarded: removing the force-off, which would provision a hogland box from a Modal `VM_BASE` config.

Not run locally: the DB/ClickHouse-backed tests, because this sandbox has no ClickHouse (the new test and existing ones error identically on the CH connection). They run in CI. `ruff check`/`ruff format` clean; targeted mypy on the changed module surfaced no new errors (the repo-wide pre-existing ones are in unrelated files).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent-authored (Claude Code), directed by Tom Owers. The change follows a session that got the hogland env (`HOGLAND_API_URL`) and the `tasks-hogland-sandbox` flag live, then found runs still pinned to Modal by the two broadly-on Modal flags at a gate ahead of the hogland flag. The design keeps hard incapabilities (custom image, Pi, EU, token) ahead of the flag and lets the flag win only over the two Modal preferences, then forces those preferences off so the hogland provisioning path stays internally consistent. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. Left for a human: the egress-layer confirmation noted under Changes.
