### PR TITLE
chore(product-analytics): stop core tests driving the trends runner

### DIFF
--- a/posthog/api/test/dashboards/test_dashboard.py
+++ b/posthog/api/test/dashboards/test_dashboard.py
@@ -809,7 +809,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         insight = Insight.objects.create(
             team=self.team,
             created_by=self.user,
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            query={"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"]}},
         )
         DashboardTile.objects.create(dashboard=dashboard, insight=insight)
         mock_calculate.return_value = InsightResult(
@@ -3658,8 +3658,8 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             {
                 "dashboards": [dashboard_id],
                 "query": {
-                    "kind": "InsightVizNode",
-                    "source": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+                    "kind": "DataVisualizationNode",
+                    "source": {"kind": "HogQLQuery", "query": "select count() from events"},
                 },
             }
         )
@@ -3676,7 +3676,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
             name="tile alert",
             threshold=threshold,
             condition={"type": "absolute_value"},
-            config={"type": "TrendsAlertConfig", "series_index": 0},
+            config={"type": "HogQLAlertConfig", "evaluation": "last_row"},
         )
 
         regular_response = self.dashboard_api.get_dashboard(dashboard_id)
@@ -3703,7 +3703,7 @@ class TestDashboard(APIBaseTest, QueryMatchingTest):
         dashboard = Dashboard.objects.create(team=self.team, name="dashboard with broken tile", created_by=self.user)
         insight = Insight.objects.create(
             team=self.team,
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            query={"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"]}},
         )
         DashboardTile.objects.create(dashboard=dashboard, insight=insight)
 

--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -3179,39 +3179,6 @@ email@example.org,
         )
         self.assertEqual(response.status_code, 400, response.content)
 
-    @parameterized.expand(
-        [
-            ("time_series_without_day", None, None),
-            ("total_value_with_day", "BoldNumber", "2026-07-01"),
-        ]
-    )
-    def test_creating_static_cohort_from_trends_actors_with_invalid_day_is_rejected(
-        self, _name: str, display: str | None, day: str | None
-    ) -> None:
-        trends_filter = {"display": display} if display else None
-        actors_source: dict[str, Any] = {
-            "kind": "InsightActorsQuery",
-            "source": {
-                "kind": "TrendsQuery",
-                "series": [{"kind": "EventsNode", "event": "$pageview"}],
-                **({"trendsFilter": trends_filter} if trends_filter else {}),
-            },
-            **({"day": day} if day else {}),
-        }
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/cohorts",
-            data={
-                "name": "cohort A",
-                "is_static": True,
-                "query": {
-                    "kind": "ActorsQuery",
-                    "select": ["person"],
-                    "source": actors_source,
-                },
-            },
-        )
-        self.assertEqual(response.status_code, 400, response.content)
-
     @patch("posthog.api.cohort.report_user_action")
     def test_creating_with_query_and_fields(self, patch_capture):
         _create_person(
@@ -6079,9 +6046,10 @@ class TestCohortUsedIn(ClickhouseTestMixin, APIBaseTest):
             team=self.team,
             name="Insight Referencing Cohort",
             query={
-                "kind": "InsightVizNode",
+                "kind": "DataTableNode",
                 "source": {
-                    "kind": "TrendsQuery",
+                    "kind": "EventsQuery",
+                    "select": ["*"],
                     "properties": [{"type": "cohort", "key": "id", "value": cohort_id}],
                 },
             },
@@ -6106,13 +6074,12 @@ class TestCohortUsedIn(ClickhouseTestMixin, APIBaseTest):
 
         insight = Insight.objects.create(
             team=self.team,
-            name="Trends With Cohort Breakdown",
+            name="Insight With Cohort Breakdown",
+            # `get_insights_using_cohort` matches `source.breakdownFilter` by JSON path and never
+            # reads the query kind, so the fixture carries only the path the predicate walks.
             query={
                 "kind": "InsightVizNode",
-                "source": {
-                    "kind": "TrendsQuery",
-                    "breakdownFilter": {"breakdown_type": "cohort", "breakdown": [cohort_id]},
-                },
+                "source": {"breakdownFilter": {"breakdown_type": "cohort", "breakdown": [cohort_id]}},
             },
         )
 
@@ -6132,9 +6099,10 @@ class TestCohortUsedIn(ClickhouseTestMixin, APIBaseTest):
         )
         cohort_id = response.json()["id"]
         cohort_query = {
-            "kind": "InsightVizNode",
+            "kind": "DataTableNode",
             "source": {
-                "kind": "TrendsQuery",
+                "kind": "EventsQuery",
+                "select": ["*"],
                 "properties": [{"type": "cohort", "key": "id", "value": cohort_id}],
             },
         }
