### PR TITLE
feat(experiments): add endpoint for experiment running-time estimates

### DIFF
--- a/products/experiments/backend/facade/api.py
+++ b/products/experiments/backend/facade/api.py
@@ -5,6 +5,8 @@ This module provides the public interface for creating and managing experiments
 using framework-free DTOs, wrapping the existing ExperimentService.
 """
 
+from collections.abc import Iterable
+
 from rest_framework.exceptions import ValidationError
 
 from posthog.models.team import Team
@@ -12,6 +14,8 @@ from posthog.models.user import User
 
 from products.experiments.backend.experiment_service import ExperimentService
 from products.experiments.backend.models.experiment import Experiment as ExperimentModel
+from products.experiments.backend.running_time_calculator import RunningTimeEstimate
+from products.experiments.backend.running_time_estimate_service import compute_running_time_estimate
 
 from .contracts import CreateExperimentInput, Experiment
 
@@ -87,6 +91,15 @@ def create_experiment(*, team: Team, user: User, input_dto: CreateExperimentInpu
 
     # Convert model to DTO
     return _experiment_model_to_dto(experiment_model)
+
+
+def get_running_time_estimates(experiments: Iterable[ExperimentModel]) -> dict[str, RunningTimeEstimate]:
+    """Running-time estimate per experiment, keyed by id, for the caller's already team-scoped experiments.
+
+    Reads a short-lived cache and, in automatic mode, the latest metric result. The caller owns team
+    scoping; this only computes over the experiments it is handed.
+    """
+    return {str(experiment.id): compute_running_time_estimate(experiment) for experiment in experiments}
 
 
 def _experiment_model_to_dto(experiment: ExperimentModel) -> Experiment:

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -1578,6 +1578,32 @@ class RunningTimeCalculationResultSerializer(serializers.Serializer):
     )
 
 
+class RunningTimeEstimateSerializer(serializers.Serializer):
+    """Derived running-time state for one experiment, computed from its live results or manual config."""
+
+    target_sample_size = serializers.IntegerField(
+        allow_null=True,
+        help_text="Recommended total sample size across all variants. Null when inputs are insufficient.",
+    )
+    current_exposures = serializers.IntegerField(
+        allow_null=True,
+        help_text="Exposed users so far across control and variants. Null in manual mode or when no results exist.",
+    )
+    remaining_days = serializers.IntegerField(
+        allow_null=True,
+        help_text="Estimated days left to reach the target sample size. Null when it cannot be estimated.",
+    )
+
+
+class RunningTimeEstimatesResponseSerializer(serializers.Serializer):
+    """Batch running-time estimates keyed by experiment id."""
+
+    results = serializers.DictField(
+        child=RunningTimeEstimateSerializer(),
+        help_text="Estimates keyed by experiment id. Requested ids with no matching experiment are omitted.",
+    )
+
+
 class ExperimentSessionMetricSourceHitSerializer(serializers.Serializer):
     """One event/action source of a metric with at least one matching event in a session recording."""
 

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -1409,7 +1409,9 @@ class EnterpriseExperimentsViewSet(
         if not ids:
             return Response({"results": {}})
 
-        experiments = self.get_queryset().filter(id__in=ids)
+        # detail=False actions skip the list action's object-level ACL filtering, so filter explicitly.
+        # Otherwise a project member could read running-time data for an experiment they cannot view.
+        experiments = self.user_access_control.filter_queryset_by_access_level(self.get_queryset().filter(id__in=ids))
         estimates = experiments_facade.get_running_time_estimates(experiments)
         results = {
             experiment_id: RunningTimeEstimateSerializer(estimate).data for experiment_id, estimate in estimates.items()

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -55,6 +55,7 @@ from products.access_control.backend.facade.user_access_control import UserAcces
 from products.access_control.backend.presentation.access_control import AccessControlViewSetMixin
 from products.approvals.backend.mixins import ApprovalHandlingMixin
 from products.experiments.backend.experiment_service import ExperimentService, ExperimentVersionConflict
+from products.experiments.backend.facade import api as experiments_facade
 from products.experiments.backend.llm_metric_templates import build_template, list_templates
 
 # TODO: Route through facade instead of direct import
@@ -88,6 +89,8 @@ from products.experiments.backend.presentation.serializers import (
     RecalculateMetricsRequestSerializer,
     RunningTimeCalculationInputSerializer,
     RunningTimeCalculationResultSerializer,
+    RunningTimeEstimateSerializer,
+    RunningTimeEstimatesResponseSerializer,
     ShipVariantSerializer,
 )
 from products.experiments.backend.recalculation import (
@@ -150,6 +153,27 @@ LIST_DEFERRED_FIELDS = (
 # `list[str]` annotation there resolves to that method (a runtime crash, and a mypy error).
 # Reference this module-level alias instead.
 RequiredScopes = list[str]
+
+# Cap the batch so one request can't fan out an unbounded number of per-experiment reads.
+MAX_RUNNING_TIME_ESTIMATE_IDS = 100
+
+
+def _parse_experiment_ids(ids_param: str | None) -> list[int]:
+    """Parse a comma-separated experiment-id query param, skipping blanks and non-integers."""
+    if not ids_param:
+        return []
+    parsed: list[int] = []
+    for raw in ids_param.split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            parsed.append(int(raw))
+        except ValueError:
+            continue
+        if len(parsed) >= MAX_RUNNING_TIME_ESTIMATE_IDS:
+            break
+    return parsed
 
 
 def flag_evaluation_contexts_prefetch() -> Prefetch:
@@ -1354,6 +1378,43 @@ class EnterpriseExperimentsViewSet(
                 "recommended_running_time_days": calculate_running_time_days(recommended_sample_size, exposure_rate),
             }
         )
+
+    @extend_schema(
+        description=(
+            "Running-time estimates for a batch of experiments, keyed by experiment id. Derives each estimate "
+            "from the experiment's latest results (automatic mode) or saved manual config, reading a short-lived "
+            "cache. Pass a comma-separated `ids` query param; unknown ids are omitted from the response."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="ids",
+                location=OpenApiParameter.QUERY,
+                type=str,
+                required=True,
+                description="Comma-separated experiment ids to estimate, e.g. `12,45,88`.",
+            )
+        ],
+        responses={200: OpenApiResponse(response=RunningTimeEstimatesResponseSerializer)},
+    )
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_path="running_time_estimates",
+        required_scopes=["experiment:read"],
+        pagination_class=None,
+    )
+    def running_time_estimates(self, request: Request, **kwargs: Any) -> Response:
+        """Batch running-time estimates keyed by experiment id, for the experiments list."""
+        ids = _parse_experiment_ids(request.query_params.get("ids"))
+        if not ids:
+            return Response({"results": {}})
+
+        experiments = self.get_queryset().filter(id__in=ids)
+        estimates = experiments_facade.get_running_time_estimates(experiments)
+        results = {
+            experiment_id: RunningTimeEstimateSerializer(estimate).data for experiment_id, estimate in estimates.items()
+        }
+        return Response({"results": results})
 
     @extend_schema(
         description=(

--- a/products/experiments/backend/running_time_calculator.py
+++ b/products/experiments/backend/running_time_calculator.py
@@ -235,11 +235,10 @@ def select_sizing_metric(
     order = {uuid: index for index, uuid in enumerate(ordered_uuids or [])}
     fallback = len(order)
 
-    def rank(pair: tuple[int, dict[str, Any]]) -> tuple[int, int]:
-        index, metric = pair
-        return order.get(metric.get("uuid", ""), fallback), index
+    # Sort by the metric's saved display rank, falling back to list order for metrics not in the ordering.
+    ordered_metrics = sorted(metrics, key=lambda metric: order.get(metric.get("uuid", ""), fallback))
 
-    for _, metric in sorted(enumerate(metrics), key=rank):
+    for metric in ordered_metrics:
         calc_type = _calculator_metric_type(metric)
         if calc_type is not None:
             return metric, calc_type

--- a/products/experiments/backend/running_time_calculator.py
+++ b/products/experiments/backend/running_time_calculator.py
@@ -23,6 +23,23 @@ VARIANCE_SCALING_FACTOR_SUM = 0.25
 # 4 · 1.96² ≈ 16: critical-value multiplier for 95% confidence / 80% power, two-tailed, two variants.
 SAMPLE_SIZE_Z_FACTOR = 16
 
+# Fallback MDE when neither the experiment nor the team sets one. Mirrors the frontend DEFAULT_MDE.
+DEFAULT_MINIMUM_DETECTABLE_EFFECT = 30
+
+
+def resolve_minimum_detectable_effect(saved_mde: float | None, team_default: float | None) -> float:
+    """Resolve the MDE the same way the frontend does: experiment value, then team default, then 30.
+
+    A zero or missing value at either level falls through to the next, so an experiment with no saved
+    MDE still gets a usable estimate instead of an all-null result.
+    """
+    if saved_mde:
+        return saved_mde
+    if team_default:
+        return team_default
+    return DEFAULT_MINIMUM_DETECTABLE_EFFECT
+
+
 # Manual calculator only supports these types (ratio/retention require full baseline data).
 ManualCalculatorMetricType = Literal["funnel", "mean_count", "mean_sum_or_avg"]
 # Full calculator supports all metric types.
@@ -334,7 +351,7 @@ def estimate_running_time_for_experiment(
         return RunningTimeEstimate(target_sample_size=None, current_exposures=None, remaining_days=None)
 
     if is_manual:
-        return _estimate_manual(exposure_config, mde, number_of_variants)
+        return _estimate_manual(exposure_config, mde, number_of_variants, start_date, result_blob, now)
 
     return _estimate_automatic(
         metrics=metrics,
@@ -347,7 +364,14 @@ def estimate_running_time_for_experiment(
     )
 
 
-def _estimate_manual(exposure_config: dict[str, Any], mde: float, number_of_variants: int) -> RunningTimeEstimate:
+def _estimate_manual(
+    exposure_config: dict[str, Any],
+    mde: float,
+    number_of_variants: int,
+    start_date: datetime | None,
+    result_blob: dict[str, Any] | None,
+    now: datetime,
+) -> RunningTimeEstimate:
     raw_metric_type = exposure_config.get("manualMetricType")
     metric_type: ManualCalculatorMetricType = (
         raw_metric_type if raw_metric_type in ("funnel", "mean_count", "mean_sum_or_avg") else "funnel"
@@ -361,8 +385,12 @@ def _estimate_manual(exposure_config: dict[str, Any], mde: float, number_of_vari
     # Funnel baseline is entered as a percentage; the calculator wants a 0-1 rate.
     resolved_baseline = baseline_value / 100 if metric_type == "funnel" else baseline_value
     target = calculate_recommended_sample_size(metric_type, mde, resolved_baseline, number_of_variants)
-    remaining = calculate_running_time_days(target, exposure_rate)
-    return RunningTimeEstimate(target_sample_size=target, current_exposures=None, remaining_days=remaining)
+
+    # The detail page subtracts live exposures even in manual mode; the only manual-specific input is the
+    # fixed exposure rate. Mirror that so the list agrees with the detail page.
+    current_exposures = current_exposures_from_result_blob(result_blob)
+    remaining = _remaining_days(target, current_exposures, exposure_rate, _days_elapsed(start_date, now))
+    return RunningTimeEstimate(target_sample_size=target, current_exposures=current_exposures, remaining_days=remaining)
 
 
 def _estimate_automatic(

--- a/products/experiments/backend/running_time_calculator.py
+++ b/products/experiments/backend/running_time_calculator.py
@@ -10,8 +10,12 @@ two-tailed test at 95% confidence and 80% power comparing two variants.
 """
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Literal
+from datetime import datetime
+from typing import Any, Literal
+
+from posthog.dataclasses import frozen
 
 VARIANCE_SCALING_FACTOR_TOTAL_COUNT = 2
 VARIANCE_SCALING_FACTOR_SUM = 0.25
