### PR TITLE
fix(logs): parse log bodies before capping them for pattern masking

### DIFF
--- a/nodejs/src/logs/config.ts
+++ b/nodejs/src/logs/config.ts
@@ -14,9 +14,6 @@ import { isProdEnv } from '~/common/utils/env-utils'
 
 import { LogsProducerName, WARPSTREAM_INGESTION_PRODUCER, WARPSTREAM_LOGS_PRODUCER } from './outputs/producers'
 
-export const DEFAULT_PATTERN_MAX_INPUT_CHARS = 8192
-export const DEFAULT_PATTERN_MAX_OUTPUT_CHARS = 1024
-
 export type LogsIngestionOutputsConfig = {
     LOGS_INGESTION_OUTPUT_APP_METRICS_TOPIC: string
     LOGS_INGESTION_OUTPUT_APP_METRICS_PRODUCER: LogsProducerName
@@ -70,10 +67,6 @@ export type LogsIngestionConsumerConfig = {
     LOGS_RETENTION_KILLSWITCH: boolean
     /** Comma-separated team IDs, or `*` for all teams, or empty (default) to disable measure-only pattern masking. */
     LOGS_PATTERN_MASKING_ENABLED_TEAMS: string
-    /** Ceiling on body chars fed to the pattern masker; longer bodies are cut first (CPU guard). */
-    LOGS_PATTERN_MASKING_MAX_INPUT_CHARS: number
-    /** Truncation applied to the masked pattern, after masking (so more real content survives the cut). */
-    LOGS_PATTERN_MASKING_MAX_OUTPUT_CHARS: number
     /**
      * When `true`, rows removed by drop rules are credited back to the billed usage metrics
      * (`bytes_ingested` / `records_ingested`). When `false` (default), the credit is only
@@ -127,8 +120,6 @@ export function getDefaultLogsIngestionConsumerConfig(): LogsIngestionConsumerCo
         LOGS_RETENTION_KILLSWITCH: false,
         // Off by default: enabling forces decode+re-encode for allowlisted teams.
         LOGS_PATTERN_MASKING_ENABLED_TEAMS: '',
-        LOGS_PATTERN_MASKING_MAX_INPUT_CHARS: DEFAULT_PATTERN_MAX_INPUT_CHARS,
-        LOGS_PATTERN_MASKING_MAX_OUTPUT_CHARS: DEFAULT_PATTERN_MAX_OUTPUT_CHARS,
         LOGS_BILLING_PRORATE_ENABLED: false,
         LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '',
         LOGS_TRANSFORMATIONS_KILLSWITCH: false,

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -1,9 +1,17 @@
 import { createHash } from 'node:crypto'
 import RE2 from 're2'
 
-import { JSON_ARRAY, MASK_RULES, PATTERN_VERSION, computeLogPattern, maskString } from './log-pattern-mask'
+import {
+    JSON_ARRAY,
+    MASK_RULES,
+    PATTERN_CAPS,
+    PATTERN_VERSION,
+    type PatternCaps,
+    computeLogPattern,
+    maskString,
+} from './log-pattern-mask'
 
-const NO_CAP = 100_000
+const caps = (overrides: Partial<PatternCaps>): PatternCaps => ({ ...PATTERN_CAPS, ...overrides })
 
 describe('log-pattern-mask', () => {
     describe('maskString', () => {
@@ -116,26 +124,26 @@ describe('log-pattern-mask', () => {
     describe('computeLogPattern', () => {
         it('masks before truncating, so a UUID straddling the cut point still yields its placeholder', () => {
             const body = 'abcdefghij 0f2d6faf-07e3-4cff-bf47-7efa1024aee2'
-            const result = computeLogPattern(body, NO_CAP, 20)
+            const result = computeLogPattern(body, caps({ maxOutputChars: 20 }))
             expect(result.pattern).toEqual('abcdefghij <UUID>')
             expect(result.maskedLength).toEqual('abcdefghij <UUID>'.length)
         })
 
         it('reports the pre-truncation masked length and truncates the pattern', () => {
-            const result = computeLogPattern('x'.repeat(50), NO_CAP, 10)
+            const result = computeLogPattern('x'.repeat(50), caps({ maxOutputChars: 10 }))
             expect(result.pattern).toEqual('x'.repeat(10))
             expect(result.maskedLength).toEqual(50)
         })
 
         it('caps the input before masking and reports it', () => {
-            const result = computeLogPattern('abc 12345678', 6, NO_CAP)
+            const result = computeLogPattern('abc 12345678', caps({ maxInputChars: 6 }))
             expect(result.inputCapped).toEqual(true)
             expect(result.pattern).toEqual('abc <N>')
         })
 
         it('caps the raw body before the JSON parse, so an oversized JSON body is treated as truncated prose', () => {
             const body = JSON.stringify({ message: 'x'.repeat(100) })
-            const result = computeLogPattern(body, 20, NO_CAP)
+            const result = computeLogPattern(body, caps({ maxInputChars: 20 }))
             expect(result.inputCapped).toEqual(true)
             expect(result.bodyKind).toEqual('plaintext')
             expect(result.pattern).toEqual(body.slice(0, 20))
@@ -159,13 +167,13 @@ describe('log-pattern-mask', () => {
             ['json number primitive', '42', 'primitive', '<N>'],
             ['prose body', 'plain text 3', 'plaintext', 'plain text <N>'],
         ])('body kind %s', (_name, body, expectedKind, expectedPattern) => {
-            const result = computeLogPattern(body, NO_CAP, NO_CAP)
+            const result = computeLogPattern(body)
             expect(result.bodyKind).toEqual(expectedKind)
             expect(result.pattern).toEqual(expectedPattern)
         })
 
         describe('key-set identity for message-less JSON objects', () => {
-            const patternOf = (body: string): string => computeLogPattern(body, NO_CAP, NO_CAP).pattern
+            const patternOf = (body: string): string => computeLogPattern(body).pattern
 
             it('is independent of source key order', () => {
                 expect(patternOf('{"b":1,"a":2}')).toEqual('<JSON:a,b>')
@@ -179,13 +187,13 @@ describe('log-pattern-mask', () => {
                 const expected = `<JSON:${keys.slice(0, 32).join(',')},+8>`
                 expect(patternOf(forward)).toEqual(expected)
                 expect(patternOf(reversed)).toEqual(expected)
-                expect(computeLogPattern(forward, NO_CAP, NO_CAP).jsonKeyCount).toEqual(40)
+                expect(computeLogPattern(forward).jsonKeyCount).toEqual(40)
             })
 
             it('reports the key count only for key-set patterns', () => {
-                expect(computeLogPattern('{"a":1}', NO_CAP, NO_CAP).jsonKeyCount).toEqual(1)
-                expect(computeLogPattern('[1,2]', NO_CAP, NO_CAP).jsonKeyCount).toBeUndefined()
-                expect(computeLogPattern('{"message":"hi"}', NO_CAP, NO_CAP).jsonKeyCount).toBeUndefined()
+                expect(computeLogPattern('{"a":1}').jsonKeyCount).toEqual(1)
+                expect(computeLogPattern('[1,2]').jsonKeyCount).toBeUndefined()
+                expect(computeLogPattern('{"message":"hi"}').jsonKeyCount).toBeUndefined()
             })
 
             it('renders an empty object as an empty key set', () => {
@@ -205,12 +213,63 @@ describe('log-pattern-mask', () => {
     })
 
     describe('PATTERN_VERSION ratchet', () => {
-        it('moves whenever MASK_RULES changes', () => {
-            const digest = createHash('sha256')
-                .update(MASK_RULES.map((rule) => `${rule.name}\0${rule.pattern}\0${rule.replacement}`).join('\x01'))
+        /**
+         * Bodies chosen to reach every branch that decides a pattern's shape: each mask rule, the
+         * message keys, the key-set and array forms, both caps, and the order of parse and cap.
+         */
+        const CORPUS: (string | null)[] = [
+            null,
+            '',
+            'started at 2026-08-24T10:20:45.123Z ok',
+            'I0827 11:39:40.307946 1 proxier.go:1484] reloading',
+            'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 took 7141ms',
+            'mail ops@example.com via api.example.com at 10.0.0.7 slot 0xdeadbeef',
+            '{"message":"user 5 logged in","level":"info"}',
+            '{"msg":"served 3 requests"}',
+            '{"level":"info","count":3}',
+            '[1,2,3]',
+            '"a bare json string with 4 words"',
+            'true',
+            'x'.repeat(PATTERN_CAPS.maxInputChars + 10),
+            JSON.stringify({ msg: 'discovered 3 peers', pad: 'y'.repeat(PATTERN_CAPS.maxInputChars) }),
+            `head ${'z'.repeat(PATTERN_CAPS.maxOutputChars)} tail`,
+        ]
+
+        /**
+         * One frozen digest per version, never edited in place. Editing an entry rewrites the shape of
+         * rows already in ClickHouse under that version, so the only correct fix for a red digest is a
+         * new entry under a new `PATTERN_VERSION`.
+         *
+         * Versions before 3 predate this ratchet, so no digest was recorded for them.
+         */
+        const SHAPE_DIGESTS: Record<number, string> = {
+            3: '1dfc6aa769551bae',
+        }
+
+        const shapeDigest = (): string =>
+            createHash('sha256')
+                .update(CORPUS.map((body) => computeLogPattern(body).pattern).join('\x01'))
                 .digest('hex')
                 .slice(0, 16)
-            expect({ version: PATTERN_VERSION, digest }).toEqual({ version: 3, digest: '599889a916d04e14' })
+
+        it('pins the emitted patterns to the current version', () => {
+            // Hashing emitted patterns rather than the rules that make them is what makes this a gate:
+            // MASK_RULES, PATTERN_CAPS, MESSAGE_KEYS, the key-set form, and the order of parse and cap
+            // all move the digest. Do not edit the entry for the current version to make this pass.
+            expect({ [PATTERN_VERSION]: shapeDigest() }).toEqual({ [PATTERN_VERSION]: SHAPE_DIGESTS[PATTERN_VERSION] })
+        })
+
+        it('carries a digest for every version since the ratchet, so a bump cannot drop its predecessor', () => {
+            const recorded = Object.keys(SHAPE_DIGESTS)
+                .map(Number)
+                .sort((left, right) => left - right)
+            const expected = Array.from({ length: PATTERN_VERSION - 2 }, (_unused, index) => index + 3)
+            expect(recorded).toEqual(expected)
+        })
+
+        it('never reuses a digest across versions, so a bump without a shape change is caught', () => {
+            const digests = Object.values(SHAPE_DIGESTS)
+            expect(new Set(digests).size).toEqual(digests.length)
         })
     })
 

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -3,16 +3,14 @@ import RE2 from 're2'
 
 import {
     JSON_ARRAY,
+    KEY_SET_MAX_KEYS,
     MASK_RULES,
     MESSAGE_KEYS,
     PATTERN_CAPS,
     PATTERN_VERSION,
-    type PatternCaps,
     computeLogPattern,
     maskString,
 } from './log-pattern-mask'
