### PR TITLE
chore(signals): trim canonical scout descriptions to cut plugin tokens

### DIFF
--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -2,8 +2,7 @@
 name: signals-scout-ai-observability
 description: >
   Signals scout for PostHog AI observability. Watches LLM traces for cost, latency, error,
-  volume, and eval-performance regressions, sliced by the dimensions it discovers over time,
-  and files each validated regression as a report in the inbox.
+  volume, and eval-performance regressions.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only analytics plus signal_scout_internal:write (for scratchpad) +

--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: signals-scout-anomaly-detection
 description: >
-  Signals scout that watches a project's most-viewed dashboards and insights for recent
-  anomalies — bursts, drops, flat-lines, and trend breaks scored against each insight's own
-  seasonality-matched baseline. Files each anomaly as a finished 1:1 inbox report on the
-  report channel (emit_report / edit_report) rather than a weak signal.
+  Signals scout that watches the project's most-viewed dashboards and insights for anomalies —
+  bursts, drops, flat-lines, and trend breaks — against each insight's own seasonality-matched
+  baseline.
 compatibility: >
   Runs as the PostHog Signals scout in a Claude sandbox with read-only analytics scopes
   plus signal_scout_internal:write (scratchpad), signal_scout_report:write (the report

--- a/products/signals/skills/signals-scout-apm/SKILL.md
+++ b/products/signals/skills/signals-scout-apm/SKILL.md
@@ -1,10 +1,8 @@
 ---
 name: signals-scout-apm
 description: >
-  Signals scout for PostHog distributed tracing (APM / OpenTelemetry spans). Watches RED
-  metrics per (service, operation) — error rate, p95 latency, request volume — for
-  regressions, new error signatures, and traffic cliffs, and files each validated regression
-  as a report in the inbox.
+  Signals scout for PostHog distributed tracing (APM / OpenTelemetry spans). Watches per-service
+  RED metrics for error-rate and latency regressions, new error signatures, and traffic cliffs.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the apm-* tool family

--- a/products/signals/skills/signals-scout-conversations/SKILL.md
+++ b/products/signals/skills/signals-scout-conversations/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: signals-scout-conversations
 description: >
-  Signals scout for the PostHog Conversations (support inbox) product. Watches the
-  `$conversation_*` ticket-lifecycle events for support-delivery regressions — SLA
-  breach-rate steps, first-response latency blowouts, backlog inflow-vs-resolution
-  imbalance, and channel / assignment concentration — and files each dated regression
-  as a report. Complements the per-ticket product-feedback signals the emission pipeline
-  already fires; does not re-surface individual ticket content.
+  Signals scout for PostHog Conversations (support inbox). Watches `$conversation_*` ticket-
+  lifecycle events for SLA breach steps, first-response latency blowouts, backlog imbalance, and
+  channel or assignment concentration.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus `execute-sql` over the

--- a/products/signals/skills/signals-scout-csp-violations/SKILL.md
+++ b/products/signals/skills/signals-scout-csp-violations/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: signals-scout-csp-violations
 description: >
-  Signals scout for Content Security Policy violation reports. Watches `$csp_violation` events
-  for blocked-URL clusters, per-directive bursts, post-deploy regressions, and suspicious
-  third-party domains, and files each validated cluster as a report in the inbox. Also files
-  occasional advisory reports on policy posture: enforcement readiness, inline-script debt,
-  and reporting noise budget.
+  Signals scout for Content Security Policy violations. Watches `$csp_violation` events for
+  blocked-URL clusters, per-directive bursts, post-deploy regressions, and suspicious third-
+  party domains.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the analytics tools in the

--- a/products/signals/skills/signals-scout-customer-analytics-billing-and-usage/SKILL.md
+++ b/products/signals/skills/signals-scout-customer-analytics-billing-and-usage/SKILL.md
@@ -2,11 +2,8 @@
 name: signals-scout-customer-analytics-billing-and-usage
 description: >
   Signals scout for per-account product-mix shifts. Watches each staked account's usage and
-  forecasted MRR at the product grain for one product dropping or spiking against its own
-  same-weekday trailing baseline while the account total holds — the shape account-level
-  monitoring is blind to. Sweeps account notes, channel summaries, and synced comms for a
-  planned-change explanation before filing, and files each validated shift as a report in the
-  inbox.
+  forecasted MRR per product for one product dropping or spiking against its own baseline while
+  the account total holds.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only analytics plus signal_scout_internal:write (scratchpad) +

--- a/products/signals/skills/signals-scout-customer-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-customer-analytics/SKILL.md
@@ -3,8 +3,7 @@ name: signals-scout-customer-analytics
 description: >
   Signals scout for PostHog Customer analytics (Accounts). Watches per-account engagement for
   churn-risk shapes — engagement cliffs, dormancy, champion departure — and the expansion
-  inverse, weighted by commercial ownership, and files each validated risk as a report in the
-  inbox.
+  inverse.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the customer-analytics tools

--- a/products/signals/skills/signals-scout-data-pipelines/SKILL.md
+++ b/products/signals/skills/signals-scout-data-pipelines/SKILL.md
@@ -2,9 +2,8 @@
 name: signals-scout-data-pipelines
 description: >
   Signals scout for PostHog data pipelines — CDP destinations and transformations, batch
-  exports, and hog flows. Watches for delivery failures, degraded functions, and stalled
-  exports against each pipeline's baseline, and files each validated delivery contradiction
-  as a report in the inbox.
+  exports, and hog flows. Watches for delivery failures, degraded functions, and stalled exports
+  against each pipeline's baseline.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the CDP function, batch

--- a/products/signals/skills/signals-scout-data-warehouse/SKILL.md
+++ b/products/signals/skills/signals-scout-data-warehouse/SKILL.md
@@ -1,17 +1,9 @@
 ---
 name: signals-scout-data-warehouse
 description: >
-  Focused Signals scout for PostHog projects importing external data into the warehouse.
-  Watches the import side — external data sources, per-table sync schemas, webhook push
-  channels, and materialized views — for the moments an import quietly stops keeping its
-  promise: a source connection in Error, a schema Failed or stuck Running, silent
-  staleness behind a green Completed status, a broken webhook push channel, a row-volume
-  cliff, and failed materialized views. When armed imports are healthy, switches to the
-  optimization lane: reads the per-team `query_log` table for recurring, multi-user query
-  time and read-bytes concentrated on warehouse tables or repeated query shapes, filing
-  materialization candidates and unused matviews as P3 suggestions. Files each validated
-  import contradiction as an inbox report; otherwise writes durable memory and closes out
-  empty.
+  Signals scout for warehouse imports. Watches external data sources, sync schemas, webhook push
+  channels, and materialized views for failures, silent staleness, and row-volume cliffs, and
+  suggests materialization candidates from recurring query-log hot spots.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the external-data

--- a/products/signals/skills/signals-scout-error-tracking/SKILL.md
+++ b/products/signals/skills/signals-scout-error-tracking/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: signals-scout-error-tracking
 description: >
-  Signals scout for PostHog error tracking. Watches `$exception` bursts, stuck loops,
-  multi-fingerprint clusters, and status regressions, and files each validated issue as a
-  report in the inbox.
+  Signals scout for PostHog error tracking. Watches `$exception` bursts, stuck loops, multi-
+  fingerprint clusters, and status regressions.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the error-tracking tools in

--- a/products/signals/skills/signals-scout-experiments/SKILL.md
+++ b/products/signals/skills/signals-scout-experiments/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: signals-scout-experiments
 description: >
-  Signals scout for PostHog A/B experiments. Watches running experiments for validity threats
-  (sample ratio mismatch, contamination, exposure stalls, mid-run flag mutations) and
-  lifecycle drift (zombies, decided-but-running), and files each validated validity threat as
-  a report in the inbox.
+  Signals scout for PostHog A/B experiments. Watches running experiments for validity threats —
+  sample ratio mismatch, contamination, exposure stalls, mid-run flag mutations — and lifecycle
+  drift.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the experiments,

--- a/products/signals/skills/signals-scout-feature-flags/SKILL.md
+++ b/products/signals/skills/signals-scout-feature-flags/SKILL.md
@@ -3,7 +3,7 @@ name: signals-scout-feature-flags
 description: >
   Signals scout for PostHog feature flags. Watches the flag roster and the
   `$feature_flag_called` stream for evaluation cliffs, ghost flags, response-distribution
-  shifts, and flag debt, and files each validated contradiction as a report in the inbox.
+  shifts, and flag debt.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the feature-flag and

--- a/products/signals/skills/signals-scout-health-checks/SKILL.md
+++ b/products/signals/skills/signals-scout-health-checks/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: signals-scout-health-checks
 description: >
-  Signals scout over PostHog's own health checks. Reads the project's active health issues,
-  bundles them by kind, weights by blast radius, and files the ones genuinely worth acting on
-  as reports in the inbox.
+  Signals scout over PostHog's own health checks. Bundles the project's active health issues by
+  kind, weights them by blast radius, and surfaces the ones worth acting on.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the health-issues read tools

--- a/products/signals/skills/signals-scout-inbox-validation/SKILL.md
+++ b/products/signals/skills/signals-scout-inbox-validation/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: signals-scout-inbox-validation
 description: >
-  Follow-up Signals scout for the inbox itself. After a deployment soak window, re-measures
-  the problems behind recently resolved reports and files a report when a fix didn't hold,
-  plus a gated escalation check on dismissed reports.
+  Follow-up Signals scout for the inbox itself. Re-measures the problems behind recently
+  resolved reports after a soak window and reports when a fix didn't hold, plus a gated
+  escalation check on dismissed reports.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus inbox-reports-list /

--- a/products/signals/skills/signals-scout-insight-alerts/SKILL.md
+++ b/products/signals/skills/signals-scout-insight-alerts/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: signals-scout-insight-alerts
 description: >
-  Signals scout over a project's own configured insight alerts. Reads each alert's recent
-  firing history and files a report for the firings a human likely missed — especially ones
-  the standard notification path stayed silent on.
+  Signals scout over the project's configured insight alerts. Reads each alert's recent firing
+  history and surfaces the firings a human likely missed.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the alert tools (alerts-list,

--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: signals-scout-logs
 description: >
-  Signals scout for PostHog logs. Watches for emerging and rate-shifted message patterns
-  (window-over-window deltas), volume bursts, severity-distribution shifts, service
-  silence, and trace-correlated bursts.
+  Signals scout for PostHog logs. Watches for emerging and rate-shifted message patterns, volume
+  bursts, severity-distribution shifts, service silence, and trace-correlated bursts.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only analytics plus signal_scout_internal:write (for scratchpad) +

--- a/products/signals/skills/signals-scout-mcp-tool-calls/SKILL.md
+++ b/products/signals/skills/signals-scout-mcp-tool-calls/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: signals-scout-mcp-tool-calls
 description: >
-  Signals scout for PostHog MCP tool calls. Watches $mcp_tool_call telemetry for tools that
-  need improvement — high, broad-reach failure rates, retry/hammering that betrays a confusing
-  schema, slow or context-bloating responses — groups problem tools by $mcp_tool_category (the
-  owning product team) and files one report per problem category listing that category's
-  problem tools each with a fix suggestion; falls back to one report per tool where category
-  coverage is absent. Immediately-actionable reports carry a fix-loop metric (measurement query,
-  baseline, goal) so the auto-started implementation task iterates until the number moves.
-  Otherwise writes durable memory and closes out empty. Adapts to which fields the project
-  actually captures.
+  Signals scout for PostHog MCP tool calls. Watches `$mcp_tool_call` telemetry for tools that
+  need improvement — broad-reach failure rates, retry hammering, slow or context-bloating
+  responses — grouped by owning product category, each with a fix suggestion.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus execute-sql,

--- a/products/signals/skills/signals-scout-observability-gaps/SKILL.md
+++ b/products/signals/skills/signals-scout-observability-gaps/SKILL.md
@@ -2,8 +2,7 @@
 name: signals-scout-observability-gaps
 description: >
   Signals scout for observability gaps — significant event volumes with no insight, dashboard,
-  or alert coverage. Files a report recommending new insights, dashboards, or alerts as the
-  team's product evolves.
+  or alert coverage. Recommends new insights, dashboards, or alerts as the product evolves.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the analytics and entity

--- a/products/signals/skills/signals-scout-product-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-product-analytics/SKILL.md
@@ -2,8 +2,7 @@
 name: signals-scout-product-analytics
 description: >
   Signals scout for core product-analytics flows — funnels, retention, lifecycle, stickiness,
-  and paths. Watches the team's saved flows for a derived-rate regression (conversion or
-  retention sliding) while entrants hold, and files it as a report in the inbox.
+  and paths. Watches the team's saved flows for a derived-rate regression while entrants hold.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only analytics plus signal_scout_internal:write (for scratchpad) +

--- a/products/signals/skills/signals-scout-replay-vision/SKILL.md
+++ b/products/signals/skills/signals-scout-replay-vision/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: signals-scout-replay-vision
 description: >
-  Signals scout for PostHog Replay Vision scanners. Watches that enabled scanners keep
-  observing (throughput / quota cliffs) and that what they see in aggregate gets surfaced
-  (score shifts, recurring themes across sessions), and files each validated finding as a
-  report in the inbox.
+  Signals scout for PostHog Replay Vision scanners. Watches that enabled scanners keep observing
+  (throughput and quota cliffs) and that aggregate score shifts and recurring themes get
+  surfaced.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the replay-vision tools in

--- a/products/signals/skills/signals-scout-revenue-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-revenue-analytics/SKILL.md
@@ -2,8 +2,7 @@
 name: signals-scout-revenue-analytics
 description: >
   Signals scout for PostHog revenue analytics. Watches for upstream failures (Stripe sync
-  stalls, capture regressions), config drift, and goal-miss escalations, and files each
-  validated finding as a report in the inbox.
+  stalls, capture regressions), config drift, and goal-miss escalations.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only analytics plus signal_scout_internal:write (for scratchpad) +

