### PR TITLE
feat(workflows): notify teams when their email sending tier changes

### DIFF
--- a/docs/internal/workflows-email-sending-tiers.md
+++ b/docs/internal/workflows-email-sending-tiers.md
@@ -41,6 +41,9 @@ In order: staff suspension or an AWS-paused tenant drops to tier 0; a dirty 7-da
 Rates only count on a meaningful denominator; below the complaint floor, the absolute complaint backstop still applies, including in windows with no sends.
 Pinned teams never move automatically.
 
+While the tier is enforced, the sweep notifies teams it moved: a rate demotion sends an in-app notification plus an email to project admins, and an earned promotion sends an in-app notification only.
+Decay, suspension drops, admin recomputes, and the backfill stay silent.
+
 ## Rollout order
 
 1. Merge and deploy with both modes `off`. The daily sweep starts computing and storing tiers immediately.

--- a/docs/internal/workflows-email-sending-tiers.md
+++ b/docs/internal/workflows-email-sending-tiers.md
@@ -24,7 +24,6 @@ Django (`posthog/settings/web.py`):
 - `WORKFLOWS_EMAIL_TIER_MODE`: `off` (default), `shadow`, or `enforce`. Unrecognized values read as `off`.
 - `WORKFLOWS_EMAIL_TIER_HOURLY_CAPS`, `WORKFLOWS_EMAIL_TIER_DAILY_CAPS`, `WORKFLOWS_EMAIL_TIER_BATCH_AUDIENCE_CAPS`: comma-separated tables indexed by tier. The shortest table decides the tier count.
 - `WORKFLOWS_EMAIL_TIER_MIN_DAYS_AT_TIER`: per-tier dwell before promotion, comma-separated, clamped to the last entry.
-- `WORKFLOWS_EMAIL_TIER_ENFORCE_TEAMS_CREATED_AFTER`: ISO date. Empty enforces every team; a valid date enforces only teams created on or after it; an unparseable value enforces nobody, so a typo narrows instead of widening.
 - Promotion and demotion knobs: `WORKFLOWS_EMAIL_TIER_RATE_WINDOW_DAYS` (promotion window), `WORKFLOWS_EMAIL_TIER_DEMOTION_WINDOW_DAYS`, `WORKFLOWS_EMAIL_TIER_DEMOTION_COOLDOWN_DAYS` (keep at least as long as the demotion window), `WORKFLOWS_EMAIL_TIER_INACTIVITY_DECAY_DAYS` (0 disables decay), `WORKFLOWS_EMAIL_TIER_MIN_ACTIVE_DAYS`, `WORKFLOWS_EMAIL_TIER_MIN_DAILY_USE_RATIO`, `WORKFLOWS_EMAIL_TIER_MAX_COMPLAINT_RATE`, `WORKFLOWS_EMAIL_TIER_MAX_BOUNCE_RATE`, `WORKFLOWS_EMAIL_TIER_COMPLAINT_RATE_MIN_SENDS`, `WORKFLOWS_EMAIL_TIER_COMPLAINT_COUNT_BACKSTOP`, `WORKFLOWS_EMAIL_TIER_BOUNCE_RATE_MIN_SENDS`.
 - `HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS`: the pre-tier allowlist. It overrides the tier entirely, so a saved tier does nothing for a listed team.
 
@@ -32,7 +31,6 @@ Worker (`nodejs/src/cdp/config.ts`):
 
 - `EMAIL_TEAM_SENDING_CAP_MODE`: `off` (default), `shadow`, or `enforce`.
 - `EMAIL_TEAM_SENDING_CAP_HOURLY_BY_TIER`, `EMAIL_TEAM_SENDING_CAP_DAILY_BY_TIER`: must mirror the Django tables. An unusable table turns the cap off rather than applying a wrong number.
-- `EMAIL_TEAM_SENDING_CAP_TEAMS_CREATED_AFTER`: same three-state semantics as the Django cutoff, except that empty caps every team and an unparseable value caps nobody.
 
 All of these reach production as environment variables through `posthog/charts` (with any secret values via `posthog/secrets`).
 None of them are wired there yet; the charts change is part of turning the rollout mode on, not part of merging the code.
@@ -48,7 +46,7 @@ Pinned teams never move automatically.
 1. Merge and deploy with both modes `off`. The daily sweep starts computing and storing tiers immediately.
 2. Run `python manage.py backfill_workflows_email_sending_tiers` per region, read the printed distribution, then re-run with `--apply`. This lands established senders on their earned tier in one step.
 3. Set both modes to `shadow` via charts. Nothing is delayed; would-be delays log and count in `cdp_team_email_cap_delayed_total{mode="shadow"}`. Watch that against real traffic.
