### PR TITLE
feat(tasks): improve workflow dispatch RPC metrics

### DIFF
--- a/products/tasks/backend/management/commands/run_task_workflow_dispatcher.py
+++ b/products/tasks/backend/management/commands/run_task_workflow_dispatcher.py
@@ -42,6 +42,7 @@ from products.tasks.backend.logic.services.workflow_dispatch import (
 from products.tasks.backend.metrics import (
     WORKFLOW_DISPATCH_ATTEMPT_TOTAL,
     WORKFLOW_DISPATCH_START_DURATION_SECONDS,
+    WORKFLOW_DISPATCH_START_RPC_DURATION_SECONDS,
     observe_task_run_workflow_start,
 )
 from products.tasks.backend.models import TaskRun, TaskWorkflowDispatch
@@ -239,19 +240,24 @@ class Command(BaseCommand):
                 return
             started = monotonic()
             try:
-                await client.start_workflow(
-                    "process-task",
-                    workflow_input,
-                    id=dispatch.workflow_id,
-                    id_reuse_policy=(
-                        WorkflowIDReusePolicy.TERMINATE_IF_RUNNING
-                        if is_restart
-                        else WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY
-                    ),
-                    task_queue=settings.TASKS_TASK_QUEUE,
-                    retry_policy=RetryPolicy(maximum_attempts=3),
-                    rpc_timeout=timedelta(seconds=settings.TASKS_DISPATCHER_RPC_TIMEOUT_SECONDS),
-                )
+                try:
+                    await client.start_workflow(
+                        "process-task",
+                        workflow_input,
+                        id=dispatch.workflow_id,
+                        id_reuse_policy=(
+                            WorkflowIDReusePolicy.TERMINATE_IF_RUNNING
+                            if is_restart
+                            else WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY
+                        ),
+                        task_queue=settings.TASKS_TASK_QUEUE,
+                        retry_policy=RetryPolicy(maximum_attempts=3),
+                        rpc_timeout=timedelta(seconds=settings.TASKS_DISPATCHER_RPC_TIMEOUT_SECONDS),
+                    )
+                finally:
+                    duration = monotonic() - started
+                    WORKFLOW_DISPATCH_START_DURATION_SECONDS.observe(duration)
+                    WORKFLOW_DISPATCH_START_RPC_DURATION_SECONDS.labels(kind=dispatch.dispatch_kind).observe(duration)
             except WorkflowAlreadyStartedError:
                 if is_restart:
                     await sync_to_async(reschedule)(dispatch.id, instance_id, "Restart workflow is already running")
@@ -266,5 +272,3 @@ class Command(BaseCommand):
                 await sync_to_async(mark_accepted)(dispatch.id, instance_id)
                 WORKFLOW_DISPATCH_ATTEMPT_TOTAL.labels(kind=dispatch.dispatch_kind, outcome="accepted").inc()
                 observe_task_run_workflow_start(run, outcome="started", reason="dispatcher")
-            finally:
-                WORKFLOW_DISPATCH_START_DURATION_SECONDS.observe(monotonic() - started)

--- a/products/tasks/backend/metrics.py
+++ b/products/tasks/backend/metrics.py
@@ -86,6 +86,12 @@ WORKFLOW_DISPATCH_ATTEMPT_TOTAL = Counter(
 WORKFLOW_DISPATCH_START_DURATION_SECONDS = Histogram(
     "posthog_tasks_workflow_dispatch_start_duration_seconds", "Temporal workflow start RPC duration"
 )
+WORKFLOW_DISPATCH_START_RPC_DURATION_SECONDS = Histogram(
+    "posthog_tasks_workflow_dispatch_start_rpc_duration_seconds",
+    "Temporal workflow start RPC duration",
+    labelnames=["kind"],
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 5, 7.5, 10),
+)
 WORKFLOW_DISPATCH_READY = Gauge("posthog_tasks_workflow_dispatch_ready", "Ready workflow dispatches")
 WORKFLOW_DISPATCH_OLDEST_READY_AGE_SECONDS = Gauge(
     "posthog_tasks_workflow_dispatch_oldest_ready_age_seconds", "Age of the oldest ready workflow dispatch"


### PR DESCRIPTION
## Problem

Operators cannot separate workflow-start latency by dispatch kind, and coarse histogram buckets obscure the tail.

**Why:** Clear RPC measurements are needed to diagnose slow workflow handoffs without confusing them with downstream worker time.

## Changes

- Records start RPC latency with tighter buckets and a bounded dispatch-kind label.
- Preserves the existing metric while the detailed series accumulates data.

