### PR TITLE
refactor(capture): outputs carry their own connection and topic config

### DIFF
--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -13,7 +13,7 @@ use common_redis::RedisClient;
 use metrics::gauge;
 use tracing::{info, warn};
 
-use crate::config::{CaptureMode, Config};
+use crate::config::{CaptureMode, Config, KafkaConfig};
 use crate::event_restrictions::{EventRestrictionService, Pipeline, RedisRestrictionsRepository};
 use crate::global_rate_limiter::{ai_byte_limit_window, GlobalRateLimiter};
 use crate::outputs::{Output, OutputRegistry};
@@ -23,7 +23,7 @@ use crate::quota_limiters::{
 };
 use crate::router;
 use crate::router::BATCH_BODY_SIZE;
-use crate::sinks::kafka::KafkaSink;
+use crate::sinks::kafka::{KafkaOutputConfig, KafkaSink, OutputKafkaConfig};
 use crate::sinks::noop::NoOpSink;
 use crate::sinks::print::PrintSink;
 use crate::sinks::s3::S3Sink;
@@ -574,6 +574,61 @@ async fn create_output_registry(
     Ok(OutputRegistry::new(output))
 }
 
+/// How often librdkafka fires the stats callback for the primary output. Not
+/// an operator knob on the deployment-wide block, so it is named here.
+const PRIMARY_STATISTICS_INTERVAL_MS: u32 = 10_000;
+
+/// The primary output's own config block, resolved from the deployment-wide
+/// `KAFKA_*` variables. Those are the only ones existing deployments set, so
+/// the primary output produces to exactly the cluster and topics it does
+/// today.
+pub fn primary_kafka_output_config(kafka: &KafkaConfig) -> KafkaOutputConfig {
+    KafkaOutputConfig {
+        kafka: OutputKafkaConfig {
+            hosts: kafka.kafka_hosts.clone(),
+            tls: kafka.kafka_tls,
+            client_id: kafka.kafka_client_id.clone(),
+
+            linger_ms: kafka.kafka_producer_linger_ms,
+            queue_mib: kafka.kafka_producer_queue_mib,
+            message_timeout_ms: kafka.kafka_message_timeout_ms,
+            message_max_bytes: kafka.kafka_producer_message_max_bytes,
+            compression_codec: kafka.kafka_compression_codec.clone(),
+            acks: kafka.kafka_producer_acks.clone(),
+            enable_idempotence: kafka.kafka_producer_enable_idempotence,
+            batch_num_messages: kafka.kafka_producer_batch_num_messages,
+            batch_size: kafka.kafka_producer_batch_size,
+            metadata_refresh_interval_ms: kafka.kafka_topic_metadata_refresh_interval_ms,
+            metadata_max_age_ms: kafka.kafka_metadata_max_age_ms,
+            socket_timeout_ms: kafka.kafka_socket_timeout_ms,
+            statistics_interval_ms: PRIMARY_STATISTICS_INTERVAL_MS,
+            partitioner: kafka.kafka_producer_partitioner.clone(),
+            max_retries: kafka.kafka_producer_max_retries,
+            max_in_flight_requests: kafka.kafka_producer_max_in_flight_requests,
+            sticky_partitioning_linger_ms: kafka.kafka_producer_sticky_partitioning_linger_ms,
+            broker_address_family: kafka.kafka_broker_address_family.clone(),
+            log_connection_close: kafka.kafka_log_connection_close,
+            queue_buffering_max_messages: kafka.kafka_producer_queue_buffering_max_messages,
+            retry_backoff_max_ms: kafka.kafka_retry_backoff_max_ms,
+            socket_send_buffer_bytes: kafka.kafka_socket_send_buffer_bytes,
+            socket_receive_buffer_bytes: kafka.kafka_socket_receive_buffer_bytes,
+
+            topic_main: kafka.kafka_topic.clone(),
+            topic_historical: kafka.kafka_historical_topic.clone(),
+            topic_overflow: kafka.kafka_overflow_topic.clone(),
+            topic_dlq: kafka.kafka_dlq_topic.clone(),
+            topic_exception: kafka.kafka_error_tracking_topic.clone(),
+            topic_heatmap: kafka.kafka_heatmaps_topic.clone(),
+            topic_client_ingestion_warning: kafka.kafka_client_ingestion_warning_topic.clone(),
+            topic_ai: kafka.capture_analytics_ai_events_topic.clone(),
+            topic_ai_overflow: kafka.capture_analytics_ai_events_overflow_topic.clone(),
+            topic_replay_overflow: Some(kafka.kafka_replay_overflow_topic.clone()),
+        },
+        replay_envelope_compression: kafka.kafka_replay_envelope_compression,
+        completeness_check_enabled: kafka.outputs_completeness_check_enabled,
+    }
+}
+
 async fn create_output(
     config: &Config,
     sink_handle: Option<lifecycle::Handle>,
@@ -588,9 +643,12 @@ async fn create_output(
         let s3_handle = sink_handle.expect("sink lifecycle handle required for S3 fallback");
         let kafka_handle = advisory_handle.expect("kafka advisory handle required for fallback");
 
-        let kafka_sink = KafkaSink::new(config.kafka.clone(), Some(kafka_handle.clone()))
-            .await
-            .context("failed to start Kafka sink")?;
+        let kafka_sink = KafkaSink::new(
+            primary_kafka_output_config(&config.kafka),
+            Some(kafka_handle.clone()),
+        )
+        .await
+        .context("failed to start Kafka sink")?;
 
         let s3_sink = S3Sink::new(
             config
@@ -610,7 +668,7 @@ async fn create_output(
             Some(kafka_handle),
         ))
     } else {
-        let kafka_sink = KafkaSink::new(config.kafka.clone(), sink_handle)
+        let kafka_sink = KafkaSink::new(primary_kafka_output_config(&config.kafka), sink_handle)
             .await
             .context("failed to start Kafka sink")?;
 

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -18,7 +18,7 @@
 //! cost in the scatter-gather batch path at two `Arc::clone` calls (producer
 //! + topics) rather than deep copies of limiter state.
 use crate::api::CaptureError;
-use crate::config::{EnvelopeCompression, KafkaConfig};
+use crate::config::EnvelopeCompression;
 use crate::ordering::OrderingGuarantee;
 use crate::outputs::PublishEvents;
 use crate::pipeline::{self, Address, Lane, Pipeline};
@@ -39,6 +39,10 @@ use tracing::log::{debug, error, info};
 use tracing::{info_span, instrument, Instrument};
 
 use super::producer::RdKafkaProducer;
+
+/// The connection, producer tuning, and topics one Kafka output produces
+/// with. Shared with the v1 sinks, which read the same block per sink.
+pub use crate::v1::sinks::kafka::config::Config as OutputKafkaConfig;
 
 pub struct KafkaContext {
     /// Lifecycle handle this producer reports liveness to. `None` for a producer
@@ -234,114 +238,112 @@ fn dlq_reroute_effects(headers: &mut common_types::CapturedEventHeaders, reason:
         .set_dlq_timestamp(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
 }
 
+/// One Kafka output's own configuration: the cluster it connects to, the
+/// producer tuning it uses, and the topics it produces to. Two Kafka outputs
+/// in the same tree can name different clusters and different topics, because
+/// each leaf reads only its own block and never consults deployment-wide
+/// state.
+///
+/// Composed the way v1 composes its per-sink config: the shared Kafka block
+/// plus the leaf's own non-Kafka settings.
+#[derive(Clone, Debug)]
+pub struct KafkaOutputConfig {
+    /// Connection, producer tuning, and topics.
+    pub kafka: OutputKafkaConfig,
+    /// Envelope applied to this output's session-replay payloads.
+    pub replay_envelope_compression: EnvelopeCompression,
+    /// Refuse to boot when one of this output's topics is blank.
+    pub completeness_check_enabled: bool,
+}
+
 /// The default KafkaSink using rdkafka's FutureProducer
 pub type KafkaSink = KafkaSinkBase<RdKafkaProducer<KafkaContext>>;
 
 impl KafkaSink {
     pub async fn new(
-        config: KafkaConfig,
+        config: KafkaOutputConfig,
         liveness: Option<lifecycle::Handle>,
     ) -> anyhow::Result<KafkaSink> {
+        let kafka = &config.kafka;
+
         // Refuse to boot on incomplete output wiring: a blank topic fails
         // here, at startup, instead of at first produce. Config-only, so it
         // runs before the producer is built and the broker is pinged — the
         // refusal is instant, not one connect attempt later.
-        let registry = TopicTable::from(&config);
-        if config.outputs_completeness_check_enabled {
+        let registry = TopicTable::from(kafka);
+        if config.completeness_check_enabled {
             registry.check_complete()?;
         } else {
             info!("outputs completeness check disabled; a blank output topic will fail at first produce instead of at boot");
         }
 
-        info!("connecting to Kafka brokers at {}...", config.kafka_hosts);
+        info!("connecting to Kafka brokers at {}...", kafka.hosts);
 
         let mut client_config = ClientConfig::new();
         client_config
-            .set("bootstrap.servers", &config.kafka_hosts)
-            .set("statistics.interval.ms", "10000")
-            .set("partitioner", &config.kafka_producer_partitioner)
+            .set("bootstrap.servers", &kafka.hosts)
             .set(
-                "metadata.max.age.ms",
-                config.kafka_metadata_max_age_ms.to_string(),
+                "statistics.interval.ms",
+                kafka.statistics_interval_ms.to_string(),
             )
+            .set("partitioner", &kafka.partitioner)
+            .set("metadata.max.age.ms", kafka.metadata_max_age_ms.to_string())
             .set(
                 "topic.metadata.refresh.interval.ms",
-                config.kafka_topic_metadata_refresh_interval_ms.to_string(),
+                kafka.metadata_refresh_interval_ms.to_string(),
             )
-            .set(
-                "message.send.max.retries",
-                config.kafka_producer_max_retries.to_string(),
-            )
-            .set("linger.ms", config.kafka_producer_linger_ms.to_string())
-            .set(
-                "message.max.bytes",
-                config.kafka_producer_message_max_bytes.to_string(),
-            )
-            .set(
-                "message.timeout.ms",
-                config.kafka_message_timeout_ms.to_string(),
-            )
-            .set(
-                "socket.timeout.ms",
-                config.kafka_socket_timeout_ms.to_string(),
-            )
-            .set("compression.codec", &config.kafka_compression_codec)
+            .set("message.send.max.retries", kafka.max_retries.to_string())
+            .set("linger.ms", kafka.linger_ms.to_string())
+            .set("message.max.bytes", kafka.message_max_bytes.to_string())
+            .set("message.timeout.ms", kafka.message_timeout_ms.to_string())
+            .set("socket.timeout.ms", kafka.socket_timeout_ms.to_string())
+            .set("compression.codec", &kafka.compression_codec)
             .set(
                 "queue.buffering.max.kbytes",
-                (config.kafka_producer_queue_mib * 1024).to_string(),
+                (kafka.queue_mib * 1024).to_string(),
             )
-            .set("acks", &config.kafka_producer_acks)
-            .set(
-                "batch.num.messages",
-                config.kafka_producer_batch_num_messages.to_string(),
-            )
-            .set("batch.size", config.kafka_producer_batch_size.to_string())
+            .set("acks", &kafka.acks)
+            .set("batch.num.messages", kafka.batch_num_messages.to_string())
+            .set("batch.size", kafka.batch_size.to_string())
             .set(
                 "max.in.flight.requests.per.connection",
-                config.kafka_producer_max_in_flight_requests.to_string(),
+                kafka.max_in_flight_requests.to_string(),
             )
             .set(
                 "sticky.partitioning.linger.ms",
-                config
-                    .kafka_producer_sticky_partitioning_linger_ms
-                    .to_string(),
+                kafka.sticky_partitioning_linger_ms.to_string(),
             )
-            .set(
-                "enable.idempotence",
-                config.kafka_producer_enable_idempotence.to_string(),
-            )
+            .set("enable.idempotence", kafka.enable_idempotence.to_string())
             .set(
                 "log.connection.close",
-                config.kafka_log_connection_close.to_string(),
+                kafka.log_connection_close.to_string(),
             )
             .set(
                 "queue.buffering.max.messages",
-                config
-                    .kafka_producer_queue_buffering_max_messages
-                    .to_string(),
+                kafka.queue_buffering_max_messages.to_string(),
             )
             .set(
                 "retry.backoff.max.ms",
-                config.kafka_retry_backoff_max_ms.to_string(),
+                kafka.retry_backoff_max_ms.to_string(),
             )
             .set(
                 "socket.send.buffer.bytes",
-                config.kafka_socket_send_buffer_bytes.to_string(),
+                kafka.socket_send_buffer_bytes.to_string(),
             )
             .set(
                 "socket.receive.buffer.bytes",
-                config.kafka_socket_receive_buffer_bytes.to_string(),
+                kafka.socket_receive_buffer_bytes.to_string(),
             );
 
-        if !config.kafka_broker_address_family.is_empty() {
-            client_config.set("broker.address.family", &config.kafka_broker_address_family);
+        if !kafka.broker_address_family.is_empty() {
+            client_config.set("broker.address.family", &kafka.broker_address_family);
         }
 
-        if !&config.kafka_client_id.is_empty() {
-            client_config.set("client.id", &config.kafka_client_id);
+        if !kafka.client_id.is_empty() {
+            client_config.set("client.id", &kafka.client_id);
         }
 
-        if config.kafka_tls {
+        if kafka.tls {
             client_config
                 .set("security.protocol", "ssl")
                 .set("enable.ssl.certificate.verification", "false");
@@ -376,7 +378,7 @@ impl KafkaSink {
         Ok(KafkaSinkBase {
             producer: Arc::new(rd_producer),
             topics,
-            replay_envelope_compression: config.kafka_replay_envelope_compression,
+            replay_envelope_compression: config.replay_envelope_compression,
         })
     }
 }
@@ -789,9 +791,9 @@ pub(crate) use crate::sinks::registry::test_topics;
 #[cfg(test)]
 mod tests {
     use crate::api::CaptureError;
-    use crate::config::{self, EnvelopeCompression};
+    use crate::config::EnvelopeCompression;
     use crate::outputs::PublishEvents;
-    use crate::sinks::kafka::KafkaSink;
+    use crate::sinks::kafka::{KafkaOutputConfig, KafkaSink, OutputKafkaConfig};
     use crate::utils::uuid_v7_from_datetime;
     use crate::v0_request::{DataType, OverflowReason, ProcessedEvent, ProcessedEventMetadata};
     use common_types::CapturedEvent;
@@ -818,70 +820,49 @@ mod tests {
         );
         let _monitor = manager.monitor_background();
         let cluster = MockCluster::new(1).expect("failed to create mock brokers");
-        let config = config::KafkaConfig {
-            kafka_producer_linger_ms: 0,
-            kafka_producer_queue_mib: 50,
-            kafka_message_timeout_ms: 500,
-            kafka_topic_metadata_refresh_interval_ms: 20000,
-            kafka_producer_message_max_bytes: message_max_bytes.unwrap_or(1000000),
-            kafka_compression_codec: "none".to_string(),
-            kafka_hosts: cluster.bootstrap_servers(),
-            kafka_topic: "events_plugin_ingestion".to_string(),
-            kafka_overflow_topic: "events_plugin_ingestion_overflow".to_string(),
-            kafka_historical_topic: "events_plugin_ingestion_historical".to_string(),
-            kafka_client_ingestion_warning_topic: "events_plugin_ingestion".to_string(),
-            kafka_error_tracking_topic: "error_tracking_events".to_string(),
-            kafka_heatmaps_topic: "events_plugin_ingestion".to_string(),
-            kafka_replay_overflow_topic: "session_recording_snapshot_item_overflow".to_string(),
-            kafka_dlq_topic: "events_plugin_ingestion_dlq".to_string(),
-            outputs_completeness_check_enabled: true,
-            capture_analytics_ai_events_topic: "events_plugin_ingestion_ai".to_string(),
-            capture_analytics_ai_events_overflow_topic: None,
-            kafka_traces_topic: "traces_ingestion".to_string(),
-            kafka_metrics_topic: "metrics_ingestion".to_string(),
-            kafka_tls: false,
-            kafka_client_id: "".to_string(),
-            kafka_metadata_max_age_ms: 60000,
-            kafka_producer_max_retries: 2,
-            kafka_producer_acks: "all".to_string(),
-            kafka_socket_timeout_ms: 60000,
-            kafka_producer_batch_num_messages: 10000,
-            kafka_producer_batch_size: 1000000,
-            kafka_producer_max_in_flight_requests: 1000000,
-            kafka_producer_sticky_partitioning_linger_ms: 10,
-            kafka_producer_enable_idempotence: false,
-            kafka_producer_partitioner: "murmur2_random".to_string(),
-            kafka_broker_address_family: String::new(),
-            kafka_log_connection_close: true,
-            kafka_producer_queue_buffering_max_messages: 100000,
-            kafka_retry_backoff_max_ms: 1000,
-            kafka_socket_send_buffer_bytes: 0,
-            kafka_socket_receive_buffer_bytes: 0,
-            kafka_traces_hosts: None,
-            kafka_traces_tls: None,
-            kafka_traces_client_id: None,
-            kafka_traces_compression_codec: None,
-            kafka_traces_producer_acks: None,
-            kafka_traces_producer_linger_ms: None,
-            kafka_traces_producer_queue_mib: None,
-            kafka_traces_message_timeout_ms: None,
-            kafka_traces_producer_message_max_bytes: None,
-            kafka_traces_producer_max_retries: None,
-            kafka_traces_topic_metadata_refresh_interval_ms: None,
-            kafka_traces_metadata_max_age_ms: None,
-            kafka_metrics_hosts: None,
-            kafka_metrics_tls: None,
-            kafka_metrics_client_id: None,
-            kafka_metrics_compression_codec: None,
-            kafka_metrics_producer_acks: None,
-            kafka_metrics_producer_linger_ms: None,
-            kafka_metrics_producer_queue_mib: None,
-            kafka_metrics_message_timeout_ms: None,
-            kafka_metrics_producer_message_max_bytes: None,
-            kafka_metrics_producer_max_retries: None,
-            kafka_metrics_topic_metadata_refresh_interval_ms: None,
-            kafka_metrics_metadata_max_age_ms: None,
-            kafka_replay_envelope_compression: EnvelopeCompression::None,
+        let config = KafkaOutputConfig {
+            kafka: OutputKafkaConfig {
+                hosts: cluster.bootstrap_servers(),
+                tls: false,
+                client_id: String::new(),
+
+                linger_ms: 0,
+                queue_mib: 50,
+                message_timeout_ms: 500,
+                message_max_bytes: message_max_bytes.unwrap_or(1000000),
+                compression_codec: "none".to_string(),
+                acks: "all".to_string(),
+                enable_idempotence: false,
+                batch_num_messages: 10000,
+                batch_size: 1000000,
+                metadata_refresh_interval_ms: 20000,
+                metadata_max_age_ms: 60000,
+                socket_timeout_ms: 60000,
+                statistics_interval_ms: 10000,
+                partitioner: "murmur2_random".to_string(),
+                max_retries: 2,
+                max_in_flight_requests: 1000000,
+                sticky_partitioning_linger_ms: 10,
+                broker_address_family: String::new(),
+                log_connection_close: true,
+                queue_buffering_max_messages: 100000,
+                retry_backoff_max_ms: 1000,
+                socket_send_buffer_bytes: 0,
+                socket_receive_buffer_bytes: 0,
+
+                topic_main: "events_plugin_ingestion".to_string(),
+                topic_historical: "events_plugin_ingestion_historical".to_string(),
+                topic_overflow: "events_plugin_ingestion_overflow".to_string(),
+                topic_dlq: "events_plugin_ingestion_dlq".to_string(),
+                topic_exception: "error_tracking_events".to_string(),
+                topic_heatmap: "events_plugin_ingestion".to_string(),
+                topic_client_ingestion_warning: "events_plugin_ingestion".to_string(),
+                topic_ai: "events_plugin_ingestion_ai".to_string(),
+                topic_ai_overflow: None,
+                topic_replay_overflow: Some("session_recording_snapshot_item_overflow".to_string()),
+            },
+            replay_envelope_compression: EnvelopeCompression::None,
+            completeness_check_enabled: true,
         };
         let sink = KafkaSink::new(config, Some(handle))
             .await

--- a/rust/capture/src/sinks/registry.rs
+++ b/rust/capture/src/sinks/registry.rs
@@ -14,7 +14,7 @@
 //! and `AiOverflow` is the opt-in overflow valve — unset means routing never
 //! selects it.
 
-use crate::config::KafkaConfig;
+use crate::v1::sinks::kafka::config::Config as OutputKafkaConfig;
 
 /// Which configured output a routing decision selects, named **pipeline +
 /// lane** — the vocabulary the refactor converges on (typed per-pipeline
@@ -179,19 +179,21 @@ impl TopicTable {
     }
 }
 
-impl From<&KafkaConfig> for TopicTable {
-    fn from(config: &KafkaConfig) -> Self {
+/// An output's topic wiring comes from that output's own config block, so two
+/// outputs in one tree can name different topics.
+impl From<&OutputKafkaConfig> for TopicTable {
+    fn from(config: &OutputKafkaConfig) -> Self {
         Self {
-            main: config.kafka_topic.clone(),
-            overflow: config.kafka_overflow_topic.clone(),
-            historical: config.kafka_historical_topic.clone(),
-            client_ingestion_warning: config.kafka_client_ingestion_warning_topic.clone(),
-            heatmaps: config.kafka_heatmaps_topic.clone(),
-            replay_overflow: config.kafka_replay_overflow_topic.clone(),
-            dlq: config.kafka_dlq_topic.clone(),
-            error_tracking: config.kafka_error_tracking_topic.clone(),
-            ai_events: config.capture_analytics_ai_events_topic.clone(),
-            ai_events_overflow: config.capture_analytics_ai_events_overflow_topic.clone(),
+            main: config.topic_main.clone(),
+            overflow: config.topic_overflow.clone(),
+            historical: config.topic_historical.clone(),
+            client_ingestion_warning: config.topic_client_ingestion_warning.clone(),
+            heatmaps: config.topic_heatmap.clone(),
+            replay_overflow: config.topic_replay_overflow.clone().unwrap_or_default(),
+            dlq: config.topic_dlq.clone(),
+            error_tracking: config.topic_exception.clone(),
+            ai_events: config.topic_ai.clone(),
+            ai_events_overflow: config.topic_ai_overflow.clone(),
         }
     }
 }

--- a/rust/capture/src/v1/sinks/kafka/config.rs
+++ b/rust/capture/src/v1/sinks/kafka/config.rs
@@ -115,6 +115,11 @@ pub struct Config {
     /// setup from the deployment-level `CAPTURE_ANALYTICS_AI_EVENTS_OVERFLOW_TOPIC`; unset
     /// means the pipeline never produces `Destination::AiEventsOverflow`.
     pub topic_ai_overflow: Option<String>,
+
+    /// Overflow topic for the session-replay lane. Optional because only the
+    /// replay pipeline produces to it; a sink that serves no replay traffic
+    /// leaves it unset.
+    pub topic_replay_overflow: Option<String>,
 }
 
 const VALID_ACKS: &[&str] = &["0", "1", "-1", "all"];
@@ -231,6 +236,7 @@ mod tests {
         env.insert("RETRY_BACKOFF_MAX_MS".into(), "2000".into());
         env.insert("SOCKET_SEND_BUFFER_BYTES".into(), "65536".into());
         env.insert("SOCKET_RECEIVE_BUFFER_BYTES".into(), "65536".into());
+        env.insert("TOPIC_REPLAY_OVERFLOW".into(), "replay_overflow".into());
 
         let cfg = Config::init_from_hashmap(&env).unwrap();
         assert_eq!(cfg.hosts, "localhost:9092");
@@ -260,6 +266,10 @@ mod tests {
         assert_eq!(cfg.socket_send_buffer_bytes, 65536);
         assert_eq!(cfg.socket_receive_buffer_bytes, 65536);
         assert_eq!(cfg.topic_main, "events_main");
+        assert_eq!(
+            cfg.topic_replay_overflow,
+            Some("replay_overflow".to_string())
+        );
     }
 
     #[test]
@@ -291,6 +301,7 @@ mod tests {
         assert_eq!(cfg.retry_backoff_max_ms, 1000);
         assert_eq!(cfg.socket_send_buffer_bytes, 0);
         assert_eq!(cfg.socket_receive_buffer_bytes, 0);
+        assert_eq!(cfg.topic_replay_overflow, None);
     }
 
     #[rstest]

--- a/rust/capture/tests/integration_person_processing_matrix.rs
+++ b/rust/capture/tests/integration_person_processing_matrix.rs
@@ -227,7 +227,9 @@ async fn run_v0(inputs: Inputs, distinct_ids: &[&str]) -> Batch {
     let service = build_restrictions(inputs).await;
 
     let producer = MockKafkaProducer::new();
-    let sink = KafkaSinkBase::with_producer(producer.clone(), TopicTable::from(&cfg.kafka));
+    let output_config = capture::setup::primary_kafka_output_config(&cfg.kafka);
+    let sink =
+        KafkaSinkBase::with_producer(producer.clone(), TopicTable::from(&output_config.kafka));
     let quota_limiter =
         CaptureQuotaLimiter::new(&cfg, redis.clone(), Duration::from_secs(60 * 60 * 24 * 7));
 


### PR DESCRIPTION
## Problem

Pointing a capture output at a different Kafka cluster requires new code today: every leaf output reads the one deployment-wide `KafkaConfig`, so two outputs in the same tree cannot name different brokers or topics. That blocks the capture-analytics emergency fallback — a second, independently configured Kafka target — which is Step F1 of `rust/capture/OUTPUTS_REFACTOR_PLAN.md` as revised in #91761.

## Changes

No behavior change — deployments boot from the same variables and produce to the same clusters and topics.

- The Kafka leaf sink is built from an output-scoped config block (`KafkaOutputConfig`): connection, producer tuning, and that output's own topic names. It no longer reads the deployment-wide `KafkaConfig`.
- The block reuses `v1::sinks::kafka::config::Config` rather than inventing a third config model; that struct gains an optional `topic_replay_overflow`, its one missing routed topic.
- `setup::primary_kafka_output_config` maps the existing deployment-wide `KAFKA_*` variables onto the primary output's block field by field — no env var added, removed, or renamed.
- `TopicTable` derives from the output's block, so two outputs in one tree can name different topics.
- Mechanical: the mocked-sink test fixture shrinks from a 65-field `KafkaConfig` literal to the output block, with every producer value preserved explicitly.

Out of scope, per the plan: requiring configuration for reachable outputs (F2 — the `#[envconfig(default)]`s stay), broker topic verification (F3), and any fallback arming (F4).

## How did you test this code?

Agent-run automated checks only, from `rust/` under flox:

- `cargo test -p capture --no-fail-fast` — green, including the routing goldens and both v1 parity suites, all unmodified.
- `cargo clippy -p capture --all-targets -- -D warnings` and `cargo fmt --check` — clean.

Flagged, not changed: `Config::validate()` is not called on the v0 path — it would newly reject tunings v0 accepts today (the metadata refresh/max-age ratio), which belongs with F2's boot-time requirements.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — the plan doc update rides separately in #91761.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented by a Claude Code subagent from the F1 spec in #91761, then reviewed in the directing session before push (session: https://claude.ai/code/session_012MiByJdB2CefkPhG2p6b1V). Decisions along the way: `replay_envelope_compression` (a serializer concern) and `completeness_check_enabled` (deployment arming that F2 deletes) sit beside the shared Kafka block in the composite rather than inside it; hoisting the completeness check into `setup::create_output` was considered and rejected to keep the commit a pure structure change; v0's hardcoded `statistics.interval.ms` became a named constant fed through the struct so the emitted value is unchanged.