@@ -6157,9 +6125,10 @@ class TestCohortUsedIn(ClickhouseTestMixin, APIBaseTest):
         )
         cohort_id = response.json()["id"]
         cohort_query = {
-            "kind": "InsightVizNode",
+            "kind": "DataTableNode",
             "source": {
-                "kind": "TrendsQuery",
+                "kind": "EventsQuery",
+                "select": ["*"],
                 "properties": [{"type": "cohort", "key": "id", "value": cohort_id}],
             },
         }
@@ -6239,9 +6208,10 @@ class TestCohortUsedIn(ClickhouseTestMixin, APIBaseTest):
             team=other_team,
             name="Sibling Insight",
             query={
-                "kind": "InsightVizNode",
+                "kind": "DataTableNode",
                 "source": {
-                    "kind": "TrendsQuery",
+                    "kind": "EventsQuery",
+                    "select": ["*"],
                     "properties": [{"type": "cohort", "key": "id", "value": cohort_id}],
                 },
             },

--- a/posthog/api/test/test_query.py
+++ b/posthog/api/test/test_query.py
@@ -1338,40 +1338,6 @@ class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
     ENDPOINT = "query"
 
     @patch("posthog.api.query.process_query_model")
-    def test_trends_query_includes_formatted_results(self, mock_process_query_model):
-        mock_process_query_model.return_value = {
-            "results": [
-                {
-                    "data": [100, 200, 150],
-                    "labels": ["2024-01-01", "2024-01-02", "2024-01-03"],
-                    "days": ["2024-01-01", "2024-01-02", "2024-01-03"],
-                    "count": 450,
-                    "label": "$pageview",
-                    "action": {
-                        "days": ["2024-01-01", "2024-01-02", "2024-01-03"],
-                        "id": "$pageview",
-                        "type": "events",
-                    },
-                }
-            ],
-            "is_cached": False,
-        }
-
-        response = self.client.post(
-            f"/api/environments/{self.team.id}/query/",
-            {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
-            HTTP_X_POSTHOG_CLIENT="mcp",
-        )
-
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-        self.assertIn("results", data)
-        self.assertIn("formatted_results", data)
-        self.assertIn("$pageview", data["formatted_results"])
-        self.assertIn("100", data["formatted_results"])
-        self.assertIn("|", data["formatted_results"])
-
-    @patch("posthog.api.query.process_query_model")
     def test_hogql_query_includes_formatted_results(self, mock_process_query_model):
         mock_process_query_model.return_value = {
             "results": [["sign up", 10], ["sign out", 5]],
@@ -1394,22 +1360,14 @@ class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
     @patch("posthog.api.query.process_query_model")
     def test_no_formatted_results_without_header(self, mock_process_query_model):
         mock_process_query_model.return_value = {
-            "results": [
-                {
-                    "data": [100],
-                    "labels": ["2024-01-01"],
-                    "days": ["2024-01-01"],
-                    "count": 100,
-                    "label": "$pageview",
-                    "action": {"days": ["2024-01-01"], "id": "$pageview", "type": "events"},
-                }
-            ],
+            "results": [["sign up", 10]],
+            "columns": ["event", "count"],
             "is_cached": False,
         }
 
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
-            {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
+            {"query": {"kind": "HogQLQuery", "query": "select event, count() from events group by event"}},
         )
 
         self.assertEqual(response.status_code, 200)
@@ -1444,22 +1402,14 @@ class TestQueryLLMFormatting(ClickhouseTestMixin, APIBaseTest):
             setattr(mock_settings, attr, getattr(__import__("posthog").settings, attr))
 
         mock_process_query_model.return_value = {
-            "results": [
-                {
-                    "data": [100],
-                    "labels": ["2024-01-01"],
-                    "days": ["2024-01-01"],
-                    "count": 100,
-                    "label": "$pageview",
-                    "action": {"days": ["2024-01-01"], "id": "$pageview", "type": "events"},
-                }
-            ],
+            "results": [["sign up", 10]],
+            "columns": ["event", "count"],
             "is_cached": False,
         }
 
         response = self.client.post(
             f"/api/environments/{self.team.id}/query/",
-            {"query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]}},
+            {"query": {"kind": "HogQLQuery", "query": "select event, count() from events group by event"}},
             HTTP_X_POSTHOG_CLIENT="mcp",
         )
 

--- a/posthog/api/test/test_sharing.py
+++ b/posthog/api/test/test_sharing.py
@@ -1444,7 +1444,7 @@ class TestExportCacheKeyFlow(APIBaseTest):
         cls.insight = Insight.objects.create(
             team=cls.team,
             name="Test Insight",
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            query={"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"]}},
         )
         cls.sharing_config = SharingConfiguration.objects.create(
             team=cls.team,
@@ -1581,7 +1581,7 @@ class TestSharedAdhocQueryExport(APIBaseTest):
     """The /exporter page for an insight-less PNG asset (export_context.source) must inline the
     pre-computed query result — the anonymous page can't authenticate against the query API."""
 
-    _SOURCE_QUERY = {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery", "series": [{"event": "$pageview"}]}}
+    _SOURCE_QUERY = {"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"]}}
 
     def _create_asset(self) -> ExportedAsset:
         return ExportedAsset.objects.create(
@@ -1636,13 +1636,13 @@ class TestSharedCohortInlining(APIBaseTest):
 
         insight = Insight.objects.create(
             team=self.team,
-            name="Trend by cohort",
+            name="Insight by cohort",
             query={
-                "kind": "InsightVizNode",
+                "kind": "DataTableNode",
                 "source": {
-                    "kind": "TrendsQuery",
-                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
-                    "breakdownFilter": {"breakdown_type": "cohort", "breakdown": [cohort.id]},
+                    "kind": "EventsQuery",
+                    "select": ["*"],
+                    "properties": [{"type": "cohort", "key": "id", "value": cohort.id}],
                 },
             },
         )
@@ -1660,13 +1660,7 @@ class TestSharedCohortInlining(APIBaseTest):
         insight = Insight.objects.create(
             team=self.team,
             name="No cohorts",
-            query={
-                "kind": "InsightVizNode",
-                "source": {
-                    "kind": "TrendsQuery",
-                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
-                },
-            },
+            query={"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"]}},
         )
         config = SharingConfiguration.objects.create(team=self.team, insight=insight, enabled=True)
 
