### PR TITLE
chore(ci): resync depot skills and document check-run semantics

### DIFF
--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -133,7 +133,7 @@ Three cases behave in ways the name does not suggest:
 - A **job-level** `continue-on-error: true` posts a `failure` check run even though dependents read `success` and the run goes green. Use step-level `continue-on-error` plus an explicit verdict step instead.
 - A **matrix that expands to zero cells** fails its dependents on GitHub Actions and posts no check run at all. Guard any `fromJSON` matrix with an `if:` that skips the job when the list is empty.
 
-Required contexts are pinned to one app: every entry in this repo's `master` ruleset carries `integration_id: 15368`, the `github-actions` app, so a check run from any other app never satisfies one however exactly the name matches. [`/depot-github-runners`](../depot-github-runners/references/depot-ci-check-runs.md) has the measurements, the rulesets query, and how Depot CI differs.
+Required contexts are pinned to one app: every entry in this repo's `master` ruleset carries `integration_id: 15368`, the `github-actions` app, so a check run from any other app never satisfies one however exactly the name matches. [`/depot-ci`](../depot-ci/references/posthog-check-run-semantics.md) has the measurements, the rulesets query, and how Depot CI differs.
 
 ## Checkout / clone — sparse first, then shallow
 

--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -123,6 +123,18 @@ Four rules for the gate body:
 `WF007` enforces 1, 4, and the `always()` condition, and it takes the dependency list from `needs:` as well as the step body, so a job you wired into `needs:` and then forgot to test is reported rather than silently trusted.
 The half of rule 2 it cannot check is whether you named the right jobs in `needs:` to begin with: "reporting job" and "coverage job" look identical to a linter, so that one is on you and the reviewer.
 
