### PR TITLE
fix(ci): keep the parallel lane in the node.js test-speed report

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -542,7 +542,9 @@ jobs:
                   # jest-junit's outputDir resolves against the jest process cwd, which is the
                   # workspace root for the turbo invocation but `nodejs/` if a shard ever runs
                   # jest directly; cover both.
-                  name: junit-results-nodejs-${{ matrix.shard }}${{ github.run_attempt != '1' && format('-attempt{0}', github.run_attempt) || '' }}
+                  # Lane-qualified: serial 1/3 and parallel 1/1 are both shard 1, and the
+                  # artifact list returns one entry per name, so a lane-less name hides one.
+                  name: junit-results-nodejs-${{ matrix.lane }}-${{ matrix.shard }}${{ github.run_attempt != '1' && format('-attempt{0}', github.run_attempt) || '' }}
                   path: |
                       junit-results/junit-nodejs-*.xml
                       junit-results/posthog-jest-quarantine-*.jsonl


### PR DESCRIPTION
## Problem

The Node.js test-speed report hides the parallel lane, so anyone moving tests onto it cannot see what those tests cost.
[Run 33059687609](https://github.com/PostHog/posthog/actions/runs/33059687609) rendered three serial shards and no parallel row.

- The upload step names its artifact `junit-results-nodejs-<shard>`, with no lane.
- Serial 1/3 and parallel 1/1 are both shard `1`, so both upload under `junit-results-nodejs-1`.
- The artifact list returns one entry per name.
- The report job logged `Found 3 artifact(s)` and took the serial one.
- The parallel lane's 292 KB of results never reached the report.

The lane keeps gaining suites. #89152 moved eleven of them onto it, and #90032 moved the ingestion e2e suite.
Both landed with their new cost invisible.

## Changes

- The speed report now shows a `parallel` row next to the serial shards.
- The artifact name carries the lane: `junit-results-nodejs-<lane>-<shard>`.

Nothing else changes.
The report script already parses this shape, and the download pattern `junit-results-nodejs-*` still matches.
Producer and consumer sit in the same workflow file, so an unrebased PR gets both.

## How did you test this code?

Fed the four artifact names the workflow will now produce to `report_test_timings.collect_shards`.
It resolved them to distinct rows with correct shard totals:

<details>
<summary>Output</summary>

```
nodejs parallel 1 1
nodejs serial   1 3
nodejs serial   2 3
nodejs serial   3 3
```

</details>

`bin/hogli lint:workflows` passes.

Not checked: a real CI run under the new name. That needs this branch to run the Node.js matrix.

No test added. The defect lives in the workflow YAML, and no test on the Python report script can reach it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) diagnosed and wrote this. Skills invoked: `/writing-pr-descriptions`.

The session started from the symptom: a speed report listing shards with no parallel entry.
Reading the report script first suggested the parser dropped the lane.
The job logs ruled that out. The parallel lane uploaded 292471 bytes, and the report job then listed a 5061-byte artifact of the same name, so the loss happened in the artifact list rather than the parser.

The branch was first based on #90032, which merged mid-session, then rebased onto master.
