### PR TITLE
feat(logs): tell learning series when their band arrives

### DIFF
--- a/products/logs/backend/presentation/views/anomalies_api.py
+++ b/products/logs/backend/presentation/views/anomalies_api.py
@@ -233,6 +233,16 @@ class LogsSeriesBandSeriesSerializer(serializers.Serializer):
             f"Below {MIN_BASELINE_WEEKS_FOR_BAND} the series is still learning and its buckets carry no band."
         )
     )
+    history_start = serializers.DateTimeField(
+        help_text="Earliest bucket with data inside the fetched lookback.",
+    )
+    band_ready_at = serializers.DateTimeField(
+        allow_null=True,
+        help_text=(
+            "When this series has enough history to carry a band, so a learning series can count down to it. "
+            "Null once the band is drawn."
+        ),
+    )
     buckets = LogsSeriesBandBucketSerializer(
         many=True,
         help_text="One entry per display bucket across the whole window, oldest first, zero-filled.",

--- a/products/logs/backend/presentation/views/anomalies_api.py
+++ b/products/logs/backend/presentation/views/anomalies_api.py
@@ -239,8 +239,7 @@ class LogsSeriesBandSeriesSerializer(serializers.Serializer):
     band_ready_at = serializers.DateTimeField(
         allow_null=True,
         help_text=(
-            "When this series has enough history to carry a band, so a learning series can count down to it. "
-            "Null once the band is drawn."
+            "When this series gains its band, so a learning series can count down to it. Null once the band is drawn."
         ),
     )
     buckets = LogsSeriesBandBucketSerializer(

--- a/products/logs/backend/series_bands.py
+++ b/products/logs/backend/series_bands.py
@@ -59,6 +59,8 @@ class BandSeries:
     severity: str
     total_count: int
     baseline_weeks: int
+    history_start: dt.datetime
+    band_ready_at: dt.datetime | None
     buckets: list[BandBucket]
 
 
@@ -255,6 +257,8 @@ def _build_series(
         severity=key.severity,
         total_count=total_count,
         baseline_weeks=baseline_weeks,
+        history_start=earliest_slot,
+        band_ready_at=None if banded else earliest_slot + dt.timedelta(weeks=MIN_BASELINE_WEEKS_FOR_BAND),
         buckets=buckets,
     )
 

--- a/products/logs/backend/series_bands.py
+++ b/products/logs/backend/series_bands.py
@@ -214,6 +214,22 @@ def _baseline_weeks_available(later: dt.datetime, earliest_slot: dt.datetime) ->
     return min(BASELINE_WEEKS, max(0, weeks))
 
 
+def _band_gate(
+    window_start: dt.datetime, window_end: dt.datetime, earliest_slot: dt.datetime
+) -> tuple[int, dt.datetime | None]:
+    """Baseline depth at the window start, and when a shallow series gains its band.
+
+    The gate reads history before window_start, so a live window must travel a
+    whole window length past the history threshold before a band is drawn. One
+    rule returns both, so the countdown cannot drift off the gate it counts to.
+    """
+    baseline_weeks = _baseline_weeks_available(window_start, earliest_slot)
+    if baseline_weeks >= MIN_BASELINE_WEEKS_FOR_BAND:
+        return baseline_weeks, None
+    threshold = earliest_slot + dt.timedelta(weeks=MIN_BASELINE_WEEKS_FOR_BAND)
+    return baseline_weeks, threshold + (window_end - window_start)
+
+
 def _build_series(
     key: _SeriesKey,
     slot_rows: list[_SlotRow],
@@ -223,8 +239,8 @@ def _build_series(
 ) -> BandSeries:
     by_time = {row.target_time: row for row in slot_rows}
     earliest_slot = min(row.earliest_slot for row in slot_rows)
-    baseline_weeks = _baseline_weeks_available(window_start, earliest_slot)
-    banded = baseline_weeks >= MIN_BASELINE_WEEKS_FOR_BAND
+    baseline_weeks, band_ready_at = _band_gate(window_start, window_end, earliest_slot)
+    banded = band_ready_at is None
     floor = BAND_FLOOR_PER_HOUR * interval_minutes / 60
 
     buckets: list[BandBucket] = []
@@ -258,7 +274,7 @@ def _build_series(
         total_count=total_count,
         baseline_weeks=baseline_weeks,
         history_start=earliest_slot,
-        band_ready_at=None if banded else earliest_slot + dt.timedelta(weeks=MIN_BASELINE_WEEKS_FOR_BAND),
+        band_ready_at=band_ready_at,
         buckets=buckets,
     )
 

--- a/products/logs/backend/test/test_anomalies_api.py
+++ b/products/logs/backend/test/test_anomalies_api.py
@@ -198,6 +198,8 @@ class TestLogsSeriesBandsAPI(APIBaseTest):
                     severity="error",
                     total_count=25,
                     baseline_weeks=5,
+                    history_start=T0 - dt.timedelta(weeks=5),
+                    band_ready_at=None,
                     buckets=[BandBucket(time=T0 - dt.timedelta(hours=1), observed=25, lower=9.0, upper=57.0)],
                 )
             ],
@@ -216,6 +218,8 @@ class TestLogsSeriesBandsAPI(APIBaseTest):
         series = data["series"][0]
         assert (series["namespace"], series["environment"], series["severity"]) == ("ns", "prod", "error")
         assert series["baseline_weeks"] == 5
+        assert series["history_start"] == (T0 - dt.timedelta(weeks=5)).isoformat().replace("+00:00", "Z")
+        assert series["band_ready_at"] is None
         assert series["buckets"][0] == {
             "time": (T0 - dt.timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
             "observed": 25,

--- a/products/logs/backend/test/test_series_bands.py
+++ b/products/logs/backend/test/test_series_bands.py
@@ -5,7 +5,7 @@ from posthog.test.base import BaseTest, ClickhouseTestMixin
 
 from posthog.clickhouse.client import sync_execute
 
-from products.logs.backend.series_bands import run_series_bands
+from products.logs.backend.series_bands import _band_gate, run_series_bands
 
 UTC = dt.UTC
 # The scan clock sits ahead of real time so the whole 6-week fixture range stays
@@ -89,9 +89,18 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
         series = result.series[0]
         assert series.baseline_weeks == 1
         assert series.history_start == WINDOW_START - dt.timedelta(weeks=1)
-        assert series.band_ready_at == WINDOW_START + dt.timedelta(weeks=1)
+        assert series.band_ready_at == WINDOW_END + dt.timedelta(weeks=1)
         assert all(bucket.lower is None and bucket.upper is None for bucket in series.buckets)
         assert series.total_count == 12
+
+    def test_band_ready_at_is_when_the_gate_opens(self):
+        earliest = WINDOW_START - dt.timedelta(weeks=1)
+
+        _, ready_at = _band_gate(WINDOW_START, WINDOW_END, earliest)
+
+        assert ready_at is not None
+        window = WINDOW_END - WINDOW_START
+        assert _band_gate(ready_at - window, ready_at, earliest)[1] is None
 
     def test_missing_baseline_week_drags_floor_to_zero(self):
         service = "svc-gappy"

--- a/products/logs/backend/test/test_series_bands.py
+++ b/products/logs/backend/test/test_series_bands.py
@@ -57,6 +57,7 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
         series = result.series[0]
         assert (series.namespace, series.environment, series.severity) == ("ns", "prod", "error")
         assert series.baseline_weeks == 5
+        assert series.band_ready_at is None
         assert series.total_count == 25
         assert len(series.buckets) == 7 * 24
 
@@ -87,6 +88,8 @@ class TestSeriesBands(ClickhouseTestMixin, BaseTest):
         assert len(result.series) == 1
         series = result.series[0]
         assert series.baseline_weeks == 1
+        assert series.history_start == WINDOW_START - dt.timedelta(weeks=1)
+        assert series.band_ready_at == WINDOW_START + dt.timedelta(weeks=1)
         assert all(bucket.lower is None and bucket.upper is None for bucket in series.buckets)
         assert series.total_count == 12
 

--- a/products/logs/frontend/LogsAnomalies.test.ts
+++ b/products/logs/frontend/LogsAnomalies.test.ts
@@ -1,0 +1,24 @@
+import { learningBaselineLabel } from './LogsAnomalies'
+
+const WINDOW_END = '2026-08-06T00:00:00Z'
+
+describe('LogsAnomalies', () => {
+    describe('learningBaselineLabel', () => {
+        // A truncating diff read a 2.9 day wait as "2 more days", which promises the
+        // band a day early. A partial day still needs a whole day of data.
+        it.each([
+            ['2026-08-08T21:36:00Z', 'Learning baseline · 3 more days'],
+            ['2026-08-07T04:48:00Z', 'Learning baseline · 2 more days'],
+            ['2026-08-07T00:00:00Z', 'Learning baseline · 1 more day'],
+            ['2026-08-20T00:00:00Z', 'Learning baseline · 14 more days'],
+        ])('rounds a wait ending %s up to whole days', (bandReadyAt, expected) => {
+            expect(learningBaselineLabel(bandReadyAt, WINDOW_END)).toBe(expected)
+        })
+
+        // The band can land between the fetch and the render. The tag still has to read
+        // as a wait, never as "0 more days".
+        it.each([WINDOW_END, '2026-08-05T00:00:00Z'])('floors a lapsed wait at one day (%s)', (bandReadyAt) => {
+            expect(learningBaselineLabel(bandReadyAt, WINDOW_END)).toBe('Learning baseline · 1 more day')
+        })
+    })
+})

--- a/products/logs/frontend/LogsAnomalies.tsx
+++ b/products/logs/frontend/LogsAnomalies.tsx
@@ -4,7 +4,9 @@ import { memo } from 'react'
 import { LemonBanner, LemonButton, LemonTag } from '@posthog/lemon-ui'
 
 import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
+import { dayjs } from 'lib/dayjs'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 
 import type { LogMessage } from '~/queries/schema/schema-general'
 
@@ -96,7 +98,11 @@ function SeriesBands(): JSX.Element {
                 </div>
             ) : null}
             {visibleSeries.map((series) => (
-                <SeriesCard key={`${series.namespace}/${series.environment}/${series.severity}`} series={series} />
+                <SeriesCard
+                    key={`${series.namespace}/${series.environment}/${series.severity}`}
+                    series={series}
+                    windowEnd={seriesBands.window_end}
+                />
             ))}
             {hiddenSeriesCount > 0 ? (
                 <LemonButton type="secondary" center onClick={showMoreSeries} data-attr="logs-anomalies-show-more">
@@ -107,23 +113,42 @@ function SeriesBands(): JSX.Element {
     )
 }
 
+function learningBaselineLabel(bandReadyAt: string, windowEnd: string): string {
+    // Round up: a wait of just over two days still needs a third day of data.
+    const days = Math.max(1, Math.ceil(dayjs(bandReadyAt).diff(windowEnd, 'day', true)))
+    return `Learning baseline · ${days} more ${days === 1 ? 'day' : 'days'}`
+}
+
+function formatDay(timestamp: string): string {
+    return dayjs(timestamp).format('MMM D, YYYY')
+}
+
 // "Show more" grows the visible slice without touching the cards already on screen, so the charts
 // they hold should not reconcile again.
-const SeriesCard = memo(function SeriesCard({ series }: { series: LogsSeriesBandSeriesApi }): JSX.Element {
+const SeriesCard = memo(function SeriesCard({
+    series,
+    windowEnd,
+}: {
+    series: LogsSeriesBandSeriesApi
+    windowEnd: string
+}): JSX.Element {
     const { openLogsForBucket } = useActions(logsAnomaliesLogic)
-    // A banded series carries a band on every bucket, so their absence is the backend's own
-    // "still learning" verdict. Restating its week threshold here would let the two drift.
-    const learning = series.buckets.length > 0 && series.buckets.every((bucket) => bucket.lower == null)
+    // The backend dates the wait, so its history threshold stays out of here and the two cannot drift.
+    const bandReadyAt = series.band_ready_at
     return (
         <div className="rounded border bg-surface-primary p-3" data-attr="logs-anomalies-series">
             <div className="mb-2 flex items-center gap-2">
                 <LogTag level={series.severity as LogMessage['severity_text']} />
                 {series.namespace ? <LemonTag>{series.namespace}</LemonTag> : null}
                 {series.environment ? <LemonTag>{series.environment}</LemonTag> : null}
-                {learning ? (
-                    <LemonTag type="caution" title="This series has too little history for an expected range yet.">
-                        Learning baseline
-                    </LemonTag>
+                {bandReadyAt ? (
+                    <Tooltip
+                        title={`First seen ${formatDay(series.history_start)}. The expected range starts ${formatDay(
+                            bandReadyAt
+                        )}.`}
+                    >
+                        <LemonTag type="caution">{learningBaselineLabel(bandReadyAt, windowEnd)}</LemonTag>
+                    </Tooltip>
                 ) : null}
             </div>
             <AnomalyBandChart

--- a/products/logs/frontend/LogsAnomalies.tsx
+++ b/products/logs/frontend/LogsAnomalies.tsx
@@ -113,7 +113,7 @@ function SeriesBands(): JSX.Element {
     )
 }
 
-function learningBaselineLabel(bandReadyAt: string, windowEnd: string): string {
+export function learningBaselineLabel(bandReadyAt: string, windowEnd: string): string {
     // Round up: a wait of just over two days still needs a third day of data.
     const days = Math.max(1, Math.ceil(dayjs(bandReadyAt).diff(windowEnd, 'day', true)))
     return `Learning baseline · ${days} more ${days === 1 ? 'day' : 'days'}`

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1288,6 +1288,13 @@ export interface LogsSeriesBandSeriesApi {
     total_count: number
     /** Full weeks of history behind the band, 0 to 5. Below 2 the series is still learning and its buckets carry no band. */
     baseline_weeks: number
+    /** Earliest bucket with data inside the fetched lookback. */
+    history_start: string
+    /**
+     * When this series has enough history to carry a band, so a learning series can count down to it. Null once the band is drawn.
+     * @nullable
+     */
+    band_ready_at: string | null
     /** One entry per display bucket across the whole window, oldest first, zero-filled. */
     buckets: LogsSeriesBandBucketApi[]
 }

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1291,7 +1291,7 @@ export interface LogsSeriesBandSeriesApi {
     /** Earliest bucket with data inside the fetched lookback. */
     history_start: string
     /**
-     * When this series has enough history to carry a band, so a learning series can count down to it. Null once the band is drawn.
+     * When this series gains its band, so a learning series can count down to it. Null once the band is drawn.
      * @nullable
      */
     band_ready_at: string | null

--- a/products/logs/frontend/logsAnomaliesLogic.test.ts
+++ b/products/logs/frontend/logsAnomaliesLogic.test.ts
@@ -21,6 +21,8 @@ function seriesBandsResponse(seriesCount: number): LogsSeriesBandsResponseApi {
             severity: `severity-${index}`,
             total_count: 100 - index,
             baseline_weeks: 5,
+            history_start: '2026-07-13T10:00:00Z',
+            band_ready_at: null,
             buckets: [],
         })),
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48593,6 +48593,13 @@ export namespace Schemas {
       total_count: number;
       /** Full weeks of history behind the band, 0 to 5. Below 2 the series is still learning and its buckets carry no band. */
       baseline_weeks: number;
+      /** Earliest bucket with data inside the fetched lookback. */
+      history_start: string;
+      /**
+         * When this series has enough history to carry a band, so a learning series can count down to it. Null once the band is drawn.
+         * @nullable
+         */
+      band_ready_at: string | null;
       /** One entry per display bucket across the whole window, oldest first, zero-filled. */
       buckets: LogsSeriesBandBucket[];
     }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48596,7 +48596,7 @@ export namespace Schemas {
       /** Earliest bucket with data inside the fetched lookback. */
       history_start: string;
       /**
-         * When this series has enough history to carry a band, so a learning series can count down to it. Null once the band is drawn.
+         * When this series gains its band, so a learning series can count down to it. Null once the band is drawn.
          * @nullable
          */
       band_ready_at: string | null;


### PR DESCRIPTION
## Problem

On the logs Anomalies tab, a series with too little history for an expected range shows a bare "Learning baseline" tag over a flat chart. Nothing says how long the wait is, so a warming-up series looks broken.

A week selector lands on this tab next. Moving the window back in time thins the available baseline, so more series fall back to learning. Without a countdown that reads as a regression.

## Changes

- The tag now reads "Learning baseline · 3 more days". Its tooltip gives the date the series was first seen and the date its expected range starts.
- The band series carries `history_start` and `band_ready_at`. `_build_series` derives both from values it already held, so no new query runs.
- `_band_gate` returns the band gate and its readiness date from one rule. `banded` now reads as `band_ready_at is None`. The gate measures history before `window_start`. A live window travels one further window length first, and the emitted date carries that offset.
- The frontend reads `band_ready_at` instead of inferring the learning state from every bucket having a null band. Dating the wait on the backend keeps the two-week history threshold in one place, where the previous comment said it belonged.
- The day count rounds up. A wait of just over two days still needs a third day of data.
- Regenerated API types are mechanical. The MCP tool for this endpoint stays disabled, so no agent surface changes.

Run on a local stack against seeded log volume, so the countdown and the tooltip above come from this branch rather than from a description.

### Screenshots

One service with five series. Two carry a band and show no tag. Three are still learning, at 13, 3 and 1 days out.

![comparison](https://raw.githubusercontent.com/PostHog/pr-assets/e60b69f6941661f1777f034818907abf1e2ec5e0/2026/09/b1eff309-3e2d-4b6b-8641-fc0c7fad6ba1.png)

The tooltip gives both dates. The series was first seen on Aug 24 and its range starts on Sep 14, which is 14 days of history plus the 7 day window.

![after-tooltip](https://raw.githubusercontent.com/PostHog/pr-assets/c18578e5b41197478ae83a4f414423fee64bfc83/2026/09/24960d27-3734-4615-aa6b-dbd46d047429.png)

## How did you test this code?

Automated, plus a browser check on a local stack running this branch. The screenshots above come from that run. `logs_volume_buckets` was seeded with one service whose five series start at 41, 20, 18 and 8 days old, so the same page renders both band states and three different countdowns.

New assertions and the regression each one catches:

- A banded series returns `band_ready_at` null. Without this, a series that already has an expected range could still render a countdown.
- A learning series dates its countdown from its own first bucket plus one window length. Without this, the tag counts down to a date a week early. It then sits at "1 more day" for that week.
- A window ending at `band_ready_at` carries a band. Without this, the countdown target and the gate can drift apart again.
- The endpoint serializes both fields. Without this, the fields could exist on the dataclass and never reach the client.
- The tag rounds a partial day up. Without this, a truncating diff reads a 2.9 day wait as "2 more days" and promises the band a day early.
- The tag floors a lapsed wait at one day. Without this, a band that arrives between the fetch and the render reads "0 more days".

The countdown tests live in `products/logs/frontend/LogsAnomalies.test.ts`. I checked they fail against the truncating diff they guard.

Not covered by a test: the tooltip dates. `formatDay` is a one-line dayjs `format` passthrough, so a test there asserts library behavior. The tooltip renders dates in the viewer's local timezone rather than the project timezone. That matches `AnomalyBandChart`, which already uses the guessed local zone, and was left alone deliberately.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None. No documented workflow or API contract changes for users.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this change under direction, split across two subagents working on disjoint file sets: one for the dataclass, serializer and backend tests, one for the tag and the logic fixture. Skills invoked: `improving-drf-endpoints`, `writing-tests`, `writing-user-facing-copy`, `writing-code-comments`, `writing-ui-components`, `writing-pr-descriptions`.

Two decisions worth surfacing:

- The countdown is derived on the backend rather than in the tag. The frontend previously inferred "still learning" from all-null bands precisely to avoid restating the threshold, and a frontend countdown would have reintroduced that duplication.
- The first draft used `dayjs().diff(x, 'day')`, which truncates. A 2.9 day wait rendered as "2 more days". The count now rounds up.

A later session replaced the Storybook screenshots with the live-stack ones above. Skills invoked there: `writing-pr-descriptions`.

A review pass caught a bug. The first `band_ready_at` left out the window length. The gate compares the history threshold against `window_start`, but the tag counts down against `window_end`. So the countdown reached zero a week early. The tooltip also named a date that no band would match. `_band_gate` now produces the gate and the date together.



