### PR TITLE
fix(experiments): add stats_config to the recalculation fingerprint computation

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_metric_fingerprint.py
+++ b/products/experiments/backend/hogql_queries/experiment_metric_fingerprint.py
@@ -21,6 +21,15 @@ METRIC_FIELDS_TO_IGNORE: set[str] = {
     "only_count_matured_users",
 }
 
+# stats_config keys that do NOT change a computed metric result, so they must not move the fingerprint.
+# Everything else in stats_config (method, frequentist/bayesian/cuped sub-configs, baseline_variant_key)
+# feeds the stored result, so it is hashed by default. Add a key here only when it is purely bookkeeping
+# or display state; a new result-affecting setting needs no change and is captured automatically.
+STATS_CONFIG_FIELDS_TO_IGNORE: set[str] = {
+    "migrated_from",
+    "migrated_to",
+}
+
 
 def compute_metric_fingerprint(
     metric: dict,
@@ -29,6 +38,7 @@ def compute_metric_fingerprint(
     exposure_criteria: dict | None = None,
     only_count_matured_users: bool = False,
     excluded_variants: list[str] | None = None,
+    stats_config: dict | None = None,
 ) -> str:
     """
     Compute fingerprint for a metric.
@@ -41,6 +51,9 @@ def compute_metric_fingerprint(
         only_count_matured_users
         excluded_variants: Variant keys excluded from analysis — changing the set
             invalidates cached results since it alters which data is computed
+        stats_config: Experiment stats settings (CUPED, sequential, confidence, baseline variant).
+            These feed the stored result, so a change must invalidate the cache. Only the keys in
+            STATS_CONFIG_FIELDS_TO_IGNORE are dropped. Callers on the timeseries path may omit this.
 
     Returns:
         SHA256 hash string representing the metric fingerprint
@@ -73,6 +86,10 @@ def compute_metric_fingerprint(
 
     if excluded_variants:
         fingerprint_data["excluded_variants"] = sorted(set(excluded_variants))
+
+    result_affecting_stats = {k: v for k, v in (stats_config or {}).items() if k not in STATS_CONFIG_FIELDS_TO_IGNORE}
+    if result_affecting_stats:
+        fingerprint_data["stats_config"] = result_affecting_stats
 
     # Create deterministic JSON string with sorted keys at all levels
     json_str = json.dumps(fingerprint_data, sort_keys=True, separators=(",", ":"))

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_excluded_variants.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_excluded_variants.py
@@ -90,3 +90,31 @@ def test_fingerprint_changes_when_excluded_variants_change():
     assert fp_two != fp_one
     assert fp_two_reversed == fp_two, "Order of excluded keys must not affect fingerprint"
     assert fp_one != fp_one_other
+
+
+@parameterized.expand(
+    [
+        # name, stats_config, moves_fingerprint: result-affecting settings must invalidate the cache;
+        # bookkeeping keys must not, or every admin migration would recompute every metric.
+        ("cuped_enabled", {"cuped": {"enabled": True}}, True),
+        ("cuped_lookback", {"cuped": {"enabled": True, "lookback_days": 30}}, True),
+        ("frequentist_alpha", {"frequentist": {"alpha": 0.1}}, True),
+        ("sequential_enabled", {"frequentist": {"sequential_testing_enabled": True}}, True),
+        ("bayesian_ci_level", {"bayesian": {"ci_level": 0.9}}, True),
+        ("bayesian_prior", {"bayesian": {"prior_type": "informative"}}, True),
+        ("baseline_variant_key", {"baseline_variant_key": "test"}, True),
+        ("migrated_from_ignored", {"migrated_from": 123}, False),
+        ("migrated_to_ignored", {"migrated_to": 456}, False),
+    ]
+)
+def test_fingerprint_tracks_result_affecting_stats_config(name, stats_config, moves_fingerprint):
+    metric = {"kind": "ExperimentMeanMetric", "source": {"kind": "EventsNode", "event": "$pageview"}}
+    start = "2026-01-01T00:00:00+00:00"
+
+    baseline = compute_metric_fingerprint(metric, start, stats_config=None)
+    with_config = compute_metric_fingerprint(metric, start, stats_config=stats_config)
+
+    if moves_fingerprint:
+        assert with_config != baseline
+    else:
+        assert with_config == baseline

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -391,6 +391,7 @@ def _recalc_fingerprints_for_run(experiment: Experiment, recalc: ExperimentMetri
             experiment.exposure_criteria,
             only_count_matured_users=experiment.only_count_matured_users,
             excluded_variants=experiment.excluded_variants,
+            stats_config=experiment.stats_config,
         )
         fingerprints[metric_uuid] = compute_recalc_fingerprint(config_fp)
     return fingerprints
@@ -455,6 +456,7 @@ def build_timeseries_cold_start_payload(experiment: Experiment) -> dict | None:
                 experiment.exposure_criteria,
                 only_count_matured_users=experiment.only_count_matured_users,
                 excluded_variants=experiment.excluded_variants,
+                stats_config=experiment.stats_config,
             )
             row = (
                 ExperimentMetricResult.objects.filter(

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -638,6 +638,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
             experiment.exposure_criteria,
             only_count_matured_users=experiment.only_count_matured_users,
             excluded_variants=experiment.excluded_variants,
+            stats_config=experiment.stats_config,
         )
         recalc_fp = compute_recalc_fingerprint(config_fp)
 

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -349,6 +349,43 @@ class TestRecalculationService(BaseTest):
         recalc.refresh_from_db()
         assert get_run_results(recalc) == []
 
+    def test_changing_stats_config_invalidates_run_results(self):
+        # A stopped experiment pins query_to at end_date, so a stats-settings change (CUPED, confidence,
+        # sequential) can only invalidate the cache through the fingerprint. Enabling CUPED changes what the
+        # metric computes, so the cached row must stop matching even at the same query_to.
+        exp = self._launched_experiment(flag_key="reuse-stats-config")
+        assert exp.start_date is not None
+        query_to = datetime(2026, 1, 10, tzinfo=UTC)
+        recalc_fp = compute_recalc_fingerprint(
+            compute_metric_fingerprint(
+                _mean_metric("m1"),
+                exp.start_date,
+                get_experiment_stats_method(exp),
+                exp.exposure_criteria,
+                only_count_matured_users=exp.only_count_matured_users,
+                excluded_variants=exp.excluded_variants,
+                stats_config=exp.stats_config,
+            )
+        )
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=recalc_fp,
+            query_from=exp.start_date,
+            query_to=query_to,
+            status=ExperimentMetricResult.Status.COMPLETED,
+            result={"some": "result"},
+        )
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team, experiment=exp, metric_uuids=["m1"], query_to=query_to
+        )
+        assert [r["metric_uuid"] for r in get_run_results(recalc)] == ["m1"]
+
+        exp.stats_config = {**(exp.stats_config or {}), "cuped": {"enabled": True}}
+        exp.save(update_fields=["stats_config"])
+        recalc.refresh_from_db()
+        assert get_run_results(recalc) == []
+
     def test_get_run_results_strips_step_sessions(self):
         # step_sessions carries per-step person IDs, session IDs, and event UUIDs. It powers the frontend's
         # "view sessions per step" affordance off a separate per-metric query, so it does not belong in the


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

On a stopped experiment, changing a statistics setting (CUPED, confidence level, sequential testing, baseline variant) did nothing: the results kept showing the old numbers. A stopped experiment pins the recalculation window to `end_date`, so `query_to` never moves, and the recalculation fingerprint hashed only the stats method, not the rest of `stats_config`. With both the window and the fingerprint unchanged, the calc activity's `already_computed` check matched the existing result row and skipped the query, so the new setting never applied.

## Changes

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR adds the result-affecting slice of `stats_config` to the metric recalculation fingerprint, so a stats-settings change invalidates the cached result and forces a recompute.

### Fingerprint computation

`compute_metric_fingerprint` gains a `stats_config` parameter and hashes every key in it except a small denylist. The denylist, `STATS_CONFIG_FIELDS_TO_IGNORE`, holds only `migrated_from` and `migrated_to`, which are admin-migration bookkeeping and do not change what a metric computes. Everything else (`method`, the `frequentist` and `bayesian` sub-configs, `cuped`, and `baseline_variant_key`) feeds the stored result, so it is hashed by default. A new result-affecting setting is captured automatically; only a new display-only key needs a denylist entry, and there is a comment saying so.

- `products/experiments/backend/hogql_queries/experiment_metric_fingerprint.py`

### Recalculation path

The three recalculation call sites now pass `experiment.stats_config` into the fingerprint: the calc activity that writes result rows, and the two read sites that recompute the fingerprint to look up a run's rows. Passing it at all three keeps the write-side and read-side fingerprints in agreement, so a settings change makes the lookup miss and the metric recompute.

Scope is intentionally limited to the recalculation workflow. The other fingerprint callers (experiment create and update, the serializer read) feed the separate timeseries path and are left unchanged; routing them through a shared helper is a later refactor.

- `products/experiments/backend/temporal/recalculation_logic.py`
- `products/experiments/backend/recalculation.py`

### Side effects

Every recalculation fingerprint changes once, so existing `ExperimentMetricResult` rows stop matching and recompute on the next run. This is the intended correctness fix, not a regression. There is no migration; the rows miss and recompute lazily.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/d81c4029-c9e1-4b8c-ad75-085d5eae949e)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

None.

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8

Manually refactored: **no**

Skills used:

- /writing-tests (local)
- /django-migrations (local)
- /writing-pull-requests (local)

Relevant decisions:

- Denylist over allowlist: only `migrated_from` and `migrated_to` are result-irrelevant, so hashing everything else fails safe. A forgotten allowlist entry would silently ignore a real setting; a needless recompute from a future display-only key is just wasted work, and the comment tells maintainers to denylist it.
- Scope held to the recalculation path (three call sites). The create, update, and serializer-read callers feed the separate timeseries fingerprint, so they stay unchanged; a curried `fingerprint_for_experiment` wrapper to remove the field-unpacking duplication is deferred.
- `stats_config` added alongside the existing `stats_method` argument rather than replacing it, to keep the signature and its positional test callers stable.