### PR TITLE
chore(experiments): product folder migration stats method modal

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/SettingsTab.tsx
@@ -11,13 +11,13 @@ import { ExperimentStatsMethod, PropertyFilterType, PropertyOperator } from '~/t
 
 import { DEFAULT_LOOKBACK_DAYS } from 'products/experiments/frontend/constants'
 import { CupedModal } from 'products/experiments/frontend/modals/CupedModal/CupedModal'
+import { StatsMethodModal } from 'products/experiments/frontend/modals/StatsMethodModal/StatsMethodModal'
 
 import { experimentLogic } from '../experimentLogic'
 import { modalsLogic } from '../modalsLogic'
 import { getBaselineVariantKey } from '../utils'
 import { getCupedSelection, resolveCupedEnabled, resolveCupedLookbackDays } from './cuped'
 import { resolveSequentialEnabled } from './sequential'
-import { StatsMethodModal } from './StatsMethodModal'
 
 export function SettingsTab(): JSX.Element {
     const { experiment, statsMethod, variants } = useValues(experimentLogic)

--- a/products/experiments/frontend/modals/StatsMethodModal/StatsMethodModal.tsx
+++ b/products/experiments/frontend/modals/StatsMethodModal/StatsMethodModal.tsx
@@ -3,22 +3,21 @@ import { useActions, useValues } from 'kea'
 import { LemonButton, LemonInput, LemonLabel, LemonSelect } from '@posthog/lemon-ui'
 import { LemonModal } from '@posthog/lemon-ui'
 
-import { experimentsConfigLogic } from 'scenes/settings/environment/experimentsConfigLogic'
-
-import { ExperimentStatsMethod } from '~/types'
-
-import { CONFIDENCE_LEVEL_OPTIONS } from 'products/experiments/frontend/constants'
-
-import { StatsMethodSelector } from '../components/StatsMethodSelector'
-import { experimentLogic } from '../experimentLogic'
-import { modalsLogic } from '../modalsLogic'
+import { StatsMethodSelector } from 'scenes/experiments/components/StatsMethodSelector'
+import { experimentLogic } from 'scenes/experiments/experimentLogic'
 import {
     DEFAULT_SEQUENTIAL_TUNING_PARAMETER,
     MAX_SEQUENTIAL_TUNING_PARAMETER,
     SequentialSelection,
     getSequentialSelection,
     resolveSequentialTuningParameter,
-} from './sequential'
+} from 'scenes/experiments/ExperimentView/sequential'
+import { modalsLogic } from 'scenes/experiments/modalsLogic'
+import { experimentsConfigLogic } from 'scenes/settings/environment/experimentsConfigLogic'
+
+import { ExperimentStatsMethod } from '~/types'
+
+import { CONFIDENCE_LEVEL_OPTIONS } from 'products/experiments/frontend/constants'
 
 export function StatsMethodModal(): JSX.Element {
     const { experiment, statsMethod } = useValues(experimentLogic)


### PR DESCRIPTION
## Problem

The stats method modal still lives under `frontend/src/scenes/experiments`. It belongs in the experiments product folder.

## Changes

Mechanical move of the stats method modal to `products/experiments/frontend/modals`. Its logic and test move with it. All importers now use `products/` or `scenes/` aliases, no `../`. No behavior change.

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest products/experiments/frontend/modals frontend/src/scenes/experiments
```

![cat-type-small](https://github.com/user-attachments/assets/f3d67867-fa92-418c-ae2a-dd682359d7fa)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /stacking-prs (local)
- /writing-ui-components (local)
- /writing-pull-requests (local)

Relevant decisions:

- One modal per stacked PR, so each review stays small and mechanical.
- Each modal lands in its own `products/experiments/frontend/modals/<Name>/` folder with colocated logic and test.