### PR TITLE
fix(mcp-analytics): freeze the clock in timeBuckets interval tests

### DIFF
--- a/products/mcp_analytics/frontend/timeBuckets.test.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.test.ts
@@ -154,24 +154,34 @@ describe('timeBuckets', () => {
             ['-1y', 'day', 'day'], // 367 daily buckets: fits, and beats the auto-choice
             ['-1y', null, 'month'], // nothing pinned: the auto-choice
         ])('groups a %s window pinned to %s by %s', (dateFrom, pinned, expected) => {
-            expect(resolveInterval(dateFrom, null, 'UTC', pinned as IntervalType | null)).toBe(expected)
+            jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
+            try {
+                expect(resolveInterval(dateFrom, null, 'UTC', pinned as IntervalType | null)).toBe(expected)
+            } finally {
+                jest.useRealTimers()
+            }
         })
     })
 
     describe('intervalOptionsForWindow', () => {
         it('disables the intervals that would smear or collapse the window', () => {
-            expect(intervalOptionsForWindow('-1y', null, 'UTC')).toEqual([
-                { value: 'hour', label: 'Hour', disabledReason: 'Range too long' },
-                { value: 'day', label: 'Day', disabledReason: null },
-                { value: 'week', label: 'Week', disabledReason: null },
-                { value: 'month', label: 'Month', disabledReason: null },
-            ])
-            expect(intervalOptionsForWindow('-7d', null, 'UTC')).toEqual([
-                { value: 'hour', label: 'Hour', disabledReason: null },
-                { value: 'day', label: 'Day', disabledReason: null },
-                { value: 'week', label: 'Week', disabledReason: null },
-                { value: 'month', label: 'Month', disabledReason: 'Range too short' },
-            ])
+            jest.useFakeTimers().setSystemTime(new Date('2026-06-18T12:00:00Z'))
+            try {
+                expect(intervalOptionsForWindow('-1y', null, 'UTC')).toEqual([
+                    { value: 'hour', label: 'Hour', disabledReason: 'Range too long' },
+                    { value: 'day', label: 'Day', disabledReason: null },
+                    { value: 'week', label: 'Week', disabledReason: null },
+                    { value: 'month', label: 'Month', disabledReason: null },
+                ])
+                expect(intervalOptionsForWindow('-7d', null, 'UTC')).toEqual([
+                    { value: 'hour', label: 'Hour', disabledReason: null },
+                    { value: 'day', label: 'Day', disabledReason: null },
+                    { value: 'week', label: 'Week', disabledReason: null },
+                    { value: 'month', label: 'Month', disabledReason: 'Range too short' },
+                ])
+            } finally {
+                jest.useRealTimers()
+            }
         })
     })
 })


### PR DESCRIPTION
## Problem

`Jest test (EE - 4)` fails on every PR today: two `timeBuckets` tests read the real clock, and on the first days of a month a `-7d` window crosses a month boundary, flipping the month-interval logic. Example failure: [this run](https://github.com/PostHog/posthog/actions/runs/33517210761/job/99888234179) on an unrelated docs PR (#91989).

## Changes

- The `resolveInterval` and `intervalOptionsForWindow` tests now freeze the clock with `jest.useFakeTimers().setSystemTime(...)`, the same pattern the file's other date-relative tests already use.
- No assertions changed and no production code changed.

## How did you test this code?

- `hogli test products/mcp_analytics/frontend/timeBuckets.test.ts` on 2026-09-01: 2 failed before the change, 23 passed after.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed by Claude Code while watching CI on #91989: the failure reproduced locally in a file that PR never touches, dated tests confirmed the month-boundary trigger. Skills invoked: /writing-pr-descriptions.
