### PR TITLE
feat(devex): let labeled drafts get a hogbox preview

### DIFF
--- a/.github/workflows/hogbox-preview-env.yml
+++ b/.github/workflows/hogbox-preview-env.yml
@@ -25,10 +25,11 @@
 # to --reset-db.
 #
 # --- TRIGGER (who gets a preview) -----------------------------------------------
-# The `decide` job (cheap, credential-free) is the gate. A same-repo, human,
-# ready (non-draft) PR gets a preview when it carries the `hogbox-preview` label
-# (manual opt-in, ANY paths) OR its diff touches the frontend (frontend/**,
-# products/*/frontend/**, common/esbuilder/**). The `no-preview` label opts out.
+# The `decide` job (cheap, credential-free) is the gate. A same-repo, human PR
+# gets a preview when it carries the `hogbox-preview` label (manual opt-in, ANY
+# paths, draft or ready) OR it is ready (non-draft) and its diff touches the
+# frontend (frontend/**, products/*/frontend/**, common/esbuilder/**). A draft
+# only ever previews through the label. The `no-preview` label opts out.
 # Auto-previews for frontend PRs are org-visible default behavior; the opt-out +
 # hibernation (below) keep them cheap. See the trigger notes on `on.pull_request`.
 #
@@ -52,7 +53,8 @@
 #   - the golden is referenced by its global alias `posthog-preview-golden`
 #   - target hogland deploy has HOG_GITHUB_OIDC_AUDIENCE + a github_oidc
 #     TrustMapping for PostHog/posthog on prod-us
-#   - frontend PRs auto-preview; `hogbox-preview` forces it for any paths,
+#   - ready frontend PRs auto-preview; `hogbox-preview` forces it for any paths
+#     and any draft state,
 #     `no-preview` opts out (see the TRIGGER section above)
 # The box is driven entirely by the posthog-hogland SDK (pip-installable, keyless
 # over hogplane's HTTP API) — no `hogland` CLI binary and no box SSH key needed.
@@ -179,8 +181,9 @@ jobs:
                           return decide(false, false, `label ${action} '${label}' — not preview-relevant → skip`);
                       }
 
-                      // Build eligibility: same-repo AND human AND ready AND not
-                      // opted-out AND (labeled OR frontend-touching).
+                      // Build eligibility: same-repo AND human AND (ready OR
+                      // labeled) AND not opted-out AND (labeled OR
+                      // frontend-touching).
                       const labels = (pr.labels || []).map(l => l.name);
                       const hasPreviewLabel = labels.includes('hogbox-preview');
                       const optedOut = labels.includes('no-preview');
@@ -193,8 +196,19 @@ jobs:
 
                       if (!sameRepo) return decide(false, false, `fork PR (${pr.head && pr.head.repo && pr.head.repo.full_name}) → skip`);
                       if (isBot) return decide(false, false, `bot author (${login}) → skip`);
-                      if (!ready) return decide(false, false, 'draft PR → skip');
+                      // A draft never AUTO-previews, but `hogbox-preview` opts one
+                      // in: self-review wants a clickable box before the PR is
+                      // ready. An unlabeled draft still waits for the draft→ready
+                      // flip.
+                      if (!ready && !hasPreviewLabel) return decide(false, false, 'draft PR without hogbox-preview → skip');
                       if (optedOut) return decide(false, false, 'no-preview label present → skip');
+
+                      // A labeled draft already has its preview (pushes keep it
+                      // current), so the draft→ready flip has nothing to build —
+                      // skip the identical rebuild at the same SHA.
+                      if (action === 'ready_for_review' && hasPreviewLabel) {
+                          return decide(false, false, 'ready_for_review on an already-previewed draft → skip');
+                      }
 
                       // The manual label opts a PR in for ANY paths; without it we
                       // require a frontend-touching diff. Only pay for the files
@@ -330,7 +344,7 @@ jobs:
               with:
                   # A dispatched run would otherwise check out master (the dispatch ref)
                   # and ship master's SPA as the "PR frontend" — dispatch is the only
