### PR TITLE
chore(ci): skip Desktop cloud commits in email nudge

### DIFF
--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -169,6 +169,17 @@ jobs:
                           if (c.author?.login !== author) {
                               continue;
                           }
+                          const messageLines = (c.commit?.message || '').split(/\r?\n/).map((line) => line.trim());
+                          const isDesktopCloudCommit =
+                              c.committer?.login === 'web-flow' &&
+                              (c.commit?.committer?.email || '').toLowerCase() === 'noreply@github.com' &&
+                              c.commit?.verification?.verified === true &&
+                              messageLines.includes('Generated-By: PostHog Desktop') &&
+                              messageLines.some((line) => /^Task-Id:\s+\S+$/.test(line));
+                          if (isDesktopCloudCommit) {
+                              console.log(`Skipping PostHog Desktop cloud commit ${c.sha}.`);
+                              continue;
+                          }
                           const email = (c.commit?.author?.email || '').toLowerCase();
                           // Skip GitHub noreply addresses (`id+user@users.noreply.github.com`):
                           // the commit stays attributable to a real account, and it's a
@@ -183,7 +194,7 @@ jobs:
                       }
 
                       if (offendingEmails.size === 0) {
-                          console.log('All author commits use a @posthog.com email — nothing to nudge.');
+                          console.log('No actionable non-PostHog author emails found — nothing to nudge.');
                           return;
                       }
 


### PR DESCRIPTION
## Problem

Git email nudge is annoying.

## Changes

- Desktop cloud commits now bypass the nudge when GitHub and Desktop metadata identify the signed task commit

Before:

```mermaid
flowchart LR
    A[Employee opens PR] --> B{PostHog author email?}
    B -->|Yes| C[Stay quiet]
    B -->|No| D[Post nudge]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phBlue;
    class C,D phGray;
```

After:

```mermaid
flowchart LR
    A[Employee opens PR] --> B{Desktop cloud commit?}
    B -->|Yes| C[Stay quiet]
    B -->|No| D{PostHog author email?}
    D -->|Yes| C
    D -->|No| E[Post nudge]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,D phBlue;
    class C,E phGray;
```

