### PR TITLE
fix(replay-vision): validate session ids before scanning

### DIFF
--- a/ee/hogai/tools/replay/filter_session_recordings.py
+++ b/ee/hogai/tools/replay/filter_session_recordings.py
@@ -211,6 +211,12 @@ class FilterSessionRecordingsTool(MaxTool):
 
         parts = []
 
+        # The id is what downstream tools (e.g. scan_replay_vision_sessions) take as input, so the
+        # model must see it here rather than invent one.
+        session_id = recording.get("session_id")
+        if session_id:
+            parts.append(f"ID: {session_id}")
+
         # Person/distinct_id
         distinct_id = recording.get("distinct_id", "Unknown")
         parts.append(f"User: {distinct_id}")

--- a/ee/hogai/tools/replay/test/test_filter_session_recordings.py
+++ b/ee/hogai/tools/replay/test/test_filter_session_recordings.py
@@ -281,6 +281,7 @@ class TestFilterSessionRecordingsToolFormatting(NonAtomicBaseTest):
 
         tool = FilterSessionRecordingsTool(team=self.team, user=self.user)
         recording = {
+            "session_id": "0195e1c0-0000-7000-8000-000000000000",
             "distinct_id": "test_user",
             "start_time": datetime(2025, 1, 15, 10, 30, 0),
             "duration": 3665,  # 1h 1m 5s
@@ -295,6 +296,7 @@ class TestFilterSessionRecordingsToolFormatting(NonAtomicBaseTest):
 
         result = tool._format_recording_metadata(recording)
 
+        self.assertIn("ID: 0195e1c0-0000-7000-8000-000000000000", result)
         self.assertIn("User: test_user", result)
         self.assertIn("Started: 2025-01-15 10:30:00 UTC", result)
         self.assertIn("Duration: 1h 1m 5s", result)

--- a/products/replay_vision/backend/max_tools.py
+++ b/products/replay_vision/backend/max_tools.py
@@ -16,6 +16,7 @@ from posthog.exceptions import QuotaLimitExceeded
 from posthog.models.team import Team
 from posthog.models.user import User
 from posthog.scopes import APIScopeObject
+from posthog.session_recordings.queries.session_replay_events import SessionReplayEvents
 from posthog.sync import database_sync_to_async, database_sync_to_async_pool
 
 from products.access_control.backend.facade.user_access_control import AccessControlLevel, UserAccessControl
@@ -620,6 +621,13 @@ def _dedup(session_ids: list[str]) -> list[str]:
     return [s for s in dict.fromkeys(sid.strip() for sid in session_ids) if s]
 
 
+def _missing_sessions_sentence(missing: list[str]) -> str:
+    return (
+        f"{len(missing)} session id(s) have no recording in this project and were not scanned: "
+        f"{', '.join(missing)}. Only pass ids from a recordings list, page context, or the user."
+    )
+
+
 def _truncate(text: str, limit: int = 120) -> str:
     collapsed = " ".join(text.split())
     return collapsed if len(collapsed) <= limit else collapsed[: limit - 1] + "\u2026"
@@ -676,9 +684,14 @@ SCAN_SESSIONS_TOOL_DESCRIPTION = """
 Use this tool to have Replay Vision watch specific session recordings and answer a question about them.
 
 # When to use
-- The user has recordings in hand (from search_session_recordings, from context, or as explicit ids) and
-  asks what happened in them, whether something occurred, or to classify or score them
+- The user has recordings in hand (ids from a filter_session_recordings result, from page context, or
+  given explicitly by the user) and asks what happened in them, whether something occurred, or to
+  classify or score them
 - The user asks to run an existing scanner against particular sessions
+
+# Session ids
+Only pass ids you were given: from a recordings list result, from page context, or from the user.
+Never construct or guess ids. Ids with no recording behind them are rejected without being scanned.
 
 # How it works
 Each session is scanned by an LLM that watches the recording. Scanning costs credits from the project's
@@ -697,7 +710,10 @@ search_replay_vision_observations afterwards to read them.
 
 class ScanSessionsArgs(BaseModel):
     session_ids: list[str] = Field(
-        description="Session recording ids to scan. Ask the user rather than guessing if you don't have them."
+        description=(
+            "Session recording ids to scan. Only use ids you were given (a recordings list result, "
+            "page context, or the user); never construct or guess them. Ask the user if you have none."
+        )
     )
     prompt: str | None = Field(
         default=None,
@@ -777,10 +793,18 @@ class ScanReplayVisionSessionsTool(ReplayVisionGatesMixin, MaxTool):
             scanner = self._scanner_for(scanner_id)
             if scanner is None:
                 return f"Scanner {scanner_id} not found.", {"error": "not_found"}
+            sessions, missing = self._split_by_recording_existence(sessions)
+            if not sessions:
+                return f"Nothing started. {_missing_sessions_sentence(missing)}", {
+                    "error": "no_recordings_found",
+                    "unknown_session_ids": missing,
+                }
             started, results = scan_existing_scanner(scanner=scanner, session_ids=sessions, user=self._user)
             if any(result["scan_outcome"] == "skipped_scanner_limit" for result in results):
                 record_scanner_limit_reached("max_tool")
-            return _scan_summary(started, results), {"scan_id": str(scanner.id), "results": results}
+            return self._with_missing(
+                _scan_summary(started, results), {"scan_id": str(scanner.id), "results": results}, missing
+            )
 
         if not prompt or not prompt.strip():
             return "Pass either a prompt or a scanner_id.", {"error": "no_prompt"}
@@ -794,6 +818,12 @@ class ScanReplayVisionSessionsTool(ReplayVisionGatesMixin, MaxTool):
         message = scanner_config_error(ScannerType(resolved_type), config)
         if message is not None:
             return message, {"error": "invalid_config"}
+        sessions, missing = self._split_by_recording_existence(sessions)
+        if not sessions:
+            return f"Nothing started. {_missing_sessions_sentence(missing)}", {
+                "error": "no_recordings_found",
+                "unknown_session_ids": missing,
+            }
         scan = run_inline_scan(
             team=self._team,
             user=self._user,
@@ -807,7 +837,24 @@ class ScanReplayVisionSessionsTool(ReplayVisionGatesMixin, MaxTool):
                 "Nothing started: this project's monthly Replay Vision credits are used up.",
                 {"error": "quota_exhausted"},
             )
-        return _scan_summary(scan.started, scan.results), {"scan_id": str(scan.scanner.id), "results": scan.results}
+        return self._with_missing(
+            _scan_summary(scan.started, scan.results),
+            {"scan_id": str(scan.scanner.id), "results": scan.results},
+            missing,
+        )
+
+    def _split_by_recording_existence(self, sessions: list[str]) -> tuple[list[str], list[str]]:
+        """Checked here rather than trusted, because the model supplies the ids: a guessed or stale id
+        would otherwise start a workflow that fails minutes later as no_recording."""
+        existence = SessionReplayEvents().batch_exists(sessions, self._team)
+        return [s for s in sessions if existence.get(s)], [s for s in sessions if not existence.get(s)]
+
+    @staticmethod
+    def _with_missing(summary: str, artifact: dict[str, Any], missing: list[str]) -> tuple[str, dict[str, Any]]:
+        if missing:
+            summary = f"{summary} {_missing_sessions_sentence(missing)}"
+            artifact["unknown_session_ids"] = missing
+        return summary, artifact
 
 
 QUOTA_TOOL_DESCRIPTION = """

--- a/products/replay_vision/backend/tests/test_max_tools.py
+++ b/products/replay_vision/backend/tests/test_max_tools.py
@@ -60,6 +60,13 @@ _GENERATE_EMBEDDING_PATH = "products.replay_vision.backend.max_tools.async_gener
 _EXECUTE_HOGQL_PATH = "products.replay_vision.backend.search.execute_hogql_query"
 
 
+def _recordings_exist(existing: set[str]):
+    return patch(
+        "products.replay_vision.backend.max_tools.SessionReplayEvents.batch_exists",
+        side_effect=lambda session_ids, team: {sid: sid in existing for sid in session_ids},
+    )
+
+
 class TestDraftReplayVisionScannerPromptTool(BaseTest):
     def _tool(self, context: dict | None = None) -> DraftReplayVisionScannerPromptTool:
         configurable: dict = {"team": self.team, "user": self.user}
@@ -566,7 +573,10 @@ class TestScanReplayVisionSessionsScannerLimit(BaseTest):
         # Without the sentence and the metric, the user just sees fewer scans started and nothing
         # records that the scanner's own limit was the reason.
         scanner = await sync_to_async(self._capped_scanner)()
-        with patch("products.replay_vision.backend.max_tools.record_scanner_limit_reached") as record:
+        with (
+            patch("products.replay_vision.backend.max_tools.record_scanner_limit_reached") as record,
+            _recordings_exist({"s1", "s2"}),
+        ):
             content, artifact = await self._tool()._arun_impl(session_ids=["s1", "s2"], scanner_id=str(scanner.id))
 
         assert {r["scan_outcome"] for r in artifact["results"]} == {"skipped_scanner_limit"}
@@ -589,12 +599,60 @@ class TestScanReplayVisionSessionsScannerLimit(BaseTest):
             patch("products.replay_vision.backend.api.trigger.sync_connect", MagicMock()),
             patch("products.replay_vision.backend.api.trigger.async_to_sync", return_value=start),
             patch("products.replay_vision.backend.max_tools.record_scanner_limit_reached") as record,
+            _recordings_exist({"s1"}),
         ):
             content, artifact = await self._tool()._arun_impl(session_ids=["s1"], scanner_id=str(scanner.id))
 
         assert [r["scan_outcome"] for r in artifact["results"]] == ["started"]
         assert "credit limit" not in content
         record.assert_not_called()
