### PR TITLE
fix(data-warehouse): re-read the full table when a revive rebuilds it

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -367,7 +367,15 @@ async def _import_data_with_reporting(inputs: ImportDataActivityInputs, logger: 
         # The cursor as stored, before the lookback shift below moves it back.
         incremental_last_value_before_lookback = None
 
-        if reset_pipeline is not True:
+        # A pending corrupt-delta revive rebuilds this table inside this run: handle_corrupted_delta_log
+        # resets the Delta table before extraction, so the loader overwrites it from batch 0. The
+        # extraction has to re-pull every row to match that overwrite. Keeping the incremental cursor
+        # would extract only the rows after the stored watermark and collapse the table to that slice.
+        delta_rebuild_pending = schema.delta_revive_required is not None
+        if delta_rebuild_pending:
+            await logger.adebug("Ignoring the incremental cursor: a corrupt-delta revive rebuilds the table this run")
+
+        if reset_pipeline is not True and not delta_rebuild_pending:
             processed_incremental_last_value = process_incremental_value(
                 schema.sync_type_config.get("incremental_field_last_value"),
                 schema.sync_type_config.get("incremental_field_type"),

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -72,6 +72,7 @@ def _patched_activity(source_mock):
     schema = mock.MagicMock()
     schema.should_use_incremental_field = False
     schema.row_filters = None
+    schema.delta_revive_required = None
 
     with (
         mock.patch.object(module, "tag_queries"),
@@ -614,6 +615,7 @@ def _incremental_schema(*, is_incremental: bool, lookback_seconds: int | None) -
     schema.incremental_field_earliest_value = None
     schema.row_filters = None
     schema.api_version = None
+    schema.delta_revive_required = None
     schema.sync_type_config = {
         "incremental_field_last_value": "2026-06-14T15:33:31.802833",
         "incremental_field_type": "timestamp",
@@ -684,6 +686,31 @@ async def test_incremental_lookback_shifts_query_value_not_stored_watermark(
     # from new ground, and capturing it after the shift would make them equal and silently disarm
     # that rule with every test still passing.
     assert source_inputs.db_incremental_field_last_value_before_lookback == expected_before_lookback
+
+
+@pytest.mark.asyncio
+async def test_pending_delta_revive_extracts_full_table_not_incremental_slice():
+    source = mock.MagicMock(spec=SimpleSource)
+    source.parse_config.return_value = {}
+    source.source_for_pipeline.return_value = mock.MagicMock()
+    schema = _incremental_schema(is_incremental=True, lookback_seconds=3600)
+    schema.incremental_field_earliest_value = "2026-01-01T00:00:00"
+    schema.delta_revive_required = {
+        "reason": "missing_data_file",
+        "missing_path": "part-0.parquet",
+        "detected_at": "2026-06-15T00:00:00+00:00",
+    }
+
+    with _patched_activity_reaching_run(source, schema):
+        await import_data_activity_sync(_inputs_no_reset())
+
+    _, source_inputs = source.source_for_pipeline.call_args.args
+    # The revive resets the table and the loader overwrites it from batch 0, so any bound cursor
+    # replaces the whole table with the rows after the watermark.
+    assert source_inputs.db_incremental_field_last_value is None
+    assert source_inputs.db_incremental_field_earliest_value is None
+    # The stored watermark stays put, so a completed rebuild advances it from the rows it read.
+    assert schema.sync_type_config["incremental_field_last_value"] == "2026-06-14T15:33:31.802833"
 
 
 @pytest.mark.asyncio

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -616,9 +616,12 @@ def _incremental_schema(*, is_incremental: bool, lookback_seconds: int | None) -
     schema.row_filters = None
     schema.api_version = None
     schema.delta_revive_required = None
+    # The model reads this marker out of the persisted config through a property. Set both, because
+    # the mock cannot run the property, and the config carries the shape a real revive leaves behind.
     schema.sync_type_config = {
         "incremental_field_last_value": "2026-06-14T15:33:31.802833",
         "incremental_field_type": "timestamp",
+        "delta_revive_required": None,
     }
     return schema
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -695,11 +695,15 @@ async def test_pending_delta_revive_extracts_full_table_not_incremental_slice():
     source.source_for_pipeline.return_value = mock.MagicMock()
     schema = _incremental_schema(is_incremental=True, lookback_seconds=3600)
     schema.incremental_field_earliest_value = "2026-01-01T00:00:00"
-    schema.delta_revive_required = {
+    # The model reads this marker out of the persisted config through a property. Set both, because
+    # the mock cannot run the property, and the config carries the shape a real revive leaves behind.
+    revive_marker = {
         "reason": "missing_data_file",
         "missing_path": "part-0.parquet",
         "detected_at": "2026-06-15T00:00:00+00:00",
     }
+    schema.sync_type_config["delta_revive_required"] = revive_marker
+    schema.delta_revive_required = revive_marker
 
     with _patched_activity_reaching_run(source, schema):
         await import_data_activity_sync(_inputs_no_reset())


### PR DESCRIPTION
## Problem

A warehouse table that syncs incrementally can lose almost all of its rows, and stay collapsed across many scheduled runs.

- The import pipeline resets a table when it finds the Delta log references data files that are gone from object storage. It then rebuilds the table in the same run and marks that run non-billable, because the corruption is ours.
- The rebuild overwrites the table from the first batch, but extraction still applies the stored incremental cursor, so it reads only the rows after the watermark.
- The overwrite replaces the whole table with that slice. The job reports `Completed`.
- The revive clears the cursor, so later runs do attempt a full re-read. On a large table that read can exceed the time a worker stays available, so the table can stay collapsed while every run restarts the same re-read.

## Changes

- A table that the pipeline rebuilds after corrupt-delta detection now reads every row in that run, so the rebuild restores the full table instead of collapsing it to recent rows.
- The stored watermark stays untouched, so a completed rebuild advances the cursor from the rows it actually read.
- The activity logs at debug level when it drops the cursor, because the marker and the reset are handled in two different modules.
- Setting `reset_pipeline` for the run would also drop the cursor, but it changes behavior elsewhere: a buffered CDC schema raises on it, and webhook-only resources consume it differently. Dropping only the cursor keeps the change to the failure this fixes.

> [!NOTE]
> This guard reads the persisted revive marker, which the activity sees before extraction starts. Two other paths reach the same reset only once the pipeline runs: an unreadable Delta log, and a failed salvage of an interrupted repartition swap. Those still bind the cursor. Covering them needs the extraction query rebuilt after the reset, which is a larger change than this fix.

## How did you test this code?

Automated tests only. No run against a live source, so the behavior on a real corrupt table is not verified here.

- New `test_pending_delta_revive_extracts_full_table_not_incremental_slice` catches the regression directly: a schema carrying a pending revive marker must not receive the watermark in `SourceInputs`. Reverting the guard alone fails it on `db_incremental_field_last_value`.
- Two mock fixtures in that file now set `delta_revive_required = None`, the realistic default. Without it a bare `MagicMock` reads as a pending rebuild and every existing test in the file takes the new branch.
- Not run: the database-backed case in that file, `test_folder_path_needs_no_query_after_load`, because this sandbox has no Postgres. It fails identically on unmodified master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing setting or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code in a PostHog Desktop cloud task. Skills invoked: `/triaging-warehouse-sync-tickets` for the diagnosis, then `/writing-tests`, `/writing-code-comments` and `/writing-pr-descriptions` for this change.
- The diagnosis came from reading one production sync's job history and logs. Everything committed here is written from the code path instead: the fixture values, the marker contents and the comments are invented, and no customer identifier, host, table name, column name or row count appears anywhere in this PR.
- An earlier pass in the same session blamed a different cause, an incremental cursor that never matches rows whose cursor value is null. The job logs contradicted it, because the collapse coincided with a reset-and-overwrite whose extraction still carried the watermark. This fix follows the logs rather than that first explanation.
