### PR TITLE
fix(lemon-ui): close a popover when its own trigger is clicked

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { LemonDropdown } from './LemonDropdown'
 
@@ -10,6 +11,30 @@ describe('LemonDropdown', () => {
         cleanup()
         jest.useRealTimers()
     })
+
+    // The press that opened the dropdown must not also count as an outside press, or the dismiss
+    // and the trigger's own toggle cancel out and the dropdown can never be closed from its trigger.
+    it.each([{ closeOnClickInside: true }, { closeOnClickInside: false }])(
+        'closes on a second trigger click with closeOnClickInside $closeOnClickInside',
+        async ({ closeOnClickInside }) => {
+            const visibilities: boolean[] = []
+
+            render(
+                <LemonDropdown
+                    closeOnClickInside={closeOnClickInside}
+                    onVisibilityChange={(visible) => visibilities.push(visible)}
+                    overlay={<div>Menu</div>}
+                >
+                    <button>Open</button>
+                </LemonDropdown>
+            )
+
+            await userEvent.click(screen.getByText('Open'))
+            await userEvent.click(screen.getByText('Open'))
+
+            expect(visibilities).toEqual([true, false])
+        }
+    )
 
     it('delays opening a hover dropdown when configured', () => {
         jest.useFakeTimers()

--- a/frontend/src/lib/lemon-ui/Popover/Popover.test.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.test.tsx
@@ -25,27 +25,28 @@ describe('Popover', () => {
         return { onClickOutside }
     }
 
-    it('dismisses when clicking a plain outside element', async () => {
-        const { onClickOutside } = renderPopover(<button type="button">outside</button>)
+    it.each([
+        { target: 'outside', extra: <button type="button">outside</button>, dismisses: true },
+        {
+            // A nested menu portaled out of a parent popover's *reference* subtree (e.g. the
+            // TaxonomicFilter category pill in the search input suffix) inherits the wrong overlay
+            // level, so the parent can't recognize it as nested. It opts out via the block class.
+            target: 'nested menu item',
+            extra: (
+                <button type="button" className={CLICK_OUTSIDE_BLOCK_CLASS}>
+                    nested menu item
+                </button>
+            ),
+            dismisses: false,
+        },
+        // The reference is the popover's own trigger. Dismissing on it fights the trigger's toggle
+        // handler, which reopens the popover right after — so it never closes.
+        { target: 'reference', extra: undefined, dismisses: false },
+    ])('clicking $target dismisses: $dismisses', async ({ target, extra, dismisses }) => {
+        const { onClickOutside } = renderPopover(extra)
 
-        await userEvent.click(screen.getByText('outside'))
+        await userEvent.click(screen.getByText(target))
 
-        expect(onClickOutside).toHaveBeenCalled()
-    })
-
-    // Regression: a nested menu portaled out of a parent popover's *reference* subtree
-    // (e.g. the TaxonomicFilter category pill in the search input suffix) inherits the
-    // wrong overlay level, so the parent can't recognize it as nested. The element opts
-    // out via CLICK_OUTSIDE_BLOCK_CLASS — clicking it must not dismiss the parent.
-    it('does not dismiss when clicking an element marked with CLICK_OUTSIDE_BLOCK_CLASS', async () => {
-        const { onClickOutside } = renderPopover(
-            <button type="button" className={CLICK_OUTSIDE_BLOCK_CLASS}>
-                nested menu item
-            </button>
-        )
-
-        await userEvent.click(screen.getByText('nested menu item'))
-
-        expect(onClickOutside).not.toHaveBeenCalled()
+        expect(onClickOutside).toHaveBeenCalledTimes(dismisses ? 1 : 0)
     })
 })

--- a/frontend/src/lib/lemon-ui/Popover/Popover.tsx
+++ b/frontend/src/lib/lemon-ui/Popover/Popover.tsx
@@ -282,14 +282,22 @@ export const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(function P
 
     const dismiss = useDismiss(context, {
         enabled: visible,
-        // useDismiss only treats the floating + reference elements as "inside". Three things
-        // need explicit exemption: elements opting out via CLICK_OUTSIDE_BLOCK_CLASS,
+        // useDismiss only treats the floating + reference elements as "inside", and it only knows
+        // the reference when it was registered through `setReference` — the `children` path
+        // attaches it as a plain ref, so it is invisible here. Four things need explicit
+        // exemption: that reference, elements opting out via CLICK_OUTSIDE_BLOCK_CLASS,
         // additionalRefs (consumer-registered companion elements), and deeper-nested popovers
         // (portaled, so DOM-siblings rather than descendants).
         outsidePress: (event) => {
             const target = event.target as Node | null
             if (!target) {
                 return true
+            }
+            // Without this, pressing an open popover's own trigger dismisses it here and the
+            // trigger's toggle handler then reopens it — the popover never closes.
+            const reference = referenceRef.current
+            if (reference && 'contains' in reference && reference.contains(target)) {
+                return false
             }
             // Honor the block class on the floating-ui dismiss path too, not just onClickInside —
             // a nested menu in a parent popover's *reference* subtree (e.g. the TaxonomicFilter


### PR DESCRIPTION
## Problem

Clicking an open dropdown's trigger a second time leaves it open, so a person cannot dismiss a filter chip, menu, or picker from the control that opened it. The Self-driving inbox filter chips are one case; every `Popover` and `LemonDropdown` consumer in the app has it.

- floating-ui's `useDismiss` only recognizes a reference registered through `refs.setReference`.
- `Popover` attaches its `children` reference as a plain ref, so `useDismiss` never sees it.
- A press on the trigger therefore counts as an outside press. The dismiss closes the popover and the trigger's own toggle handler reopens it in the same click.
- The legacy `useOutsideClickHandler` excluded the reference. The switch to `useDismiss` dropped that exclusion.

## Changes

- A second click on a trigger now closes its popover, everywhere in the app.
- `outsidePress` exempts the reference subtree, next to the existing exemptions for the block class, `additionalRefs`, and nested popovers.
- Outside clicks and clicks inside the overlay keep their current behavior.
- Nothing looks different. The change is interaction only, so there are no screenshots.

## How did you test this code?

- Verified in headless Chromium against Storybook (`Lemon UI/Lemon Button` → `More_`). Before the change the second trigger click leaves the popover open. After it, the popover closes. Outside click and menu item click close it either way.
- New `Popover` case: a click on the reference must not fire `onClickOutside`. No case covered the reference before, and the two existing cases became rows of the same table.
- New `LemonDropdown` cases: two trigger clicks report exactly `[true, false]`, with `closeOnClickInside` set both ways. This catches the trigger toggle breaking on its own, which the `Popover` case cannot see.
- The whole frontend Jest suite passes apart from `products/mcp_analytics/frontend/timeBuckets.test.ts`, which fails the same way on `master`.
- Not run: `tsgo --noEmit`. The sandbox kills it for memory.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a Slack thread reporting that the Self-driving inbox filters dropdown stays open. The thread carried no GitHub handle for the person who drove it, so the PR is unassigned rather than assigned to a guessed account.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The report read as an inbox bug. A jsdom reproduction of the inbox `FilterPopover` showed the visibility sequence `[true, false, true]` on a second trigger click, which put the cause in `Popover` rather than the inbox. A headless Chromium run against Storybook then confirmed the same before and after. Narrowing the fix to the inbox was considered and rejected: those popovers use `LemonDropdown` with no special handling, so the fix belongs where the bug is.

Nothing in this PR carries material from the session that is not already public.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1788257737277229)*
