### PR TITLE
chore(cli): deprecate event release mode on the mobile uploads

### DIFF
--- a/cli/.sampo/changesets/deprecate-mobile-release-mode.md
+++ b/cli/.sampo/changesets/deprecate-mobile-release-mode.md
@@ -1,0 +1,7 @@
+---
+cargo/posthog-cli: minor
+---
+
+Deprecate `--release-mode` on `proguard upload` and `--no-release-bind` on `dsym upload`. Both flags are hidden no-ops now: each command uploads its symbol sets bound to the release it creates, which is what it did before the flags existed. A supplied flag prints a deprecation warning instead of changing the upload, so a released gradle plugin or upload-symbols.sh that still passes one keeps working. `proguard upload` no longer reads `POSTHOG_RELEASE_MODE`; the variable keeps steering `sourcemap inject`, `sourcemap process`, `sourcemap upload`, `hermes inject`, `hermes clone` and `hermes upload`.
+
+Event mode pays off when two releases ship a byte-identical artifact. A proguard map id is a hash of the mapping, and a dSYM symbol set is keyed on the Mach-O `LC_UUID`, so an ordinary release that changes code already gets its own symbol set. The dSYM path also lost release attribution for embedded targets, because one upload covers every target's dSYM but creates one release.

--- a/cli/.sampo/changesets/remove-mobile-release-mode.md
+++ b/cli/.sampo/changesets/remove-mobile-release-mode.md
@@ -1,7 +1,0 @@
----
-cargo/posthog-cli: minor
----
-
-Remove `--release-mode` from `proguard upload` and `--no-release-bind` from `dsym upload`. Both commands upload their symbol sets bound to the release they create, which is what they did before those flags existed. `--release-mode` stays on `sourcemap inject`, `sourcemap process`, `sourcemap upload`, `hermes inject`, `hermes clone` and `hermes upload`.
-
-Event mode pays off when two releases ship a byte-identical artifact. A proguard map id is a hash of the mapping, and a dSYM symbol set is keyed on the Mach-O `LC_UUID`, so an ordinary release that changes code already gets its own symbol set. The dSYM path also lost release attribution for embedded targets, because one upload covers every target's dSYM but creates one release. Both flags were experimental and undocumented.

--- a/cli/.sampo/changesets/remove-mobile-release-mode.md
+++ b/cli/.sampo/changesets/remove-mobile-release-mode.md
@@ -1,0 +1,7 @@
+---
+cargo/posthog-cli: minor
+---
+
+Remove `--release-mode` from `proguard upload` and `--no-release-bind` from `dsym upload`. Both commands upload their symbol sets bound to the release they create, which is what they did before those flags existed. `--release-mode` stays on `sourcemap inject`, `sourcemap process`, `sourcemap upload`, `hermes inject`, `hermes clone` and `hermes upload`.
+
+Event mode pays off when two releases ship a byte-identical artifact. A proguard map id is a hash of the mapping, and a dSYM symbol set is keyed on the Mach-O `LC_UUID`, so an ordinary release that changes code already gets its own symbol set. The dSYM path also lost release attribution for embedded targets, because one upload covers every target's dSYM but creates one release. Both flags were experimental and undocumented.