-                  # preview path for draft/bot-authored PRs. The PR head is safe here:
+                  # preview path for bot-authored PRs. The PR head is safe here:
                   # the fork guard above has already hard-failed non-same-repo numbers,
                   # and this job runs without credentials. pull_request events keep the
                   # default merge-ref behavior (empty ref).

--- a/tools/hogbox-preview/README.md
+++ b/tools/hogbox-preview/README.md
@@ -80,15 +80,20 @@ builds a preview when **all** hold:
   hogland token in scope),
 - the author is a **human** (bots — `user.type == 'Bot'`, `…[bot]`, and the usual
   suspects like dependabot/renovate — are skipped),
-- the PR is **ready** (not draft; flipping draft→ready builds it),
 - it does **not** carry the **`no-preview`** opt-out label, and
 - it either carries the **`hogbox-preview`** label (manual opt-in, works for **any**
-  paths) **or** its diff touches the frontend (`frontend/**`,
-  `products/*/frontend/**`, `common/esbuilder/**`).
+  paths and on a **draft**) **or** it is **ready** (not draft) and its diff touches
+  the frontend (`frontend/**`, `products/*/frontend/**`, `common/esbuilder/**`).
+
+A draft only previews through the label, so drafts still cost nothing by default.
+Label a draft and it builds right away, then rebuilds on every push like any other
+preview; flipping that draft to ready skips the rebuild, because the box is already
+serving that commit. An unlabeled draft builds on the draft→ready flip as before.
 
 Two labels, two escape hatches: **`hogbox-preview`** forces a preview on a PR that
-wouldn't auto-qualify (e.g. a backend-only change you want to click through);
-**`no-preview`** suppresses one on a PR that would (and tears down a live one).
+wouldn't auto-qualify (a backend-only change you want to click through, or work
+you're still self-reviewing in draft); **`no-preview`** suppresses one on a PR that
+would (and tears down a live one).
 
 Why a `decide` job and not an `on.pull_request.paths` filter: a path filter would
 kill the label-only path for backend PRs, so the trigger stays broad and


### PR DESCRIPTION
## Problem

The `hogbox-preview` label does nothing on a draft PR. The `decide` gate returns
`draft PR → skip` before it ever reads the labels, so anyone doing self-review in
a draft has to mark the PR ready just to get a clickable box — which is exactly
when a preview is most useful.

## Changes

- Labeling a draft with `hogbox-preview` now builds a preview immediately, and
  every push to that draft refreshes it, like any other preview.
- An unlabeled draft still gets nothing and still builds on the draft→ready flip,
  so drafts cost nothing by default.
- Flipping a labeled draft to ready no longer rebuilds the same commit — the box
  is already serving it, so that event is now a no-op.
- Mechanical: the workflow header comments and `tools/hogbox-preview/README.md`
  follow the new rule.

Everything else in the gate is untouched. Fork PRs, bot authors, and the
`no-preview` opt-out still win over the label, and teardown on label removal, PR
close, and the daily stale sweep are unchanged.

## How did you test this code?

No new tests — the gate is an inline `github-script` block with no test harness.
I extracted the script from the YAML and ran it against 13 payloads covering
draft/ready, labeled/unlabeled, frontend/backend diffs, fork, bot, `no-preview`,
label removal, and both `ready_for_review` paths; each produced the intended
build/teardown pair. `hogli lint:workflows` passes (8 checks, 129 workflows).

Not verified: an end-to-end preview build from a labeled draft. Worth confirming
on this PR itself once it's up.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`tools/hogbox-preview/README.md` is updated in this PR.

## 🤖 Agent context

Written by the PostHog Slack app from a request in #team-devex about requesting
preview boxes while still in draft. The finding that the label was inert on
drafts came from that thread.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1788259592071829?thread_ts=1788259592.071829&cid=C09G8QA6740)*