@@ -1686,11 +1680,11 @@ class TestSharedCohortInlining(APIBaseTest):
         insight_a = Insight.objects.create(
             team=self.team,
             query={
-                "kind": "InsightVizNode",
+                "kind": "DataTableNode",
                 "source": {
-                    "kind": "TrendsQuery",
-                    "series": [{"kind": "EventsNode", "event": "$pageview"}],
-                    "breakdownFilter": {"breakdown_type": "cohort", "breakdown": [cohort_a.id]},
+                    "kind": "EventsQuery",
+                    "select": ["*"],
+                    "properties": [{"type": "cohort", "key": "id", "value": cohort_a.id}],
                 },
             },
         )
@@ -1765,13 +1759,18 @@ class TestSharedCohortInlining(APIBaseTest):
         dashboard = Dashboard.objects.create(team=self.team, name="dash", created_by=self.user)
         insight = Insight.objects.create(
             team=self.team,
-            name="Pageviews",
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            name="Event count",
+            # Alerts only render for an alertable insight kind, so the empty-alerts assertion
+            # below needs one — otherwise it holds for the wrong reason.
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {"kind": "HogQLQuery", "query": "select count() from events"},
+            },
             created_by=self.user,
             last_modified_by=self.user,
         )
         AlertConfiguration.objects.create(
-            team=self.team, insight=insight, name="High pageviews", enabled=True, created_by=self.user
+            team=self.team, insight=insight, name="High event count", enabled=True, created_by=self.user
         )
         DashboardTile.objects.create(dashboard=dashboard, team_id=self.team.id, insight=insight)
         text = Text.objects.create(team=self.team, body="Read me", created_by=self.user, last_modified_by=self.user)

