### PR TITLE
feat(mcp-store): add Folklore to the MCP server catalog

### DIFF
--- a/products/mcp_store/backend/catalog.py
+++ b/products/mcp_store/backend/catalog.py
@@ -150,6 +150,15 @@ MCP_SERVER_CATALOG: list[CatalogEntry] = [
         icon_domain="firetiger.com",
     ),
     CatalogEntry(
+        name="Folklore",
+        url="https://api.helena.bio/folklore/v1/mcp",
+        description="Interpret supported GRCh38 germline variants with structured ACMG/AMP evidence and literature.",
+        auth_type="api_key",
+        category="data",
+        icon_domain="helena.bio",
+        docs_url="https://folklore.helena.bio",
+    ),
+    CatalogEntry(
         name="GitLab",
         url="https://gitlab.com/api/v4/mcp",
         description="Manage GitLab issues, merge requests, pipelines, and repos.",

--- a/products/mcp_store/backend/catalog.py
+++ b/products/mcp_store/backend/catalog.py
@@ -152,7 +152,7 @@ MCP_SERVER_CATALOG: list[CatalogEntry] = [
     CatalogEntry(
         name="Folklore",
         url="https://api.helena.bio/folklore/v1/mcp",
-        description="Interpret supported GRCh38 germline variants with structured ACMG/AMP evidence and literature.",
+        description="Interpret GRCh38 germline variants, retrieve ClinGen gene-disease evidence and search literature.",
         auth_type="api_key",
         category="data",
         icon_domain="helena.bio",


### PR DESCRIPTION
## Summary

Adds Folklore to the MCP store catalogue and updates its description. This does not change PostHog runtime behavior.

**Current Folklore MCP release: 1.5.0.** Bioinformatics MCP for genomic variant interpretation, gene-disease evidence and literature.

## Public connection and capabilities

- Endpoint: https://api.helena.bio/folklore/v1/mcp (Streamable HTTP; no account or API key).
- Source: https://github.com/helena-bioinformatics/folklore-mcp
- Connection guide: https://folklore.helena.bio/integrations
- Registry identity: `io.github.helena-bioinformatics/folklore`
- Release: https://github.com/helena-bioinformatics/folklore-mcp/releases/tag/folklore-mcp-v1.5.0

The live endpoint exposes seven tools:

1. `search_variant_evidence`
2. `search_variant_literature`
3. `get_publication_details`
4. `search_literature_corpus`
5. `support_helena` (separate optional support discovery)
6. `get_gene_disease_associations`
7. `search_disease_genes`

The two new scientific tools return ClinGen Gene-Disease Validity assertions by exact gene symbol/HGNC ID or MONDO ID/disease-name search. They preserve distinct disease identities, inheritance, source classifications, reports and snapshot provenance. Existing variant and literature tools are retained; this release does not change the variant classifier.

## Scope and validation

Variant interpretation is limited to supported GRCh38 germline variants. Gene-disease validity is not individual variant pathogenicity or a patient diagnosis. No raw DNA/VCF ingestion, batch variant processing, patient symptoms or private case data. Results require qualified professional review.

The upstream release and live seven-tool catalogue were verified on 2026-09-11. This confirms the hosted service, not acceptance or complete compatibility testing by this project. Refer to this pull request's checks and current diff for project-specific validation.
