### PR TITLE
feat(desktop): mobile align the self-driving inbox with web

### DIFF
--- a/products/desktop/apps/mobile/src/app/(tabs)/inbox.tsx
+++ b/products/desktop/apps/mobile/src/app/(tabs)/inbox.tsx
@@ -1,5 +1,6 @@
 import { buildInboxViewedProperties } from "@posthog/core/inbox/engagement";
 import { INBOX_PIPELINE_STATUSES } from "@posthog/core/inbox/reportFiltering";
+import type { InboxReviewerScope } from "@posthog/shared";
 import type { SignalReport } from "@posthog/shared/domain-types";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -123,6 +124,57 @@ export default function InboxScreen() {
       setCurrentIndex(0);
     }
   }, [viewMode, setCurrentIndex]);
+
+  const hasActiveFilters =
+    sourceProductFilter.length > 0 ||
+    priorityFilter.length > 0 ||
+    statusFilter.length < INBOX_PIPELINE_STATUSES.length ||
+    suggestedReviewerFilter.length > 0;
+
+  // Coarse reviewer scope. Mobile has no scope control yet, so a non-empty
+  // reviewer filter reads as "teammate" without leaking a specific UUID.
+  const triageScope: InboxReviewerScope =
+    suggestedReviewerFilter.length > 0 ? "teammate" : "entire-project";
+
+  // Bracket tinder mode with triage_started / triage_ended so we can measure
+  // how many cards users clear before exiting. The live ref lets the cleanup
+  // read the current decided count without re-firing the pair on every swipe;
+  // it is set in an effect so we don't mutate refs during render.
+  const triageLiveRef = useRef({ decided: 0 });
+  useEffect(() => {
+    triageLiveRef.current.decided = decided.length;
+  });
+  // Snapshot filters/queue at tinder-mode entry; swipes don't re-fire the pair.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional snapshot
+  useEffect(() => {
+    if (viewMode !== "tinder") return;
+    const startedAt = Date.now();
+    const entry = {
+      queueSize: tinderReports.length,
+      initialDecided: decided.length,
+      hasActiveFilters,
+      scope: triageScope,
+    };
+    analytics.track(ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED, {
+      queue_size: entry.queueSize,
+      has_active_filters: entry.hasActiveFilters,
+      scope: entry.scope,
+    });
+    return () => {
+      const reviewed = Math.max(
+        0,
+        triageLiveRef.current.decided - entry.initialDecided,
+      );
+      analytics.track(ANALYTICS_EVENTS.INBOX_TRIAGE_ENDED, {
+        queue_size: entry.queueSize,
+        has_active_filters: entry.hasActiveFilters,
+        scope: entry.scope,
+        reports_reviewed: reviewed,
+        duration_ms: Date.now() - startedAt,
+        end_reason: reviewed >= entry.queueSize ? "completed" : "exited",
+      });
+    };
+  }, [viewMode, analytics]);
 
   // ── List mode handlers ────────────────────────────────────────────────────
   const handleReportPress = useCallback(

--- a/products/desktop/apps/mobile/src/app/inbox/[...id].tsx
+++ b/products/desktop/apps/mobile/src/app/inbox/[...id].tsx
@@ -2,7 +2,9 @@ import { Text } from "@components/text";
 import { computeRefundEligibility } from "@posthog/core/inbox/refundEligibility";
 import {
   formatSignalReportSummaryMarkdown,
+  humanizeReportTitle,
   inboxStatusLabel,
+  parseConventionalCommitTitle,
 } from "@posthog/core/inbox/reportPresentation";
 import {
   DISMISSAL_REASON_OPTIONS,
@@ -42,6 +44,7 @@ import { useUserQuery } from "@/features/auth";
 import { MarkdownText } from "@/features/chat/components/MarkdownText";
 import { getReportRepository } from "@/features/inbox/api";
 import { buildCreatePrReportPrompt } from "@/features/inbox/buildCreatePrReportPrompt";
+import { ConventionalCommitTag } from "@/features/inbox/components/ConventionalCommitTag";
 import { CreatePrFeedbackSheet } from "@/features/inbox/components/CreatePrFeedbackSheet";
 import { DiscussReportSheet } from "@/features/inbox/components/DiscussReportSheet";
 import {
@@ -441,6 +444,7 @@ export default function ReportDetailScreen() {
     );
   }
 
+  const conventionalTitle = parseConventionalCommitTitle(report.title);
   const updatedAt = new Date(report.updated_at);
   const hoursSince = differenceInHours(new Date(), updatedAt);
   const timeDisplay =
@@ -484,6 +488,12 @@ export default function ReportDetailScreen() {
           {report.actionability && (
             <ActionabilityBadge value={report.actionability} />
           )}
+          {conventionalTitle ? (
+            <ConventionalCommitTag
+              type={conventionalTitle.type}
+              scope={conventionalTitle.scope}
+            />
+          ) : null}
           {report.is_suggested_reviewer && (
             <View className="rounded bg-status-warning/20 px-2 py-1">
               <Text className="font-medium text-[12px] text-status-warning">
@@ -495,7 +505,7 @@ export default function ReportDetailScreen() {
 
         {/* Title */}
         <Text className="mb-2 font-semibold text-[18px] text-gray-12">
-          {report.title ?? "Untitled report"}
+          {humanizeReportTitle(report.title, "Untitled report")}
         </Text>
 
         {/* Meta row */}

--- a/products/desktop/apps/mobile/src/features/inbox/components/ConventionalCommitTag.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/ConventionalCommitTag.tsx
@@ -1,0 +1,71 @@
+import { Text } from "@components/text";
+import {
+  ArrowCounterClockwise,
+  ArrowsClockwise,
+  BookOpen,
+  Broom,
+  Flask,
+  type Icon,
+  Lightning,
+  Package,
+  PaintBrush,
+  PlayCircle,
+  Question,
+  Sparkle,
+  Wrench,
+} from "phosphor-react-native";
+import { View } from "react-native";
+import { type ThemeColors, useThemeColors } from "@/lib/theme";
+
+type TagColor = "green" | "blue" | "amber" | "gray";
+
+interface TypeMeta {
+  icon: Icon;
+  color: TagColor;
+}
+
+const TYPE_META: Record<string, TypeMeta> = {
+  feat: { icon: Sparkle, color: "green" },
+  fix: { icon: Wrench, color: "blue" },
+  docs: { icon: BookOpen, color: "blue" },
+  style: { icon: PaintBrush, color: "gray" },
+  refactor: { icon: ArrowsClockwise, color: "amber" },
+  test: { icon: Flask, color: "blue" },
+  chore: { icon: Broom, color: "gray" },
+  build: { icon: Package, color: "gray" },
+  ci: { icon: PlayCircle, color: "blue" },
+  perf: { icon: Lightning, color: "amber" },
+  revert: { icon: ArrowCounterClockwise, color: "gray" },
+};
+
+const DEFAULT_META: TypeMeta = { icon: Question, color: "gray" };
+
+const COLOR_RESOLVERS: Record<TagColor, (t: ThemeColors) => string> = {
+  green: (t) => t.status.success,
+  blue: (t) => t.status.info,
+  amber: (t) => t.status.warning,
+  gray: (t) => t.gray[10],
+};
+
+interface ConventionalCommitTagProps {
+  type: string;
+  scope: string | null;
+}
+
+export function ConventionalCommitTag({
+  type,
+  scope,
+}: ConventionalCommitTagProps) {
+  const themeColors = useThemeColors();
+  const meta = TYPE_META[type] ?? DEFAULT_META;
+  const IconCmp = meta.icon;
+  const label = scope ? `${type}(${scope})` : type;
+  const iconColor = COLOR_RESOLVERS[meta.color](themeColors);
+
+  return (
+    <View className="shrink-0 flex-row items-center gap-1 rounded border border-gray-6 bg-gray-2 px-1.5 py-0.5">
+      <IconCmp size={10} color={iconColor} weight="bold" />
+      <Text className="font-mono text-[11px] text-gray-11">{label}</Text>
+    </View>
+  );
+}

--- a/products/desktop/apps/mobile/src/features/inbox/components/InboxReportSection.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/InboxReportSection.tsx
@@ -1,0 +1,96 @@
+import { Text } from "@components/text";
+import type { SignalReport } from "@posthog/shared/domain-types";
+import { CaretDown } from "phosphor-react-native";
+import { useState } from "react";
+import { Pressable, View } from "react-native";
+import { useThemeColors } from "@/lib/theme";
+
+const SECTION_PREVIEW_LIMIT = 5;
+
+interface InboxReportSectionProps {
+  title: string;
+  reports: SignalReport[];
+  count: number;
+  emptyNote?: string;
+  defaultOpen?: boolean;
+  renderReport: (report: SignalReport) => React.ReactNode;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function InboxReportSection({
+  title,
+  reports,
+  count,
+  emptyNote,
+  defaultOpen = true,
+  renderReport,
+  onOpenChange,
+}: InboxReportSectionProps) {
+  const themeColors = useThemeColors();
+  const [open, setOpen] = useState(defaultOpen);
+  const [visibleCount, setVisibleCount] = useState(SECTION_PREVIEW_LIMIT);
+  if (count === 0 && reports.length === 0 && !emptyNote) return null;
+
+  const visible = reports.slice(0, visibleCount);
+  const remainingHidden = Math.max(0, count - visible.length);
+  const revealMore = () =>
+    setVisibleCount((current) =>
+      Math.min(current + SECTION_PREVIEW_LIMIT, count),
+    );
+
+  return (
+    <View className="mb-3">
+      <Pressable
+        onPress={() =>
+          setOpen((current) => {
+            const next = !current;
+            onOpenChange?.(next);
+            return next;
+          })
+        }
+        hitSlop={6}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: open }}
+        className="mb-1 flex-row items-center gap-2 px-3 py-2 active:opacity-70"
+      >
+        <View className="flex-row items-center gap-1">
+          <Text className="font-mono font-semibold text-[11px] text-gray-10 uppercase tracking-widest">
+            {title}
+          </Text>
+          <Text className="font-mono text-[11px] text-gray-10 tabular-nums">
+            ({count})
+          </Text>
+        </View>
+        <View className="h-px flex-1 bg-gray-5" />
+        <CaretDown
+          size={12}
+          color={themeColors.gray[9]}
+          style={{ transform: [{ rotate: open ? "180deg" : "0deg" }] }}
+        />
+      </Pressable>
+      {open ? (
+        reports.length === 0 && emptyNote ? (
+          <Text className="px-3 py-2 text-[13px] text-gray-10">
+            {emptyNote}
+          </Text>
+        ) : (
+          <View>
+            {visible.map((report) => renderReport(report))}
+            {remainingHidden > 0 ? (
+              <Pressable
+                onPress={revealMore}
+                hitSlop={6}
+                accessibilityRole="button"
+                className="self-center px-3 py-2 active:opacity-70"
+              >
+                <Text className="font-medium text-[13px] text-gray-10">
+                  Show more ({remainingHidden})
+                </Text>
+              </Pressable>
+            ) : null}
+          </View>
+        )
+      ) : null}
+    </View>
+  );
+}

--- a/products/desktop/apps/mobile/src/features/inbox/components/ReportList.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/ReportList.tsx
@@ -1,15 +1,18 @@
 import { Text } from "@components/text";
+import { partitionInboxReports } from "@posthog/core/inbox/reportInboxSections";
 import type { SignalReport } from "@posthog/shared/domain-types";
 import { Tray } from "phosphor-react-native";
+import { useMemo, useState } from "react";
 import {
   ActivityIndicator,
-  FlatList,
   Pressable,
   RefreshControl,
+  ScrollView,
   View,
 } from "react-native";
 import { useThemeColors } from "@/lib/theme";
-import { useInboxReports } from "../hooks/useInboxReports";
+import { useArchivedReports, useInboxReports } from "../hooks/useInboxReports";
+import { InboxReportSection } from "./InboxReportSection";
 import { ReportListRow } from "./ReportListRow";
 
 interface ReportListProps {
@@ -32,9 +35,25 @@ export function ReportList({
   } = useInboxReports();
   const themeColors = useThemeColors();
 
+  const { reviewAndMerge, needsPr } = useMemo(
+    () => partitionInboxReports(reports),
+    [reports],
+  );
+
+  // Resolved (terminal) reports are loaded only when the section is opened.
+  const isEmpty = reviewAndMerge.length === 0 && needsPr.length === 0;
+  const [resolvedOpen, setResolvedOpen] = useState(false);
+  const resolved = useArchivedReports({
+    enabled: !isEmpty && resolvedOpen,
+  });
+
   const handlePress = (report: SignalReport) => {
     onReportPress?.(report);
   };
+
+  const renderReport = (report: SignalReport) => (
+    <ReportListRow key={report.id} report={report} onPress={handlePress} />
+  );
 
   if (error) {
     return (
@@ -59,29 +78,18 @@ export function ReportList({
     );
   }
 
-  if (reports.length === 0) {
-    return (
-      <View className="flex-1 items-center justify-center p-6">
-        <View className="mb-6 h-16 w-16 items-center justify-center rounded-full bg-gray-3">
-          <Tray size={28} color={themeColors.gray[10]} />
-        </View>
-        <Text className="mb-2 text-center font-semibold text-[16px] text-gray-12">
-          Inbox is empty
-        </Text>
-        <Text className="text-center text-[13px] text-gray-11">
-          Reports will appear here as signals come in.
-        </Text>
-      </View>
-    );
-  }
-
   return (
-    <FlatList
-      data={reports}
-      keyExtractor={(item) => item.id}
-      renderItem={({ item }) => (
-        <ReportListRow report={item} onPress={handlePress} />
-      )}
+    <ScrollView
+      onScrollEndDrag={({ nativeEvent }) => {
+        const { layoutMeasurement, contentOffset, contentSize } = nativeEvent;
+        const nearBottom =
+          layoutMeasurement.height + contentOffset.y >=
+          contentSize.height - 200;
+        if (nearBottom && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      }}
+      scrollEventThrottle={200}
       refreshControl={
         <RefreshControl
           refreshing={isLoading}
@@ -90,23 +98,54 @@ export function ReportList({
           progressViewOffset={contentInsetTop}
         />
       }
-      onEndReachedThreshold={0.5}
-      onEndReached={() => {
-        if (hasNextPage && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      }}
-      ListFooterComponent={
-        isFetchingNextPage ? (
-          <View className="py-4">
-            <ActivityIndicator color={themeColors.accent[9]} />
-          </View>
-        ) : null
-      }
       contentContainerStyle={{
         paddingTop: contentInsetTop,
         paddingBottom: 100,
+        flexGrow: 1,
       }}
-    />
+    >
+      {isEmpty ? (
+        <View className="flex-1 items-center justify-center px-6 py-16">
+          <Tray size={28} color={themeColors.gray[10]} />
+          <Text className="mt-3 text-center font-semibold text-[16px] text-gray-12">
+            Nothing to review
+          </Text>
+          <Text className="mt-1 text-center text-[13px] text-gray-11">
+            Reports show up here as your agents find things worth acting on.
+          </Text>
+        </View>
+      ) : (
+        <>
+          <InboxReportSection
+            title="Review and merge"
+            reports={reviewAndMerge}
+            count={reviewAndMerge.length}
+            emptyNote="No pull requests open yet. Start one from a report below."
+            renderReport={renderReport}
+          />
+          <InboxReportSection
+            title="Needs a PR"
+            reports={needsPr}
+            count={needsPr.length}
+            emptyNote="No reports are waiting for a pull request."
+            renderReport={renderReport}
+          />
+          {isFetchingNextPage ? (
+            <View className="py-4">
+              <ActivityIndicator color={themeColors.accent[9]} />
+            </View>
+          ) : null}
+          <InboxReportSection
+            title="Resolved"
+            reports={resolved.reports}
+            count={resolved.totalCount}
+            defaultOpen={false}
+            emptyNote="Nothing resolved or archived yet."
+            onOpenChange={setResolvedOpen}
+            renderReport={renderReport}
+          />
+        </>
+      )}
+    </ScrollView>
   );
 }

--- a/products/desktop/apps/mobile/src/features/inbox/components/ReportListRow.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/ReportListRow.tsx
@@ -1,10 +1,15 @@
 import { Text } from "@components/text";
+import {
+  humanizeReportTitle,
+  parseConventionalCommitTitle,
+} from "@posthog/core/inbox/reportPresentation";
 import type { SignalReport } from "@posthog/shared/domain-types";
 import { memo } from "react";
 import { Pressable, View } from "react-native";
 import { PrStatusBadge } from "@/features/tasks/components/PrStatusBadge";
 import { useThemeColors } from "@/lib/theme";
 import { formatReportTimestamp } from "../utils";
+import { ConventionalCommitTag } from "./ConventionalCommitTag";
 import { SuggestedReviewerAvatarStack } from "./SuggestedReviewerAvatarStack";
 
 interface ReportListRowProps {
@@ -36,6 +41,8 @@ const priorityColorMap: Record<string, string> = {
 function ReportListRowComponent({ report, onPress }: ReportListRowProps) {
   const themeColors = useThemeColors();
   const timeDisplay = formatReportTimestamp(new Date(report.updated_at));
+  const conventionalTitle = parseConventionalCommitTitle(report.title);
+  const displayTitle = humanizeReportTitle(report.title, "Untitled report");
 
   const dotKind = statusDotMap[report.status] ?? "muted";
   const dotColor =
@@ -71,8 +78,17 @@ function ReportListRowComponent({ report, onPress }: ReportListRowProps) {
           numberOfLines={2}
           ellipsizeMode="tail"
         >
-          {report.title ?? "Untitled report"}
+          {displayTitle}
         </Text>
+
+        {conventionalTitle ? (
+          <View className="mt-1 flex-row">
+            <ConventionalCommitTag
+              type={conventionalTitle.type}
+              scope={conventionalTitle.scope}
+            />
+          </View>
+        ) : null}
 
         <View className="mt-1 flex-row items-center gap-2">
           {priorityClass ? (

--- a/products/desktop/apps/mobile/src/features/inbox/components/SwipeableReportCard.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/SwipeableReportCard.tsx
@@ -1,5 +1,9 @@
 import { Text } from "@components/text";
-import { inboxStatusLabel } from "@posthog/core/inbox/reportPresentation";
+import {
+  humanizeReportTitle,
+  inboxStatusLabel,
+  parseConventionalCommitTitle,
+} from "@posthog/core/inbox/reportPresentation";
 import type {
   SignalReport,
   SignalReportPriority,
@@ -13,6 +17,7 @@ import { Animated, PanResponder, Pressable, View } from "react-native";
 import { MarkdownText } from "@/features/chat/components/MarkdownText";
 import { PrStatusBadge } from "@/features/tasks/components/PrStatusBadge";
 import { useThemeColors } from "@/lib/theme";
+import { ConventionalCommitTag } from "./ConventionalCommitTag";
 
 const SWIPE_THRESHOLD = 120;
 const TAP_THRESHOLD = 10;
@@ -249,6 +254,8 @@ function CardContent({
   themeColors,
   repo,
 }: CardContentProps) {
+  const conventionalTitle = parseConventionalCommitTitle(report.title);
+  const displayTitle = humanizeReportTitle(report.title, "Untitled report");
   return (
     <View className="flex-1 p-4">
       {/* Title */}
@@ -256,13 +263,19 @@ function CardContent({
         className="font-bold text-[16px] text-gray-12 leading-snug"
         numberOfLines={2}
       >
-        {report.title ?? "Untitled report"}
+        {displayTitle}
       </Text>
 
       {/* Badges row */}
       <View className="mt-2 flex-row flex-wrap items-center gap-1.5">
         <StatusBadge status={report.status} />
         {report.priority && <PriorityBadge priority={report.priority} />}
+        {conventionalTitle ? (
+          <ConventionalCommitTag
+            type={conventionalTitle.type}
+            scope={conventionalTitle.scope}
+          />
+        ) : null}
       </View>
 
       {/* Summary — fills remaining space so footer sticks to the bottom */}

--- a/products/desktop/apps/mobile/src/features/inbox/components/TinderView.tsx
+++ b/products/desktop/apps/mobile/src/features/inbox/components/TinderView.tsx
@@ -1,7 +1,9 @@
 import { Text } from "@components/text";
 import {
   formatSignalReportSummaryMarkdown,
+  humanizeReportTitle,
   inboxStatusLabel,
+  parseConventionalCommitTitle,
 } from "@posthog/core/inbox/reportPresentation";
 import type {
   SignalReport,
@@ -43,6 +45,7 @@ import { useThemeColors } from "@/lib/theme";
 import { getReportRepository } from "../api";
 import { useDismissedReportsStore } from "../stores/dismissedReportsStore";
 import { useInboxStore } from "../stores/inboxStore";
+import { ConventionalCommitTag } from "./ConventionalCommitTag";
 import { SwipeableReportCard } from "./SwipeableReportCard";
 
 const log = logger.scope("tinder-view");
@@ -166,9 +169,7 @@ export function TinderView({
         priority: report.priority ?? null,
         actionability: report.actionability ?? null,
         action_type: actionType,
-        // Tinder cards stack like a list of rows the user is acting on
-        // without opening a detail view — closest desktop analogue.
-        surface: "list_row",
+        surface: "triage",
         is_bulk: false,
         bulk_size: 1,
         rank: position,
@@ -407,7 +408,7 @@ export function TinderView({
                   className="flex-1 font-semibold text-[17px] text-gray-12"
                   numberOfLines={1}
                 >
-                  {expandedReport.title ?? "Untitled report"}
+                  {humanizeReportTitle(expandedReport.title, "Untitled report")}
                 </Text>
                 <Pressable
                   onPress={() => setExpandedReport(null)}
@@ -429,6 +430,17 @@ export function TinderView({
                   {expandedReport.priority && (
                     <PriorityBadge priority={expandedReport.priority} />
                   )}
+                  {(() => {
+                    const conv = parseConventionalCommitTitle(
+                      expandedReport.title,
+                    );
+                    return conv ? (
+                      <ConventionalCommitTag
+                        type={conv.type}
+                        scope={conv.scope}
+                      />
+                    ) : null;
+                  })()}
                 </View>
 
                 {/* Summary */}

--- a/products/desktop/apps/mobile/src/features/inbox/hooks/useInboxReports.ts
+++ b/products/desktop/apps/mobile/src/features/inbox/hooks/useInboxReports.ts
@@ -4,6 +4,7 @@ import {
   buildSignalReportListOrdering,
   buildStatusFilterParam,
   buildSuggestedReviewerFilterParam,
+  INBOX_ACTIONABLE_ACTIONABILITY_FILTER,
   INBOX_DISMISSED_STATUS_FILTER,
   INBOX_REFETCH_INTERVAL_MS,
 } from "@posthog/core/inbox/reportFiltering";
@@ -74,6 +75,7 @@ export function useInboxReports(options?: { enabled?: boolean }) {
   const params: SignalReportsQueryParams = {
     status: buildStatusFilterParam(statusFilter),
     ordering: buildSignalReportListOrdering(sortField, sortDirection),
+    actionability: INBOX_ACTIONABLE_ACTIONABILITY_FILTER,
     source_product:
       sourceProductFilter.length > 0
         ? sourceProductFilter.join(",")

--- a/products/desktop/apps/mobile/src/lib/analytics.ts
+++ b/products/desktop/apps/mobile/src/lib/analytics.ts
@@ -1,4 +1,8 @@
-import type { AgentTurnFeedbackProperties } from "@posthog/shared";
+import type {
+  AgentTurnFeedbackProperties,
+  InboxTriageEndedProperties,
+  InboxTriageStartedProperties,
+} from "@posthog/shared";
 import { ANALYTICS_EVENTS as SHARED_ANALYTICS_EVENTS } from "@posthog/shared";
 import { type PostHog, usePostHog } from "posthog-react-native";
 import { useEffect, useMemo } from "react";
@@ -15,6 +19,8 @@ export const ANALYTICS_EVENTS = {
   INBOX_REPORT_ACTION: "Inbox report action",
   INBOX_REPORT_FEEDBACK: "Inbox report feedback",
   INBOX_REPORT_FEEDBACK_NOTE: "Inbox report feedback note",
+  INBOX_TRIAGE_STARTED: SHARED_ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED,
+  INBOX_TRIAGE_ENDED: SHARED_ANALYTICS_EVENTS.INBOX_TRIAGE_ENDED,
   SIGN_IN_STARTED: "Sign in started",
   SIGN_IN_COMPLETED: "Sign in completed",
   SIGN_IN_FAILED: "Sign in failed",
@@ -83,7 +89,8 @@ export type InboxReportActionSurface =
   | "detail_footer"
   | "toolbar"
   | "keyboard"
-  | "list_row";
+  | "list_row"
+  | "triage";
 
 /** Sentiment captured by the report usefulness thumbs. */
 export type InboxReportFeedbackSentiment = "positive" | "negative";
@@ -226,6 +233,8 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.INBOX_REPORT_ACTION]: InboxReportActionProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK]: InboxReportFeedbackProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK_NOTE]: InboxReportFeedbackNoteProperties;
+  [ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED]: InboxTriageStartedProperties;
+  [ANALYTICS_EVENTS.INBOX_TRIAGE_ENDED]: InboxTriageEndedProperties;
   [ANALYTICS_EVENTS.SIGN_IN_STARTED]: SignInStartedProperties;
   [ANALYTICS_EVENTS.SIGN_IN_COMPLETED]: SignInCompletedProperties;
   [ANALYTICS_EVENTS.SIGN_IN_FAILED]: SignInFailedProperties;
@@ -256,6 +265,8 @@ export const INBOX_ANALYTICS_EVENT_NAMES: ReadonlySet<string> = new Set([
   ANALYTICS_EVENTS.INBOX_REPORT_ACTION,
   ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK,
   ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK_NOTE,
+  ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED,
+  ANALYTICS_EVENTS.INBOX_TRIAGE_ENDED,
 ]);
 
 export function useAnalytics(): Analytics {


### PR DESCRIPTION
## Problem

The mobile app's Self-driving inbox still uses the pre-redesign shape: a flat list of every ready/queued/live/potential report, with the report's raw title on each row. The web/Desktop redesign in #86671 / #90586 replaced that with two actionable sections — reports whose PR is ready to review, and reports that still need a PR — and hid the machinery of pipeline and failed runs behind the Runs tab. Mobile users see a busier, less-decided screen than desktop and web users looking at the same reports.

Port of #90586.

## Changes

- The reports list now shows two live sections. **Review and merge** holds ready reports whose implementation PR is open; **Needs a PR** holds actionable ready/pending-input reports with no PR. Each section reveals five more rows per "Show more" tap. Sectioning uses `partitionInboxReports` from `@posthog/core`, so mobile and desktop group the same set.
- A collapsed **Resolved** section holds merged and archived reports and only fetches when opened.
- When the inbox has no live rows, mobile shows a plain unboxed empty state instead of empty section boxes.
- The reports query now sends `actionability=immediately_actionable,requires_human_input`, so the sections hold the same reports web and Desktop show.
- List rows, the swipeable triage card, its expanded modal, and the report detail screen now render the humanized report title plus a conventional-commit type/scope chip (`feat(inbox)` etc.), same derivation as desktop's `parseConventionalCommitTitle` / `humanizeReportTitle`.
- Tinder-mode inbox actions now record `surface: "triage"` instead of `"list_row"`, and each entry into tinder mode is bracketed with `Inbox triage started` / `Inbox triage ended` events. These reuse `InboxTriageStartedProperties` / `InboxTriageEndedProperties` from `@posthog/shared`. Scope is emitted at the coarse `entire-project` / `teammate` level derived from the reviewer filter — mobile has no reviewer-scope control yet, so a specific teammate UUID never enters analytics.

Mechanical: replaced `FlatList` in `ReportList.tsx` with a `ScrollView` because the sectioned layout needs multiple headers; kept refresh + pagination behavior.

### Not ported
- The desktop keyboard shortcut legend, Storybook stories, and Electron/window behavior: no mobile surface for them.
- The `canCreateImplementationPr(report, context)` signature update accepts a `context` param with defaults, so mobile's `canCreateImplementationPr(report)` call keeps working; mobile has no continuable-task lookup to feed into that context, so `hasLiveImplementationTask` / `isTaskLookupPending` are never set. This matches the note already in `reportVerdictAction.ts`.
- Reviewer removal already lives inside the mobile reviewer menu (`SuggestedReviewers.tsx` X button); there was no "Not for me" status to remove.

## How did you test this code?

- `pnpm --filter @posthog/mobile typecheck` — clean against baseline
- `pnpm --filter @posthog/mobile lint` — clean
- `pnpm --filter @posthog/mobile test` — 613 tests pass
- Did not run the mobile app in a simulator; no visual verification of the new sections, empty state, or conventional-commit chip rendering.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Skills invoked: `/simplify` on the diff before opening the PR (findings applied: reuse the shared `@posthog/shared` triage-event types instead of redeclaring them locally, gate the Resolved-section archive fetch on section open, consolidate the empty-state ScrollView with the main ScrollView, and swap the nested-ternary color derivation in `ConventionalCommitTag` for a lookup table). Skipped: extracting the type-to-icon-and-color map out of `ConventionalCommitTag.tsx` into `@posthog/core` — icons diverge between hosts (`phosphor-react` vs `phosphor-react-native`), and the port's rules ask that any `packages/*` change be additive and minimal.

Decisions:
- Sectioned `ScrollView` rather than a `SectionList` keeps parity with the desktop `ReportsInboxViewPresentation` layout; the "Show more" cap on each section bounds how many rows are ever mounted at once.
- Mobile `scope` on the triage events reads as `teammate` when the reviewer filter is non-empty and `entire-project` otherwise. Mobile has no `for-you` control yet, so we don't invent one — the shared type comment already notes that mobile omits `scope` on `InboxViewedProperties` until it exposes the same control, so we keep that omission and only fill scope where the shared triage-event type requires it.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*