--- a/products/signals/skills/signals-scout-session-replay/SKILL.md
+++ b/products/signals/skills/signals-scout-session-replay/SKILL.md
@@ -2,9 +2,8 @@
 name: signals-scout-session-replay
 description: >
   Signals scout for PostHog session replay. Watches that sessions keep recording (capture
-  cliffs) and that friction inside recordings — rage/dead-click clusters,
-  error-after-interaction cohorts — gets surfaced, and files each validated cliff or cluster
-  as a report in the inbox.
+  cliffs) and surfaces friction inside recordings — rage/dead-click clusters, error-after-
+  interaction cohorts.
 compatibility: >
   PostHog Signals agent (Claude sandbox). Read-only analytics + signal_scout_internal:write
   (scratchpad) + signal_scout_report:write (report channel), plus the session-replay tools in

--- a/products/signals/skills/signals-scout-skills-store/SKILL.md
+++ b/products/signals/skills/signals-scout-skills-store/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: signals-scout-skills-store
 description: >
-  Skill-hygiene scout for the team's PostHog skills store, read entirely via the MCP skill tools.
-  Watches recently-changed skills — plus a slow rotation over the most-used, highest-leverage ones — for statically-verifiable authoring violations:
-  vague descriptions, bloated bodies, dead bundled-file links, kitchen-sink scope, committed secrets.
-  Files each non-compliant skill as a report in the inbox, with the copy-ready fix inside.
+  Skill-hygiene scout for the team's PostHog skills store. Watches recently-changed and most-
+  used skills for authoring violations — vague descriptions, bloated bodies, dead file links,
+  kitchen-sink scope, committed secrets.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only plus signal_scout_internal:write (for scratchpad) + signal_scout_report:write (for emit-report/edit-report, granted because this scout authors reports directly via the report channel).