@@ -192,3 +196,207 @@ def calculate_running_time_days(sample_size: int | None, exposure_rate_per_day: 
     if not sample_size or not exposure_rate_per_day or exposure_rate_per_day <= 0:
         return None
     return math.ceil(sample_size / exposure_rate_per_day)
+
+
+def baseline_stats_from_result_blob(result: dict[str, Any]) -> BaselineStats | None:
+    """Map a stored metric result blob's control baseline into :class:`BaselineStats`.
+
+    Mirrors the frontend ``baselineStatsFromResults``. The blob is a model-dumped
+    ``ExperimentQueryResponse`` (post ``strip_step_sessions``); its ``baseline`` object
+    carries the same snake_case keys. Returns ``None`` when the blob has no usable baseline.
+    """
+    baseline = result.get("baseline")
+    if not isinstance(baseline, dict) or baseline.get("number_of_samples") is None:
+        return None
+
+    return BaselineStats(
+        number_of_samples=baseline["number_of_samples"],
+        sum=baseline.get("sum", 0.0),
+        sum_squares=baseline.get("sum_squares", 0.0),
+        denominator_sum=baseline.get("denominator_sum"),
+        denominator_sum_squares=baseline.get("denominator_sum_squares"),
+        numerator_denominator_sum_product=baseline.get("numerator_denominator_sum_product"),
+        step_counts=baseline.get("step_counts") or [],
+    )
+
+
+def select_sizing_metric(
+    metrics: list[dict[str, Any]] | None,
+    ordered_uuids: Sequence[str] | None,
+) -> tuple[dict[str, Any], CalculatorMetricType] | None:
+    """Pick the first primary metric to size the experiment on, in display order.
+
+    Classifies it the same way the frontend ``getCalculatorMetricType`` does. Returns the
+    metric dict and its calculator type, or ``None`` when there is no usable primary metric.
+    """
+    if not metrics:
+        return None
+
+    order = {uuid: index for index, uuid in enumerate(ordered_uuids or [])}
+    fallback = len(order)
+
+    def rank(pair: tuple[int, dict[str, Any]]) -> tuple[int, int]:
+        index, metric = pair
+        return order.get(metric.get("uuid", ""), fallback), index
+
+    for _, metric in sorted(enumerate(metrics), key=rank):
+        calc_type = _calculator_metric_type(metric)
+        if calc_type is not None:
+            return metric, calc_type
+    return None
+
+
+def _calculator_metric_type(metric: dict[str, Any]) -> CalculatorMetricType | None:
+    metric_type = metric.get("metric_type")
+    if metric_type == "funnel":
+        return "funnel"
+    if metric_type == "ratio":
+        return "ratio"
+    if metric_type == "retention":
+        return "retention"
+    if metric_type == "mean":
+        math_value = (metric.get("source") or {}).get("math")
+        return "mean_sum_or_avg" if math_value == "sum" else "mean_count"
+    return None
+
+
+@frozen
+class RunningTimeEstimate:
+    """Derived running-time state for one experiment, computed from live results or manual config."""
+
+    target_sample_size: int | None
+    current_exposures: int | None
+    remaining_days: int | None
+
+
+def current_exposures_from_result_blob(result: dict[str, Any] | None) -> int | None:
+    """Total exposed users across control and every variant, or ``None`` when the blob is unusable."""
+    if not result:
+        return None
+    baseline = result.get("baseline")
+    if not isinstance(baseline, dict) or baseline.get("number_of_samples") is None:
+        return None
+    total = baseline["number_of_samples"]
+    for variant in result.get("variant_results") or []:
+        if isinstance(variant, dict) and variant.get("number_of_samples") is not None:
+            total += variant["number_of_samples"]
+    return total
+
+
+def _days_elapsed(start_date: datetime | None, now: datetime) -> float | None:
+    if start_date is None:
+        return None
+    return (now - start_date).total_seconds() / 86400
+
+
+def _remaining_days(
+    target_sample_size: int | None,
+    current_exposures: int | None,
+    rate_per_day: float | None,
+    days_elapsed: float | None,
+) -> int | None:
+    """Days to reach the target, mirroring the frontend ``remainingDays`` selector."""
+    if not target_sample_size or target_sample_size <= 0 or not rate_per_day or rate_per_day <= 0:
+        return None
+
+    # Not enough live data yet: show the total estimated time from the rate alone.
+    if not days_elapsed or days_elapsed < 1 or not current_exposures or current_exposures < 100:
+        return math.ceil(target_sample_size / rate_per_day)
+
+    if current_exposures >= target_sample_size:
+        return 0
+
+    return math.ceil((target_sample_size - current_exposures) / rate_per_day)
+
+
+def estimate_running_time_for_experiment(
+    *,
+    metrics: list[dict[str, Any]] | None,
+    primary_metrics_ordered_uuids: Sequence[str] | None,
+    running_time_calculation: dict[str, Any] | None,
+    start_date: datetime | None,
+    number_of_variants: int,
+    result_blob: dict[str, Any] | None,
+    now: datetime,
+    mde_override: float | None = None,
+) -> RunningTimeEstimate:
+    """Estimate sample size, current exposures, and remaining days for one experiment.
+
+    Manual mode reads the saved exposure-estimate config; automatic mode derives the baseline
+    and exposure rate from ``result_blob`` (the latest metric result). Mirrors the frontend
+    ``runningTimeLogic`` so the list matches the detail page.
+    """
+    config = running_time_calculation or {}
+    exposure_config = config.get("exposure_estimate_config") or {}
+    is_manual = exposure_config.get("conversionRateInputType") == "manual"
+    mde = mde_override if mde_override is not None else config.get("minimum_detectable_effect")
+
+    if mde is None or mde <= 0:
+        return RunningTimeEstimate(target_sample_size=None, current_exposures=None, remaining_days=None)
+
+    if is_manual:
+        return _estimate_manual(exposure_config, mde, number_of_variants)
+
+    return _estimate_automatic(
+        metrics=metrics,
+        primary_metrics_ordered_uuids=primary_metrics_ordered_uuids,
+        mde=mde,
+        start_date=start_date,
+        number_of_variants=number_of_variants,
+        result_blob=result_blob,
+        now=now,
+    )
+
+
+def _estimate_manual(exposure_config: dict[str, Any], mde: float, number_of_variants: int) -> RunningTimeEstimate:
+    raw_metric_type = exposure_config.get("manualMetricType")
+    metric_type: ManualCalculatorMetricType = (
+        raw_metric_type if raw_metric_type in ("funnel", "mean_count", "mean_sum_or_avg") else "funnel"
+    )
+    baseline_value = exposure_config.get("manualBaselineValue")
+    exposure_rate = exposure_config.get("manualExposureRate")
+
+    if baseline_value is None or baseline_value <= 0:
+        return RunningTimeEstimate(target_sample_size=None, current_exposures=None, remaining_days=None)
+
+    # Funnel baseline is entered as a percentage; the calculator wants a 0-1 rate.
+    resolved_baseline = baseline_value / 100 if metric_type == "funnel" else baseline_value
+    target = calculate_recommended_sample_size(metric_type, mde, resolved_baseline, number_of_variants)
+    remaining = calculate_running_time_days(target, exposure_rate)
+    return RunningTimeEstimate(target_sample_size=target, current_exposures=None, remaining_days=remaining)
+
+
+def _estimate_automatic(
+    *,
+    metrics: list[dict[str, Any]] | None,
+    primary_metrics_ordered_uuids: Sequence[str] | None,
+    mde: float,
+    start_date: datetime | None,
+    number_of_variants: int,
+    result_blob: dict[str, Any] | None,
+    now: datetime,
+) -> RunningTimeEstimate:
+    empty = RunningTimeEstimate(target_sample_size=None, current_exposures=None, remaining_days=None)
+
+    selected = select_sizing_metric(metrics, primary_metrics_ordered_uuids)
+    baseline = baseline_stats_from_result_blob(result_blob) if result_blob else None
+    if selected is None or baseline is None:
+        return empty
+
+    _, metric_type = selected
+    if metric_type in ("ratio", "retention") and not baseline.denominator_sum:
+        return empty
+
+    baseline_value = calculate_baseline_value(baseline, metric_type)
+    if baseline_value is None:
+        return empty
+
+    target = calculate_recommended_sample_size(metric_type, mde, baseline_value, number_of_variants, baseline)
+    current_exposures = current_exposures_from_result_blob(result_blob)
+
+    days_elapsed = _days_elapsed(start_date, now)
+    rate_per_day = (
+        current_exposures / days_elapsed if current_exposures and days_elapsed and days_elapsed >= 0.1 else None
+    )
+    remaining = _remaining_days(target, current_exposures, rate_per_day, days_elapsed)
+    return RunningTimeEstimate(target_sample_size=target, current_exposures=current_exposures, remaining_days=remaining)

--- a/products/experiments/backend/running_time_estimate_service.py
+++ b/products/experiments/backend/running_time_estimate_service.py
@@ -10,15 +10,20 @@ from datetime import datetime
 
 from django.utils import timezone
 
+from posthog.models.team.extensions import get_or_create_team_extension
 from posthog.utils import get_safe_cache, safe_cache_set
 
-from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
-from products.experiments.backend.hogql_queries.utils import get_experiment_stats_method
-from products.experiments.backend.models.experiment import Experiment, ExperimentMetricResult
-from products.experiments.backend.result_serialization import strip_step_sessions
+from products.experiments.backend.models.experiment import Experiment
+from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
+from products.experiments.backend.recalculation import (
+    build_timeseries_cold_start_payload,
+    get_latest_recalculation,
+    get_run_results,
+)
 from products.experiments.backend.running_time_calculator import (
     RunningTimeEstimate,
     estimate_running_time_for_experiment,
+    resolve_minimum_detectable_effect,
     select_sizing_metric,
 )
 
@@ -27,32 +32,27 @@ _CACHE_VERSION = "v1"
 CACHE_TTL_SECONDS = 15 * 60
 
 
-def _latest_completed_result_blob(experiment: Experiment, metric: dict) -> dict | None:
-    """Latest completed timeseries result for one metric, under its config fingerprint.
+def _latest_result_blob_for_metric(experiment: Experiment, metric_uuid: str | None) -> dict | None:
+    """The result blob the detail page shows for one metric, or None.
 
-    Mirrors the read in ``build_timeseries_cold_start_payload`` but scoped to a single metric.
+    Mirrors the precedence in the ``metrics_recalculation/latest`` endpoint: the latest terminal
+    recalculation run first, then the timeseries cold-start payload. Reuses the recalculation module
+    so the list reads the exact same source the detail page does.
     """
-    config_fingerprint = compute_metric_fingerprint(
-        metric,
-        experiment.start_date,
-        get_experiment_stats_method(experiment),
-        experiment.exposure_criteria,
-        only_count_matured_users=experiment.only_count_matured_users,
-        excluded_variants=experiment.excluded_variants,
-    )
-    row = (
-        ExperimentMetricResult.objects.filter(
-            experiment=experiment,
-            metric_uuid=metric.get("uuid"),
-            fingerprint=config_fingerprint,
-            status=ExperimentMetricResult.Status.COMPLETED,
-        )
-        .order_by("-query_to")
-        .first()
-    )
-    if row is None:
+    if metric_uuid is None:
         return None
-    return strip_step_sessions(row.result)
+
+    recalc = get_latest_recalculation(experiment)
+    if recalc is not None:
+        results = get_run_results(recalc)
+    else:
+        payload = build_timeseries_cold_start_payload(experiment)
+        results = payload["results"] if payload is not None else []
+
+    for entry in results:
+        if entry.get("metric_uuid") == metric_uuid and entry.get("status") == "completed":
+            return entry.get("result")
+    return None
 
 
 def _number_of_variants(experiment: Experiment) -> int:
@@ -78,23 +78,29 @@ def compute_running_time_estimate(experiment: Experiment, now: datetime | None =
     """
     now = now or timezone.now()
     config = experiment.running_time_calculation or {}
-    exposure_config = config.get("exposure_estimate_config") or {}
-    is_manual = exposure_config.get("conversionRateInputType") == "manual"
 
+    # Both modes use live exposures for remaining time (manual differs only in using a fixed rate), so
+    # read the sizing metric's latest result for either. See estimate_running_time_for_experiment.
     result_blob: dict | None = None
     query_to = None
-    if not is_manual:
-        selected = select_sizing_metric(experiment.metrics, experiment.primary_metrics_ordered_uuids)
-        if selected is not None:
-            metric, _ = selected
-            result_blob = _latest_completed_result_blob(experiment, metric)
-            if result_blob is not None:
-                query_to = result_blob.get("query_to")
+    selected = select_sizing_metric(experiment.metrics, experiment.primary_metrics_ordered_uuids)
+    if selected is not None:
+        metric, _ = selected
+        result_blob = _latest_result_blob_for_metric(experiment, metric.get("uuid"))
+        if result_blob is not None:
+            query_to = result_blob.get("query_to")
 
     cache_key = _cache_key(experiment, query_to)
     cached = get_safe_cache(cache_key)
     if isinstance(cached, RunningTimeEstimate):
         return cached
+
+    # Most experiments never save an MDE; the detail page falls back to the team default, then to 30.
+    # Match that here or every such experiment would size to null.
+    team_config = get_or_create_team_extension(experiment.team, TeamExperimentsConfig)
+    mde = resolve_minimum_detectable_effect(
+        config.get("minimum_detectable_effect"), team_config.default_minimum_detectable_effect
+    )
 
     estimate = estimate_running_time_for_experiment(
         metrics=experiment.metrics,
@@ -104,6 +110,7 @@ def compute_running_time_estimate(experiment: Experiment, now: datetime | None =
         number_of_variants=_number_of_variants(experiment),
         result_blob=result_blob,
         now=now,
+        mde_override=mde,
     )
     safe_cache_set(cache_key, estimate, timeout=CACHE_TTL_SECONDS)
     return estimate

--- a/products/experiments/backend/running_time_estimate_service.py
+++ b/products/experiments/backend/running_time_estimate_service.py
@@ -26,33 +26,39 @@ from products.experiments.backend.running_time_calculator import (
     resolve_minimum_detectable_effect,
     select_sizing_metric,
 )
+from products.experiments.backend.temporal.metric_resolution import primary_metric_dicts
 
 # Bump when the cached value's shape changes; pickled values would otherwise deserialize stale-shaped.
 _CACHE_VERSION = "v1"
 CACHE_TTL_SECONDS = 15 * 60
 
 
-def _latest_result_blob_for_metric(experiment: Experiment, metric_uuid: str | None) -> dict | None:
-    """The result blob the detail page shows for one metric, or None.
+def _latest_result_blob_for_metric(
+    experiment: Experiment, metric_uuid: str | None
+) -> tuple[dict | None, datetime | None]:
+    """The result blob the detail page shows for one metric and the window it covers, or ``(None, None)``.
 
     Mirrors the precedence in the ``metrics_recalculation/latest`` endpoint: the latest terminal
     recalculation run first, then the timeseries cold-start payload. Reuses the recalculation module
-    so the list reads the exact same source the detail page does.
+    so the list reads the exact same source the detail page does. ``query_to`` is the source row's
+    window, not part of the blob, so the caller can key its cache on a fresher result.
     """
     if metric_uuid is None:
-        return None
+        return None, None
 
     recalc = get_latest_recalculation(experiment)
     if recalc is not None:
         results = get_run_results(recalc)
+        query_to = recalc.query_to
     else:
         payload = build_timeseries_cold_start_payload(experiment)
         results = payload["results"] if payload is not None else []
+        query_to = payload["query_to"] if payload is not None else None
 
     for entry in results:
         if entry.get("metric_uuid") == metric_uuid and entry.get("status") == "completed":
-            return entry.get("result")
-    return None
+            return entry.get("result"), query_to
+    return None, None
 
 
 def _number_of_variants(experiment: Experiment) -> int:
@@ -83,12 +89,12 @@ def compute_running_time_estimate(experiment: Experiment, now: datetime | None =
     # read the sizing metric's latest result for either. See estimate_running_time_for_experiment.
     result_blob: dict | None = None
     query_to = None
-    selected = select_sizing_metric(experiment.metrics, experiment.primary_metrics_ordered_uuids)
+    # Include saved (shared) primary metrics, not only inline ones, so the sizing metric matches the
+    # detail page when a saved metric is the first primary metric.
+    selected = select_sizing_metric(primary_metric_dicts(experiment), experiment.primary_metrics_ordered_uuids)
     if selected is not None:
         metric, _ = selected
-        result_blob = _latest_result_blob_for_metric(experiment, metric.get("uuid"))
-        if result_blob is not None:
-            query_to = result_blob.get("query_to")
+        result_blob, query_to = _latest_result_blob_for_metric(experiment, metric.get("uuid"))
 
     cache_key = _cache_key(experiment, query_to)
     cached = get_safe_cache(cache_key)

--- a/products/experiments/backend/running_time_estimate_service.py
+++ b/products/experiments/backend/running_time_estimate_service.py
@@ -1,0 +1,109 @@
+"""Service layer for the running-time estimate list endpoint.
+
+Composes the pure math in ``running_time_calculator`` with a cheap Postgres read of the latest
+metric result and a short-lived cache. Automatic mode reads the sizing metric's latest completed
+``ExperimentMetricResult`` blob; manual mode needs no read. Never runs a ClickHouse query.
+"""
+
+import hashlib
+from datetime import datetime
+
+from django.utils import timezone
+
+from posthog.utils import get_safe_cache, safe_cache_set
+
+from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
+from products.experiments.backend.hogql_queries.utils import get_experiment_stats_method
+from products.experiments.backend.models.experiment import Experiment, ExperimentMetricResult
+from products.experiments.backend.result_serialization import strip_step_sessions
+from products.experiments.backend.running_time_calculator import (
+    RunningTimeEstimate,
+    estimate_running_time_for_experiment,
+    select_sizing_metric,
+)
+
+# Bump when the cached value's shape changes; pickled values would otherwise deserialize stale-shaped.
+_CACHE_VERSION = "v1"
+CACHE_TTL_SECONDS = 15 * 60
+
+
+def _latest_completed_result_blob(experiment: Experiment, metric: dict) -> dict | None:
+    """Latest completed timeseries result for one metric, under its config fingerprint.
+
+    Mirrors the read in ``build_timeseries_cold_start_payload`` but scoped to a single metric.
+    """
+    config_fingerprint = compute_metric_fingerprint(
+        metric,
+        experiment.start_date,
+        get_experiment_stats_method(experiment),
+        experiment.exposure_criteria,
+        only_count_matured_users=experiment.only_count_matured_users,
+        excluded_variants=experiment.excluded_variants,
+    )
+    row = (
+        ExperimentMetricResult.objects.filter(
+            experiment=experiment,
+            metric_uuid=metric.get("uuid"),
+            fingerprint=config_fingerprint,
+            status=ExperimentMetricResult.Status.COMPLETED,
+        )
+        .order_by("-query_to")
+        .first()
+    )
+    if row is None:
+        return None
+    return strip_step_sessions(row.result)
+
+
+def _number_of_variants(experiment: Experiment) -> int:
+    return len(experiment.feature_flag.variants) or 2
+
+
+def _cache_key(experiment: Experiment, query_to: datetime | None) -> str:
+    flag_updated = experiment.feature_flag.updated_at if experiment.feature_flag_id else None
+    parts = ":".join(
+        value.isoformat() if isinstance(value, datetime) else ""
+        for value in (experiment.updated_at, flag_updated, query_to)
+    )
+    digest = hashlib.sha256(parts.encode()).hexdigest()[:16]
+    return f"experiment_running_time_{_CACHE_VERSION}_{experiment.team_id}_{experiment.pk}_{digest}"
+
+
+def compute_running_time_estimate(experiment: Experiment, now: datetime | None = None) -> RunningTimeEstimate:
+    """Estimate for one experiment, reading a cached snapshot when the inputs are unchanged.
+
+    Automatic mode reads the sizing metric's latest completed result; manual mode reads only saved
+    config. The cache key folds in the experiment and flag ``updated_at`` and the result window, so an
+    edit or a fresher result misses the cache instead of serving stale numbers.
+    """
+    now = now or timezone.now()
+    config = experiment.running_time_calculation or {}
+    exposure_config = config.get("exposure_estimate_config") or {}
+    is_manual = exposure_config.get("conversionRateInputType") == "manual"
+
+    result_blob: dict | None = None
+    query_to = None
+    if not is_manual:
+        selected = select_sizing_metric(experiment.metrics, experiment.primary_metrics_ordered_uuids)
+        if selected is not None:
+            metric, _ = selected
+            result_blob = _latest_completed_result_blob(experiment, metric)
+            if result_blob is not None:
+                query_to = result_blob.get("query_to")
+
+    cache_key = _cache_key(experiment, query_to)
+    cached = get_safe_cache(cache_key)
+    if isinstance(cached, RunningTimeEstimate):
+        return cached
+
+    estimate = estimate_running_time_for_experiment(
+        metrics=experiment.metrics,
+        primary_metrics_ordered_uuids=experiment.primary_metrics_ordered_uuids,
+        running_time_calculation=config,
+        start_date=experiment.start_date,
+        number_of_variants=_number_of_variants(experiment),
+        result_blob=result_blob,
+        now=now,
+    )
+    safe_cache_set(cache_key, estimate, timeout=CACHE_TTL_SECONDS)
+    return estimate

--- a/products/experiments/backend/temporal/metric_resolution.py
+++ b/products/experiments/backend/temporal/metric_resolution.py
@@ -58,6 +58,23 @@ def iter_metric_dicts(experiment: Experiment) -> list[dict[str, Any]]:
     return dicts
 
 
+def primary_metric_dicts(experiment: Experiment) -> list[dict[str, Any]]:
+    """Primary metric definition dicts only: inline primary metrics plus saved metrics linked as primary.
+
+    A saved metric's role is on its M2M link metadata (``metadata["type"]``, defaulting to primary).
+    Callers that must match the detail page's primary-metric selection need saved primaries too, not
+    only ``experiment.metrics``.
+    """
+    dicts: list[dict[str, Any]] = [metric for metric in (experiment.metrics or []) if metric.get("uuid")]
+    for link in experiment.experimenttosavedmetric_set.select_related("saved_metric").all():
+        if (link.metadata or {}).get("type", "primary") != "primary":
+            continue
+        saved_query = link.saved_metric.query
+        if saved_query and saved_query.get("uuid"):
+            dicts.append(_merge_saved_metric_breakdowns(saved_query, link.metadata))
+    return dicts
+
+
 def find_metric_dict(experiment: Experiment, metric_uuid: str) -> dict[str, Any] | None:
     """Resolve a metric_uuid to its definition dict, across inline AND saved/shared metrics."""
     return next((metric for metric in iter_metric_dicts(experiment) if metric.get("uuid") == metric_uuid), None)

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -8847,6 +8847,69 @@ class TestCalculateRunningTimeEndpoint(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
 
 
+class TestRunningTimeEstimatesEndpoint(APILicensedTest):
+    def _manual_experiment(self, name: str, flag_key: str) -> Experiment:
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=flag_key,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+        return Experiment.objects.create(
+            team=self.team,
+            name=name,
+            feature_flag=flag,
+            running_time_calculation={
+                "minimum_detectable_effect": 50,
+                "exposure_estimate_config": {
+                    "conversionRateInputType": "manual",
+                    "manualMetricType": "funnel",
+                    "manualBaselineValue": 10,
+                    "manualExposureRate": 100,
+                },
+            },
+        )
+
+    def _get(self, ids: str):
+        return self.client.get(f"/api/projects/{self.team.id}/experiments/running_time_estimates/?ids={ids}")
+
+    def test_returns_manual_estimate_keyed_by_id(self):
+        experiment = self._manual_experiment("Manual estimate", "manual-estimate-flag")
+        response = self._get(str(experiment.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        results = response.json()["results"]
+        # funnel p=0.10, mde 50% -> N=1152; at 100/day -> 12 days.
+        self.assertEqual(
+            results[str(experiment.id)],
+            {"target_sample_size": 1152, "current_exposures": None, "remaining_days": 12},
+        )
+
+    def test_omits_experiment_from_another_team(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+        other_flag = FeatureFlag.objects.create(team=other_team, created_by=self.user, key="other-team-flag")
+        other = Experiment.objects.create(team=other_team, name="Other", feature_flag=other_flag)
+        mine = self._manual_experiment("Mine", "mine-flag")
+
+        response = self._get(f"{mine.id},{other.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        results = response.json()["results"]
+        self.assertIn(str(mine.id), results)
+        self.assertNotIn(str(other.id), results)
+
+    def test_empty_ids_returns_empty_object(self):
+        response = self._get("")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertEqual(response.json(), {"results": {}})
+
+
 class TestExperimentSerializerSuperset(unittest.TestCase):
     """Structural guard: ExperimentBasicSerializer must stay a subset of ExperimentSerializer.
 

--- a/products/experiments/backend/test/test_running_time_calculator.py
+++ b/products/experiments/backend/test/test_running_time_calculator.py
@@ -14,6 +14,7 @@ from products.experiments.backend.running_time_calculator import (
     calculate_variance,
     calculate_variance_from_stats,
     estimate_running_time_for_experiment,
+    resolve_minimum_detectable_effect,
     select_sizing_metric,
 )
 
@@ -338,6 +339,20 @@ class TestSelectSizingMetric:
         assert select_sizing_metric(metrics, None) is None
 
 
+class TestResolveMinimumDetectableEffect:
+    @parameterized.expand(
+        [
+            ("saved_wins", 5, 20, 5),
+            ("team_default_when_no_saved", None, 20, 20),
+            ("fallback_when_neither", None, None, 30),
+            ("saved_zero_is_ignored", 0, 20, 20),
+            ("team_zero_is_ignored", None, 0, 30),
+        ]
+    )
+    def test_resolution_chain(self, _name, saved, team_default, expected):
+        assert resolve_minimum_detectable_effect(saved, team_default) == expected
+
+
 class TestEstimateRunningTimeForExperiment:
     NOW = datetime(2026, 8, 27, tzinfo=UTC)
 
@@ -355,28 +370,75 @@ class TestEstimateRunningTimeForExperiment:
             }
         }
 
