### PR TITLE
chore(ci): probe check-run semantics on both CI engines

### DIFF
--- a/.depot/workflows/check-semantics-probe.yml
+++ b/.depot/workflows/check-semantics-probe.yml
@@ -1,0 +1,133 @@
+# Throwaway probe. Records how this engine reports job results as GitHub check runs.
+# A twin workflow runs the identical job graph on the other engine, so the two check
+# lists can be diffed name by name and conclusion by conclusion.
+name: Check semantics probe (Depot)
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+        paths:
+            - .github/workflows/ci-check-semantics-probe.yml
+            - .depot/workflows/check-semantics-probe.yml
+    workflow_dispatch: {}
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    plan:
+        name: Plan
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        outputs:
+            never: ${{ steps.out.outputs.never }}
+            empty_matrix: ${{ steps.out.outputs.empty_matrix }}
+        steps:
+            - id: out
+              run: |
+                  echo "never=false" >> "$GITHUB_OUTPUT"
+                  echo 'empty_matrix=[]' >> "$GITHUB_OUTPUT"
+
+    plain-success:
+        name: Plain success
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo ok
+
+    skipped-by-literal-if:
+        name: Skipped by literal if
+        if: false
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo unreachable
+
+    skipped-by-expression:
+        name: Skipped by expression
+        needs: plan
+        if: needs.plan.outputs.never == 'true'
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo unreachable
+
+    skipped-by-needs-cascade:
+        name: Skipped by needs cascade
+        needs: skipped-by-literal-if
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo unreachable
+
+    skipped-by-empty-matrix:
+        name: Skipped by empty matrix
+        needs: plan
+        strategy:
+            matrix:
+                shard: ${{ fromJSON(needs.plan.outputs.empty_matrix) }}
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo unreachable
+
+    two-cell-matrix:
+        name: Two cell matrix
+        strategy:
+            matrix:
+                shard: [1, 2]
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo "shard ${{ matrix.shard }}"
+
+    failure-swallowed:
+        name: Failure swallowed by continue-on-error
+        continue-on-error: true
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: exit 1
+
+    step-level-continue-on-error:
+        name: Step level continue-on-error
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: exit 1
+              continue-on-error: true
+            - run: echo reached
+
+    hard-failure:
+        name: Hard failure
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: exit 1
+
+    gate:
+        name: Probe gate
+        if: always()
+        needs:
+            - plan
+            - plain-success
+            - skipped-by-literal-if
+            - skipped-by-expression
+            - skipped-by-needs-cascade
+            - skipped-by-empty-matrix
+            - two-cell-matrix
+            - failure-swallowed
+            - step-level-continue-on-error
+            - hard-failure
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - name: Print the needs context
+              run: |
+                  cat <<'EOF'
+                  ${{ toJSON(needs) }}
+                  EOF

--- a/.github/workflows/ci-check-semantics-probe.yml
+++ b/.github/workflows/ci-check-semantics-probe.yml
@@ -1,0 +1,133 @@
+# Throwaway probe. Records how this engine reports job results as GitHub check runs.
+# A twin workflow runs the identical job graph on the other engine, so the two check
+# lists can be diffed name by name and conclusion by conclusion.
+name: Check semantics probe (GHA)
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+        paths:
+            - .github/workflows/ci-check-semantics-probe.yml
+            - .depot/workflows/check-semantics-probe.yml
+    workflow_dispatch: {}
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    plan:
+        name: Plan
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        outputs:
+            never: ${{ steps.out.outputs.never }}
+            empty_matrix: ${{ steps.out.outputs.empty_matrix }}
+        steps:
+            - id: out
+              run: |
+                  echo "never=false" >> "$GITHUB_OUTPUT"
+                  echo 'empty_matrix=[]' >> "$GITHUB_OUTPUT"
+
+    plain-success:
+        name: Plain success
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo ok
+
+    skipped-by-literal-if:
+        name: Skipped by literal if
+        if: false
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo unreachable
+
+    skipped-by-expression:
+        name: Skipped by expression
+        needs: plan
+        if: needs.plan.outputs.never == 'true'
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo unreachable
+
+    skipped-by-needs-cascade:
+        name: Skipped by needs cascade
+        needs: skipped-by-literal-if
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo unreachable
+
+    skipped-by-empty-matrix:
+        name: Skipped by empty matrix
+        needs: plan
+        strategy:
+            matrix:
+                shard: ${{ fromJSON(needs.plan.outputs.empty_matrix) }}
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo unreachable
+
+    two-cell-matrix:
+        name: Two cell matrix
+        strategy:
+            matrix:
+                shard: [1, 2]
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: echo "shard ${{ matrix.shard }}"
+
+    failure-swallowed:
+        name: Failure swallowed by continue-on-error
+        continue-on-error: true
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: exit 1
+
+    step-level-continue-on-error:
+        name: Step level continue-on-error
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: exit 1
+              continue-on-error: true
+            - run: echo reached
+
+    hard-failure:
+        name: Hard failure
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - run: exit 1
+
+    gate:
+        name: Probe gate
+        if: always()
+        needs:
+            - plan
+            - plain-success
+            - skipped-by-literal-if
+            - skipped-by-expression
+            - skipped-by-needs-cascade
+            - skipped-by-empty-matrix
+            - two-cell-matrix
+            - failure-swallowed
+            - step-level-continue-on-error
+            - hard-failure
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - name: Print the needs context
+              run: |
+                  cat <<'EOF'
+                  ${{ toJSON(needs) }}
+                  EOF


### PR DESCRIPTION
> [!NOTE]
> Throwaway experiment. Not for merge. Close it once the results are recorded.

## Problem

Nobody can say from the docs how a skipped job reaches a GitHub required status check, so anyone reasoning about required checks is guessing. The `master` ruleset pins all 14 required contexts to one app id, and neither GitHub nor Trunk documents how a `skipped` conclusion is scored.

## Changes

- Two twin workflows run an identical job graph on the GitHub Actions engine and the Depot engine.
- The graph covers a plain success, four ways to skip a job, a two cell matrix, a hard failure, and both forms of `continue-on-error`.
- The `Probe gate` job prints the `needs` context, so each engine's internal job result sits next to the check run it posted.
- Nothing user-visible changes. Both files are throwaway.

## How did you test this code?

- `bin/hogli lint:workflows` passes. The first draft failed `WF008-pr-event-fanout`, so both triggers carry a `paths:` filter.
- The run itself is the test. Results go in the session notes, not here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code wrote both workflows. Skills invoked: `/writing-pr-descriptions`.
- The probe exists to settle one question with evidence rather than inference: what conclusion each engine posts for a skipped job, and under which app id.
