### PR TITLE
feat(owners): add per-team test file census

### DIFF
--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -65,7 +65,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.trace import Status, StatusCode
-from posthog_owners import OwnersResolver
+from posthog_owners import OwnersResolver, first_team_owner
 
 logger = logging.getLogger("report_test_timings")
 
@@ -824,9 +824,7 @@ def owner_team_lookup() -> Callable[[str], str]:
         except Exception:
             logger.exception("owners resolution failed for %s; emitting span without team attribution", file)
             return ""
-        # An `@handle` first owner is a person, not a team; stamping it would mint a
-        # one-person "team" in every per-team rollup.
-        return next((owner for owner in owners or [] if not owner.startswith("@")), "")
+        return first_team_owner(owners)
 
     return lookup
 

--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -297,10 +297,14 @@ def normalize_jest_file(file: str, jest_root: str = "frontend") -> str:
     mangles the path or drops the file as un-normalizable, so the root follows the
     artifact's suite.
     """
+    return _normalize_repo_file(file, jest_root)
+
+
+def _normalize_repo_file(file: str, root: str) -> str:
     if not file:
         return ""
-    normalized = posixpath.normpath(posixpath.join(jest_root, file.replace("\\", "/")))
-    if normalized == ".." or normalized.startswith("../") or normalized.startswith("/"):
+    normalized = posixpath.normpath(posixpath.join(root, file.replace("\\", "/")))
+    if normalized == ".." or normalized.startswith(("../", "/")):
         return ""
     return normalized
 
@@ -321,12 +325,7 @@ def normalize_pytest_file(file: str) -> str:
     (``../../../opt/.../unittest/mock.py``). Such a path can never resolve an owner, so it is
     discarded here and the caller falls back to inferring the file from the JUnit classname.
     """
-    if not file:
-        return ""
-    normalized = posixpath.normpath(file.replace("\\", "/"))
-    if normalized == ".." or normalized.startswith(("../", "/")):
-        return ""
-    return normalized
+    return _normalize_repo_file(file, ".")
 
 
 def infer_pytest_file(classname: str) -> str:

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -124,8 +124,7 @@ def test_find_repo_root_walks_to_repository_markers(tmp_path: Path) -> None:
     "junit_file",
     [
         "",
-        # pytest reports the decorator's own file for tests wrapped in mock.patch/freeze_time/
-        # parameterized; a path escaping the repo must fall back to classname inference.
+        # a decorator's site-packages path (see normalize_pytest_file)
         "../../../../../opt/hostedtoolcache/Python/3.13.13/x64/lib/python3.13/unittest/mock.py",
     ],
 )

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1086,6 +1086,9 @@ owners:
     owners:who:
         click: posthog_owners.cli:cmd_who
         description: Show who owns a single path (owners, status, slack, source)
+    owners:census:
+        click: posthog_owners.cli:cmd_census
+        description: Count test files per owning team (optional PREFIX; --json for machine output)
     owners:unowned:
         click: posthog_owners.cli:cmd_unowned
         description: List unowned tracked files, respecting owners:null exemptions (optional PREFIX)

--- a/tools/owners/posthog_owners/__init__.py
+++ b/tools/owners/posthog_owners/__init__.py
@@ -1,6 +1,6 @@
 """Distributed ownership: owners.yaml matcher, schema, resolver, and CLI."""
 
-from .census import TeamTestCensus, census, first_team_owner
+from .census import TeamTestCensus, census, first_team_owner, runner_for_path
 from .matcher import compile_pattern, path_matches_pattern
 from .resolver import OwnersResolver, Resolution
 
@@ -12,4 +12,5 @@ __all__ = [
     "compile_pattern",
     "first_team_owner",
     "path_matches_pattern",
+    "runner_for_path",
 ]

--- a/tools/owners/posthog_owners/__init__.py
+++ b/tools/owners/posthog_owners/__init__.py
@@ -1,11 +1,15 @@
 """Distributed ownership: owners.yaml matcher, schema, resolver, and CLI."""
 
+from .census import TeamTestCensus, census, first_team_owner
 from .matcher import compile_pattern, path_matches_pattern
 from .resolver import OwnersResolver, Resolution
 
 __all__ = [
     "OwnersResolver",
     "Resolution",
+    "TeamTestCensus",
+    "census",
     "compile_pattern",
+    "first_team_owner",
     "path_matches_pattern",
 ]