-    def test_manual_mode_uses_config_not_results(self):
+    def _manual_config(self):
+        return {
+            "minimum_detectable_effect": 50,
+            "exposure_estimate_config": {
+                "conversionRateInputType": "manual",
+                "manualMetricType": "funnel",
+                "manualBaselineValue": 10,
+                "manualExposureRate": 100,
+            },
+        }
+
+    def test_manual_mode_uses_live_exposures_like_detail_page(self):
+        # Manual uses the fixed rate but live exposures, matching the detail page:
+        # target 1152, 300 exposed so far, 100/day -> (1152-300)/100 = 8.52 -> 9.
         estimate = estimate_running_time_for_experiment(
             metrics=[self._funnel_metric()],
             primary_metrics_ordered_uuids=None,
-            running_time_calculation={
-                "minimum_detectable_effect": 50,
-                "exposure_estimate_config": {
-                    "conversionRateInputType": "manual",
-                    "manualMetricType": "funnel",
-                    "manualBaselineValue": 10,
-                    "manualExposureRate": 100,
-                },
-            },
-            start_date=None,
+            running_time_calculation=self._manual_config(),
+            start_date=self.NOW - timedelta(days=4),
+            number_of_variants=2,
+            result_blob=self._funnel_blob(samples=300),
+            now=self.NOW,
+        )
+        assert estimate.target_sample_size == 1152
+        assert estimate.current_exposures == 300
+        assert estimate.remaining_days == 9
+
+    def test_manual_mode_too_little_data_shows_total(self):
+        # <100 exposures -> fall back to total from the fixed rate: 1152/100 = 12.
+        estimate = estimate_running_time_for_experiment(
+            metrics=[self._funnel_metric()],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation=self._manual_config(),
+            start_date=self.NOW - timedelta(hours=6),
+            number_of_variants=2,
+            result_blob=self._funnel_blob(samples=20),
+            now=self.NOW,
+        )
+        assert estimate.remaining_days == 12
+
+    def test_manual_mode_without_results_shows_total(self):
+        estimate = estimate_running_time_for_experiment(
+            metrics=[self._funnel_metric()],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation=self._manual_config(),
+            start_date=self.NOW - timedelta(days=4),
             number_of_variants=2,
             result_blob=None,
             now=self.NOW,
         )