--- a/posthog/api/test/test_sharing_access_token_security.py
+++ b/posthog/api/test/test_sharing_access_token_security.py
@@ -46,7 +46,7 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             name="Shared Insight",
             team=self.team,
             created_by=self.user,
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "test_event"}]},
+            query={"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"], "event": "test_event"}},
         )
         self.dashboard.tiles.create(
             insight=insight,
@@ -84,7 +84,7 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             name="Shared Insight",
             team=self.team,
             created_by=self.user,
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "test_event"}]},
+            query={"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"], "event": "test_event"}},
         )
         self.dashboard.tiles.create(
             insight=insight,
@@ -143,8 +143,8 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             team=self.team,
             created_by=self.user,
             query={
-                "kind": "TrendsQuery",
-                "series": [{"kind": "EventsNode", "event": "test_event"}],
+                "kind": "DataTableNode",
+                "source": {"kind": "EventsQuery", "select": ["*"], "event": "test_event"},
             },
         )
 
@@ -154,8 +154,8 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             team=self.team,
             created_by=self.user,
             query={
-                "kind": "TrendsQuery",
-                "series": [{"kind": "EventsNode", "event": "secret_event"}],
+                "kind": "DataTableNode",
+                "source": {"kind": "EventsQuery", "select": ["*"], "event": "secret_event"},
             },
         )
 
@@ -200,8 +200,8 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             team=self.team,
             created_by=self.user,
             query={
-                "kind": "TrendsQuery",
-                "series": [{"kind": "EventsNode", "event": "original_event"}],
+                "kind": "TracesQuery",
+                "searchTerm": "original_event",
                 "dateRange": {"date_from": "-7d"},
             },
         )
@@ -234,7 +234,7 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
         # The response should contain the original query, not the overridden one
         response_data = response.json()
         original_query = response_data.get("query", {})
-        assert original_query.get("series", [{}])[0].get("event") == "original_event"
+        assert original_query.get("searchTerm") == "original_event"
 
         # CRITICAL: This is the vulnerability - the date range should NOT be overridden to -365d
         # It should remain the original -7d from the insight definition
@@ -336,8 +336,8 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             team=other_team,
             created_by=self.user,
             query={
-                "kind": "TrendsQuery",
-                "series": [{"kind": "EventsNode", "event": "other_team_event"}],
+                "kind": "DataTableNode",
+                "source": {"kind": "EventsQuery", "select": ["*"], "event": "other_team_event"},
             },
         )
 
@@ -367,14 +367,20 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             name="On Dashboard",
             team=self.team,
             created_by=self.user,
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "dashboard_event"}]},
+            query={
+                "kind": "DataTableNode",
+                "source": {"kind": "EventsQuery", "select": ["*"], "event": "dashboard_event"},
+            },
         )
 
         insight_not_on_dashboard = Insight.objects.create(
             name="Not on Dashboard",
             team=self.team,
             created_by=self.user,
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "secret_event"}]},
+            query={
+                "kind": "DataTableNode",
+                "source": {"kind": "EventsQuery", "select": ["*"], "event": "secret_event"},
+            },
         )
 
         # Add only one to the dashboard
@@ -419,7 +425,10 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             f"/api/environments/{self.team.id}/insights/?sharing_access_token={sharing_config.access_token}",
             {
                 "name": "Malicious Insight",
-                "query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "malicious_event"}]},
+                "query": {
+                    "kind": "DataTableNode",
+                    "source": {"kind": "EventsQuery", "select": ["*"], "event": "malicious_event"},
+                },
             },
         )
         assert response.status_code in [401, 403], (
@@ -431,7 +440,10 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             f"/api/environments/{self.team.id}/insights/",
             {
                 "name": "Malicious Insight",
-                "query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "malicious_event"}]},
+                "query": {
+                    "kind": "DataTableNode",
+                    "source": {"kind": "EventsQuery", "select": ["*"], "event": "malicious_event"},
+                },
                 "sharing_access_token": sharing_config.access_token,
             },
         )