--- a/cli/src/dsym/upload.rs
+++ b/cli/src/dsym/upload.rs
@@ -35,6 +35,12 @@ pub struct Args {
     /// Implies --force unless --skip-on-conflict is set. [default: false]
     #[arg(long, default_value_t = false)]
     pub include_source: bool,
+
+    /// Deprecated: the symbol sets always bind to the release the build creates. The flag stays
+    /// accepted so a released posthog-ios upload-symbols.sh that still passes it does not fail
+    /// the Xcode build with a parse error.
+    #[arg(long, default_value_t = false, hide = true)]
+    pub no_release_bind: bool,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -44,7 +50,16 @@ pub fn upload(args: &Args) -> Result<()> {
         conflict,
         main_dsym,
         include_source,
+        no_release_bind,
     } = args;
+
+    if *no_release_bind {
+        tracing::warn!(
+            "--no-release-bind is deprecated and does nothing. The symbol sets are uploaded bound \
+             to the release this build creates. Remove the flag."
+        );
+    }
+
     let release_args = release.resolve_info_plist()?;
 
     let directory = directory.canonicalize().map_err(|e| {
@@ -214,4 +229,46 @@ pub fn upload(args: &Args) -> Result<()> {
     info!("dSYM upload complete");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    #[derive(Parser)]
+    struct DsymCli {
+        #[command(subcommand)]
+        command: crate::dsym::DsymSubcommand,
+    }
+
+    fn parse(extra: &[&str]) -> Args {
+        let mut argv = vec!["dsym", "upload", "--directory", "dsyms"];
+        argv.extend_from_slice(extra);
+        let crate::dsym::DsymSubcommand::Upload(args) = DsymCli::parse_from(argv).command;
+        args
+    }
+
+    #[test]
+    fn accepts_the_deprecated_no_release_bind_flag() {
+        // Released posthog-ios upload-symbols.sh passes `--no-release-bind` when
+        // POSTHOG_NO_RELEASE_BIND=1. Rejecting the flag would fail the Xcode build phase with a
+        // parse error on CLI upgrade.
+        assert!(parse(&["--no-release-bind"]).no_release_bind);
+        assert!(!parse(&[]).no_release_bind);
+    }
+
+    #[test]
+    fn deprecated_no_release_bind_is_hidden() {
+        let cmd = DsymCli::command();
+        let upload = cmd
+            .find_subcommand("upload")
+            .expect("expected the upload subcommand");
+        let arg = upload
+            .get_arguments()
+            .find(|a| a.get_id() == "no_release_bind")
+            .expect("expected the no_release_bind argument");
+
+        assert!(arg.is_hide_set());
+    }
 }

--- a/cli/src/dsym/upload.rs
+++ b/cli/src/dsym/upload.rs
@@ -35,12 +35,6 @@ pub struct Args {
     /// Implies --force unless --skip-on-conflict is set. [default: false]
     #[arg(long, default_value_t = false)]
     pub include_source: bool,
-
-    /// Don't bind the uploaded symbol sets to the release. The release is still created, so the
-    /// server resolves it from the app version and namespace the SDK sends on every event, but the
-    /// chunks stay content-addressed and release-independent. [default: false]
-    #[arg(long, default_value_t = false)]
-    pub no_release_bind: bool,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -50,7 +44,6 @@ pub fn upload(args: &Args) -> Result<()> {
         conflict,
         main_dsym,
         include_source,
-        no_release_bind,
     } = args;
     let release_args = release.resolve_info_plist()?;
 
@@ -175,14 +168,7 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let release_id = created_release.map(|r| r.id.to_string());
 
-    // With --no-release-bind the release is still created above (so the server can resolve it from
-    // the app metadata the SDK sends on each event), but the uploaded chunks are left
-    // release-independent.
-    let chunk_release_id = if *no_release_bind {
-        None
-    } else {
-        release_id.clone()
-    };
+    let chunk_release_id = release_id.clone();
 
     // Process each dSYM
     let mut uploads: Vec<SymbolSetUpload> = Vec::new();

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -1,12 +1,11 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
-use tracing::warn;
 
 use crate::{
     api::{self, releases::ReleaseBuilder, symbol_sets::SymbolSetUpload},
     proguard::ProguardFile,
-    sourcemaps::args::{pack_version, ReleaseArgs, ReleaseMode, UploadConflictArgs},
+    sourcemaps::args::{pack_version, ReleaseArgs, UploadConflictArgs},
     utils::git::get_git_info,
 };
 
@@ -30,20 +29,6 @@ pub struct Args {
 
     #[clap(flatten)]
     pub conflict: UploadConflictArgs,
-
-    /// How the release is associated with exceptions. `symbol-set`, the default, stamps the
-    /// release id onto the uploaded mapping, and an exception takes the release of the mappings
-    /// its frames resolved against. EXPERIMENTAL `event` leaves the mapping
-    /// release-independent, and each event resolves its own release from the app version and
-    /// namespace the SDK already sends, so the release coordinates have to match the app's. The
-    /// release is created either way. Also settable via `POSTHOG_RELEASE_MODE`.
-    #[arg(
-        long,
-        env = "POSTHOG_RELEASE_MODE",
-        value_enum,
-        default_value = "symbol-set"
-    )]
-    pub release_mode: ReleaseMode,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -53,7 +38,6 @@ pub fn upload(args: &Args) -> Result<()> {
         batch_size,
         release,
         conflict,
-        release_mode,
     } = args;
 
     let resolved_release = release.resolve_info_plist()?;
@@ -64,18 +48,6 @@ pub fn upload(args: &Args) -> Result<()> {
         info_plist: _,
         skip_release_on_fail,
     } = &resolved_release;
-
-    // Event mode leaves nothing on the symbol set for the server to fall back to, so an
-    // exception resolves its release only from the app metadata on the event itself. Coordinates
-    // derived from git rather than passed explicitly will not match that metadata, and the
-    // exception then reports no release at all, silently.
-    if *release_mode == ReleaseMode::Event && (name.is_none() || version.is_none()) {
-        warn!(
-            "--release-mode=event resolves each exception's release from the app's namespace and \
-             version. Pass --release-name, --release-version and --build matching the app's \
-             applicationId, versionName and versionCode, or exceptions will report no release."
-        );
-    }
 
     let path = path
         .canonicalize()
@@ -105,18 +77,9 @@ pub fn upload(args: &Args) -> Result<()> {
 
     // The release is created in both modes, so the server has a row to resolve an event's
     // `$app_namespace` / `$app_version` / `$app_build` onto. Event mode only skips binding it to
-    // the mapping: a map id is derived from the mapping's own content, so the same mapping keeps
-    // one symbol set across releases instead of colliding with the release the first upload
-    // stamped on it.
-    //
-    // Unlike sourcemaps, event mode does not imply `--force` here. The uploaded bytes are the
-    // mapping itself, with no injected release id, so a rebuild of unchanged code produces
-    // identical content under the same id and never conflicts. A conflict means the caller reused
-    // a `--map-id` for a different mapping, which is worth reporting in either mode.
-    file.release_id = match release_mode {
-        ReleaseMode::Event => None,
-        ReleaseMode::SymbolSet => release.map(|r| r.id.to_string()),
-    };
+    // The mapping keeps the release the upload creates, so an exception takes the release of the
+    // mappings its frames resolved against.
+    file.release_id = release.map(|r| r.id.to_string());
 
     let to_upload: SymbolSetUpload = file.try_into()?;
 
@@ -156,20 +119,5 @@ mod tests {
         let crate::proguard::ProguardSubcommand::Upload(args) =
             ProguardCli::parse_from(argv).command;
         args
-    }
-
-    #[test]
-    fn defaults_to_binding_the_release_to_the_mapping() {
-        // Every existing caller omits the flag, and they must keep uploading mappings stamped with
-        // their release.
-        assert_eq!(parse(&[]).release_mode, ReleaseMode::SymbolSet);
-    }
-
-    #[test]
-    fn accepts_event_release_mode() {
-        assert_eq!(
-            parse(&["--release-mode", "event"]).release_mode,
-            ReleaseMode::Event
-        );
     }
 }

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -75,8 +75,10 @@ pub fn upload(args: &Args) -> Result<()> {
         .then(|| release_builder.fetch_or_create())
         .transpose()?;
 
-    // Bind the mapping to the release created for this build, so an exception symbolicated with
-    // this mapping is attributed to that release.
+    // Bind the mapping to the release this build resolved, so an exception symbolicated with this
+    // mapping takes that release. A build with no release name or version resolves none, and the
+    // upload then carries no release id. `--skip-release-on-fail` can also drop the binding when
+    // the server rejects it.
     file.release_id = release.map(|r| r.id.to_string());
 
     let to_upload: SymbolSetUpload = file.try_into()?;

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -92,30 +92,3 @@ pub fn upload(args: &Args) -> Result<()> {
 
     Ok(())
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use clap::Parser;
-
-    #[derive(Parser)]
-    struct ProguardCli {
-        #[command(subcommand)]
-        command: crate::proguard::ProguardSubcommand,
-    }
-
-    fn parse(extra: &[&str]) -> Args {
-        let mut argv = vec![
-            "proguard",
-            "upload",
-            "--path",
-            "mapping.txt",
-            "--map-id",
-            "id",
-        ];
-        argv.extend_from_slice(extra);
-        let crate::proguard::ProguardSubcommand::Upload(args) =
-            ProguardCli::parse_from(argv).command;
-        args
-    }
-}

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -75,10 +75,8 @@ pub fn upload(args: &Args) -> Result<()> {
         .then(|| release_builder.fetch_or_create())
         .transpose()?;
 
-    // The release is created in both modes, so the server has a row to resolve an event's
-    // `$app_namespace` / `$app_version` / `$app_build` onto. Event mode only skips binding it to
-    // The mapping keeps the release the upload creates, so an exception takes the release of the
-    // mappings its frames resolved against.
+    // Bind the mapping to the release created for this build, so an exception symbolicated with
+    // this mapping is attributed to that release.
     file.release_id = release.map(|r| r.id.to_string());
 
     let to_upload: SymbolSetUpload = file.try_into()?;

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -1,11 +1,12 @@
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use tracing::warn;
 
 use crate::{
     api::{self, releases::ReleaseBuilder, symbol_sets::SymbolSetUpload},
     proguard::ProguardFile,
-    sourcemaps::args::{pack_version, ReleaseArgs, UploadConflictArgs},
+    sourcemaps::args::{pack_version, ReleaseArgs, ReleaseMode, UploadConflictArgs},
     utils::git::get_git_info,
 };
 
@@ -29,6 +30,12 @@ pub struct Args {
 
     #[clap(flatten)]
     pub conflict: UploadConflictArgs,
+
+    /// Deprecated: the mapping always binds to the release the build creates. The flag stays
+    /// accepted so a gradle plugin that still passes it does not fail to parse, and it no longer
+    /// reads `POSTHOG_RELEASE_MODE`, which keeps steering the sourcemap and hermes commands.
+    #[arg(long, value_enum, hide = true)]
+    pub release_mode: Option<ReleaseMode>,
 }
 
 pub fn upload(args: &Args) -> Result<()> {
@@ -38,7 +45,15 @@ pub fn upload(args: &Args) -> Result<()> {
         batch_size,
         release,
         conflict,
+        release_mode,
     } = args;
+
+    if release_mode.is_some() {
+        warn!(
+            "--release-mode is deprecated and does nothing. The mapping is uploaded bound to the \
+             release this build creates. Remove the flag."
+        );
+    }
 
     let resolved_release = release.resolve_info_plist()?;
     let ReleaseArgs {
@@ -93,4 +108,63 @@ pub fn upload(args: &Args) -> Result<()> {
     upload_result?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    #[derive(Parser)]
+    struct ProguardCli {
+        #[command(subcommand)]
+        command: crate::proguard::ProguardSubcommand,
+    }
+
+    fn parse(extra: &[&str]) -> Args {
+        let mut argv = vec![
+            "proguard",
+            "upload",
+            "--path",
+            "mapping.txt",
+            "--map-id",
+            "id",
+        ];
+        argv.extend_from_slice(extra);
+        let crate::proguard::ProguardSubcommand::Upload(args) =
+            ProguardCli::parse_from(argv).command;
+        args
+    }
+
+    #[test]
+    fn accepts_the_deprecated_release_mode_flag() {
+        // Released gradle plugins pass `--release-mode event`. Rejecting the flag would fail
+        // their builds with a parse error on CLI upgrade.
+        assert_eq!(
+            parse(&["--release-mode", "event"]).release_mode,
+            Some(ReleaseMode::Event)
+        );
+        assert_eq!(
+            parse(&["--release-mode", "symbol-set"]).release_mode,
+            Some(ReleaseMode::SymbolSet)
+        );
+        assert_eq!(parse(&[]).release_mode, None);
+    }
+
+    #[test]
+    fn deprecated_release_mode_is_hidden_and_reads_no_environment() {
+        // A default or an env binding would mark unconfigured runs as deprecated callers, and
+        // POSTHOG_RELEASE_MODE stays a real control for the sourcemap and hermes commands.
+        let cmd = ProguardCli::command();
+        let upload = cmd
+            .find_subcommand("upload")
+            .expect("expected the upload subcommand");
+        let arg = upload
+            .get_arguments()
+            .find(|a| a.get_id() == "release_mode")
+            .expect("expected the release_mode argument");
+
+        assert!(arg.is_hide_set());
+        assert!(arg.get_env().is_none());
+    }
 }

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -135,14 +135,14 @@ pub struct ReleaseArgs {
 
 #[derive(clap::Args, Clone, Default)]
 pub struct UploadConflictArgs {
-    /// Allow overwriting an existing symbol set whose content has changed. A sourcemap upload
-    /// always overwrites with `--release-mode=event`. [default: false]
+    /// Allow overwriting an existing symbol set whose content has changed. A command that takes
+    /// `--release-mode` always overwrites in `event` mode. [default: false]
     #[arg(long, default_value_t = false, conflicts_with = "skip_on_conflict")]
     pub force: bool,
 
     /// Skip symbol sets that already exist with different content instead of failing.
-    /// Existing symbol sets are left unchanged. A sourcemap upload ignores this with
-    /// `--release-mode=event`. [default: false]
+    /// Existing symbol sets are left unchanged. A command that takes `--release-mode` ignores this
+    /// in `event` mode. [default: false]
     #[arg(long, default_value_t = false, conflicts_with = "force")]
     pub skip_on_conflict: bool,
 }

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -135,13 +135,14 @@ pub struct ReleaseArgs {
 
 #[derive(clap::Args, Clone, Default)]
 pub struct UploadConflictArgs {
-    /// Allow overwriting an existing symbol set whose content has changed. Always on with
-    /// `--release-mode=event`. [default: false]
+    /// Allow overwriting an existing symbol set whose content has changed. A sourcemap upload
+    /// always overwrites with `--release-mode=event`. [default: false]
     #[arg(long, default_value_t = false, conflicts_with = "skip_on_conflict")]
     pub force: bool,
 
     /// Skip symbol sets that already exist with different content instead of failing.
-    /// Existing symbol sets are left unchanged. Ignored with `--release-mode=event`. [default: false]
+    /// Existing symbol sets are left unchanged. A sourcemap upload ignores this with
+    /// `--release-mode=event`. [default: false]
     #[arg(long, default_value_t = false, conflicts_with = "force")]
     pub skip_on_conflict: bool,
 }

--- a/cli/src/sourcemaps/args.rs
+++ b/cli/src/sourcemaps/args.rs
@@ -135,14 +135,14 @@ pub struct ReleaseArgs {
 
 #[derive(clap::Args, Clone, Default)]
 pub struct UploadConflictArgs {
-    /// Allow overwriting an existing symbol set whose content has changed. A command that takes
-    /// `--release-mode` always overwrites in `event` mode. [default: false]
+    /// Allow overwriting an existing symbol set whose content has changed. The sourcemap and
+    /// hermes uploads always overwrite in `event` release mode. [default: false]
     #[arg(long, default_value_t = false, conflicts_with = "skip_on_conflict")]
     pub force: bool,
 
     /// Skip symbol sets that already exist with different content instead of failing.
-    /// Existing symbol sets are left unchanged. A command that takes `--release-mode` ignores this
-    /// in `event` mode. [default: false]
+    /// Existing symbol sets are left unchanged. The sourcemap and hermes uploads ignore this in
+    /// `event` release mode. [default: false]
     #[arg(long, default_value_t = false, conflicts_with = "force")]
     pub skip_on_conflict: bool,
 }


### PR DESCRIPTION
## Related PRs

Event mode is live today, and it is opt-in. These PRs settle where it stays and where it goes.

**Deprecating the mobile knobs.** The symbol id on these paths is already a content hash, so two releases collide only when they ship a byte-identical artifact. An ordinary release that changes code gets its own symbol set and never collides. The dSYM path also lost release attribution for embedded targets, because one upload covers every target while it creates one release. Review asked for deprecation instead of removal, so every knob stays accepted as a warned no-op.

- PostHog/posthog#92401 ← this PR
- PostHog/posthog-android#747
- PostHog/posthog-ios#791

**Making it the default.**

- PostHog/posthog#91823 (stacked on this PR)
- PostHog/posthog-js#4705

**React Native.** Scopes the mode to the Hermes upload and defaults it to event. That is the one path where two releases really do ship the same artifact.

- PostHog/posthog-js#4717

## Problem

- Event mode on the mobile uploads adds nothing: it pays off only when two releases ship a byte-identical artifact.
- A proguard map id is a hash of the mapping, and a dSYM symbol set is keyed on the Mach-O `LC_UUID`.
- An ordinary release that changes code gets its own symbol set and never collides.
- The dSYM path also lost release attribution for embedded targets. One upload covers every target's dSYM, but it creates one release.
- Removing the flags outright would break released callers. The Android gradle plugin and posthog-ios upload-symbols.sh still pass them, so an upgraded CLI would stop those builds with a parse error.

## Changes

- `proguard upload --release-mode` and `dsym upload --no-release-bind` become hidden no-ops. Both commands always bind their symbol sets to the release they create.
- A build that still passes a flag keeps working. It prints a deprecation warning, and its opt-in unbinding stops.
- `proguard upload` no longer reads `POSTHOG_RELEASE_MODE`. The variable keeps steering the sourcemap and hermes commands, so a global `symbol-set` opt-out for those cannot trigger warnings here.
- `--release-mode` stays visible on `sourcemap inject`, `sourcemap process`, `sourcemap upload`, `hermes inject`, `hermes clone` and `hermes upload`.
- Mechanical: the shared conflict help now names the sourcemap and hermes uploads instead of "a command that takes `--release-mode`", because proguard now takes it invisibly.

## How did you test this code?

- New parse tests pin the compatibility contract: both flags parse and default off, stay out of `--help`, and `--release-mode` binds no environment variable. They catch a future re-removal, which is the build break this PR prevents.
- A local run with `--release-mode event` printed the warning and kept the release binding.
- Not run: an upload against a real project.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Both knobs were experimental and undocumented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5); reshaped from removal to deprecation with Claude Code (Fable 5). Skills invoked: `/writing-pr-descriptions`.

Reviews here and on PostHog/posthog-android#747 and PostHog/posthog-ios#791 asked for warned no-ops instead of removal. PostHog/posthog#91823 stacks on this PR and flips the defaults for the commands that keep the flag.