--- a/products/signals/skills/signals-scout-surveys/SKILL.md
+++ b/products/signals/skills/signals-scout-surveys/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: signals-scout-surveys
 description: >
-  Signals scout for PostHog surveys. Watches active surveys for score regressions,
-  response-volume drops, abandonment spikes, and targeting drift, and aggregates open-text
-  responses into recurring themes — filing each as a report in the inbox.
+  Signals scout for PostHog surveys. Watches active surveys for score regressions, response-
+  volume drops, abandonment spikes, and targeting drift, and aggregates open-text responses into
+  recurring themes.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only analytics plus signal_scout_internal:write (for scratchpad) +

--- a/products/signals/skills/signals-scout-tasks/SKILL.md
+++ b/products/signals/skills/signals-scout-tasks/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: signals-scout-tasks
 description: >
-  Signals scout for PostHog Tasks, the agent work items a project runs. Two lenses: delivery health
-  (runs failing, clustered by repository and error class, and retry storms) every run, and on a slower
-  rotation demand (recurring asks across human-authored tasks that point at a product gap). Skips the
-  scout fleet's own run rows.
+  Signals scout for PostHog Tasks. Watches delivery health — failing runs clustered by
+  repository and error class, retry storms — and, on a slower rotation, recurring demand across
+  human-authored tasks. Skips the scout fleet's own runs.
 allowed_tools:
   - emit_report
   - edit_report

