### PR TITLE
chore(ai): keep insight eval judge schemas under the size guard

### DIFF
--- a/ee/hogai/eval/ci/eval_funnel.py
+++ b/ee/hogai/eval/ci/eval_funnel.py
@@ -13,8 +13,6 @@ from posthog.schema import (
     NodeKind,
 )
 
-from ee.hogai.chat_agent.funnels.toolkit import FUNNEL_SCHEMA
-
 from ..base import MaxPublicEval
 from ..scorers import PlanAndQueryOutput, PlanCorrectness, QueryAndPlanAlignment, QueryKindSelection, TimeRangeRelevancy
 
@@ -40,7 +38,7 @@ async def eval_funnel(call_root_for_insight_generation, pytestconfig):
             ),
             QueryAndPlanAlignment(
                 query_kind=NodeKind.FUNNELS_QUERY,
-                json_schema=FUNNEL_SCHEMA,
+                query_model=AssistantFunnelsQuery,
                 evaluation_criteria="""
 1. Series sequence: Verify that the funnel steps in the query's `series` array match the sequence order and events specified in the plan. The order must be preserved if funnel steps are set to be sequential (ordered).
 2. Event names: Ensure each funnel step uses the exact event name specified in the plan for that step position.
@@ -68,7 +66,7 @@ async def eval_funnel(call_root_for_insight_generation, pytestconfig):
 9. Aggregation: Check if group aggregation is correctly set when plan specifies group-based funnels (`aggregation_group_type_index`).
 10. Missing implementation: Heavily penalize when key plan elements are missing (e.g., missing exclusions, wrong sequence order, incorrect breakdown).
 11. Unnecessary fields: Penalize inclusion of fields not mentioned in the plan or that don't align with the funnel intent.
-12. Schema compliance: Ensure all query fields conform to the FUNNEL_SCHEMA structure and constraints.
+12. Schema compliance: Ensure all query fields conform to the JSON schema structure and constraints above.
 """,
             ),
             TimeRangeRelevancy(query_kind=NodeKind.FUNNELS_QUERY),

--- a/ee/hogai/eval/ci/eval_retention.py
+++ b/ee/hogai/eval/ci/eval_retention.py
@@ -4,8 +4,6 @@ from braintrust import EvalCase
 
 from posthog.schema import AssistantRetentionEventsNode, AssistantRetentionFilter, AssistantRetentionQuery, NodeKind
 
-from ee.hogai.chat_agent.retention.toolkit import RETENTION_SCHEMA
-
 from ..base import MaxPublicEval
 from ..scorers import PlanAndQueryOutput, PlanCorrectness, QueryAndPlanAlignment, QueryKindSelection, TimeRangeRelevancy
 
@@ -30,7 +28,7 @@ async def eval_retention(call_root_for_insight_generation, pytestconfig):
             ),
             QueryAndPlanAlignment(
                 query_kind=NodeKind.RETENTION_QUERY,
-                json_schema=RETENTION_SCHEMA,
+                query_model=AssistantRetentionQuery,
                 evaluation_criteria="""
 1. Returning event alignment: Verify that the returning event in `retentionFilter.returningEntity.name` exactly matches the returning event specified in the plan.
 2. Target event alignment: Verify that the target event in `retentionFilter.targetEntity.name` exactly matches the target event specified in the plan.

--- a/ee/hogai/eval/ci/eval_trends.py
+++ b/ee/hogai/eval/ci/eval_trends.py
@@ -15,8 +15,6 @@ from posthog.schema import (
     TrendsFormulaNode,
 )
 
-from ee.hogai.chat_agent.trends.toolkit import TRENDS_SCHEMA
-
 from ..base import MaxPublicEval
 from ..scorers import PlanAndQueryOutput, PlanCorrectness, QueryAndPlanAlignment, QueryKindSelection, TimeRangeRelevancy
 
@@ -433,7 +431,7 @@ async def eval_trends(call_root_for_insight_generation, pytestconfig):
             ),
             QueryAndPlanAlignment(
                 query_kind=NodeKind.TRENDS_QUERY,
-                json_schema=TRENDS_SCHEMA,
+                query_model=AssistantTrendsQuery,
                 evaluation_criteria="""
 1. Events alignment: Verify that all events mentioned in the plan are correctly represented in the query's `series` array. For "All events", the `event` field should be `null`.
 2. Series math: Ensure the math operation for each event in the query matches what's specified in the plan, for example:

--- a/ee/hogai/eval/scorers/__init__.py
+++ b/ee/hogai/eval/scorers/__init__.py
@@ -5,6 +5,7 @@ from autoevals.llm import LLMClassifier
 from autoevals.partial import ScorerWithPartial
 from autoevals.ragas import AnswerSimilarity
 from braintrust import Score
+from pydantic import BaseModel
 
 from posthog.schema import AssistantMessage, AssistantToolCall, NodeKind
 
@@ -184,6 +185,25 @@ Details matter greatly here - including math types or property types - so be har
         )
 
 
