### PR TITLE
fix(dashboards): let dashboard delete run without a personhog client

### DIFF
--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -726,9 +726,15 @@ def clear_dashboard_from_group_type_mapping(
 
     Uses GetGroupTypeMappingByDashboardId to find the mapping, then UpdateGroupTypeMapping to clear it.
     """
+    # Imported here so a patched or faked client is picked up at call time.
+    from posthog.personhog_client.client import get_personhog_client
     from posthog.personhog_client.proto import GetGroupTypeMappingByDashboardIdRequest, UpdateGroupTypeMappingRequest
 
-    client = require_personhog_client()
+    client = get_personhog_client()
+    if client is None:
+        # personhog is the only group type mapping store, so without a client there is
+        # no mapping that can reference this dashboard. Let the delete proceed.
+        return
 
     def _fn() -> None:
         resp = client.get_group_type_mapping_by_dashboard_id(

--- a/posthog/models/test/test_group_type_mapping.py
+++ b/posthog/models/test/test_group_type_mapping.py
@@ -708,6 +708,15 @@ class TestClearDashboardFromGroupTypeMapping(SimpleTestCase):
         mock_client.update_group_type_mapping.assert_not_called()
         mock_invalidate.assert_not_called()
 
+    @patch("posthog.models.group_type_mapping.invalidate_group_types_cache")
+    @patch(_CLIENT_PATCH)
+    def test_unconfigured_client_is_a_no_op(self, mock_get_client, mock_invalidate):
+        mock_get_client.return_value = None
+
+        clear_dashboard_from_group_type_mapping(team_id=10, dashboard_id=42)
+
+        mock_invalidate.assert_not_called()
+
 
 # ── Terminal-failure hardening tests ──────────────────────────────────
 


### PR DESCRIPTION
## Problem

Deleting a dashboard fails with `RuntimeError: personhog client not configured` in any environment that runs without personhog. The AI evals CI job is one: it errors in the teardown of `eval_upsert_dashboard.py`, which deletes the dashboards a test created, and the job then exits non-zero even though all 16 evals pass ([example run](https://github.com/PostHog/posthog/actions/runs/33497359863/job/99822514123)).

`Dashboard.delete()` clears `detail_dashboard_id` from any `GroupTypeMapping` that points at the dashboard, and that helper called `require_personhog_client()`, which raises when `PERSONHOG_ADDR` is unset.

## Changes

- A dashboard delete now succeeds when no personhog client is configured, so the eval job stops failing on a passing run.
- `clear_dashboard_from_group_type_mapping` returns early when the client is `None`. personhog is the only group type mapping store, so without a client no mapping can reference the dashboard and there is nothing to clear.
- The client lookup moved into the function body so a patched or faked client resolves at call time.
- Production behavior does not change: personhog is configured there, so the clear runs as before. A configured but failing client still raises, as before.

## How did you test this code?

- Ran `posthog/models/test/test_group_type_mapping.py -k ClearDashboard` locally, 4 passed.
- Added one case, `test_unconfigured_client_is_a_no_op`. It catches a return to a hard `require_personhog_client()` in this path, which is the failure above.
- Not run: the AI evals job. It needs the docker stack and provider API keys, which this sandbox has no access to.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in a PostHog Desktop cloud task, from a request to fix the failing `AI evals / root-and-tools` job on [#89122](https://github.com/PostHog/posthog/pull/89122). The failure is unrelated to that PR's diff, so the fix lands separately.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The alternative considered was activating the personhog fake for the eval suite, which has its own `pytest.ini` and therefore never loads the repo-root conftest. That was rejected: the fake also blocks persons ORM access, and it would turn loud personhog failures into silent empty reads across every eval.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