--- a/products/signals/skills/signals-scout-web-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-web-analytics/SKILL.md
@@ -2,9 +2,8 @@
 name: signals-scout-web-analytics
 description: >
   Signals scout for PostHog web traffic. Watches per-channel session volume, attribution
-  breakage, and landing-page health (bounce / 404 steps) against the site's own baseline, and
-  files each validated divergence as a report in the inbox. Per-page web vitals have their own
-  dedicated `signals-scout-web-vitals`.
+  breakage, and landing-page health (bounce and 404 steps) against the site's own baseline. Per-
+  page web vitals belong to `signals-scout-web-vitals`.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only analytics plus signal_scout_internal:write (for scratchpad) +

--- a/products/signals/skills/signals-scout-web-vitals/SKILL.md
+++ b/products/signals/skills/signals-scout-web-vitals/SKILL.md
@@ -1,18 +1,9 @@
 ---
 name: signals-scout-web-vitals
 description: >
-  Focused Signals scout for PostHog projects capturing Core Web Vitals (`$web_vitals`).
-  Watches each page's p75 LCP / INP / CLS / FCP against the absolute Google thresholds
-  (good / needs-improvement / poor) and against its own history: pages standing in the
-  poor band, pages crossing a band boundary after a deploy, and sharp in-band
-  regressions. Reads the historical trajectory — not just the moment a value changes —
-  so a page that is steadily slow surfaces even when nothing moved today. Dates a
-  regression to a sub-hour boundary and correlates it with the project's own deploy
-  markers and feature flag rollouts, confirming a flag or variant cause by splitting the
-  metric on it. Every finding carries a metric-specific cause hypothesis and a concrete
-  remediation, filed as a report in the inbox only above the confidence bar; otherwise
-  writes durable memory and closes out empty. Self-contained peer in the
-  signals-scout-* fleet.
+  Signals scout for Core Web Vitals (`$web_vitals`). Watches each page's p75 LCP / INP / CLS /
+  FCP against Google's thresholds and its own history — poor-band pages, band crossings, sharp
+  regressions — and dates each regression against deploys and flag rollouts.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
   read-only analytics plus signal_scout_internal:write (for scratchpad) +


