### PR TITLE
fix(hogql): scope taxonomy validation lookups by project

### DIFF
--- a/posthog/hogql/taxonomy_validation.py
+++ b/posthog/hogql/taxonomy_validation.py
@@ -14,6 +14,8 @@ from posthog.hogql.visitor import TraversingVisitor
 
 from posthog.models import EventDefinition, PropertyDefinition, Team
 
+from products.event_definitions.backend.models.property_definition import effective_project_id_expr
+
 logger = getLogger(__name__)
 
 # How a suggested name is rendered back into the marked range for a one-click fix:
@@ -110,7 +112,11 @@ def validate_taxonomy_references(
         if visitor.event_literals:
             warnings.extend(
                 _warnings_for_unknown_references(
-                    "Event", visitor.event_literals, EventDefinition.objects.filter(team=team)
+                    "Event",
+                    visitor.event_literals,
+                    EventDefinition.objects.alias(effective_project_id=effective_project_id_expr()).filter(
+                        effective_project_id=team.project_id
+                    ),
                 )
             )
 
@@ -123,7 +129,9 @@ def validate_taxonomy_references(
                     _warnings_for_unknown_references(
                         "Property",
                         property_references,
-                        PropertyDefinition.objects.filter(team=team, type=PropertyDefinition.Type.EVENT),
+                        PropertyDefinition.objects.alias(effective_project_id=effective_project_id_expr()).filter(
+                            effective_project_id=team.project_id, type=PropertyDefinition.Type.EVENT
+                        ),
                     )
                 )
     except DatabaseError:

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -366,7 +366,7 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
         EventDefinition.objects.create(team=self.team, name="paid_bill")
 
         with patch(
-            "posthog.hogql.taxonomy_validation.EventDefinition.objects.filter",
+            "posthog.hogql.taxonomy_validation.EventDefinition.objects.alias",
             side_effect=DatabaseError("boom"),
         ):
             metadata = self._select("SELECT count() FROM events WHERE event = 'purchase'")
@@ -377,14 +377,14 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
 
     def test_metadata_does_not_query_taxonomy_without_taxonomy_references(self):
         with (
-            patch("posthog.hogql.taxonomy_validation.EventDefinition.objects.filter") as event_filter,
-            patch("posthog.hogql.taxonomy_validation.PropertyDefinition.objects.filter") as property_filter,
+            patch("posthog.hogql.taxonomy_validation.EventDefinition.objects.alias") as event_alias,
+            patch("posthog.hogql.taxonomy_validation.PropertyDefinition.objects.alias") as property_alias,
         ):
             metadata = self._select("SELECT count() FROM events")
 
         self.assertTrue(metadata.isValid)
-        event_filter.assert_not_called()
-        property_filter.assert_not_called()
+        event_alias.assert_not_called()
+        property_alias.assert_not_called()
 
     def test_metadata_does_not_warn_for_event_column_outside_events_table(self):
         EventDefinition.objects.create(team=self.team, name="paid_bill")


### PR DESCRIPTION
## Problem

HogQL taxonomy warnings ("… is not in your project taxonomy") ran a Postgres lookup that took over a minute in the worst cases. The check is advisory, but it runs on every HogQL compile in the SQL editor and in the AI `execute_sql` tool, and it showed up in pganalyze's slow query list on prod-US.

- The lookup filtered `PropertyDefinition` by `team_id`, `type` and `name IN (…)`.
- No index covers `team_id` together with `name`, so Postgres combined the `(team_id, type)` btree with the trigram GIN on `name`.
- The trigram side walks the posting lists for each name across every team before the team filter applies.
- The `team_id` scope also missed definitions written by a sibling environment of the same project, so the warning could flag a name the taxonomy page shows.

## Changes

- Taxonomy warnings no longer flag a property or event that exists in another environment of the same project.
- Both lookups filter on `COALESCE(project_id, team_id)` via `effective_project_id_expr()`, the leading expression of `posthog_propdef_proj_uniq` and `event_definition_proj_uniq`.
- The `name IN (…)` existence check becomes one index scan on those unique indexes. Only `name` is selected, so the scan reads no heap pages.
- Mechanical: two tests patch `.objects.alias` instead of `.objects.filter` so they still intercept the real call.

### EXPLAIN on prod-US, same inputs

`EXPLAIN (ANALYZE, BUFFERS)` against the prod-US read replica, one project, the same five property names for both shapes.

| | Before: `team_id = … AND type = 1 AND name IN (…)` | After: `COALESCE(project_id, team_id) = … AND name IN (…) AND type = 1` |
|---|---|---|
| Plan | `BitmapAnd` of `(team_id, type)` btree and trigram GIN on `name` | `Index Scan using posthog_propdef_proj_uniq` |
| Buffers | 533,219 (415,696 hit, 117,523 read) | 41 (35 hit, 6 read) |
| I/O wait | 105.5 s, 103.4 s of it on the GIN index | 7.9 ms |
| Execution time | 108,124 ms | 8.0 ms |
| Rows returned | 5 | 5 |

> [!NOTE]
> The old shape ran cold on the replica, so a warm run is faster than 108 s (pganalyze's average for it is about 130 ms). The buffer count does not depend on cache state, and that volume is what produces the I/O tail on the writer.

Both queries returned the same five rows when run as plain `SELECT`s.

<details>
<summary>Full plans (project id and names elided)</summary>

Before:

```text
Bitmap Heap Scan on posthog_propertydefinition  (cost=5339.86..5356.20 rows=16 width=58) (actual time=108124.175..108124.344 rows=5 loops=1)
  Recheck Cond: ((team_id = <id>) AND (type = 1) AND ((name)::text = ANY (<names>)))
  Rows Removed by Index Recheck: 167
  Heap Blocks: exact=118
  Buffers: shared hit=415696 read=117523
  I/O Timings: shared read=105491.466
  ->  BitmapAnd  (cost=5339.86..5339.86 rows=16 width=0) (actual time=108124.015..108124.016 rows=0 loops=1)
        ->  Bitmap Index Scan on posthog_pro_team_id_eac36d_idx  (cost=0.00..1728.96 rows=93939 width=0) (actual time=2061.181..2061.181 rows=87433 loops=1)
              Index Cond: ((team_id = <id>) AND (type = 1))
              Buffers: shared hit=6 read=2281
              I/O Timings: shared read=2050.373
        ->  Bitmap Index Scan on index_property_definition_name  (cost=0.00..3610.64 rows=19553 width=0) (actual time=106061.746..106061.746 rows=38321 loops=1)
              Index Cond: ((name)::text = ANY (<names>))
              Buffers: shared hit=415572 read=115242
              I/O Timings: shared read=103441.093
Planning Time: 3.605 ms
Execution Time: 108124.491 ms
```

After:

```text
Index Scan using posthog_propdef_proj_uniq on posthog_propertydefinition  (cost=0.82..20.58 rows=16 width=58) (actual time=2.685..8.007 rows=5 loops=1)
  Index Cond: ((COALESCE(project_id, (team_id)::bigint) = <id>) AND ((name)::text = ANY (<names>)) AND (type = 1))
  Buffers: shared hit=35 read=6
  I/O Timings: shared read=7.930
Planning Time: 0.125 ms
Execution Time: 8.024 ms
```

</details>

## How did you test this code?

- `hogli test posthog/hogql/test/test_metadata.py`: the existing taxonomy tests, including the fail-open and no-query-without-references tests that now patch the new call.
- `EXPLAIN (ANALYZE, BUFFERS)` and a result comparison of both shapes on the prod-US read replica, shown above.
- Not run: repo-wide mypy. The change alters no signatures or return types.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Fable 5) with the pganalyze MCP to find and profile the query, and `hogli metabase:query` for the prod EXPLAIN comparison.
- Skills invoked: `/query-clickhouse-via-metabase` for Metabase access, `/writing-pr-descriptions`.
- The change came out of a pganalyze slow-query sweep of the event and property definition tables. The other two items from that sweep, the event definition list join (#90387) and the replay-vision description lookup (#90365), landed separately. Scoping the event lookup too was a choice for consistency; it was not slow on its own because `(team_id, name)` already has a btree.
