### PR TITLE
fix(cdp): report zero depth for a drained cyclotron queue

### DIFF
--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -1,4 +1,5 @@
 import { Pool } from 'pg'
+import { register } from 'prom-client'
 import { v7 as uuidv7 } from 'uuid'
 
 import { parseJSON } from '~/common/utils/json-parse'
@@ -157,6 +158,12 @@ async function dequeueOneBatch(worker: CyclotronV2Worker, timeoutMs = 2000): Pro
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
+
+async function gaugeValueForQueue(queue: string): Promise<number | null> {
+    const metric = await register.getSingleMetricAsString('cdp_cyclotron_v2_queue_depth')
+    const line = metric.split('\n').find((l) => l.includes(`queue="${queue}"`))
+    return line ? Number(line.trim().split(' ').pop()) : null
+}
 
 describe('Cyclotron V2', () => {
     jest.setTimeout(3000)
@@ -2488,6 +2495,24 @@ describe('Cyclotron V2', () => {
                 await expect(queryJob(id)).rejects.toThrow()
             }
         )
+
+        it('measureQueueDepths reports 0 for a queue that drains', async () => {
+            // GROUP BY returns no row for an empty queue. Without the zero write the gauge
+            // keeps the last depth, and a depth alert then fires on an idle queue.
+            const jobId = uuidv7()
+            await insertRawJob({ id: jobId, queue_name: 'queue-drains', status: 'available' })
+
+            const janitor = createJanitor({ stallTimeoutMs: 60_000 })
+            const before = await janitor.runOnce()
+            expect(before.depths.get('queue-drains')).toBe(1)
+            expect(await gaugeValueForQueue('queue-drains')).toBe(1)
+
+            await assertPool.query('DELETE FROM cyclotron_jobs WHERE id = $1', [jobId])
+            await janitor.runOnce()
+            await janitor.stop()
+
+            expect(await gaugeValueForQueue('queue-drains')).toBe(0)
+        })
 
         it('measureQueueDepths returns correct counts per queue', async () => {
             await insertRawJob({ id: uuidv7(), queue_name: 'queue-a', status: 'available' })

--- a/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/janitor.ts
@@ -91,6 +91,8 @@ interface PoisonRow {
 export class CyclotronV2Janitor {
     private pool: Pool
     private intervalHandle: ReturnType<typeof setInterval> | null = null
+    // Queue names this process has seen hold work, so a drained queue can report 0.
+    private readonly seenQueues = new Set<string>()
 
     private readonly cleanupBatchSize: number
     private readonly cleanupIntervalMs: number
@@ -481,7 +483,19 @@ export class CyclotronV2Janitor {
         for (const row of result.rows) {
             const count = parseInt(row.count, 10)
             depths.set(row.queue_name, count)
+            this.seenQueues.add(row.queue_name)
             queueDepthGauge.labels({ queue: row.queue_name }).set(count)
+        }
+
+        // GROUP BY returns no row for a queue that is empty. Without the write below,
+        // that queue keeps the last depth this process set, and an alert on the value
+        // fires while the queue is idle. Write 0 for every queue this process saw
+        // before. The set holds only observed queue names, so it needs no maintenance
+        // and it adds no series for a queue that does not use this table.
+        for (const queue of this.seenQueues) {
+            if (!depths.has(queue)) {
+                queueDepthGauge.labels({ queue }).set(0)
+            }
         }
 
         return depths


### PR DESCRIPTION
## Problem

`cdp_cyclotron_v2_queue_depth` reports a queue as non-empty long after it drains, so anything reading it sees work that is not there.

- `measureQueueDepths` counts claimable jobs with `GROUP BY queue_name`.
- An empty queue produces no row, so `queueDepthGauge.labels({queue}).set(...)` is never called for it.
- Nothing else writes that label, so it keeps the last non-zero value until the queue has work again or the process restarts.

The value is therefore not a current depth. It is the last depth the janitor happened to observe. A busy queue overwrites it every cycle and looks correct, which is why this survived unnoticed; a queue that is usually empty reports a number that is almost always stale.

I confirmed the behavior against production metrics and job rows before writing the fix.

## Changes

- `measureQueueDepths` records every queue name it sees hold work, and writes `0` for any of those queues that the current query does not return. A drained queue then reports zero instead of its last depth.
- The set holds observed names only. It needs no maintenance, and it adds no series for a queue that does not use this table, such as the Kafka-backed hog queues.
- A queue reports nothing until the first time a process sees work on it, and the set is per process, so a restart resets it. A queue can therefore read 0 in one process and be absent in another. Dashboards sum by queue and alerts take a max, so neither is affected.

The `depths` map that `runOnce` returns is unaffected; it was always built from the current query.

## How did you test this code?

- Added `measureQueueDepths reports 0 for a queue that drains` next to the existing depth test. It seeds one claimable job, asserts the gauge reads 1, deletes the row, runs the janitor again, and asserts the gauge reads 0.
- Verified that test fails without the change: the gauge still reads 1 once the queue is empty.
- Drove the real janitor against a real Postgres over four queues and six stages, running the same script with and without the change. Without it, the metric reported 19 waiting jobs across three queues after the table was emptied and the janitor had run five times. With it, every drained queue reported 0, queues that still held work were untouched, and a queue that received work again reported the new depth.
- Full `cyclotron-v2` suite passes, 152 of 152, against a real Postgres.
- Typecheck reports no new errors.
- Checked every dashboard that reads this metric. All use a plain `sum by (queue)`, so a zero draws a flat line instead of breaking a panel.

Not verified: the change has not run in production. After it deploys, a queue that is normally idle should read 0 during a quiet period rather than holding its last depth.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Agent-driven, author-reviewed

I (actually Claude) found this while backtesting a proposed alert that reads this metric. The alert appeared to trigger during periods when no rerun was running at all, which pointed at the gauge rather than at the queue.

Worth knowing for anyone reading dashboards: historical panels on this metric show latched values on idle queues, so a past reading of a quiet queue is not evidence of backlog. Peaks were real; troughs were not.

Skills invoked: `/writing-tests` before adding the case, `/writing-code-comments` for the comment on the zero write.
