### PR TITLE
chore(experiments): product folder migration details modal

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -56,6 +56,7 @@ import {
 import { Experiment, InsightType, BreakdownAttributionType } from '~/types'
 
 import { isLaunched } from 'products/experiments/frontend/experimentStatus'
+import { DetailsModal } from 'products/experiments/frontend/modals/DetailsModal/DetailsModal'
 
 import { ChartCell } from './ChartCell'
 import {
@@ -69,7 +70,6 @@ import {
     VIEW_BOX_WIDTH,
 } from './constants'
 import { DetailsButton } from './DetailsButton'
-import { DetailsModal } from './DetailsModal'
 import { GridLines } from './GridLines'
 import { renderTooltipContent } from './MetricRowGroupTooltip'
 import { TimeseriesModal } from './TimeseriesModal'

--- a/products/experiments/frontend/modals/DetailsModal/DetailsModal.tsx
+++ b/products/experiments/frontend/modals/DetailsModal/DetailsModal.tsx
@@ -1,9 +1,9 @@
 import { LemonButton, LemonModal } from '@posthog/lemon-ui'
 
+import { ResultDetails } from 'scenes/experiments/MetricsView/new/ResultDetails'
+
 import { ExperimentFunnelsQuery, ExperimentMetric, ExperimentTrendsQuery } from '~/queries/schema/schema-general'
 import type { Experiment } from '~/types'
-
-import { ResultDetails } from './ResultDetails'
 
 interface DetailsModalProps {
     isOpen: boolean


### PR DESCRIPTION
## Problem

The details modal still lives under `frontend/src/scenes/experiments`. It belongs in the experiments product folder.

## Changes

Mechanical move of the details modal to `products/experiments/frontend/modals`. Its logic and test move with it. All importers now use `products/` or `scenes/` aliases, no `../`. No behavior change.

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend jest products/experiments/frontend/modals frontend/src/scenes/experiments
```

![cat-type-small](https://github.com/user-attachments/assets/a2d81976-6904-4c0b-ae49-263a8ce9c635)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /stacking-prs (local)
- /writing-ui-components (local)
- /writing-pull-requests (local)

Relevant decisions:

- One modal per stacked PR, so each review stays small and mechanical.
- Each modal lands in its own `products/experiments/frontend/modals/<Name>/` folder with colocated logic and test.