### PR TITLE
feat(tasks): treat the org default image as hogland-eligible, not a custom image

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -858,18 +858,17 @@ def _resolve_sandbox_backend(
     run_id: str,
     state: dict | None,
     task_runtime: str,
-    custom_image_name: str | None,
+    has_user_custom_image: bool,
 ) -> str:
     """Pick the sandbox provider for this run.
 
-    Hogland only takes plain default-template ACP runs. A custom image (hogland has
-    only the default golden template) or the Pi runtime are hard incapabilities —
-    hogland cannot run them, so they force Modal even with the flag on. The Modal
-    VM-sandbox and network-allowlist flags are runtime *preferences*, not
-    incapabilities: a run the hogland flag (or override) selects wins hogland over
-    them. The caller then forces both off so the run provisions as a plain hogland
-    box; egress stays enforced in-box by agentsh via the run's allowed_domains.
-    Fails closed to Modal.
+    Hogland only takes plain golden-template ACP runs. A user/environment custom image
+    or the Pi runtime are hard incapabilities — hogland runs only its own golden, so
+    those force Modal even with the flag on. The Modal VM-sandbox / network-allowlist
+    flags and the org *default* image are runtime preferences, not incapabilities: a
+    run the hogland flag (or override) selects wins hogland over them, and the caller
+    forces them off so the run provisions on hogland's golden. Egress stays enforced
+    in-box by agentsh via the run's allowed_domains. Fails closed to Modal.
     """
     raw_override = (state or {}).get("sandbox_backend")
     override = raw_override if isinstance(raw_override, str) and raw_override in ("modal", "hogland") else None
@@ -881,19 +880,20 @@ def _resolve_sandbox_backend(
 
     # Hard gates: a "hogland" result (override OR flag) is only allowed when hogland is
     # available (US region + configured URL/token) and can actually run this run (no
-    # custom image, no Pi runtime). These sit ahead of the override so a stale or forged
-    # `hogland` carried across a cloud resume can't defeat the EU guard or route an
-    # incapable run to hogland.
+    # user custom image, no Pi runtime). These sit ahead of the override so a stale or
+    # forged `hogland` carried across a cloud resume can't defeat the EU guard or route
+    # an incapable run to hogland.
     if not settings.HOGLAND_API_URL or not (settings.HOGLAND_API_TOKEN_FILE or settings.HOGLAND_API_TOKEN):
         return "modal"
     # Hogland runs in the US only; EU runs stay on Modal regardless of flag/override state.
     if getattr(settings, "CLOUD_DEPLOYMENT", None) == "EU":
         return "modal"
-    # Hard hogland incapabilities: a custom image or the Pi runtime cannot run on the
-    # default golden template, so keep those on Modal even when the flag is on. The
-    # Modal VM-sandbox / network-allowlist flags are deliberately NOT gated here — a
-    # flagged run wins hogland over them (the caller forces both off for hogland runs).
-    if custom_image_name is not None or task_runtime == Task.Runtime.PI:
+    # Hard hogland incapabilities: a user/environment custom image or the Pi runtime
+    # cannot run on hogland's golden, so keep those on Modal even when the flag is on.
+    # The org default image (default_custom_image) is NOT gated here — hogland serves
+    # its golden equivalent — nor are the Modal VM-sandbox / network-allowlist flags; a
+    # flagged run wins hogland over all of them (the caller forces them off).
+    if has_user_custom_image or task_runtime == Task.Runtime.PI:
         return "modal"
 
     # Past the gates, a "hogland" override pins the run (the canary lever), no flag eval.
@@ -1364,16 +1364,21 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         run_id=run_id,
         state=state,
         task_runtime=task.runtime,
-        custom_image_name=custom_image_name,
+        # Only a real user/environment image is a hogland incapability. The org default
+        # image (default_custom_image, applied when the user picked none) is not — hogland
+        # serves its golden equivalent — so it must not gate the run onto Modal.
+        has_user_custom_image=environment_custom_image_name is not None,
     )
     if sandbox_backend == "hogland":
