### PR TITLE
fix(signals): show newest evidence first in the inbox redesign

### DIFF
--- a/products/signals/frontend/inbox/components/detail/ReportDetail.tsx
+++ b/products/signals/frontend/inbox/components/detail/ReportDetail.tsx
@@ -214,7 +214,11 @@ export function InboxDetailFrame({
     const { setDetailTab } = useActions(inboxReportDetailLogic(logicProps))
     const { evidenceRailCollapsed } = useValues(inboxDetailLayoutLogic)
     const { toggleEvidenceRail } = useActions(inboxDetailLayoutLogic)
-    const signals = reportSignals ?? []
+    // The API returns evidence oldest-first, but a reader wants the most recent signal at the top of
+    // the rail rather than after a scroll.
+    const signals = [...(reportSignals ?? [])].sort(
+        (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    )
     const evidenceCount = reportSignals !== null ? signals.length : report.signal_count
     const hasEvidence = evidenceCount > 0
 


### PR DESCRIPTION
## Problem

In the self-driving inbox redesign, the Evidence rail on a report listed signals oldest first, so the most recent signal sat at the bottom. Readers had to scroll past stale evidence to reach what happened most recently.

## Changes

- The Evidence rail on a report now lists signals newest first, so the latest signal is the first card.
- The legacy (pre-redesign) detail view is unchanged.

The API returns signals ordered oldest first, so the redesign detail view sorts a copy by timestamp descending before rendering.

## How did you test this code?

No automated test added — the change is a single sort over a list the API already returns in a known order, and no existing test asserts evidence ordering. Formatting checked with oxfmt. The rendered rail was not opened in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised as feedback in a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788255649076579?thread_ts=1788255649.076579&cid=C09SK2PAGKF), where readers reported scrolling to the bottom of the Evidence rail to reach the newest signal.

The sort sits in the redesign detail component rather than the shared kea loader, which would also have reordered the legacy view the redesign replaces. Scoped deliberately to the redesign variation.

Tools: PostHog Slack app (Claude Code harness), with an exploration subagent to locate the render path.

Nothing in this PR carries material from the agent session beyond the linked thread.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788255649076579?thread_ts=1788255649.076579&cid=C09SK2PAGKF)*