@@ -468,7 +480,7 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             name="Shared Insight",
             team=self.team,
             created_by=self.user,
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "test_event"}]},
+            query={"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"], "event": "test_event"}},
         )
         self.dashboard.tiles.create(
             insight=insight,
@@ -538,7 +550,7 @@ class SharingAccessTokenSecurityTest(APIBaseTest):
             name="Shared Insight",
             team=self.team,
             created_by=self.user,
-            query={"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "test_event"}]},
+            query={"kind": "DataTableNode", "source": {"kind": "EventsQuery", "select": ["*"], "event": "test_event"}},
         )
         self.dashboard.tiles.create(
             insight=insight,

--- a/posthog/test/activity_log_utils.py
+++ b/posthog/test/activity_log_utils.py
@@ -755,7 +755,11 @@ class ActivityLogTestHelper(APILicensedTest):
         data = {
             "name": name,
             "description": "Test saved metric",
-            "query": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode", "event": "$pageview"}]},
+            "query": {
+                "kind": "ExperimentMetric",
+                "metric_type": "mean",
+                "source": {"kind": "EventsNode", "event": "$pageview"},
+            },
             **kwargs,
         }
         response = self.client.post(f"/api/projects/{self.team.id}/experiment_saved_metrics/", data, format="json")

--- a/products/model_crossing_uses_baseline.txt
+++ b/products/model_crossing_uses_baseline.txt
@@ -825,13 +825,9 @@ warehouse_sources.WarehouseColumnAnnotation products.data_warehouse.backend.pres
 warehouse_sources.WarehouseColumnAnnotation products.posthog_ai.evals.data_warehouse.seeder construct 2
 warehouse_sources.WarehouseColumnAnnotation products.posthog_ai.evals.data_warehouse.seeder write(bulk_create) 1
 web_analytics:backend/hogql_queries/ ee.clickhouse.views.test.test_experiment_saved_metrics drives(TrendsQuery) 2
-web_analytics:backend/hogql_queries/ posthog.api.test.dashboards.test_dashboard drives(TrendsQuery) 5
+web_analytics:backend/hogql_queries/ posthog.api.test.dashboards.test_dashboard drives(TrendsQuery) 2
 web_analytics:backend/hogql_queries/ posthog.api.test.test_alert_15_minute_interval drives(TrendsQuery) 1
 web_analytics:backend/hogql_queries/ posthog.api.test.test_alert_real_time_interval drives(TrendsQuery) 1
-web_analytics:backend/hogql_queries/ posthog.api.test.test_cohort drives(TrendsQuery) 6
-web_analytics:backend/hogql_queries/ posthog.api.test.test_query drives(TrendsQuery) 3
-web_analytics:backend/hogql_queries/ posthog.api.test.test_sharing drives(TrendsQuery) 6
-web_analytics:backend/hogql_queries/ posthog.api.test.test_sharing_access_token_security drives(TrendsQuery) 12
 web_analytics:backend/hogql_queries/ posthog.hogql.database.schema.test.test_persons drives(TrendsQuery) 1
 web_analytics:backend/hogql_queries/ posthog.hogql.functions.test.test_traffic_type_functions drives(BOT_DEFINITIONS) 7
 web_analytics:backend/hogql_queries/ posthog.hogql.functions.test.test_traffic_type_functions drives(BOT_IP_DEFINITIONS) 4
@@ -856,7 +852,6 @@ web_analytics:backend/hogql_queries/ posthog.tasks.alerts.test.test_alert_subscr
 web_analytics:backend/hogql_queries/ posthog.tasks.alerts.test.test_metrics_alerts drives(TrendsQuery) 1
 web_analytics:backend/hogql_queries/ posthog.tasks.alerts.test.test_trends_absolute_alerts drives(TrendsQuery) 2
 web_analytics:backend/hogql_queries/ posthog.tasks.alerts.test.test_trends_relative_alerts drives(TrendsQuery) 1
-web_analytics:backend/hogql_queries/ posthog.test.activity_log_utils drives(TrendsQuery) 1
 web_analytics:backend/hogql_queries/ posthog.test.base drives(stats_table) 1
 web_analytics:backend/hogql_queries/ posthog.test.base drives(web_overview) 1
 web_analytics:backend/hogql_queries/ products.actions.backend.api.test.test_action drives(TrendsQuery) 9


### PR DESCRIPTION
## Problem

Nobody sees this change, but the product-analytics team is waiting on it. `hogli product:crossings` counts any core test that builds and runs a product query kind as a driver of that product's query runners, and while a driver stands, `backend/hogql_queries/` stays in the owning product's contract-check inputs. That is what blocks moving the trends runner out of core.

Six core test modules carry `TrendsQuery` purely as a generic "some insight" fixture. None of them assert anything about trends. They still count, so they hold the input open for every runner the owning product has.

This is one slice of the trends precondition, not the whole of it. The `drives(TrendsQuery)` list still names 36 outside modules after this PR.

## Changes

Nothing user-visible changes. Every edit is in test fixtures, plus the regenerated crossings baseline.

- Plain "an insight row exists" fixtures now use `EventsQuery` under a `DataTableNode`.
- Two dashboard and sharing fixtures use `HogQLQuery` under a `DataVisualizationNode`, because `Insight.alertable_query_kind` only renders alerts for trends, HogQL, funnels and metrics. `EventsQuery` would have made both alert assertions hold for the wrong reason.
- The sharing filters-override fixture uses `TracesQuery`, the core-owned kind that carries a `dateRange`, and asserts on `searchTerm` instead of a trends series.
- The shared-metric helper in `activity_log_utils.py` uses the `ExperimentMetric` shape its serializer documents.
- Two tests go rather than move to another kind, each because an existing test already covers it. See below.
- `products/model_crossing_uses_baseline.txt` loses five `drives(TrendsQuery)` lines and drops `test_dashboard` from 5 to 2.

`test_dashboard.py::test_return_cached_results_dashboard_has_filters` keeps its two sites. It warms the query cache and asserts on computed `days`, so it is a real executor and moves when the runner does.

### The two deletions

`test_query.py::test_trends_query_includes_formatted_results` asserts that an MCP request gets `formatted_results` back. Repointed at `HogQLQuery` it becomes the test directly below it. The trends formatter itself has 14 cases in `ee/hogai/context/insight/format/test/test_trends.py`.

`test_cohort.py::test_creating_static_cohort_from_trends_actors_with_invalid_day_is_rejected` could not be repointed: `validate_actors_query_for_cohort` matches on the literal string `TrendsQuery`. Its two parameterized cases are a subset of `TestCohortQueryValidation` in `products/cohorts/backend/models/test/test_util.py`, which runs eight day and display combinations against the same validator. The 400 it asserted is covered by other cohort validation tests in the same file.

## How did you test this code?

No new tests. The value of this PR is the tests that stop counting as drivers.

Ran locally against a dev stack: the four affected classes in `test_sharing.py` and `test_cohort.py`, the whole of `test_sharing_access_token_security.py`, `TestQueryLLMFormatting`, the three edited cases in `test_dashboard.py`, and `TestCohortQueryValidation`.

Also ran `hogli product:lint --all` and the crossings repo-invariant tests, which pin the baseline against a fresh scan.

Not run: the rest of the backend suite, and anything the dev stack cannot reach.

One check is worth naming, because the fixture swap could have silently gutted two assertions. `get_alerts` returns `[]` when `Insight.alertable_query_kind` is `None`, so a non-alertable fixture would make both alert assertions pass without exercising anything. Both now use `HogQLQuery`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code in a PostHog cloud task. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The worklist came from running the crossings scanner's own passes over each file to get the exact counted sites, rather than grepping for the kind name. That mattered: `test_dashboard.py` mentions `TrendsQuery` ten times and only five count.

Two picks were reversed during the session. `CalendarHeatmapQuery` looked ideal for the filters-override fixture, since it carries both `series` and `dateRange`, until it turned out not to be in `QuerySchemaRoot`. And `EventsQuery` went into both alert fixtures before `alertable_query_kind` showed that would make the assertions vacuous.

The cohort breakdown fixture keeps its `InsightVizNode` envelope with no kind under `source`. The `used_in` predicate reads `source.breakdownFilter` by JSON path, no core-owned kind has that field, and putting `breakdownFilter` on an `EventsQuery` would be wrong rather than partial. `posthog/models/resource_transfer/test/test_visitors.py` already writes those fixtures the same way.

Public artifact: nothing here draws on anything outside this repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
