### PR TITLE
fix(context-layer): send dream summaries as text

### DIFF
--- a/products/context_layer/backend/repo_lint.py
+++ b/products/context_layer/backend/repo_lint.py
@@ -279,7 +279,8 @@ fi
 summary_file="${1:-}"
 set --
 if [ -n "$summary_file" ]; then
-    set -- "$@" -F "summary=@$summary_file"
+    summary="$(cat "$summary_file")"
+    set -- "$@" --form-string "summary=$summary"
 fi
 if [ "$branch" != "main" ]; then
     set -- "$@" -F "branch=$branch"

--- a/products/context_layer/backend/test/test_repo_lint.py
+++ b/products/context_layer/backend/test/test_repo_lint.py
@@ -1,6 +1,8 @@
+import os
 import uuid
 import shutil
 import tempfile
+import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
@@ -111,6 +113,45 @@ class TestRepoLint(SimpleTestCase):
 
     def test_default_structure_is_clean(self) -> None:
         assert lint_repo(self.root) == []
+
+    def test_publish_sends_summary_contents_as_text(self) -> None:
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "git").write_text(
+            """#!/bin/sh
+if [ "$1" = "rev-parse" ]; then
+    echo "dream/2026-09-01"
+fi
+"""
+        )
+        (bin_dir / "curl").write_text(
+            """#!/bin/sh
+for arg do
+    printf '<%s>\\n' "$arg"
+done
+"""
+        )
+        (bin_dir / "git").chmod(0o755)
+        (bin_dir / "curl").chmod(0o755)
+        summary_file = self.root / "dream summary.md"
+        summary_file.write_text("Reviewed recent activity")
+
+        result = subprocess.run(
+            [self.root / "scripts" / "publish", summary_file],
+            cwd=self.root,
+            env={
+                **os.environ,
+                "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                "POSTHOG_API_URL": "https://example.com",
+                "POSTHOG_PERSONAL_API_KEY": "test-key",
+                "POSTHOG_CONTEXT_LAYER_COMMITS_PATH": "/commits/",
+            },
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        assert "<--form-string>\n<summary=Reviewed recent activity>" in result.stdout
 
     def test_valid_pages_in_every_directory_are_clean(self) -> None:
         (self.root / "areas").mkdir()


### PR DESCRIPTION
## Problem

Nightly context-layer dreams cannot publish when they attach a run summary. The publisher uploads the summary as a file, but the API accepts text.

**Why:** Failed publication prevents completed dream updates from landing in the organization wiki.

## Changes

- Nightly dreams can publish their run summary and land wiki updates.
- The publisher reads the summary file and sends literal text through curl. The bundle and branch fields remain unchanged.

## How did you test this code?

- A shell-level regression test verifies the generated publisher sends summary contents as a text form field.
- `./bin/hogli test products/context_layer/backend/test/test_repo_lint.py`
- `./bin/hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The existing workflow still accepts the same summary-file argument.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex in PostHog Desktop authored the fix. Skills invoked: `/context-layer-dreaming` and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
