### PR TITLE
fix(sentry): skip issue on persistent tags endpoint server error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -402,6 +402,29 @@ def _skip_rows_on_stale_issue_404(
         raise
 
 
+def _skip_issue_on_tags_server_error(
+    rows: Iterator[dict[str, Any]], organization_slug: str, issue_id: str
+) -> Iterator[dict[str, Any]]:
+    """Swallow a persistent 5xx raised while iterating an issue's tags endpoint.
+
+    Retries are already exhausted by _request_with_retry; skip this issue's tags
+    rather than failing the whole sync — same graceful-skip as the values endpoint.
+    """
+    try:
+        yield from rows
+    except HTTPError as exc:
+        response = exc.response
+        if response is not None and response.status_code >= 500:
+            logger.warning(
+                "sentry_source.issue_tags_server_error_skipped",
+                organization_slug=organization_slug,
+                issue_id=issue_id,
+                status_code=response.status_code,
+            )
+            return
+        raise
+
+
 # lastSeen carries the scan floor, so it is always projected. A parent whose column selection
 # dropped it fails the eager resolve check and drives this child from the API instead.
 _ISSUES_PARENT_COLUMNS = ["id", "lastSeen"]
@@ -557,7 +580,7 @@ def _iter_issue_tag_values_rows(
             # schema last synced; their tags endpoint 404s. A fresh API parent pull would
             # simply not list them, so skip instead of failing the sync.
             tags = _skip_rows_on_stale_issue_404(tags, organization_slug, issue_id, stale_issues)
-        for tag in tags:
+        for tag in _skip_issue_on_tags_server_error(tags, organization_slug, issue_id):
             tag_key = tag.get("key") or tag.get("id")
             if not isinstance(tag_key, str) or not tag_key:
                 continue

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -818,6 +818,35 @@ class TestSentrySourceValidation:
         with pytest.raises(HTTPError):
             list(cast(Any, resp.items()))
 
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
+    def test_issue_tag_values_skips_issue_on_persistent_tags_server_error(self, mock_request) -> None:
+        def side_effect(url, headers=None, params=None, timeout=None):
+            if url.endswith("/organizations/acme/issues/"):
+                return _response([{"id": "100"}, {"id": "200"}])
+            if url.endswith("/organizations/acme/issues/100/tags/"):
+                # Sentry persistently 503s for this issue's tags endpoint.
+                return _response(None, status_code=503)
+            if url.endswith("/organizations/acme/issues/200/tags/"):
+                return _response([{"key": "browser"}])
+            if url.endswith("/organizations/acme/issues/200/tags/browser/values/"):
+                return _response([{"value": "Chrome"}])
+            return _response([])
+
+        mock_request.side_effect = side_effect
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="issue_tag_values",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        # The 503 on issue 100's tags endpoint is skipped; issue 200 still yields its values.
+        rows = list(cast(Any, resp.items()))
+        assert rows == [{"value": "Chrome", "issue_id": "200", "tag_key": "browser"}]
+
 
 class TestSentrySourceResumable:
     """Resume behaviour for flat endpoints (rest_api_resource path)."""


### PR DESCRIPTION
## Problem

A Sentry import sync fails entirely when Sentry's API returns a persistent 503 on an issue's tags endpoint. The `_request_with_retry` helper already retries 503 responses three times; once those retries are exhausted the error propagates up and aborts the job.

The values-per-tag path (`/issues/{id}/tags/{key}/values/`) already catches persistent 5xx and skips the affected tag. The tags-per-issue path (`/issues/{id}/tags/`) had no equivalent guard, so a single unavailable issue terminated the whole schema sync.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/01a05c58-7c23-7af3-aa92-38a3ab39d591

## Changes

- A persistent 5xx on an issue's tags endpoint is now logged and skipped; later issues in the listing continue to sync.
- Mechanical: new `_skip_issue_on_tags_server_error` generator mirrors the existing `_skip_rows_on_stale_issue_404` / values-path skip pattern.

## How did you test this code?

Added `test_issue_tag_values_skips_issue_on_persistent_tags_server_error`: patches `_request_with_retry` to return a 503 on one issue's tags endpoint and asserts the next issue's tag values still arrive. Without the fix this test raises `HTTPError` instead of yielding the row.

All 161 existing tests in `test_sentry.py` pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated error tracking issue 01a05c58-7c23-7af3-aa92-38a3ab39d591, read the Sentry source implementation, confirmed the bug in `_iter_issue_tag_values_rows`, and verified the values-path pattern to match. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*