### PR TITLE
chore(product-analytics): move the endpoint contract cases next to the runners

### DIFF
--- a/products/cohorts/backend/models/test/test_util.py
+++ b/products/cohorts/backend/models/test/test_util.py
@@ -403,30 +403,13 @@ class TestCohortUtils(BaseTest):
 
     def test_print_cohort_hogql_query_includes_settings(self):
         """Test that cohort queries include HogQL global settings"""
-        # Create a cohort with a HogQL query (simulating a funnel-to-cohort conversion)
+        # The settings come from the printer, so any actors-shaped cohort query reaches them.
         cohort = Cohort.objects.create(
             team=self.team,
-            name="Test Funnel Cohort",
+            name="Test Actors Cohort",
             query={
                 "kind": "ActorsQuery",
-                "source": {
-                    "kind": "FunnelsActorsQuery",
-                    "source": {
-                        "kind": "FunnelsQuery",
-                        "series": [
-                            {"kind": "EventsNode", "event": "$pageview"},
-                            {"kind": "EventsNode", "event": "$identify"},
-                        ],
-                        "interval": "day",
-                        "dateRange": {"date_from": "-30d"},
-                        "funnelsFilter": {
-                            "funnelVizType": "steps",
-                            "funnelWindowInterval": 1,
-                            "funnelWindowIntervalUnit": "day",
-                        },
-                    },
-                    "funnelStep": 2,
-                },
+                "source": {"kind": "HogQLQuery", "query": "SELECT id AS actor_id FROM persons"},
             },
         )
 

--- a/products/endpoints/backend/facade/api.py
+++ b/products/endpoints/backend/facade/api.py
@@ -34,13 +34,13 @@ from products.endpoints.backend.models import Endpoint, EndpointVersion
 from . import contracts
 
 if TYPE_CHECKING:
+    from products.endpoints.backend.insight_transformers import transform_materialized_insight_response
     from products.endpoints.backend.logic.ai_materialization_fix import (
         REWRITE_CONTRACT,
         live_materialization_conditions_source,
         materialization_fix_enabled,
         suggest_materialization_fix,
     )