-        # funnel p=0.10, mde 50% -> N=1152; at 100/day -> 12 days. No live exposures in manual mode.
-        assert estimate.target_sample_size == 1152
-        assert estimate.remaining_days == 12
         assert estimate.current_exposures is None
+        assert estimate.remaining_days == 12
+
+    def test_manual_mode_target_reached_is_zero(self):
+        blob = {
+            "baseline": {"key": "control", "number_of_samples": 1000, "sum": 100, "step_counts": [1000, 100]},
+            "variant_results": [{"key": "test", "number_of_samples": 1000, "sum": 110}],
+        }
+        estimate = estimate_running_time_for_experiment(
+            metrics=[self._funnel_metric()],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation=self._manual_config(),
+            start_date=self.NOW - timedelta(days=20),
+            number_of_variants=2,
+            result_blob=blob,  # 2000 exposed > 1152 target
+            now=self.NOW,
+        )
+        assert estimate.current_exposures == 2000
+        assert estimate.remaining_days == 0
 
     def test_automatic_mode_with_enough_data_subtracts_current_exposures(self):
         # 10 days elapsed, 2000 exposures so far -> 200/day. Target 1152, remaining 1152-2000<0 -> complete.
@@ -417,6 +479,34 @@ class TestEstimateRunningTimeForExperiment:
         assert estimate.current_exposures == 40
         # rate = 40 exposures / 0.5 days = 80/day; ceil(1152/80) = 15
         assert estimate.remaining_days == 15