### PR DESCRIPTION
## Problem

Every canonical scout's frontmatter `description` loads into users' agents together through the AI plugin's skill listing, so wordy descriptions spend the user's context budget on boilerplate. Claude Code [caps that listing at ~1% of the context window](https://code.claude.com/docs/en/skills#skill-descriptions-are-cut-short) and shortens or drops descriptions when it overflows.

Descriptions grew back after the last trim (#66977): the fleet totaled ~9.6k characters, with three scouts over 700 (`web-vitals` at 930, `data-warehouse` at 868, `mcp-tool-calls` at 745).

## Changes

- Rewrites 27 scout descriptions down to the bar the `authoring-scouts` skill sets: a sentence or two naming the surface and the shapes it watches.
- Cuts the per-scout copies of fleet-wide boilerplate ("files each validated X as a report in the inbox", durable-memory and close-out notes, "self-contained peer").
- Fleet total drops from ~9.6k to ~5.3k characters. The longest description drops from 930 to 260.
- Mechanical throughout: only frontmatter `description` fields change. Scout bodies, tools, and schedules are untouched, so run behavior does not change.
- `signals-scout-general` (138 chars) stays as-is.

No UI change.

<details>
<summary>Per-scout description length, before → after</summary>

| Scout | Before | After |
|---|---:|---:|
| web-vitals | 930 | 260 |
| data-warehouse | 868 | 258 |
| mcp-tool-calls | 745 | 255 |
| conversations | 475 | 221 |
| customer-analytics-billing-and-usage | 451 | 208 |
| skills-store | 431 | 221 |
| csp-violations | 389 | 194 |
| anomaly-detection | 332 | 195 |
| tasks | 326 | 234 |
| web-analytics | 309 | 234 |
| experiments | 290 | 194 |
| data-pipelines | 289 | 215 |
| apm | 284 | 188 |
| replay-vision | 281 | 191 |
| customer-analytics | 278 | 188 |
| session-replay | 276 | 196 |
| product-analytics | 257 | 184 |
| feature-flags | 248 | 183 |
| ai-observability | 241 | 130 |
| surveys | 241 | 202 |
| inbox-validation | 230 | 211 |
| insight-alerts | 226 | 148 |
| revenue-analytics | 217 | 158 |
| logs | 206 | 178 |
| health-checks | 206 | 168 |
| observability-gaps | 206 | 182 |
| error-tracking | 192 | 135 |
| general | 138 | 138 |

</details>

## How did you test this code?

- `hogli lint:skills` passes (validates frontmatter, including the description length cap).
- `hogli build:skills` passes.
- Not run: scout runs. The harness loads the skill body as the run prompt, not the description, so a description edit cannot change run behavior.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, directed by the assignee. Skills invoked: `/writing-skills`, `authoring-scouts` (plugin), `/writing-pr-descriptions`. The new descriptions were written fresh against each scout's existing frontmatter; no session-private material is in the diff.
