### PR TITLE
fix(activity-logs): stop system.activity_logs failing on numeric item ids

### DIFF
--- a/posthog/hogql/database/schema/activity_log_visibility.py
+++ b/posthog/hogql/database/schema/activity_log_visibility.py
@@ -19,8 +19,13 @@ from posthog.hogql.parser import parse_expr
 CANVASES_TABLE = "system.canvases"
 _LOOP_ROWS_HIDDEN = "NOT (scope = 'Loop')"
 _CANVAS_ROWS_HIDDEN = "NOT (scope = 'Canvas')"
+# `toString` on the canvas id is load-bearing. `item_id` is a String holding the id of whatever object
+# the row is about, and most of those are numeric (`11510926` for an insight), while a canvas id is a
+# real UUID once the federated read types it. ClickHouse coerces the left side of an IN to the set's
+# type, and it does that for every row rather than only the Canvas ones, so an unconverted set makes
+# any read of this table die on the first numeric id: "Cannot parse uuid 11510926".
 _CANVAS_ROWS_LIMITED_TO_READABLE_CANVASES = (
-    f"NOT (scope = 'Canvas' AND item_id NOT IN (SELECT id FROM {CANVASES_TABLE}))"
+    f"NOT (scope = 'Canvas' AND item_id NOT IN (SELECT toString(id) FROM {CANVASES_TABLE}))"
 )
 
 # Bumped whenever the compilation shape changes in a way the hashed inputs below cannot see, e.g. a rule

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -1095,6 +1095,36 @@ class TestSystemTablesCanvasDeletedExclusionIsolation(NonAtomicBaseTest):
         assert str(deleted_canvas.pk) not in ids
 
 
+class TestSystemTablesActivityLogsCanvasIdCoercion(NonAtomicBaseTest):
+    """The Canvas visibility rule compares `item_id` against canvas ids, which are UUIDs."""
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def test_numeric_item_id_readable_while_canvases_exist(self):
+        # One canvas is enough to make the rule's id set non-empty and UUID-typed. `item_id` is a
+        # String holding whatever object the row is about, and most of those ids are numeric, so
+        # ClickHouse coerced every row's item_id to UUID and the whole table failed to read.
+        with team_scope(self.team.pk):
+            channel = Channel.objects.create(team=self.team, name="activity-log-canvas-channel")
+            Canvas.objects.create(team=self.team, channel=channel, name="live")
+        ActivityLog.objects.create(
+            team_id=self.team.pk,
+            organization_id=self.organization.id,
+            activity="created",
+            scope="Insight",
+            item_id="11510926",
+            detail={},
+        )
+
+        response = execute_hogql_query(
+            "SELECT item_id FROM system.activity_logs WHERE item_id = '11510926'",
+            team=self.team,
+            user=self.user,
+        )
+
+        assert [row[0] for row in response.results] == ["11510926"]
+
+
 class TestSystemTablesTaskInternalExclusion(BaseTest):
     """Verify the tasks system table excludes internal tasks (signals pipeline, etc.)
     mirroring the REST API's default filter."""

--- a/posthog/hogql/database/test/test_activity_logs_restrictions.py
+++ b/posthog/hogql/database/test/test_activity_logs_restrictions.py
@@ -137,7 +137,9 @@ class TestActivityLogsSqlRestrictions(BaseTest):
 
         hogql, _ = self._print(dialect="hogql")
 
-        self.assertIn("NOT(and(equals(scope, 'Canvas'), notIn(item_id, (SELECT id FROM canvases", hogql)
+        # toString keeps the set String-typed. Canvas ids are UUIDs, item_id is a String holding
+        # mostly numeric ids, and ClickHouse coerces item_id to the set's type for every row.
+        self.assertIn("NOT(and(equals(scope, 'Canvas'), notIn(item_id, (SELECT toString(id) FROM canvases", hogql)
         # The canvases subquery keeps that table's own guards, so its access control carries over.
         self.assertIn("_task_public_channels", hogql)
 


### PR DESCRIPTION
## Problem

Every read of `system.activity_logs` fails in production for any team that has a canvas. Not a subset of rows — the whole table, including `SELECT count()`.

```
Cannot parse uuid 11510926: Cannot parse UUID from String
  in FUNCTION notNullIn(item_id, __set_...)
```

- The Canvas visibility rule from #82573 compares `item_id` against the ids in `system.canvases`.
- `item_id` is a String holding the id of whatever object a row is about. Most are numeric, like `11510926` for an insight.
- A canvas id is a real UUID once the federated read types it.
- ClickHouse coerces the left side of an `IN` to the set's type, and does it for **every** row rather than only the `scope = 'Canvas'` ones. The first numeric id takes the query down.

It fails closed, so no restricted rows were exposed while it was broken. The table was simply unreadable.

## Changes

- Cast the set to String, so both sides of the comparison are the same type.
- The policy fingerprint hashes this predicate, so the cache key moves on its own and results stored under the broken rule are retired.

I found this by querying the table through the PostHog MCP against production, after the deploy. Local tests never saw it: a dev canvas table is usually empty, an empty set skips the coercion entirely, and the existing tests only assert printed SQL, which was correct all along.

> [!NOTE]
> The new test executes the read rather than asserting SQL text. It creates a canvas, so the set is non-empty and UUID-typed, and an activity log row with a numeric `item_id`. Reverted against the fix it reproduces the production error exactly, same `notNullIn` frame.

## How did you test this code?

- Added `TestSystemTablesActivityLogsCanvasIdCoercion` to `test_system_tables.py`, which already executes federated system-table reads. It fails with `CHQueryErrorCannotParseUuid` without the fix and passes with it.
- Updated the printed-SQL assertion in `test_activity_logs_restrictions.py` to pin `toString(id)`, so removing the cast breaks a second test.
- 279 tests pass across `test_system_tables.py`, `test_activity_logs_restrictions.py`, and `test_hogql_query_runner.py`.

Not checked: whether any team saw errors between the deploy and this fix. The failure is loud and client-visible, so it would show up as failed queries rather than bad data.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this, directed by @yasen-posthog. It fixes a regression from #82573, which I also wrote.

The bug survived a full local test pass, an end-to-end run against a local ClickHouse and Postgres, and a browser pass, because every one of those ran against a dev database with no canvases. The set was empty, so ClickHouse never had to coerce the types. It surfaced on the first real query against production data.

The lesson worth keeping: a predicate whose behavior depends on the *contents* of another table needs a test that puts data in that table. The new test does that.

No customer data went into this branch. The numeric id in the test is the one from the production error message, which is an insight id, not customer content.
