### PR TITLE
feat(experiments): allow experiment:read on project secret API keys

### DIFF
--- a/posthog/api/routing.py
+++ b/posthog/api/routing.py
@@ -39,6 +39,7 @@ from posthog.permissions import (
     SharingTokenPermission,
     TeamMemberAccessPermission,
     VerifiedDomainEnforcementPermission,
+    is_service_auth,
 )
 from posthog.products import is_product_module
 from posthog.scopes import APIScopeObjectOrNotSupported
@@ -366,6 +367,13 @@ class TeamAndOrgViewSetMixin(_GenericViewSet):
         if self.action != "list":
             # NOTE: If we are getting an individual object then we don't filter it out here - this is handled by the permission logic
             # The reason being, that if we filter out here already, we can't load the object which is required for checking access controls for it
+            return queryset
+
+        # Mirrors AccessControlPermission.has_object_permission: service credentials (TST, PSAK)
+        # authenticate as synthetic users UserAccessControl cannot evaluate, so they are gated by
+        # API scope and project membership instead of object-level RBAC. Without this the filter
+        # passes a non-model user into a `created_by` lookup and raises TypeError.
+        if is_service_auth(self.request):
             return queryset
 
         # NOTE: Half implemented - for admins, they may want to include listing of results that are not accessible (like private resources)

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -221,6 +221,10 @@ PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION: list[tuple[APIScopeObject, APIS
     # `loops/:id/trigger/`. PSAKs are project-wide, so a leaked key can fire any loop
     # in the project (accepted and documented in products/tasks/docs/LOOPS.md).
     ("loop", "write"),
+    # Reading experiment definitions for warehouse/ETL syncs, so the credential isn't tied
+    # to one person's account. Read-only: `experiment:write` stays off PSAKs, and the
+    # viewset limits the key to `list` and `retrieve` via `psak_allowed_actions`.
+    ("experiment", "read"),
 ]
 
 # Server-side scope assignment string-set constants (see RFC: server-side scope

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -29,7 +29,12 @@ from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.mixins import ValidatedRequest, validated_request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
-from posthog.auth import IDJagAccessTokenAuthentication, OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.auth import (
+    IDJagAccessTokenAuthentication,
+    OAuthAccessTokenAuthentication,
+    PersonalAPIKeyAuthentication,
+    ProjectSecretAPIKeyAuthentication,
+)
 from posthog.models.activity_logging.activity_log import ActivityLog, get_activity_page
 from posthog.models.activity_logging.activity_page import ActivityLogPaginatedResponseSerializer, activity_page_response
 from posthog.models.organization import OrganizationMembership
@@ -366,6 +371,12 @@ class EnterpriseExperimentsViewSet(
     viewsets.ModelViewSet,
 ):
     scope_object: Literal["experiment"] = "experiment"
+    # A project secret API key can read experiment definitions, so a warehouse or ETL sync runs on
+    # a project-wide credential instead of one tied to a person's account. Reading only: creating
+    # and mutating experiments stays session/PAT/OAuth-only, and `experiment:write` is not a
+    # grantable PSAK scope.
+    authentication_classes = [ProjectSecretAPIKeyAuthentication]
+    psak_allowed_actions = ["list", "retrieve"]
     serializer_class = ExperimentSerializer
     queryset = (
         Experiment.objects.select_related(

--- a/products/experiments/backend/test/test_experiment_psak_auth.py
+++ b/products/experiments/backend/test/test_experiment_psak_auth.py
@@ -1,0 +1,170 @@
+from posthog.test.base import APIBaseTest
+
+from rest_framework import status
+
+from posthog.models.organization import OrganizationMembership
+from posthog.models.project_secret_api_key import ProjectSecretAPIKey
+from posthog.models.team import Team
+from posthog.models.utils import hash_key_value
+
+from products.access_control.backend.models.access_control import AccessControl
+from products.experiments.backend.models.experiment import Experiment
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+
+def _make_psak(team, label="psak", scopes=None):
+    # Token must match _SECRET_API_KEY_RE = r"^phs_[a-zA-Z0-9]+$", so only alphanumerics after phs_.
+    suffix = "".join(c for c in label if c.isalnum())
+    token = "phs_" + ("a" * 35) + suffix
+    psak = ProjectSecretAPIKey.objects.create(
+        team=team,
+        label=label,
+        mask_value=f"phs_...{suffix[:4]}",
+        secure_value=hash_key_value(token),
+        scopes=["experiment:read"] if scopes is None else scopes,
+    )
+    return token, psak
+
+
+class TestExperimentPSAKScopeAssignment(APIBaseTest):
+    """experiment:read must be assignable to a project secret API key."""
+
+    def setUp(self):
+        super().setUp()
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+
+    def test_experiment_read_scope_can_be_assigned(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "warehouse sync", "scopes": ["experiment:read"]},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        assert response.json()["scopes"] == ["experiment:read"]
+
+    def test_experiment_write_scope_is_still_rejected(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "writer", "scopes": ["experiment:write"]},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "can not be assigned" in response.json()["detail"]
+
+
+class TestExperimentViewSetPSAKAuth(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.flag = FeatureFlag.objects.create(team=self.team, key="psak-experiment-flag", created_by=self.user)
+        self.experiment = Experiment.objects.create(
+            team=self.team,
+            name="PSAK readable experiment",
+            feature_flag=self.flag,
+            created_by=self.user,
+        )
+        # Log out the test client so only the PSAK header authenticates requests
+        self.client.logout()
+
+    def _auth_headers(self, token):
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def test_psak_can_list_experiments(self):
+        token, _ = _make_psak(self.team, label="listkey")
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/experiments/",
+            **self._auth_headers(token),
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert [item["name"] for item in response.json()["results"]] == ["PSAK readable experiment"]
+
+    def test_psak_can_retrieve_experiment(self):
+        token, _ = _make_psak(self.team, label="retrievekey")
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/experiments/{self.experiment.id}/",
+            **self._auth_headers(token),
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert response.json()["name"] == "PSAK readable experiment"
+
+    def test_psak_list_ignores_object_level_access_controls(self):
+        # A PSAK authenticates as a synthetic user that has neither a membership nor a role, so
+        # UserAccessControl cannot evaluate it. Object-level RBAC therefore does not apply, matching
+        # AccessControlPermission.has_object_permission. Before the routing guard this raised a
+        # TypeError instead, because the list filter passed the synthetic user into a created_by lookup.
+        AccessControl.objects.create(
+            team=self.team,
+            resource="experiment",
+            resource_id=str(self.experiment.id),
+            access_level="none",
+        )
+        token, _ = _make_psak(self.team, label="rbackey")
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/experiments/",
+            **self._auth_headers(token),
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert [item["id"] for item in response.json()["results"]] == [self.experiment.id]
+
+    def test_psak_cannot_create_experiment(self):
+        token, _ = _make_psak(self.team, label="createkey")
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            data={"name": "nope", "feature_flag_key": "nope"},
+            content_type="application/json",
+            **self._auth_headers(token),
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+
+    def test_psak_cannot_update_experiment(self):
+        token, _ = _make_psak(self.team, label="updatekey")
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{self.experiment.id}/",
+            data={"name": "renamed"},
+            content_type="application/json",
+            **self._auth_headers(token),
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+
+    def test_psak_cannot_reach_non_read_actions(self):
+        # psak_allowed_actions is an allowlist, so custom read actions stay closed even though
+        # they only require experiment:read.
+        token, _ = _make_psak(self.team, label="actionkey")
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/experiments/{self.experiment.id}/flag_cleanup_target/",
+            **self._auth_headers(token),
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+
+    def test_psak_without_experiment_scope_is_rejected(self):
+        token, _ = _make_psak(self.team, label="wrongscopekey", scopes=["endpoint:read"])
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/experiments/",
+            **self._auth_headers(token),
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+
+    def test_psak_cannot_read_another_projects_experiments(self):
+        other_team = Team.objects.create(organization=self.organization, name="other")
+        token, _ = _make_psak(self.team, label="otherteamkey")
+
+        response = self.client.get(
+            f"/api/projects/{other_team.id}/experiments/",
+            **self._auth_headers(token),
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content


### PR DESCRIPTION
## Problem

Someone syncing experiment definitions into their own warehouse has to use a personal API key, because `experiment:read` is not an assignable project secret API key scope. That ties a service integration to one person's account, and the key dies with their access.

Closes #91899

## Changes

- A project secret API key can now be created with the `experiment:read` scope.
- Such a key can call `GET /api/projects/:id/experiments/` and `GET /api/projects/:id/experiments/:id/`. Nothing else on the resource opens up: every write action and every custom action still rejects the key, and `experiment:write` remains unassignable to a project secret key.
- The list endpoint returns every experiment in the project. Project secret keys authenticate as synthetic users with no membership or role, so object-level RBAC does not apply to them — the same rule `AccessControlPermission` already applies on the retrieve path.

Enabling a scope was not sufficient on its own. A project secret key is gated in three independent places, and only the first was about scopes:

| Gate | Location | Without it |
| --- | --- | --- |
| Scope is assignable | `PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION` | key cannot be created |
| Viewset accepts the authenticator | `authentication_classes` | key gets 401, since `TeamAndOrgViewSetMixin.get_authenticators()` never adds it |
| Action is allowlisted | `psak_allowed_actions` (defaults to `[]`) | key gets 403 on every action |

The third change is a latent bug rather than new wiring. `_filter_queryset_by_access_level` runs only on `list`, and it passes `request.user` into a `created_by` lookup. A synthetic user is not a Django model, so `pk = -1` is not consulted and the ORM raises `TypeError: Field 'id' expected a number`. No viewset allowlists `list` for a service credential today, so nothing reached it; this PR is the first to. The guard mirrors the short-circuit already in `AccessControlPermission.has_object_permission` and in `ExternalDataSchemaViewSet.filter_queryset`.

## How did you test this code?

Added `products/experiments/backend/test/test_experiment_psak_auth.py` — 10 tests in two classes. The regressions they catch that nothing existing did:

- **Scope assignment**: `experiment:read` is accepted by `ProjectSecretAPIKeySerializer` and `experiment:write` is still refused. No existing test covers an `experiment` scope on a project secret key.
- **Read access**: `list` and `retrieve` succeed with a project-secret-key bearer token.
- **The list RBAC path**: an object-level `AccessControl` row denying the experiment does not hide it from the key, and — the point of the test — the request does not raise `TypeError`. This is the only coverage of the `routing.py` guard; every other service-credential viewset allowlists non-`list` actions, so it is unreachable from their tests.
- **Everything else stays shut**: `create`, `partial_update`, a custom read action (`flag_cleanup_target`), a key missing `experiment:read`, and a key from another project all get 403.

**What was verified locally, and what was not.** This machine has no container runtime, so the full pytest suite could not be executed. These ran and passed:

- `ruff check` and `ruff format --check` on all four changed files, on the `ruff~=0.15.20` pinned in `pyproject.toml`.
- Against a booted Django app context: `("experiment", "read")` is in the allowlist and `("experiment", "write")` is not; `ProjectSecretAPIKeySerializer.validate_scopes(["experiment:read"])` returns cleanly while `["experiment:write"]` and `["insight:read"]` raise the expected "can not be assigned" error.
- Resolved off the real viewset class: `psak_allowed_actions == ["list", "retrieve"]`; `ProjectSecretAPIKeyAuthentication` is first in `get_authenticators()`, ahead of the eight mixin defaults; `list`/`retrieve` resolve to `experiment:read` and `create` to `experiment:write`.
- The `TypeError` behind the `routing.py` guard, reproduced against a minimal Django model to confirm the ORM raises rather than silently filtering.

<details>
<summary>Why the suite could not run here</summary>

`posthog/conftest.py` builds the ClickHouse schema for every Django test. Postgres, Redis, ClickHouse and `sqlx-cli` were installed natively and the persons migrations applied, but single-node ClickHouse with embedded Keeper never accepts inserts into `ReplicatedMergeTree`: a one-row insert into a freshly created replicated table, outside PostHog entirely, times out after 120s, and `system.replicas` reports every replica read-only. The 10 tests error in the shared `django_db_setup` fixture and never reach a test body. CI runs them properly.

</details>

**Not run:** the test file itself, `hogli build:openapi`, and `hogli ci:preflight` (all need the dev stack). The diff touches three `build:openapi` trigger globs, but no schema drift is expected: `ProjectSecretAPIKeyAuthentication` has no `OpenApiAuthenticationExtension` — only `PersonalAPIKeyAuthentication` does — and `EndpointViewSet` and `LoopViewSet` already declare it without one.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe the project-secret-key scope list.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). No repo-provided skills were invoked; `/writing-pr-descriptions` and `/simplify` were not available in this environment, so this description follows `.github/pull_request_template.md` and the AGENTS.md guidance directly.

The session began by reading the issue as a one-line scope addition. Tracing the request path showed a key with only the scope would authenticate nowhere, and tracing the `list` path further found the `UserAccessControl` crash, which was then confirmed against the ORM rather than assumed. Those two findings set the final shape; the alternative of shipping only the scope entry would have produced a creatable key that 401s on every call.

Kept deliberately narrow: `list` and `retrieve` only. Opening the custom read actions was considered and rejected — the issue only needs definitions, and `psak_allowed_actions` is an allowlist worth keeping short. Happy to widen it, or to split the `routing.py` guard into its own PR, if reviewers prefer.

Public artifact: nothing in this PR carries non-public material. The originating report mentions a specific customer situation; none of it appears in the code, tests, fixtures, commit messages, or this description. Test fixtures are invented from the properties each case exercises.