-        # Hogland runs are plain default-template runs, so the Modal VM-runtime and
-        # network-allowlist preferences don't apply. Force both off so provisioning
-        # builds a DEFAULT_BASE hogland box (not a Modal VM_BASE config) and skips the
-        # Modal provider-layer allowlist. Egress stays enforced in-box by agentsh, which
-        # keys on the run's allowed_domains independently of use_modal_network_allowlist.
+        # Hogland runs are plain golden-template runs, so the Modal VM-runtime,
+        # network-allowlist, and org-default-image preferences don't apply. Force them off
+        # so provisioning builds a plain hogland box on the golden (not a Modal VM_BASE
+        # config with a default image) and skips the Modal provider-layer allowlist. Egress
+        # stays enforced in-box by agentsh, which keys on the run's allowed_domains
+        # independently of use_modal_network_allowlist.
         use_modal_vm_sandbox = False
         use_modal_network_allowlist = False
+        custom_image_name = None
     emit_agent_log(
         run_id,
         "debug",

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -1474,17 +1474,22 @@ class TestGetTaskProcessingContextActivity:
 
     @pytest.mark.django_db(transaction=True)
     @override_settings(HOGLAND_API_URL="https://hogland.example", HOGLAND_API_TOKEN="hog-tok")
-    def test_hogland_run_forces_off_modal_vm_and_network_allowlist(self, activity_environment, test_task):
+    def test_hogland_run_drops_modal_vm_allowlist_and_default_image(self, activity_environment, test_task):
         # A run that resolves to hogland must carry use_modal_vm_sandbox and
-        # use_modal_network_allowlist as False, so provisioning builds a plain hogland
-        # box instead of a Modal VM_BASE config with the Modal provider allowlist. The
-        # VM payload and the flag below would each set their value True; the force-off
-        # must still land both at False for a hogland run.
+        # use_modal_network_allowlist as False and custom_image_name as None, so
+        # provisioning builds a plain hogland box on the golden instead of a Modal
+        # VM_BASE config with the org default image and the provider allowlist. The
+        # payload's default_custom_image (applied because the user picked none) must not
+        # gate the run onto Modal, and the force-off must land all three Modal-only
+        # values at their hogland state.
         task_run = test_task.create_run()
         input_data = GetTaskProcessingContextInput(run_id=str(task_run.id))
 
         with (
-            patch(VM_FLAG_PAYLOAD_TARGET, return_value='{"default_base_origin_products": ["user_created"]}'),
+            patch(
+                VM_FLAG_PAYLOAD_TARGET,
+                return_value='{"default_base_origin_products": ["user_created"], "default_custom_image": "posthog-dev-stack"}',
+            ),
             patch(
                 "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
                 return_value=True,
@@ -1495,6 +1500,7 @@ class TestGetTaskProcessingContextActivity:
         assert result.sandbox_backend == "hogland"
         assert result.use_modal_vm_sandbox is False
         assert result.use_modal_network_allowlist is False
+        assert result.custom_image_name is None
 
     @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_exposes_ci_prompt(self, activity_environment, test_task):
@@ -1540,7 +1546,7 @@ class TestResolveSandboxBackend:
             "run_id": "run-1",
             "state": None,
             "task_runtime": "acp",
-            "custom_image_name": None,
+            "has_user_custom_image": False,
         }
         kwargs.update(overrides)
         return _resolve_sandbox_backend(**kwargs)
@@ -1560,17 +1566,18 @@ class TestResolveSandboxBackend:
     @pytest.mark.parametrize(
         "overrides",
         [
-            {"custom_image_name": "posthog-sandbox-custom-x"},
+            {"has_user_custom_image": True},
             {"task_runtime": "pi"},
         ],
-        ids=["custom_image", "pi_runtime"],
+        ids=["user_custom_image", "pi_runtime"],
     )
     @override_settings(**_HOGLAND_SETTINGS)
     def test_hard_incapabilities_fall_back_to_modal_even_with_the_flag_on(self, overrides):
-        # A custom image or the Pi runtime cannot run on hogland's default template, so
-        # they force Modal even with the flag on. The Modal VM-sandbox and
-        # network-allowlist preferences are deliberately not gated here — a flagged run
-        # wins hogland over them (covered by the caller force-off test).
+        # A real user/environment custom image or the Pi runtime cannot run on hogland's
+        # golden, so they force Modal even with the flag on. The Modal VM-sandbox /
+        # network-allowlist preferences and the org default image are deliberately not
+        # gated here — a flagged run wins hogland over them (covered by the caller
+        # force-off test).
         assert self._resolve_with_flag(True, **overrides) == "modal"
 
     @override_settings(**_HOGLAND_SETTINGS, CLOUD_DEPLOYMENT="EU")
@@ -1622,15 +1629,15 @@ class TestResolveSandboxBackend:
     @pytest.mark.parametrize(
         "overrides",
         [
-            {"custom_image_name": "img"},
+            {"has_user_custom_image": True},
             {"task_runtime": "pi"},
         ],
-        ids=["custom_image", "pi_runtime"],
+        ids=["user_custom_image", "pi_runtime"],
     )
     @override_settings(**_HOGLAND_SETTINGS)
     def test_hogland_override_cannot_defeat_hard_incapabilities(self, overrides):
         # A stale or forged hogland override surviving a cloud resume must not route a
-        # custom-image or Pi run to hogland — the capability gates sit ahead of the override.
+        # user-custom-image or Pi run to hogland — the capability gates sit ahead of the override.
         assert self._resolve_with_flag(True, state={"sandbox_backend": "hogland"}, **overrides) == "modal"
 
     @override_settings(**_HOGLAND_SETTINGS)


### PR DESCRIPTION
## Problem

After #92209, a plain `user_created` task still runs on Modal, not hogland, even for a user the `tasks-hogland-sandbox` flag targets. The org's VM-sandbox payload assigns a **default** image (`posthog-dev-stack`) to every such run; the activity lands it in `custom_image_name`, and the resolver's `custom_image_name is not None` gate forces Modal ahead of the hogland flag. So the flag still never wins for a normal run.

## Changes

- The resolver now gates only on a **real user/environment** custom image (`has_user_custom_image`), not the org default. A default-image run reaches hogland and provisions on hogland's golden (`posthog-tasks-default`), which is the hogland equivalent of `posthog-dev-stack`.
- When a run resolves to hogland, the activity also forces `custom_image_name` to `None` — alongside the VM-sandbox and network-allowlist flags from #92209 — so provisioning builds a plain golden box, never a Modal `VM_BASE` config with a default image.
- A genuine user/environment custom image still forces Modal: hogland runs only its golden template.
- Mechanical: `_resolve_sandbox_backend` takes `has_user_custom_image: bool` instead of `custom_image_name`.

The behavior change stays flag-gated, so only `tasks-hogland-sandbox`-targeted users are affected; every other run is unchanged.

### The point to review

This treats hogland's golden as a valid stand-in for the org default image `posthog-dev-stack`. That is the intended design — the `posthog-tasks-default` golden was baked to be the tasks default environment — but please confirm the two are functionally equivalent enough to route real default-image runs onto the golden. A run that names its own custom image is unaffected; it stays on Modal.

## How did you test this code?

I am an agent (Claude Code). Automated tests I ran:

- Updated `TestResolveSandboxBackend` and ran it: 13 pass. A real user/environment custom image (`has_user_custom_image=True`) and the Pi runtime stay hard gates; the org default no longer gates. Guards someone re-gating hogland on the org default image.
- Extended the full-context force-off test (`test_hogland_run_drops_modal_vm_allowlist_and_default_image`): a hogland run whose VM payload carries `default_custom_image` resolves to `sandbox_backend == "hogland"` with `custom_image_name is None` and both Modal flags False. Guards the force-off and the default-image path together.

Not run locally: the DB/ClickHouse-backed tests (this sandbox has no ClickHouse); they run in CI. `ruff check`/`format` clean; targeted mypy on the changed module surfaced no new errors.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent-authored (Claude Code), directed by Tom Owers. Follow-up to #92209: after that change let the flag win over the Modal VM-sandbox / network-allowlist flags, a live smoke run showed tasks still pinned to Modal because the org default image lands in `custom_image_name` and the resolver treated it as a hard incapability. This change distinguishes the org default image (hogland-eligible, served by the golden) from a real user/environment custom image (still Modal-only). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. Left for a human: confirming the golden is a valid stand-in for `posthog-dev-stack` (noted under Changes).