--- a/tools/owners/posthog_owners/census.py
+++ b/tools/owners/posthog_owners/census.py
@@ -1,0 +1,62 @@
+"""Per-team census of the repo's test files, resolved through the distributed owners.yaml
+map. A static read of the tree, so it carries the denominator the signal-only CI spans cannot."""
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .resolver import OwnersResolver
+
+UNOWNED_TEAM = "unowned"
+
+_PYTEST_FILE = re.compile(r"(^|/)test_[^/]*\.py$|_test\.py$")
+_JEST_FILE = re.compile(r"\.(test|spec)\.[jt]sx?$")
+
+
+def first_team_owner(owners: list[str] | None) -> str:
+    """First owner that is a team slug; an ``@handle`` is a person, not a team."""
+    return next((owner for owner in owners or [] if not owner.startswith("@")), "")
+
+
+def runner_for_path(path: str) -> str | None:
+    if _PYTEST_FILE.search(path):
+        return "pytest"
+    if _JEST_FILE.search(path):
+        return "jest"
+    return None
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class TeamTestCensus:
+    owner_team: str
+    pytest_file_count: int
+    jest_file_count: int
+
+    @property
+    def test_file_count(self) -> int:
+        return self.pytest_file_count + self.jest_file_count
+
+
+def census(paths: Iterable[str], repo_root: Path) -> list[TeamTestCensus]:
+    """Count test files per owning team over repo-relative ``paths``, most tests first.
+    Uncovered files and files owned only by ``@handles`` count under ``unowned``."""
+    resolver = OwnersResolver(repo_root)
+    counts: dict[str, dict[str, int]] = {}
+    for path in paths:
+        runner = runner_for_path(path)
+        if runner is None:
+            continue
+        team = first_team_owner(resolver.resolve(path).owners) or UNOWNED_TEAM
+        counts.setdefault(team, {"pytest": 0, "jest": 0})[runner] += 1
+    return sorted(
+        (
+            TeamTestCensus(
+                owner_team=team,
+                pytest_file_count=by_runner["pytest"],
+                jest_file_count=by_runner["jest"],
+            )
+            for team, by_runner in counts.items()
+        ),
+        key=lambda c: (-c.test_file_count, c.owner_team),
+    )

--- a/tools/owners/posthog_owners/census.py
+++ b/tools/owners/posthog_owners/census.py
@@ -37,6 +37,15 @@ class TeamTestCensus:
     def test_file_count(self) -> int:
         return self.pytest_file_count + self.jest_file_count
 
+    def as_payload(self) -> dict[str, int | str]:
+        """The wire shape shared by ``owners:census --json`` and the census events."""
+        return {
+            "owner_team": self.owner_team,
+            "pytest_file_count": self.pytest_file_count,
+            "jest_file_count": self.jest_file_count,
+            "test_file_count": self.test_file_count,
+        }
+
 
 def census(paths: Iterable[str], repo_root: Path) -> list[TeamTestCensus]:
     """Count test files per owning team over repo-relative ``paths``, most tests first.

--- a/tools/owners/posthog_owners/cli.py
+++ b/tools/owners/posthog_owners/cli.py
@@ -69,20 +69,7 @@ def cmd_census(as_json: bool, prefix: str | None) -> None:
     resolver = OwnersResolver()
     rows = census(resolver.tracked_files(prefix), resolver.repo_root)
     if as_json:
-        click.echo(
-            json.dumps(
-                [
-                    {
-                        "owner_team": row.owner_team,
-                        "pytest_file_count": row.pytest_file_count,
-                        "jest_file_count": row.jest_file_count,
-                        "test_file_count": row.test_file_count,
-                    }
-                    for row in rows
-                ],
-                indent=2,
-            )
-        )
+        click.echo(json.dumps([row.as_payload() for row in rows], indent=2))
         return
     for row in rows:
         click.echo(

--- a/tools/owners/posthog_owners/cli.py
+++ b/tools/owners/posthog_owners/cli.py
@@ -10,6 +10,7 @@ from typing import cast
 
 import click
 
+from .census import census
 from .matcher import compile_pattern, normalize_path
 from .resolver import OWNERS_FILENAME, PRODUCT_FILENAME, OwnersResolver, Purpose, read_stdin_paths, resolution_to_wire
 from .schema import is_simple_owners_file, normalize_product_owners
@@ -59,6 +60,35 @@ def cmd_who(path: str) -> None:
     click.echo(f"status:  {r.status}")
     click.echo(f"slack:   {r.slack or '(none)'}")
     click.echo(f"source:  {r.source or '(none)'}")
+
+
+@click.command(name="owners:census", help="Count test files per owning team")
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON list of per-team counts")
+@click.argument("prefix", required=False)
+def cmd_census(as_json: bool, prefix: str | None) -> None:
+    resolver = OwnersResolver()
+    rows = census(resolver.tracked_files(prefix), resolver.repo_root)
+    if as_json:
+        click.echo(
+            json.dumps(
+                [
+                    {
+                        "owner_team": row.owner_team,
+                        "pytest_file_count": row.pytest_file_count,
+                        "jest_file_count": row.jest_file_count,
+                        "test_file_count": row.test_file_count,
+                    }
+                    for row in rows
+                ],
+                indent=2,
+            )
+        )
+        return
+    for row in rows:
+        click.echo(
+            f"{row.test_file_count:6d}  {row.pytest_file_count:6d} py  {row.jest_file_count:6d} js  {row.owner_team}"
+        )
+    click.echo(f"\n{sum(r.test_file_count for r in rows)} test file(s) across {len(rows)} team(s)", err=True)
 
 
 @click.command(name="owners:unowned", help="List unowned tracked files (respecting owners: null exemptions)")
@@ -317,6 +347,7 @@ def main() -> None:
     """
 
 