+
+    def test_automatic_mode_without_saved_mde_is_all_null(self):
+        # Guards the reported bug: an experiment with no saved MDE must not silently size to null.
+        # The service is responsible for passing a fallback via mde_override (see resolve_minimum_detectable_effect).
+        estimate = estimate_running_time_for_experiment(
+            metrics=[self._funnel_metric()],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation={"exposure_estimate_config": {"conversionRateInputType": "automatic"}},
+            start_date=self.NOW - timedelta(days=10),
+            number_of_variants=2,
+            result_blob=self._funnel_blob(samples=1000),
+            now=self.NOW,
+        )
+        assert estimate.target_sample_size is None
+
+    def test_automatic_mode_with_mde_override_when_no_saved_mde(self):
+        estimate = estimate_running_time_for_experiment(
+            metrics=[self._funnel_metric()],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation={"exposure_estimate_config": {"conversionRateInputType": "automatic"}},
+            start_date=self.NOW - timedelta(days=10),
+            number_of_variants=2,
+            result_blob=self._funnel_blob(samples=1000),
+            now=self.NOW,
+            mde_override=30,
+        )
+        assert estimate.target_sample_size is not None
+        assert estimate.current_exposures == 1000
 
     def test_automatic_mode_without_usable_metric_returns_empty(self):
         estimate = estimate_running_time_for_experiment(

--- a/products/experiments/backend/test/test_running_time_calculator.py
+++ b/products/experiments/backend/test/test_running_time_calculator.py
@@ -1,15 +1,20 @@
 import math
+from datetime import UTC, datetime, timedelta
 
 from parameterized import parameterized
 
 from products.experiments.backend.running_time_calculator import (
     BaselineStats,
+    RunningTimeEstimate,
+    baseline_stats_from_result_blob,
     calculate_baseline_value,
     calculate_recommended_sample_size,
     calculate_running_time_days,
     calculate_sample_size,
     calculate_variance,
     calculate_variance_from_stats,
+    estimate_running_time_for_experiment,
+    select_sizing_metric,
 )
 
 
@@ -220,3 +225,227 @@ class TestCalculateRunningTimeDays:
     )
     def test_running_time(self, sample_size, exposure_rate, expected):
         assert calculate_running_time_days(sample_size, exposure_rate) == expected
