### PR TITLE
feat(desktop): pick the right repository when dismissing as wrong repo

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -5072,6 +5072,8 @@ export class PostHogAPIClient {
           /** When omitted, the server suppresses without creating a dismissal artefact. */
           dismissal_reason?: DismissalReasonOptionValue;
           dismissal_note?: string;
+          /** 'owner/repo' the report should have targeted; only allowed with dismissal_reason 'wrong_repo'. */
+          corrected_repository?: string;
           reset_weight?: boolean;
           error?: string;
         },

--- a/products/desktop/packages/core/src/inbox/bulkActions.ts
+++ b/products/desktop/packages/core/src/inbox/bulkActions.ts
@@ -8,12 +8,15 @@ export interface BulkActionResult {
 export interface DismissReportInput {
   reason: DismissalReasonOptionValue;
   note: string;
+  /** 'owner/repo' the reports should have targeted; only set when reason is 'wrong_repo'. */
+  correctedRepository?: string | null;
 }
 
 export type SuppressStateRequest = {
   state: "suppressed";
   dismissal_reason?: DismissalReasonOptionValue;
   dismissal_note?: string;
+  corrected_repository?: string;
 };
 
 /** Body for `updateSignalReportState` when suppressing/dismissing. Notes are clamped to 4000 chars. */
@@ -27,6 +30,11 @@ export function buildSuppressRequest(
     state: "suppressed",
     dismissal_reason: dismissal.reason,
     dismissal_note: dismissal.note.slice(0, 4000),
+    // The API rejects corrected_repository with any other reason, so the gate lives here
+    // rather than in every caller that builds a DismissReportInput.
+    ...(dismissal.reason === "wrong_repo" && dismissal.correctedRepository
+      ? { corrected_repository: dismissal.correctedRepository }
+      : {}),
   };
 }
 

--- a/products/desktop/packages/core/src/inbox/engagement.test.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.test.ts
@@ -85,10 +85,18 @@ describe("buildBulkActionEvents", () => {
       reports: [fakeReport({ id: "a" })],
       actionType: "dismiss",
       surface: "toolbar",
-      dismissal: { reason: "not_relevant", note: longNote },
+      dismissal: {
+        reason: "wrong_repo",
+        note: longNote,
+        correctedRepository: "acme/private-repo",
+      },
     });
-    expect(dismissed.dismissal_reason).toBe("not_relevant");
+    expect(dismissed.dismissal_reason).toBe("wrong_repo");
     expect(dismissed.dismissal_note).toHaveLength(500);
