### PR TITLE
feat(desktop): group images in cloud picker and polish env wizard

### DIFF
--- a/products/desktop/packages/core/src/settings/environmentSetup.test.ts
+++ b/products/desktop/packages/core/src/settings/environmentSetup.test.ts
@@ -29,6 +29,26 @@ describe("environmentSetup", () => {
     expect(seeded.imageName).toBe("posthog toolchain");
   });
 
+  it("seeds a preselected image as the existing base, except for an image scope", () => {
+    const seeded = emptyEnvironmentSetupPlan({ existingImageId: "image-1" });
+    expect(seeded.baseImage).toBe("existing");
+    expect(seeded.existingImageId).toBe("image-1");
+
+    const imageScoped = emptyEnvironmentSetupPlan({
+      scope: "image",
+      existingImageId: "image-1",
+    });
+    expect(imageScoped.baseImage).toBe("new");
+    expect(imageScoped.existingImageId).toBeNull();
+
+    const withoutImages = emptyEnvironmentSetupPlan({
+      customImages: false,
+      existingImageId: "image-1",
+    });
+    expect(withoutImages.baseImage).toBe("default");
+    expect(withoutImages.existingImageId).toBeNull();
+  });
+
   it("keeps a typed environment name when the repositories change", () => {
     const typed = withEnvironmentName(plan(), "Internal APIs");
     const moved = withRepositories(typed, ["posthog/hogql"]);

--- a/products/desktop/packages/core/src/settings/environmentSetup.ts
+++ b/products/desktop/packages/core/src/settings/environmentSetup.ts
@@ -105,6 +105,7 @@ export interface EmptyPlanOptions {
   scope?: SetupScope;
   /** False when custom images are unavailable to this account. */
   customImages?: boolean;
+  existingImageId?: string | null;
 }
 
 /**
@@ -116,7 +117,16 @@ export function emptyEnvironmentSetupPlan({
   repository = null,
   scope = "environment",
   customImages = true,
+  existingImageId = null,
 }: EmptyPlanOptions = {}): EnvironmentSetupPlan {
+  const seededImageId =
+    customImages && scope === "environment" ? existingImageId : null;
+  const baseImage: BaseImageChoice =
+    customImages && scope === "image"
+      ? "new"
+      : seededImageId !== null
+        ? "existing"
+        : "default";
   return {
     scope,
     target: "new",
@@ -130,8 +140,8 @@ export function emptyEnvironmentSetupPlan({
     includeDefaultDomains: true,
     envVars: [],
     customImages,
-    baseImage: customImages && scope === "image" ? "new" : "default",
-    existingImageId: null,
+    baseImage,
+    existingImageId: seededImageId,
     imageName: repository === null ? "" : imagePresetName(repository),
     imageNameEdited: false,
     excludedToolIds: IMAGE_PRESET_TOOLS.filter(

--- a/products/desktop/packages/core/src/settings/imagePreset.ts
+++ b/products/desktop/packages/core/src/settings/imagePreset.ts
@@ -428,6 +428,56 @@ export function imagePresetName(repository: string): string {
   return `${repoName} toolchain`;
 }
 
+const IMAGE_NAME_ADJECTIVES = [
+  "amber",
+  "brisk",
+  "calm",
+  "cedar",
+  "clever",
+  "crisp",
+  "dapper",
+  "deft",
+  "mellow",
+  "nimble",
+  "quiet",
+  "rapid",
+  "rustic",
+  "snappy",
+  "solar",
+  "sturdy",
+  "swift",
+  "tidy",
+  "zesty",
+] as const;
+
+const IMAGE_NAME_NOUNS = [
+  "badger",
+  "beacon",
+  "comet",
+  "falcon",
+  "fern",
+  "forge",
+  "harbor",
+  "hedgehog",
+  "lantern",
+  "maple",
+  "meadow",
+  "otter",
+  "pebble",
+  "pine",
+  "quill",
+  "ridge",
+  "sparrow",
+  "summit",
+  "willow",
+] as const;
+
+export function randomImageName(): string {
+  const pick = (words: readonly string[]): string =>
+    words[Math.floor(Math.random() * words.length)];
+  return `${pick(IMAGE_NAME_ADJECTIVES)}-${pick(IMAGE_NAME_NOUNS)}`;
+}
+
 /**
  * The brief handed to the builder session. The builder authors and verifies the
  * spec, so this states the goal, the tools and the setup commands rather than

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/CloudEnvironmentsSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/CloudEnvironmentsSettings.tsx
@@ -39,12 +39,17 @@ export function CloudEnvironmentsSettings() {
   const setFormMode = useSettingsPageStore((s) => s.setFormMode);
   const [editingEnv, setEditingEnv] = useState<SandboxEnvironment | null>(null);
   const [openImage, setOpenImage] = useState<SandboxCustomImage | null>(null);
-  const [setupFlow, setSetupFlow] = useState<SetupScope | null>(null);
+  const [setupFlow, setSetupFlow] = useState<{
+    scope: SetupScope;
+    imageId: string | null;
+  } | null>(null);
+  const openSetup = (scope: SetupScope, imageId: string | null = null) =>
+    setSetupFlow({ scope, imageId });
 
   useEffect(() => {
     const action = consumeInitialAction();
     if (action === "create") {
-      setSetupFlow("environment");
+      setSetupFlow({ scope: "environment", imageId: null });
     }
   }, [consumeInitialAction]);
 
@@ -68,8 +73,9 @@ export function CloudEnvironmentsSettings() {
   if (setupFlow) {
     return (
       <EnvironmentSetupFlow
-        scope={setupFlow}
+        scope={setupFlow.scope}
         defaultRepository={null}
+        defaultImageId={setupFlow.imageId}
         onDone={() => setSetupFlow(null)}
       />
     );
@@ -82,7 +88,7 @@ export function CloudEnvironmentsSettings() {
         onDone={() => setEditingEnv(null)}
         onBuildNewImage={() => {
           setEditingEnv(null);
-          setSetupFlow("image");
+          openSetup("image");
         }}
       />
     );
@@ -94,6 +100,10 @@ export function CloudEnvironmentsSettings() {
         image={openImage}
         usedBy={environmentsUsing(openImage.id)}
         onDone={() => setOpenImage(null)}
+        onUseInEnvironment={() => {
+          setOpenImage(null);
+          openSetup("environment", openImage.id);
+        }}
       />
     );
   }
@@ -108,7 +118,7 @@ export function CloudEnvironmentsSettings() {
             variant="outline"
             size="sm"
             data-attr="environment-new"
-            onClick={() => setSetupFlow("environment")}
+            onClick={() => openSetup("environment")}
           >
             <Plus size={12} />
             New environment
@@ -147,7 +157,7 @@ export function CloudEnvironmentsSettings() {
               variant="outline"
               size="sm"
               data-attr="custom-image-new"
-              onClick={() => setSetupFlow("image")}
+              onClick={() => openSetup("image")}
             >
               <Plus size={12} />
               New image

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/ImageDetailPage.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/ImageDetailPage.tsx
@@ -33,6 +33,7 @@ interface ImageDetailPageProps {
   /** Names of the environments starting from this image, or null while unknown. */
   usedBy: readonly string[] | null;
   onDone: () => void;
+  onUseInEnvironment: () => void;
 }
 
 /**
@@ -44,6 +45,7 @@ export function ImageDetailPage({
   image,
   usedBy,
   onDone,
+  onUseInEnvironment,
 }: ImageDetailPageProps) {
   const { data } = useSandboxCustomImageDetail(image.id);
   const { buildMutation, builderTaskMutation, updateMutation, deleteMutation } =
@@ -166,6 +168,16 @@ export function ImageDetailPage({
               ? "No environment starts from it yet"
               : `Used by ${usedBy.join(", ")}`}
         </Text>
+        {current.status === "ready" && (
+          <Button
+            variant="link-muted"
+            size="sm"
+            data-attr="image-detail-use-in-environment"
+            onClick={onUseInEnvironment}
+          >
+            Use in an environment
+          </Button>
+        )}
       </div>
 
       {isImageBuildFailed(current.status) && (

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/EnvironmentEditForm.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/EnvironmentEditForm.tsx
@@ -48,10 +48,10 @@ export function EnvironmentEditForm({
   onBuildNewImage,
   dirty,
 }: EnvironmentEditFormProps) {
-  const error =
-    stepError(plan, "environment") ??
-    stepError(plan, "access") ??
-    stepError(plan, "image");
+  const environmentError = stepError(plan, "environment");
+  const accessError = stepError(plan, "access");
+  const imageError = stepError(plan, "image");
+  const error = environmentError ?? accessError ?? imageError;
 
   return (
     <div className="flex flex-col gap-5">
@@ -81,6 +81,7 @@ export function EnvironmentEditForm({
             plan={plan}
             environments={[]}
             onChange={onChange}
+            error={environmentError}
           />
         </Section>
         <Section>
@@ -88,6 +89,7 @@ export function EnvironmentEditForm({
             plan={plan}
             onChange={onChange}
             savedVariableKeys={savedVariableKeys}
+            error={accessError}
           />
         </Section>
         {plan.customImages && (
@@ -100,6 +102,7 @@ export function EnvironmentEditForm({
               buildNewDisabledReason={
                 dirty ? "Save your changes first, then build one." : null
               }
+              error={imageError}
             />
           </Section>
         )}

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/EnvironmentSetupFlow.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/EnvironmentSetupFlow.tsx
@@ -22,6 +22,7 @@ interface EnvironmentSetupFlowProps {
   /** "image" creates only an image; "environment" creates or updates one. */
   scope: SetupScope;
   defaultRepository: string | null;
+  defaultImageId?: string | null;
   /** Called with the image whose build just started, so a caller can follow it. */
   onDone: (building: SandboxCustomImage | null) => void;
   /** True when a surrounding dialog already supplies the title and the way back. */
@@ -40,6 +41,7 @@ interface EnvironmentSetupFlowProps {
 export function EnvironmentSetupFlow({
   scope,
   defaultRepository,
+  defaultImageId = null,
   onDone,
   embedded = false,
 }: EnvironmentSetupFlowProps) {
@@ -64,6 +66,7 @@ export function EnvironmentSetupFlow({
     <LoadedSetupFlow
       scope={scope}
       defaultRepository={defaultRepository}
+      defaultImageId={defaultImageId}
       customImages={customImagesEnabled && !customImagesDisabled}
       images={images}
       environments={environments}
@@ -76,6 +79,7 @@ export function EnvironmentSetupFlow({
 interface LoadedSetupFlowProps {
   scope: SetupScope;
   defaultRepository: string | null;
+  defaultImageId: string | null;
   customImages: boolean;
   images: readonly SandboxCustomImage[];
   environments: readonly { id: string; name: string }[];
@@ -86,6 +90,7 @@ interface LoadedSetupFlowProps {
 function LoadedSetupFlow({
   scope,
   defaultRepository,
+  defaultImageId,
   customImages,
   images,
   environments,
@@ -103,6 +108,7 @@ function LoadedSetupFlow({
       repository: defaultRepository,
       scope,
       customImages,
+      existingImageId: defaultImageId,
     }),
   );
   // Survives a failed submit: if the image was created but a later step

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/EnvironmentSetupForm.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/EnvironmentSetupForm.tsx
@@ -4,6 +4,7 @@ import {
   buildsImage,
   type EnvironmentSetupPlan,
   planTools,
+  type SetupStepKey,
   setupSteps,
   setupStepsComplete,
   stepError,
@@ -56,10 +57,16 @@ export function EnvironmentSetupForm({
   embedded = false,
 }: EnvironmentSetupFormProps) {
   const [step, setStep] = useState(0);
+  const [attempted, setAttempted] = useState<ReadonlySet<SetupStepKey>>(
+    () => new Set(),
+  );
   const steps = setupSteps(plan);
   const complete = setupStepsComplete(plan);
   const current = Math.min(step, steps.length - 1);
   const currentKey = steps[current].key;
+  const stepMessage = attempted.has(currentKey)
+    ? stepError(plan, currentKey)
+    : null;
   const isLastStep = current === steps.length - 1;
   const building = buildsImage(plan);
   const needsBuilder =
@@ -126,16 +133,26 @@ export function EnvironmentSetupForm({
               plan={plan}
               environments={environments}
               onChange={onChange}
+              error={stepMessage}
             />
           )}
           {currentKey === "access" && (
-            <AccessStep plan={plan} onChange={onChange} />
+            <AccessStep plan={plan} onChange={onChange} error={stepMessage} />
           )}
           {currentKey === "image" && plan.scope === "image" && (
-            <ImageDetailsStep plan={plan} onChange={onChange} />
+            <ImageDetailsStep
+              plan={plan}
+              onChange={onChange}
+              error={stepMessage}
+            />
           )}
           {currentKey === "image" && plan.scope === "environment" && (
-            <BaseImageStep plan={plan} images={images} onChange={onChange} />
+            <BaseImageStep
+              plan={plan}
+              images={images}
+              onChange={onChange}
+              error={stepMessage}
+            />
           )}
           {currentKey === "tools" && (
             <ToolsStep plan={plan} onChange={onChange} />
@@ -184,8 +201,13 @@ export function EnvironmentSetupForm({
             <Button
               variant="primary"
               size="sm"
-              disabled={complete[current] !== true}
-              onClick={() => setStep(current + 1)}
+              onClick={() => {
+                if (complete[current] === true) {
+                  setStep(current + 1);
+                  return;
+                }
+                setAttempted((prev) => new Set(prev).add(currentKey));
+              }}
             >
               Next
             </Button>

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/StepFieldError.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/StepFieldError.tsx
@@ -1,0 +1,16 @@
+import { Text } from "@posthog/quill";
+import type { ReactNode } from "react";
+
+export function StepFieldError({
+  id,
+  children,
+}: {
+  id?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Text id={id} role="alert" className="text-(--red-11) text-[11.5px]">
+      {children}
+    </Text>
+  );
+}

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/AccessStep.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/AccessStep.stories.tsx
@@ -21,6 +21,7 @@ function AccessStepStory({
         plan={plan}
         onChange={setPlan}
         savedVariableKeys={savedVariableKeys}
+        error={null}
       />
     </div>
   );

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/AccessStep.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/AccessStep.tsx
@@ -3,6 +3,7 @@ import { validateDomains } from "@posthog/core/settings/environmentSetup";
 import { Checkbox, Label, Text, Textarea } from "@posthog/quill";
 import { NetworkAccessSelect } from "@posthog/ui/features/settings/sections/environments/NetworkAccessSelect";
 import { StepBody } from "@posthog/ui/features/settings/sections/environments/setup/StepBody";
+import { StepFieldError } from "@posthog/ui/features/settings/sections/environments/setup/StepFieldError";
 import { EnvVarRows } from "@posthog/ui/features/settings/sections/environments/setup/steps/EnvVarRows";
 import { useId } from "react";
 
@@ -11,6 +12,7 @@ interface AccessStepProps {
   onChange: (plan: EnvironmentSetupPlan) => void;
   /** Names of the variables the environment already holds; their values are not shown back. */
   savedVariableKeys?: readonly string[];
+  error: string | null;
 }
 
 /** What the sandbox may reach, and what it gets in its shell. */
@@ -18,10 +20,13 @@ export function AccessStep({
   plan,
   onChange,
   savedVariableKeys = [],
+  error,
 }: AccessStepProps) {
   const defaultsId = useId();
   const domainsId = useId();
   const domains = validateDomains(plan.allowedDomainsText);
+  const attemptError =
+    domains.errors.length === 0 && domains.domains.length === 0 ? error : null;
 
   return (
     <StepBody
@@ -64,6 +69,7 @@ export function AccessStep({
               {error}
             </Text>
           ))}
+          {attemptError && <StepFieldError>{attemptError}</StepFieldError>}
           <label
             htmlFor={defaultsId}
             className="flex w-fit cursor-pointer items-start gap-2"

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/BaseImageStep.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/BaseImageStep.tsx
@@ -1,14 +1,14 @@
-import {
-  type BaseImageChoice,
-  type EnvironmentSetupPlan,
-  withImageName,
+import type {
+  BaseImageChoice,
+  EnvironmentSetupPlan,
 } from "@posthog/core/settings/environmentSetup";
-import { Button, Input, Label, Text } from "@posthog/quill";
+import { Button, Label, Text } from "@posthog/quill";
 import type { SandboxCustomImage } from "@posthog/shared/domain-types";
 import { SettingsSelect } from "@posthog/ui/features/settings/components/SettingsSelect";
 import { StepBody } from "@posthog/ui/features/settings/sections/environments/setup/StepBody";
+import { StepFieldError } from "@posthog/ui/features/settings/sections/environments/setup/StepFieldError";
+import { ImageNameField } from "@posthog/ui/features/settings/sections/environments/setup/steps/ImageNameField";
 import { RadioCards } from "@posthog/ui/primitives/RadioCards";
-import { useId } from "react";
 
 interface BaseImageStepProps {
   plan: EnvironmentSetupPlan;
@@ -22,6 +22,7 @@ interface BaseImageStepProps {
   onBuildNewImage?: () => void;
   /** Why leaving now is not offered, e.g. unsaved changes. */
   buildNewDisabledReason?: string | null;
+  error: string | null;
 }
 
 /** Where sessions start from: the standard image, one you have, or a new one. */
@@ -31,8 +32,8 @@ export function BaseImageStep({
   onChange,
   onBuildNewImage,
   buildNewDisabledReason,
+  error,
 }: BaseImageStepProps) {
-  const nameId = useId();
   const ready = images.filter((image) => image.status === "ready");
   const linksOut = onBuildNewImage !== undefined;
 
@@ -110,27 +111,20 @@ export function BaseImageStep({
               onChange({ ...plan, existingImageId })
             }
           />
+          {error && <StepFieldError>{error}</StepFieldError>}
         </div>
       )}
 
       {plan.baseImage === "new" && (
         <div className="flex max-w-[520px] flex-col gap-2 border-(--gray-4) border-t border-dashed pt-4">
-          <Label htmlFor={nameId} className="font-medium text-[12.5px]">
-            Image name
-          </Label>
-          <Input
-            id={nameId}
-            className="h-8 text-[12.5px]"
-            value={plan.imageName}
-            placeholder="e.g. Playwright + Node 22"
-            data-attr="environment-setup-image-name"
-            onChange={(event) =>
-              onChange(withImageName(plan, event.target.value))
-            }
+          <ImageNameField
+            plan={plan}
+            onChange={onChange}
+            error={error}
+            label="Image name"
+            dataAttr="environment-setup-image-name"
+            randomNameDataAttr="environment-setup-image-random-name"
           />
-          <Text className="text-(--gray-10) text-[11.5px]">
-            Shown wherever an environment picks its base image.
-          </Text>
         </div>
       )}
     </StepBody>

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/EnvironmentStep.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/EnvironmentStep.tsx
@@ -1,7 +1,6 @@
 import {
   type EnvironmentSetupPlan,
   type SetupTarget,
-  stepError,
   withEnvironmentName,
   withRepositories,
 } from "@posthog/core/settings/environmentSetup";
@@ -9,6 +8,7 @@ import { Checkbox, Input, Label, Text } from "@posthog/quill";
 import { RepositoriesField } from "@posthog/ui/features/integrations/components/RepositoriesField";
 import { SettingsSelect } from "@posthog/ui/features/settings/components/SettingsSelect";
 import { StepBody } from "@posthog/ui/features/settings/sections/environments/setup/StepBody";
+import { StepFieldError } from "@posthog/ui/features/settings/sections/environments/setup/StepFieldError";
 import { RadioCards } from "@posthog/ui/primitives/RadioCards";
 import { useId } from "react";
 
@@ -26,6 +26,7 @@ interface EnvironmentStepProps {
    * between a new one and an existing one has no place on the page.
    */
   editing?: boolean;
+  error: string | null;
 }
 
 /**
@@ -38,10 +39,10 @@ export function EnvironmentStep({
   environments,
   onChange,
   editing = false,
+  error,
 }: EnvironmentStepProps) {
   const nameId = useId();
   const privateId = useId();
-  const nameError = stepError(plan, "environment");
 
   return (
     <StepBody
@@ -87,7 +88,7 @@ export function EnvironmentStep({
             }
           />
           <Text className="text-(--gray-10) text-[11.5px]">
-            {nameError ?? "Shown in the workspace picker."}
+            {error ?? "Shown in the workspace picker."}
           </Text>
         </div>
       )}
@@ -105,9 +106,13 @@ export function EnvironmentStep({
             }))}
             onChange={(environmentId) => onChange({ ...plan, environmentId })}
           />
-          <Text className="text-(--gray-10) text-[11.5px]">
-            It keeps its own access settings. Only its base image changes.
-          </Text>
+          {error ? (
+            <StepFieldError>{error}</StepFieldError>
+          ) : (
+            <Text className="text-(--gray-10) text-[11.5px]">
+              It keeps its own access settings. Only its base image changes.
+            </Text>
+          )}
         </div>
       )}
 

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/ImageDetailsStep.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/ImageDetailsStep.tsx
@@ -1,17 +1,17 @@
 import {
   type EnvironmentSetupPlan,
-  stepError,
-  withImageName,
   withRepositories,
 } from "@posthog/core/settings/environmentSetup";
-import { Checkbox, Input, Label, Text } from "@posthog/quill";
+import { Checkbox, Label, Text } from "@posthog/quill";
 import { RepositoriesField } from "@posthog/ui/features/integrations/components/RepositoriesField";
 import { StepBody } from "@posthog/ui/features/settings/sections/environments/setup/StepBody";
+import { ImageNameField } from "@posthog/ui/features/settings/sections/environments/setup/steps/ImageNameField";
 import { useId } from "react";
 
 interface ImageDetailsStepProps {
   plan: EnvironmentSetupPlan;
   onChange: (plan: EnvironmentSetupPlan) => void;
+  error: string | null;
 }
 
 /**
@@ -19,46 +19,27 @@ interface ImageDetailsStepProps {
  * No environment is created here. An image is reused by any environment that
  * picks it as its base.
  */
-export function ImageDetailsStep({ plan, onChange }: ImageDetailsStepProps) {
-  const nameId = useId();
-  const errorId = useId();
+export function ImageDetailsStep({
+  plan,
+  onChange,
+  error,
+}: ImageDetailsStepProps) {
   const privateId = useId();
-  const error = stepError(plan, "image");
 
   return (
     <StepBody
       title="What is this image for?"
       description="A sandbox image with your tools already installed; any environment can start from it"
     >
-      <div className="flex flex-col gap-2">
-        <Label htmlFor={nameId} className="font-medium text-[12.5px]">
-          Name
-        </Label>
-        <Input
-          id={nameId}
-          className="h-8 max-w-[320px] text-[12.5px]"
-          value={plan.imageName}
-          placeholder="e.g. Playwright + Node 22"
-          data-attr="image-setup-name"
-          aria-invalid={error ? true : undefined}
-          aria-describedby={error ? errorId : undefined}
-          onChange={(event) =>
-            onChange(withImageName(plan, event.target.value))
-          }
+      <div className="flex max-w-[520px] flex-col gap-2">
+        <ImageNameField
+          plan={plan}
+          onChange={onChange}
+          error={error}
+          label="Name"
+          dataAttr="image-setup-name"
+          randomNameDataAttr="image-setup-random-name"
         />
-        {error ? (
-          <Text
-            id={errorId}
-            role="alert"
-            className="text-(--red-11) text-[11.5px]"
-          >
-            {error}
-          </Text>
-        ) : (
-          <Text className="text-(--gray-10) text-[11.5px]">
-            Shown wherever an environment picks its base image.
-          </Text>
-        )}
       </div>
 
       <div className="flex flex-col gap-2 border-(--gray-4) border-t border-dashed pt-4">

--- a/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/ImageNameField.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/environments/setup/steps/ImageNameField.tsx
@@ -1,0 +1,68 @@
+import { Shuffle } from "@phosphor-icons/react";
+import {
+  type EnvironmentSetupPlan,
+  withImageName,
+} from "@posthog/core/settings/environmentSetup";
+import { randomImageName } from "@posthog/core/settings/imagePreset";
+import { Button, Input, Label, Text } from "@posthog/quill";
+import { StepFieldError } from "@posthog/ui/features/settings/sections/environments/setup/StepFieldError";
+import { useId } from "react";
+
+interface ImageNameFieldProps {
+  plan: EnvironmentSetupPlan;
+  onChange: (plan: EnvironmentSetupPlan) => void;
+  error: string | null;
+  label: string;
+  dataAttr: string;
+  randomNameDataAttr: string;
+}
+
+export function ImageNameField({
+  plan,
+  onChange,
+  error,
+  label,
+  dataAttr,
+  randomNameDataAttr,
+}: ImageNameFieldProps) {
+  const nameId = useId();
+  const errorId = useId();
+
+  return (
+    <>
+      <Label htmlFor={nameId} className="font-medium text-[12.5px]">
+        {label}
+      </Label>
+      <div className="flex items-center gap-2">
+        <Input
+          id={nameId}
+          className="h-8 flex-1 text-[12.5px]"
+          value={plan.imageName}
+          placeholder="e.g. Playwright + Node 22"
+          data-attr={dataAttr}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
+          onChange={(event) =>
+            onChange(withImageName(plan, event.target.value))
+          }
+        />
+        <Button
+          variant="outline"
+          size="sm"
+          data-attr={randomNameDataAttr}
+          onClick={() => onChange(withImageName(plan, randomImageName()))}
+        >
+          <Shuffle size={12} />
+          Random name
+        </Button>
+      </div>
+      {error ? (
+        <StepFieldError id={errorId}>{error}</StepFieldError>
+      ) : (
+        <Text className="text-(--gray-10) text-[11.5px]">
+          Shown wherever an environment picks its base image.
+        </Text>
+      )}
+    </>
+  );
+}

--- a/products/desktop/packages/ui/src/features/task-detail/cloudTargets.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/cloudTargets.ts
@@ -86,7 +86,7 @@ export function buildCloudTargetOptions({
       key: cloudTargetKey({ kind: "image", id: image.id }),
       target: { kind: "image" as const, id: image.id },
       name: image.name,
-      description: `Image v${image.version}, full network access`,
+      description: `v${image.version}, full network access`,
     })),
   ];
 }

--- a/products/desktop/packages/ui/src/features/task-detail/components/WorkspaceModeSelect.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/WorkspaceModeSelect.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowsSplit,
   Cloud,
+  Cube,
   Gear,
   Laptop,
   Plus,
@@ -33,6 +34,7 @@ import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { useCallback, useMemo, useState } from "react";
 import {
   type CloudTarget,
+  type CloudTargetOption,
   cloudTargetKey,
   DEFAULT_CLOUD_TARGET,
 } from "../cloudTargets";
@@ -74,6 +76,8 @@ const LOCAL_MODES: {
 
 const CLOUD_ICON = <Cloud size={14} weight="regular" />;
 
+const IMAGE_ICON = <Cube size={14} weight="regular" />;
+
 const ICON_BUTTON_CLASS =
   "flex cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0.5 text-muted-foreground transition-colors hover:bg-fill-hover hover:text-foreground";
 
@@ -93,10 +97,25 @@ export function WorkspaceModeSelect({
   const { options, favoriteKey, toggleFavorite } = useCloudTargetOptions();
   const [menuOpen, setMenuOpen] = useState(false);
 
+  const environmentOptions = options.filter(
+    (option) => option.target.kind !== "image",
+  );
+  const imageOptions = options.filter(
+    (option) => option.target.kind === "image",
+  );
+
   const handleAddEnvironment = useCallback(() => {
     setMenuOpen(false);
     openSettings("cloud-environments", "create");
   }, []);
+
+  const selectTarget = useCallback(
+    (target: CloudTarget) => {
+      onChange("cloud");
+      onCloudTargetChange?.(target);
+    },
+    [onChange, onCloudTargetChange],
+  );
 
   const showCloud = overrideModes
     ? overrideModes.includes("cloud")
@@ -209,10 +228,7 @@ export function WorkspaceModeSelect({
 
         {showCloud && options.length === 1 && (
           <DropdownMenuItem
-            onClick={() => {
-              onChange("cloud");
-              onCloudTargetChange?.(DEFAULT_CLOUD_TARGET);
-            }}
+            onClick={() => selectTarget(DEFAULT_CLOUD_TARGET)}
             render={
               <ItemMenuItem size="xs" className="w-full">
                 <ItemMedia variant="icon" className="mt-2 ml-2">
@@ -245,71 +261,99 @@ export function WorkspaceModeSelect({
             </div>
 
             <DropdownMenuGroup>
-              {options.map((option) => {
-                const isFavorite = favoriteKey === option.key;
-                return (
-                  <DropdownMenuItem
-                    key={option.key}
-                    onClick={() => {
-                      onChange("cloud");
-                      onCloudTargetChange?.(option.target);
-                    }}
-                    render={
-                      <ItemMenuItem
-                        size="xs"
-                        className="w-full"
-                        render={<div />}
-                      >
-                        <ItemMedia variant="icon" className="mt-2 ml-2">
-                          <span>{CLOUD_ICON}</span>
-                        </ItemMedia>
-                        <ItemContent variant="menuItem">
-                          <ItemTitle>{option.name}</ItemTitle>
-                          <ItemDescription className="whitespace-nowrap leading-none">
-                            {option.description}
-                          </ItemDescription>
-                        </ItemContent>
-                        <ItemActions className="mr-1.5 ml-auto self-center">
-                          <button
-                            type="button"
-                            tabIndex={-1}
-                            aria-label={
-                              isFavorite
-                                ? `Stop using ${option.name} by default`
-                                : `Use ${option.name} by default`
-                            }
-                            aria-pressed={isFavorite}
-                            onPointerDown={(event) => {
-                              event.preventDefault();
-                              event.stopPropagation();
-                            }}
-                            onClick={(event) => {
-                              event.preventDefault();
-                              event.stopPropagation();
-                              toggleFavorite(option.target);
-                            }}
-                            className={cn(
-                              "flex cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0.5 transition-colors hover:text-foreground",
-                              isFavorite
-                                ? "text-foreground"
-                                : "text-muted-foreground opacity-0 group-hover/dropdown-menu-item:opacity-100",
-                            )}
-                          >
-                            <Star
-                              size={12}
-                              weight={isFavorite ? "fill" : "regular"}
-                            />
-                          </button>
-                        </ItemActions>
-                      </ItemMenuItem>
-                    }
-                  />
-                );
-              })}
+              {environmentOptions.map((option) => (
+                <CloudTargetItem
+                  key={option.key}
+                  option={option}
+                  isFavorite={favoriteKey === option.key}
+                  onSelect={selectTarget}
+                  onToggleFavorite={toggleFavorite}
+                />
+              ))}
             </DropdownMenuGroup>
+
+            {imageOptions.length > 0 && (
+              <>
+                <div className="px-2 py-1">
+                  <MenuLabel className="p-0">Images</MenuLabel>
+                </div>
+                <DropdownMenuGroup>
+                  {imageOptions.map((option) => (
+                    <CloudTargetItem
+                      key={option.key}
+                      option={option}
+                      isFavorite={favoriteKey === option.key}
+                      onSelect={selectTarget}
+                      onToggleFavorite={toggleFavorite}
+                    />
+                  ))}
+                </DropdownMenuGroup>
+              </>
+            )}
           </>
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function CloudTargetItem({
+  option,
+  isFavorite,
+  onSelect,
+  onToggleFavorite,
+}: {
+  option: CloudTargetOption;
+  isFavorite: boolean;
+  onSelect: (target: CloudTarget) => void;
+  onToggleFavorite: (target: CloudTarget) => void;
+}) {
+  const icon = option.target.kind === "image" ? IMAGE_ICON : CLOUD_ICON;
+  return (
+    <DropdownMenuItem
+      onClick={() => onSelect(option.target)}
+      render={
+        <ItemMenuItem size="xs" className="w-full" render={<div />}>
+          <ItemMedia variant="icon" className="mt-2 ml-2">
+            <span>{icon}</span>
+          </ItemMedia>
+          <ItemContent variant="menuItem">
+            <ItemTitle>{option.name}</ItemTitle>
+            <ItemDescription className="whitespace-nowrap leading-none">
+              {option.description}
+            </ItemDescription>
+          </ItemContent>
+          <ItemActions className="mr-1.5 ml-auto self-center">
+            <button
+              type="button"
+              tabIndex={-1}
+              aria-label={
+                isFavorite
+                  ? `Stop using ${option.name} by default`
+                  : `Use ${option.name} by default`
+              }
+              aria-pressed={isFavorite}
+              onPointerDown={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+              }}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                onToggleFavorite(option.target);
+              }}
+              className={cn(
+                "flex cursor-pointer items-center justify-center rounded-sm border-0 bg-transparent p-0.5 transition-colors hover:text-foreground",
+                isFavorite
+                  ? "text-foreground"
+                  : "text-muted-foreground opacity-0 group-hover/dropdown-menu-item:opacity-100",
+              )}
+            >
+              <Star size={12} weight={isFavorite ? "fill" : "regular"} />
+            </button>
+          </ItemActions>
+        </ItemMenuItem>
+      }
+    />
   );
 }


### PR DESCRIPTION
## Problem

- In the composer's cloud picker, a standalone image looks exactly like an environment, while the settings page says it belongs to no environment.
- The new image and new environment wizards open with a red "Give the image a name." before any input, and Next sits disabled with no way to see why.
- A ready image offers no way to attach it to an environment; only the environment form can pick an image.

## Changes

- The picker shows standalone ready images under their own "Images" label with a cube icon. Selection semantics are unchanged.

![picker-grouped](https://raw.githubusercontent.com/PostHog/pr-assets/491152476c9537538a2868716de8bbac4231a731/2026/09/11eb94ae-997e-426a-bd54-503e26c7f2e7.png)

- Wizard steps show a required-field error only after Next is clicked. Next stays enabled, and a failed click reveals the error instead of advancing.
- Two errors that never rendered before now do: "Pick the environment to add to." and "Pick an image."
- A "Random name" button fills a generated name (for example `snappy-fern`) on both image name fields.

![wizard-name](https://raw.githubusercontent.com/PostHog/pr-assets/dbb9b9b2b447a2a78a8b68eb997e4082238a8619/2026/09/787828c0-0c2f-408a-b2d0-f19dcf89b336.png)

- The image detail page gains "Use in an environment", which opens the environment wizard with that image preselected as the base, for a new environment or an existing one.
- Mechanical: shared `ImageNameField` and `StepFieldError` components replace copy-pasted blocks, and steps receive a resolved `error` string instead of computing their own.