+### What GitHub does with each conclusion
+
+Rule 3 works because a `skipped` check run satisfies a required context. `Build Docker image` concludes `SKIPPED` on merged PRs [92414](https://github.com/PostHog/posthog/pull/92414) and [92402](https://github.com/PostHog/posthog/pull/92402), and both merged through the Trunk queue, which scores it the same way.
+
+Three cases behave in ways the name does not suggest:
+
+- A required context that **no check run reports** stays pending and blocks. A trigger-level `paths:` filter that silences the whole workflow produces exactly this.
+- A **job-level** `continue-on-error: true` posts a `failure` check run even though dependents read `success` and the run goes green. Use step-level `continue-on-error` plus an explicit verdict step instead.
+- A **matrix that expands to zero cells** fails its dependents on GitHub Actions and posts no check run at all. Guard any `fromJSON` matrix with an `if:` that skips the job when the list is empty.
+
+Required contexts are pinned to one app: every entry in this repo's `master` ruleset carries `integration_id: 15368`, the `github-actions` app, so a check run from any other app never satisfies one however exactly the name matches. [`/depot-github-runners`](../depot-github-runners/references/depot-ci-check-runs.md) has the measurements, the rulesets query, and how Depot CI differs.
+
 ## Checkout / clone — sparse first, then shallow
 
 This repo is 45k tracked files and 4.6 GiB of packed objects, so **what you materialize costs more than how much history you fetch**.

--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -125,7 +125,7 @@ The half of rule 2 it cannot check is whether you named the right jobs in `needs
 
 ### What GitHub does with each conclusion
 
-Rule 3 works because a `skipped` check run satisfies a required context. `Build Docker image` concludes `SKIPPED` on merged PRs [92414](https://github.com/PostHog/posthog/pull/92414) and [92402](https://github.com/PostHog/posthog/pull/92402), and both merged through the Trunk queue, which scores it the same way.
+Rule 3 works because a `skipped` check run satisfies a required context, in the Trunk queue as well as on GitHub. `Build Docker image` rides on that: it concludes `skipped` on most PRs and they merge anyway.
 
 Three cases behave in ways the name does not suggest:
 

--- a/.agents/skills/depot-ci/SKILL.md
+++ b/.agents/skills/depot-ci/SKILL.md
@@ -23,7 +23,7 @@ This SKILL.md covers the core workflow plus the most common commands. Detailed f
 <!-- PostHog-local section. Keep it when resyncing from upstream; see UPSTREAM.md. -->
 
 PostHog addition: read [references/posthog-check-run-semantics.md](references/posthog-check-run-semantics.md) before you reason about what a Depot CI run reports to GitHub.
-It carries measured results for what Depot CI and GitHub Actions each post for a skipped, empty-matrix or `continue-on-error` job, how GitHub and the Trunk merge queue score those conclusions against a required status check, and the check-run naming and rerun differences between the two engines.
+It covers what Depot CI and GitHub Actions each post for a skipped, empty-matrix or `continue-on-error` job, how GitHub and the Trunk merge queue score those conclusions, and how the two engines differ on check naming and reruns.
 This repo runs Depot CI workflows out of `.depot/workflows/` alongside GitHub Actions, so both engines report on the same commit.
 
 <!-- End PostHog-local section. -->

--- a/.agents/skills/depot-ci/SKILL.md
+++ b/.agents/skills/depot-ci/SKILL.md
@@ -1,0 +1,401 @@
+---
+name: depot-ci
+description: >
+  Configures and manages Depot CI, a drop-in replacement for GitHub Actions that runs workflows
+  entirely within Depot. Use when migrating GitHub Actions workflows to Depot CI, running
+  `depot ci migrate`, managing Depot CI secrets and variables, running workflows with
+  `depot ci run`, debugging Depot CI runs with `depot ci run list`, `depot ci status`,
+  `depot ci logs`, `depot ci diagnose`, or `depot ci ssh`, inspecting test results with
+  `depot tests` or run artifacts with `depot ci artifacts`, checking workflow compatibility,
+  or understanding Depot CI capabilities. Also use when the user mentions .depot/ directory,
+  depot ci commands, or asks about running GitHub Actions workflows on Depot's infrastructure
+  without GitHub-hosted runners. Also use when comparing what Depot CI and GitHub Actions
+  report for a skipped, empty-matrix or continue-on-error job, or when working out whether a
+  check run satisfies a required status check or a merge queue.
+---
+
+# Depot CI
+
+Depot CI is a programmable CI system for engineers and agents. Workflows in Depot CI run entirely on Depot compute with built-in job visibility, debuggability, and control. GitHub Actions is the first syntax Depot CI supports: migrate your existing GitHub Actions workflows, and get fast, reliable runs on optimized infrastructure.
+
+This SKILL.md covers the core workflow plus the most common commands. Detailed flag tables, JSON output shapes, and less-common commands live in three reference files under `references/`, pointed to from the relevant sections below. Load a reference file only when you need detail it points to.
+
+<!-- PostHog-local section. Keep it when resyncing from upstream; see UPSTREAM.md. -->
+
+PostHog addition: read [references/posthog-check-run-semantics.md](references/posthog-check-run-semantics.md) before you reason about what a Depot CI run reports to GitHub.
+It carries measured results for what Depot CI and GitHub Actions each post for a skipped, empty-matrix or `continue-on-error` job, how GitHub and the Trunk merge queue score those conclusions against a required status check, and the check-run naming and rerun differences between the two engines.
+This repo runs Depot CI workflows out of `.depot/workflows/` alongside GitHub Actions, so both engines report on the same commit.
+
+<!-- End PostHog-local section. -->
+
+## Architecture
+
+Three subsystems: **compute** (provisions and executes work), **orchestrator** (schedules multi-step workflows, handles dependencies), **GitHub Actions parser** (translates Actions YAML into orchestrator workflows). The system is fully programmable.
+
+## Common flags
+
+Nearly every `depot ci` command (and `depot tests`) accepts:
+
+- `--org <id>`: organization ID, required when the user belongs to multiple organizations (see Org Context Check below).
+- `--token <token>`: Depot API token.
+- `-o, --output json`: machine-readable output, useful for agents and scripting. Most `depot ci` subcommands accept the `-o` shorthand, but `depot tests`, `depot ci secrets`, and `depot ci vars` accept only the long `--output` form.
+
+Per-command tables in the reference files omit these to cut noise; assume they're available.
+
+## Org Context Check for Multi-Org Users
+
+If a user belongs to multiple organizations, before setup/migration or if CI commands can't find expected workflows, verify Depot org context first:
+
+```bash
+depot org show              # Current org ID
+depot org list              # Orgs the user belongs to
+depot org switch <org-id>   # Option A: switch default org for this shell/session
+
+# Option B: keep current org and target explicitly per command
+depot ci run --org <org-id> --workflow .depot/workflows/ci.yml
+```
+
+Use `--org <org-id>` when the workflow/repo lives in a different org than the current default.
+
+## Getting Started
+
+### 1. Install the Depot Code Access GitHub App
+
+Depot dashboard → Settings → GitHub Code Access → Connect to GitHub. (If you've used Claude Code on Depot, this may already be installed.)
+
+### 2. Migrate workflows
+
+```bash
+depot ci migrate
+```
+
+This interactive wizard:
+
+1. Checks that the Depot Code Access app is installed and configured.
+1. Discovers all workflows in `.github/workflows/` and analyzes each for Depot CI compatibility.
+1. Copies selected workflows to `.depot/workflows/` with inline corrections and comments, and copies local actions from `.github/actions/` to `.depot/actions/`.
+1. Detects secrets and variables referenced in workflows and prints next steps for importing them.
+
+Your `.github/` directory is untouched, so workflows run in both GitHub and Depot simultaneously. **Warning:** workflows that cause side effects (deploys, artifact updates) will execute twice.
+
+### 3. Import secrets and variables
+
+```bash
+depot ci migrate secrets-and-vars
+```
+
+This creates and runs a one-shot GitHub Actions workflow on a temporary branch that reads your existing secrets and variables and imports them into Depot CI. You can also add them manually with `depot ci secrets add` / `depot ci vars add` (see Managing Secrets and Variables below).
+
+**For migration detail** (the `preflight`/`workflows`/`secrets-and-vars` subcommands, their flag tables, exactly what gets transformed, and manual setup), read `references/migration.md`.
+
+## Managing Secrets and Variables
+
+Secrets (referenced as `${{ secrets.NAME }}`, encrypted, never readable after creation) and variables (referenced as `${{ vars.NAME }}`, values readable) share a **variant model**. A name groups one or more variants; each variant holds a value plus optional selectors (`--repo`, `--env`, `--branch`, `--workflow`) that match jobs by repository, GitHub environment, branch, and workflow file. A variant with no selectors applies to every job in the organization. The CLI manages all four selector kinds directly, so variants no longer require the dashboard.
+
+Secret values come from an interactive prompt, piped stdin, or `KEY=VALUE` bulk pairs (no `--value` flag for secrets). Variable values use `--value`, a prompt, or `KEY=VALUE` pairs.
+
+```bash
+# Secrets: add (prompt or piped stdin), list, remove
+depot ci secrets add SECRET_NAME                                   # Prompts securely
+printf '%s' "$NPM_TOKEN" | depot ci secrets add SECRET_NAME        # From stdin (scripts)
+depot ci secrets add SECRET_NAME --repo owner/repo --branch main   # Scoped variant
+depot ci secrets list
+depot ci secrets remove SECRET_NAME
+
+# Variables: add, list, remove
+depot ci vars add VAR_NAME --value "some-value"
+depot ci vars add VAR_NAME --value "prod" --repo owner/repo --env production   # Scoped variant
+depot ci vars list
+depot ci vars remove VAR_NAME
+```
+
+**For the full command surface** (the `set`, `bulk`, and `get` secrets subcommands, every flag table, and how Depot resolves which variant wins at run time), read `references/secrets-and-variables.md`.
+
+### Credential safety
+
+Treat credentials as sensitive input and never echo them back in outputs.
+
+- For non-interactive flows, pipe secret values via stdin (for example `printf '%s' "$NPM_TOKEN" | depot ci secrets set SECRET_NAME --from-stdin`), not command-line literals.
+- Prefer interactive prompts over passing secret values as command arguments. Don't hardcode secrets or tokens in commands, scripts, workflow YAML, logs, or examples.
+- Use CI secret stores for `DEPOT_TOKEN` and other credentials; pass at runtime only.
+- Avoid force/non-interactive destructive flags unless explicitly requested. Before running credential-affecting commands, confirm scope (org, repo, workflow) and intended target.
+
+## Running Workflows
+
+```bash
+# Run a workflow (auto-detects repo from git remotes, applies local uncommitted changes)
+depot ci run --workflow .depot/workflows/ci.yml
+
+# Run in a specific org (for multi-org users)
+depot ci run --org <org-id> --workflow .depot/workflows/ci.yml
+
+# Run specific jobs only
+depot ci run --workflow .depot/workflows/ci.yml --job build --job test
+
+# Trigger a run and stream its logs live
+depot ci run --workflow .depot/workflows/ci.yml --job test --follow
+
+# Run a job and connect via SSH
+depot ci run --workflow .depot/workflows/ci.yml --job build --ssh
+
+# Debug with a tmate session after step N (requires a single --job)
+depot ci run --workflow .depot/workflows/ci.yml --job build --ssh-after-step 3
+
+# Override the auto-detected repository (multiple remotes or no origin)
+depot ci run --workflow .depot/workflows/ci.yml --repo owner/repo
+```
+
+The CLI auto-detects the GitHub repository from git remotes (preferring `origin`); pass `--repo owner/repo` to override. It also auto-detects uncommitted changes vs. the default branch, uploads a patch to Depot Cache, and injects a step to apply it after checkout, so your local working state runs without needing a push. Use `--ssh` / `--ssh-after-step` to start a debug session when launching a new run; use `depot ci ssh` to connect to an already-running job. Pass `--follow` (or `-f`) to stream the triggered run's logs as soon as it starts: it follows the single `--job` you request, or auto-selects when the run has one job and prompts when several are running. `--follow` cannot be combined with `--ssh` / `--ssh-after-step`.
+
+## Dispatching Workflows
+
+`depot ci dispatch` triggers a workflow via `workflow_dispatch` from the terminal. Inputs are validated against the workflow's declared input schema (required inputs must be supplied, typed inputs are coerced).
+
+```bash
+depot ci dispatch --repo depot/cli --workflow deploy.yml --ref main
+depot ci dispatch --repo depot/cli --workflow deploy.yml --ref main \
+  --input environment=staging --input dry_run=true
+depot ci dispatch --repo depot/cli --workflow deploy.yml --ref main --output json
+```
+
+`--workflow` takes the workflow file's **basename** (for example `deploy.yml`), not the full path `.depot/workflows/deploy.yml`, matching GitHub's `workflow_dispatch` API convention. Required flags: `--repo <owner/repo>`, `--workflow <filename>`, `--ref <branch-or-tag>`. `--input <key>=<value>` is repeatable.
+
+## Custom Images
+
+Build a custom image once and reuse it across jobs to skip repeated setup steps. A custom image is a snapshot of a Depot CI sandbox, stored in your org's Depot registry, that any job in any workflow can reference by name.
+
+### Build the image
+
+Add the `snapshot:` keyword to a job that runs your setup steps. After the steps complete, Depot captures the sandbox state and pushes it to the Depot registry as a reusable image. Snapshot jobs first check whether the requested tags already exist: if they do, Depot skips the job and reuses the snapshot; if not, Depot runs the job and creates it.
+
+```yaml
+jobs:
+  build-image:
+    runs-on: depot-ubuntu-latest
+    snapshot: ci-base:v1
+    steps:
+      - run: sudo apt-get update && sudo apt-get install -y your-tool
+```
+
+For advanced configuration, use the expanded `snapshot:` form. The `with:` block configures the underlying `depot/snapshot-action`; for example, `max-age` forces a rebuild after the configured age:
+
+```yaml
+jobs:
+  build-image:
+    runs-on: depot-ubuntu-latest
+    snapshot:
+      image-name: ci-base
+      version: v1
+      with:
+        max-age: 5d
+    steps:
+      - run: sudo apt-get update && sudo apt-get install -y your-tool
+```
+
+If no version is given, Depot uses the `latest` tag. An explicit version like `v1` tags the snapshot as both `v1` and `latest`, so consumers can pin a version or follow `latest`.
+
+### Use the image
+
+Reference the image in any Depot CI job with the `runs-on` object syntax, specifying `size` and `image` (both required):
+
+```yaml
+jobs:
+  test:
+    runs-on:
+      size: 2x8
+      image: ci-base
+    steps:
+      - uses: actions/checkout@v4
+```
+
+The `image` value can be a shorthand name like `ci-base` (which Depot expands to `{orgId}.registry.depot.dev/depot/snapshots/ci-base`) or a full Depot Registry reference `{orgId}.registry.depot.dev/some-image`. It must reference an image created by a snapshot job, not an arbitrary image.
+
+Available sizes: `2x8`, `4x16`, `8x32`, `16x64`, `32x128`, `64x256` (CPUs x RAM in GB).
+
+**Constraints:** images get pushed to and must be pulled from the Depot registry (`registry.depot.dev`), external registries are not supported.
+
+## Parallel Steps
+
+Depot CI supports running steps concurrently within a single job using `parallel:` blocks, reducing job duration to the slowest branch rather than the sum of all steps. This is a Depot CI-specific feature, not compatible with GitHub Actions runners.
+
+Use `parallel:` inside `steps:` with individual steps or `sequential:` groups. Each branch starts from the same job state; step outputs, environment variable, and `$GITHUB_PATH` changes from all branches are merged back when the block completes.
+
+```yaml
+# Run lint, typecheck, and tests concurrently
+steps:
+  - uses: actions/checkout@v4
+  - name: Install dependencies
+    run: pnpm install
+  - parallel:
+      - name: Lint
+        run: pnpm lint
+      - name: Typecheck
+        run: pnpm type-check
+      - name: Test
+        run: pnpm test
+```
+
+Use `sequential:` inside `parallel:` to group steps that must run in order within one branch:
+
+```yaml
+- parallel:
+    - sequential:
+        - name: Build
+          run: npm run build
+        - name: Test
+          run: npm test
+    - name: Lint
+      run: npm run lint
+```
+
+Control failure behavior with `fail-fast:`. It defaults to `true` (cancels remaining steps in the block); `false` lets all steps run to completion:
+
+```yaml
+- fail-fast: false
+  parallel:
+    - name: Lint
+      run: pnpm lint
+    - name: Typecheck
+      run: pnpm type-check
+```
+
+Set `continue-on-error: true` on an individual step inside a `parallel:` block to absorb that step's failure so the group can still succeed. This differs from `fail-fast:`, which only controls whether the remaining steps are cancelled when a failure occurs, not whether the group fails:
+
+```yaml
+- parallel:
+    - name: Optional check
+      continue-on-error: true
+      run: pnpm optional-check
+    - name: Required check
+      run: pnpm required-check
+```
+
+**Limitations:**
+
+- `parallel:` cannot be nested inside another `parallel:` (use `sequential:` inside `parallel:` instead).
+- Step `id` values must be unique across the entire job (including across different parallel blocks).
+
+## Retry Steps
+
+Automatically re-run a failed `run:` step to recover from flaky commands (network blips, transient registry errors) by adding a `retry:` key. Depot re-runs the step in place after a backoff delay and lets the job continue if a later attempt succeeds. Retries fire on any non-zero exit (no exit-code filtering) and are supported on `run:` steps only; `retry:` on a `uses:` action step is rejected at parse time, because actions carry `post:` and state machinery that is unsafe to re-run.
+
+Shorthand form sets the number of additional attempts:
+
+```yaml
+steps:
+  - run: npm ci
+    retry: 3 # up to 4 total runs
+```
+
+Structured form controls backoff and delays:
+
+```yaml
+steps:
+  - run: ./flaky-integration-test.sh
+    retry:
+      retries: 3 # additional attempts after the first run (1-10)
+      backoff: exponential # 'constant' (default) or 'exponential'
+      delay-seconds: 5 # base delay before the first retry (default 5)
+      max-delay-seconds: 60 # cap on a single delay (default 60)
+```
+
+`retries: N` means up to `N + 1` total runs. `constant` waits `delay-seconds` before every retry; `exponential` doubles the wait each attempt (attempt _n_ waits `delay-seconds × 2^(n-1)`) up to `max-delay-seconds`. `timeout-minutes` applies per attempt (each gets a fresh budget), and `continue-on-error` is applied only after all retries are exhausted. State is not reset between attempts, since retries reuse the same sandbox, so prepend your own cleanup if a step needs a clean slate.
+
+## Sandbox Capabilities
+
+- **Nested virtualization**: every Depot CI sandbox exposes `/dev/kvm` with hardware virtualization enabled by default, so KVM/QEMU, Android emulator, and VM-based end-to-end tests run without extra configuration.
+- **`DEPOT_JOB_URL`**: each job's environment includes `DEPOT_JOB_URL`, a direct link to the job in the Depot dashboard.
+- **GitHub checks**: Depot CI automatically reports a GitHub check for each job in a workflow run.
+
+## OIDC for Cloud Authentication
+
+Depot CI issues a signed JWT to each job so workflows can authenticate to cloud providers (AWS, GCP, Azure) with short-lived tokens instead of static credentials. Set `permissions: id-token: write` in the workflow for the token to be issued; the issuer is `https://identity.depot.dev`. Depot injects the token-request credentials into the environment, so standard actions like `aws-actions/configure-aws-credentials` work without extra configuration.
+
+For provider trust-policy setup, the `sub` spiffe claim format and wildcards, the full token claim reference, and migrating an existing GitHub Actions OIDC trust policy, read `references/oidc.md`.
+
+## Running, Monitoring, and Debugging Runs
+
+Common triage and inspection commands:
+
+```bash
+# Find recent/failed runs (defaults to queued + running)
+depot ci run list
+depot ci run list --status failed -n 10
+depot ci run list --repo depot/api --status failed --pr 42
+
+# Inspect a run's full workflow -> job -> attempt hierarchy
+depot ci status <run-id>
+
+# Pull logs (accepts run, job, or attempt ID; auto-selects the job if only one)
+depot ci logs <run-id>
+depot ci logs <run-id> --job build
+depot ci logs <job-id> --follow
+
+# Group and explain a run's failures, with a suggested fix per group
+depot ci diagnose --run <run-id>
+
+# Inspect parsed test results (Depot CI or GitHub Actions)
+depot tests <attempt-id> --ci --status failed
+```
+
+Full command index, all in `references/runs-and-debugging.md`:
+
+| Command                  | Purpose                                                                     |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `depot ci run list`      | List runs (triage entrypoint); filter by status, repo, sha, trigger, PR     |
+| `depot ci run show`      | Flat record for one run                                                     |
+| `depot ci workflow list` | List workflow executions with per-job counts; filter by `--name`            |
+| `depot ci workflow show` | One workflow's executions, jobs, and attempts                               |
+| `depot ci status`        | Full run → workflow → job → attempt hierarchy                               |
+| `depot ci logs`          | Fetch or `--follow` job logs; JSON/JSONL export                             |
+| `depot ci summary`       | GitHub Actions step summary markdown for an attempt                         |
+| `depot ci metrics`       | CPU and memory utilization for an attempt, job, or run                      |
+| `depot ci artifacts`     | `list` run artifacts and `download` one by ID                               |
+| `depot ci diagnose`      | Diagnose a failed run/workflow/job/attempt with grouped failures and fixes  |
+| `depot tests`            | List parsed test results; `--ci` or `--gha`, with status/suite/test filters |
+| `depot ci ssh`           | Interactive terminal into a running job's sandbox                           |
+| `depot ci cancel`        | Cancel a whole run, a workflow, or a single job                             |
+| `depot ci rerun`         | Re-run every terminal-state job in a workflow                               |
+| `depot ci retry`         | Retry a single failed/cancelled job, or all of them with `--failed`         |
+
+Read `references/runs-and-debugging.md` when you need a complete flag table, JSON output shape, or any command not shown in the triage examples above.
+
+## Compatibility with GitHub Actions
+
+Depot CI executes GitHub Actions YAML workflows. There are a few limitations where compatibility isn't 1:1. The full support and compatibility list is in `references/github-actions-compatibility.md`.
+
+Read the compatibility reference when you need to answer or act on any of the following or similar questions:
+
+- Whether a specific workflow-, job-, or step-level field is supported, for example `concurrency`, `jobs.<id>.environment`, `jobs.<id>.snapshot`, `jobs.<id>.container`, `jobs.<id>.services`, `jobs.<id>.strategy.matrix`, `steps[*].shell`.
+- Whether a trigger event is accepted: the supported list (`push`, `pull_request`, `pull_request_target`, `pull_request_review`, `deployment_status`, `repository_dispatch`, `schedule`, `workflow_call`, `workflow_dispatch`, `workflow_run`, `merge_group`) and the GitHub-only events Depot CI rejects (for example, `release`, `issues`, `deployment`, `branch_protection_rule`).
+- Which expression contexts (`github`, `env`, `vars`, `secrets`, `needs`, `strategy`, `matrix`, `steps`, `job`, `runner`, `inputs`) and functions (`always()`, `success()`, `failure()`, `cancelled()`, `case()`, `contains()`, `startsWith()`, `endsWith()`, `format()`, `join()`, `toJSON()`, `fromJSON()`, `hashFiles()`) are available.
+- Which `permissions` scopes work (`actions`, `checks`, `contents`, `id-token`, `metadata`, `pull_requests`, `statuses`, `workflows`).
+- Which action types run (JavaScript Node 12/16/20/24, Composite, Docker).
+- Which `runs-on` Depot runner labels and sandbox sizes Depot CI supports (x86_64 and Arm only, no macOS nor Windows), and how unrecognized labels are treated.
+- Diagnosing why `depot ci migrate` auto-disabled a job, stripped a trigger from `on:`, or remapped a `runs-on` label.
+- Recommending workarounds for known unsupported features (cross-repo reusable workflows, fork-triggered PRs, deployment environments).
+
+For routine migrate, run, secrets, or debug tasks that don't depend on a specific GHA feature, you don't need to load `references/github-actions-compatibility.md`.
+
+## Directory Structure
+
+```text
+your-repo/
+├── .github/
+│   ├── workflows/     # Original GHA workflows (keep running)
+│   └── actions/       # Local composite actions
+├── .depot/
+│   ├── workflows/     # Depot CI copies of workflows
+│   └── actions/       # Depot CI copies of local actions
+```
+
+## Common Mistakes
+
+| Mistake                                          | Fix                                                                                      |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Removing `.github/workflows/` after migration    | Keep them during transition to verify Depot CI parity                                    |
+| Using cross-repo reusable workflows              | Not supported yet, inline the workflow or copy it locally                                |
+| Expecting branch/env variants need the dashboard | The CLI manages variants directly via `--repo`/`--env`/`--branch`/`--workflow` selectors |
+| Running in the wrong org context                 | Check `depot org show`, list with `depot org list`, then switch org or pass `--org <id>` |
+| Forgetting `--org` flag with multiple orgs       | Migration or run commands may miss the expected repo/workflow; specify `--org <id>`      |
+| Workflows with `runs-on: windows-latest`         | Treated as `depot-ubuntu-latest`, may fail                                               |

--- a/.agents/skills/depot-ci/UPSTREAM.md
+++ b/.agents/skills/depot-ci/UPSTREAM.md
@@ -1,0 +1,32 @@
+# Upstream
+
+Vendored from [depot/skills](https://github.com/depot/skills) — used by the Depot CI workflows this repo keeps under `.depot/workflows/`.
+
+- Source: `skills/depot-ci/SKILL.md` and `skills/depot-ci/references/`
+- Commit: [`81795ab`](https://github.com/depot/skills/tree/81795abf98f81fb112cda35720e19b2aa3efa640/skills/depot-ci) (2026-09-01)
+- License: none in upstream at this commit; README documents `cp SKILL.md` install.
+
+Upstream also ships `agents/openai.yaml` and `assets/` icons in this directory. Neither is vendored: we do not run the OpenAI agent definition, and the icons are branding for Depot's own docs.
+
+## Local additions
+
+- `references/posthog-check-run-semantics.md`, which upstream has no equivalent of.
+- In `SKILL.md`, the paragraph between the PostHog-local comment markers, and the two sentences appended to the frontmatter `description`.
+- Three code fences tagged `text` to satisfy markdownlint MD040, which the pre-commit hook enforces: the directory tree in `SKILL.md` and `references/migration.md`, and the SPIFFE id in `references/oidc.md`. Upstream leaves them untagged, so a resync reintroduces the error.
+
+## Resync
+
+The resync overwrites `SKILL.md`, so re-apply the local additions afterwards.
+
+```bash
+SHA=$(curl -s https://api.github.com/repos/depot/skills/commits/main | jq -r .sha)
+BASE=https://raw.githubusercontent.com/depot/skills/$SHA/skills/depot-ci
+cp .agents/skills/depot-ci/SKILL.md /tmp/depot-ci-local.md
+curl -sfL "$BASE/SKILL.md" -o .agents/skills/depot-ci/SKILL.md
+for r in github-actions-compatibility migration oidc runs-and-debugging secrets-and-variables; do
+  curl -sfL "$BASE/references/$r.md" -o ".agents/skills/depot-ci/references/$r.md"
+done
+diff /tmp/depot-ci-local.md .agents/skills/depot-ci/SKILL.md
+# Re-add the local paragraph and the description sentences, then update `Commit:` above.
+# Check whether upstream added or renamed reference files; the loop above is a fixed list.
+```

--- a/.agents/skills/depot-ci/references/github-actions-compatibility.md
+++ b/.agents/skills/depot-ci/references/github-actions-compatibility.md
@@ -1,0 +1,81 @@
+# Depot CI compatibility with GitHub Actions
+
+Depot CI runs GitHub Actions YAML on Depot's own orchestrator and compute, so most workflows execute unmodified. The lists below enumerate exactly which GHA features Depot CI accepts, which it ignores, and which it rejects. They mirror `app/content/docs/ci/compatibility.mdx` in the Depot docs repo.
+
+## Supported
+
+### Workflow level
+
+`name`, `run-name`, `on`, `permissions`, `env`, `concurrency`, `defaults`, `jobs`, `on.workflow_call` (with inputs, outputs, secrets)
+
+### Triggers
+
+`push` (branches, tags, paths), `pull_request` (branches, paths), `pull_request_target`, `pull_request_review`, `deployment_status`, `repository_dispatch` (with `types`), `schedule`, `workflow_call`, `workflow_dispatch` (with inputs), `workflow_run`, `merge_group`
+
+`repository_dispatch` lets you trigger runs from outside GitHub via the GitHub API; the custom event type and `client_payload` are available through `github.event.action` and `github.event.client_payload`. GitHub delivers these events only against the default branch, so the default-branch workflow runs.
+
+### Job level
+
+`name`, `needs`, `if`, `permissions`, `outputs`, `env`, `defaults`, `timeout-minutes`, `concurrency`, `strategy` (matrix, fail-fast, max-parallel), `continue-on-error`, `container`, `services`, `uses` (reusable workflows), `with`, `secrets`, `secrets.inherit`, `steps`, `snapshot` (custom images from sandbox snapshots)
+
+### Step level
+
+`id`, `name`, `if`, `uses`, `run`, `shell`, `with`, `env`, `working-directory`, `continue-on-error`, `timeout-minutes`
+
+### Permissions
+
+`actions`, `checks`, `contents`, `id-token`, `metadata`, `pull_requests`, `statuses`, `workflows`
+
+### Expressions
+
+Contexts: `github`, `env`, `vars`, `secrets`, `needs`, `strategy`, `matrix`, `steps`, `job`, `runner`, `inputs`.
+
+Functions: `always()`, `success()`, `failure()`, `cancelled()`, `case()`, `contains()`, `startsWith()`, `endsWith()`, `format()`, `join()`, `toJSON()`, `fromJSON()`, `hashFiles()`.
+
+### Action types
+
+JavaScript (Node 12/16/20/24), Composite, Docker.
+
+## Not Supported
+
+- **Cross-repo reusable workflows**: `uses` referencing workflows in other repositories is not supported. Local reusable workflows work.
+- **Fork-triggered PRs**: `pull_request` and `pull_request_target` from forks not supported yet.
+- **Non-Ubuntu runner labels**: all non-Depot labels silently treated as `depot-ubuntu-latest` (no error, runs on Ubuntu).
+- **Deployment environments**: the `environment` field is not supported.
+- **GitHub-specific event triggers**: `branch_protection_rule`, `check_run`, `check_suite`, `create`, `delete`, `deployment`, `discussion`, `discussion_comment`, `fork`, `gollum`, `image_version`, `issue_comment`, `issues`, `label`, `milestone`, `page_build`, `public`, `pull_request_comment`, `pull_request_review_comment`, `registry_package`, `release`, `status`, `watch`.
+
+## Runner labels
+
+Depot CI sandboxes are x86_64 and arm only. There is no macOS or Windows support: those Depot GitHub Actions runner labels (`depot-macos-*`, `depot-windows-*`) are not compatible with Depot CI.
+
+Supported labels:
+
+| Label                       | Sandbox size | CPUs | RAM    |
+| --------------------------- | ------------ | ---- | ------ |
+| `depot-ubuntu-latest`       | `2x8`        | 2    | 8 GB   |
+| `depot-ubuntu-24.04`        | `2x8`        | 2    | 8 GB   |
+| `depot-ubuntu-24.04-4`      | `4x16`       | 4    | 16 GB  |
+| `depot-ubuntu-24.04-8`      | `8x32`       | 8    | 32 GB  |
+| `depot-ubuntu-24.04-16`     | `16x64`      | 16   | 64 GB  |
+| `depot-ubuntu-24.04-32`     | `32x128`     | 32   | 128 GB |
+| `depot-ubuntu-24.04-64`     | `64x256`     | 64   | 256 GB |
+| `depot-ubuntu-latest-arm`   | `2x8`        | 2    | 8 GB   |
+| `depot-ubuntu-24.04-arm`    | `2x8`        | 2    | 8 GB   |
+| `depot-ubuntu-24.04-4-arm`  | `4x16`       | 4    | 16 GB  |
+| `depot-ubuntu-24.04-8-arm`  | `8x32`       | 8    | 32 GB  |
+| `depot-ubuntu-24.04-16-arm` | `16x64`      | 16   | 64 GB  |
+| `depot-ubuntu-24.04-32-arm` | `32x128`     | 32   | 128 GB |
+| `depot-ubuntu-24.04-64-arm` | `64x256`     | 64   | 256 GB |
+
+Any label Depot CI can't parse is silently treated as `depot-ubuntu-latest`.
+
+## Migration behavior
+
+`depot ci migrate` reads workflows under `.github/workflows/`, transforms them, and writes copies under `.depot/workflows/`. When it encounters an unsupported feature, it does one of the following with inline comments explaining the change:
+
+- **Unsupported triggers** are removed from the `on:` block.
+- **Jobs that depend on unsupported features** are commented out and labeled `DISABLED`.
+- **`runs-on` labels** are remapped to Depot equivalents (for example, `ubuntu-latest` → `depot-ubuntu-latest`).
+- **`.github/` path references** in copied files are rewritten to their `.depot/` equivalents.
+
+If a user reports an auto-disabled job or a stripped trigger after migration, cross-reference the "Not Supported" list above to explain why.

--- a/.agents/skills/depot-ci/references/migration.md
+++ b/.agents/skills/depot-ci/references/migration.md
@@ -1,0 +1,79 @@
+# Depot CI: migration reference
+
+Detail for `depot ci migrate` and its subcommands, the transformations migration applies, and manual setup. SKILL.md keeps the high-level "Getting Started" flow; load this file for the subcommand flag tables and the exact set of changes migration makes to your workflows.
+
+**Common flags:** `depot ci migrate` and its subcommands accept `--org <id>` (required when the user belongs to multiple organizations) and `--token <token>`.
+
+## Migrate subcommands
+
+`depot ci migrate` runs the full flow: a preflight check, then copying and transforming selected workflows into `.depot/workflows/`, then reporting the secrets and variables they reference. Each phase is also a standalone subcommand:
+
+```bash
+# Validate auth, detect the repo, check the Depot Code Access GitHub App is installed
+depot ci migrate preflight
+
+# Copy and transform workflows from .github/workflows/ to .depot/workflows/
+depot ci migrate workflows
+
+# Import GitHub Actions secrets and variables into Depot CI
+depot ci migrate secrets-and-vars
+```
+
+### `depot ci migrate workflows` steps
+
+1. Discovers all workflow files in `.github/workflows/`.
+2. Analyzes each workflow for Depot CI compatibility.
+3. Prompts you to select which workflows to migrate.
+4. Copies selected workflows to `.depot/workflows/` and any local actions from `.github/actions/` to `.depot/actions/`.
+5. Applies compatibility fixes and adds inline comments documenting each change.
+6. Disables jobs that use unsupported features, with a `DISABLED` comment noting the reason.
+7. Reports any secrets and variables detected in the migrated workflows.
+
+### What gets transformed
+
+The command applies these changes, each documented with inline comments, and writes a header comment to every migrated file summarizing them:
+
+- **`runs-on` labels** are remapped from GitHub runner labels (like `ubuntu-latest`) to their Depot equivalents (like `depot-ubuntu-latest`).
+- **Unsupported triggers** (like `release` or `issues`) are removed from the `on:` block with a comment explaining why.
+- **Jobs with unsupported features** are commented out entirely, with a `DISABLED` comment.
+- **`.github/` path references** in copied workflow and action files are rewritten to their `.depot/` equivalents.
+
+For the full compatibility matrix, see `github-actions-compatibility.md` in this directory.
+
+## Flag tables
+
+### `depot ci migrate` and `depot ci migrate workflows`
+
+| Flag          | Description                                                 |
+| ------------- | ----------------------------------------------------------- |
+| `-y, --yes`   | Non-interactive: migrate all discovered workflows           |
+| `--overwrite` | Overwrite an existing `.depot/` directory without prompting |
+
+(`depot ci migrate preflight` takes only the common flags.)
+
+### `depot ci migrate secrets-and-vars`
+
+Creates a one-shot GitHub Actions workflow on a temporary branch that reads your existing GitHub secrets and variables and imports them into Depot CI. In interactive mode you can preview the generated workflow first; the branch is safe to delete afterward. You can also add secrets and variables manually with `depot ci secrets add` / `depot ci vars add` (see `secrets-and-variables.md`).
+
+| Flag               | Description                                                |
+| ------------------ | ---------------------------------------------------------- |
+| `-y, --yes`        | Skip preview and confirmation prompts                      |
+| `--branch <name>`  | Override the branch name used for the migration workflow   |
+| `--secrets <name>` | Secret name to include; repeatable. Omit to include all.   |
+| `--vars <name>`    | Variable name to include; repeatable. Omit to include all. |
+
+## Manual setup (without the migrate command)
+
+Create `.depot/workflows/` and `.depot/actions/` directories manually, copy workflow files from `.github/workflows/`, and configure secrets via the CLI (`depot ci secrets add`). The resulting layout:
+
+```text
+your-repo/
+├── .github/
+│   ├── workflows/     # Original GHA workflows (keep running)
+│   └── actions/       # Local composite actions
+├── .depot/
+│   ├── workflows/     # Depot CI copies of workflows
+│   └── actions/       # Depot CI copies of local actions
+```
+
+Keep `.github/workflows/` during the transition so workflows run in both GitHub and Depot, letting you verify parity. Note this means workflows with side effects (deploys, artifact updates) execute twice.

--- a/.agents/skills/depot-ci/references/oidc.md
+++ b/.agents/skills/depot-ci/references/oidc.md
@@ -1,0 +1,105 @@
+# Depot CI OIDC for cloud authentication
+
+Depot CI supports OpenID Connect (OIDC) so workflows authenticate to cloud providers (AWS, GCP, Azure) with short-lived tokens instead of static credentials. This file mirrors `app/content/docs/ci/oidc.mdx`.
+
+Contents:
+
+- How it works and the token
+- Configure a cloud provider (AWS example)
+- The `sub` claim and wildcards
+- Migrating from GitHub Actions OIDC
+- Token claim reference
+
+## How it works and the token
+
+Depot CI automatically issues a signed JWT to each job. Set `permissions: id-token: write` in the workflow YAML for the token to be issued. The cloud provider verifies the token against Depot CI's public endpoint and grants access based on the claims inside it.
+
+- **Issuer (`iss`)**: `https://identity.depot.dev`
+- **JWKS endpoint**: `https://identity.depot.dev/keys`
+- **Expiry (`exp`)**: 5 minutes from issuance
+- **Subject (`sub`)**: `spiffe://identity.depot.dev/org/<orgID>/ci/github/<owner>/<repo>/ref/<ref>/sandbox/<sandboxID>`
+
+## Configure a cloud provider
+
+The general steps are the same for any OIDC-compatible provider:
+
+1. Add `https://identity.depot.dev` as a trusted OIDC issuer.
+2. Create a role or service account that grants access based on token claims.
+3. Request the token in the workflow and use it to authenticate.
+
+### AWS example
+
+1. Add Depot CI as an identity provider in AWS IAM: provider URL `https://identity.depot.dev`, audience `sts.amazonaws.com`.
+2. Create an IAM role with a trust policy scoped by the `sub` and `aud` claims:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Principal": { "Federated": "arn:aws:iam::ACCOUNT:oidc-provider/identity.depot.dev" },
+         "Action": "sts:AssumeRoleWithWebIdentity",
+         "Condition": {
+           "StringEquals": { "identity.depot.dev:aud": "sts.amazonaws.com" },
+           "StringLike": {
+             "identity.depot.dev:sub": "spiffe://identity.depot.dev/org/<orgID>/ci/github/my-org/my-repo/*"
+           }
+         }
+       }
+     ]
+   }
+   ```
+
+3. Use the role in a workflow. Depot injects the token-request credentials into the environment, so `aws-actions/configure-aws-credentials` works without extra configuration:
+
+   ```yaml
+   jobs:
+     deploy:
+       runs-on: depot-ubuntu-latest
+       permissions:
+         id-token: write
+         contents: read
+       steps:
+         - uses: actions/checkout@v4
+         - uses: aws-actions/configure-aws-credentials@v4
+           with:
+             role-to-assume: arn:aws:iam::123456789012:role/my-role
+             aws-region: us-east-1
+         - run: aws s3 ls
+   ```
+
+## The `sub` claim and wildcards
+
+Scope trust policies by matching the `sub` claim. Full form:
+
+```text
+spiffe://identity.depot.dev/org/<orgID>/ci/github/<owner>/<repo>/ref/<ref>/sandbox/<sandboxID>
+```
+
+Wildcard matches:
+
+- Everything in a GitHub org: `spiffe://identity.depot.dev/org/<orgID>/ci/github/<owner>/*`
+- A specific repository: `spiffe://identity.depot.dev/org/<orgID>/ci/github/<owner>/<repo>/*`
+- A specific branch: `spiffe://identity.depot.dev/org/<orgID>/ci/github/<owner>/<repo>/ref/<ref>/sandbox/*`
+
+## Migrating from GitHub Actions OIDC
+
+`permissions: id-token: write` is required just as in GitHub Actions. What changes on the cloud-provider side:
+
+|                     | GitHub Actions                                                      | Depot CI                                                                                         |
+| ------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Issuer (`iss`)      | `https://token.actions.githubusercontent.com`                       | `https://identity.depot.dev`                                                                     |
+| Subject (`sub`)     | `repo:owner/repo:ref:refs/heads/main`                               | `spiffe://identity.depot.dev/org/<orgID>/ci/github/<owner>/<repo>/ref/<ref>/sandbox/<sandboxID>` |
+| Repo/branch scoping | `sub` (encoded in the subject)                                      | `sub`, or `repository` + `ref` claims (separate conditions)                                      |
+| JWKS endpoint       | `https://token.actions.githubusercontent.com/.well-known/jwks.json` | `https://identity.depot.dev/keys`                                                                |
+
+Add `https://identity.depot.dev` as a new identity provider and create a new trust policy rather than modifying the existing GitHub Actions one, so both providers work in parallel during the transition.
+
+## Token claim reference
+
+Standard claims: `iss`, `sub`, `aud` (set by the workload request, for example `sts.amazonaws.com`), `exp`, `iat`.
+
+GitHub Actions-compatible claims: `repository`, `repository_owner`, `repository_id`, `repository_owner_id`, `repository_visibility`, `ref`, `ref_type`, `sha`, `actor`, `actor_id`, `event_name`, `head_ref`, `base_ref`, `workflow`, `workflow_ref`, `workflow_sha`, `run_id`, `run_number`, `run_attempt`.
+
+Depot-specific claims: `org_id` (Depot organization ID), `job_id` (Depot CI job ID).

