### PR TITLE
chore(logs): pin every pattern shape input to PATTERN_VERSION

### DIFF
--- a/nodejs/src/logs/config.ts
+++ b/nodejs/src/logs/config.ts
@@ -14,9 +14,6 @@ import { isProdEnv } from '~/common/utils/env-utils'
 
 import { LogsProducerName, WARPSTREAM_INGESTION_PRODUCER, WARPSTREAM_LOGS_PRODUCER } from './outputs/producers'
 
-export const DEFAULT_PATTERN_MAX_INPUT_CHARS = 8192
-export const DEFAULT_PATTERN_MAX_OUTPUT_CHARS = 1024
-
 export type LogsIngestionOutputsConfig = {
     LOGS_INGESTION_OUTPUT_APP_METRICS_TOPIC: string
     LOGS_INGESTION_OUTPUT_APP_METRICS_PRODUCER: LogsProducerName
@@ -70,10 +67,6 @@ export type LogsIngestionConsumerConfig = {
     LOGS_RETENTION_KILLSWITCH: boolean
     /** Comma-separated team IDs, or `*` for all teams, or empty (default) to disable measure-only pattern masking. */
     LOGS_PATTERN_MASKING_ENABLED_TEAMS: string
-    /** Ceiling on body chars fed to the pattern masker; longer bodies are cut first (CPU guard). */
-    LOGS_PATTERN_MASKING_MAX_INPUT_CHARS: number
-    /** Truncation applied to the masked pattern, after masking (so more real content survives the cut). */
-    LOGS_PATTERN_MASKING_MAX_OUTPUT_CHARS: number
     /**
      * When `true`, rows removed by drop rules are credited back to the billed usage metrics
      * (`bytes_ingested` / `records_ingested`). When `false` (default), the credit is only
@@ -127,8 +120,6 @@ export function getDefaultLogsIngestionConsumerConfig(): LogsIngestionConsumerCo
         LOGS_RETENTION_KILLSWITCH: false,
         // Off by default: enabling forces decode+re-encode for allowlisted teams.
         LOGS_PATTERN_MASKING_ENABLED_TEAMS: '',
-        LOGS_PATTERN_MASKING_MAX_INPUT_CHARS: DEFAULT_PATTERN_MAX_INPUT_CHARS,
-        LOGS_PATTERN_MASKING_MAX_OUTPUT_CHARS: DEFAULT_PATTERN_MAX_OUTPUT_CHARS,
         LOGS_BILLING_PRORATE_ENABLED: false,
         LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '',
         LOGS_TRANSFORMATIONS_KILLSWITCH: false,

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -1,9 +1,17 @@
 import { createHash } from 'node:crypto'
 import RE2 from 're2'
 
-import { JSON_ARRAY, MASK_RULES, PATTERN_VERSION, computeLogPattern, maskString } from './log-pattern-mask'
+import {
+    JSON_ARRAY,
+    MASK_RULES,
+    PATTERN_CAPS,
+    PATTERN_VERSION,
+    type PatternCaps,
+    computeLogPattern,
+    maskString,
+} from './log-pattern-mask'
 
-const NO_CAP = 100_000
+const caps = (overrides: Partial<PatternCaps>): PatternCaps => ({ ...PATTERN_CAPS, ...overrides })
 
 describe('log-pattern-mask', () => {
     describe('maskString', () => {
@@ -116,26 +124,26 @@ describe('log-pattern-mask', () => {
     describe('computeLogPattern', () => {
         it('masks before truncating, so a UUID straddling the cut point still yields its placeholder', () => {
             const body = 'abcdefghij 0f2d6faf-07e3-4cff-bf47-7efa1024aee2'
-            const result = computeLogPattern(body, NO_CAP, 20)
+            const result = computeLogPattern(body, caps({ maxOutputChars: 20 }))
             expect(result.pattern).toEqual('abcdefghij <UUID>')
             expect(result.maskedLength).toEqual('abcdefghij <UUID>'.length)
         })
 
         it('reports the pre-truncation masked length and truncates the pattern', () => {
-            const result = computeLogPattern('x'.repeat(50), NO_CAP, 10)
+            const result = computeLogPattern('x'.repeat(50), caps({ maxOutputChars: 10 }))
             expect(result.pattern).toEqual('x'.repeat(10))
             expect(result.maskedLength).toEqual(50)
         })
 
         it('caps the input before masking and reports it', () => {
-            const result = computeLogPattern('abc 12345678', 6, NO_CAP)
+            const result = computeLogPattern('abc 12345678', caps({ maxInputChars: 6 }))
             expect(result.inputCapped).toEqual(true)
             expect(result.pattern).toEqual('abc <N>')
         })
 
         it('caps the raw body before the JSON parse, so an oversized JSON body is treated as truncated prose', () => {
             const body = JSON.stringify({ message: 'x'.repeat(100) })
-            const result = computeLogPattern(body, 20, NO_CAP)
+            const result = computeLogPattern(body, caps({ maxInputChars: 20 }))
             expect(result.inputCapped).toEqual(true)
             expect(result.bodyKind).toEqual('plaintext')
             expect(result.pattern).toEqual(body.slice(0, 20))
@@ -159,13 +167,13 @@ describe('log-pattern-mask', () => {
             ['json number primitive', '42', 'primitive', '<N>'],
             ['prose body', 'plain text 3', 'plaintext', 'plain text <N>'],
         ])('body kind %s', (_name, body, expectedKind, expectedPattern) => {
-            const result = computeLogPattern(body, NO_CAP, NO_CAP)
+            const result = computeLogPattern(body)
             expect(result.bodyKind).toEqual(expectedKind)
             expect(result.pattern).toEqual(expectedPattern)
         })
 
         describe('key-set identity for message-less JSON objects', () => {
-            const patternOf = (body: string): string => computeLogPattern(body, NO_CAP, NO_CAP).pattern
+            const patternOf = (body: string): string => computeLogPattern(body).pattern
 
             it('is independent of source key order', () => {
                 expect(patternOf('{"b":1,"a":2}')).toEqual('<JSON:a,b>')
@@ -179,13 +187,13 @@ describe('log-pattern-mask', () => {
                 const expected = `<JSON:${keys.slice(0, 32).join(',')},+8>`
                 expect(patternOf(forward)).toEqual(expected)
                 expect(patternOf(reversed)).toEqual(expected)
-                expect(computeLogPattern(forward, NO_CAP, NO_CAP).jsonKeyCount).toEqual(40)
+                expect(computeLogPattern(forward).jsonKeyCount).toEqual(40)
             })
 
             it('reports the key count only for key-set patterns', () => {
-                expect(computeLogPattern('{"a":1}', NO_CAP, NO_CAP).jsonKeyCount).toEqual(1)
-                expect(computeLogPattern('[1,2]', NO_CAP, NO_CAP).jsonKeyCount).toBeUndefined()
-                expect(computeLogPattern('{"message":"hi"}', NO_CAP, NO_CAP).jsonKeyCount).toBeUndefined()
+                expect(computeLogPattern('{"a":1}').jsonKeyCount).toEqual(1)
+                expect(computeLogPattern('[1,2]').jsonKeyCount).toBeUndefined()
+                expect(computeLogPattern('{"message":"hi"}').jsonKeyCount).toBeUndefined()
             })
 
             it('renders an empty object as an empty key set', () => {
@@ -205,12 +213,63 @@ describe('log-pattern-mask', () => {
     })
 
     describe('PATTERN_VERSION ratchet', () => {
-        it('moves whenever MASK_RULES changes', () => {
-            const digest = createHash('sha256')
-                .update(MASK_RULES.map((rule) => `${rule.name}\0${rule.pattern}\0${rule.replacement}`).join('\x01'))
+        /**
+         * Bodies chosen to reach every branch that decides a pattern's shape: each mask rule, the
+         * message keys, the key-set and array forms, both caps, and the order of parse and cap.
+         */
+        const CORPUS: (string | null)[] = [
+            null,
+            '',
+            'started at 2026-08-24T10:20:45.123Z ok',
+            'I0827 11:39:40.307946 1 proxier.go:1484] reloading',
+            'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 took 7141ms',
+            'mail ops@example.com via api.example.com at 10.0.0.7 slot 0xdeadbeef',
+            '{"message":"user 5 logged in","level":"info"}',
+            '{"msg":"served 3 requests"}',
+            '{"level":"info","count":3}',
+            '[1,2,3]',
+            '"a bare json string with 4 words"',
+            'true',
+            'x'.repeat(PATTERN_CAPS.maxInputChars + 10),
+            JSON.stringify({ msg: 'discovered 3 peers', pad: 'y'.repeat(PATTERN_CAPS.maxInputChars) }),
+            `head ${'z'.repeat(PATTERN_CAPS.maxOutputChars)} tail`,
+        ]
+
+        /**
+         * One frozen digest per version, never edited in place. Editing an entry rewrites the shape of
+         * rows already in ClickHouse under that version, so the only correct fix for a red digest is a
+         * new entry under a new `PATTERN_VERSION`.
+         *
+         * Versions before 3 predate this ratchet, so no digest was recorded for them.
+         */
+        const SHAPE_DIGESTS: Record<number, string> = {
+            3: '1dfc6aa769551bae',
+        }
+
+        const shapeDigest = (): string =>
+            createHash('sha256')
+                .update(CORPUS.map((body) => computeLogPattern(body).pattern).join('\x01'))
                 .digest('hex')
                 .slice(0, 16)
-            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 3, digest: '599889a916d04e14' })
+
+        it('pins the emitted patterns to the current version', () => {
+            // Hashing emitted patterns rather than the rules that make them is what makes this a gate:
+            // MASK_RULES, PATTERN_CAPS, MESSAGE_KEYS, the key-set form, and the order of parse and cap
+            // all move the digest. Do not edit the entry for the current version to make this pass.
+            expect({ [PATTERN_VERSION]: shapeDigest() }).toEqual({ [PATTERN_VERSION]: SHAPE_DIGESTS[PATTERN_VERSION] })
+        })
+
+        it('carries a digest for every version since the ratchet, so a bump cannot drop its predecessor', () => {
+            const recorded = Object.keys(SHAPE_DIGESTS)
+                .map(Number)
+                .sort((left, right) => left - right)
+            const expected = Array.from({ length: PATTERN_VERSION - 2 }, (_unused, index) => index + 3)
+            expect(recorded).toEqual(expected)
+        })
+
+        it('never reuses a digest across versions, so a bump without a shape change is caught', () => {
+            const digests = Object.values(SHAPE_DIGESTS)
+            expect(new Set(digests).size).toEqual(digests.length)
         })
     })
 

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -3,16 +3,14 @@ import RE2 from 're2'
 
 import {
     JSON_ARRAY,
+    KEY_SET_MAX_KEYS,
     MASK_RULES,
     MESSAGE_KEYS,
     PATTERN_CAPS,
     PATTERN_VERSION,
-    type PatternCaps,
     computeLogPattern,
     maskString,
 } from './log-pattern-mask'
