### PR TITLE
fix(mcp-store): link Datadog catalog entries to the vendor setup docs

### DIFF
--- a/products/mcp_store/backend/catalog.py
+++ b/products/mcp_store/backend/catalog.py
@@ -116,6 +116,7 @@ MCP_SERVER_CATALOG: list[CatalogEntry] = [
         auth_type="oauth",
         category="data",
         icon_domain="datadoghq.com",
+        docs_url="https://docs.datadoghq.com/mcp_server/setup/?site=eu",
     ),
     CatalogEntry(
         name="Datadog (US)",
@@ -124,6 +125,7 @@ MCP_SERVER_CATALOG: list[CatalogEntry] = [
         auth_type="oauth",
         category="data",
         icon_domain="datadoghq.com",
+        docs_url="https://docs.datadoghq.com/mcp_server/setup/?site=us",
     ),
     CatalogEntry(
         name="dbt Labs",


### PR DESCRIPTION
## Problem

Connecting either Datadog MCP server can fail on Datadog's authorize page with "Mismatching redirect URI", even after the region split in #85635. The cause is on the Datadog side: each Datadog org has an admin-only "MCP OAuth Redirect URLs" allowlist (Organization Settings → Preferences), and Datadog's authorize endpoint validates the redirect URI against it. Users in https://github.com/PostHog/posthog/issues/85619 only found this through a Datadog support ticket.

The failure happens on Datadog's page before the user returns to PostHog, so PostHog cannot surface guidance at error time. The catalog entries also linked no documentation.

## Changes

- The Datadog (EU) and Datadog (US) server pages now show a "Docs" link to [Datadog's MCP server setup page](https://docs.datadoghq.com/mcp_server/setup/), region-matched via the `?site=` parameter. Its Authentication section covers the redirect URL allowlist.
- The change sets `docs_url` on the two existing catalog entries. `docs_url` is a synced content field, so it propagates to existing rows on the next deploy with no migration. The server `url` fields are unchanged, so no re-registration or probe is involved.

## How did you test this code?

- `products/mcp_store/backend/test/test_catalog_sync.py` passes locally (13 tests); it already covers `docs_url` propagation on sync, so no new tests.
- Both doc URLs return 200.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. There is no PostHog-side docs page for the MCP store catalog entries.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code while investigating the follow-up reports on #85619. Skills invoked: /writing-pr-descriptions. The session verified the allowlist behavior against Datadog's published setup docs and confirmed `docs_url` sync semantics in `catalog_sync.py`. Nothing from the support context appears in the diff.
