### PR TITLE
fix(cli): hash the injected snippet variant in event mode

### DIFF
--- a/cli/.sampo/changesets/event-mode-hash-snippet-variant.md
+++ b/cli/.sampo/changesets/event-mode-hash-snippet-variant.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Fix `--release-mode event` keeping a stale source map for a chunk that gains a release. The content hash ignored which snippet the chunk carried. The release snippet is longer than the chunk-id snippet, so it shifts the generated columns the uploaded map records. The two uploads therefore shared one hash, the server kept the first map, and later frames resolved to the wrong source positions. The hash now covers the snippet variant. It still ignores the release id itself, so a new release does not re-upload every chunk.

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -396,6 +396,14 @@ impl MinifiedSourceFile {
         None
     }
 
+    /// Whether the snippet injected for `chunk_id` carries a release id.
+    ///
+    /// The two snippet variants have different lengths, so the choice shifts every generated
+    /// column the sourcemap records for the injected chunk.
+    pub fn has_release_snippet(&self, chunk_id: &str) -> bool {
+        find_release_snippet(&self.inner.content, chunk_id).is_some()
+    }
+
     pub fn remove_chunk_id(&mut self, chunk_id: String) -> Result<SourceMap> {
         let (new_source_content, source_adjustment) = {
             // Update source content with chunk ID

--- a/cli/src/sourcemaps/source_pairs.rs
+++ b/cli/src/sourcemaps/source_pairs.rs
@@ -148,12 +148,16 @@ impl SourcePair {
     /// only the content hash depends on the mode.
     ///
     /// In event mode the hash is computed over the pair with the injection undone (snippet and
-    /// chunk-id comment removed, sourcemap adjustment reversed), because the injected bytes vary
-    /// while the chunk id does not: the embedded release id changes every release, and a chunk
-    /// injected before a release could be resolved carries a shorter snippet (and a differently
-    /// adjusted sourcemap) than the same chunk after a later run adds the release. The server
-    /// keys its skip-or-conflict decision on this hash per chunk id, so any injection-state
-    /// dependence turns an unchanged chunk into a `content_hash_mismatch` rejection.
+    /// chunk-id comment removed, sourcemap adjustment reversed), because the embedded release id
+    /// changes every release while the chunk id does not. The server keys its skip-or-conflict
+    /// decision on this hash per chunk id, so hashing the embedded id would re-upload every chunk
+    /// on every release.
+    ///
+    /// The hash does cover which snippet variant is embedded. The release variant is longer, so it
+    /// shifts every generated column in the uploaded sourcemap. Two builds of one unchanged chunk,
+    /// one before a release could be resolved and one after, therefore ship different maps. Equal
+    /// hashes would make the server keep the first map and resolve later frames to the wrong
+    /// source positions.
     ///
     /// In symbol-set mode no hash is set and the upload layer hashes the raw payload, matching
     /// the hashes the server already stores for previous uploads.
@@ -167,6 +171,12 @@ impl SourcePair {
 
         let content_hash = match release_mode {
             ReleaseMode::Event => {
+                // Read the variant before the removal, which erases the evidence.
+                let snippet_variant: &[u8] = if self.source.has_release_snippet(&chunk_id) {
+                    b"with-release"
+                } else {
+                    b"chunk-id-only"
+                };
                 self.remove_chunk_id(chunk_id.clone())?;
                 let pristine_map = serde_json::to_string(&self.sourcemap.inner.content)?;
                 // JSON serialization never contains a raw NUL, so it unambiguously separates
@@ -175,6 +185,8 @@ impl SourcePair {
                     self.source.inner.content.as_bytes(),
                     b"\0".as_slice(),
                     pristine_map.as_bytes(),
+                    b"\0".as_slice(),
+                    snippet_variant,
                 ]))
             }
             ReleaseMode::SymbolSet => None,

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -472,11 +472,11 @@ fn test_upload_set() {
 }
 
 #[test]
-fn test_event_mode_content_hash_is_stable_across_release_states() {
-    // The hash must not depend on which snippet variant is embedded. A chunk injected while
-    // no release was resolvable, the same chunk injected with a release, and the transition
-    // between the two all keep one chunk id, so they must hash identically or the server
-    // rejects the later upload as a content_hash_mismatch.
+fn test_event_mode_content_hash_tracks_the_snippet_variant() {
+    // The hash must ignore which release id is embedded, or every release re-uploads every
+    // chunk. It must still track whether a release id is embedded at all: the release snippet is
+    // longer, so it shifts the generated columns the uploaded map records. Equal hashes there
+    // make the server keep the first map and resolve later frames to the wrong positions.
     let case_path = get_case_path("inject");
     let load = || {
         read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs")
@@ -505,8 +505,14 @@ fn test_event_mode_content_hash_is_stable_across_release_states() {
         )
     };
 
-    assert_eq!(releaseless, with_release);
-    assert_eq!(releaseless, transitioned);
+    assert_ne!(
+        releaseless, with_release,
+        "a chunk that gains a release ships a different map, so it must not reuse the stored one"
+    );
+    assert_eq!(
+        with_release, transitioned,
+        "a different release id leaves the map identical, so the hash must not change"
+    );
 }
 
 const BUNDLER_DEBUG_ID: &str = "11111111-2222-4333-8444-555555555555";


### PR DESCRIPTION
Merge this before PostHog/posthog#91823, which makes event mode the default.

## Problem

- The event mode content hash ignores which snippet a chunk carries.
- The release snippet is longer than the chunk-id snippet. It shifts the generated columns in the map.
- Two builds of one chunk can therefore share a hash and ship different maps.
- The server keeps the first map. Frames then resolve to wrong source positions.

## Changes

- The event mode content hash now covers which snippet the chunk carries.
- The hash still ignores the release id, so a new release does not re-upload every chunk.

## How did you test this code?

- `cargo test` in `cli/`.
- `test_event_mode_content_hash_tracks_the_snippet_variant` covers both directions. It fails against the previous hash.
- I measured the hash on a real esbuild bundle from `error-tracking-examples/web-raw`. The old code returns one hash for both snippet variants. The new code returns two.
- I ran `sourcemap process` against a local PostHog with both binaries. Both uploaded the second build. That run does not separate them, so it is evidence of no regression rather than evidence of the fix.
- Not run: an upload against PostHog Cloud.

<details>
<summary>Hash measured on the esbuild bundle</summary>

Same pristine `index.js` and `index.js.map`, injected twice.

```
# old code
PROBE releaseless     = 7687592a09eea292e2fb51636992edce9d9101eeb6a004a94b24288f45281b064de4c38b74c538c0058f0d3ca6fb849dd65ced17957453f9cadcf2e2fde7fbfa
PROBE with_release    = 7687592a09eea292e2fb51636992edce9d9101eeb6a004a94b24288f45281b064de4c38b74c538c0058f0d3ca6fb849dd65ced17957453f9cadcf2e2fde7fbfa
PROBE variant_differs = false

# new code
PROBE releaseless      = 849e71e009f6727739a5ba7bd6226bc0dd34bf826f4eff52fe45ce084435cfecc275a77b628c4e46dd001f63fe9535c0703630573da6b42e00aec4736f5bb2c8
PROBE with_release     = 5d69732f9e61fea62b9e02eb9b1354fdd6c7c4b347a1a92ca6e70831d07d69538d7571e531e94b0721e492cbcc0a5e8f93d096496d02d8562d29f20776df054c
PROBE other_release    = 5d69732f9e61fea62b9e02eb9b1354fdd6c7c4b347a1a92ca6e70831d07d69538d7571e531e94b0721e492cbcc0a5e8f93d096496d02d8562d29f20776df054c
PROBE variant_differs  = true
PROBE uuid_stable      = true
```

`uuid_stable` is the property the hash has to keep. A second release id leaves the map identical, so the hash must not move.

</details>

<details>
<summary>posthog-cli sourcemap process against a local PostHog</summary>

One chunk, uploaded three times. Step 2 repeats step 1 and confirms the server stores and compares the hash.

```
# old binary
s1 unfixed, no release (first upload):
  INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
s2 unfixed, no release again (control):
  INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 1 skipped (1 already present, 0 too large)
s3 unfixed, same code WITH release:
  INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)

# new binary
s1 fixed, no release (first upload):
  INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
s2 fixed, no release again (control):
  INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 1 skipped (1 already present, 0 too large)
s3 fixed, same code WITH release:
  INFO posthog_cli::api::symbol_sets: Upload summary: 1 chunk(s) uploaded, 0 skipped (0 already present, 0 too large)
```

Both binaries upload at s3. Through `sourcemap process` the restored map already differs between the two variants, which separates the hashes without this change. The collision needs the restored map to match, which the measurement above shows it does.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-pr-descriptions`.

A review on PostHog/posthog#91823 reported this. The test named above asserted the old behavior, so this PR changes what it claims.

The end-to-end run does not reproduce the stale map. The fix makes the hash depend on the snippet variant by construction, rather than through a difference in the restored map that happens to fall the right way.