+    // A corrected repository is reported as a boolean; the raw 'owner/repo' slug
+    // must never reach shared telemetry.
+    expect(dismissed.has_corrected_repository).toBe(true);
+    expect(JSON.stringify(dismissed)).not.toContain("acme/private-repo");
 
     const [snoozed] = buildBulkActionEvents({
       reports: [fakeReport({ id: "a" })],

--- a/products/desktop/packages/core/src/inbox/engagement.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.ts
@@ -59,7 +59,11 @@ export interface BuildBulkActionEventsInput {
   actionType: InboxBulkActionType;
   surface: InboxReportActionSurface;
   /** Dismissal metadata, only meaningful for `dismiss`. Note is truncated to 500 chars. */
-  dismissal?: { reason?: string; note?: string };
+  dismissal?: {
+    reason?: string;
+    note?: string;
+    correctedRepository?: string | null;
+  };
 }
 
 /**
@@ -94,6 +98,9 @@ export function buildBulkActionEvents(
       : {}),
     ...(actionType === "dismiss" && dismissal?.note
       ? { dismissal_note: dismissal.note.slice(0, 500) }
+      : {}),
+    ...(actionType === "dismiss" && dismissal?.correctedRepository
+      ? { dismissal_corrected_repository: dismissal.correctedRepository }
       : {}),
   }));
 }

--- a/products/desktop/packages/core/src/inbox/engagement.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.ts
@@ -100,7 +100,7 @@ export function buildBulkActionEvents(
       ? { dismissal_note: dismissal.note.slice(0, 500) }
       : {}),
     ...(actionType === "dismiss" && dismissal?.correctedRepository
-      ? { dismissal_corrected_repository: dismissal.correctedRepository }
+      ? { has_corrected_repository: true }
       : {}),
   }));
 }

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -832,6 +832,8 @@ export interface InboxReportActionProperties {
   list_size: number;
   dismissal_reason?: string;
   dismissal_note?: string;
+  // 'owner/repo' correction from a wrong_repo dismissal.
+  dismissal_corrected_repository?: string;
   signal_id?: string;
   signal_source_product?: string;
   signal_source_type?: string;

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -832,8 +832,10 @@ export interface InboxReportActionProperties {
   list_size: number;
   dismissal_reason?: string;
   dismissal_note?: string;
-  // 'owner/repo' correction from a wrong_repo dismissal.
-  dismissal_corrected_repository?: string;
+  // True when a wrong_repo dismissal supplied a corrected repository. The
+  // 'owner/repo' slug itself stays in the team-scoped API record, since shared
+  // telemetry must not carry repository identity.
+  has_corrected_repository?: boolean;
   signal_id?: string;
   signal_source_product?: string;
   signal_source_type?: string;

--- a/products/desktop/packages/shared/src/dismissal-reasons.ts
+++ b/products/desktop/packages/shared/src/dismissal-reasons.ts
@@ -17,6 +17,10 @@ export const DISMISSAL_REASON_OPTIONS = [
     label: "Agent's analysis is wrong",
   },
   {
+    value: "wrong_repo",
+    label: "Agent picked the wrong repository",
+  },
+  {
     value: "wontfix_intentional",
     label: "Won't fix - intentional behavior",
   },

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.test.tsx
@@ -1,8 +1,32 @@
 import type { SignalReport } from "@posthog/shared/types";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { DismissReportDialog } from "./DismissReportDialog";
+
+const connectedRepositories = ["posthog/posthog", "posthog/posthog-js"];
+
+// Mirrors the real hook's cold-cache behavior: it yields repositories only while enabled
+// (the query is gated off when disabled, so the list is empty). Capturing the enabled
+// argument is what lets the test assert the fetch is driven by the reason, not the popover.
+const useGithubRepositoriesSpy = vi.fn((_search: string, enabled: boolean) => ({
+  repositories: enabled ? connectedRepositories : [],
+  isPending: false,
+  isFetchingMore: false,
+  hasMore: false,
+  loadMore: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/integrations/useIntegrations", () => ({
+  useIntegrations: vi.fn(),
+  useGithubRepositories: (search: string, enabled: boolean) =>
+    useGithubRepositoriesSpy(search, enabled),
+}));
+
+vi.mock("@posthog/ui/features/integrations/store", () => ({
+  useIntegrationSelectors: () => ({ hasGithubIntegration: true }),
+}));
 
 const report = {
   id: "report-1",
@@ -17,6 +41,10 @@ const report = {
 } satisfies SignalReport;
 
 describe("DismissReportDialog", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("distinguishes a project-wide archive from a temporary pause", async () => {
     const user = userEvent.setup();
     render(
@@ -44,5 +72,34 @@ describe("DismissReportDialog", () => {
     expect(
       screen.getByRole("button", { name: "Pause for everyone" }),
     ).toBeInTheDocument();
+  });
+
+  it("offers an openable repository picker on a cold cache once wrong-repo is chosen", () => {
+    render(
+      <DismissReportDialog
+        open
+        onOpenChange={vi.fn()}
+        report={report}
+        isSubmitting={false}
+        snoozeDisabledReason={null}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    const wrongRepoRadio = screen
+      .getByText("Agent picked the wrong repository")
+      .closest("div")
+      ?.querySelector("#dismiss-report-dialog-reason-wrong_repo");
+    if (!wrongRepoRadio) {
+      throw new Error("Expected the wrong-repo reason radio to render");
+    }
+    fireEvent.click(wrongRepoRadio);
+
+    // The repositories load on the reason alone, so with the picker still closed it renders
+    // its openable trigger, not the dead-end disabled "No GitHub repos" button that a
+    // fetch gated on the popover state would leave the reviewer stuck on.
+    expect(screen.getByText("Search repositories")).toBeInTheDocument();
+    expect(screen.queryByText("No GitHub repos")).not.toBeInTheDocument();
+    expect(useGithubRepositoriesSpy).toHaveBeenLastCalledWith("", true);
   });
 });

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
@@ -54,8 +54,8 @@ export function DismissReportDialog({
 
   // Quill's combobox portals its popup to document.body, outside Dialog.Content, so Radix
   // treats clicks on the popup as "outside the dialog". While the picker is open, every
-  // dismiss path below must close only the popup — otherwise selecting a repository slams
-  // the dialog shut and drops the reason and note already entered.
+  // dismiss path below must close only the popup. Otherwise selecting a repository closes
+  // the whole dialog and drops the reason and note already entered.
   const [isRepoPickerOpen, setIsRepoPickerOpen] = useState(false);
 
   useEffect(() => {

--- a/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DismissReportDialog.tsx
@@ -4,10 +4,16 @@ import {
   isDismissalReasonSnooze,
 } from "@posthog/shared/dismissalReasons";
 import type { SignalReport } from "@posthog/shared/types";
+import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
 import {
   ExplainedPauseLabel,
   ExplainedSuppressLabel,
 } from "@posthog/ui/features/inbox/components/utils/ExplainedDismissOptionLabels";
+import { useIntegrationSelectors } from "@posthog/ui/features/integrations/store";
+import {
+  useGithubRepositories,
+  useIntegrations,
+} from "@posthog/ui/features/integrations/useIntegrations";
 import { Button } from "@posthog/ui/primitives/Button";
 import { Dialog, Flex, RadioGroup, Text, TextArea } from "@radix-ui/themes";
 import { useEffect, useRef, useState } from "react";
@@ -15,6 +21,8 @@ import { useEffect, useRef, useState } from "react";
 export interface DismissReportDialogResult {
   reason: DismissalReasonOptionValue;
   note: string;
+  /** 'owner/repo' the reports should have targeted; only set when reason is 'wrong_repo'. */
+  correctedRepository: string | null;
 }
 
 export interface DismissReportDialogProps {
@@ -44,10 +52,20 @@ export function DismissReportDialog({
   const onOpenChangeRef = useRef(onOpenChange);
   onOpenChangeRef.current = onOpenChange;
 
+  // Quill's combobox portals its popup to document.body, outside Dialog.Content, so Radix
+  // treats clicks on the popup as "outside the dialog". While the picker is open, every
+  // dismiss path below must close only the popup — otherwise selecting a repository slams
+  // the dialog shut and drops the reason and note already entered.
+  const [isRepoPickerOpen, setIsRepoPickerOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) setIsRepoPickerOpen(false);
+  }, [open]);
+
   // Radix Themes nests Content inside the overlay scroll area, so backdrop clicks
   // often land on padding/overlay nodes that never reach Content's dismiss layer.
   useEffect(() => {
-    if (!open || isSubmitting) return;
+    if (!open || isSubmitting || isRepoPickerOpen) return;
 
     const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
@@ -67,17 +85,27 @@ export function DismissReportDialog({
     document.addEventListener("pointerdown", handlePointerDown, true);
     return () =>
       document.removeEventListener("pointerdown", handlePointerDown, true);
-  }, [open, isSubmitting]);
+  }, [open, isSubmitting, isRepoPickerOpen]);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Content
         maxWidth="480px"
-        onPointerDownOutside={() => {
-          if (!isSubmitting) onOpenChange(false);
+        onPointerDownOutside={(event) => {
+          // preventDefault, not just skipping onOpenChange: Radix also dismisses a controlled
+          // dialog through Root's own onOpenChange unless the event is cancelled.
+          if (isSubmitting || isRepoPickerOpen) {
+            event.preventDefault();
+            return;
+          }
+          onOpenChange(false);
         }}
-        onEscapeKeyDown={() => {
-          if (!isSubmitting) onOpenChange(false);
+        onEscapeKeyDown={(event) => {
+          if (isSubmitting || isRepoPickerOpen) {
+            event.preventDefault();
+            return;
+          }
+          onOpenChange(false);
         }}
       >
         <DismissReportDialogBody
@@ -86,6 +114,8 @@ export function DismissReportDialog({
           isSubmitting={isSubmitting}
           snoozeDisabledReason={snoozeDisabledReason}
           onConfirm={onConfirm}
+          isRepoPickerOpen={isRepoPickerOpen}
+          onRepoPickerOpenChange={setIsRepoPickerOpen}
         />
       </Dialog.Content>
     </Dialog.Root>
@@ -98,15 +128,38 @@ function DismissReportDialogBody({
   isSubmitting,
   snoozeDisabledReason,
   onConfirm,
+  isRepoPickerOpen,
+  onRepoPickerOpenChange,
 }: Omit<DismissReportDialogProps, "open" | "onOpenChange"> & {
   selectedCount: number;
+  /** Owned by the dialog wrapper, which suppresses its dismiss paths while the picker is open. */
+  isRepoPickerOpen: boolean;
+  onRepoPickerOpenChange: (open: boolean) => void;
 }) {
   const [reason, setReason] = useState<DismissalReasonOptionValue | null>(null);
   const [note, setNote] = useState("");
+  const [correctedRepository, setCorrectedRepository] = useState<string | null>(
+    null,
+  );
+  const [repoSearch, setRepoSearch] = useState("");
+
+  const isWrongRepo = reason === "wrong_repo";
+  // Populates the integration store in case no other surface loaded it yet; react-query dedupes.
+  useIntegrations();
+  const { hasGithubIntegration } = useIntegrationSelectors();
+  // Enabled on the reason alone, not on isRepoPickerOpen: when the list is empty the picker
+  // renders a disabled "No GitHub repos" trigger that cannot be opened, so gating the fetch on
+  // the open state would deadlock on a cold cache (never open -> never fetch -> never open).
+  const repoPage = useGithubRepositories(repoSearch, isWrongRepo);
 
   const handleConfirm = () => {
     if (!reason) return;
-    onConfirm({ reason, note: note.trim() });
+    onConfirm({
+      reason,
+      note: note.trim(),
+      // A correction picked and then abandoned for another reason must not ride along.
+      correctedRepository: isWrongRepo ? correctedRepository : null,
+    });
   };
 
   const alreadyFixedDisabled = snoozeDisabledReason !== null;
@@ -165,6 +218,34 @@ function DismissReportDialogBody({
             })}
           </Flex>
         </RadioGroup.Root>
+
+        {isWrongRepo && hasGithubIntegration ? (
+          <div className="flex flex-col gap-1">
+            <span className="text-(--gray-12) text-xs">
+              Which repository should it have been?
+            </span>
+            <GitHubRepoPicker
+              value={correctedRepository}
+              onChange={setCorrectedRepository}
+              repositories={repoPage.repositories}
+              isLoading={repoPage.isPending}
+              isLoadingMore={repoPage.isFetchingMore}
+              open={isRepoPickerOpen}
+              onOpenChange={onRepoPickerOpenChange}
+              searchQuery={repoSearch}
+              onSearchQueryChange={setRepoSearch}
+              hasMore={repoPage.hasMore}
+              onLoadMore={repoPage.loadMore}
+              disabled={isSubmitting}
+              placeholder="Search repositories"
+              size="1"
+            />
+            <span className="text-(--gray-10) text-xs">
+              Optional. The agent uses your correction when picking repositories
+              in the future.
+            </span>
+          </div>
+        ) : null}
 
         <TextArea
           value={note}

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBulkActions.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBulkActions.ts
@@ -1,3 +1,4 @@
+import { buildSuppressRequest } from "@posthog/core/inbox/bulkActions";
 import {
   buildBulkActionEvents,
   type InboxBulkActionType,
@@ -253,9 +254,7 @@ export function useInboxBulkActions(
         reports: succeeded,
         actionType,
         surface,
-        dismissal: dismissal
-          ? { reason: dismissal.reason, note: dismissal.note }
-          : undefined,
+        dismissal,
       });
       for (const event of events) {
         track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION, event);
@@ -310,15 +309,10 @@ export function useInboxBulkActions(
       // TODO: When dismissing a report that has an open implementation PR
       // (implementation_pr_url), close that PR on GitHub – likely in main, not here.
       return runBulkAction(input.reportIds, (reportId) =>
-        client.updateSignalReportState(reportId, {
-          state: "suppressed",
-          ...(input.dismissal
-            ? {
-                dismissal_reason: input.dismissal.reason,
-                dismissal_note: input.dismissal.note.slice(0, 4000),
-              }
-            : {}),
-        }),
+        client.updateSignalReportState(
+          reportId,
+          buildSuppressRequest(input.dismissal),
+        ),
       );
     },
     {


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