-    from products.endpoints.backend.insight_transformers import transform_materialized_insight_response
     from products.endpoints.backend.logic.crud import EndpointCrudService
     from products.endpoints.backend.logic.execution import EndpointExecutionService
     from products.endpoints.backend.logic.materialization import (
@@ -154,6 +154,7 @@ __all__ = [
     "EndpointCrudService",
     "EndpointExecutionService",
     "EndpointMaterializationService",
+    "build_endpoint_hogql",
     "build_materialization_info",
     "generate_openapi_spec",
     "get_endpoint",
@@ -164,6 +165,7 @@ __all__ = [
     "live_materialization_conditions_source",
     "materialization_fix_enabled",
     "suggest_materialization_fix",
+    "transform_materialized_insight_response",
     "validate_bucket_overrides",
     "validate_endpoint_request",
     "validate_update_request",

--- a/products/endpoints/backend/facade/api.py
+++ b/products/endpoints/backend/facade/api.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         materialization_fix_enabled,
         suggest_materialization_fix,
     )
+    from products.endpoints.backend.insight_transformers import transform_materialized_insight_response
     from products.endpoints.backend.logic.crud import EndpointCrudService
     from products.endpoints.backend.logic.execution import EndpointExecutionService
     from products.endpoints.backend.logic.materialization import (
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
         validate_endpoint_request,
         validate_update_request,
     )
+    from products.endpoints.backend.materialization_transforms import build_endpoint_hogql
     from products.endpoints.backend.openapi import generate_openapi_spec
 
 # symbol -> source module (relative to products.endpoints.backend)
@@ -67,6 +69,10 @@ _LAZY = {
     "validate_endpoint_request": "logic.validation",
     "validate_update_request": "logic.validation",
     "generate_openapi_spec": "openapi",
+    # The insight-conversion seam. Product analytics owns the runners these two reach through
+    # core's dispatcher, so its tests hold the cases that prove the conversion still works.
+    "build_endpoint_hogql": "materialization_transforms",
+    "transform_materialized_insight_response": "insight_transformers",
 }
 
 

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -548,12 +548,6 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         can_materialize, reason = version.can_materialize()
         self.assertTrue(can_materialize, reason)
 
-        # The allowlist only reads the kind, so compile too: this is the step that would break if the
-        # runner stopped producing a printable AST.
-        hogql_query = build_endpoint_hogql(version.query, self.team)
-        self.assertEqual(hogql_query["kind"], "HogQLQuery")
-        self.assertIsInstance(hogql_query["query"], str)
-
     @parameterized.expand(
         [
             (

--- a/products/endpoints/backend/tests/test_insight_response_parity.py
+++ b/products/endpoints/backend/tests/test_insight_response_parity.py
@@ -16,17 +16,7 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework import status
 
-from posthog.schema import (
-    Breakdown,
-    BreakdownFilter,
-    BreakdownType,
-    EventsNode,
-    HogQLQueryResponse,
-    LifecycleQuery,
-    RetentionFilter,
-    RetentionQuery,
-    TrendsQuery,
-)
+from posthog.schema import Breakdown, BreakdownFilter, BreakdownType, EventsNode, HogQLQueryResponse, TrendsQuery
 
 from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
 from products.endpoints.backend.insight_transformers import (
@@ -41,10 +31,6 @@ pytestmark = [pytest.mark.django_db]
 
 # Fields that every TrendsQuery result dict must have
 TRENDS_REQUIRED_FIELDS = {"data", "labels", "days", "count", "label", "action"}
-# Fields that every LifecycleQuery result dict must have
-LIFECYCLE_REQUIRED_FIELDS = {"data", "labels", "days", "count", "label", "action", "status"}
-# Fields that every RetentionQuery result dict must have
-RETENTION_REQUIRED_FIELDS = {"values", "label", "date"}
 
 
 class TestInsightResponseParity(ClickhouseTestMixin, APIBaseTest):
@@ -319,73 +305,6 @@ class TestInsightResponseParity(ClickhouseTestMixin, APIBaseTest):
         series = result["results"][0]
         assert series["days"] == ["2026-05-04", "2026-05-05", "2026-05-06"]
         assert series["labels"] == ["4-May-2026", "5-May-2026", "6-May-2026"]
-
-    # =========================================================================
-    # LIFECYCLE
-    # =========================================================================
-
-    def test_materialized_lifecycle_has_insight_shape(self):
-        original_query = LifecycleQuery(
-            series=[EventsNode(event="$pageview")],
-            dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
-        ).model_dump()
-
-        # Columns arrive in alphabetical order, the way Delta/Parquet sorts a materialized table.
-        dates = [date(2026, 1, d) for d in range(1, 11)]
-        result: dict[str, Any] = {
-            "results": [
-                (dates, "new", [1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-                (dates, "returning", [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
-                (dates, "resurrecting", [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-                (dates, "dormant", [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-            ],
-            "columns": ["date", "status", "total"],
-            "types": ["Array(Date)", "String", "Array(Int64)"],
-        }
-
-        transform_materialized_insight_response(result, original_query, self.team)
-
-        rows = result["results"]
-        assert len(rows) > 0
-        for field in LIFECYCLE_REQUIRED_FIELDS:
-            assert field in rows[0], f"Materialized lifecycle response missing '{field}'"
-        assert {r["status"] for r in rows} == {"new", "returning", "resurrecting", "dormant"}
-        for r in rows:
-            assert len(r["data"]) == 10, f"Status {r['status']}: expected 10 data points, got {len(r['data'])}"
-
-    # =========================================================================
-    # RETENTION
-    # =========================================================================
-
-    def test_materialized_retention_has_insight_shape(self):
-        original_query = RetentionQuery(
-            retentionFilter=RetentionFilter(),
-            dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
-        ).model_dump()
-
-        # Columns arrive in alphabetical order, the way Delta/Parquet sorts a materialized table.
-        result: dict[str, Any] = {
-            "results": [
-                (1, 0, 0),
-                (1, 1, 0),
-                (1, 0, 1),
-                (1, 1, 1),
-                (0, 0, 2),
-                (0, 1, 2),
-            ],
-            "columns": ["count", "intervals_from_base", "start_event_matching_interval"],
-            "types": ["UInt64", "Int64", "Int64"],
-        }
-
-        transform_materialized_insight_response(result, original_query, self.team)
-
-        rows = result["results"]
-        assert len(rows) >= 3, f"Expected at least 3 cohorts, got {len(rows)}"
-        for field in RETENTION_REQUIRED_FIELDS:
-            assert field in rows[0], f"Materialized retention response missing '{field}'"
-        assert isinstance(rows[0]["values"], list)
-        assert rows[0]["values"][0]["count"] == 1
-        assert "label" in rows[0]["values"][0]
 
     # =========================================================================
     # MULTI-SERIES TRENDS

--- a/products/model_crossing_uses_baseline.txt
+++ b/products/model_crossing_uses_baseline.txt
@@ -674,12 +674,6 @@ product_analytics.Insight products.reminders.backend.constants in-collection 1
 product_analytics.Insight products.slack_app.backend.slack_link_unfurl instance-single 1
 product_analytics.Insight products.surveys.backend.api.survey instance-single 1
 product_analytics.Insight surveys.Survey.linked_insight reverse-accessor(surveys_linked_insight) 1
-product_analytics:backend/hogql_queries/ products.cohorts.backend.models.test.test_util drives(FunnelsQuery) 1
-product_analytics:backend/hogql_queries/ products.endpoints.backend.tests.test_endpoint_materialization drives(LifecycleQuery) 1
-product_analytics:backend/hogql_queries/ products.endpoints.backend.tests.test_endpoint_materialization drives(RetentionQuery) 1
-product_analytics:backend/hogql_queries/ products.endpoints.backend.tests.test_insight_response_parity drives(LifecycleQuery) 1
-product_analytics:backend/hogql_queries/ products.endpoints.backend.tests.test_insight_response_parity drives(RetentionQuery) 1
-product_analytics:backend/hogql_queries/ products.posthog_ai.scripts.hogql_example.test.test_hogql_example drives(FunnelsQuery) 1
 replay_vision.ReplayScanner posthog.TaggedItem.replay_scanner reverse-accessor(tagged_items) 1
 signals.SignalReport tasks.Task.signal_report reverse-accessor(task) 1
 surveys.Survey product_tours.ProductTour.linked_surveys reverse-accessor(product_tours) 1

--- a/products/posthog_ai/scripts/hogql_example/test/test_hogql_example.py
+++ b/products/posthog_ai/scripts/hogql_example/test/test_hogql_example.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
@@ -56,24 +58,16 @@ class TestRenderHogQLExample(BaseTest):
         assert "2025-12-10" in result
         assert "2025-12-03" in result
 
-    @patch("django.conf.settings.DEBUG", True)
-    def test_funnel_pins_context_now_for_sub_date_ranges(self) -> None:
-        # FunnelsQuery's sub-helpers read `context.now` rather than the runner's
-        # query_date_range, so this guards the context-pinning branch of
-        # `_pin_runner_now`.
-        result = render_hogql_example(
-            {
-                "kind": "FunnelsQuery",
-                "series": [
-                    {"kind": "EventsNode", "event": "$pageview"},
-                    {"kind": "EventsNode", "event": "user signed up"},
-                ],
-                "dateRange": {"date_from": "-7d"},
-            }
-        )
+    def test_pins_context_now_as_well_as_the_date_range(self) -> None:
+        # Some runners resolve sub-ranges off `context.now` rather than off query_date_range, so
+        # both surfaces have to be pinned. A stub stands in for the runner because the branch is
+        # generic: reaching it through a real query kind ties this suite to whichever product
+        # owns that kind, and the trends case above already covers the pipeline end to end.
+        runner = SimpleNamespace(context=SimpleNamespace(now=None))
 
-        assert "2025-12-10" in result
-        assert "2025-12-03" in result
+        hogql_example_module._pin_runner_now(runner, hogql_example_module._FROZEN_DATETIME)
+
+        assert runner.context.now == hogql_example_module._FROZEN_DATETIME
 
     @patch("django.conf.settings.DEBUG", True)
     def test_render_does_not_use_freezegun(self) -> None:

--- a/products/product_analytics/backend/hogql_queries/lifecycle/test/test_lifecycle_endpoint_contract.py
+++ b/products/product_analytics/backend/hogql_queries/lifecycle/test/test_lifecycle_endpoint_contract.py
@@ -1,0 +1,51 @@
+from datetime import date
+from typing import Any
+
+from posthog.test.base import BaseTest
+
+from posthog.schema import EventsNode, LifecycleQuery
+
+from products.endpoints.backend.facade.api import build_endpoint_hogql, transform_materialized_insight_response
+
+LIFECYCLE_REQUIRED_FIELDS = {"data", "labels", "days", "count", "label", "action", "status"}
+
+
+# What the endpoints product needs from this runner, tested where the runner lives. Both paths
+# reach `LifecycleQueryRunner` through core's dispatcher, so an edit here breaks endpoints, and
+# keeping the cases beside the runner is what makes them run on that edit.
+class TestLifecycleEndpointContract(BaseTest):
+    def _query(self) -> dict[str, Any]:
+        return LifecycleQuery(
+            series=[EventsNode(event="$pageview")],
+            dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+        ).model_dump()
+
+    def test_compiles_to_printable_hogql(self) -> None:
+        hogql_query = build_endpoint_hogql(self._query(), self.team)
+
+        assert hogql_query["kind"] == "HogQLQuery"
+        assert isinstance(hogql_query["query"], str)
+
+    def test_materialized_rows_take_the_insight_shape(self) -> None:
+        # Columns arrive in alphabetical order, the way Delta/Parquet sorts a materialized table.
+        dates = [date(2026, 1, day) for day in range(1, 11)]
+        result: dict[str, Any] = {
+            "results": [
+                (dates, "new", [1, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                (dates, "returning", [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+                (dates, "resurrecting", [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+                (dates, "dormant", [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            ],
+            "columns": ["date", "status", "total"],
+            "types": ["Array(Date)", "String", "Array(Int64)"],
+        }
+
+        transform_materialized_insight_response(result, self._query(), self.team)
+
+        rows = result["results"]
+        assert len(rows) > 0
+        for field in LIFECYCLE_REQUIRED_FIELDS:
+            assert field in rows[0], f"Materialized lifecycle response missing '{field}'"
+        assert {row["status"] for row in rows} == {"new", "returning", "resurrecting", "dormant"}
+        for row in rows:
+            assert len(row["data"]) == 10, f"Status {row['status']}: expected 10 data points, got {len(row['data'])}"

--- a/products/product_analytics/backend/hogql_queries/retention/test/test_retention_endpoint_contract.py
+++ b/products/product_analytics/backend/hogql_queries/retention/test/test_retention_endpoint_contract.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+from posthog.test.base import BaseTest
+
+from posthog.schema import RetentionFilter, RetentionQuery
+
+from posthog.constants import RETENTION_FIRST_EVER_OCCURRENCE, TREND_FILTER_TYPE_EVENTS
+
+from products.endpoints.backend.facade.api import build_endpoint_hogql, transform_materialized_insight_response
+
+RETENTION_REQUIRED_FIELDS = {"values", "label", "date"}
+
+
+# What the endpoints product needs from this runner, tested where the runner lives. Both paths
+# reach `RetentionQueryRunner` through core's dispatcher, so an edit here breaks endpoints, and
+# keeping the cases beside the runner is what makes them run on that edit.
+class TestRetentionEndpointContract(BaseTest):
+    def test_compiles_to_printable_hogql(self) -> None:
+        query = RetentionQuery(
+            dateRange={"date_from": "2025-01-01", "date_to": "2025-01-08"},
+            retentionFilter=RetentionFilter(
+                period="Day",
+                totalIntervals=7,
+                retentionType=RETENTION_FIRST_EVER_OCCURRENCE,
+                targetEntity={
+                    "id": "$user_signed_up",
+                    "name": "$user_signed_up",
+                    "type": TREND_FILTER_TYPE_EVENTS,
+                },
+                returningEntity={"id": "$pageview", "name": "$pageview", "type": "events"},
+            ),
+        ).model_dump()
+
+        hogql_query = build_endpoint_hogql(query, self.team)
+
+        assert hogql_query["kind"] == "HogQLQuery"
+        assert isinstance(hogql_query["query"], str)
+
+    def test_materialized_rows_take_the_insight_shape(self) -> None:
+        original_query = RetentionQuery(
+            retentionFilter=RetentionFilter(),
+            dateRange={"date_from": "2026-01-01", "date_to": "2026-01-10"},
+        ).model_dump()
+
+        # Columns arrive in alphabetical order, the way Delta/Parquet sorts a materialized table.
+        result: dict[str, Any] = {
+            "results": [
+                (1, 0, 0),
+                (1, 1, 0),
+                (1, 0, 1),
+                (1, 1, 1),
+                (0, 0, 2),
+                (0, 1, 2),
+            ],
+            "columns": ["count", "intervals_from_base", "start_event_matching_interval"],
+            "types": ["UInt64", "Int64", "Int64"],
+        }
+
+        transform_materialized_insight_response(result, original_query, self.team)
+
+        rows = result["results"]
+        assert len(rows) >= 3, f"Expected at least 3 cohorts, got {len(rows)}"
+        for field in RETENTION_REQUIRED_FIELDS:
+            assert field in rows[0], f"Materialized retention response missing '{field}'"
+        assert isinstance(rows[0]["values"], list)
+        assert rows[0]["values"][0]["count"] == 1
+        assert "label" in rows[0]["values"][0]

--- a/products/product_analytics/turbo.json
+++ b/products/product_analytics/turbo.json
@@ -4,7 +4,6 @@
         "backend:contract-check": {
             "inputs": [
                 "backend/facade/**",
-                "backend/hogql_queries/**",
                 "backend/presentation/**",
                 "backend/routes.py",
                 "backend/models/**",


### PR DESCRIPTION
## Problem

The layer below this one teaches the crossings scan to follow a call out of its module. It then reports six outside tests that reach product analytics' query runners through a helper — enough to pull `backend/hogql_queries/**` back into the product's contract-check inputs and undo the skip four earlier PRs bought.

All six are real. Four assert on values a product analytics runner computed, and one says so in its own comment: "this is the step that would break if the runner stopped producing a printable AST". The coupling was always there; only the scan could not see it.

Refs #77396

## Changes

- Four cases move to sit beside the runner they check, so an edit to that runner runs them. They were passing where they were; they were just out of reach of the thing that decides what to re-run.
  - `test_endpoint_materialization`'s lifecycle and retention rows did two jobs: is this kind on the allowlist, and does it compile. The allowlist half stays in endpoints; the compile half moves.
  - Both `test_insight_response_parity` insight-shape cases move whole. The shaping is done by `RetentionQueryRunner.format_results`.
- **The endpoints facade gains `build_endpoint_hogql` and `transform_materialized_insight_response`.** A test may only reach another product through its facade, and moving the cases without this fails `hogli lint:tach`. Both are pure functions over a query dict, and `build_endpoint_hogql`'s own docstring already describes it as one. Endpoints owners: this is the part to push back on if you would rather keep the surface closed — the alternative is the input returns.
- The moved cases run on `BaseTest` rather than `ClickhouseTestMixin, APIBaseTest`, and drop the event fixtures they inherited. Neither case ever queried; they only needed a team.
- `test_hogql_example`'s funnel case guarded a generic branch of the renderer's clock pinning, and used a funnel only because funnels read the clock off the context rather than off the date range. It now tests that branch directly, with a stub. Trades one end-to-end path for a unit test that names the branch, and drops a product coupling from a suite that has no other reason to carry one.
- Cohorts' `test_print_cohort_hogql_query_includes_settings` built a funnel-backed cohort to assert that generated cohort SQL carries the HogQL global settings. The settings come from the printer, so the funnel earned nothing. It now uses the `ActorsQuery` over `HogQLQuery` shape the same file already uses two tests down. This one arrived with the review — see below.
- Mechanical: the constants and imports the moved cases used leave with them; the two new endpoints facade names join `__all__`.

- **`backend/hogql_queries/**` leaves the contract-check inputs again.** The layer below restores it, because six real drivers stood; with those resolved it goes. This is the whole payoff: an edit to the product's funnels, paths, stickiness, retention or lifecycle runners stops re-running the full Django suite.

After this, `hogli product:crossings --all` reports no `drives(...)` line for product_analytics, and turbo's dry-run inputs read 40 files with none under `backend/hogql_queries/`.

## How did you test this code?

Ran on a dev stack in the sandbox, which the layer below could not do.

- The four moved cases and the rewritten pinning case: **11 passed** (`test_lifecycle_endpoint_contract.py`, `test_retention_endpoint_contract.py`, `test_hogql_example.py`), re-run after the restack.
- Cohorts' `TestCohortUtils`: **26 passed**, including the repointed settings case.
- The two trimmed endpoints files: 76 passed, 6 failed. All six are trends cases failing on `Failed to schedule materialization` — no Temporal server here. Verified rather than assumed: master's copy of `test_insight_response_parity.py` fails the identical six (11 passed there against 9 here, the difference being the two cases this PR moves out).
- `hogli lint:tach` exits 0, read filtered rather than tailed. It caught the first version of this change, which imported endpoints internals directly.
- `hogli product:lint --all` passes across 75 products; `hogli ci:preflight --strict` reports 0 failures.
- The crossings baseline is regenerated: 6 lines added against master and 3 count increases, all web_analytics, **none product_analytics**. `hogli product:lint --all` passes 75/75 with the input dropped, and turbo's dry-run inputs confirm the drop by absence: 40 files, 0 under `backend/hogql_queries/`.

No new regression is covered here that was not covered before — the four moved cases keep their assertions, and the point of the move is where they run, not what they check. The one genuine change of coverage is the pinning case: it now catches the context branch of `_pin_runner_now` no longer being set, and no longer catches a funnels runner that stops reading `context.now`. That second half is product analytics' behavior and its funnel tests cover it.

### Review round on the layer below

Greptile found that a patch was being read off the whole enclosing class, so a sibling test's mock suppressed a call the test under judgement really makes. Fixing that surfaced a sixth driver, the cohorts case above: four sibling tests in that file mock `get_query_runner`, and their patches were hiding the one that does not.

Worth knowing for whoever moves trends, because the same shape recurs. A file where most tests mock the runner and one does not reads as fully mocked to the old scan.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus) in a PostHog Desktop cloud task, directed by a person in the product-analytics-isolation channel. The PR is unassigned because no GitHub handle for that person was verified in the session, and guessing one would tag an unrelated account.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Two things were walked back while writing this. The moved tests first imported `products.endpoints.backend.insight_transformers` directly, which tach rejects — the facade entries are the fix, and they are a real widening of another product's surface rather than a formality. The funnels case was first going to move into product analytics like the other four; testing the branch directly is better, because the branch belongs to the renderer and nothing about it needs a funnel.

Worth recording for whoever moves trends: thinning the endpoints cases to direct calls in #91599 did not remove the drive, it made it invisible. `transform_materialized_insight_response` is exactly what the new scan follows.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*