+MAX_JUDGE_JSON_SCHEMA_CHARS = 100_000
+
+
+def build_judge_json_schema(query_kind: NodeKind, query_model: type[BaseModel]) -> str:
+    """Serialize a query schema for an LLM judge, keeping `$ref`s instead of inlining shared definitions.
+
+    Insight toolkits dereference their schemas because the query generator's tool call needs a flat one.
+    That repeats the property filter unions inside every series node and roughly doubles the size, while
+    a judge reads references just as well.
+    """
+    json_schema_str = json.dumps(query_model.model_json_schema())
+    if len(json_schema_str) > MAX_JUDGE_JSON_SCHEMA_CHARS:
+        raise ValueError(
+            f"JSON schema of {query_kind} has blown up in size, are you sure you want to put this into an LLM? "
+            "You CAN increase this limit if you're sure"
+        )
+    return json_schema_str
+
+
 class QueryAndPlanAlignment(LLMClassifier):
     """Evaluate if the generated SQL query aligns with the plan generated in the previous step."""
 
@@ -213,13 +233,8 @@ class QueryAndPlanAlignment(LLMClassifier):
             return Score(name=self._name(), score=0.0, metadata={"reason": "Query failed to be generated"})
         return super()._run_eval_sync(serialize_output(output), serialize_output(expected), **kwargs)
 
-    def __init__(self, query_kind: NodeKind, json_schema: dict, evaluation_criteria: str, **kwargs):
-        json_schema_str = json.dumps(json_schema)
-        if len(json_schema_str) > 100_000:
-            raise ValueError(
-                f"JSON schema of {query_kind} has blown up in size, are you sure you want to put this into an LLM? "
-                "You CAN increase this limit if you're sure"
-            )
+    def __init__(self, query_kind: NodeKind, query_model: type[BaseModel], evaluation_criteria: str, **kwargs):
+        json_schema_str = build_judge_json_schema(query_kind, query_model)
         super().__init__(
             name="query_and_plan_alignment",
             prompt_template="""

--- a/ee/hogai/test/test_eval_scorers.py
+++ b/ee/hogai/test/test_eval_scorers.py
@@ -1,0 +1,27 @@
+import json
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+from pydantic import BaseModel
+
+from posthog.schema import AssistantFunnelsQuery, AssistantRetentionQuery, AssistantTrendsQuery, NodeKind
+
+from ee.hogai.eval.scorers import MAX_JUDGE_JSON_SCHEMA_CHARS, build_judge_json_schema
+
+
+class TestBuildJudgeJsonSchema(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (NodeKind.TRENDS_QUERY, AssistantTrendsQuery),
+            (NodeKind.FUNNELS_QUERY, AssistantFunnelsQuery),
+            (NodeKind.RETENTION_QUERY, AssistantRetentionQuery),
+        ]
+    )
+    def test_insight_query_schema_fits_the_judge_budget(
+        self, query_kind: NodeKind, query_model: type[BaseModel]
+    ) -> None:
+        json_schema_str = build_judge_json_schema(query_kind, query_model)
+
+        self.assertLessEqual(len(json_schema_str), MAX_JUDGE_JSON_SCHEMA_CHARS)
+        self.assertEqual(json.loads(json_schema_str)["title"], query_model.__name__)


### PR DESCRIPTION
## Problem

The `AI evals / insights` job fails for every PR that touches Max's insight generation, and it fails after about 30 minutes, before any eval score comes out. [Example run.](https://github.com/PostHog/posthog/actions/runs/33497359863/job/99822514302)

- `QueryAndPlanAlignment` refuses a query schema over 100,000 characters, and the trends schema now serializes to 112,062.
- The scorer received the toolkit's dereferenced schema. Dereferencing inlines the shared property filter definitions into every series node, which roughly doubles the size.

## Changes

- The trends, funnel, and retention eval judges run again.
- The judges now read the referenced schema, keeping shared definitions in `$defs`. The trends judge prompt drops from 112,062 to 53,820 characters with the same field descriptions.
- `QueryAndPlanAlignment` takes the query model instead of a schema dict, so a dereferenced schema cannot reach a judge again.
- Nothing a PostHog user sees changes. This is eval-only code.

The alternative was raising the guard. That keeps 112,062 characters of mostly duplicated JSON in every trends judge call, and the schema would cross the next limit too.

## How did you test this code?

- `ee/hogai/test/test_eval_scorers.py` is new. It catches an insight query schema crossing the judge budget, which no test caught before: only the 30 minute eval job did.
- Not run: the insight evals themselves, which need a seeded stack and LLM credentials. Checked instead that the three scorers construct and the three eval modules import.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus wrote this after reading the failing job log. Skills invoked: `/writing-pr-descriptions`.

The first idea was to raise the guard, since its own error message offers that. Measuring the schema showed the growth was duplication from dereferencing, not new fields, so the fix removes the duplication and leaves the guard where it is.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