+
+
+class TestScanReplayVisionSessionsExistence(BaseTest):
+    """Ids the model guessed (or that lost their recording) must fail here, not minutes later in the workflow."""
+
+    def _tool(self) -> ScanReplayVisionSessionsTool:
+        config: RunnableConfig = {"configurable": {"team": self.team, "user": self.user}}
+        return ScanReplayVisionSessionsTool(team=self.team, user=self.user, config=config)
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_ids_without_recordings_start_nothing(self):
+        start = MagicMock()
+        with (
+            patch("products.replay_vision.backend.api.trigger.sync_connect", MagicMock()),
+            patch("products.replay_vision.backend.api.trigger.async_to_sync", return_value=start),
+            _recordings_exist(set()),
+        ):
+            content, artifact = await self._tool()._arun_impl(session_ids=["s1", "s2"], prompt="did it fail?")
+
+        assert artifact["error"] == "no_recordings_found"
+        assert artifact["unknown_session_ids"] == ["s1", "s2"]
+        assert "s1, s2" in content
+        start.assert_not_called()
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_only_ids_with_recordings_are_scanned(self):
+        scanner = await sync_to_async(ReplayScanner.objects.create)(
+            team=self.team,
+            name="checkout",
+            scanner_type=ScannerType.MONITOR,
+            scanner_config={"prompt": "p"},
+            model=ScannerModel.GEMINI_3_7_FLASH,
+        )
+        start = MagicMock(return_value=MagicMock())
+        with (
+            patch("products.replay_vision.backend.api.trigger.sync_connect", MagicMock()),
+            patch("products.replay_vision.backend.api.trigger.async_to_sync", return_value=start),
+            _recordings_exist({"s1"}),
+        ):
+            content, artifact = await self._tool()._arun_impl(session_ids=["s1", "s2"], scanner_id=str(scanner.id))
+
+        assert [r["session_id"] for r in artifact["results"]] == ["s1"]
+        assert artifact["unknown_session_ids"] == ["s2"]
+        assert "s2" in content
+        assert start.call_count == 1
 
 
 class TestCreateReplayVisionScannerTool(BaseTest):
