### PR TITLE
fix(tasks): build the hogland client off the egress proxy (trust_env=False)

### DIFF
--- a/products/tasks/backend/logic/services/hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/hogland_sandbox.py
@@ -97,7 +97,9 @@ _STATIC_BOX_ENV = {
 
 @lru_cache(maxsize=4)
 def _cached_client(base_url: str, token: str) -> Hogland:
-    return Hogland(token=token, base_url=base_url, timeout=_HTTP_TIMEOUT)
+    # trust_env=False keeps the in-cluster PrivateLink call off the egress proxy, which
+    # rejects the internal hogland host with 407.
+    return Hogland(token=token, base_url=base_url, timeout=_HTTP_TIMEOUT, trust_env=False)
 
 
 def _read_token_file() -> str | None:
@@ -128,10 +130,11 @@ def get_hogland_client() -> Hogland:
     file_token = _read_token_file()
     if base_url and file_token:
         # SDK 0.3.x binds the token at construction, so a cached client would keep a
-        # rotated-out JWT and 401. Build a fresh client per call until the SDK ships
-        # Hogland.from_token_file with per-request re-reads; then this collapses to a
-        # cached Hogland.from_token_file(...) client.
-        return Hogland(token=file_token, base_url=base_url, timeout=_HTTP_TIMEOUT)
+        # rotated-out JWT and 401. Build a fresh client per call until this adopts the
+        # SDK's Hogland.from_token_file (0.4.x) with per-request re-reads; then this
+        # collapses to a cached client. trust_env=False keeps the in-cluster PrivateLink
+        # call off the egress proxy, which rejects the internal hogland host with 407.
+        return Hogland(token=file_token, base_url=base_url, timeout=_HTTP_TIMEOUT, trust_env=False)
     token = settings.HOGLAND_API_TOKEN
     if not base_url or not token:
         raise SandboxProvisionError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ dependencies = [
     "wrapt==1.17.3",
     "limits==5.8.0",
     "deltalite==0.1.7",
-    "posthog-hogland==0.3.1",
+    "posthog-hogland==0.4.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -5952,7 +5952,7 @@ requires-dist = [
     { name = "pixelhog", specifier = "~=1.2.0" },
     { name = "playwright", specifier = "~=1.60.0" },
     { name = "polars", specifier = "==1.37.1" },
-    { name = "posthog-hogland", specifier = "==0.3.1" },
+    { name = "posthog-hogland", specifier = "==0.4.1" },
     { name = "posthog-owners", editable = "tools/owners" },
     { name = "posthoganalytics", specifier = "==7.44.2" },
     { name = "protobuf", specifier = "~=5.29.6" },
@@ -6094,16 +6094,16 @@ sentiment = [
 
 [[package]]
 name = "posthog-hogland"
-version = "0.3.1"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/ec/dc5991a1015bf2beeb901d023f784be17322162b5011ef6e2b49eb2051f6/posthog_hogland-0.3.1.tar.gz", hash = "sha256:6cffa11ebc66c3f6cb4a38f8aadfd59ec658969fdb0f111a2bf9d81e5501d6c4", size = 46155, upload-time = "2026-07-06T08:55:16.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ca/c67965f512f9d4e2afc805bd878650f8cb5a5b91eb530f1ee9004fb5fb4b/posthog_hogland-0.4.1.tar.gz", hash = "sha256:9f89e6768ba28eb29ffa8868797f8229d196caa9e3e6e56e85df598981325462", size = 51084, upload-time = "2026-09-01T14:21:02.617Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/69/57f187f0497072a2d776417514b69959bbeb79c939a9d0a369cd81a04ccf/posthog_hogland-0.3.1-py3-none-any.whl", hash = "sha256:cd565d9839163d6f5567952c7e8b998d88123b02aaa8f86df3daafdefbc11c00", size = 34955, upload-time = "2026-07-06T08:55:14.798Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2a/527ef6d0c3eee98b676bf5c9878c3010e749601210eb1b32dd99548b51b4/posthog_hogland-0.4.1-py3-none-any.whl", hash = "sha256:2bc2fd6bf4a710df8eaf4e5bfa1a4ffd8d29751eb13edc650b89bdcba045eaf2", size = 38357, upload-time = "2026-09-01T14:21:01.536Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

A PostHog Code task now routes to hogland, but creating the hogbox fails with `ProxyError: 407 Request rejected by proxy`. The hogland client's HTTPS call to the internal PrivateLink endpoint (`hogland.<env>.posthog.dev/v1/hogboxes`) is routed through the egress proxy (smokescreen), which rejects the internal destination. A process-wide `NO_PROXY` on the worker is the wrong scope (a security check flags it); the correct opt-out is `trust_env=False` on the specific client, matching PostHog's in-cluster LLM-gateway pattern.

## Changes

- Bump `posthog-hogland` 0.3.1 → 0.4.1. The new release adds `trust_env` to the client (PostHog/hogland#436); it also brings the 0.4.0 `token_provider` work, which posthog can adopt later to cache the client instead of rebuilding it per call.
- Build the hogland client with `trust_env=False` in both `_cached_client()` and `get_hogland_client()`, so the in-cluster PrivateLink call skips the egress proxy. Default behavior for every other client is unchanged.

## How did you test this code?

I am an agent (Claude Code). Automated tests I ran (with `posthog-hogland==0.4.1` installed):

- Verified the constructed client's httpx `trust_env` is `False`.
- `test_hogland_sandbox.py` + `test_agent_command.py`: 98 pass. `ruff` clean; targeted mypy on the changed module clean.

Not run locally: the broader DB/ClickHouse-backed suites (no ClickHouse in this sandbox); they run in CI.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent-authored (Claude Code), directed by Tom Owers. Final piece of routing PostHog Code tasks to hogland: after the routing changes landed and deployed, a live run reached hogland but failed to create the box with a 407 because the SDK's httpx client went through the egress proxy. Rather than a process-wide `NO_PROXY` (flagged as too broad), the hogland SDK gained a `trust_env` knob (released as `posthog-hogland` 0.4.1) and this scopes the opt-out to the hogland client. Skills invoked: `/writing-pr-descriptions`. Left for a human: nothing blocking; a later cleanup could adopt `Hogland.from_token_file` (now available in 0.4.x) to cache the client.
