### PR TITLE
fix(posthog-ai): unblock non-admins at the AI consent gate

### DIFF
--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.test.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.test.tsx
@@ -3,6 +3,7 @@ import { MOCK_DEFAULT_ORGANIZATION } from 'lib/api.mock'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { BindLogic } from 'kea'
 
+import { OrganizationMembershipLevel } from 'lib/constants'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { organizationLogic } from 'scenes/organizationLogic'
 
@@ -28,6 +29,14 @@ describe('HomepageAiInput', () => {
         return container
     }
 
+    function setUpOrganization(membershipLevel: OrganizationMembershipLevel): void {
+        initKeaTests(true, undefined, undefined, {
+            ...MOCK_DEFAULT_ORGANIZATION,
+            is_ai_data_processing_approved: false,
+            membership_level: membershipLevel,
+        })
+    }
+
     beforeEach(() => {
         useMocks({
             patch: {
@@ -39,11 +48,11 @@ describe('HomepageAiInput', () => {
                     },
                 ],
             },
+            post: {
+                '/api/organizations/:id/request_ai_access/': () => [200, { success: true }],
+            },
         })
-        initKeaTests(true, undefined, undefined, {
-            ...MOCK_DEFAULT_ORGANIZATION,
-            is_ai_data_processing_approved: false,
-        })
+        setUpOrganization(OrganizationMembershipLevel.Admin)
     })
 
     it('approves AI data processing and swaps in the composer when the button is clicked', async () => {
@@ -55,5 +64,15 @@ describe('HomepageAiInput', () => {
             expect(organizationLogic.values.currentOrganization?.is_ai_data_processing_approved).toBe(true)
         )
         expect(container.querySelector('[data-attr="mock-question-input"]')).toBeTruthy()
+    })
+
+    it('lets a member ask an admin to approve, instead of dead-ending on the disabled reason', async () => {
+        setUpOrganization(OrganizationMembershipLevel.Member)
+        renderInput()
+
+        expect(screen.queryByText(APPROVE_LABEL)).toBeNull()
+        fireEvent.click(screen.getByText('Request access'))
+
+        await waitFor(() => expect(screen.getByText(/Request sent\./)).toBeTruthy())
     })
 })

--- a/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
+++ b/frontend/src/scenes/project-homepage/ai-first/HomepageInput.tsx
@@ -3,7 +3,7 @@ import { router } from 'kea-router'
 import posthog from 'posthog-js'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import { IconArrowRight, IconClock, IconInfo, IconLock, IconMicrophone, IconPin, IconStar } from '@posthog/icons'