-
-const caps = (overrides: Partial<PatternCaps>): PatternCaps => ({ ...PATTERN_CAPS, ...overrides })
 
 describe('log-pattern-mask', () => {
     describe('maskString', () => {
@@ -124,30 +122,37 @@ describe('log-pattern-mask', () => {
 
     describe('computeLogPattern', () => {
         it('masks before truncating, so a UUID straddling the cut point still yields its placeholder', () => {
-            const body = 'abcdefghij 0f2d6faf-07e3-4cff-bf47-7efa1024aee2'
-            const result = computeLogPattern(body, caps({ maxOutputChars: 20 }))
-            expect(result.pattern).toEqual('abcdefghij <UUID>')
-            expect(result.maskedLength).toEqual('abcdefghij <UUID>'.length)
+            // Long enough that the raw UUID crosses the output cap, short enough that `<UUID>` does not.
+            // Filled with a non-hex letter, or the run itself masks to `<HEX>`.
+            const head = 'z'.repeat(PATTERN_CAPS.maxOutputChars - 24)
+            const body = `${head} 0f2d6faf-07e3-4cff-bf47-7efa1024aee2`
+            expect(body.length).toBeGreaterThan(PATTERN_CAPS.maxOutputChars)
+
+            const result = computeLogPattern(body)
+            expect(result.pattern).toEqual(`${head} <UUID>`)
+            expect(result.maskedLength).toEqual(`${head} <UUID>`.length)
         })
 
         it('reports the pre-truncation masked length and truncates the pattern', () => {
-            const result = computeLogPattern('x'.repeat(50), caps({ maxOutputChars: 10 }))
-            expect(result.pattern).toEqual('x'.repeat(10))
-            expect(result.maskedLength).toEqual(50)
+            const result = computeLogPattern('x'.repeat(PATTERN_CAPS.maxOutputChars * 2))
+            expect(result.pattern).toEqual('x'.repeat(PATTERN_CAPS.maxOutputChars))
+            expect(result.maskedLength).toEqual(PATTERN_CAPS.maxOutputChars * 2)
         })
 
         it('caps the input before masking and reports it', () => {
-            const result = computeLogPattern('abc 12345678', caps({ maxInputChars: 6 }))
+            const result = computeLogPattern(`${'z'.repeat(PATTERN_CAPS.maxInputChars)} 12345678`)
             expect(result.inputCapped).toEqual(true)
-            expect(result.pattern).toEqual('abc <N>')
+            // The number sat past the input cap, so no rule ever saw it.
+            expect(result.maskedLength).toEqual(PATTERN_CAPS.maxInputChars)
+            expect(result.ruleFires.every((fires) => fires === 0)).toEqual(true)
         })
 
         it('caps the raw body before the JSON parse, so an oversized JSON body is treated as truncated prose', () => {
-            const body = JSON.stringify({ message: 'x'.repeat(100) })
-            const result = computeLogPattern(body, caps({ maxInputChars: 20 }))
+            const body = JSON.stringify({ message: 'x'.repeat(PATTERN_CAPS.maxInputChars) })
+            const result = computeLogPattern(body)
             expect(result.inputCapped).toEqual(true)
             expect(result.bodyKind).toEqual('plaintext')
-            expect(result.pattern).toEqual(body.slice(0, 20))
+            expect(result.pattern).toEqual(body.slice(0, PATTERN_CAPS.maxOutputChars))
         })
 
         it.each([
@@ -250,12 +255,13 @@ describe('log-pattern-mask', () => {
          * One frozen digest per version. A red digest means the emitted shape moved, and the only correct
          * fix is a new entry under a new `PATTERN_VERSION` — editing an entry in place relabels rows
          * already in ClickHouse under that version. The one exception is growing `CORPUS`, which moves the
-         * digest without moving the shape; re-record only in a commit that touches nothing but the corpus.
+         * digest without moving the shape. Growing `SHAPE_INPUTS` does the same. Re-record for either only
+         * in a commit that moves no emitted pattern, and say so in the message.
          *
          * Versions before `RATCHET_FIRST_VERSION` predate this ratchet, so no digest was recorded for them.
          */
         const SHAPE_DIGESTS: Record<number, string> = {
-            3: 'ed312a5324f9f760',
+            3: '5e6a9ab3f22b15ea',
         }
 
         /**
@@ -271,6 +277,8 @@ describe('log-pattern-mask', () => {
             rules: MASK_RULES.map((rule) => [rule.name, rule.pattern, rule.replacement]),
             caps: PATTERN_CAPS,
             messageKeys: MESSAGE_KEYS,
+            keySetMaxKeys: KEY_SET_MAX_KEYS,
+            jsonArray: JSON_ARRAY,
         })
 
         const shapeDigest = (): string =>
@@ -291,6 +299,14 @@ describe('log-pattern-mask', () => {
             // Reported by pattern, not name: klogtime is four rules under one name, so a name would
             // not say which of them the corpus misses.
             expect(MASK_RULES.filter((_rule, index) => fires[index] === 0).map((rule) => rule.pattern)).toEqual([])
+        })
+
+        it('reaches every body kind, so a parse change cannot land without moving the digest', () => {
+            // `parseLogBodyForIngestion` picks which branch of `computeLogPattern` runs, and it lives in
+            // another module that neither half of the digest hashes. Reaching every kind is what makes a
+            // change over there surface as a moved digest instead of as silence.
+            const kinds = [...new Set(CORPUS.map((body) => computeLogPattern(body).bodyKind))].sort()
+            expect(kinds).toEqual(['empty', 'json_object_or_array', 'json_string', 'plaintext', 'primitive'])
         })
 
         it('carries a digest for every version since the ratchet, so a bump cannot drop its predecessor', () => {

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -147,16 +147,9 @@ describe('log-pattern-mask', () => {
             expect(result.ruleFires.every((fires) => fires === 0)).toEqual(true)
         })
 
-        it('parses before capping, so a JSON body past the mask-input cap still yields its message', () => {
-            const body = JSON.stringify({ message: 'served 7 requests', pad: 'x'.repeat(PATTERN_CAPS.maxInputChars) })
-            const result = computeLogPattern(body)
-            expect(result.bodyKind).toEqual('json_object_or_array')
-            expect(result.inputCapped).toEqual(false)
-            expect(result.pattern).toEqual('served <N> requests')
-        })
-
-        it('reduces a verbose structured line to its message, not to a slice of its own fields', () => {
+        it('parses before capping, so a verbose structured line reduces to its message', () => {
             // Shaped like a Go service logger: a short message, then a nested array that dwarfs it.
+            // Capping first left this as a slice of its own field names, near-unique per record.
             const body = JSON.stringify({
                 time: '2026-08-24T10:20:45.123Z',
                 level: 'INFO',
@@ -168,9 +161,12 @@ describe('log-pattern-mask', () => {
                     zone: 'zone-a',
                 })),
             })
-
             expect(body.length).toBeGreaterThan(PATTERN_CAPS.maxInputChars)
-            expect(computeLogPattern(body).pattern).toEqual('successfully discovered <N> peer addresses')
+
+            const result = computeLogPattern(body)
+            expect(result.bodyKind).toEqual('json_object_or_array')
+            expect(result.inputCapped).toEqual(false)
+            expect(result.pattern).toEqual('successfully discovered <N> peer addresses')
         })
 
         it('skips the parse past the parse ceiling, so one record cannot stall the loop', () => {
@@ -246,7 +242,7 @@ describe('log-pattern-mask', () => {
     describe('PATTERN_VERSION ratchet', () => {
         /**
          * Bodies chosen to reach every branch that decides a pattern's shape: each mask rule, the
-         * message keys, the key-set and array forms, both caps, and the order of parse and cap.
+         * message keys, the key-set and array forms, every cap, and the order of parse and cap.
          *
          * The message-key bodies are derived from `MESSAGE_KEYS` so a new key joins the corpus, and
          * moves the digest, on arrival. Mask rules cannot be derived that way, so a coverage test
@@ -278,7 +274,6 @@ describe('log-pattern-mask', () => {
             JSON.stringify({ msg: 'discovered 3 peers', pad: 'y'.repeat(PATTERN_CAPS.maxInputChars) }),
             `head ${'z'.repeat(PATTERN_CAPS.maxOutputChars)} tail`,
             JSON.stringify({ msg: 'past the parse ceiling', pad: 'w'.repeat(PATTERN_CAPS.maxParseChars) }),
-            JSON.stringify({ msg: 'past the parse ceiling', pad: 'w'.repeat(PATTERN_CAPS.maxParseChars) }),
         ]
 
         const RATCHET_FIRST_VERSION = 3
@@ -294,7 +289,7 @@ describe('log-pattern-mask', () => {
          */
         const SHAPE_DIGESTS: Record<number, string> = {
             3: 'd7b045b1054244d1',
-            4: '00bc38384cb92f37',
+            4: 'b31c069b42353d04',
         }
 
         /**

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -4,6 +4,7 @@ import RE2 from 're2'
 import {
     JSON_ARRAY,
     MASK_RULES,
+    MESSAGE_KEYS,
     PATTERN_CAPS,
     PATTERN_VERSION,
     type PatternCaps,
@@ -216,17 +217,25 @@ describe('log-pattern-mask', () => {
         /**
          * Bodies chosen to reach every branch that decides a pattern's shape: each mask rule, the
          * message keys, the key-set and array forms, both caps, and the order of parse and cap.
+         *
+         * The message-key bodies are derived from `MESSAGE_KEYS` so a new key joins the corpus, and
+         * moves the digest, on arrival. Mask rules cannot be derived that way, so a coverage test
+         * below holds the equivalent line for them.
          */
         const CORPUS: (string | null)[] = [
             null,
             '',
             'started at 2026-08-24T10:20:45.123Z ok',
             'I0827 11:39:40.307946 1 proxier.go:1484] reloading',
+            'W0101 00:00:00 rotate E0102 01:02:03 retry F0103 02:03:04 exit',
             'request 0f2d6faf-07e3-4cff-bf47-7efa1024aee2 took 7141ms',
             'mail ops@example.com via api.example.com at 10.0.0.7 slot 0xdeadbeef',
-            '{"message":"user 5 logged in","level":"info"}',
-            '{"msg":"served 3 requests"}',
+            'checksum deadbeefdeadbeef00 verified',
+            ...MESSAGE_KEYS.map((key) => JSON.stringify({ [key]: 'served 3 requests', level: 'info' })),
+            '{"msg":"loses 2","message":"wins 1"}',
             '{"level":"info","count":3}',
+            '{}',
+            JSON.stringify(Object.fromEntries(Array.from({ length: 40 }, (_unused, index) => [`k${index}`, 1]))),
             '[1,2,3]',
             '"a bare json string with 4 words"',
             'true',
@@ -235,35 +244,63 @@ describe('log-pattern-mask', () => {
             `head ${'z'.repeat(PATTERN_CAPS.maxOutputChars)} tail`,
         ]
 
+        const RATCHET_FIRST_VERSION = 3
+
         /**
-         * One frozen digest per version, never edited in place. Editing an entry rewrites the shape of
-         * rows already in ClickHouse under that version, so the only correct fix for a red digest is a
-         * new entry under a new `PATTERN_VERSION`.
+         * One frozen digest per version. A red digest means the emitted shape moved, and the only correct
+         * fix is a new entry under a new `PATTERN_VERSION` — editing an entry in place relabels rows
+         * already in ClickHouse under that version. The one exception is growing `CORPUS`, which moves the
+         * digest without moving the shape; re-record only in a commit that touches nothing but the corpus.
          *
-         * Versions before 3 predate this ratchet, so no digest was recorded for them.
+         * Versions before `RATCHET_FIRST_VERSION` predate this ratchet, so no digest was recorded for them.
          */
         const SHAPE_DIGESTS: Record<number, string> = {
-            3: '1dfc6aa769551bae',
+            3: 'ed312a5324f9f760',
         }
+
+        /**
+         * The shape inputs no corpus body can reveal, hashed alongside the patterns the corpus emits.
+         *
+         * Emitted patterns catch control flow — the order of parse and cap, the key-set form — which a
+         * hash of the rules cannot see. They do not catch a rule broadened without changing what the
+         * corpus emits: adding a TLD to `host`, or widening `hex` from 16 chars to 12, leaves every
+         * corpus pattern byte-identical while real bodies change shape. Neither half covers the other,
+         * so the digest takes both.
+         */
+        const SHAPE_INPUTS = JSON.stringify({
+            rules: MASK_RULES.map((rule) => [rule.name, rule.pattern, rule.replacement]),
+            caps: PATTERN_CAPS,
+            messageKeys: MESSAGE_KEYS,
+        })
 
         const shapeDigest = (): string =>
             createHash('sha256')
-                .update(CORPUS.map((body) => computeLogPattern(body).pattern).join('\x01'))
+                .update([SHAPE_INPUTS, ...CORPUS.map((body) => computeLogPattern(body).pattern)].join('\x01'))
                 .digest('hex')
                 .slice(0, 16)
 
         it('pins the emitted patterns to the current version', () => {
-            // Hashing emitted patterns rather than the rules that make them is what makes this a gate:
-            // MASK_RULES, PATTERN_CAPS, MESSAGE_KEYS, the key-set form, and the order of parse and cap
-            // all move the digest. Do not edit the entry for the current version to make this pass.
             expect({ [PATTERN_VERSION]: shapeDigest() }).toEqual({ [PATTERN_VERSION]: SHAPE_DIGESTS[PATTERN_VERSION] })
+        })
+
+        it('reaches every mask rule, so a new rule cannot land without moving the digest', () => {
+            const fires = MASK_RULES.map(() => 0)
+            for (const body of CORPUS) {
+                computeLogPattern(body).ruleFires.forEach((count, index) => (fires[index] += count))
+            }
+            // Reported by pattern, not name: klogtime is four rules under one name, so a name would
+            // not say which of them the corpus misses.
+            expect(MASK_RULES.filter((_rule, index) => fires[index] === 0).map((rule) => rule.pattern)).toEqual([])
         })
 
         it('carries a digest for every version since the ratchet, so a bump cannot drop its predecessor', () => {
             const recorded = Object.keys(SHAPE_DIGESTS)
                 .map(Number)
                 .sort((left, right) => left - right)
-            const expected = Array.from({ length: PATTERN_VERSION - 2 }, (_unused, index) => index + 3)
+            const expected = Array.from(
+                { length: PATTERN_VERSION - RATCHET_FIRST_VERSION + 1 },
+                (_unused, index) => RATCHET_FIRST_VERSION + index
+            )
             expect(recorded).toEqual(expected)
         })
 

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -147,12 +147,37 @@ describe('log-pattern-mask', () => {
             expect(result.ruleFires.every((fires) => fires === 0)).toEqual(true)
         })
 
-        it('caps the raw body before the JSON parse, so an oversized JSON body is treated as truncated prose', () => {
-            const body = JSON.stringify({ message: 'x'.repeat(PATTERN_CAPS.maxInputChars) })
+        it('parses before capping, so a JSON body past the mask-input cap still yields its message', () => {
+            const body = JSON.stringify({ message: 'served 7 requests', pad: 'x'.repeat(PATTERN_CAPS.maxInputChars) })
             const result = computeLogPattern(body)
-            expect(result.inputCapped).toEqual(true)
+            expect(result.bodyKind).toEqual('json_object_or_array')
+            expect(result.inputCapped).toEqual(false)
+            expect(result.pattern).toEqual('served <N> requests')
+        })
+
+        it('reduces a verbose structured line to its message, not to a slice of its own fields', () => {
+            // Shaped like a Go service logger: a short message, then a nested array that dwarfs it.
+            const body = JSON.stringify({
+                time: '2026-08-24T10:20:45.123Z',
+                level: 'INFO',
+                msg: 'successfully discovered 3 peer addresses',
+                host: 'worker-01.example.com',
+                peers: Array.from({ length: 400 }, (_unused, index) => ({
+                    host: `10.0.0.${index % 256}`,
+                    port: 9092 + index,
+                    zone: 'zone-a',
+                })),
+            })
+
+            expect(body.length).toBeGreaterThan(PATTERN_CAPS.maxInputChars)
+            expect(computeLogPattern(body).pattern).toEqual('successfully discovered <N> peer addresses')
+        })
+
+        it('skips the parse past the parse ceiling, so one record cannot stall the loop', () => {
+            const body = JSON.stringify({ msg: 'hi', pad: 'x'.repeat(PATTERN_CAPS.maxParseChars) })
+            const result = computeLogPattern(body)
+            expect(result.parseSkipped).toEqual(true)
             expect(result.bodyKind).toEqual('plaintext')
-            expect(result.pattern).toEqual(body.slice(0, PATTERN_CAPS.maxOutputChars))
         })
 
         it.each([
@@ -252,6 +277,8 @@ describe('log-pattern-mask', () => {
             'x'.repeat(PATTERN_CAPS.maxInputChars + 10),
             JSON.stringify({ msg: 'discovered 3 peers', pad: 'y'.repeat(PATTERN_CAPS.maxInputChars) }),
             `head ${'z'.repeat(PATTERN_CAPS.maxOutputChars)} tail`,
+            JSON.stringify({ msg: 'past the parse ceiling', pad: 'w'.repeat(PATTERN_CAPS.maxParseChars) }),
+            JSON.stringify({ msg: 'past the parse ceiling', pad: 'w'.repeat(PATTERN_CAPS.maxParseChars) }),
         ]
 
         const RATCHET_FIRST_VERSION = 3
@@ -267,6 +294,7 @@ describe('log-pattern-mask', () => {
          */
         const SHAPE_DIGESTS: Record<number, string> = {
             3: 'd7b045b1054244d1',
+            4: '00bc38384cb92f37',
         }
 
         /**

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -238,6 +238,11 @@ describe('log-pattern-mask', () => {
             'checksum deadbeefdeadbeef00 verified',
             ...MESSAGE_KEYS.map((key) => JSON.stringify({ [key]: 'served 3 requests', level: 'info' })),
             '{"msg":"loses 2","message":"wins 1"}',
+            // Reach `extractJsonMessage` itself, not just the keys it reads. Widening it to accept a
+            // number, or trimming what it returns, reshapes real bodies while leaving every other
+            // corpus pattern byte-identical.
+            '{"msg":12345}',
+            '{"msg":"  padded 3  "}',
             '{"level":"info","count":3}',
             '{}',
             JSON.stringify(Object.fromEntries(Array.from({ length: 40 }, (_unused, index) => [`k${index}`, 1]))),
@@ -261,7 +266,7 @@ describe('log-pattern-mask', () => {
          * Versions before `RATCHET_FIRST_VERSION` predate this ratchet, so no digest was recorded for them.
          */
         const SHAPE_DIGESTS: Record<number, string> = {
-            3: '5e6a9ab3f22b15ea',
+            3: 'd7b045b1054244d1',
         }
 
         /**

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -14,9 +14,9 @@ export const PATTERN_VERSION = 3
  */
 export type PatternCaps = {
     /** Ceiling on the body chars fed to the masker; longer bodies are cut first (CPU guard). */
-    maxInputChars: number
+    readonly maxInputChars: number
     /** Truncation applied to the masked pattern, after masking, so more real content survives the cut. */
-    maxOutputChars: number
+    readonly maxOutputChars: number
 }
 
 export const PATTERN_CAPS: PatternCaps = {
@@ -122,7 +122,7 @@ export type LogPatternResult = {
     ruleFires: number[]
 }
 
-const MESSAGE_KEYS = ['message', 'msg', 'event'] as const
+export const MESSAGE_KEYS = ['message', 'msg', 'event'] as const
 
 function extractJsonMessage(value: object): string | null {
     if (Array.isArray(value)) {
@@ -136,6 +136,9 @@ function extractJsonMessage(value: object): string | null {
     }
     return null
 }
+
+const capOutput = (pattern: string, caps: PatternCaps): string =>
+    pattern.length > caps.maxOutputChars ? pattern.slice(0, caps.maxOutputChars) : pattern
 
 function jsonKeySetPattern(value: object): string {
     const keys = Object.keys(value).sort()
@@ -166,7 +169,7 @@ export function computeLogPattern(body: string | null | undefined, caps: Pattern
                 const isArray = Array.isArray(parsed.value)
                 const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(parsed.value)
                 return {
-                    pattern: pattern.length > caps.maxOutputChars ? pattern.slice(0, caps.maxOutputChars) : pattern,
+                    pattern: capOutput(pattern, caps),
                     bodyKind,
                     inputCapped,
                     maskedLength: pattern.length,
@@ -190,7 +193,7 @@ export function computeLogPattern(body: string | null | undefined, caps: Pattern
 
     const { masked, ruleFires } = maskString(maskInput)
     return {
-        pattern: masked.length > caps.maxOutputChars ? masked.slice(0, caps.maxOutputChars) : masked,
+        pattern: capOutput(masked, caps),
         bodyKind,
         inputCapped,
         maskedLength: masked.length,

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -11,6 +11,10 @@ export const PATTERN_VERSION = 3
  * These are constants rather than config for that reason. A per-pod override would let two pods stamp
  * one version onto differently shaped patterns, which no consumer could detect. The shape-safe
  * operational lever is `LOGS_PATTERN_MASKING_ENABLED_TEAMS`, which stops masking instead of changing it.
+ *
+ * `computeLogPattern` takes no caps argument, so there is no override path to reach at all. `readonly`
+ * states the intent to the compiler and `Object.freeze` holds it at runtime, because a caller reaching
+ * this object through an `any` would otherwise reshape every pattern under an unchanged version.
  */
 export type PatternCaps = {
     /** Ceiling on the body chars fed to the masker; longer bodies are cut first (CPU guard). */
@@ -19,10 +23,10 @@ export type PatternCaps = {
     readonly maxOutputChars: number
 }
 
-export const PATTERN_CAPS: PatternCaps = {
+export const PATTERN_CAPS: PatternCaps = Object.freeze({
     maxInputChars: 8192,
     maxOutputChars: 1024,
-}
+})
 
 export type MaskRuleName = 'timestamp' | 'klogtime' | 'uuid' | 'email' | 'host' | 'hex0x' | 'hex' | 'ipv4' | 'num'
 
@@ -84,7 +88,7 @@ export const MASK_RULES: readonly MaskRule[] = [
 
 export const JSON_ARRAY = '<JSON_ARRAY>'
 
-const KEY_SET_MAX_KEYS = 32
+export const KEY_SET_MAX_KEYS = 32
 
 const MASK_COMBINED_RE = createTrackedRE2(
     MASK_RULES.map((rule) => `(${rule.pattern})`).join('|'),
@@ -137,8 +141,8 @@ function extractJsonMessage(value: object): string | null {
     return null
 }
 
-const capOutput = (pattern: string, caps: PatternCaps): string =>
-    pattern.length > caps.maxOutputChars ? pattern.slice(0, caps.maxOutputChars) : pattern
+const capOutput = (pattern: string): string =>
+    pattern.length > PATTERN_CAPS.maxOutputChars ? pattern.slice(0, PATTERN_CAPS.maxOutputChars) : pattern
 
 function jsonKeySetPattern(value: object): string {
     const keys = Object.keys(value).sort()
@@ -147,13 +151,13 @@ function jsonKeySetPattern(value: object): string {
     return `<JSON:${kept.join(',')}${overflow > 0 ? `,+${overflow}` : ''}>`
 }
 
-export function computeLogPattern(body: string | null | undefined, caps: PatternCaps = PATTERN_CAPS): LogPatternResult {
+export function computeLogPattern(body: string | null | undefined): LogPatternResult {
     if (body === null || body === undefined || body === '') {
         return { pattern: '', bodyKind: 'empty', inputCapped: false, maskedLength: 0, ruleFires: [] }
     }
 
-    const inputCapped = body.length > caps.maxInputChars
-    const cappedBody = inputCapped ? body.slice(0, caps.maxInputChars) : body
+    const inputCapped = body.length > PATTERN_CAPS.maxInputChars
+    const cappedBody = inputCapped ? body.slice(0, PATTERN_CAPS.maxInputChars) : body
     const parsed = parseLogBodyForIngestion(cappedBody)
     const bodyKind: PatternBodyKind =
         parsed.kind === 'json_primitive' ? 'primitive' : parsed.kind === 'invalid_json' ? 'plaintext' : parsed.kind
@@ -169,7 +173,7 @@ export function computeLogPattern(body: string | null | undefined, caps: Pattern
                 const isArray = Array.isArray(parsed.value)
                 const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(parsed.value)
                 return {
-                    pattern: capOutput(pattern, caps),
+                    pattern: capOutput(pattern),
                     bodyKind,
                     inputCapped,
                     maskedLength: pattern.length,
@@ -193,7 +197,7 @@ export function computeLogPattern(body: string | null | undefined, caps: Pattern
 
     const { masked, ruleFires } = maskString(maskInput)
     return {
-        pattern: capOutput(masked, caps),
+        pattern: capOutput(masked),
         bodyKind,
         inputCapped,
         maskedLength: masked.length,

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -4,6 +4,26 @@ import { parseLogBodyForIngestion } from './log-body-parse'
 
 export const PATTERN_VERSION = 3
 
+/**
+ * Everything here shapes the emitted pattern, so it sits inside `PATTERN_VERSION`: two records may
+ * only be grouped by `pattern` when they carry the same version.
+ *
+ * These are constants rather than config for that reason. A per-pod override would let two pods stamp
+ * one version onto differently shaped patterns, which no consumer could detect. The shape-safe
+ * operational lever is `LOGS_PATTERN_MASKING_ENABLED_TEAMS`, which stops masking instead of changing it.
+ */
+export type PatternCaps = {
+    /** Ceiling on the body chars fed to the masker; longer bodies are cut first (CPU guard). */
+    maxInputChars: number
+    /** Truncation applied to the masked pattern, after masking, so more real content survives the cut. */
+    maxOutputChars: number
+}
+
+export const PATTERN_CAPS: PatternCaps = {
+    maxInputChars: 8192,
+    maxOutputChars: 1024,
+}
+
 export type MaskRuleName = 'timestamp' | 'klogtime' | 'uuid' | 'email' | 'host' | 'hex0x' | 'hex' | 'ipv4' | 'num'
 
 export type MaskRule = {
@@ -124,17 +144,13 @@ function jsonKeySetPattern(value: object): string {
     return `<JSON:${kept.join(',')}${overflow > 0 ? `,+${overflow}` : ''}>`
 }
 
-export function computeLogPattern(
-    body: string | null | undefined,
-    maxInputChars: number,
-    maxOutputChars: number
-): LogPatternResult {
+export function computeLogPattern(body: string | null | undefined, caps: PatternCaps = PATTERN_CAPS): LogPatternResult {
     if (body === null || body === undefined || body === '') {
         return { pattern: '', bodyKind: 'empty', inputCapped: false, maskedLength: 0, ruleFires: [] }
     }
 
-    const inputCapped = body.length > maxInputChars
-    const cappedBody = inputCapped ? body.slice(0, maxInputChars) : body
+    const inputCapped = body.length > caps.maxInputChars
+    const cappedBody = inputCapped ? body.slice(0, caps.maxInputChars) : body
     const parsed = parseLogBodyForIngestion(cappedBody)
     const bodyKind: PatternBodyKind =
         parsed.kind === 'json_primitive' ? 'primitive' : parsed.kind === 'invalid_json' ? 'plaintext' : parsed.kind
@@ -150,7 +166,7 @@ export function computeLogPattern(
                 const isArray = Array.isArray(parsed.value)
                 const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(parsed.value)
                 return {
-                    pattern: pattern.length > maxOutputChars ? pattern.slice(0, maxOutputChars) : pattern,
+                    pattern: pattern.length > caps.maxOutputChars ? pattern.slice(0, caps.maxOutputChars) : pattern,
                     bodyKind,
                     inputCapped,
                     maskedLength: pattern.length,
@@ -174,7 +190,7 @@ export function computeLogPattern(
 
     const { masked, ruleFires } = maskString(maskInput)
     return {
-        pattern: masked.length > maxOutputChars ? masked.slice(0, maxOutputChars) : masked,
+        pattern: masked.length > caps.maxOutputChars ? masked.slice(0, caps.maxOutputChars) : masked,
         bodyKind,
         inputCapped,
         maskedLength: masked.length,

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -148,12 +148,13 @@ function extractJsonMessage(value: object): string | null {
     return null
 }
 
-const capOutput = (pattern: string): string =>
-    pattern.length > PATTERN_CAPS.maxOutputChars ? pattern.slice(0, PATTERN_CAPS.maxOutputChars) : pattern
+function truncate(value: string, max: number): string {
+    return value.length > max ? value.slice(0, max) : value
+}
 
-function jsonKeySetPattern(value: object): string {
-    const keys = Object.keys(value).sort()
-    const kept = keys.slice(0, KEY_SET_MAX_KEYS)
+/** Sorts `keys` in place, so the caller must not read its order afterwards. */
+function jsonKeySetPattern(keys: string[]): string {
+    const kept = keys.sort().slice(0, KEY_SET_MAX_KEYS)
     const overflow = keys.length - kept.length
     return `<JSON:${kept.join(',')}${overflow > 0 ? `,+${overflow}` : ''}>`
 }
@@ -171,9 +172,9 @@ export function computeLogPattern(body: string | null | undefined): LogPatternRe
     }
 
     // Parse before capping, so a long structured body still yields its message rather than a slice of
-    // itself. Cutting first left every JSON body over the cap as invalid JSON, and a truncated-prose
-    // pattern is near-unique per record: it carries hostnames and field order past the cut, so each
-    // oversized record minted its own pattern. `maxParseChars` keeps a bound on one record's parse cost.
+    // itself. Cutting first would leave every oversized JSON body as invalid JSON, and truncated prose
+    // is near-unique per record: it carries hostnames and field order past the cut, so each oversized
+    // record would mint its own pattern. `maxParseChars` bounds one record's parse cost.
     const parseSkipped = body.length > PATTERN_CAPS.maxParseChars
     const parsed = parseSkipped ? ({ kind: 'invalid_json', raw: body } as const) : parseLogBodyForIngestion(body)
     const bodyKind: PatternBodyKind =
@@ -188,14 +189,15 @@ export function computeLogPattern(body: string | null | undefined): LogPatternRe
             const message = extractJsonMessage(parsed.value)
             if (message === null) {
                 const isArray = Array.isArray(parsed.value)
-                const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(parsed.value)
+                const keys = isArray ? [] : Object.keys(parsed.value)
+                const pattern = isArray ? JSON_ARRAY : jsonKeySetPattern(keys)
                 return {
-                    pattern: capOutput(pattern),
+                    pattern: truncate(pattern, PATTERN_CAPS.maxOutputChars),
                     bodyKind,
                     inputCapped: false,
                     parseSkipped,
                     maskedLength: pattern.length,
-                    ...(isArray ? {} : { jsonKeyCount: Object.keys(parsed.value).length }),
+                    ...(isArray ? {} : { jsonKeyCount: keys.length }),
                     ruleFires: [],
                 }
             }
@@ -214,9 +216,9 @@ export function computeLogPattern(body: string | null | undefined): LogPatternRe
     }
 
     const inputCapped = maskInput.length > PATTERN_CAPS.maxInputChars
-    const { masked, ruleFires } = maskString(inputCapped ? maskInput.slice(0, PATTERN_CAPS.maxInputChars) : maskInput)
+    const { masked, ruleFires } = maskString(truncate(maskInput, PATTERN_CAPS.maxInputChars))
     return {
-        pattern: capOutput(masked),
+        pattern: truncate(masked, PATTERN_CAPS.maxOutputChars),
         bodyKind,
         inputCapped,
         parseSkipped,

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -2,7 +2,7 @@ import { createTrackedRE2 } from '~/common/utils/tracked-re2'
 
 import { parseLogBodyForIngestion } from './log-body-parse'
 
-export const PATTERN_VERSION = 3
+export const PATTERN_VERSION = 4
 
 /**
  * Everything here shapes the emitted pattern, so it sits inside `PATTERN_VERSION`: two records may
@@ -17,13 +17,18 @@ export const PATTERN_VERSION = 3
  * this object through an `any` would otherwise reshape every pattern under an unchanged version.
  */
 export type PatternCaps = {
-    /** Ceiling on the body chars fed to the masker; longer bodies are cut first (CPU guard). */
+    /** Bodies longer than this skip the JSON parse and mask as prose, bounding one record's parse cost. */
+    readonly maxParseChars: number
+    /** Ceiling on the chars handed to the masker, applied after the message is extracted. */
     readonly maxInputChars: number
     /** Truncation applied to the masked pattern, after masking, so more real content survives the cut. */
     readonly maxOutputChars: number
 }
 
 export const PATTERN_CAPS: PatternCaps = Object.freeze({
+    // 0.2% of bodies pass 8 KiB, but the tail collapses fast above it and the largest seen is ~6 MiB.
+    // 256 KiB covers all but a handful of records per hour while still bounding one synchronous parse.
+    maxParseChars: 262144,
     maxInputChars: 8192,
     maxOutputChars: 1024,
 })
@@ -121,6 +126,8 @@ export type LogPatternResult = {
     pattern: string
     bodyKind: PatternBodyKind
     inputCapped: boolean
+    /** Body was too long to parse, so it masked as prose without a structured read. */
+    parseSkipped: boolean
     maskedLength: number
     jsonKeyCount?: number
     ruleFires: number[]
@@ -153,12 +160,22 @@ function jsonKeySetPattern(value: object): string {
 
 export function computeLogPattern(body: string | null | undefined): LogPatternResult {
     if (body === null || body === undefined || body === '') {
-        return { pattern: '', bodyKind: 'empty', inputCapped: false, maskedLength: 0, ruleFires: [] }
+        return {
+            pattern: '',
+            bodyKind: 'empty',
+            inputCapped: false,
+            parseSkipped: false,
+            maskedLength: 0,
+            ruleFires: [],
+        }
     }
 
-    const inputCapped = body.length > PATTERN_CAPS.maxInputChars
-    const cappedBody = inputCapped ? body.slice(0, PATTERN_CAPS.maxInputChars) : body
-    const parsed = parseLogBodyForIngestion(cappedBody)
+    // Parse before capping, so a long structured body still yields its message rather than a slice of
+    // itself. Cutting first left every JSON body over the cap as invalid JSON, and a truncated-prose
+    // pattern is near-unique per record: it carries hostnames and field order past the cut, so each
+    // oversized record minted its own pattern. `maxParseChars` keeps a bound on one record's parse cost.
+    const parseSkipped = body.length > PATTERN_CAPS.maxParseChars
+    const parsed = parseSkipped ? ({ kind: 'invalid_json', raw: body } as const) : parseLogBodyForIngestion(body)
     const bodyKind: PatternBodyKind =
         parsed.kind === 'json_primitive' ? 'primitive' : parsed.kind === 'invalid_json' ? 'plaintext' : parsed.kind
 
@@ -175,7 +192,8 @@ export function computeLogPattern(body: string | null | undefined): LogPatternRe
                 return {
                     pattern: capOutput(pattern),
                     bodyKind,
-                    inputCapped,
+                    inputCapped: false,
+                    parseSkipped,
                     maskedLength: pattern.length,
                     ...(isArray ? {} : { jsonKeyCount: Object.keys(parsed.value).length }),
                     ruleFires: [],
@@ -188,18 +206,20 @@ export function computeLogPattern(body: string | null | undefined): LogPatternRe
             maskInput = parsed.value
             break
         case 'json_primitive':
-            maskInput = cappedBody
+            maskInput = body
             break
         case 'invalid_json':
             maskInput = parsed.raw
             break
     }
 
-    const { masked, ruleFires } = maskString(maskInput)
+    const inputCapped = maskInput.length > PATTERN_CAPS.maxInputChars
+    const { masked, ruleFires } = maskString(inputCapped ? maskInput.slice(0, PATTERN_CAPS.maxInputChars) : maskInput)
     return {
         pattern: capOutput(masked),
         bodyKind,
         inputCapped,
+        parseSkipped,
         maskedLength: masked.length,
         ruleFires,
     }

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -1,7 +1,6 @@
 import type { Counter } from 'prom-client'
 
-import { DEFAULT_PATTERN_MAX_INPUT_CHARS } from './config'
-import { PATTERN_VERSION } from './log-pattern-mask'
+import { PATTERN_CAPS, PATTERN_VERSION } from './log-pattern-mask'
 import {
     logsPatternBodyKindCounter,
     logsPatternInputCappedCounter,
@@ -42,12 +41,12 @@ describe('log-pattern-stage', () => {
     }
 
     it('tallies body kinds, rule fires, and input caps across a batch without touching the body', async () => {
-        const stage = makePatternMaskingStage(20, 1024)
+        const stage = makePatternMaskingStage()
         const records = [
             makeRecord(null),
             makeRecord('plain 5'),
             makeRecord('{"message":"hi"}'),
-            makeRecord('a long body over the input cap 123'),
+            makeRecord('x'.repeat(PATTERN_CAPS.maxInputChars + 1)),
         ]
         const bodiesBefore = records.map((r) => r.body)
 
@@ -72,7 +71,7 @@ describe('log-pattern-stage', () => {
         ['a plain body', 'retry 5', 'retry <N>'],
         ['an empty body, which must still carry a version or it reads as written before masking', null, ''],
     ])('stamps pattern and version onto the record: %s', async (_name, body, expected) => {
-        const stage = makePatternMaskingStage(1024, 1024)
+        const stage = makePatternMaskingStage()
         const record = makeRecord(body)
 
         await stage.run([record])
@@ -80,14 +79,14 @@ describe('log-pattern-stage', () => {
         expect(record).toMatchObject({ pattern: expected, pattern_version: PATTERN_VERSION })
     })
 
-    it('falls back to the default caps when a configured cap is not a positive integer', async () => {
-        const stage = makePatternMaskingStage(Number.NaN, -1)
-        await stage.run([makeRecord('x'.repeat(DEFAULT_PATTERN_MAX_INPUT_CHARS + 1))])
+    it('counts a body past the versioned input cap', async () => {
+        const stage = makePatternMaskingStage()
+        await stage.run([makeRecord('x'.repeat(PATTERN_CAPS.maxInputChars + 1))])
         expect((await logsPatternInputCappedCounter.get()).values[0].value).toEqual(1)
     })
 
     it('keeps the batch when masking throws, so a measurement fault cannot DLQ customer logs', async () => {
-        const stage = makePatternMaskingStage(1024, 1024)
+        const stage = makePatternMaskingStage()
         const record = makeRecord(null)
         Object.defineProperty(record, 'body', {
             get: () => {

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -4,6 +4,7 @@ import { PATTERN_CAPS, PATTERN_VERSION } from './log-pattern-mask'
 import {
     logsPatternBodyKindCounter,
     logsPatternInputCappedCounter,
+    logsPatternParseSkippedCounter,
     logsPatternRuleFiredCounter,
     logsPatternStageErrorCounter,
     makePatternMaskingStage,
@@ -32,6 +33,7 @@ describe('log-pattern-stage', () => {
         logsPatternBodyKindCounter.reset()
         logsPatternRuleFiredCounter.reset()
         logsPatternInputCappedCounter.reset()
+        logsPatternParseSkippedCounter.reset()
         logsPatternStageErrorCounter.reset()
     })
 
@@ -77,6 +79,16 @@ describe('log-pattern-stage', () => {
         await stage.run([record])
 
         expect(record).toMatchObject({ pattern: expected, pattern_version: PATTERN_VERSION })
+    })
+
+    it('counts a body too long to parse apart from a genuinely unstructured one', async () => {
+        const stage = makePatternMaskingStage()
+        const oversized = JSON.stringify({ msg: 'hi', pad: 'x'.repeat(PATTERN_CAPS.maxParseChars) })
+
+        await stage.run([oversized, 'plain prose'].map(makeRecord))
+
+        expect((await logsPatternParseSkippedCounter.get()).values[0].value).toEqual(1)
+        expect(await counterValues(logsPatternBodyKindCounter)).toEqual({ plaintext: 2 })
     })
 
     it('keeps the batch when masking throws, so a measurement fault cannot DLQ customer logs', async () => {

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -79,12 +79,6 @@ describe('log-pattern-stage', () => {
         expect(record).toMatchObject({ pattern: expected, pattern_version: PATTERN_VERSION })
     })
 
-    it('counts a body past the versioned input cap', async () => {
-        const stage = makePatternMaskingStage()
-        await stage.run([makeRecord('x'.repeat(PATTERN_CAPS.maxInputChars + 1))])
-        expect((await logsPatternInputCappedCounter.get()).values[0].value).toEqual(1)
-    })
-
     it('keeps the batch when masking throws, so a measurement fault cannot DLQ customer logs', async () => {
         const stage = makePatternMaskingStage()
         const record = makeRecord(null)

--- a/nodejs/src/logs/log-pattern-stage.ts
+++ b/nodejs/src/logs/log-pattern-stage.ts
@@ -1,7 +1,6 @@
 import { performance } from 'node:perf_hooks'
 import { Counter, Histogram } from 'prom-client'
 
-import { DEFAULT_PATTERN_MAX_INPUT_CHARS, DEFAULT_PATTERN_MAX_OUTPUT_CHARS } from './config'
 import { MASK_RULES, PATTERN_VERSION, computeLogPattern } from './log-pattern-mask'
 import type { LogRecord } from './log-record-avro'
 import type { PipelineStage } from './pipeline/log-processing-pipeline'
@@ -52,18 +51,13 @@ export const logsPatternStageErrorCounter = new Counter({
     help: 'Batches where the pattern masking stage threw. The records survive. Any record the throw came before keeps its stamp, and the rest stay unstamped, which reads as version 0.',
 })
 
-const positiveIntOr = (value: number, fallback: number): number =>
-    Number.isInteger(value) && value > 0 ? value : fallback
-
-export function makePatternMaskingStage(maxInputChars: number, maxOutputChars: number): PipelineStage {
-    const inputCap = positiveIntOr(maxInputChars, DEFAULT_PATTERN_MAX_INPUT_CHARS)
-    const outputCap = positiveIntOr(maxOutputChars, DEFAULT_PATTERN_MAX_OUTPUT_CHARS)
+export function makePatternMaskingStage(): PipelineStage {
     return {
         kind: 'mutate',
         name: 'pattern_masking',
         run: (records) => {
             try {
-                stampBatch(records, inputCap, outputCap)
+                stampBatch(records)
             } catch {
                 logsPatternStageErrorCounter.inc()
             }
@@ -71,14 +65,14 @@ export function makePatternMaskingStage(maxInputChars: number, maxOutputChars: n
     }
 }
 
-function stampBatch(records: LogRecord[], inputCap: number, outputCap: number): void {
+function stampBatch(records: LogRecord[]): void {
     const kindCounts = new Map<string, number>()
     const ruleFires: number[] = new Array(MASK_RULES.length).fill(0)
     let inputCapped = 0
 
     for (const record of records) {
         const start = performance.now()
-        const result = computeLogPattern(record.body, inputCap, outputCap)
+        const result = computeLogPattern(record.body)
         record.pattern = result.pattern
         record.pattern_version = PATTERN_VERSION
         logsPatternMaskingDurationHistogram.observe((performance.now() - start) / 1000)

--- a/nodejs/src/logs/log-pattern-stage.ts
+++ b/nodejs/src/logs/log-pattern-stage.ts
@@ -37,7 +37,12 @@ export const logsPatternRuleFiredCounter = new Counter({
 
 export const logsPatternInputCappedCounter = new Counter({
     name: 'logs_ingestion_pattern_input_capped_total',
-    help: 'Log bodies cut at the masking input ceiling. Sizes the long-line problem.',
+    help: 'Mask inputs cut at the masking input ceiling, after the message is extracted. Sizes the long-line problem.',
+})
+
+export const logsPatternParseSkippedCounter = new Counter({
+    name: 'logs_ingestion_pattern_parse_skipped_total',
+    help: 'Bodies too long to parse, masked as prose instead. Separates giving up from genuinely unstructured in the body-kind split.',
 })
 
 export const logsPatternForcedDecodeCounter = new Counter({
@@ -69,6 +74,7 @@ function stampBatch(records: LogRecord[]): void {
     const kindCounts = new Map<string, number>()
     const ruleFires: number[] = new Array(MASK_RULES.length).fill(0)
     let inputCapped = 0
+    let parseSkipped = 0
 
     for (const record of records) {
         const start = performance.now()
@@ -88,6 +94,9 @@ function stampBatch(records: LogRecord[]): void {
         if (result.inputCapped) {
             inputCapped++
         }
+        if (result.parseSkipped) {
+            parseSkipped++
+        }
     }
 
     for (const [kind, count] of kindCounts) {
@@ -100,5 +109,8 @@ function stampBatch(records: LogRecord[]): void {
     }
     if (inputCapped > 0) {
         logsPatternInputCappedCounter.inc(inputCapped)
+    }
+    if (parseSkipped > 0) {
+        logsPatternParseSkippedCounter.inc(parseSkipped)
     }
 }

--- a/nodejs/src/logs/log-pattern-stage.ts
+++ b/nodejs/src/logs/log-pattern-stage.ts
@@ -20,13 +20,22 @@ export const logsPatternMaskedLengthHistogram = new Histogram({
 export const logsPatternKeySetKeysHistogram = new Histogram({
     name: 'logs_ingestion_pattern_keyset_keys',
     help: 'Top-level key count of message-less JSON objects. Everything above the 32 bucket was capped; validates the key-set cap from data.',
-    buckets: [1, 2, 4, 8, 16, 24, 32, 48, 64, 128],
+    // Reaches past 32k because a body just under `maxParseChars` can carry that many top-level keys.
+    buckets: [1, 2, 4, 8, 16, 24, 32, 48, 64, 128, 512, 2048, 8192, 32768],
+})
+
+export const logsPatternBodyLengthHistogram = new Histogram({
+    name: 'logs_ingestion_pattern_body_length_chars',
+    help: 'Raw body length seen by the stage. Sizes the long-line problem; the mask-input counter measures the extracted message instead.',
+    buckets: [256, 1024, 4096, 8192, 32768, 131072, 262144, 1048576],
 })
 
 export const logsPatternMaskingDurationHistogram = new Histogram({
     name: 'logs_ingestion_pattern_masking_duration_seconds',
     help: 'Per-record pattern masking duration.',
-    buckets: [0.000001, 0.000005, 0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01],
+    // A body near `maxParseChars` parses in milliseconds, so the buckets run past 10ms to keep the
+    // tail that ceiling governs measurable rather than collapsed into +Inf.
+    buckets: [0.000001, 0.000005, 0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1],
 })
 
 export const logsPatternRuleFiredCounter = new Counter({
@@ -83,6 +92,7 @@ function stampBatch(records: LogRecord[]): void {
         record.pattern_version = PATTERN_VERSION
         logsPatternMaskingDurationHistogram.observe((performance.now() - start) / 1000)
 
+        logsPatternBodyLengthHistogram.observe(record.body?.length ?? 0)
         logsPatternMaskedLengthHistogram.observe(result.maskedLength)
         if (result.jsonKeyCount !== undefined) {
             logsPatternKeySetKeysHistogram.observe(result.jsonKeyCount)

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -370,10 +370,7 @@ export class LogsIngestionConsumer {
         this.retentionEnabledTeamsRaw = mergedConfig.LOGS_RETENTION_ENABLED_TEAMS
         this.retentionKillswitch = mergedConfig.LOGS_RETENTION_KILLSWITCH
         this.patternMaskingEnabledTeamsRaw = mergedConfig.LOGS_PATTERN_MASKING_ENABLED_TEAMS
-        this.patternMaskingStage = makePatternMaskingStage(
-            mergedConfig.LOGS_PATTERN_MASKING_MAX_INPUT_CHARS,
-            mergedConfig.LOGS_PATTERN_MASKING_MAX_OUTPUT_CHARS
-        )
+        this.patternMaskingStage = makePatternMaskingStage()
     }
 
     private isSamplingEvalEnabledForTeam(teamId: number): boolean {


### PR DESCRIPTION
## Problem

A verbose JSON log line loses its message and gets a pattern that no other record shares.

A Go service logging `{"time":...,"level":"INFO","msg":"discovered 3 peers","peers":[...400 entries...]}` should reduce to `discovered <N> peers`. Instead it produces a 1024-character slice of its own field names, carrying hostnames and field order past the cut.

- `computeLogPattern` cut the body to 8192 characters before parsing it.
- The cut lands mid-structure, so `JSON.parse` throws and the body is treated as prose.
- The masker then runs over the whole truncated JSON text, and the output cap trims the result to 1024 characters.
- Those patterns are near-unique per record, which is the cardinality explosion the patterns feature exists to prevent.

Measured across 2 hours of production logs: 0.203% of bodies pass 8192 characters, and 57% of those are JSON. Teams with at least one are a small but broad minority of the fleet, so this is a broad pattern rather than one noisy producer.

## Changes

A structured log line past the cap now reduces to its message, so records that share a message share a pattern.

- `computeLogPattern` parses first, then caps the mask input after the message is extracted.
- `maxParseChars` at 256 KiB bounds one record's parse cost. `JSON.parse` is synchronous, and the largest body seen in production is about 6 MiB.
- `logs_ingestion_pattern_parse_skipped_total` counts bodies past that ceiling. Without it the `plaintext` body kind merges "genuinely unstructured" with "gave up on the JSON".
- `inputCapped` now reports whether the mask input was cut, not whether the body was. The JSON key-set branch reports `false`, because it never touches the mask input.
- The masking dashboards resolve the slow tail instead of piling it into `+Inf`. The key-set and duration histograms run out to 32k keys and 100 ms, which is where a body near the ceiling lands.
- `logs_ingestion_pattern_body_length_chars` is new and sizes the raw body. The mask-input counter measures the extracted message, so nothing else did.
- `PATTERN_VERSION` moves to 4, with its digest recorded in the `SHAPE_DIGESTS` map from #92255.
- `maxParseChars` joins `PATTERN_CAPS`, so the ratchet in #92255 constrains it like every other shape input. A mutation lowering it to 128 KiB fails that ratchet.
- The corpus gains a body past the parse ceiling, so the new `parseSkipped` branch is reached.

256 KiB rather than no ceiling at all. Parsing every body costs 7.48% more parse input than today; stopping at 256 KiB costs 7.27%. The remaining 0.198% of coverage is not worth letting a single 6 MiB body run a synchronous parse on the ingestion event loop.

> [!NOTE]
> Patterns stamped version 3 and version 4 are not comparable. Any query that groups by `pattern` must filter on `pattern_version`.

## How did you test this code?

- A test builds a verbose service log line whose payload dwarfs its message, and asserts the pattern is the message. Before this change that body produced a truncated slice of its own fields. No existing test covered a JSON body past the cap yielding its message, because the old behavior made it impossible.
- A second test asserts a body past the parse ceiling masks as prose and sets `parseSkipped`, covering the new bound.
- The ratchet from #92255 failed on this change and named the version it wanted, which is the check working as intended.
- A fifteen-mutation sweep runs green on this branch: every change to a shape input, including reverting the parse-before-cap order itself, fails the ratchet.
- The whole `src/logs` suite passes locally, 21 suites.
- Not measured: the real CPU cost in production. The 7.48% figure is parse input bytes from a ClickHouse query over `logs_distributed`, not observed CPU time. Watch `logs_ingestion_pattern_masking_duration_seconds` after rollout.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this. Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.

The session started from a production log line whose pattern looked wrong, and traced it to the cap sitting above the parse rather than below it.

The first proposal was to share the existing uncapped parse in `log-record-avro.ts`, on the assumption that the fleet already paid for it. A query against the production app database killed that: `json_parse_logs` is enabled for only a handful of teams. The parse is new work, and the ceiling was sized from the measured body-length distribution instead.

The versioning half of the work moved to #92255 so this PR holds only the behavior change.

#92255 was then redesigned under this branch, so this layer was rebased onto it and its tests rewritten. `computeLogPattern` no longer takes a caps argument, so the cap-override tests were replaced with real-sized bodies. One removed stage test was not reinstated during the rebase: #92255 dropped it as a strict subset of the batch test above it, and that still holds.

Public artifact: the test fixture was written from a list of the properties it has to exercise, not adapted from any real log. It uses reserved domains, invented hostnames, and made-up identifiers. The production figures quoted above are aggregate percentages of body counts, with no team, customer, or service named, and no team counts.



