### PR TITLE
chore(kafka-consumer): name the ledger charge input offset_charges

### DIFF
--- a/rust/common/kafka-consumer/src/ledger.rs
+++ b/rust/common/kafka-consumer/src/ledger.rs
@@ -62,9 +62,9 @@ impl OffsetLedger {
     /// When an offset is not above every offset already recorded. Duplicate
     /// or out-of-order delivery is a caller bug, and recording it would
     /// corrupt the commit accounting.
-    pub fn charge(&mut self, offsets: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
+    pub fn charge(&mut self, offset_charges: impl IntoIterator<Item = (Offset, Charge)>) -> Charge {
         let mut total = Charge::ZERO;
-        for (offset, charge) in offsets {
+        for (offset, charge) in offset_charges {
             let base_offset = *self.base_offset.get_or_insert(offset);
             let next_offset = base_offset + self.slots.len();
             assert!(


### PR DESCRIPTION
## Problem

- `OffsetLedger::charge` names its `(Offset, Charge)` pairs `offsets`, which reads as plain offsets.

## Changes

- Renames the parameter to `offset_charges`. No behavior change.

## How did you test this code?

- The existing crate suite covers `charge`; a rename either compiles or does not.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None