-
-const caps = (overrides: Partial<PatternCaps>): PatternCaps => ({ ...PATTERN_CAPS, ...overrides })
 
 describe('log-pattern-mask', () => {
     describe('maskString', () => {
@@ -124,30 +122,37 @@ describe('log-pattern-mask', () => {
 
     describe('computeLogPattern', () => {
         it('masks before truncating, so a UUID straddling the cut point still yields its placeholder', () => {
-            const body = 'abcdefghij 0f2d6faf-07e3-4cff-bf47-7efa1024aee2'
-            const result = computeLogPattern(body, caps({ maxOutputChars: 20 }))
-            expect(result.pattern).toEqual('abcdefghij <UUID>')
-            expect(result.maskedLength).toEqual('abcdefghij <UUID>'.length)
+            // Long enough that the raw UUID crosses the output cap, short enough that `<UUID>` does not.
+            // Filled with a non-hex letter, or the run itself masks to `<HEX>`.
+            const head = 'z'.repeat(PATTERN_CAPS.maxOutputChars - 24)
+            const body = `${head} 0f2d6faf-07e3-4cff-bf47-7efa1024aee2`
+            expect(body.length).toBeGreaterThan(PATTERN_CAPS.maxOutputChars)
+
+            const result = computeLogPattern(body)
+            expect(result.pattern).toEqual(`${head} <UUID>`)
+            expect(result.maskedLength).toEqual(`${head} <UUID>`.length)
         })
 
         it('reports the pre-truncation masked length and truncates the pattern', () => {
-            const result = computeLogPattern('x'.repeat(50), caps({ maxOutputChars: 10 }))
-            expect(result.pattern).toEqual('x'.repeat(10))
-            expect(result.maskedLength).toEqual(50)
+            const result = computeLogPattern('x'.repeat(PATTERN_CAPS.maxOutputChars * 2))
+            expect(result.pattern).toEqual('x'.repeat(PATTERN_CAPS.maxOutputChars))
+            expect(result.maskedLength).toEqual(PATTERN_CAPS.maxOutputChars * 2)
         })
 
         it('caps the input before masking and reports it', () => {
-            const result = computeLogPattern('abc 12345678', caps({ maxInputChars: 6 }))
+            const result = computeLogPattern(`${'z'.repeat(PATTERN_CAPS.maxInputChars)} 12345678`)
             expect(result.inputCapped).toEqual(true)
-            expect(result.pattern).toEqual('abc <N>')
+            // The number sat past the input cap, so no rule ever saw it.
+            expect(result.maskedLength).toEqual(PATTERN_CAPS.maxInputChars)
+            expect(result.ruleFires.every((fires) => fires === 0)).toEqual(true)
         })
 
         it('caps the raw body before the JSON parse, so an oversized JSON body is treated as truncated prose', () => {
-            const body = JSON.stringify({ message: 'x'.repeat(100) })
-            const result = computeLogPattern(body, caps({ maxInputChars: 20 }))
+            const body = JSON.stringify({ message: 'x'.repeat(PATTERN_CAPS.maxInputChars) })
+            const result = computeLogPattern(body)
             expect(result.inputCapped).toEqual(true)
             expect(result.bodyKind).toEqual('plaintext')
-            expect(result.pattern).toEqual(body.slice(0, 20))
+            expect(result.pattern).toEqual(body.slice(0, PATTERN_CAPS.maxOutputChars))
         })
 
         it.each([
@@ -250,12 +255,13 @@ describe('log-pattern-mask', () => {
          * One frozen digest per version. A red digest means the emitted shape moved, and the only correct
          * fix is a new entry under a new `PATTERN_VERSION` — editing an entry in place relabels rows
          * already in ClickHouse under that version. The one exception is growing `CORPUS`, which moves the
-         * digest without moving the shape; re-record only in a commit that touches nothing but the corpus.
+         * digest without moving the shape. Growing `SHAPE_INPUTS` does the same. Re-record for either only
+         * in a commit that moves no emitted pattern, and say so in the message.
          *
          * Versions before `RATCHET_FIRST_VERSION` predate this ratchet, so no digest was recorded for them.
          */
         const SHAPE_DIGESTS: Record<number, string> = {
-            3: 'ed312a5324f9f760',
+            3: '5e6a9ab3f22b15ea',
         }
 
         /**
@@ -271,6 +277,8 @@ describe('log-pattern-mask', () => {
             rules: MASK_RULES.map((rule) => [rule.name, rule.pattern, rule.replacement]),
             caps: PATTERN_CAPS,
             messageKeys: MESSAGE_KEYS,
+            keySetMaxKeys: KEY_SET_MAX_KEYS,
+            jsonArray: JSON_ARRAY,
         })
 
         const shapeDigest = (): string =>
@@ -291,6 +299,14 @@ describe('log-pattern-mask', () => {
             // Reported by pattern, not name: klogtime is four rules under one name, so a name would
             // not say which of them the corpus misses.
             expect(MASK_RULES.filter((_rule, index) => fires[index] === 0).map((rule) => rule.pattern)).toEqual([])
+        })
+
+        it('reaches every body kind, so a parse change cannot land without moving the digest', () => {
+            // `parseLogBodyForIngestion` picks which branch of `computeLogPattern` runs, and it lives in
+            // another module that neither half of the digest hashes. Reaching every kind is what makes a
+            // change over there surface as a moved digest instead of as silence.
+            const kinds = [...new Set(CORPUS.map((body) => computeLogPattern(body).bodyKind))].sort()
+            expect(kinds).toEqual(['empty', 'json_object_or_array', 'json_string', 'plaintext', 'primitive'])
         })
 
         it('carries a digest for every version since the ratchet, so a bump cannot drop its predecessor', () => {

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -4,6 +4,7 @@ import RE2 from 're2'
 import {
     JSON_ARRAY,
     MASK_RULES,
+    MESSAGE_KEYS,
     PATTERN_CAPS,
     PATTERN_VERSION,
     type PatternCaps,
@@ -216,17 +217,25 @@ describe('log-pattern-mask', () => {
         /**
          * Bodies chosen to reach every branch that decides a pattern's shape: each mask rule, the
          * message keys, the key-set and array forms, both caps, and the order of parse and cap.
+         *
+         * The message-key bodies are derived from `MESSAGE_KEYS` so a new key joins the corpus, and
+         * moves the digest, on arrival. Mask rules cannot be derived that way, so a coverage test
+         * below holds the equivalent line for them.
          */
         const CORPUS: (string | null)[] = [
             null,
             '',
             'started at 2026-08-24T10:20:45.123Z ok',
             'I0827 11:39:40.307946 1 proxier.go:1484] reloading',
+            'W0101 00:00:00 rotate E0102 01:02:03 retry F0103 02:03:04 exit',
             'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 took 7141ms',
             'mail ops@example.com via api.example.com at 10.0.0.7 slot 0xdeadbeef',
-            '{"message":"user 5 logged in","level":"info"}',
-            '{"msg":"served 3 requests"}',
+            'checksum deadbeefdeadbeef00 verified',
+            ...MESSAGE_KEYS.map((key) => JSON.stringify({ [key]: 'served 3 requests', level: 'info' })),
+            '{"msg":"loses 2","message":"wins 1"}',
             '{"level":"info","count":3}',
+            '{}',
+            JSON.stringify(Object.fromEntries(Array.from({ length: 40 }, (_unused, index) => [`k${index}`, 1]))),
             '[1,2,3]',
             '"a bare json string with 4 words"',
             'true',
@@ -235,35 +244,63 @@ describe('log-pattern-mask', () => {
             `head ${'z'.repeat(PATTERN_CAPS.maxOutputChars)} tail`,
         ]
 
+        const RATCHET_FIRST_VERSION = 3
+
         /**
-         * One frozen digest per version, never edited in place. Editing an entry rewrites the shape of
-         * rows already in ClickHouse under that version, so the only correct fix for a red digest is a
-         * new entry under a new `PATTERN_VERSION`.
+         * One frozen digest per version. A red digest means the emitted shape moved, and the only correct
+         * fix is a new entry under a new `PATTERN_VERSION` — editing an entry in place relabels rows
+         * already in ClickHouse under that version. The one exception is growing `CORPUS`, which moves the
+         * digest without moving the shape; re-record only in a commit that touches nothing but the corpus.
          *
-         * Versions before 3 predate this ratchet, so no digest was recorded for them.
+         * Versions before `RATCHET_FIRST_VERSION` predate this ratchet, so no digest was recorded for them.
          */
         const SHAPE_DIGESTS: Record<number, string> = {
-            3: '1dfc6aa769551bae',
+            3: 'ed312a5324f9f760',
         }
+
+        /**
+         * The shape inputs no corpus body can reveal, hashed alongside the patterns the corpus emits.
+         *
+         * Emitted patterns catch control flow — the order of parse and cap, the key-set form — which a
+         * hash of the rules cannot see. They do not catch a rule broadened without changing what the
+         * corpus emits: adding a TLD to `host`, or widening `hex` from 16 chars to 12, leaves every
+         * corpus pattern byte-identical while real bodies change shape. Neither half covers the other,
+         * so the digest takes both.
+         */
+        const SHAPE_INPUTS = JSON.stringify({
+            rules: MASK_RULES.map((rule) => [rule.name, rule.pattern, rule.replacement]),
+            caps: PATTERN_CAPS,
+            messageKeys: MESSAGE_KEYS,
+        })
 
         const shapeDigest = (): string =>
             createHash('sha256')
-                .update(CORPUS.map((body) => computeLogPattern(body).pattern).join('\x01'))
+                .update([SHAPE_INPUTS, ...CORPUS.map((body) => computeLogPattern(body).pattern)].join('\x01'))
                 .digest('hex')
                 .slice(0, 16)
 
         it('pins the emitted patterns to the current version', () => {
-            // Hashing emitted patterns rather than the rules that make them is what makes this a gate:
-            // MASK_RULES, PATTERN_CAPS, MESSAGE_KEYS, the key-set form, and the order of parse and cap
-            // all move the digest. Do not edit the entry for the current version to make this pass.
             expect({ [PATTERN_VERSION]: shapeDigest() }).toEqual({ [PATTERN_VERSION]: SHAPE_DIGESTS[PATTERN_VERSION] })
+        })
+
+        it('reaches every mask rule, so a new rule cannot land without moving the digest', () => {
+            const fires = MASK_RULES.map(() => 0)
+            for (const body of CORPUS) {
+                computeLogPattern(body).ruleFires.forEach((count, index) => (fires[index] += count))
+            }
+            // Reported by pattern, not name: klogtime is four rules under one name, so a name would
+            // not say which of them the corpus misses.
+            expect(MASK_RULES.filter((_rule, index) => fires[index] === 0).map((rule) => rule.pattern)).toEqual([])
         })
 
         it('carries a digest for every version since the ratchet, so a bump cannot drop its predecessor', () => {
             const recorded = Object.keys(SHAPE_DIGESTS)
                 .map(Number)
                 .sort((left, right) => left - right)
-            const expected = Array.from({ length: PATTERN_VERSION - 2 }, (_unused, index) => index + 3)
+            const expected = Array.from(
+                { length: PATTERN_VERSION - RATCHET_FIRST_VERSION + 1 },
+                (_unused, index) => RATCHET_FIRST_VERSION + index
+            )
             expect(recorded).toEqual(expected)
         })
 

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -238,6 +238,11 @@ describe('log-pattern-mask', () => {
             'checksum deadbeefdeadbeef00 verified',
             ...MESSAGE_KEYS.map((key) => JSON.stringify({ [key]: 'served 3 requests', level: 'info' })),
             '{"msg":"loses 2","message":"wins 1"}',
+            // Reach `extractJsonMessage` itself, not just the keys it reads. Widening it to accept a
+            // number, or trimming what it returns, reshapes real bodies while leaving every other
+            // corpus pattern byte-identical.
+            '{"msg":12345}',
+            '{"msg":"  padded 3  "}',
             '{"level":"info","count":3}',
             '{}',
             JSON.stringify(Object.fromEntries(Array.from({ length: 40 }, (_unused, index) => [`k${index}`, 1]))),
@@ -261,7 +266,7 @@ describe('log-pattern-mask', () => {
          * Versions before `RATCHET_FIRST_VERSION` predate this ratchet, so no digest was recorded for them.
          */
         const SHAPE_DIGESTS: Record<number, string> = {
-            3: '5e6a9ab3f22b15ea',
+            3: 'd7b045b1054244d1',
         }
 
         /**

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -14,9 +14,9 @@ export const PATTERN_VERSION = 3
  */
 export type PatternCaps = {
     /** Ceiling on the body chars fed to the masker; longer bodies are cut first (CPU guard). */
-    maxInputChars: number
+    readonly maxInputChars: number
     /** Truncation applied to the masked pattern, after masking, so more real content survives the cut. */
-    maxOutputChars: number
+    readonly maxOutputChars: number
 }
 
 export const PATTERN_CAPS: PatternCaps = {
@@ -122,7 +122,7 @@ export type LogPatternResult = {
     ruleFires: number[]
 }
 
-const MESSAGE_KEYS = ['message', 'msg', 'event'] as const
+export const MESSAGE_KEYS = ['message', 'msg', 'event'] as const
 
 function extractJsonMessage(value: object): string | null {
     if (Array.isArray(value)) {
@@ -136,6 +136,9 @@ function extractJsonMessage(value: object): string | null {
     }
     return null
 }
+
+const capOutput = (pattern: string, caps: PatternCaps): string =>
+    pattern.length > caps.maxOutputChars ? pattern.slice(0, caps.maxOutputChars) : pattern
 
 function jsonKeySetPattern(value: object): string {
     const keys = Object.keys(value).sort()
@@ -166,7 +169,7 @@ export function computeLogPattern(body: string | null | undefined, caps: Pattern
                 const isArray = Array.isArray(parsed.value)
                 const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(parsed.value)
                 return {
-                    pattern: pattern.length > caps.maxOutputChars ? pattern.slice(0, caps.maxOutputChars) : pattern,
+                    pattern: capOutput(pattern, caps),
                     bodyKind,
                     inputCapped,
                     maskedLength: pattern.length,
@@ -190,7 +193,7 @@ export function computeLogPattern(body: string | null | undefined, caps: Pattern
 
     const { masked, ruleFires } = maskString(maskInput)
     return {
-        pattern: masked.length > caps.maxOutputChars ? masked.slice(0, caps.maxOutputChars) : masked,
+        pattern: capOutput(masked, caps),
         bodyKind,
         inputCapped,
         maskedLength: masked.length,

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -11,6 +11,10 @@ export const PATTERN_VERSION = 3
  * These are constants rather than config for that reason. A per-pod override would let two pods stamp
  * one version onto differently shaped patterns, which no consumer could detect. The shape-safe
  * operational lever is `LOGS_PATTERN_MASKING_ENABLED_TEAMS`, which stops masking instead of changing it.
+ *
+ * `computeLogPattern` takes no caps argument, so there is no override path to reach at all. `readonly`
+ * states the intent to the compiler and `Object.freeze` holds it at runtime, because a caller reaching
+ * this object through an `any` would otherwise reshape every pattern under an unchanged version.
  */
 export type PatternCaps = {
     /** Ceiling on the body chars fed to the masker; longer bodies are cut first (CPU guard). */
@@ -19,10 +23,10 @@ export type PatternCaps = {
     readonly maxOutputChars: number
 }
 
-export const PATTERN_CAPS: PatternCaps = {
+export const PATTERN_CAPS: PatternCaps = Object.freeze({
     maxInputChars: 8192,
     maxOutputChars: 1024,
-}
+})
 
 export type MaskRuleName = 'timestamp' | 'klogtime' | 'uuid' | 'email' | 'host' | 'hex0x' | 'hex' | 'ipv4' | 'num'
 
@@ -84,7 +88,7 @@ export const MASK_RULES: readonly MaskRule[] = [
 
 export const JSON_ARRAY = '<JSON_ARRAY>'
 
-const KEY_SET_MAX_KEYS = 32
+export const KEY_SET_MAX_KEYS = 32
 
 const MASK_COMBINED_RE = createTrackedRE2(
     MASK_RULES.map((rule) => `(${rule.pattern})`).join('|'),
@@ -137,8 +141,8 @@ function extractJsonMessage(value: object): string | null {
     return null
 }
 
-const capOutput = (pattern: string, caps: PatternCaps): string =>
-    pattern.length > caps.maxOutputChars ? pattern.slice(0, caps.maxOutputChars) : pattern
+const capOutput = (pattern: string): string =>
+    pattern.length > PATTERN_CAPS.maxOutputChars ? pattern.slice(0, PATTERN_CAPS.maxOutputChars) : pattern
 
 function jsonKeySetPattern(value: object): string {
     const keys = Object.keys(value).sort()
@@ -147,13 +151,13 @@ function jsonKeySetPattern(value: object): string {
     return `<JSON:${kept.join(',')}${overflow > 0 ? `,+${overflow}` : ''}>`
 }
 
-export function computeLogPattern(body: string | null | undefined, caps: PatternCaps = PATTERN_CAPS): LogPatternResult {
+export function computeLogPattern(body: string | null | undefined): LogPatternResult {
     if (body === null || body === undefined || body === '') {
         return { pattern: '', bodyKind: 'empty', inputCapped: false, maskedLength: 0, ruleFires: [] }
     }
 
-    const inputCapped = body.length > caps.maxInputChars
-    const cappedBody = inputCapped ? body.slice(0, caps.maxInputChars) : body
+    const inputCapped = body.length > PATTERN_CAPS.maxInputChars
+    const cappedBody = inputCapped ? body.slice(0, PATTERN_CAPS.maxInputChars) : body
     const parsed = parseLogBodyForIngestion(cappedBody)
     const bodyKind: PatternBodyKind =
         parsed.kind === 'json_primitive' ? 'primitive' : parsed.kind === 'invalid_json' ? 'plaintext' : parsed.kind
@@ -169,7 +173,7 @@ export function computeLogPattern(body: string | null | undefined, caps: Pattern
                 const isArray = Array.isArray(parsed.value)
                 const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(parsed.value)
                 return {
-                    pattern: capOutput(pattern, caps),
+                    pattern: capOutput(pattern),
                     bodyKind,
                     inputCapped,
                     maskedLength: pattern.length,
@@ -193,7 +197,7 @@ export function computeLogPattern(body: string | null | undefined, caps: Pattern
 
     const { masked, ruleFires } = maskString(maskInput)
     return {
-        pattern: capOutput(masked, caps),
+        pattern: capOutput(masked),
         bodyKind,
         inputCapped,
         maskedLength: masked.length,

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -4,6 +4,26 @@ import { parseLogBodyForIngestion } from './log-body-parse'
 
 export const PATTERN_VERSION = 3
 
+/**
+ * Everything here shapes the emitted pattern, so it sits inside `PATTERN_VERSION`: two records may
+ * only be grouped by `pattern` when they carry the same version.
+ *
+ * These are constants rather than config for that reason. A per-pod override would let two pods stamp
+ * one version onto differently shaped patterns, which no consumer could detect. The shape-safe
+ * operational lever is `LOGS_PATTERN_MASKING_ENABLED_TEAMS`, which stops masking instead of changing it.
+ */
+export type PatternCaps = {
+    /** Ceiling on the body chars fed to the masker; longer bodies are cut first (CPU guard). */
+    maxInputChars: number
+    /** Truncation applied to the masked pattern, after masking, so more real content survives the cut. */
+    maxOutputChars: number
+}
+
+export const PATTERN_CAPS: PatternCaps = {
+    maxInputChars: 8192,
+    maxOutputChars: 1024,
+}
+
 export type MaskRuleName = 'timestamp' | 'klogtime' | 'uuid' | 'email' | 'host' | 'hex0x' | 'hex' | 'ipv4' | 'num'
 
 export type MaskRule = {
@@ -124,17 +144,13 @@ function jsonKeySetPattern(value: object): string {
     return `<JSON:${kept.join(',')}${overflow > 0 ? `,+${overflow}` : ''}>`
 }
 
-export function computeLogPattern(
-    body: string | null | undefined,
-    maxInputChars: number,
-    maxOutputChars: number
-): LogPatternResult {
+export function computeLogPattern(body: string | null | undefined, caps: PatternCaps = PATTERN_CAPS): LogPatternResult {
     if (body === null || body === undefined || body === '') {
         return { pattern: '', bodyKind: 'empty', inputCapped: false, maskedLength: 0, ruleFires: [] }
     }
 
-    const inputCapped = body.length > maxInputChars
-    const cappedBody = inputCapped ? body.slice(0, maxInputChars) : body
+    const inputCapped = body.length > caps.maxInputChars
+    const cappedBody = inputCapped ? body.slice(0, caps.maxInputChars) : body
     const parsed = parseLogBodyForIngestion(cappedBody)
     const bodyKind: PatternBodyKind =
         parsed.kind === 'json_primitive' ? 'primitive' : parsed.kind === 'invalid_json' ? 'plaintext' : parsed.kind
@@ -150,7 +166,7 @@ export function computeLogPattern(
                 const isArray = Array.isArray(parsed.value)
                 const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(parsed.value)
                 return {
-                    pattern: pattern.length > maxOutputChars ? pattern.slice(0, maxOutputChars) : pattern,
+                    pattern: pattern.length > caps.maxOutputChars ? pattern.slice(0, caps.maxOutputChars) : pattern,
                     bodyKind,
                     inputCapped,
                     maskedLength: pattern.length,
@@ -174,7 +190,7 @@ export function computeLogPattern(
 
     const { masked, ruleFires } = maskString(maskInput)
     return {
-        pattern: masked.length > maxOutputChars ? masked.slice(0, maxOutputChars) : masked,
+        pattern: masked.length > caps.maxOutputChars ? masked.slice(0, caps.maxOutputChars) : masked,
         bodyKind,
         inputCapped,
         maskedLength: masked.length,

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -1,7 +1,6 @@
 import type { Counter } from 'prom-client'
 
-import { DEFAULT_PATTERN_MAX_INPUT_CHARS } from './config'
-import { PATTERN_VERSION } from './log-pattern-mask'
+import { PATTERN_CAPS, PATTERN_VERSION } from './log-pattern-mask'
 import {
     logsPatternBodyKindCounter,
     logsPatternInputCappedCounter,
@@ -42,12 +41,12 @@ describe('log-pattern-stage', () => {
     }
 
     it('tallies body kinds, rule fires, and input caps across a batch without touching the body', async () => {
-        const stage = makePatternMaskingStage(20, 1024)
+        const stage = makePatternMaskingStage()
         const records = [
             makeRecord(null),
             makeRecord('plain 5'),
             makeRecord('{"message":"hi"}'),
-            makeRecord('a long body over the input cap 123'),
+            makeRecord('x'.repeat(PATTERN_CAPS.maxInputChars + 1)),
         ]
         const bodiesBefore = records.map((r) => r.body)
 
@@ -72,7 +71,7 @@ describe('log-pattern-stage', () => {
         ['a plain body', 'retry 5', 'retry <N>'],
         ['an empty body, which must still carry a version or it reads as written before masking', null, ''],
     ])('stamps pattern and version onto the record: %s', async (_name, body, expected) => {
-        const stage = makePatternMaskingStage(1024, 1024)
+        const stage = makePatternMaskingStage()
         const record = makeRecord(body)
 
         await stage.run([record])
@@ -80,14 +79,14 @@ describe('log-pattern-stage', () => {
         expect(record).toMatchObject({ pattern: expected, pattern_version: PATTERN_VERSION })
     })
 
-    it('falls back to the default caps when a configured cap is not a positive integer', async () => {
-        const stage = makePatternMaskingStage(Number.NaN, -1)
-        await stage.run([makeRecord('x'.repeat(DEFAULT_PATTERN_MAX_INPUT_CHARS + 1))])
+    it('counts a body past the versioned input cap', async () => {
+        const stage = makePatternMaskingStage()
+        await stage.run([makeRecord('x'.repeat(PATTERN_CAPS.maxInputChars + 1))])
         expect((await logsPatternInputCappedCounter.get()).values[0].value).toEqual(1)
     })
 
     it('keeps the batch when masking throws, so a measurement fault cannot DLQ customer logs', async () => {
-        const stage = makePatternMaskingStage(1024, 1024)
+        const stage = makePatternMaskingStage()
         const record = makeRecord(null)
         Object.defineProperty(record, 'body', {
             get: () => {

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -79,12 +79,6 @@ describe('log-pattern-stage', () => {
         expect(record).toMatchObject({ pattern: expected, pattern_version: PATTERN_VERSION })
     })
 
-    it('counts a body past the versioned input cap', async () => {
-        const stage = makePatternMaskingStage()
-        await stage.run([makeRecord('x'.repeat(PATTERN_CAPS.maxInputChars + 1))])
-        expect((await logsPatternInputCappedCounter.get()).values[0].value).toEqual(1)
-    })
-
     it('keeps the batch when masking throws, so a measurement fault cannot DLQ customer logs', async () => {
         const stage = makePatternMaskingStage()
         const record = makeRecord(null)

--- a/nodejs/src/logs/log-pattern-stage.ts
+++ b/nodejs/src/logs/log-pattern-stage.ts
@@ -1,7 +1,6 @@
 import { performance } from 'node:perf_hooks'
 import { Counter, Histogram } from 'prom-client'
 
-import { DEFAULT_PATTERN_MAX_INPUT_CHARS, DEFAULT_PATTERN_MAX_OUTPUT_CHARS } from './config'
 import { MASK_RULES, PATTERN_VERSION, computeLogPattern } from './log-pattern-mask'
 import type { LogRecord } from './log-record-avro'
 import type { PipelineStage } from './pipeline/log-processing-pipeline'
@@ -52,18 +51,13 @@ export const logsPatternStageErrorCounter = new Counter({
     help: 'Batches where the pattern masking stage threw. The records survive. Any record the throw came before keeps its stamp, and the rest stay unstamped, which reads as version 0.',
 })
 
-const positiveIntOr = (value: number, fallback: number): number =>
-    Number.isInteger(value) && value > 0 ? value : fallback
-
-export function makePatternMaskingStage(maxInputChars: number, maxOutputChars: number): PipelineStage {
-    const inputCap = positiveIntOr(maxInputChars, DEFAULT_PATTERN_MAX_INPUT_CHARS)
-    const outputCap = positiveIntOr(maxOutputChars, DEFAULT_PATTERN_MAX_OUTPUT_CHARS)
+export function makePatternMaskingStage(): PipelineStage {
     return {
         kind: 'mutate',
         name: 'pattern_masking',
         run: (records) => {
             try {
-                stampBatch(records, inputCap, outputCap)
+                stampBatch(records)
             } catch {
                 logsPatternStageErrorCounter.inc()
             }
@@ -71,14 +65,14 @@ export function makePatternMaskingStage(maxInputChars: number, maxOutputChars: n
     }
 }
 
-function stampBatch(records: LogRecord[], inputCap: number, outputCap: number): void {
+function stampBatch(records: LogRecord[]): void {
     const kindCounts = new Map<string, number>()
     const ruleFires: number[] = new Array(MASK_RULES.length).fill(0)
     let inputCapped = 0
 
     for (const record of records) {
         const start = performance.now()
-        const result = computeLogPattern(record.body, inputCap, outputCap)
+        const result = computeLogPattern(record.body)
         record.pattern = result.pattern
         record.pattern_version = PATTERN_VERSION
         logsPatternMaskingDurationHistogram.observe((performance.now() - start) / 1000)

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -370,10 +370,7 @@ export class LogsIngestionConsumer {
         this.retentionEnabledTeamsRaw = mergedConfig.LOGS_RETENTION_ENABLED_TEAMS
         this.retentionKillswitch = mergedConfig.LOGS_RETENTION_KILLSWITCH
         this.patternMaskingEnabledTeamsRaw = mergedConfig.LOGS_PATTERN_MASKING_ENABLED_TEAMS
-        this.patternMaskingStage = makePatternMaskingStage(
-            mergedConfig.LOGS_PATTERN_MASKING_MAX_INPUT_CHARS,
-            mergedConfig.LOGS_PATTERN_MASKING_MAX_OUTPUT_CHARS
-        )
+        this.patternMaskingStage = makePatternMaskingStage()
     }
 
     private isSamplingEvalEnabledForTeam(teamId: number): boolean {


### PR DESCRIPTION
## Problem

Nobody can trust that two log patterns carrying the same `pattern_version` were built the same way.

- The masking caps live in `config.ts` and are env-overridable through `LOGS_PATTERN_MASKING_MAX_INPUT_CHARS` and `LOGS_PATTERN_MASKING_MAX_OUTPUT_CHARS`.
- Two pods with different env stamp one `pattern_version` onto differently shaped patterns. No consumer can detect that.
- `computeLogPattern` also takes a caps argument, so any caller can emit a shape no version describes.
- The ratchet hashes `MASK_RULES` only. It sees a rule change and misses a cap change, a message-key change, or a change to the order of parse and cap.
- `pattern_version` is `UInt8` in ClickHouse, so it is a small enum. It cannot encode config variation even if that were wanted.

## Changes

Nothing user-visible changes. The emitted patterns are byte-identical, so `PATTERN_VERSION` stays 3.

- `PATTERN_CAPS` moves into `log-pattern-mask.ts`, beside `PATTERN_VERSION`, as the single home for every value that shapes a pattern.
- The two cap env keys are deleted. `LOGS_PATTERN_MASKING_ENABLED_TEAMS` stays as the operational lever, and it is shape-safe because it stops masking rather than changing it.
- `computeLogPattern` takes no caps argument, so no caller can reach an override. `PATTERN_CAPS` is frozen, because `readonly` binds the compiler and not the runtime.
- The digest covers two halves. One hashes the shape inputs: the rules, the caps, the message keys, the key-set cap, and the array form. The other hashes the patterns a frozen corpus emits.
- Neither half covers the other. Inputs catch a rule broadened without changing what the corpus emits, such as widening `hex` from 16 chars to 12. Outputs catch control flow, such as the order of parse and cap.
- Two coverage tests keep the corpus honest. One fails when a mask rule goes unreached. The other fails when a body kind does, which is how a change in `log-body-parse.ts` reaches the digest at all.
- The message-key bodies derive from `MESSAGE_KEYS`, so a new key joins the corpus, and moves the digest, on arrival.
- Two corpus bodies reach `extractJsonMessage` itself, not only the keys it reads. Neither half of the digest saw that function before: the inputs hash `MESSAGE_KEYS`, and every corpus message was a plain string.
- `SHAPE_DIGESTS` records one digest per version. A completeness test requires an entry for every version since 3, so a bump cannot drop its predecessor. A uniqueness test catches a bump with no shape change.

> [!NOTE]
> One gap stays open. Editing a recorded digest in place still goes green, because a test cannot know what the file said yesterday. Closing it needs a repo invariant that checks the map is append-only against the merge base. That is not in this PR.

## How did you test this code?

- A mutation sweep is the evidence for the coverage claim, rather than reading the corpus. Fifteen changes to shape-determining code were applied one at a time to this branch, each checked against the ratchet, and each confirmed to have actually applied. All fifteen fail the ratchet.
- The sweep covers `KEY_SET_MAX_KEYS`, `JSON_ARRAY`, `MESSAGE_KEYS`, all three caps, a broadened `host` rule, a widened `hex` rule, a dropped key-set sort, a dropped regex `g` flag, a widened message extractor, a trimmed message, an unreachable new rule, and a reclassified branch in `log-body-parse.ts`.
- The sweep found one gap, which the last commit closes. Widening `extractJsonMessage` to accept a number moved `{"msg":12345}` from `<JSON:msg>` to `<N>` while the ratchet stayed green. Two corpus bodies now reach it.
- The corpus reaches every mask rule, every message key, every body kind, both caps, and the key-set and array forms. Two coverage tests fail if that stops being true.
- The regression this catches: a shape change that ships under an unchanged `pattern_version`, which mixes two pattern shapes in one ClickHouse column and silently corrupts any grouping by `pattern`.
- The second regression: a rule broadened without moving any corpus output. The input half of the digest catches it, and the old `MASK_RULES` hash could not.
- Re-recording the digest for version 3 is safe here because the emitted half is byte-identical before and after. Only the input half moved.
- The whole `src/logs` suite passes locally, 21 suites. An earlier run reported two suites failing on a missing local Redis; with Redis up they pass.
- Not measured: nothing here runs against production data. Every claim above is about this branch's tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`, `/ste-writing`.

The session started from a production log line whose pattern looked wrong. Diagnosis found the parse-before-cap bug that PR #92256 fixes. Splitting the versioning fix out came from review feedback during the session, on the grounds that the config change and the behavior change are separately reviewable.

The ratchet went through three shapes. A single digest constant came first, and it failed the real test: a red digest is satisfied by pasting the new value and never touching the version. A version-keyed map plus a completeness test replaced it, so adding a row is the natural fix and deleting history fails. The output-only hash then turned out to miss a rule broadened without changing corpus output, so the digest took both halves.

A later session ran the mutation sweep and owns the final commit. That sweep is what turned the coverage claim from a reading of the corpus into a measurement, and it is what found the message-extractor gap.

Review feedback drove the preceding commit. Greptile flagged the corpus gaps and then the caps argument as a bypass seam. Both were valid, and the caps argument was the last shape input the version did not constrain.

Public artifact: this PR carries nothing from the session that is not already public. The test corpus is invented, using reserved domains and made-up hosts.

