### PR TITLE
fix(error-tracking): index stack frames by team and created_at

### DIFF
--- a/products/error_tracking/backend/migrations/0030_add_stackframe_team_created_at_index.py
+++ b/products/error_tracking/backend/migrations/0030_add_stackframe_team_created_at_index.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("error_tracking", "0029_remove_symbolset_used_created_index"),
+    ]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="errortrackingstackframe",
+            index=models.Index(fields=["team", "created_at"], name="et_frame_team_created_at_idx"),
+        ),
+    ]

--- a/products/error_tracking/backend/migrations/max_migration.txt
+++ b/products/error_tracking/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0029_remove_symbolset_used_created_index
+0030_add_stackframe_team_created_at_index

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -613,7 +613,11 @@ class ErrorTrackingStackFrame(UUIDTModel):
     context = models.JSONField(null=True, blank=True)
 
     class Meta:
-        indexes = []
+        indexes = [
+            # Recent-frames-per-team scans, such as the source maps recommendation. Without
+            # created_at in the index, a 24h window has to visit every frame the team ever stored.
+            models.Index(fields=["team", "created_at"], name="et_frame_team_created_at_idx"),
+        ]
 
         constraints = [
             models.UniqueConstraint(fields=["team_id", "raw_id", "part"], name="unique_team_id_raw_id_part"),


### PR DESCRIPTION
## Problem

The source maps recommendation makes Postgres read a team's entire stack frame history to count the frames from the last 24 hours.

- `SourceMapsRecommendation.compute_batch` filters `ErrorTrackingStackFrame` by `team_id`, `created_at >= now - 24h`, and `contents->'lang'`.
- The table only has indexes on `team_id`, `(team_id, raw_id)`, and `(team_id, raw_id, part)`.
- The planner scans the `team_id` index and applies the `created_at` filter row by row, so every frame the team ever stored gets a heap fetch.
- Frames are wide jsonb rows scattered across the heap, so for large teams the query runs for seconds to minutes and is mostly disk reads.
- The hourly recommendations sweep runs this query for every team with recent exceptions, and the on-demand recommendations API runs the single-team variant.

The affected query, as the ORM emits it:

```sql
SELECT team_id,
       COUNT(id) AS total,
       COUNT(id) FILTER (WHERE NOT resolved) AS unresolved
FROM posthog_errortrackingstackframe
WHERE (contents -> 'lang') = '"javascript"'::jsonb
  AND created_at >= $1::timestamptz
  AND team_id IN ($2, $3, ...)
GROUP BY 1
```

Query statistics from pganalyze over the 24 hours before this PR:

| Region | Calls / day | Avg time | Avg I/O time | Buffer hit ratio | Slowest auto-explain samples |
| --- | --- | --- | --- | --- | --- |
| EU | 390 | 359 ms | 314 ms | 49% | no plans captured |
| US | 175 | 1.27 s | 1.19 s | 27% | 10 s to 228 s |

Every captured plan has the same shape:

```text
GroupAggregate
  -> Index Scan using posthog_errortrackingstackframe_team_id_d078a816
       Index Cond: (team_id = ANY ('{...}'))
       Filter: (created_at >= '...' AND (contents -> 'lang') = '"javascript"')
```

The 228 s sample covered a batch of three teams.

## Changes

- Adds a `(team_id, created_at)` btree index on `posthog_errortrackingstackframe`, so the 24h window becomes an index range per team.
- The migration uses `SafeAddIndexConcurrently`, so the build takes no lock that blocks reads or writes.
- Nothing user-visible changes; the recommendation and health check return the same numbers, faster.

## How did you test this code?

- `makemigrations --check` reports no drift and `sqlmigrate` emits `CREATE INDEX CONCURRENTLY` with `lock_timeout` and `statement_timeout` set to 0.
- `analyze_migration_risk` classifies the migration as Safe.
- Applied the migration on a local database and confirmed the index exists in `pg_indexes`.
- Ran `products/error_tracking/backend/tests/api/test_recommendations.py`; no tests added since an index does not change behavior.
- Not checked: query timing on a production-sized table. The plans above show `created_at` as a post-filter on the `team_id` index scan, which this index replaces with an index range.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) found the call site from a slow-query report, read the auto-explain plans and table statistics with the pganalyze MCP, and wrote the index and migration. Skills invoked: `/django-migrations`, `/writing-pr-descriptions`. Computing the counts in ClickHouse instead of Postgres was considered and left as a possible follow-up; the index is the smaller change and also fixes the on-demand API path.