+
+
+class TestBaselineStatsFromResultBlob:
+    def test_maps_funnel_blob_including_step_counts(self):
+        blob = {
+            "baseline": {
+                "key": "control",
+                "number_of_samples": 12500,
+                "sum": 3120.0,
+                "sum_squares": 3120.0,
+                "step_counts": [12500, 8400, 3120],
+            }
+        }
+        stats = baseline_stats_from_result_blob(blob)
+        assert stats == BaselineStats(
+            number_of_samples=12500,
+            sum=3120.0,
+            sum_squares=3120.0,
+            step_counts=[12500, 8400, 3120],
+        )
+
+    def test_maps_ratio_blob_including_denominator_stats(self):
+        blob = {
+            "baseline": {
+                "key": "control",
+                "number_of_samples": 10000,
+                "sum": 500000.0,
+                "sum_squares": 30000000.0,
+                "denominator_sum": 50000.0,
+                "denominator_sum_squares": 300000.0,
+                "numerator_denominator_sum_product": 2600000.0,
+            }
+        }
+        stats = baseline_stats_from_result_blob(blob)
+        assert stats is not None
+        assert stats.denominator_sum == 50000.0
+        assert stats.denominator_sum_squares == 300000.0
+        assert stats.numerator_denominator_sum_product == 2600000.0
+
+    def test_absent_optional_fields_become_unset(self):
+        blob = {"baseline": {"key": "control", "number_of_samples": 9800, "sum": 4567.5, "sum_squares": 8912.75}}
+        stats = baseline_stats_from_result_blob(blob)
+        assert stats is not None
+        assert stats.denominator_sum is None
+        assert stats.step_counts == []
+
+    @parameterized.expand(
+        [
+            ("no_baseline_key", {}),
+            ("null_baseline", {"baseline": None}),
+            ("baseline_not_dict", {"baseline": []}),
+            ("missing_number_of_samples", {"baseline": {"sum": 100.0}}),
+        ]
+    )
+    def test_returns_none_for_unusable_blob(self, _name, blob):
+        assert baseline_stats_from_result_blob(blob) is None
+
+
+class TestSelectSizingMetric:
+    def _funnel(self, uuid="f"):
+        return {"kind": "ExperimentMetric", "metric_type": "funnel", "uuid": uuid, "series": []}
+
+    def _mean(self, uuid="m", math="total"):
+        return {"kind": "ExperimentMetric", "metric_type": "mean", "uuid": uuid, "source": {"math": math}}
+
+    def _ratio(self, uuid="r"):
+        return {"kind": "ExperimentMetric", "metric_type": "ratio", "uuid": uuid}
+
+    def _retention(self, uuid="ret"):
+        return {"kind": "ExperimentMetric", "metric_type": "retention", "uuid": uuid}
+
+    @parameterized.expand(
+        [
+            ("funnel", "funnel", None, "funnel"),
+            ("ratio", "ratio", None, "ratio"),
+            ("retention", "retention", None, "retention"),
+            ("mean_count_total", "mean", "total", "mean_count"),
+            ("mean_count_avg", "mean", "avg", "mean_count"),
+            ("mean_sum", "mean", "sum", "mean_sum_or_avg"),
+        ]
+    )
+    def test_classifies_single_metric(self, _name, metric_type, math, expected_calc_type):
+        metric = {"kind": "ExperimentMetric", "metric_type": metric_type, "uuid": "u", "source": {"math": math}}
+        result = select_sizing_metric([metric], None)
+        assert result is not None
+        selected, calc_type = result
+        assert selected["uuid"] == "u"
+        assert calc_type == expected_calc_type
+
+    def test_picks_first_by_display_order_not_list_order(self):
+        metrics = [self._mean(uuid="second", math="sum"), self._funnel(uuid="first")]
+        result = select_sizing_metric(metrics, ["first", "second"])
+        assert result is not None
+        selected, calc_type = result
+        assert selected["uuid"] == "first"
+        assert calc_type == "funnel"
+
+    def test_falls_back_to_list_order_when_no_ordering(self):
+        metrics = [self._ratio(uuid="a"), self._funnel(uuid="b")]
+        result = select_sizing_metric(metrics, None)
+        assert result is not None
+        selected, _ = result
+        assert selected["uuid"] == "a"
+
+    @parameterized.expand([("empty", []), ("none", None)])
+    def test_returns_none_without_metrics(self, _name, metrics):
+        assert select_sizing_metric(metrics, None) is None
+
+    def test_returns_none_for_unknown_metric_type(self):
+        metrics = [{"kind": "ExperimentMetric", "metric_type": "bogus", "uuid": "x"}]
+        assert select_sizing_metric(metrics, None) is None
+
+
+class TestEstimateRunningTimeForExperiment:
+    NOW = datetime(2026, 8, 27, tzinfo=UTC)
+
+    def _funnel_metric(self):
+        return {"kind": "ExperimentMetric", "metric_type": "funnel", "uuid": "f", "series": []}
+
+    def _funnel_blob(self, samples=600):
+        # 10% conversion baseline: final step is 10% of exposed control users.
+        return {
+            "baseline": {
+                "key": "control",
+                "number_of_samples": samples,
+                "sum": samples // 10,
+                "step_counts": [samples, samples // 10],
+            }
+        }
+
+    def test_manual_mode_uses_config_not_results(self):
+        estimate = estimate_running_time_for_experiment(
+            metrics=[self._funnel_metric()],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation={
+                "minimum_detectable_effect": 50,
+                "exposure_estimate_config": {
+                    "conversionRateInputType": "manual",
+                    "manualMetricType": "funnel",
+                    "manualBaselineValue": 10,
+                    "manualExposureRate": 100,
+                },
+            },
+            start_date=None,
+            number_of_variants=2,
+            result_blob=None,
+            now=self.NOW,
+        )
+        # funnel p=0.10, mde 50% -> N=1152; at 100/day -> 12 days. No live exposures in manual mode.
+        assert estimate.target_sample_size == 1152
+        assert estimate.remaining_days == 12
+        assert estimate.current_exposures is None
+
+    def test_automatic_mode_with_enough_data_subtracts_current_exposures(self):
+        # 10 days elapsed, 2000 exposures so far -> 200/day. Target 1152, remaining 1152-2000<0 -> complete.
+        estimate = estimate_running_time_for_experiment(
+            metrics=[self._funnel_metric()],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation={
+                "minimum_detectable_effect": 50,
+                "exposure_estimate_config": {"conversionRateInputType": "automatic"},
+            },
+            start_date=self.NOW - timedelta(days=10),
+            number_of_variants=2,
+            result_blob={
+                "baseline": {"key": "control", "number_of_samples": 1000, "sum": 100, "step_counts": [1000, 100]},
+                "variant_results": [{"key": "test", "number_of_samples": 1000, "sum": 110}],
+            },
+            now=self.NOW,
+        )
+        assert estimate.target_sample_size == 1152
+        assert estimate.current_exposures == 2000
+        assert estimate.remaining_days == 0
+
+    def test_automatic_mode_too_little_data_shows_total_time(self):
+        # <1 day elapsed and <100 exposures -> fall back to ceil(target/rate) using rate from exposures/day.
+        estimate = estimate_running_time_for_experiment(
+            metrics=[self._funnel_metric()],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation={
+                "minimum_detectable_effect": 50,
+                "exposure_estimate_config": {"conversionRateInputType": "automatic"},
+            },
+            start_date=self.NOW - timedelta(hours=12),
+            number_of_variants=2,
+            result_blob=self._funnel_blob(samples=40),
+            now=self.NOW,
+        )
+        assert estimate.target_sample_size == 1152
+        assert estimate.current_exposures == 40
+        # rate = 40 exposures / 0.5 days = 80/day; ceil(1152/80) = 15
+        assert estimate.remaining_days == 15
+
+    def test_automatic_mode_without_usable_metric_returns_empty(self):
+        estimate = estimate_running_time_for_experiment(
+            metrics=[],
+            primary_metrics_ordered_uuids=None,
+            running_time_calculation={"exposure_estimate_config": {"conversionRateInputType": "automatic"}},
+            start_date=self.NOW - timedelta(days=10),
+            number_of_variants=2,
+            result_blob=None,
+            now=self.NOW,
+        )
+        assert estimate == RunningTimeEstimate(target_sample_size=None, current_exposures=None, remaining_days=None)
+
+    def test_mde_override_beats_saved_value(self):
+        base_kwargs = {
+            "metrics": [self._funnel_metric()],
+            "primary_metrics_ordered_uuids": None,
+            "running_time_calculation": {
+                "minimum_detectable_effect": 50,
+                "exposure_estimate_config": {"conversionRateInputType": "automatic"},
+            },
+            "start_date": self.NOW - timedelta(days=10),
+            "number_of_variants": 2,
+            "result_blob": self._funnel_blob(samples=1000),
+            "now": self.NOW,
+        }
+        saved = estimate_running_time_for_experiment(**base_kwargs)
+        overridden = estimate_running_time_for_experiment(**{**base_kwargs, "mde_override": 25})
+        assert overridden.target_sample_size is not None
+        assert saved.target_sample_size is not None
+        # Smaller MDE needs a larger sample; a 25% MDE roughly quadruples the 50% target.
+        assert overridden.target_sample_size > saved.target_sample_size

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -2655,6 +2655,40 @@ export interface CreateFromPromptInputApi {
 }
 
 /**
+ * Derived running-time state for one experiment, computed from its live results or manual config.
+ */
+export interface RunningTimeEstimateApi {
+    /**
+     * Recommended total sample size across all variants. Null when inputs are insufficient.
+     * @nullable
+     */
+    target_sample_size: number | null
+    /**
+     * Exposed users so far across control and variants. Null in manual mode or when no results exist.
+     * @nullable
+     */
+    current_exposures: number | null
+    /**
+     * Estimated days left to reach the target sample size. Null when it cannot be estimated.
+     * @nullable
+     */
+    remaining_days: number | null
+}
+
+/**
+ * Estimates keyed by experiment id. Requested ids with no matching experiment are omitted.
+ */
+export type RunningTimeEstimatesResponseApiResults = { [key: string]: RunningTimeEstimateApi }
+
+/**
+ * Batch running-time estimates keyed by experiment id.
+ */
+export interface RunningTimeEstimatesResponseApi {
+    /** Estimates keyed by experiment id. Requested ids with no matching experiment are omitted. */
+    results: RunningTimeEstimatesResponseApiResults
+}
+
+/**
  * * `source` - source
  * * `step` - step
  * * `numerator` - numerator
@@ -2896,6 +2930,13 @@ export type ExperimentsPromptTemplatesRetrieve200Item = {
     key: string
     label: string
     description: string
+}
+
+export type ExperimentsRunningTimeEstimatesRetrieveParams = {
+    /**
+     * Comma-separated experiment ids to estimate, e.g. `12,45,88`.
+     */
+    ids: string
 }
 
 export type ExperimentsSessionContextRetrieveParams = {

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -32,6 +32,7 @@ import type {
     ExperimentsActivityRetrieveParams,
     ExperimentsListParams,
     ExperimentsPromptTemplatesRetrieve200Item,
+    ExperimentsRunningTimeEstimatesRetrieveParams,
     ExperimentsSessionContextRetrieveParams,
     ExperimentsTimeseriesResultsRetrieveParams,
     PaginatedExperimentBasicListApi,
@@ -43,6 +44,7 @@ import type {
     RecalculateMetricsRequestApi,
     RunningTimeCalculationInputApi,
     RunningTimeCalculationResultApi,
+    RunningTimeEstimatesResponseApi,
     ShipVariantApi,
 } from './api.schemas'
 
@@ -1122,6 +1124,42 @@ export const experimentsPromptTemplatesRetrieve = async (
 ): Promise<ExperimentsPromptTemplatesRetrieve200Item[]> => {
     return apiMutator<ExperimentsPromptTemplatesRetrieve200Item[]>(
         getExperimentsPromptTemplatesRetrieveUrl(projectId),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
+}
+
+export const getExperimentsRunningTimeEstimatesRetrieveUrl = (
+    projectId: string,
+    params: ExperimentsRunningTimeEstimatesRetrieveParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/experiments/running_time_estimates/?${stringifiedParams}`
+        : `/api/projects/${projectId}/experiments/running_time_estimates/`
+}
+
+/**
+ * Running-time estimates for a batch of experiments, keyed by experiment id. Derives each estimate from the experiment's latest results (automatic mode) or saved manual config, reading a short-lived cache. Pass a comma-separated `ids` query param; unknown ids are omitted from the response.
+ */
+export const experimentsRunningTimeEstimatesRetrieve = async (
+    projectId: string,
+    params: ExperimentsRunningTimeEstimatesRetrieveParams,
+    options?: RequestInit
+): Promise<RunningTimeEstimatesResponseApi> => {
+    return apiMutator<RunningTimeEstimatesResponseApi>(
+        getExperimentsRunningTimeEstimatesRetrieveUrl(projectId, params),
         {
             ...options,
             method: 'GET',

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -1411,6 +1411,9 @@ tools:
     experiments-recalculate-timeseries:
         operation: experiments_recalculate_timeseries_create
         enabled: false
+    experiments-running-time-estimates-retrieve:
+        operation: experiments_running_time_estimates_retrieve
+        enabled: false
     experiments-session-buckets-create:
         operation: experiments_session_buckets_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -75615,6 +75615,40 @@ export namespace Schemas {
     }
 
     /**
+     * Derived running-time state for one experiment, computed from its live results or manual config.
+     */
+    export interface RunningTimeEstimate {
+      /**
+         * Recommended total sample size across all variants. Null when inputs are insufficient.
+         * @nullable
+         */
+      target_sample_size: number | null;
+      /**
+         * Exposed users so far across control and variants. Null in manual mode or when no results exist.
+         * @nullable
+         */
+      current_exposures: number | null;
+      /**
+         * Estimated days left to reach the target sample size. Null when it cannot be estimated.
+         * @nullable
+         */
+      remaining_days: number | null;
+    }
+
+    /**
+     * Estimates keyed by experiment id. Requested ids with no matching experiment are omitted.
+     */
+    export type RunningTimeEstimatesResponseResults = {[key: string]: RunningTimeEstimate};
+
+    /**
+     * Batch running-time estimates keyed by experiment id.
+     */
+    export interface RunningTimeEstimatesResponse {
+      /** Estimates keyed by experiment id. Requested ids with no matching experiment are omitted. */
+      results: RunningTimeEstimatesResponseResults;
+    }
+
+    /**
      * * `S3Compatible` - S3Compatible
      */
     export type S3CompatibleDestinationRequestTypeEnum = typeof S3CompatibleDestinationRequestTypeEnum[keyof typeof S3CompatibleDestinationRequestTypeEnum];
@@ -93755,6 +93789,13 @@ export namespace Schemas {
       key: string;
       label: string;
       description: string;
+    };
+
+    export type ExperimentsRunningTimeEstimatesRetrieveParams = {
+    /**
+     * Comma-separated experiment ids to estimate, e.g. `12,45,88`.
+     */
+    ids: string;
     };
 
     export type ExperimentsSessionContextRetrieveParams = {


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

The experiments list shows each running experiment's remaining time from a value the frontend persists back onto the experiment on every exposure refresh. That auto-save churns the experiment version and pollutes activity history. This PR adds the read-only endpoint the list needs, so remaining time can be computed on demand instead of stored.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

This PR adds a backend endpoint that returns running-time estimates for a batch of experiments, keyed by id. It is the first half of moving remaining-time off persisted experiment state; the frontend list migration and the auto-save removal are follow-ups.

### The endpoint

`GET /api/projects/{id}/experiments/running_time_estimates/?ids=12,45` returns `{"results": {"12": {...}, ...}}`. It is read-only and batch-first, so the list can fetch every visible running row in one call. It is team-scoped through the viewset queryset, caps the id count, and omits ids with no matching experiment. The existing `calculate_running_time` POST is untouched; it stays the pure calculator behind the running-time modal.

- `products/experiments/backend/presentation/views.py`
- `products/experiments/backend/presentation/serializers.py`
- `products/experiments/backend/facade/api.py`

### Estimate math

Each estimate mirrors the frontend `runningTimeLogic` so the list and the detail page agree. Automatic mode reads the sizing metric's latest completed `ExperimentMetricResult` and derives the baseline and exposure rate; manual mode reads the saved `exposure_estimate_config`. The sizing metric is the first primary metric, classified the same way as the frontend `getCalculatorMetricType`, with no extra exclusion so the two surfaces stay consistent.

- `products/experiments/backend/running_time_calculator.py`
- `products/experiments/backend/running_time_estimate_service.py`

### Caching

The per-experiment estimate reads through a 15 minute Django cache. The key folds in the experiment and feature-flag `updated_at` and the result window, so an edit or a fresher result misses the cache instead of serving stale numbers. A cache miss computes from Postgres only; no ClickHouse query runs on this path.

- `products/experiments/backend/running_time_estimate_service.py`

### Generated types

Regenerated from the new serializer and action with `hogli build:openapi`.

- `products/experiments/frontend/generated/api.ts` (generated)
- `products/experiments/frontend/generated/api.schemas.ts` (generated)
- `services/mcp/src/api/generated.ts` (generated)

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->

Most of the logic is pure and covered by fast unit tests: the result-blob mapping, sizing-metric selection, and the manual and automatic estimate branches, including the too-little-data fallback. One DB-backed test class guards the endpoint wiring: the keyed response shape, the team boundary, and the empty-ids case.

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/cd61bb7d-f54f-47d3-b8e7-3fae48fcf441)

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

None. No user-facing behavior changes yet; this endpoint has no consumer until the list migration lands.

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /brainstorming (superpowers)
- /systematic-debugging (superpowers)
- /test-driven-development (superpowers)
- /writing-tests (local)
- /improving-drf-endpoints (local)
- /writing-dataclasses (local)

Relevant decisions:

- Added a new endpoint instead of overloading `calculate_running_time`, so the pure stateless calculator stays pure and the experiment-reading logic lives on its own read path.
- Chose `GET ?ids=` returning a dict keyed by id, following the `surveys` `responses_count` precedent, since the value is read-only and the list needs every visible row at once.
- Presentation reaches the estimate through `facade/api.py`, not the service module directly, so the product-lint import surface stays clean; the compute logic sits in `running_time_estimate_service.py`.