-4. Set both modes to `enforce`, optionally with the created-after cutoffs so only new projects are enforced first. The Reputation tab's allowance card appears for enforced teams at this point.
+4. Set both modes to `enforce`. Enforcement applies to every team at once; the Reputation tab's allowance card appears at this point.
    Never set the Django mode to `enforce` on a deployment whose email worker does not carry the send-time caps: the batch audience cap alone can be sidestepped by editing a workflow while a batch is queued, and the send-time buckets are what bound that.
 5. To back out, set the modes back to `off`; the tiers keep computing and nothing else changes.
 

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -162,7 +162,6 @@ export type CdpCoreServicesConfig = Pick<
         | 'EMAIL_TEAM_SENDING_CAP_MODE'
         | 'EMAIL_TEAM_SENDING_CAP_HOURLY_BY_TIER'
         | 'EMAIL_TEAM_SENDING_CAP_DAILY_BY_TIER'
-        | 'EMAIL_TEAM_SENDING_CAP_TEAMS_CREATED_AFTER'
         | 'CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN'
         | 'CONVERSATIONS_TICKETS_JWT_SECRET'
         | 'CUSTOMER_ANALYTICS_ACCOUNTS_JWT_SECRET'
@@ -444,7 +443,6 @@ export function createCdpCoreServices(
             teamEmailCapMode: parseTeamEmailCapMode(config.EMAIL_TEAM_SENDING_CAP_MODE),
             teamEmailTierHourlyCaps: parseTierCaps(config.EMAIL_TEAM_SENDING_CAP_HOURLY_BY_TIER),
             teamEmailTierDailyCaps: parseTierCaps(config.EMAIL_TEAM_SENDING_CAP_DAILY_BY_TIER),
-            teamEmailCapTeamsCreatedAfter: config.EMAIL_TEAM_SENDING_CAP_TEAMS_CREATED_AFTER,
         },
         deps.integrationManager,
         teamWorkflowsConfigService,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -150,9 +150,6 @@ export type CdpConfig = ClickhouseConfig & {
     // Comma-separated caps indexed by tier. Both lists must be the same length.
     EMAIL_TEAM_SENDING_CAP_HOURLY_BY_TIER: string
     EMAIL_TEAM_SENDING_CAP_DAILY_BY_TIER: string
-    // ISO date. When set, only teams created on or after it are capped, so enforcement can start
-    // with new projects and leave established ones alone. Empty means every team.
-    EMAIL_TEAM_SENDING_CAP_TEAMS_CREATED_AFTER: string
 
     // Destination migration diffing
     DESTINATION_MIGRATION_DIFFING_ENABLED: boolean
@@ -341,7 +338,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         EMAIL_TEAM_SENDING_CAP_MODE: 'off',
         EMAIL_TEAM_SENDING_CAP_HOURLY_BY_TIER: '50,200,600,2000,6000,20000,60000,200000',
         EMAIL_TEAM_SENDING_CAP_DAILY_BY_TIER: '100,1000,3000,10000,30000,100000,300000,1000000',
-        EMAIL_TEAM_SENDING_CAP_TEAMS_CREATED_AFTER: '',
 
         // Destination migration diffing
         DESTINATION_MIGRATION_DIFFING_ENABLED: false,

--- a/nodejs/src/cdp/services/managers/team-workflows-config.service.ts
+++ b/nodejs/src/cdp/services/managers/team-workflows-config.service.ts
@@ -19,8 +19,6 @@ export type TeamWorkflowsConfig = {
     ses_tenant_provider_suspended: boolean
     /** Trust tier that picks the team's hourly and daily workflow email caps. */
     email_sending_tier: number
-    /** Creation date of the team, so enforcement can be narrowed to teams created after a cutoff. */
-    team_created_at: string | null
 }
 
 const DEFAULT_CONFIG: TeamWorkflowsConfig = {
@@ -29,12 +27,6 @@ const DEFAULT_CONFIG: TeamWorkflowsConfig = {
     email_sending_suspended: false,
     ses_tenant_provider_suspended: false,
     email_sending_tier: 0,
-    team_created_at: null,
-}
-
-export type TeamEmailSendingTier = {
-    tier: number
-    teamCreatedAt: string | null
 }
 
 /**
@@ -104,10 +96,10 @@ export class TeamWorkflowsConfigService {
      * daily cap. Fails open with `null`: a lookup error must let the send through rather than
      * throttle a legitimate customer, same stance as `isEmailSendingSuspended`.
      */
-    public async getEmailSendingTier(teamId: number): Promise<TeamEmailSendingTier | null> {
+    public async getEmailSendingTier(teamId: number): Promise<number | null> {
         try {
             const config = await this.get(teamId)
-            return { tier: config.email_sending_tier, teamCreatedAt: config.team_created_at }
+            return config.email_sending_tier
         } catch (error) {
             logger.error('[TeamWorkflowsConfig] Failed to read email sending tier', { teamId, error })
             return null
@@ -115,8 +107,6 @@ export class TeamWorkflowsConfigService {
     }
 
     private async fetchConfigs(teamIds: string[]): Promise<Record<string, TeamWorkflowsConfig>> {
-        // Joined to posthog_team rather than read separately: the tier cap can be scoped to teams
-        // created after a cutoff, and the send path needs both values in the same cached entry.
         const result = await this.postgres.query<{
             team_id: number
             capture_workflows_engagement_events: boolean
@@ -124,19 +114,16 @@ export class TeamWorkflowsConfigService {
             email_sending_suspended: boolean
             ses_tenant_provider_suspended: boolean
             email_sending_tier: number
-            team_created_at: string | null
         }>(
             PostgresUse.COMMON_READ,
             // Only DISABLED blocks: ENABLED and REINSTATED both permit sending, and '' means the
             // tenant state has never been synced for this team.
-            `SELECT c.team_id, c.capture_workflows_engagement_events, c.email_tracking_consent_mode,
-                    c.email_sending_suspended_at IS NOT NULL AS email_sending_suspended,
-                    c.ses_tenant_sending_status = 'DISABLED' AS ses_tenant_provider_suspended,
-                    c.email_sending_tier,
-                    t.created_at AS team_created_at
-             FROM workflows_teamworkflowsconfig c
-             LEFT JOIN posthog_team t ON t.id = c.team_id
-             WHERE c.team_id = ANY($1)`,
+            `SELECT team_id, capture_workflows_engagement_events, email_tracking_consent_mode,
+                    email_sending_suspended_at IS NOT NULL AS email_sending_suspended,
+                    ses_tenant_sending_status = 'DISABLED' AS ses_tenant_provider_suspended,
+                    email_sending_tier
+             FROM workflows_teamworkflowsconfig
+             WHERE team_id = ANY($1)`,
             [teamIds.map(Number)],
             'fetch-team-workflows-configs'
         )
@@ -152,7 +139,6 @@ export class TeamWorkflowsConfigService {
                 email_sending_suspended: row.email_sending_suspended,
                 ses_tenant_provider_suspended: row.ses_tenant_provider_suspended,
                 email_sending_tier: row.email_sending_tier ?? 0,
-                team_created_at: row.team_created_at ?? null,
             }
         }
         return configs

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -203,9 +203,6 @@ export interface EmailServiceConfig {
     teamEmailCapMode?: TeamEmailCapMode
     teamEmailTierHourlyCaps?: number[]
     teamEmailTierDailyCaps?: number[]
-    // ISO date. When set, only teams created on or after it are capped, so the caps can be turned
-    // on for new projects without touching established ones. Empty means every team.
-    teamEmailCapTeamsCreatedAfter?: string
 }
 
 /**
@@ -585,7 +582,7 @@ export class EmailService {
         }
 
         const teamTier = await this.teamWorkflowsConfigService.getEmailSendingTier(invocation.teamId)
-        if (!teamTier || !this.teamEmailCapApplies(teamTier.teamCreatedAt)) {
+        if (teamTier === null) {
             return null
         }
 
@@ -599,7 +596,7 @@ export class EmailService {
         if (topTier < 0) {
             return null
         }
-        const tier = Math.min(Math.max(teamTier.tier, 0), topTier)
+        const tier = Math.min(Math.max(teamTier, 0), topTier)
 
         const buckets = teamEmailCapBuckets(invocation.teamId, hourlyCaps[tier], dailyCaps[tier])
         // Clamped to the smaller capacity: a send with more copies than a whole allowance could
@@ -650,25 +647,6 @@ export class EmailService {
             })
         }
         return null
-    }
-
-    /** Whether the cap applies to a team, given the optional created-after cutoff. */
-    private teamEmailCapApplies(teamCreatedAt: string | null): boolean {
-        const cutoff = this.sesConfig.teamEmailCapTeamsCreatedAfter?.trim()
-        if (!cutoff) {
-            return true
-        }
-        const cutoffMs = Date.parse(cutoff)
-        if (Number.isNaN(cutoffMs)) {
-            // An unparseable cutoff caps nobody. The cutoff exists to spare established teams, so
-            // a bad value must fail towards leaving every team alone.
-            return false
-        }
-        if (!teamCreatedAt) {
-            return false
-        }
-        const createdMs = Date.parse(teamCreatedAt)
-        return !Number.isNaN(createdMs) && createdMs >= cutoffMs
     }
 
     // Returns a human-readable log string when any destination address is suppressed for the team,

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1308,14 +1308,10 @@ WORKFLOWS_EMAIL_TIER_AUTO_PAUSE_METRIC_NAMES: list[str] = get_list(
 #   "shadow"  - tiers are computed and stored, and every send that a cap would have delayed is
 #               logged, but no send is delayed and no audience is rejected.
 #   "enforce" - caps apply.
-# The email worker has its own copy of these two, EMAIL_TEAM_SENDING_CAP_MODE and
-# EMAIL_TEAM_SENDING_CAP_TEAMS_CREATED_AFTER in nodejs/src/cdp/config.ts, because it never reads
-# Django settings. Set both sides together: this pair drives the batch audience cap and what the
-# workflows UI shows, and the worker's pair drives the send-time cap.
+# The email worker has its own copy, EMAIL_TEAM_SENDING_CAP_MODE in nodejs/src/cdp/config.ts,
+# because it never reads Django settings. Set both sides together: this one drives the batch
+# audience cap and what the workflows UI shows, and the worker's drives the send-time cap.
 WORKFLOWS_EMAIL_TIER_MODE = get_from_env("WORKFLOWS_EMAIL_TIER_MODE", "off")
-# Narrows enforcement to teams created on or after this date (ISO 8601, e.g. "2026-01-01"), so the
-# caps can be turned on for new projects without touching established ones. Empty means all teams.
-WORKFLOWS_EMAIL_TIER_ENFORCE_TEAMS_CREATED_AFTER = get_from_env("WORKFLOWS_EMAIL_TIER_ENFORCE_TEAMS_CREATED_AFTER", "")
 
 # Comma-separated list of org ids allowed to receive the Error Tracking weekly digest
 # "*" for all, empty to disable feature

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -832,6 +832,36 @@ def send_email_sending_unsuspended(team_id: int, unsuspended_at: str) -> None:
     message.send()
 
 
+@shared_task(**EMAIL_TASK_KWARGS)
+@with_team_scope()
+def send_email_sending_tier_demoted(team_id: int, per_day: int, per_hour: int, demoted_at: str) -> None:
+    """
+    Tell a project's admins that its workflow email sending limit was lowered for deliverability
+    problems. Admin+ recipients and no notification-setting gate, matching the suspension emails:
+    the limit stays down until someone acts on the list quality.
+    """
+    if not is_email_available(with_absolute_urls=True):
+        return
+    team = Team.objects.get(id=team_id)
+    memberships_to_email = _get_project_admins_to_notify_of_email_sending_suspension(team)
+    if not memberships_to_email:
+        return
+    message = EmailMessage(
+        campaign_key=f"email_sending_tier_demoted_{team_id}_{demoted_at}",
+        subject=f"Workflow email sending limit lowered for project '{team}'",
+        template_name="email_sending_tier_demoted",
+        template_context={
+            "team": team,
+            "per_day": f"{per_day:,}",
+            "per_hour": f"{per_hour:,}",
+            "reputation_path": f"/project/{team.id}/workflows/reputation",
+        },
+    )
+    for membership in memberships_to_email:
+        message.add_user_recipient(membership.user)
+    message.send()
+
+
 def send_batch_export_run_failure(
     batch_export_run_id: str | UUIDT,
     failure_rate: float = 1.0,

--- a/posthog/tasks/test/__snapshots__/test_task_registration.ambr
+++ b/posthog/tasks/test/__snapshots__/test_task_registration.ambr
@@ -37,6 +37,7 @@
     'posthog.tasks.email.send_email_change_emails',
     'posthog.tasks.email.send_email_sending_reputation_finding',
     'posthog.tasks.email.send_email_sending_suspended',
+    'posthog.tasks.email.send_email_sending_tier_demoted',
     'posthog.tasks.email.send_email_sending_unsuspended',
     'posthog.tasks.email.send_email_verification',
     'posthog.tasks.email.send_email_verification_code',

--- a/posthog/templates/email/email_sending_tier_demoted.html
+++ b/posthog/templates/email/email_sending_tier_demoted.html
@@ -1,0 +1,31 @@
+{% extends "email/base.html" %}
+{% block heading %}Your workflow email sending limit was lowered{% endblock %}
+{% block section %}
+    <!-- prettier-ignore -->
+    <p>
+        Recent workflow emails from project <b>{{ team }}</b> caused deliverability problems, such as spam complaints or bounced addresses. To protect your sending reputation, we lowered the project's sending limit to <b>{{ per_day }} emails per day</b> ({{ per_hour }} per hour).
+    </p>
+    <p>Your workflows keep running. Emails over the limit are delayed and sent when capacity frees up, not dropped.</p>
+    <p><b>How to get the limit back up</b></p>
+    <ul>
+        <li>Remove old, purchased, or unengaged addresses from your lists.</li>
+        <li>Check the Reputation tab to see which workflows draw the most complaints and bounces.</li>
+        <li>Keep sending clean. After a week of healthy sending, the limit raises again automatically.</li>
+    </ul>
+    <div class="mb mt text-center">
+        <a class="button" href="{% absolute_uri reputation_path %}">View sending health</a>
+    </div>
+    <div class="mt">
+        <p>
+            If the button above doesn't work, paste this link into your browser:
+            <br />
+            <a href="{% absolute_uri reputation_path %}">{% absolute_uri reputation_path %}</a>
+        </p>
+    </div>
+{% endblock %}
+{% block footer %}
+    Need help?
+    <a href="https://posthog.com/questions?{{ utm_tags }}" target="_blank"><b>Contact support</b></a>
+    or
+    <a href="https://posthog.com/docs?{{ utm_tags }}" target="_blank"><b>read our documentation</b></a>.
+{% endblock %}

--- a/posthog/templates/email/email_sending_tier_demoted.html
+++ b/posthog/templates/email/email_sending_tier_demoted.html
@@ -10,7 +10,7 @@
     <ul>
         <li>Remove old, purchased, or unengaged addresses from your lists.</li>
         <li>Check the Reputation tab to see which workflows draw the most complaints and bounces.</li>
-        <li>Keep sending clean. After a week of healthy sending, the limit raises again automatically.</li>
+        <li>Keep sending clean and keep using your limit. The limit raises again automatically once your recent sending history is healthy.</li>
     </ul>
     <div class="mb mt text-center">
         <a class="button" href="{% absolute_uri reputation_path %}">View sending health</a>

--- a/products/workflows/backend/services/email_sending_tier_notifications.py
+++ b/products/workflows/backend/services/email_sending_tier_notifications.py
@@ -46,6 +46,17 @@ def notify_email_sending_tier_changes(decisions: list[TierDecision]) -> None:
 
 def _notify_demotion(decision: TierDecision) -> None:
     limits = get_email_sending_tier_limits(decision.new_tier)
+    # The email goes first and each channel gets its own guard: the email reaches the admins who
+    # can act on the demotion, so an in-app publish failure must not take it down with it.
+    try:
+        send_email_sending_tier_demoted.delay(
+            team_id=decision.team_id,
+            per_day=limits.per_day,
+            per_hour=limits.per_hour,
+            demoted_at=timezone.now().isoformat(),
+        )
+    except Exception:
+        logger.exception("workflows_email_tier_demotion_email_dispatch_failed", team_id=decision.team_id)
     create_notification(
         NotificationData(
             team_id=decision.team_id,
@@ -61,12 +72,6 @@ def _notify_demotion(decision: TierDecision) -> None:
             target_id=str(decision.team_id),
             source_url="/workflows/reputation",
         )
-    )
-    send_email_sending_tier_demoted.delay(
-        team_id=decision.team_id,
-        per_day=limits.per_day,
-        per_hour=limits.per_hour,
-        demoted_at=timezone.now().isoformat(),
     )
 
 

--- a/products/workflows/backend/services/email_sending_tier_notifications.py
+++ b/products/workflows/backend/services/email_sending_tier_notifications.py
@@ -1,0 +1,89 @@
+from django.utils import timezone
+
+import structlog
+
+from posthog.tasks.email import send_email_sending_tier_demoted
+
+from products.notifications.backend.facade.api import (
+    NotificationData,
+    NotificationType,
+    Priority,
+    TargetType,
+    create_notification,
+)
+from products.workflows.backend.services.email_sending_tier import RATE_DEMOTION_REASONS, TierDecision
+from products.workflows.backend.utils.email_sending_tiers import get_email_sending_tier_limits, is_tier_enforced
+
+logger = structlog.get_logger(__name__)
+
+
+def notify_email_sending_tier_changes(decisions: list[TierDecision]) -> None:
+    """
+    Tell teams the periodic sweep moved that their sending limit changed.
+
+    Only while the tier is enforced: in "off" and "shadow" the tier changes nothing a customer can
+    observe, so a notification would describe limits that do not apply. Called from the sweep task
+    only, not from the admin recompute or the backfill command: staff usually set tiers while
+    already talking to the customer, and a backfill would notify the whole fleet at once.
+    """
+    if not is_tier_enforced():
+        return
+    for decision in decisions:
+        if not decision.changed:
+            continue
+        # A notification failure must not fail the sweep or the other teams' notifications: the
+        # tier writes are already applied, and the Reputation tab shows the same state.
+        try:
+            if decision.new_tier < decision.previous_tier and decision.reason in RATE_DEMOTION_REASONS:
+                _notify_demotion(decision)
+            elif decision.new_tier > decision.previous_tier and decision.reason == "clean_and_used":
+                _notify_promotion(decision)
+            # Decay ("inactive") and suspension drops stay silent: a dormant team gains nothing
+            # from a limit email, and the suspension flow sends its own notifications.
+        except Exception:
+            logger.exception("workflows_email_tier_change_notification_failed", team_id=decision.team_id)
+
+
+def _notify_demotion(decision: TierDecision) -> None:
+    limits = get_email_sending_tier_limits(decision.new_tier)
+    create_notification(
+        NotificationData(
+            team_id=decision.team_id,
+            notification_type=NotificationType.EMAIL_REPUTATION,
+            priority=Priority.NORMAL,
+            title="Workflow email sending limit lowered",
+            body=(
+                f"Recent sends caused deliverability problems, such as spam complaints or bounces, "
+                f"so this project's limit is now {limits.per_day:,} emails per day. "
+                f"Clean sending raises it again. Check the Reputation tab for details."
+            ),
+            target_type=TargetType.TEAM,
+            target_id=str(decision.team_id),
+            source_url="/workflows/reputation",
+        )
+    )
+    send_email_sending_tier_demoted.delay(
+        team_id=decision.team_id,
+        per_day=limits.per_day,
+        per_hour=limits.per_hour,
+        demoted_at=timezone.now().isoformat(),
+    )
+
+
+def _notify_promotion(decision: TierDecision) -> None:
+    limits = get_email_sending_tier_limits(decision.new_tier)
+    create_notification(
+        NotificationData(
+            team_id=decision.team_id,
+            notification_type=NotificationType.EMAIL_REPUTATION,
+            priority=Priority.NORMAL,
+            title="Workflow email sending limit raised",
+            body=(
+                f"This project earned a higher sending limit: "
+                f"up to {limits.per_day:,} emails per day and {limits.per_hour:,} per hour."
+            ),
+            target_type=TargetType.TEAM,
+            target_id=str(decision.team_id),
+            source_url="/workflows/reputation",
+        )
+    )

--- a/products/workflows/backend/tasks/email_sending_tiers.py
+++ b/products/workflows/backend/tasks/email_sending_tiers.py
@@ -4,6 +4,7 @@ from celery import shared_task
 from posthog.tasks.utils import CeleryQueue
 
 from products.workflows.backend.services.email_sending_tier import recompute_email_sending_tiers
+from products.workflows.backend.services.email_sending_tier_notifications import notify_email_sending_tier_changes
 
 logger = structlog.get_logger(__name__)
 
@@ -14,6 +15,7 @@ def recompute_workflows_email_sending_tiers() -> None:
     clean the sending was. Runs in every rollout mode: tiers are stored before anything reads them,
     so enforcement can be switched on against a settled distribution."""
     decisions = recompute_email_sending_tiers()
+    notify_email_sending_tier_changes(decisions)
     logger.info(
         "workflows_email_sending_tier_sweep_finished",
         evaluated_teams=len(decisions),

--- a/products/workflows/backend/test/test_email_sending_tier_notifications.py
+++ b/products/workflows/backend/test/test_email_sending_tier_notifications.py
@@ -75,3 +75,5 @@ class TestNotifyEmailSendingTierChanges(SimpleTestCase):
         notify_email_sending_tier_changes([_demotion("rates_above_threshold"), second])
         assert self.create_notification.call_count == 2
         assert self.create_notification.call_args.args[0].team_id == 2
+        # The demotion email must survive the in-app failure: it reaches the admins who can act.
+        assert self.email_task.delay.call_count == 1

--- a/products/workflows/backend/test/test_email_sending_tier_notifications.py
+++ b/products/workflows/backend/test/test_email_sending_tier_notifications.py
@@ -1,0 +1,77 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from parameterized import parameterized
+
+from products.workflows.backend.services.email_sending_tier import TierDecision
+from products.workflows.backend.services.email_sending_tier_notifications import notify_email_sending_tier_changes
+
+NOTIFICATIONS_MODULE = "products.workflows.backend.services.email_sending_tier_notifications"
+
+
+def _demotion(reason: str) -> TierDecision:
+    return TierDecision(team_id=1, previous_tier=3, new_tier=2, reason=reason)
+
+
+def _promotion() -> TierDecision:
+    return TierDecision(team_id=1, previous_tier=2, new_tier=3, reason="clean_and_used")
+
+
+class TestNotifyEmailSendingTierChanges(SimpleTestCase):
+    def setUp(self) -> None:
+        create_patch = patch(f"{NOTIFICATIONS_MODULE}.create_notification")
+        email_patch = patch(f"{NOTIFICATIONS_MODULE}.send_email_sending_tier_demoted")
+        self.create_notification = create_patch.start()
+        self.email_task = email_patch.start()
+        self.addCleanup(create_patch.stop)
+        self.addCleanup(email_patch.stop)
+
+    @parameterized.expand([("off",), ("shadow",)])
+    def test_nothing_fires_until_the_mode_is_enforce(self, mode: str) -> None:
+        with override_settings(WORKFLOWS_EMAIL_TIER_MODE=mode):
+            notify_email_sending_tier_changes([_demotion("rates_above_threshold"), _promotion()])
+        self.create_notification.assert_not_called()
+        self.email_task.delay.assert_not_called()
+
+    @parameterized.expand([("rates_above_threshold",), ("workflow_auto_paused",), ("ses_reputation_high",)])
+    @override_settings(WORKFLOWS_EMAIL_TIER_MODE="enforce")
+    def test_a_rate_demotion_notifies_in_app_and_by_email(self, reason: str) -> None:
+        notify_email_sending_tier_changes([_demotion(reason)])
+        assert self.create_notification.call_count == 1
+        data = self.create_notification.call_args.args[0]
+        assert data.title == "Workflow email sending limit lowered"
+        assert data.team_id == 1
+        assert self.email_task.delay.call_count == 1
+        assert self.email_task.delay.call_args.kwargs["team_id"] == 1
+
+    @override_settings(WORKFLOWS_EMAIL_TIER_MODE="enforce")
+    def test_a_promotion_notifies_in_app_only(self) -> None:
+        notify_email_sending_tier_changes([_promotion()])
+        assert self.create_notification.call_count == 1
+        assert self.create_notification.call_args.args[0].title == "Workflow email sending limit raised"
+        self.email_task.delay.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("inactive", 3, 2),
+            ("ses_tenant_paused", 3, 0),
+            ("staff_suspension", 3, 0),
+            ("demotion_cooldown", 3, 3),
+        ]
+    )
+    @override_settings(WORKFLOWS_EMAIL_TIER_MODE="enforce")
+    def test_decay_suspensions_and_holds_stay_silent(self, reason: str, previous: int, new: int) -> None:
+        notify_email_sending_tier_changes(
+            [TierDecision(team_id=1, previous_tier=previous, new_tier=new, reason=reason)]
+        )
+        self.create_notification.assert_not_called()
+        self.email_task.delay.assert_not_called()
+
+    @override_settings(WORKFLOWS_EMAIL_TIER_MODE="enforce")
+    def test_one_failing_notification_does_not_stop_the_rest(self) -> None:
+        self.create_notification.side_effect = [Exception("kafka down"), None]
+        second = TierDecision(team_id=2, previous_tier=2, new_tier=3, reason="clean_and_used")
+        notify_email_sending_tier_changes([_demotion("rates_above_threshold"), second])
+        assert self.create_notification.call_count == 2
+        assert self.create_notification.call_args.args[0].team_id == 2

--- a/products/workflows/backend/utils/email_sending_tiers.py
+++ b/products/workflows/backend/utils/email_sending_tiers.py
@@ -1,13 +1,10 @@
-from datetime import UTC, datetime
-from typing import Literal, Optional
+from typing import Literal
 
 from django.conf import settings
-from django.utils.dateparse import parse_datetime
 
 import structlog
 
 from posthog.dataclasses import frozen
-from posthog.models.team import Team
 
 from products.workflows.backend.models.team_workflows_config import TeamWorkflowsConfig
 
@@ -33,8 +30,7 @@ class TeamEmailSendingTier:
     tier: int
     pinned: bool
     limits: EmailSendingTierLimits
-    # False while the rollout mode is "off" or "shadow", or while enforcement is narrowed to teams
-    # created after a cutoff this team predates. Callers must fall back to pre-tier behavior.
+    # False while the rollout mode is "off" or "shadow". Callers must fall back to pre-tier behavior.
     enforced: bool
 
 
@@ -97,40 +93,8 @@ def get_email_sending_tier_limits(tier: int) -> EmailSendingTierLimits:
     )
 
 
-def _enforcement_cutoff_raw() -> str:
-    return str(settings.WORKFLOWS_EMAIL_TIER_ENFORCE_TEAMS_CREATED_AFTER or "").strip()
-
-
-def _enforcement_cutoff() -> Optional[datetime]:
-    raw = _enforcement_cutoff_raw()
-    if not raw:
-        return None
-    # Read on the send path, so a typo in the env var must not raise here.
-    try:
-        parsed = parse_datetime(raw)
-    except ValueError:
-        parsed = None
-    if parsed is None:
-        logger.warning("workflows_email_tier_cutoff_unparseable", value=raw)
-        return None
-    # A bare date ("2026-01-01") parses to a naive datetime, while the team creation dates it is
-    # compared against are UTC-aware. Read a naive cutoff as UTC instead of raising on the compare.
-    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
-
-
-def is_tier_enforced_for_team(team_created_at: Optional[datetime]) -> bool:
-    if email_sending_tier_mode() != "enforce":
-        return False
-    cutoff = _enforcement_cutoff()
-    if cutoff is None:
-        # An empty cutoff enforces every team. A set but unparseable cutoff must not, because an
-        # operator typo has to narrow enforcement rather than widen it to everyone. This matches
-        # email_sending_tier_mode(), which reads an unrecognized value as "off", and the module's
-        # rule that a config problem must never throttle a paying customer.
-        return not _enforcement_cutoff_raw()
-    # An unknown creation date reads as "not after the cutoff": the cutoff exists to spare
-    # established teams, so an unresolvable team must land on the established side.
-    return team_created_at is not None and team_created_at >= cutoff
+def is_tier_enforced() -> bool:
+    return email_sending_tier_mode() == "enforce"
 
 
 def resolve_team_email_sending_tier(team_id: int) -> TeamEmailSendingTier:
@@ -157,43 +121,31 @@ def resolve_team_email_sending_tier(team_id: int) -> TeamEmailSendingTier:
 
 
 def _resolve_team_email_sending_tier(team_id: int, top_tier: int) -> TeamEmailSendingTier:
-    row = (
-        TeamWorkflowsConfig.objects.filter(team_id=team_id)
-        .values("email_sending_tier", "email_sending_tier_pinned", "team__created_at")
-        .first()
-    )
-
     if team_id in settings.HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS:
         # The pre-tier allowlist keeps working as a staff pin at the top tier.
         return TeamEmailSendingTier(
             tier=top_tier,
             pinned=True,
             limits=get_email_sending_tier_limits(top_tier),
-            enforced=is_tier_enforced_for_team(row["team__created_at"] if row else _team_created_at(team_id)),
+            enforced=is_tier_enforced(),
         )
 
+    row = (
+        TeamWorkflowsConfig.objects.filter(team_id=team_id)
+        .values("email_sending_tier", "email_sending_tier_pinned")
+        .first()
+    )
     if row is None:
-        # No row means the team never touched a workflows setting, so it starts at tier 0. Reading
-        # the creation date still matters: enforcement can be narrowed to teams created after a
-        # cutoff, and a team without a row can sit on either side of it.
+        # No row means the team never touched a workflows setting, so it starts at tier 0.
         tier = MIN_EMAIL_SENDING_TIER
         pinned = False
-        created_at = _team_created_at(team_id)
     else:
         tier = row["email_sending_tier"]
         pinned = row["email_sending_tier_pinned"]
-        created_at = row["team__created_at"]
 
     return TeamEmailSendingTier(
         tier=tier,
         pinned=pinned,
         limits=get_email_sending_tier_limits(tier),
-        enforced=is_tier_enforced_for_team(created_at),
+        enforced=is_tier_enforced(),
     )
-
-
-def _team_created_at(team_id: int) -> Optional[datetime]:
-    if _enforcement_cutoff() is None:
-        # Without a cutoff the date changes nothing, so skip the query.
-        return None
-    return Team.objects.filter(id=team_id).values_list("created_at", flat=True).first()

--- a/products/workflows/backend/utils/test_batch_trigger_limit.py
+++ b/products/workflows/backend/utils/test_batch_trigger_limit.py
@@ -77,35 +77,11 @@ class TestTieredHogflowBatchTriggerLimit(BaseTest):
         with override_settings(HOGFLOW_BATCH_TRIGGER_ELEVATED_TEAM_IDS={self.team.id}):
             assert get_hogflow_batch_trigger_limit(self.team.id) == 50000
 
-    @override_settings(
-        WORKFLOWS_EMAIL_TIER_MODE="enforce",
-        WORKFLOWS_EMAIL_TIER_ENFORCE_TEAMS_CREATED_AFTER="2099-01-01",
-    )
-    def test_team_created_before_the_cutoff_keeps_the_flat_limit(self) -> None:
-        TeamWorkflowsConfig.objects.update_or_create(team=self.team, defaults={"email_sending_tier": 0})
-        assert get_hogflow_batch_trigger_limit(self.team.id) == 5000
-
-    @override_settings(
-        WORKFLOWS_EMAIL_TIER_MODE="enforce",
-        WORKFLOWS_EMAIL_TIER_ENFORCE_TEAMS_CREATED_AFTER="not-a-date",
-    )
-    def test_unparseable_cutoff_does_not_enforce_globally(self) -> None:
-        # A typo in the cutoff must fail open. It cannot silently widen enforcement to every team,
-        # so an unparseable value leaves the team on the flat ceiling instead of the tier-0 cap.
-        TeamWorkflowsConfig.objects.update_or_create(team=self.team, defaults={"email_sending_tier": 0})
-        assert get_hogflow_batch_trigger_limit(self.team.id) == 5000
-
-    @override_settings(
-        WORKFLOWS_EMAIL_TIER_MODE="enforce",
-        WORKFLOWS_EMAIL_TIER_ENFORCE_TEAMS_CREATED_AFTER="2020-01-01",
-    )
+    @override_settings(WORKFLOWS_EMAIL_TIER_MODE="enforce")
     def test_a_database_error_during_resolution_fails_open(self) -> None:
-        # The creation-date lookup runs outside the first config query, so the fail-open guard must
-        # cover the whole resolution: a database blip on the send path returns the flat limit
-        # instead of raising.
-        TeamWorkflowsConfig.objects.filter(team=self.team).delete()
+        # A database blip on the send path returns the flat limit instead of raising.
         with patch(
-            "products.workflows.backend.utils.email_sending_tiers.Team.objects.filter",
+            "products.workflows.backend.utils.email_sending_tiers.TeamWorkflowsConfig.objects.filter",
             side_effect=Exception("db down"),
         ):
             assert get_hogflow_batch_trigger_limit(self.team.id) == 5000


### PR DESCRIPTION
## Problem

When the daily sweep moves a team's email sending tier, nobody tells the team. Once tiers are enforced, a demoted team's sends start queuing with no explanation, and the first place they would learn about it is a support ticket.

## Changes

<img width="1005" height="857" alt="Screenshot 2026-09-01 at 14 05 03" src="https://github.com/user-attachments/assets/9cbe0b5c-57f6-4c9e-b806-ae4e04d086a3" />

- Project admins get an email when the sweep lowers their sending limit for deliverability reasons. It names the new limits, says delayed sends are not dropped, and links the Reputation tab.
- Everyone in the organization gets an in-app notification for a lowered limit, and for an earned raise. Raises are in-app only, so the demotion emails stay meaningful.
- Notifications fire only while the tier is enforced: in off and shadow mode the tier changes nothing a customer can observe, so nothing is sent today.
- Silent on purpose: inactivity decay, suspension drops (the suspension flow has its own comms), admin recomputes, and the backfill command.
- Mechanical: reuses the existing `EMAIL_REPUTATION` notification type, the suspension emails' admin-recipient helper, and their template layout. A notification failure logs and never fails the sweep.

Stacked on #92398, which this uses for the simplified `is_tier_enforced()`.

## How did you test this code?

New `SimpleTestCase` suite (11 cases) covers the gating matrix no existing test touches: off/shadow modes stay silent, each rate-demotion reason sends both channels, a promotion sends in-app only, decay/suspension/hold reasons stay silent, and one team's notification failure does not stop the next team's. Not run locally: DB-backed suites, blocked by a pre-existing local ClickHouse setup issue; backend CI covers them. Repo-wide mypy run locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/workflows-email-sending-tiers.md` gains a paragraph on what the sweep notifies.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Scoped in conversation: demotions notify by email (admins and owners) plus in-app, promotions in-app only. Skills invoked: sending-notifications, writing-user-facing-copy, writing-tests, writing-pr-descriptions. No session material beyond this repo is included.