+main.add_command(cmd_census, name="census")
 main.add_command(cmd_resolve, name="resolve")
 main.add_command(cmd_who, name="who")
 main.add_command(cmd_unowned, name="unowned")

--- a/tools/owners/tests/test_owners.py
+++ b/tools/owners/tests/test_owners.py
@@ -5,7 +5,11 @@ from pathlib import Path
 
 import pytest
 
-from posthog_owners import fmt as fmt_module
+from posthog_owners import (
+    census,
+    first_team_owner,
+    fmt as fmt_module,
+)
 from posthog_owners.cli import _consolidation_suggestions, _live_scope, _reserved_location_error
 from posthog_owners.fmt import CanonicalPlacer, CanonicalPlan
 from posthog_owners.matcher import path_matches_pattern
@@ -674,3 +678,30 @@ def test_live_scope_limits_validation_to_the_given_files(paths: tuple[str, ...],
 
 def test_live_scope_ignores_stale_owners_outside_the_diff() -> None:
     assert "team-bogus" not in _live_scope(_OWNERS_BY_FILE, ("owners.yaml",))
+
+
+def test_census_counts_test_files_per_team_and_folds_gaps_into_unowned(tmp_path: Path) -> None:
+    _write(tmp_path, "owners.yaml", "version: 1\nowners: []\n")
+    _write(tmp_path, "products/a/owners.yaml", "version: 1\nowners: [team-a]\n")
+    _write(tmp_path, "products/p/owners.yaml", "version: 1\nowners: ['@someone']\n")
+    paths = [
+        "products/a/backend/test_api.py",
+        "products/a/backend/queries_test.py",
+        "products/a/frontend/thing.test.tsx",
+        "products/a/frontend/thing.tsx",
+        "products/p/backend/test_personal.py",
+        "posthog/test_uncovered.py",
+    ]
+
+    result = census(paths, tmp_path)
+
+    assert [(c.owner_team, c.pytest_file_count, c.jest_file_count) for c in result] == [
+        ("team-a", 2, 1),
+        ("unowned", 2, 0),
+    ]
+
+
+def test_first_team_owner_skips_handles() -> None:
+    assert first_team_owner(["@someone", "team-a"]) == "team-a"
+    assert first_team_owner(["@someone"]) == ""
+    assert first_team_owner(None) == ""


### PR DESCRIPTION
## Problem

- The Teams tab has no denominator: CI spans record only signal tests, so nothing says how many test surfaces a team owns or how that count moves.

## Changes

- `posthog_owners.census()` counts test files per owning team (pytest and jest); uncovered files and files owned only by `@handles` count under "unowned".
- `hogli owners:census [PREFIX] [--json]` prints the counts; the full repo resolves in seconds.
- `first_team_owner()` becomes the one home for the handle-skip rule; the CI span reporter now imports it instead of inlining it.
- Nothing user-visible changes yet; the consumers land in the layers above.

## How did you test this code?

- New cases in `tools/owners/tests/test_owners.py`: per-team counts with the unowned fold, and the `@handle` skip. Reverting either behavior fails them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code; layer 2 of stack #92563. Skills invoked: /stacking-prs, /writing-dataclasses, /writing-tests, /writing-code-comments, /writing-pr-descriptions.

https://claude.ai/code/session_01DzajHrMQxBN3nEspvVJUan