+import { IconArrowRight, IconClock, IconInfo, IconMicrophone, IconPin, IconStar } from '@posthog/icons'
 import { LemonButton, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 
 import { Search } from 'lib/components/Search/Search'
@@ -27,6 +27,7 @@ import { HOMEPAGE_CAPABILITIES } from 'scenes/max/maxCapabilities'
 import { maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { MaxThreadLogicProps, maxThreadLogic } from 'scenes/max/maxThreadLogic'
+import { AIAccessRequest } from 'scenes/settings/organization/AIAccessRequest'
 import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
 import { userLogic } from 'scenes/userLogic'
 
@@ -208,8 +209,9 @@ export function HomepageAiInput(): JSX.Element {
         return (
             <div className="border border-primary rounded-lg bg-surface-primary p-4 flex flex-col gap-2">
                 <p className="font-medium text-pretty m-0">
-                    PostHog AI needs your approval to potentially process identifying user data with external AI
-                    providers.
+                    {isAdmin
+                        ? 'PostHog AI needs your approval to potentially process identifying user data with external AI providers.'
+                        : 'PostHog AI needs an organization admin to approve processing identifying user data with external AI providers.'}
                 </p>
                 <p className="text-muted text-xs m-0">Your data won't be used for training third-party models.</p>
                 {isAdmin ? (
@@ -228,9 +230,9 @@ export function HomepageAiInput(): JSX.Element {
                         I allow AI analysis in this organization
                     </LemonButton>
                 ) : (
-                    <LemonButton type="secondary" size="small" disabled sideIcon={<IconLock />}>
-                        {dataProcessingApprovalDisabledReason}
-                    </LemonButton>
+                    <div className="flex">
+                        <AIAccessRequest size="small" />
+                    </div>
                 )}
             </div>
         )

--- a/frontend/src/scenes/settings/organization/AIAccessRequest.tsx
+++ b/frontend/src/scenes/settings/organization/AIAccessRequest.tsx
@@ -1,0 +1,39 @@
+import { useActions, useValues } from 'kea'
+
+import { IconArrowRight, IconCheck } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { aiConsentLogic } from './aiConsentLogic'
+
+/**
+ * The path forward for a member who cannot approve AI data processing themselves: ask an
+ * organization admin to do it. Shared by every surface that gates on consent, so a non-admin gets
+ * the same working affordance wherever the gate appears.
+ */
+export function AIAccessRequest({ size = 'xsmall' }: { size?: 'xsmall' | 'small' }): JSX.Element {
+    const { requestingAiAccess, aiAccessRequested } = useValues(aiConsentLogic)
+    const { requestAiAccess } = useActions(aiConsentLogic)
+
+    // An inline confirmation rather than a spent button, so a repeat visit reads as "already asked".
+    if (aiAccessRequested) {
+        return (
+            <p className="flex items-start gap-1.5 m-0 text-xs text-muted">
+                <IconCheck className="shrink-0 mt-0.5 text-success" />
+                <span>Request sent. Your organization admins have been notified and can enable PostHog AI.</span>
+            </p>
+        )
+    }
+
+    return (
+        <LemonButton
+            data-attr="ai-access-request"
+            type="primary"
+            size={size}
+            onClick={() => requestAiAccess()}
+            loading={requestingAiAccess}
+            sideIcon={<IconArrowRight />}
+        >
+            Request access
+        </LemonButton>
+    )
+}

--- a/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
+++ b/frontend/src/scenes/settings/organization/AIConsentPopoverWrapper.tsx
@@ -1,11 +1,12 @@
 import { useActions, useAsyncActions, useValues } from 'kea'
 import { useCallback } from 'react'
 
-import { IconArrowRight, IconCheck, IconLock } from '@posthog/icons'
+import { IconArrowRight, IconLock } from '@posthog/icons'
 import { LemonButton, Popover, PopoverProps, Tooltip } from '@posthog/lemon-ui'
 
 import { organizationLogic } from 'scenes/organizationLogic'
 
+import { AIAccessRequest } from './AIAccessRequest'
 import { getExternalAIProvidersTooltipTitle, openAIConsentLegalDialog } from './aiConsentCopy'
 import { aiConsentLogic } from './aiConsentLogic'
 
@@ -57,9 +58,6 @@ export function AIConsentPopoverContent({
 }
 
 function AIAccessRequestPopoverContent(): JSX.Element {
-    const { requestingAiAccess, aiAccessRequested } = useValues(aiConsentLogic)
-    const { requestAiAccess } = useActions(aiConsentLogic)
-
     return (
         <div className="flex flex-col gap-2 m-1.5 max-w-prose">
             <p className="font-medium text-pretty">
@@ -67,17 +65,7 @@ function AIAccessRequestPopoverContent(): JSX.Element {
                 organization owner or admin.
             </p>
             <div className="flex self-end">
-                <LemonButton
-                    data-attr="ai-access-request"
-                    type="primary"
-                    size="xsmall"
-                    onClick={() => requestAiAccess()}
-                    loading={requestingAiAccess}
-                    disabledReason={aiAccessRequested ? 'Your request has been sent' : undefined}
-                    sideIcon={aiAccessRequested ? <IconCheck /> : <IconArrowRight />}
-                >
-                    {aiAccessRequested ? 'Request sent' : 'Request access'}
-                </LemonButton>
+                <AIAccessRequest />
             </div>
         </div>
     )

--- a/frontend/src/scenes/settings/organization/aiConsentLogic.ts
+++ b/frontend/src/scenes/settings/organization/aiConsentLogic.ts
@@ -1,5 +1,6 @@
 import { MakeLogicType, actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { LOOKAHEAD_EXPIRY_SECONDS } from 'lib/components/TimeSensitiveAuthentication/timeSensitiveAuthenticationLogic'
 import { OrganizationMembershipLevel } from 'lib/constants'
@@ -135,6 +136,9 @@ export const aiConsentLogic = kea<aiConsentLogicType>([
     }),
     listeners(({ actions, values }) => ({
         acceptDataProcessing: async ({ testOnlyOverride, resumeUrl }) => {
+            // Attempt and outcome are captured separately so a gate that accepts clicks but never
+            // approves shows up as a gap between the two, rather than only in a session recording.
+            posthog.capture('ai_consent_approval_submitted', { is_resumed: !!resumeUrl })
             try {
                 await organizationLogic.asyncActions.updateOrganization({
                     is_ai_data_processing_approved: testOnlyOverride ?? true,
@@ -142,9 +146,11 @@ export const aiConsentLogic = kea<aiConsentLogicType>([
             } catch (error) {
                 // A real failure (a lost SSO redirect unloads the page instead of rejecting).
                 actions.setPendingApprovalRedirect(null)
+                posthog.capture('ai_consent_approval_failed')
                 throw error
             }
             actions.setPendingApprovalRedirect(null)
+            posthog.capture('ai_consent_approved')
             lemonToast.success('AI data processing approved')
             if (resumeUrl) {
                 router.actions.push(resumeUrl)
@@ -156,14 +162,17 @@ export const aiConsentLogic = kea<aiConsentLogicType>([
                 actions.requestAiAccessError()
                 return
             }
+            posthog.capture('ai_access_request_submitted')
             try {
                 // Backend notifies the org admins/owners via a customer.io email — keeps the
                 // recipient resolution server-side so it can't be tampered with from the client.
                 await requestAiAccessCreate(organization.id)
                 actions.markAiAccessRequested(organization.id)
+                posthog.capture('ai_access_requested')
                 lemonToast.success('Request sent to your organization admins')
             } catch {
                 actions.requestAiAccessError()
+                posthog.capture('ai_access_request_failed')
                 lemonToast.error('Could not send your request. Please try again.')
             }
         },

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -479,11 +479,12 @@ function EditorFooter({
     const { scanner, durationValidationError, hasUnsavedChanges } = useValues(replayScannerLogic({ id: scannerId }))
     const { searchParams } = useValues(router)
     const { discardScannerDraft } = useActions(replayScannerLogic({ id: scannerId }))
-    const { dataProcessingAccepted } = useValues(aiConsentLogic)
+    const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(aiConsentLogic)
     const [consentRequested, setConsentRequested] = useState(false)
     // The backend rejects scanner creation without org AI consent, so the popover interposes at
     // Save instead of letting the request 400.
     const needsConsent = isNew && !dataProcessingAccepted
+    const canApproveConsent = !dataProcessingApprovalDisabledReason
     const stepIndex = SCANNER_EDITOR_STEPS.indexOf(step)
     const previous = stepIndex > 0 ? SCANNER_EDITOR_STEPS[stepIndex - 1] : null
     const prevStep = previous === 'template' && !isNew ? null : previous
@@ -594,7 +595,9 @@ function EditorFooter({
                                     data-ph-capture-attribute-scanner-type={scanner?.scanner_type}
                                 >
                                     {needsConsent
-                                        ? 'Allow AI analysis and create scanner'
+                                        ? canApproveConsent
+                                            ? 'Allow AI analysis and create scanner'
+                                            : 'Ask an admin to enable AI analysis'
                                         : isNew
                                           ? 'Create scanner'
                                           : 'Save changes'}

--- a/products/replay_vision/frontend/replay_scanners/components/CreateScannerButton.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/CreateScannerButton.tsx
@@ -25,21 +25,30 @@ export function CreateScannerButton({
     dataAttr: string
     size?: 'small' | 'medium'
 }): JSX.Element {
-    const { dataProcessingAccepted } = useValues(aiConsentLogic)
+    const { dataProcessingAccepted, dataProcessingApprovalDisabledReason } = useValues(aiConsentLogic)
     const { push } = useActions(router)
     const [consentRequested, setConsentRequested] = useState(false)
     const goToCreate = (): void => push(urls.replayVisionTemplates())
+
+    // A member cannot allow anything, so don't label the CTA as if they can. Clicking still opens
+    // the popover, where their actual next step is to ask an admin.
+    const canApproveConsent = !dataProcessingApprovalDisabledReason
+    const label = dataProcessingAccepted
+        ? acceptedLabel
+        : canApproveConsent
+          ? 'Allow AI analysis and create scanner'
+          : 'Ask an admin to enable AI analysis'
 
     const button = (
         <LemonButton
             type="primary"
             size={size}
-            icon={<IconPlus />}
+            icon={dataProcessingAccepted || canApproveConsent ? <IconPlus /> : undefined}
             disabledReason={getReplayVisionEditDisabledReason()}
             data-attr={dataAttr}
             onClick={() => (dataProcessingAccepted ? goToCreate() : setConsentRequested(true))}
         >
-            {dataProcessingAccepted ? acceptedLabel : 'Allow AI analysis and create scanner'}
+            {label}
         </LemonButton>
     )
 


### PR DESCRIPTION
## Problem

A member who cannot approve AI data processing had no way forward at the consent gate, on any surface.

- On the AI-first homepage (`/home?mode=ai`), the non-admin branch rendered the disabled reason *as the button label* — "Ask an admin or owner of <org> to approve this" — on a `disabled` button with no click handler. It looks like a call to action and does nothing. Session data shows members clicking it, clicking the banner copy underneath, then leaving.
- Replay Vision offered a fully enabled primary CTA reading "Allow AI analysis and create scanner" to someone who cannot allow anything. Its only `disabledReason` was the product access-control check.
- The consent flow carried no `posthog.capture` at all, so neither dead end was visible as a metric. Both surfaced only because a replay scanner watched people struggle.

The gate fronts PostHog AI across several surfaces, so a member stuck here is blocked from the whole product, and the admin who could unblock them is never asked.

## Changes

- A member on the homepage banner now gets a working "Request access" button instead of a dead grey one, and the banner copy tells them an admin has to approve rather than implying they can.
- A member who has already requested access reads an inline "Request sent" confirmation naming who was notified, instead of a permanently disabled button.
- Replay Vision's create-scanner CTAs now read "Ask an admin to enable AI analysis" for a member who cannot consent. Clicking still opens the popover, where requesting access is the actual next step.
- Consent approvals and access requests now emit events (`ai_consent_approval_submitted`, `ai_consent_approved`, `ai_access_request_submitted`, `ai_access_requested`, plus failure counterparts), so the next regression here shows up in a dashboard.
- Mechanical: the popover's request-access affordance moves into a shared `AIAccessRequest` component that both it and the homepage banner use. Hand-rolling a second copy of this CTA is what let the two surfaces drift apart.

No screenshots — this sandbox could not build the nested `@posthog/quill` workspace that the app's styles import, so the affected surfaces were not rendered.

## How did you test this code?

Automated, in this sandbox:

- Extended `HomepageInput.test.tsx` with a member-level case. It catches the regression that shipped: if the non-admin branch goes back to a `disabled` button, the member has no way to reach an admin. Verified it fails against the pre-fix component and passes after.
- Re-ran `HomepageInput.test.tsx`, `aiConsentLogic.test.ts`, and `scannerEditorSceneLogic.test.ts`.
- `oxlint` + `oxfmt` clean. `tsgo --noEmit` reports no errors in the touched files; the repo-wide run has pre-existing failures from the unbuilt quill/hogvm workspaces.
- `hogli ci:preflight --strict`: 0 failures.

Not checked: no manual browser testing, and no visual verification of either surface.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude) from a Slack thread asking what happened to a signals report's implementation phase. The report's headline defect — a `TypeError` on the homepage consent button — was fixed separately in #83646. Investigating turned up that the three defects above were still on master: they were the parts the report flagged as untouched by any open PR, and its implementation phase never opened one because it had deferred to PRs that later closed unmerged.

Repo skills read while producing this: `/writing-tests` (gated the new test case), plus the frontend guides in `frontend/src/CLAUDE.md` and `.cursor/rules/react-typescript.mdc`. Two design calls worth flagging for review: the Replay Vision CTA stays clickable rather than becoming disabled, because the popover behind it is genuinely actionable for a member; and the "already requested" state became inline text rather than a disabled button, since a disabled control is what dead-ended people in the first place.

No customer data, session contents, or internal metrics are in this diff or description.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788253674792869)*