--- a/.agents/skills/depot-ci/references/posthog-check-run-semantics.md
+++ b/.agents/skills/depot-ci/references/posthog-check-run-semantics.md
@@ -2,10 +2,10 @@
 
 PostHog-authored. Not part of the vendored upstream skill.
 
-Depot sells two different things and they are easy to confuse:
+Two engines report on the same commit in this repo, and they are easy to confuse:
 
-- **Depot runners** run GitHub Actions jobs. GitHub is still the engine. Checks come from the `github-actions` app. This is what the rest of the skill covers.
-- **Depot CI** is its own engine. It parses workflows under `.depot/workflows/`, which GitHub Actions ignores, and reports its own check runs from the `depot-code-access` app.
+- **Depot runners** run GitHub Actions jobs from `.github/workflows/`. GitHub is still the engine, and checks come from the `github-actions` app. See the `depot-github-runners` skill.
+- **Depot CI** is its own engine. It parses workflows under `.depot/workflows/`, which GitHub Actions ignores, and reports its own check runs from the `depot-code-access` app. That is what this skill covers.
 
 Everything below was measured, not read from docs. Two twin workflows ran an identical job graph on both engines against the same commit ([probe PR](https://github.com/PostHog/posthog/pull/92542)).
 

--- a/.agents/skills/depot-ci/references/posthog-check-run-semantics.md
+++ b/.agents/skills/depot-ci/references/posthog-check-run-semantics.md
@@ -7,7 +7,7 @@ Two engines report on the same commit in this repo, and they are easy to confuse
 - **Depot runners** run GitHub Actions jobs from `.github/workflows/`. GitHub is still the engine, and checks come from the `github-actions` app. See the `depot-github-runners` skill.
 - **Depot CI** is its own engine. It parses workflows under `.depot/workflows/`, which GitHub Actions ignores, and reports its own check runs from the `depot-code-access` app. That is what this skill covers.
 
-Everything below was measured, not read from docs. Two twin workflows ran an identical job graph on both engines against the same commit ([probe PR](https://github.com/PostHog/posthog/pull/92542)).
+Neither vendor documents any of what follows. It comes from running one job graph on both engines against the same commit and reading the check runs each posted. To re-derive it, put twin workflows in `.github/workflows/` and `.depot/workflows/`, give each job a shape from the table below, and have an `if: always()` job print `toJSON(needs)`.
 
 ## Conclusions the two engines post
 
@@ -26,7 +26,7 @@ Everything below was measured, not read from docs. Two twin workflows ran an ide
 
 The engines agree everywhere except the empty matrix and the matrix check granularity.
 
-## Two traps that bite on both engines
+## Two cases where the check disagrees with the run
 
 **A job-level `continue-on-error: true` still posts a `failure` check run.** Dependents read `success`, the workflow goes green, and the check stays red. Put a required context on such a job and the merge blocks while every gate says the run passed. Prefer step-level `continue-on-error` plus an explicit verdict step, which is what `ci-backend.yml` does.
 
@@ -34,7 +34,7 @@ The engines agree everywhere except the empty matrix and the matrix check granul
 
 ## How GitHub scores a conclusion against a required context
 
-- A check run that concludes `skipped` **satisfies** a required status check. Production evidence: `Build Docker image` concludes `SKIPPED` on merged PRs [92414](https://github.com/PostHog/posthog/pull/92414), [92402](https://github.com/PostHog/posthog/pull/92402), [92396](https://github.com/PostHog/posthog/pull/92396) and [92372](https://github.com/PostHog/posthog/pull/92372). All four merged, and all four went through the Trunk merge queue, so Trunk scores it the same way.
+- A check run that concludes `skipped` **satisfies** a required status check, and the Trunk merge queue scores it the same way. The repo already depends on this: `Build Docker image` is a required context that concludes `skipped` on most PRs, and they merge.
 - A required context that **no check run ever reports** stays pending and blocks. This is the empty-matrix failure mode above, and it is also what a `paths:` filter does when it silences a whole workflow.
 - Required contexts are pinned to one app. Every entry in this repo's `master` ruleset carries `integration_id: 15368`, the `github-actions` app. Read them with:
 
@@ -56,7 +56,7 @@ Matrix jobs differ: GitHub Actions posts one check per cell and appends the cell
 
 ## Reruns
 
-Depot updates the existing check run in place. Measured by retrying one failed job: the check run kept id `99890906312` and only its timestamps moved. GitHub Actions instead creates a fresh check run per attempt and leaves the old one behind, which is why a superseded GitHub Actions run can show a stale red check next to a green one for the same name.
+Retrying a failed Depot job updates the existing check run: same check run id, new timestamps and conclusion. GitHub Actions instead creates a fresh check run per attempt and leaves the old one behind, which is why a superseded GitHub Actions run can show a stale red check beside a green one of the same name. Read the latest check run per name when you script against either engine.
 
 ## Depot CI CLI recipes
 

--- a/.agents/skills/depot-ci/references/runs-and-debugging.md
+++ b/.agents/skills/depot-ci/references/runs-and-debugging.md
@@ -1,0 +1,470 @@
+# Depot CI: runs, monitoring, and debugging reference
+
+Full command surface for finding, inspecting, monitoring, debugging, and mutating CI runs. SKILL.md keeps the common examples and a command index; load this file when you need a complete flag table, JSON output shape, or a command not shown inline (`summary`, `metrics`, `artifacts`, `diagnose`, `tests`, `workflow list/show`, `cancel`, `rerun`, `retry`).
+
+**Common flags:** every command below also accepts `--org <id>` (organization ID, required when the user belongs to multiple organizations) and `--token <token>` (Depot API token). They're omitted from the per-command tables to cut noise. Commands that emit JSON use `-o, --output json`.
+
+## Contents
+
+- [`depot ci run list`](#depot-ci-run-list) — list runs (triage entrypoint)
+- [`depot ci run show`](#depot-ci-run-show) — flat record for one run
+- [`depot ci workflow list`](#depot-ci-workflow-list) — list workflow executions with job counts
+- [`depot ci workflow show`](#depot-ci-workflow-show) — one workflow's executions, jobs, attempts
+- [`depot ci status`](#depot-ci-status) — full run → workflow → job → attempt hierarchy
+- [`depot ci logs`](#depot-ci-logs) — fetch or follow job logs
+- [`depot ci summary`](#depot-ci-summary) — step summary markdown
+- [`depot ci metrics`](#depot-ci-metrics) — CPU and memory utilization
+- [`depot ci artifacts`](#depot-ci-artifacts) — list and download run artifacts
+- [`depot ci diagnose`](#depot-ci-diagnose) — diagnose failed runs
+- [`depot tests`](#depot-tests) — list parsed test results (CI and GitHub Actions)
+- [`depot ci ssh`](#depot-ci-ssh) — interactive terminal into a running job
+- [`depot ci cancel`](#depot-ci-cancel) — cancel a run, workflow, or job
+- [`depot ci rerun`](#depot-ci-rerun) — rerun every job in a workflow
+- [`depot ci retry`](#depot-ci-retry) — retry failed/cancelled jobs
+- [Debugging failed runs](#debugging-failed-runs) — the triage flow
+
+---
+
+## `depot ci run list`
+
+The primary entrypoint for debugging active/recent CI activity across workflows. `depot ci run list` returns runs (one entry per triggering event); use `depot ci workflow list` instead when you want per-job-count breakdowns or to filter by workflow name.
+
+```bash
+# List runs (defaults to queued + running)
+depot ci run list
+
+# Filter by status (repeatable)
+depot ci run list --status failed
+depot ci run list --status finished --status failed
+
+# Filter by repository and commit SHA prefix
+depot ci run list --repo depot/api --sha abc123
+
+# Filter by trigger event
+depot ci run list --trigger workflow_dispatch
+
+# Filter failed runs for a pull request (--pr requires --repo)
+depot ci run list --repo depot/api --status failed --pr 42
+
+# Limit number of results
+depot ci run list -n 5
+
+# Machine-readable output for tooling/agents
+depot ci run list --output json
+```
+
+| Flag                  | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `-n <int>`            | Number of runs to return (default `50`)                                              |
+| `--status <name>`     | Filter by status; repeatable: `queued`, `running`, `finished`, `failed`, `cancelled` |
+| `--repo <owner/repo>` | Filter by repository                                                                 |
+| `--sha <prefix>`      | Filter by commit SHA prefix                                                          |
+| `--trigger <event>`   | Filter by trigger event, for example `push` or `workflow_dispatch`                   |
+| `--pr <number>`       | Filter by pull request number (requires `--repo`)                                    |
+| `-o, --output`        | Output format (`json`)                                                               |
+
+---
+
+## `depot ci run show`
+
+Prints a flat record for one run (org, repo, status, trigger, ref, sha, head sha, timestamps). Use `depot ci status <run-id>` instead when you need the full workflow/job/attempt hierarchy.
+
+```bash
+depot ci run show <run-id>
+depot ci run show <run-id> --output json
+```
+
+| Flag           | Description            |
+| -------------- | ---------------------- |
+| `-o, --output` | Output format (`json`) |
+
+---
+
+## `depot ci workflow list`
+
+Returns workflows (one entry per workflow execution within a run, with per-job counts). Use it to filter by workflow `--name` (for example `deploy`), or to see job-count breakdowns rather than run-level status.
+
+```bash
+# List recent workflows (default 50, max 200)
+depot ci workflow list
+
+# Filter by workflow name
+depot ci workflow list --name deploy
+
+# Filter by repo, status, head SHA, and pull request
+depot ci workflow list --repo depot/api --status failed --sha abc123 --pr 42
+
+# JSON output
+depot ci workflow list --output json
+```
+
+| Flag                  | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `-n <int>`            | Number of recent workflows to return (default `50`, max `200`)                       |
+| `--name <name>`       | Filter by workflow name                                                              |
+| `--repo <owner/repo>` | Filter by repository                                                                 |
+| `--status <name>`     | Filter by status; repeatable: `queued`, `running`, `finished`, `failed`, `cancelled` |
+| `--trigger <event>`   | Filter by trigger event, for example `push` or `workflow_dispatch`                   |
+| `--sha <prefix>`      | Filter by head SHA prefix                                                            |
+| `--pr <number>`       | Filter by pull request number                                                        |
+| `-o, --output`        | Output format (`json`)                                                               |
+
+---
+
+## `depot ci workflow show`
+
+Shows a CI workflow, including the parent run context, executions, jobs, and per-job attempt details. For each job, the output includes the latest attempt's ID, status, sandbox ID, session ID, and a ready-to-run `depot ci logs` command; if a job has multiple attempts, all are listed.
+
+```bash
+depot ci workflow show <workflow-id>
+depot ci workflow show <workflow-id> --output json
+```
+
+| Flag           | Description            |
+| -------------- | ---------------------- |
+| `-o, --output` | Output format (`json`) |
+
+---
+
+## `depot ci status`
+
+Looks up the status of a run and displays its workflows, jobs, and individual job attempts in a hierarchical view. Each attempt shows its ID, attempt number, and status, plus a ready-to-run `depot ci logs` command, a dashboard link, and (when applicable) `depot ci ssh` and log-download commands.
+
+```bash
+# Check run status (shows workflows -> jobs -> attempts hierarchy)
+depot ci status <run-id>
+
+# JSON output (full workflow/job/attempt tree, including SSH and log download metadata)
+depot ci status <run-id> --output json
+```
+
+| Flag           | Description                                          |
+| -------------- | ---------------------------------------------------- |
+| `-o, --output` | Output as JSON instead of the hierarchical text view |
+
+In the JSON tree, `download_available` becomes `true` and `download_command` appears once an attempt reaches `finished`. `ssh_available` and `ssh_command` appear only while an attempt is running with a sandbox.
+
+---
+
+## `depot ci logs`
+
+Fetches and prints log output for a CI job. Accepts a run ID, job ID, or attempt ID; when given a run or job ID it resolves to the latest attempt automatically.
+
+```bash
+# Fetch logs (accepts run ID, job ID, or attempt ID)
+depot ci logs <run-id>
+depot ci logs <attempt-id>
+
+# Specify a job when the run has multiple jobs
+depot ci logs <run-id> --job test
+
+# Disambiguate when multiple workflows share the same job key
+depot ci logs <run-id> --job build --workflow ci.yml
+
+# Follow live logs
+depot ci logs <job-id> --follow
+```
+
+| Flag                   | Description                                                                                                                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--job <key>`          | Job key to select; required for multi-job runs in non-interactive contexts (piped output, `--output json`, or `--output-file`). In an interactive terminal you can pick from a list instead |
+| `--workflow <path>`    | Workflow path to filter jobs (for example, `ci.yml`)                                                                                                                                        |
+| `-f, --follow`         | Follow live logs as they're produced                                                                                                                                                        |
+| `--timestamps`         | Prefix plain log lines with UTC timestamps                                                                                                                                                  |
+| `-o, --output`         | Output format: `text` (default) or `json` (newline-delimited events)                                                                                                                        |
+| `--output-file <path>` | Write a finite log export to the given file path (incompatible with `--follow`)                                                                                                             |
+
+Combined modes:
+
+- `--follow` streams the live attempt; pair it with `--output json` to emit newline-delimited events. JSON streaming includes `line` events plus `status` events (attempt state changes) and an `end` event with final status and line count.
+- Each `line` event carries `timestamp`, `timestamp_ms`, `stream` (`stdout`/`stderr`), `step_key`, `step_id`, `step_name`, `line_number`, and `body`.
+- `--output-file` cannot be combined with `--follow`. Use `--output json --output-file logs.jsonl` to download a JSONL export.
+- If you pass a run or job ID that hasn't started yet, the command waits up to 30 seconds for the latest attempt to start, then streams logs as they arrive.
+
+---
+
+## `depot ci summary`
+
+Fetches the GitHub Actions step summary markdown (`$GITHUB_STEP_SUMMARY`) a job attempt produced. Accepts an attempt ID or a job ID (resolves to the current/latest attempt). If no summary was authored, prints a short empty-state message and exits 0.
+
+```bash
+depot ci summary <attempt-id>
+depot ci summary <job-id>
+depot ci summary <attempt-id> --output json
+```
+
+| Flag           | Description                               |
+| -------------- | ----------------------------------------- |
+| `-o, --output` | Output format: `text` (default) or `json` |
+
+JSON includes `org_id`, `run_id`, `workflow_id`, `job_id`, `attempt_id`, `attempt`, `job_status`, `attempt_status`, `has_summary`, `empty_reason` (for example `no_summary` or `no_attempt`), `step_count`, and `markdown`.
+
+---
+
+## `depot ci metrics`
+
+Fetches CPU and memory utilization for one attempt, every attempt of a job, or every job in a run. The positional `<attempt-id>` and the `--attempt`, `--job`, `--run` flags are mutually exclusive.
+
+```bash
+# Positional attempt ID (text summary of an attempt's CPU/memory)
+depot ci metrics <attempt-id>
+
+# Equivalent with --attempt flag
+depot ci metrics --attempt <attempt-id>
+
+# Every attempt of a job
+depot ci metrics --job <job-id>
+
+# Every job and attempt in a run
+depot ci metrics --run <run-id>
+
+# Per-sample time series for one attempt (samples array only present with --attempt or positional)
+depot ci metrics <attempt-id> --output json
+
+# Per-attempt summary stats for a job or run (no samples array)
+depot ci metrics --job <job-id> --output json
+depot ci metrics --run <run-id> --output json
+```
+
+| Flag                     | Description                                             |
+| ------------------------ | ------------------------------------------------------- |
+| `--attempt <attempt-id>` | Job attempt ID (alias for the positional argument)      |
+| `--job <job-id>`         | Show metrics for every attempt of the given job         |
+| `--run <run-id>`         | Show metrics for every job and attempt in the given run |
+| `-o, --output`           | Output format: `text` (default) or `json`               |
+
+Run-level queries can hit a server-side sample limit; the error suggests narrowing to `--job <job-id>` or `<attempt-id>`. JSON shape depends on the form: `--attempt`/positional includes the full per-sample `samples` array; `--job` and `--run` return per-attempt summary stats without `samples`.
+
+---
+
+## `depot ci artifacts`
+
+Lists CI artifact metadata and downloads one artifact by ID. Download URLs are never returned by `list`; use `artifacts download` to fetch the file.
+
+### `depot ci artifacts list`
+
+```bash
+# List every artifact for a run
+depot ci artifacts list <run-id>
+
+# Narrow to one workflow, job, or attempt
+depot ci artifacts list <run-id> --job <job-id> --output json
+```
+
+| Flag              | Description                               |
+| ----------------- | ----------------------------------------- |
+| `--workflow <id>` | Workflow ID to filter artifacts           |
+| `--job <id>`      | Job ID to filter artifacts                |
+| `--attempt <id>`  | Attempt ID to filter artifacts            |
+| `-o, --output`    | Output format: `text` (default) or `json` |
+
+JSON is `{"artifacts": [...]}` where each artifact includes `artifact_id`, `run_id`, `workflow_id`, `workflow_path`, `job_id`, `job_key`, `attempt_id`, `attempt`, `name`, `size_bytes`, and `created_at`.
+
+### `depot ci artifacts download`
+
+Downloads one artifact by its artifact ID. Without `--output-file`, the file is written to the artifact's original name in the current directory (control characters and path separators are sanitized to `_`). The command refuses to overwrite an existing file.
+
+```bash
+depot ci artifacts download <artifact-id>
+depot ci artifacts download <artifact-id> --output-file coverage.zip
+```
+
+| Flag                   | Description                                                      |
+| ---------------------- | ---------------------------------------------------------------- |
+| `--output-file <path>` | Write the artifact to this file path instead of the default name |
+
+---
+
+## `depot ci diagnose`
+
+Diagnoses a failed run, workflow, job, or attempt using bounded stored failure context. The command groups similar failures across attempts and, where available, surfaces a diagnosis and a possible fix for each group, with evidence lines and drill-down commands. Exactly one of `--run`, `--workflow`, `--job`, or `--attempt` is required; positional target IDs aren't accepted.
+
+```bash
+depot ci diagnose --run <run-id>
+depot ci diagnose --workflow <workflow-id>
+depot ci diagnose --job <job-id>
+depot ci diagnose --attempt <attempt-id>
+depot ci diagnose --job <job-id> --output json
+```
+
+| Flag              | Description                                                          |
+| ----------------- | -------------------------------------------------------------------- |
+| `--run <id>`      | Diagnose a run (mutually exclusive with the other target flags)      |
+| `--workflow <id>` | Diagnose a workflow (mutually exclusive with the other target flags) |
+| `--job <id>`      | Diagnose a job (mutually exclusive with the other target flags)      |
+| `--attempt <id>`  | Diagnose an attempt (mutually exclusive with the other target flags) |
+| `-o, --output`    | Output format: `text` (default) or `json`                            |
+
+The text output adapts to the diagnosis state:
+
+- **Grouped**: lists each failure group with its failure count, diagnosis, possible fix, and a small set of representative attempts and evidence lines.
+- **Focused**: a single representative attempt with its error, diagnosis, possible fix, and relevant log lines.
+- **Empty**: prints "No CI failures found for this target." with an optional reason.
+- **Over limit**: the target spans more failed candidates than the diagnosis bounds allow; the output includes a "Narrower targets" breakdown with ready-to-run drill-down commands.
+
+JSON includes `state` (`empty`, `grouped_failures`, `focused_failure`, or `over_limit`), `target`, `context`, `bounds`, `failure_groups` (with `diagnosis`, `possible_fix`, and representative attempts), `representative_attempts`, `next_commands`, and `over_limit_breakdown` when over limit.
+
+---
+
+## `depot tests`
+
+Lists parsed test results. This is a top-level command (`depot tests`, not `depot ci tests`). Choose exactly one backend: `--ci` or `--gha`.
+
+- **`--ci`**: Depot CI results. The ID may be a run, job, or attempt ID; run and job IDs resolve to the latest matching attempt, matching `depot ci logs`.
+- **`--gha`**: GitHub Actions results. The ID may be a GitHub Actions job ID or the stored Depot GitHub job row ID.
+
+```bash
+depot tests <attempt-id> --ci
+depot tests <run-id> --ci --job test
+depot tests <github-job-id> --gha --status failed
+depot tests <attempt-id> --ci --output json
+```
+
+| Flag                 | Description                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------- |
+| `--ci`               | Read Depot CI test results                                                              |
+| `--gha`              | Read GitHub Actions test results                                                        |
+| `--job <key>`        | Depot CI job key to select when the ID is a run (`--ci` only)                           |
+| `--workflow <path>`  | Depot CI workflow path to filter jobs, for example `ci.yml` (`--ci` only)               |
+| `--status <name>`    | Test status to include: `unknown`, `passed`, `failed`, `errored`, `skipped`; repeatable |
+| `--suite <name>`     | Test suite name to include                                                              |
+| `--test <name>`      | Test case name to include                                                               |
+| `--class <name>`     | Test class name to include                                                              |
+| `--file <name>`      | Source filename to include                                                              |
+| `--page-size <n>`    | Results per page (default `100`, max `500`)                                             |
+| `--page-token <tok>` | Token to fetch the next page                                                            |
+| `--output`           | Output format: `auto` (default), `table`, or `json` (no `-o` shorthand)                 |
+
+`--job` and `--workflow` can only be used with `--ci`.
+
+---
+
+## `depot ci ssh`
+
+Opens an interactive terminal session to the sandbox running a CI job. Accepts a run ID or job ID. If the job hasn't started yet, the command waits up to 5 minutes for the sandbox to be provisioned. Use `--ssh` / `--ssh-after-step` on `depot ci run` instead to start a debug session when launching a new run.
+
+```bash
+# Connect directly using a job ID
+depot ci ssh <job-id>
+
+# Connect to a specific job in a run
+depot ci ssh <run-id> --job build
+
+# Auto-select job when there's only one
+depot ci ssh <run-id>
+
+# Print SSH connection details for automation
+depot ci ssh <run-id> --info --output json
+```
+
+| Flag           | Description                                           |
+| -------------- | ----------------------------------------------------- |
+| `--job <key>`  | Job key to connect to (required for multi-job runs)   |
+| `--info`       | Print SSH details instead of connecting interactively |
+| `-o, --output` | Output format for `--info` (`json`)                   |
+
+`--info --output json` returns `host` (`exec.depot.dev`), `sandbox_id`, `session_id`, and a ready-to-run `ssh_command`.
+
+---
+
+## `depot ci cancel`
+
+Cancels a queued or running run, an entire workflow (all its jobs), or a single job. With no scope flag the entire run is cancelled. `--workflow` and `--job` are mutually exclusive; with `--job` the CLI resolves the containing workflow from run status automatically. Runs, workflows, or jobs already in a terminal state (finished, failed, cancelled) cannot be cancelled and return an error.
+
+```bash
+# Cancel an entire run (and every workflow and job within it)
+depot ci cancel <run-id>
+
+# Cancel one workflow within the run (and all its jobs)
+depot ci cancel <run-id> --workflow <workflow-id>
+
+# Cancel a single job (workflow is resolved automatically)
+depot ci cancel <run-id> --job <job-id>
+
+# JSON output
+depot ci cancel <run-id> --output json
+```
+
+| Flag              | Description                                                                |
+| ----------------- | -------------------------------------------------------------------------- |
+| `--workflow <id>` | Workflow ID to cancel (mutually exclusive with `--job`; omit both for run) |
+| `--job <id>`      | Job ID to cancel (mutually exclusive with `--workflow`; omit both for run) |
+| `--output json`   | Output the RPC response as JSON                                            |
+
+---
+
+## `depot ci rerun`
+
+Re-runs every job in a workflow that has reached a terminal state, creating a new attempt for each. For single-workflow runs the CLI resolves the workflow automatically; for multi-workflow runs pass `--workflow <id>`. Rerunning a workflow that is still running returns a precondition error: cancel it first.
+
+```bash
+# Rerun the (single) workflow in a run
+depot ci rerun <run-id>
+
+# Rerun a specific workflow in a multi-workflow run
+depot ci rerun <run-id> --workflow <workflow-id>
+
+# JSON output
+depot ci rerun <run-id> --output json
+```
+
+| Flag              | Description                                                              |
+| ----------------- | ------------------------------------------------------------------------ |
+| `--workflow <id>` | Workflow ID to rerun (required when the run contains multiple workflows) |
+| `--output json`   | Output the RPC response as JSON                                          |
+
+---
+
+## `depot ci retry`
+
+Retries a single failed or cancelled job with `--job <job-id>`, or every failed/cancelled job in a workflow with `--failed`. Exactly one of `--job` or `--failed` must be set. With `--job` the containing workflow is resolved automatically; with `--failed` on a multi-workflow run, `--workflow <id>` is required. Each retry creates a new attempt; previous attempts remain visible in `depot ci status`.
+
+```bash
+# Retry a single job
+depot ci retry <run-id> --job <job-id>
+
+# Retry every failed/cancelled job in the (single) workflow
+depot ci retry <run-id> --failed
+
+# Retry every failed/cancelled job in a specific workflow
+depot ci retry <run-id> --failed --workflow <workflow-id>
+
+# JSON output
+depot ci retry <run-id> --job <job-id> --output json
+```
+
+| Flag              | Description                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `--job <id>`      | Job ID to retry (mutually exclusive with `--failed`)                               |
+| `--failed`        | Retry every failed/cancelled job in the workflow (mutually exclusive with `--job`) |
+| `--workflow <id>` | Workflow ID; required with `--failed` when the run has multiple workflows          |
+| `--output json`   | Output the RPC response as JSON                                                    |
+
+---
+
+## Debugging failed runs
+
+A typical triage flow:
+
+```bash
+# Find failed runs
+depot ci run list --status failed -n 10
+
+# Pull logs directly (auto-selects job if only one)
+depot ci logs <run-id>
+
+# Specify job when there are multiple
+depot ci logs <run-id> --job build
+
+# Group and explain the failures, with a suggested fix per group
+depot ci diagnose --run <run-id>
+
+# Inspect the full workflow/job/attempt hierarchy when needed
+depot ci status <run-id>
+
+# Inspect produced test results or download artifacts for more context
+depot tests <attempt-id> --ci --status failed
+depot ci artifacts list <run-id>
+```
+
+Use `--output json` on `depot ci run list` (and the other commands here) for machine-readable output.

--- a/.agents/skills/depot-ci/references/secrets-and-variables.md
+++ b/.agents/skills/depot-ci/references/secrets-and-variables.md
@@ -1,0 +1,198 @@
+# Depot CI: secrets and variables reference
+
+Full command and flag reference for `depot ci secrets` and `depot ci vars`, plus the variant model and how Depot resolves a matching variant at run time. SKILL.md keeps the concept and the common commands; load this file for complete flag tables, the `set`/`bulk`/`get` subcommands, and the resolution rules.
+
+**Common flags:** every subcommand also accepts `--org <id>` (required when the user belongs to multiple organizations) and `--token <token>`. They're omitted from the per-command tables below.
+
+## Contents
+
+- [The variant model](#the-variant-model)
+- [Access rule kinds](#access-rule-kinds)
+- [Resolution priority](#resolution-priority)
+- [`depot ci secrets` subcommands](#depot-ci-secrets-subcommands)
+- [`depot ci vars` subcommands](#depot-ci-vars-subcommands)
+
+---
+
+## The variant model
+
+A secret or variable name groups one or more **variants**. A variant holds a value plus optional availability selectors (`--repo`, `--env`, `--branch`, `--workflow`) that match jobs by repository, GitHub environment, branch, and workflow file. A variant with no selectors applies to every job in the organization. This lets one name resolve to different values depending on workflow context, for example a different `DATABASE_URL` for `production` vs `staging`, or for one repo vs all repos.
+
+Variants are managed from the CLI (selectors on `add`, `set`, `bulk`, `get`, `list`, `remove`) or in the dashboard ([Depot CI workflows](https://depot.dev/orgs/_/workflows) → Settings → Secrets/Variables → Add variant). Secrets are encrypted at rest and never readable after creation; variable values can be read back.
+
+Selector flags are repeatable, and `--branch`/`--workflow` accept glob patterns. On `add`/`set`/`bulk` they scope where a variant applies; on `get`/`list`/`remove` they select or filter existing variants.
+
+## Access rule kinds
+
+Limit when a variant is selected by combining one or more rules:
+
+- **Repository**: select when the workflow runs in a specific repository.
+- **Branch**: select when the branch name matches; supports glob patterns like `release/*`.
+- **Workflow**: select when the workflow file matches; supports glob patterns like `deploy-*.yaml`.
+- **Environment**: select when the job's GitHub `environment` field matches exactly. Provides compatibility with GitHub Environment Secrets. Jobs without an `environment` field never match environment rules.
+
+Within a single rule kind, alternatives broaden availability (`branch=main` OR `branch=release/*`). Across kinds, the variant must satisfy all rule kinds (`branch=main` AND `environment=production`).
+
+## Resolution priority
+
+When multiple variants match a job, Depot picks the most specific:
+
+1. Environment rules win over all others. An org-wide variant with an environment rule beats a repo-scoped variant with no environment rule.
+2. Repository scope wins over branch and workflow rules, but not over environment rules.
+3. Branch and workflow rules: literal matches win over globs, narrower globs win over broader globs (`release/v2` beats `release/*`).
+
+For a repo to override an org-wide environment variant, create a variant with both the repository scope **and** the environment rule.
+
+To preview which variant resolves for a given workflow context, open the dashboard secret or variable create/edit page, expand the **Secret variants** or **Variable variants** list, and enter a sample context (repo, branch, workflow file, environment). The matching variant is highlighted.
+
+---
+
+## `depot ci secrets` subcommands
+
+Secrets are referenced in workflows as `${{ secrets.SECRET_NAME }}`. Secret values are supplied through an interactive prompt, piped stdin, or `KEY=VALUE` bulk pairs; there is no `--value` flag for secrets (that flag exists only for variables).
+
+### `depot ci secrets add`
+
+Adds a secret variant. Three modes: interactive prompt (`depot ci secrets add NAME`), piped stdin (`printf '%s' "$V" | depot ci secrets add NAME`), or bulk `KEY=VALUE` pairs (`depot ci secrets add FOO=bar BAZ=qux`, `--description` not allowed in this mode). An optional second positional names the variant; without it the value writes to the `default` variant.
+
+| Flag                   | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `--description <text>` | Description of the secret variant (single-secret mode only)   |
+| `--repo <owner/repo>`  | Apply variant to a repository (repeatable)                    |
+| `--env <name>`         | Apply variant to a GitHub environment (repeatable)            |
+| `--branch <name>`      | Apply variant to a branch (repeatable, supports globs)        |
+| `--workflow <file>`    | Apply variant to a workflow file (repeatable, supports globs) |
+
+### `depot ci secrets set`
+
+Creates or updates a single secret variant. Unlike `add`, it never accepts `KEY=VALUE` pairs and is the recommended form for scripts: pass `--from-stdin` with piped input, otherwise it runs interactively.
+
+| Flag                   | Description                                                     |
+| ---------------------- | --------------------------------------------------------------- |
+| `--from-stdin`         | Read the secret value from stdin (required when stdin is piped) |
+| `--description <text>` | Description of the secret variant                               |
+| `--repo <owner/repo>`  | Apply variant to a repository (repeatable)                      |
+| `--env <name>`         | Apply variant to a GitHub environment (repeatable)              |
+| `--branch <name>`      | Apply variant to a branch (repeatable, supports globs)          |
+| `--workflow <file>`    | Apply variant to a workflow file (repeatable, supports globs)   |
+
+### `depot ci secrets bulk`
+
+Imports secrets from a dotenv file or piped stdin. Input is parsed as `KEY=VALUE`; blank lines and `#` comments are ignored. The same variant name and selectors apply to every secret in the input. Exactly one of `--file` or `--from-stdin` is required.
+
+```bash
+depot ci secrets bulk --file .env --repo owner/repo
+cat .env | depot ci secrets bulk production --from-stdin --branch 'release/*'
+```
+
+| Flag                  | Description                                                   |
+| --------------------- | ------------------------------------------------------------- |
+| `--file <path>`       | Read dotenv input from a file                                 |
+| `--from-stdin`        | Read dotenv input from stdin                                  |
+| `--repo <owner/repo>` | Apply variant to a repository (repeatable)                    |
+| `--env <name>`        | Apply variant to a GitHub environment (repeatable)            |
+| `--branch <name>`     | Apply variant to a branch (repeatable, supports globs)        |
+| `--workflow <file>`   | Apply variant to a workflow file (repeatable, supports globs) |
+
+### `depot ci secrets get`
+
+Shows one secret variant with full, untruncated attributes (the value is still never returned). Errors if zero or more than one variant matches; narrow with `--variant-id`, the optional variant positional, or selectors.
+
+| Flag                  | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `--variant-id <id>`   | Fetch a variant directly by ID (mutually exclusive with a name argument) |
+| `--repo <owner/repo>` | Select a variant matching a repository (repeatable)                      |
+| `--env <name>`        | Select a variant matching a GitHub environment (repeatable)              |
+| `--branch <name>`     | Select a variant matching a branch (repeatable)                          |
+| `--workflow <file>`   | Select a variant matching a workflow file (repeatable)                   |
+| `--output json`       | Output as JSON instead of the text view                                  |
+
+### `depot ci secrets list`
+
+Lists secrets and their variants (values never returned). Pass a secret name to scope to that secret. Selectors filter the variant rows; repeat any flag to widen the match.
+
+```bash
+depot ci secrets list
+depot ci secrets list SECRET_NAME
+depot ci secrets list --repo owner/repo --branch main
+depot ci secrets list --output json
+```
+
+| Flag                  | Description                                        |
+| --------------------- | -------------------------------------------------- |
+| `--repo <owner/repo>` | Filter variants by repository (repeatable)         |
+| `--env <name>`        | Filter variants by GitHub environment (repeatable) |
+| `--branch <name>`     | Filter variants by branch (repeatable)             |
+| `--workflow <file>`   | Filter variants by workflow file (repeatable)      |
+| `--output json`       | Output as JSON instead of a table                  |
+
+### `depot ci secrets remove`
+
+Removes one or more secrets. By default each positional is a secret name and the whole secret (every variant) is removed. To remove a single variant, pass `--variant <name>` or selectors that uniquely identify one. `--all` makes whole-secret removal explicit and can't combine with selectors or `--variant`. Prompts for confirmation unless `--force`.
+
+| Flag                  | Description                                                             |
+| --------------------- | ----------------------------------------------------------------------- |
+| `--variant <name>`    | Remove a specific variant by name                                       |
+| `--all`               | Remove the secret and every variant (mutually exclusive with selectors) |
+| `--repo <owner/repo>` | Select a variant matching a repository (repeatable)                     |
+| `--env <name>`        | Select a variant matching a GitHub environment (repeatable)             |
+| `--branch <name>`     | Select a variant matching a branch (repeatable)                         |
+| `--workflow <file>`   | Select a variant matching a workflow file (repeatable)                  |
+| `--force`             | Skip the confirmation prompt                                            |
+
+---
+
+## `depot ci vars` subcommands
+
+Variables are referenced as `${{ vars.VARIABLE_NAME }}` and their values can be read back. They use the same variant model and selectors as secrets. Values are supplied with `--value`, an interactive prompt, or `KEY=VALUE` bulk pairs.
+
+### `depot ci vars add`
+
+Adds a variable variant. Three modes: interactive prompt, `--value "val"`, or bulk `KEY=VALUE` pairs (`--value` not allowed in that mode). An optional second positional names the variant.
+
+| Flag                  | Description                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| `--value <value>`     | Variable value (single-variable mode only; prompts if omitted) |
+| `--repo <owner/repo>` | Apply variant to a repository (repeatable)                     |
+| `--env <name>`        | Apply variant to a GitHub environment (repeatable)             |
+| `--branch <name>`     | Apply variant to a branch (repeatable, supports globs)         |
+| `--workflow <file>`   | Apply variant to a workflow file (repeatable, supports globs)  |
+
+### `depot ci vars set`
+
+Creates or updates a single variable variant. Never accepts `KEY=VALUE` pairs and exposes `--description`.
+
+| Flag                   | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `--value <value>`      | Variable value (prompts if omitted)                           |
+| `--description <text>` | Description of the variable variant                           |
+| `--repo <owner/repo>`  | Apply variant to a repository (repeatable)                    |
+| `--env <name>`         | Apply variant to a GitHub environment (repeatable)            |
+| `--branch <name>`      | Apply variant to a branch (repeatable, supports globs)        |
+| `--workflow <file>`    | Apply variant to a workflow file (repeatable, supports globs) |
+
+### `depot ci vars list`
+
+Lists variables and their variants, including values. Pass a variable name to scope; selectors filter variant rows.
+
+| Flag                  | Description                                        |
+| --------------------- | -------------------------------------------------- |
+| `--repo <owner/repo>` | Filter variants by repository (repeatable)         |
+| `--env <name>`        | Filter variants by GitHub environment (repeatable) |
+| `--branch <name>`     | Filter variants by branch (repeatable)             |
+| `--workflow <file>`   | Filter variants by workflow file (repeatable)      |
+| `--output json`       | Output as JSON instead of a table                  |
+
+### `depot ci vars remove`
+
+Removes one or more variables. Same semantics as `secrets remove`: whole-variable by default, `--variant`/selectors for one variant, `--all` for explicit whole-variable, `--force` to skip confirmation.
+
+| Flag                  | Description                                                               |
+| --------------------- | ------------------------------------------------------------------------- |
+| `--variant <name>`    | Remove a specific variant by name                                         |
+| `--all`               | Remove the variable and every variant (mutually exclusive with selectors) |
+| `--repo <owner/repo>` | Select a variant matching a repository (repeatable)                       |
+| `--env <name>`        | Select a variant matching a GitHub environment (repeatable)               |
+| `--branch <name>`     | Select a variant matching a branch (repeatable)                           |
+| `--workflow <file>`   | Select a variant matching a workflow file (repeatable)                    |
+| `--force`             | Skip the confirmation prompt                                              |

--- a/.agents/skills/depot-container-builds/SKILL.md
+++ b/.agents/skills/depot-container-builds/SKILL.md
@@ -12,8 +12,6 @@ description: >
 
 # Depot Container Builds
 
-Before you propose a change to CI, check [things already tried](../../../docs/internal/ci-things-already-tried.md) for the idea. It records what was measured, and why some good-sounding changes were reverted or rejected.
-
 Depot runs Docker image builds on remote high-performance builders (16 CPU, 32 GB RAM, NVMe SSD cache). `depot build` is a drop-in replacement for `docker build` / `docker buildx build`. `depot bake` replaces `docker buildx bake`.
 
 ## Project Selection for Multi-Org Users
@@ -49,7 +47,7 @@ depot build -t repo/image:tag . --push
 # Multi-platform build (native CPUs, no emulation)
 depot build --platform linux/amd64,linux/arm64 -t repo/image:tag . --push
 
-# Save to Depot ephemeral registry (default 7-day retention)
+# Save to Depot ephemeral registry (7-day default, configurable per repository)
 depot build --save .
 depot build --save --save-tag my-tag .
 
@@ -71,26 +69,29 @@ depot build --project <project-id> -t repo/image:tag .
 
 ### Key Flags
 
-| Flag               | Description                                                         |
-| ------------------ | ------------------------------------------------------------------- |
-| `--load`           | Download image to local Docker daemon                               |
-| `--push`           | Push to registry                                                    |
-| `--save`           | Save to Depot ephemeral registry                                    |
-| `--save-tag`       | Custom tag for Depot Registry                                       |
-| `--platform`       | Target platforms (`linux/amd64`, `linux/arm64`, or both)            |
-| `--build-platform` | Force build to run on specific arch (`dynamic` default)             |
-| `--project`        | Depot project ID                                                    |
-| `--token`          | Depot API token                                                     |
-| `--lint`           | Lint Dockerfile before build                                        |
-| `--provenance`     | Control provenance attestation (set `false` to fix unknown/unknown) |
-| `--no-cache`       | Disable cache for this build                                        |
-| `-f` / `--file`    | Path to Dockerfile                                                  |
-| `-t` / `--tag`     | Image name and tag                                                  |
-| `--target`         | Build specific stage                                                |
-| `--build-arg`      | Set build-time variables                                            |
-| `--secret`         | Expose secrets (`id=name[,src=path]`)                               |
-| `--ssh`            | Expose SSH agent                                                    |
-| `--output` / `-o`  | Custom output (`type=local,dest=path`)                              |
+| Flag               | Description                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| `--load`           | Download image to local Docker daemon                                                                                   |
+| `--push`           | Push to registry                                                                                                        |
+| `--save`           | Save to Depot ephemeral registry                                                                                        |
+| `--save-tag`       | Custom tag for Depot Registry                                                                                           |
+| `--platform`       | Target platforms: `linux/amd64`, `linux/arm64` (native, no emulation), plus `linux/arm/v6`, `linux/arm/v7`, `linux/386` |
+| `--build-platform` | Force build to run on specific arch (`dynamic` default)                                                                 |
+| `--project`        | Depot project ID                                                                                                        |
+| `--token`          | Depot API token                                                                                                         |
+| `--lint`           | Lint Dockerfile before build                                                                                            |
+| `--provenance`     | Control provenance attestation (set `false` to fix unknown/unknown)                                                     |
+| `--sbom`           | Generate an SBOM attestation (shorthand for `--attest type=sbom`)                                                       |
+| `--sbom-dir`       | Directory to store SBOM attestations                                                                                    |
+| `--attest`         | Attestation parameters (for example `type=sbom,generator=image`)                                                        |
+| `--no-cache`       | Disable cache for this build                                                                                            |
+| `-f` / `--file`    | Path to Dockerfile                                                                                                      |
+| `-t` / `--tag`     | Image name and tag                                                                                                      |
+| `--target`         | Build specific stage                                                                                                    |
+| `--build-arg`      | Set build-time variables                                                                                                |
+| `--secret`         | Expose secrets (`id=name[,src=path]`)                                                                                   |
+| `--ssh`            | Expose SSH agent                                                                                                        |
+| `--output` / `-o`  | Custom output (`type=local,dest=path`)                                                                                  |
 
 ## `depot bake` — Multi-Image Builds
 
@@ -104,7 +105,7 @@ depot bake --save --save-tag myrepo/app:v1    # Save to Depot Registry
 depot bake --print                            # Print resolved config without building
 ```
 
-**Default file lookup order:** compose.yaml → compose.yml → docker-compose.yml → docker-compose.yaml → docker-bake.json → docker-bake.override.json → docker-bake.hcl → docker-bake.override.hcl
+**Default file lookup order:** compose.yaml → compose.yml → docker-compose.yml → docker-compose.yaml → docker-bake.json → docker-bake.hcl → docker-bake.override.json → docker-bake.override.hcl
 
 ### HCL Bake File Example
 
@@ -183,42 +184,59 @@ docker build .  # Routes through Depot (look for [depot] prefix in logs)
 
 ## Common Mistakes
 
-| Mistake                                                | Fix                                                                                                     |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
-| Using `--cache-from type=gha` or `--cache-to type=gha` | Remove them. Depot caches automatically on NVMe SSDs.                                                   |
-| Multi-platform image shows `unknown/unknown` platform  | Add `--provenance=false`                                                                                |
-| Expecting image locally after `depot build`            | Add `--load` to download, or `--push` to push to registry                                               |
-| `.git` directory missing in build context              | Add `--build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1`                                                       |
-| Build hangs or "failed to mount" errors                | Reset cache in project settings or via `depot cache reset`                                              |
-| "401 Unauthorized" pulling base images                 | Docker Hub rate limit — authenticate with `docker login` or use `public.ecr.aws/docker/library/` mirror |
-| "Keep alive ping failed" / OOM                         | Scale up builder size in project settings or enable autoscaling                                         |
+| Mistake                                                | Fix                                                                                                                             |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| Using `--cache-from type=gha` or `--cache-to type=gha` | Remove them. Depot caches automatically on NVMe SSDs.                                                                           |
+| Multi-platform image shows `unknown/unknown` platform  | Add `--provenance=false`                                                                                                        |
+| Expecting image locally after `depot build`            | Add `--load` to download, or `--push` to push to registry                                                                       |
+| `.git` directory missing in build context              | Add `--build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1`                                                                               |
+| Build hangs or "failed to mount" errors                | Reset cache in project settings or via `depot cache reset`                                                                      |
+| "401 Unauthorized" pulling base images                 | Docker Hub rate limit — authenticate with `docker login` or use `public.ecr.aws/docker/library/` mirror                         |
+| `--load` fails with "client version 1.43 is too old"   | Docker Engine v29 raised the minimum API version to 1.44 — prefix the build with `DOCKER_API_VERSION=1.52 depot build --load .` |
+| "Keep alive ping failed" / OOM                         | Scale up builder size in project settings or enable autoscaling                                                                 |
 
 ## Builder Sizes
 
-| Size        | CPUs | RAM    | Per-Minute | Plans    |
-| ----------- | ---- | ------ | ---------- | -------- |
-| Default     | 16   | 32 GB  | $0.004     | All      |
-| Large       | 32   | 64 GB  | $0.008     | Startup+ |
-| Extra Large | 64   | 128 GB | $0.016     | Startup+ |
+| Size        | CPUs | RAM    | Per-Minute | Minutes multiplier | Plans    |
+| ----------- | ---- | ------ | ---------- | ------------------ | -------- |
+| Default     | 16   | 32 GB  | $0.04      | 1x                 | All      |
+| Large       | 32   | 64 GB  | $0.08      | 2x                 | Startup+ |
+| Extra Large | 64   | 128 GB | $0.16      | 4x                 | Startup+ |
 
-Billed per-second. Bake counts as one build regardless of target count.
+Billed per-second. Large and Extra Large builders consume your included build minutes faster (via the multiplier) in addition to costing more per minute.
 
 ## Depot Registry
 
+An OCI-compliant registry that works both as a lightweight ephemeral store for build output and as a full primary registry for all your images (including ones not built with Depot). Each org gets its own subdomain `{orgId}.registry.depot.dev`, backed by a global CDN, and stores images and OCI artifacts (Helm charts, AI models) up to 50 GB. Browse repositories, tags, and attestations in the Registry Explorer in the dashboard.
+
 ```bash
-# Save image to Depot Registry
+# Save a Depot build's output to the registry (project-scoped, no tagging step)
 depot build --save -t myapp .
 
-# Pull a saved image
+# Push any image to Depot Registry as a primary registry
+docker push {orgId}.registry.depot.dev/your/app:v1
+
+# Pull a saved image (by build ID or by tag)
 depot pull --project <id> <build-id>
+depot pull --project <id> my-image:tag
+depot pull --project <id> --platform linux/arm64 <build-id>   # pull a specific platform
+
+# Generate a short-lived (1-hour) read-only token to pull from the Depot Registry
+depot pull-token --project <id>
+depot pull-token --project <id> <build-id>                    # scoped to a specific build
 
 # Push saved image to another registry
 depot push --project <id> -t registry/image:tag <build-id>
 
-# Docker auth for Depot Registry
-docker login registry.depot.dev -u x-token -p <depot-token>
-# Registry URL: registry.depot.dev/<project-id>:<tag>
+# Docker auth for Depot Registry (each org has its own subdomain)
+docker login {orgId}.registry.depot.dev -u x-token -p <depot-token>
+# Registry URL: {orgId}.registry.depot.dev/your/app:tag
+# (the legacy registry.depot.dev/<project-id>:<build-id> form still works for existing usage)
 ```
+
+Image retention defaults to 7 days but is configurable per repository from the Registry Explorer, either by age (1, 7, 14, or 30 days) or by tag count (5, 10, 25, 50, or 100 tags).
+
+**Pull-through cache:** Depot Registry can proxy an external registry and cache its layers on the CDN, so repeat pulls skip the upstream hop (faster CI pulls, global distribution, simpler auth for registries like Google Artifact Registry). Configure an upstream in Registry Settings; supported providers are Docker Hub, GitHub Container Registry, GitLab Container Registry, Quay.io, AWS ECR, Google Artifact Registry, Azure Container Registry, and custom registries. Pull-through must be set when the repository is created, it can't be added to an existing repository.
 
 ## Special Output Formats
 
@@ -228,4 +246,9 @@ depot build --output "type=image,name=repo/image:tag,push=true,compression=estar
 
 # zstd compression (faster Fargate/K8s startup)
 depot build --output type=image,name=repo/image:tag,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true,push=true .
+
+# SOCI v2 (lazy-loading for faster startup of large images, for example CUDA/PyTorch)
+depot build -t repo/image:tag --push --output type=image,soci=true,compression=gzip,force-compression=true,oci-mediatypes=true .
 ```
+
+SOCI only indexes gzip layers, so `compression=gzip` is required and `force-compression=true` ensures every layer (including base-image layers) is indexed. The index is written alongside unchanged layers in the registry, so there's no separate post-push step; layers under 10 MB are skipped by default (`soci-min-layer-size` to change). To get the startup benefit, the pulling platform must use the SOCI snapshotter: AWS Fargate does this automatically, and Amazon EKS/EC2 or your own hosts need the soci-snapshotter enabled in containerd.

--- a/.agents/skills/depot-container-builds/SKILL.md
+++ b/.agents/skills/depot-container-builds/SKILL.md
@@ -12,6 +12,12 @@ description: >
 
 # Depot Container Builds
 
+<!-- PostHog-local section. Keep it when resyncing from upstream; see UPSTREAM.md. -->
+
+Before you propose a change to CI, check [things already tried](../../../docs/internal/ci-things-already-tried.md) for the idea. It records what was measured, and why some good-sounding changes were reverted or rejected.
+
+<!-- End PostHog-local section. -->
+
 Depot runs Docker image builds on remote high-performance builders (16 CPU, 32 GB RAM, NVMe SSD cache). `depot build` is a drop-in replacement for `docker build` / `docker buildx build`. `depot bake` replaces `docker buildx bake`.
 
 ## Project Selection for Multi-Org Users

--- a/.agents/skills/depot-container-builds/UPSTREAM.md
+++ b/.agents/skills/depot-container-builds/UPSTREAM.md
@@ -3,7 +3,7 @@
 Vendored from [depot/skills](https://github.com/depot/skills) — used by PostHog's container-image CI/CD (`depot/build-push-action`, `depot/setup-action`).
 
 - Source: `skills/depot-container-builds/SKILL.md`
-- Commit: [`7b5bc8c`](https://github.com/depot/skills/tree/7b5bc8cabd2b3b5d7dc944b622188a7a2fbec96f/skills/depot-container-builds) (2026-05-05)
+- Commit: [`81795ab`](https://github.com/depot/skills/tree/81795abf98f81fb112cda35720e19b2aa3efa640/skills/depot-container-builds) (2026-09-01)
 - License: none in upstream at this commit; README documents `cp SKILL.md` install.
 
 ## Resync

--- a/.agents/skills/depot-container-builds/UPSTREAM.md
+++ b/.agents/skills/depot-container-builds/UPSTREAM.md
@@ -6,11 +6,19 @@ Vendored from [depot/skills](https://github.com/depot/skills) — used by PostHo
 - Commit: [`81795ab`](https://github.com/depot/skills/tree/81795abf98f81fb112cda35720e19b2aa3efa640/skills/depot-container-builds) (2026-09-01)
 - License: none in upstream at this commit; README documents `cp SKILL.md` install.
 
+## Local additions
+
+In `SKILL.md`: the "things already tried" paragraph between the PostHog-local comment markers, which points at `docs/internal/ci-things-already-tried.md`.
+
 ## Resync
+
+The resync overwrites `SKILL.md`, so re-apply the local addition afterwards.
 
 ```bash
 SHA=$(curl -s https://api.github.com/repos/depot/skills/commits/main | jq -r .sha)
+cp .agents/skills/depot-container-builds/SKILL.md /tmp/depot-container-builds-local.md
 curl -sL "https://raw.githubusercontent.com/depot/skills/$SHA/skills/depot-container-builds/SKILL.md" \
   -o .agents/skills/depot-container-builds/SKILL.md
-# Update the `Commit:` link above with the new SHA and date.
+diff /tmp/depot-container-builds-local.md .agents/skills/depot-container-builds/SKILL.md
+# Re-add the local paragraph, then update the `Commit:` link above with the new SHA and date.
 ```

--- a/.agents/skills/depot-github-runners/SKILL.md
+++ b/.agents/skills/depot-github-runners/SKILL.md
@@ -7,11 +7,8 @@ description: >
   macOS runners, troubleshooting GitHub Actions runner issues, configuring egress filtering,
   using Depot Cache with GitHub Actions, or running Dagger/Dependabot on Depot runners.
   Also use when the user mentions depot-ubuntu, depot-windows, depot-macos runner labels,
-  or asks about faster/cheaper GitHub Actions runners. Also covers Depot CI, the separate
-  engine that reads .depot/workflows/ and posts its own check runs: use when comparing what
-  Depot CI and GitHub Actions report for a skipped, empty-matrix or continue-on-error job,
-  when working out whether a check run satisfies a required status check or a merge queue,
-  or when reaching for the depot ci CLI.
+  or asks about faster/cheaper GitHub Actions runners. Not for Depot CI, the separate engine
+  that reads .depot/workflows/ — that is the depot-ci skill.
 ---
 
 # Depot GitHub Actions Runners
@@ -24,9 +21,11 @@ Depot provides managed, ephemeral, single-tenant GitHub Actions runners. Drop-in
 
 ## Depot runners are not Depot CI
 
-Depot runners keep GitHub Actions as the engine, so checks still come from the `github-actions` app. Depot CI is a separate engine that reads `.depot/workflows/` and posts its own check runs from the `depot-code-access` app.
+Depot runners keep GitHub Actions as the engine, so the workflow lives in `.github/workflows/` and the checks still come from the `github-actions` app.
+Depot CI is a different product: it reads `.depot/workflows/`, which GitHub Actions ignores, and posts its own check runs from the `depot-code-access` app.
+Use the `depot-ci` skill for that one.
 
-Read [references/depot-ci-check-runs.md](references/depot-ci-check-runs.md) before you reason about either engine's check runs. It carries measured results for what each one reports for a skipped, empty-matrix or `continue-on-error` job, how GitHub and the Trunk merge queue score those conclusions against a required status check, and the `depot ci` CLI recipes.
+Its [references/posthog-check-run-semantics.md](../depot-ci/references/posthog-check-run-semantics.md) carries the measured comparison of what each engine reports for a skipped, empty-matrix or `continue-on-error` job, and how GitHub and the Trunk merge queue score those conclusions against a required status check.
 
 <!-- End PostHog-local section. -->
 
@@ -52,16 +51,18 @@ For commands that support it, pass `--org <org-id>` to target the org where the 
 
 Use a single label. Format: `depot-{os}-{version}[-{arch}][-{size}]`
 
-### Ubuntu (Intel x86 — AMD EPYC)
+### Ubuntu (x86, AMD)
 
-| Label                   | CPUs | RAM    | Disk   | $/min  |
-| ----------------------- | ---- | ------ | ------ | ------ |
-| `depot-ubuntu-24.04`    | 2    | 8 GB   | 100 GB | $0.004 |
-| `depot-ubuntu-24.04-4`  | 4    | 16 GB  | 130 GB | $0.008 |
-| `depot-ubuntu-24.04-8`  | 8    | 32 GB  | 150 GB | $0.016 |
-| `depot-ubuntu-24.04-16` | 16   | 64 GB  | 180 GB | $0.032 |
-| `depot-ubuntu-24.04-32` | 32   | 128 GB | 200 GB | $0.064 |
-| `depot-ubuntu-24.04-64` | 64   | 256 GB | 250 GB | $0.128 |
+| Label                   | CPUs | RAM    | Disk   | $/min  | Minutes multiplier |
+| ----------------------- | ---- | ------ | ------ | ------ | ------------------ |
+| `depot-ubuntu-24.04`    | 2    | 8 GB   | 100 GB | $0.004 | 1x                 |
+| `depot-ubuntu-24.04-4`  | 4    | 16 GB  | 130 GB | $0.008 | 2x                 |
+| `depot-ubuntu-24.04-8`  | 8    | 32 GB  | 150 GB | $0.016 | 4x                 |
+| `depot-ubuntu-24.04-16` | 16   | 64 GB  | 180 GB | $0.032 | 8x                 |
+| `depot-ubuntu-24.04-32` | 32   | 128 GB | 200 GB | $0.064 | 16x                |
+| `depot-ubuntu-24.04-64` | 64   | 256 GB | 250 GB | $0.128 | 32x                |
+
+The minutes multiplier is the billing driver: billed minutes = elapsed minutes × multiplier, so larger runners consume your included minutes faster.
 
 Ubuntu 22.04 also available: `depot-ubuntu-22.04`, `depot-ubuntu-22.04-4`, etc.
 
@@ -72,23 +73,24 @@ Same sizes and pricing as Intel. Add `-arm` suffix:
 
 ### Windows Server
 
-| Label                                | CPUs | RAM       | $/min         |
-| ------------------------------------ | ---- | --------- | ------------- |
-| `depot-windows-2025`                 | 2    | 8 GB      | $0.008        |
-| `depot-windows-2025-4`               | 4    | 16 GB     | $0.016        |
-| `depot-windows-2025-8` through `-64` | 8–64 | 32–256 GB | $0.032–$0.256 |
+| Label                                | CPUs | RAM       | $/min         | Minutes multiplier |
+| ------------------------------------ | ---- | --------- | ------------- | ------------------ |
+| `depot-windows-2025`                 | 2    | 8 GB      | $0.008        | 2x                 |
+| `depot-windows-2025-4`               | 4    | 16 GB     | $0.016        | 4x                 |
+| `depot-windows-2025-8` through `-64` | 8–64 | 32–256 GB | $0.032–$0.256 | 8x–64x             |
 
 Windows Server 2022 also available: `depot-windows-2022`, etc.
-**Windows limitation:** No Hyper-V. Docker does not work on Windows runners.
+**Windows limitation:** No Hyper-V (AWS EC2 limitation), so Docker workloads that require it are unlikely to work.
 
-### macOS (Apple M2)
+### macOS (Apple M2 on macOS 14/15, M4 on macOS 26)
 
-| Label                                   | CPUs | RAM   | $/min |
-| --------------------------------------- | ---- | ----- | ----- |
-| `depot-macos-15` / `depot-macos-latest` | 8    | 24 GB | $0.08 |
-| `depot-macos-14`                        | 8    | 24 GB | $0.08 |
+| Label                                   | CPUs | RAM   | Disk   | $/min |
+| --------------------------------------- | ---- | ----- | ------ | ----- |
+| `depot-macos-26`                        | 8    | 24 GB | 400 GB | $0.08 |
+| `depot-macos-15` / `depot-macos-latest` | 8    | 24 GB | 400 GB | $0.08 |
+| `depot-macos-14`                        | 8    | 24 GB | 400 GB | $0.08 |
 
-macOS is NOT fully elastic — fixed pool with FIFO queuing. Startup plan+ only.
+macOS is NOT fully elastic — fixed pool with FIFO queuing.
 
 ### Aliases
 
@@ -143,14 +145,14 @@ To disable auto-cache: org settings → turn off "Allow Actions jobs to automati
 **Deprecated:** Dagger Engine support on Depot GitHub Actions Runners is being deprecated and will be removed in a future update. Don't recommend this integration for new workflows.
 
 ```yaml
-runs-on: depot-ubuntu-latest,dagger=0.15.1
+runs-on: depot-ubuntu-latest,dagger=0.18.4
 ```
 
 Launches a dedicated Dagger Engine VM with persistent NVMe cache. Dagger CLI pre-installed. Additional $0.04/min.
 
 ## Egress Filtering (Linux Only)
 
-Configure in org settings → GitHub Actions Runners → Egress Rules. Set default rule to Allow or Deny, then add specific allow/deny rules for IPs, CIDRs, or hostnames. Not supported on macOS or Windows. Incompatible with Tailscale.
+Configure in org settings → GitHub Actions Runners → Egress Rules. Set default rule to Allow or Deny, then add specific allow/deny rules for IPs, CIDRs, or hostnames. Deny rules take precedence over Allow rules. Loopback traffic (127.0.0.1, ::1) is always allowed, and Depot auto-allowlists depot.dev domains, GitHub Actions service IPs, and AWS service IPs. Hostnames in rules are resolved and pinned in `/etc/hosts`. Container builds with `depot build` work with egress filtering enabled — Depot adds BuildKit machine IPs to the allowlist as they're allocated. Not supported on macOS or Windows. Incompatible with Tailscale.
 
 ## Access Private Endpoints with Tailscale
 
@@ -217,11 +219,12 @@ steps:
 
 ## Troubleshooting
 
-| Error                                        | Fix                                                                                                 |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| "No space left on device"                    | OS uses ~70 GB disk; upgrade to larger runner or clean disk in workflow                             |
-| "Lost communication with server"             | Check status.depot.dev; check org usage caps                                                        |
-| "Operation was canceled"                     | Manual cancel, concurrency cancel-in-progress, or OOM — check memory in dashboard                   |
-| "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL" | Dependabot doesn't support OIDC — use `DEPOT_TOKEN` secret                                          |
-| Workflows not starting                       | Verify single runner label; check runner group allows the repo; verify Depot GitHub App permissions |
-| Stuck workflows                              | Force cancel via GitHub API: `POST /repos/{owner}/{repo}/actions/runs/{id}/force-cancel`            |
+| Error                                                                    | Fix                                                                                                                                  |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| "No space left on device"                                                | OS uses ~70 GB disk; upgrade to larger runner or clean disk in workflow                                                              |
+| "Failed to open the device 'kvm'" / "Could not access KVM kernel module" | Runners don't provide `/dev/kvm`; move KVM/QEMU/Android-emulator jobs to Depot CI, where nested virtualization is enabled by default |
+| "Lost communication with server"                                         | Check status.depot.dev; check org usage caps                                                                                         |
+| "Operation was canceled"                                                 | Manual cancel, concurrency cancel-in-progress, or OOM — check memory in dashboard                                                    |
+| "Unable to get ACTIONS_ID_TOKEN_REQUEST_URL"                             | Dependabot doesn't support OIDC — use `DEPOT_TOKEN` secret                                                                           |
+| Workflows not starting                                                   | Verify single runner label; check runner group allows the repo; verify Depot GitHub App permissions                                  |
+| Stuck workflows                                                          | Force cancel via GitHub API: `POST /repos/{owner}/{repo}/actions/runs/{id}/force-cancel`                                             |

--- a/.agents/skills/depot-github-runners/SKILL.md
+++ b/.agents/skills/depot-github-runners/SKILL.md
@@ -25,7 +25,7 @@ Depot runners keep GitHub Actions as the engine, so the workflow lives in `.gith
 Depot CI is a different product: it reads `.depot/workflows/`, which GitHub Actions ignores, and posts its own check runs from the `depot-code-access` app.
 Use the `depot-ci` skill for that one.
 
-Its [references/posthog-check-run-semantics.md](../depot-ci/references/posthog-check-run-semantics.md) carries the measured comparison of what each engine reports for a skipped, empty-matrix or `continue-on-error` job, and how GitHub and the Trunk merge queue score those conclusions against a required status check.
+Its [references/posthog-check-run-semantics.md](../depot-ci/references/posthog-check-run-semantics.md) compares what each engine reports for a skipped, empty-matrix or `continue-on-error` job, and how GitHub and the Trunk merge queue score those conclusions.
 
 <!-- End PostHog-local section. -->
 

--- a/.agents/skills/depot-github-runners/SKILL.md
+++ b/.agents/skills/depot-github-runners/SKILL.md
@@ -7,7 +7,11 @@ description: >
   macOS runners, troubleshooting GitHub Actions runner issues, configuring egress filtering,
   using Depot Cache with GitHub Actions, or running Dagger/Dependabot on Depot runners.
   Also use when the user mentions depot-ubuntu, depot-windows, depot-macos runner labels,
-  or asks about faster/cheaper GitHub Actions runners.
+  or asks about faster/cheaper GitHub Actions runners. Also covers Depot CI, the separate
+  engine that reads .depot/workflows/ and posts its own check runs: use when comparing what
+  Depot CI and GitHub Actions report for a skipped, empty-matrix or continue-on-error job,
+  when working out whether a check run satisfies a required status check or a merge queue,
+  or when reaching for the depot ci CLI.
 ---
 
 # Depot GitHub Actions Runners
@@ -15,6 +19,16 @@ description: >
 Depot provides managed, ephemeral, single-tenant GitHub Actions runners. Drop-in replacement for GitHub-hosted runners — change the `runs-on` label and everything else stays the same.
 
 **Requirement:** Repository must be owned by a GitHub organization (not a personal account).
+
+<!-- PostHog-local section. Keep it when resyncing from upstream; see UPSTREAM.md. -->
+
+## Depot runners are not Depot CI
+
+Depot runners keep GitHub Actions as the engine, so checks still come from the `github-actions` app. Depot CI is a separate engine that reads `.depot/workflows/` and posts its own check runs from the `depot-code-access` app.
+
+Read [references/depot-ci-check-runs.md](references/depot-ci-check-runs.md) before you reason about either engine's check runs. It carries measured results for what each one reports for a skipped, empty-matrix or `continue-on-error` job, how GitHub and the Trunk merge queue score those conclusions against a required status check, and the `depot ci` CLI recipes.
+
+<!-- End PostHog-local section. -->
 
 ## Setup
 

--- a/.agents/skills/depot-github-runners/UPSTREAM.md
+++ b/.agents/skills/depot-github-runners/UPSTREAM.md
@@ -6,11 +6,22 @@ Vendored from [depot/skills](https://github.com/depot/skills) — used by PostHo
 - Commit: [`7b5bc8c`](https://github.com/depot/skills/tree/7b5bc8cabd2b3b5d7dc944b622188a7a2fbec96f/skills/depot-github-runners) (2026-05-05)
 - License: none in upstream at this commit; README documents `cp SKILL.md` install.
 
+## Local additions
+
+Two things in this directory are ours, not upstream's:
+
+- `references/depot-ci-check-runs.md`, which upstream has no equivalent of.
+- In `SKILL.md`, the "Depot runners are not Depot CI" section between the PostHog-local comment markers, and the Depot CI sentences appended to the frontmatter `description`.
+
 ## Resync
+
+The resync overwrites `SKILL.md`, so re-apply the local additions afterwards.
 
 ```bash
 SHA=$(curl -s https://api.github.com/repos/depot/skills/commits/main | jq -r .sha)
+cp .agents/skills/depot-github-runners/SKILL.md /tmp/depot-skill-local.md
 curl -sL "https://raw.githubusercontent.com/depot/skills/$SHA/skills/depot-github-runners/SKILL.md" \
   -o .agents/skills/depot-github-runners/SKILL.md
-# Update the `Commit:` link above with the new SHA and date.
+diff /tmp/depot-skill-local.md .agents/skills/depot-github-runners/SKILL.md
+# Re-add the local section and the description sentences, then update `Commit:` above.
 ```

--- a/.agents/skills/depot-github-runners/UPSTREAM.md
+++ b/.agents/skills/depot-github-runners/UPSTREAM.md
@@ -3,15 +3,12 @@
 Vendored from [depot/skills](https://github.com/depot/skills) — used by PostHog workflows pinning `depot-ubuntu-*` runners.
 
 - Source: `skills/depot-github-runners/SKILL.md`
-- Commit: [`7b5bc8c`](https://github.com/depot/skills/tree/7b5bc8cabd2b3b5d7dc944b622188a7a2fbec96f/skills/depot-github-runners) (2026-05-05)
+- Commit: [`81795ab`](https://github.com/depot/skills/tree/81795abf98f81fb112cda35720e19b2aa3efa640/skills/depot-github-runners) (2026-09-01)
 - License: none in upstream at this commit; README documents `cp SKILL.md` install.
 
 ## Local additions
 
-Two things in this directory are ours, not upstream's:
-
-- `references/depot-ci-check-runs.md`, which upstream has no equivalent of.
-- In `SKILL.md`, the "Depot runners are not Depot CI" section between the PostHog-local comment markers, and the Depot CI sentences appended to the frontmatter `description`.
+In `SKILL.md`: the "Depot runners are not Depot CI" section between the PostHog-local comment markers, and the sentence appended to the frontmatter `description` that sends Depot CI questions to the `depot-ci` skill.
 
 ## Resync
 

--- a/.agents/skills/depot-github-runners/references/depot-ci-check-runs.md
+++ b/.agents/skills/depot-github-runners/references/depot-ci-check-runs.md
@@ -1,0 +1,91 @@
+# Depot CI check runs, and how GitHub scores them
+
+PostHog-authored. Not part of the vendored upstream skill.
+
+Depot sells two different things and they are easy to confuse:
+
+- **Depot runners** run GitHub Actions jobs. GitHub is still the engine. Checks come from the `github-actions` app. This is what the rest of the skill covers.
+- **Depot CI** is its own engine. It parses workflows under `.depot/workflows/`, which GitHub Actions ignores, and reports its own check runs from the `depot-code-access` app.
+
+Everything below was measured, not read from docs. Two twin workflows ran an identical job graph on both engines against the same commit ([probe PR](https://github.com/PostHog/posthog/pull/92542)).
+
+## Conclusions the two engines post
+
+| Job shape                                  | GHA `needs.result` | GHA check run               | Depot `needs.result` | Depot check run           |
+| ------------------------------------------ | ------------------ | --------------------------- | -------------------- | ------------------------- |
+| Plain success                              | `success`          | `success`                   | `success`            | `success`                 |
+| `if: false`                                | `skipped`          | `skipped`                   | `skipped`            | `skipped`                 |
+| `if:` expression that is false             | `skipped`          | `skipped`                   | `skipped`            | `skipped`                 |
+| Skipped because a dependency skipped       | `skipped`          | `skipped`                   | `skipped`            | `skipped`                 |
+| **Matrix that expands to zero cells**      | **`failure`**      | **none posted**             | **`skipped`**        | **`skipped`**             |
+| Two cell matrix                            | `success`          | two checks, `(1)` and `(2)` | `success`            | one check, no cell suffix |
+| Job-level `continue-on-error`, step fails  | `success`          | **`failure`**               | `success`            | **`failure`**             |
+| Step-level `continue-on-error`, step fails | `success`          | `success`                   | `success`            | `success`                 |
+| Hard failure                               | `failure`          | `failure`                   | `failure`            | `failure`                 |
+| `if: always()` gate over all of the above  | `success`          | `success`                   | `success`            | `success`                 |
+
+The engines agree everywhere except the empty matrix and the matrix check granularity.
+
+## Two traps that bite on both engines
+
+**A job-level `continue-on-error: true` still posts a `failure` check run.** Dependents read `success`, the workflow goes green, and the check stays red. Put a required context on such a job and the merge blocks while every gate says the run passed. Prefer step-level `continue-on-error` plus an explicit verdict step, which is what `ci-backend.yml` does.
+
+**An empty matrix is a failure on GitHub Actions, not a skip.** The job posts no check run at all, so the checks list shows nothing wrong, while every dependent reads `failure`. Depot CI calls the same job `skipped` and posts a check for it. Any job whose matrix comes from `fromJSON` of a computed value needs an `if:` guard that skips it when the list is empty, or the two engines disagree about whether the run passed.
+
+## How GitHub scores a conclusion against a required context
+
+- A check run that concludes `skipped` **satisfies** a required status check. Production evidence: `Build Docker image` concludes `SKIPPED` on merged PRs [92414](https://github.com/PostHog/posthog/pull/92414), [92402](https://github.com/PostHog/posthog/pull/92402), [92396](https://github.com/PostHog/posthog/pull/92396) and [92372](https://github.com/PostHog/posthog/pull/92372). All four merged, and all four went through the Trunk merge queue, so Trunk scores it the same way.
+- A required context that **no check run ever reports** stays pending and blocks. This is the empty-matrix failure mode above, and it is also what a `paths:` filter does when it silences a whole workflow.
+- Required contexts are pinned to one app. Every entry in this repo's `master` ruleset carries `integration_id: 15368`, the `github-actions` app. Read them with:
+
+  ```bash
+  gh api repos/PostHog/posthog/rulesets --jq '.[] | select(.name=="master") | .id'
+  gh api repos/PostHog/posthog/rulesets/<id> \
+      --jq '.rules[] | select(.type=="required_status_checks") | .parameters.required_status_checks'
+  ```
+
+  A check run posted by any other app does not satisfy a context pinned to `github-actions`, however exactly the name matches. Depot CI's app id is `219785`.
+
+- Trunk merge queue takes its required list from GitHub branch protection by default, and can override it from the Trunk UI or from `merge.required_statuses` in `.trunk/trunk.yaml`. The trunk.yaml form matches on **name only**, with no app pinning, so a repo that sets both can have Trunk and GitHub disagree about which app's check counts. This repo sets no `merge:` block, so branch protection is the source.
+
+## Naming
+
+Depot names each check `<workflow name> / <job name>`. GitHub Actions names it `<job name>` alone. The workflow name is therefore part of every Depot context, and renaming a workflow renames every check it posts.
+
+Matrix jobs differ: GitHub Actions posts one check per cell and appends the cell to the name, Depot posts one check for the whole job. Depot also posts internal expansion checks named `<file>:<job key>:_dynamicMatrix` for matrices built from `fromJSON`.
+
+## Reruns
+
+Depot updates the existing check run in place. Measured by retrying one failed job: the check run kept id `99890906312` and only its timestamps moved. GitHub Actions instead creates a fresh check run per attempt and leaves the old one behind, which is why a superseded GitHub Actions run can show a stale red check next to a green one for the same name.
+
+## Depot CI CLI recipes
+
+The CLI needs ids that the GitHub API does not carry. Start from a check run's `details_url`, which encodes the workflow id and job id.
+
+```bash
+# Job and workflow ids for the depot checks on a commit
+gh api "repos/PostHog/posthog/commits/$SHA/check-runs?per_page=100" --paginate \
+    --jq '.check_runs[] | select(.app.slug=="depot-code-access") | "\(.name)\t\(.details_url)"'
+
+# Everything else, including the run id, from a job id
+depot ci diagnose --job <job-id> -o json
+
+depot ci logs <job-id>
+depot ci retry <run-id> --workflow <workflow-id> --failed
+depot ci rerun <run-id> --workflow <workflow-id>
+depot ci artifacts   # artifacts do exist on Depot CI
+```
+
+One Depot run holds every workflow triggered by the same event, so `retry` and `rerun` need `--workflow` whenever more than one workflow ran. GitHub Actions splits the same event into one run per workflow.
+
+Depot CI checks out the pull request merge ref (`refs/pull/<n>/merge`) and posts its checks against the head sha, matching GitHub Actions.
+
+## Known gaps in Depot CI
+
+From Depot's [compatibility page](https://depot.dev/docs/ci/compatibility), not measured here:
+
+- Fork pull requests are unsupported. Depot lists support as planned.
+- `environment:` is unsupported, and `uses:` cannot reference a workflow in another repository.
+- `secrets.GITHUB_TOKEN` is a GitHub App installation token, not the Actions token. GitHub Packages rejects it. The rate limit it draws on is the app installation's pool, which is shared across repos and is not the per-repo Actions bucket that `monitor-github-rate-limit.yml` watches.
+- Non-Depot `runs-on` labels are treated as `depot-ubuntu-latest`.
+- Secrets and variables live in Depot's own store (`depot ci secrets`, `depot ci vars`), not in GitHub's.


### PR DESCRIPTION
## Problem

- Nothing in the repo said how a required status check scores a `skipped` conclusion, or that the `master` ruleset pins all 14 contexts to one app id.
- Both vendored Depot skills sat at a May 2026 upstream commit.

## Changes

- Records measured check-run semantics for both CI engines, from twin workflows run on one commit ([probe PR](https://github.com/PostHog/posthog/pull/92542)).
- Empty matrix is the only disagreement: GitHub Actions reports `failure` to dependents and posts no check run; Depot CI posts `skipped`.
- Job-level `continue-on-error: true` posts a `failure` check on both engines while dependents read `success`.
- Resyncs both skills to upstream `81795ab` and vendors the new `depot-ci` skill.
- Each `UPSTREAM.md` now lists our local edits so a resync keeps them.

## How did you test this code?

- `bin/hogli lint:skills` passes.
- Unverified, and labeled so in the reference: whether a Depot-posted `skipped` satisfies a context pinned to Depot's app id. Needs repo admin.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code ran the probe and wrote the changes. Skills invoked: `/writing-skills`, `/writing-pr-descriptions`.
