### PR TITLE
fix(mcp-analytics): pin the clock in the timeBuckets interval tests

### DIFF
--- a/products/mcp_analytics/frontend/timeBuckets.test.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.test.ts
@@ -144,6 +144,18 @@ describe('timeBuckets', () => {
     })
 
     describe('resolveInterval', () => {
+        // Relative windows resolve against the clock, so a -7d window that sits inside one calendar
+        // month on most days straddles two at a month boundary. Pin the clock mid-month, or those
+        // cases invert on the 1st of every month.
+        beforeEach(() => {
+            jest.useFakeTimers()
+            jest.setSystemTime(new Date('2026-06-15T12:00:00.000Z'))
+        })
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
         // A pin outlives the window it was set on, so it has to give way once the window outgrows it:
         // charting a year hour by hour also runs past the query's row limit, which drops the newest
         // buckets. A pin that still fits has to beat the auto-choice — that's the point of pinning.
@@ -159,6 +171,15 @@ describe('timeBuckets', () => {
     })
 
     describe('intervalOptionsForWindow', () => {
+        beforeEach(() => {
+            jest.useFakeTimers()
+            jest.setSystemTime(new Date('2026-06-15T12:00:00.000Z'))
+        })
+
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
         it('disables the intervals that would smear or collapse the window', () => {
             expect(intervalOptionsForWindow('-1y', null, 'UTC')).toEqual([
                 { value: 'hour', label: 'Hour', disabledReason: 'Range too long' },


### PR DESCRIPTION
## Problem

Every PR in the repo has a red `Frontend Tests Pass` as of today. Two tests in `products/mcp_analytics/frontend/timeBuckets.test.ts` resolve a `-7d` window against the real clock, and on the first of a month that window straddles two calendar months.

`month` then stops counting as "Range too short", so `resolveInterval('-7d', 'month')` keeps the pin and returns `month` instead of falling back to `day`, and `intervalOptionsForWindow('-7d')` reports `month` as selectable. Both assertions invert.

It reproduces on clean `master` (`b6e968e`) with no other changes.

## Changes

- `Frontend Tests Pass` goes green again on every open PR.
- The two `describe` blocks pin the clock to `2026-06-15T12:00:00.000Z` with `jest.useFakeTimers()`, so a `-7d` window sits inside one calendar month whatever today's date is.
- No production code changes. `resolveInterval` and `intervalOptionsForWindow` behave exactly as before; only the tests become date-independent.

Mid-month is the value the rest of this file already uses for its explicit `now` fixtures, and matches the convention in `exceedsRetention.test.ts` and `dashboardUtils.test.ts`.

## How did you test this code?

`pnpm --filter=@posthog/frontend exec jest products/mcp_analytics/frontend/timeBuckets.test.ts` — 23 passed.

I confirmed the failure first: the same command on unmodified `master` fails the two named cases with `Expected: "day"` / `Received: "month"`. So the change is verified against the actual break, not assumed.

The fix removes a time bomb rather than covering new behavior, so no new cases were added. Not checked: whether other suites in the repo carry the same unpinned-clock pattern.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude Code (Opus 5) while babysitting two unrelated stacks of product empty-state PRs through CI. The failure surfaced as a red `Frontend Tests Pass` on a dashboards PR; the failing suite belonged to another product, so it was reproduced on clean `master` to confirm it was repo-wide rather than caused by that stack.

Split into this standalone PR deliberately, instead of folding it into the empty-state diff that surfaced it, so an unrelated test fix for another product does not ride along inside a feature PR.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