@@ -897,6 +955,7 @@ class TestReplayVisionApprovalFlowEndToEnd(BaseTest):
                 "ee.hogai.tool.interrupt",
                 return_value=self._resume("approve", payload={"session_ids": ["s1"], "scanner_id": str(scanner.id)}),
             ),
+            _recordings_exist({"s1", "s2", "s3"}),
         ):
             _, artifact = await self._tool(ScanReplayVisionSessionsTool)._arun_with_context(
                 session_ids=["s1", "s2", "s3"], scanner_id=str(scanner.id)


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

Asking Max to scan recordings of "people who did X" starts scans that all fail minutes later with "No replay metadata found".
No tool in the session replay mode returns session ids, so Max invents plausible-looking ids, and the scan tool starts a Temporal workflow per id without checking any of them.

## Changes

- The scan tool now checks ids against `session_replay_events` before starting. Ids with no recording are named back to the model instead of scanned, so it can correct itself.
- `filter_session_recordings` output now leads each recording with its session id, giving Max a real id source.
- Mechanical: the scan tool description and `session_ids` field description now name the real id sources and forbid guessing (previously pointed at `search_session_recordings`, which returns no ids).

## How did you test this code?

- New tests: a batch of unknown ids starts nothing and returns them; a mixed batch scans only ids with recordings and names the rest. No existing test covered a nonexistent id.
- Extended the formatting test to pin the session id in the recordings list output.
👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
