### PR TITLE
feat(conversations): add an optional private note when composing a ticket

### DIFF
--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_strict.ambr
@@ -33,7 +33,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'sign up'), 1, 0) AS step_0,
                   if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -101,7 +101,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'sign up'), 1, 0) AS step_0,
                   if(and(equals(e.event, 'buy'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', ''), 'xyz'), 0)), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
                   if(equals(step_1, 1), prop_basic, []) AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -169,7 +169,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'sign up'), 1, 0) AS step_0,
                   if(equals(e.event, 'buy'), 1, 0) AS step_1,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), ''), ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$version'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN

--- a/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors.ambr
+++ b/posthog/hogql_queries/insights/funnels/test/__snapshots__/test_funnel_trends_actors.ambr
@@ -21,7 +21,7 @@
                   if(equals(e.event, 'step one'), 1, 0) AS step_0,
                   if(equals(e.event, 'step two'), 1, 0) AS step_1,
                   if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -76,7 +76,7 @@
                   if(equals(e.event, 'step one'), 1, 0) AS step_0,
                   if(equals(e.event, 'step two'), 1, 0) AS step_1,
                   if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -131,7 +131,7 @@
                   if(equals(e.event, 'step one'), 1, 0) AS step_0,
                   if(equals(e.event, 'step two'), 1, 0) AS step_1,
                   if(equals(e.event, 'step three'), 1, 0) AS step_2,
-                  [ifNull(toString(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$browser'), ''), 'null'), '^"|"$', '')), '')] AS prop_basic,
+                  [ifNull(toString(nullIf(nullIf(e.`mat_$browser`, ''), 'null')), '')] AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -36,7 +36,14 @@ from products.access_control.backend.models.role import Role
 from products.conversations.backend import reply_dedupe
 from products.conversations.backend.api.ticket_filters import query_params_to_view_filters
 from products.conversations.backend.api.tickets import TicketReplyRequestSerializer
-from products.conversations.backend.models import EmailChannel, EmailChannelKind, Ticket, TicketAssignment, TicketView
+from products.conversations.backend.models import (
+    EmailChannel,
+    EmailChannelKind,
+    EmailOutboxMessage,
+    Ticket,
+    TicketAssignment,
+    TicketView,
+)
 from products.conversations.backend.models.constants import Channel, ChannelDetail, Priority, Status
 from products.conversations.backend.person_lookup import PERSON_EMAIL_LOOKUP_QUERY, _get_persons_by_email
 from products.conversations.backend.reply_dedupe import (
@@ -2053,6 +2060,23 @@ class TestComposeTicketAPI(APIBaseTest):
         assert first.json()["id"] != second.json()["id"]
         assert Ticket.objects.filter(team=self.team).count() == 2
 
+    def test_compose_same_message_with_different_context_is_not_deduplicated(self, mock_on_commit):
+        # The same email can go out twice for different reasons. If the fingerprint ignored the
+        # private note, the second compose would collapse onto the first and lose its context.
+        base = {
+            "recipient_email": "pitch@test.com",
+            "email_config_id": str(self.email_config.id),
+            "message": "Same body",
+        }
+
+        first = self._compose({**base, "internal_context": "Asked for in the weekly sync"})
+        second = self._compose({**base, "internal_context": "Follow-up after the trial expired"})
+
+        assert first.status_code == status.HTTP_201_CREATED
+        assert second.status_code == status.HTTP_201_CREATED
+        assert first.json()["id"] != second.json()["id"]
+        assert Ticket.objects.filter(team=self.team).count() == 2
+
     def test_compose_same_message_to_different_persons_is_not_deduplicated(self, mock_on_commit):
         # Two people can share one email address (person merging leaves this common). A compose to
         # each — same subject and body, different recipient_distinct_id — is two distinct tickets,
@@ -2110,6 +2134,58 @@ class TestComposeTicketAPI(APIBaseTest):
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json()["error_type"] == reply_dedupe.COMPOSE_IN_PROGRESS_ERROR_TYPE
         assert not Ticket.objects.filter(team=self.team).exists()
+
+    @parameterized.expand([("omitted", None), ("blank", "   ")])
+    def test_compose_without_context_writes_only_the_outbound_message(self, mock_on_commit, _name, internal_context):
+        data = {
+            "recipient_email": "someone@test.com",
+            "email_config_id": str(self.email_config.id),
+            "message": "Hello!",
+        }
+        if internal_context is not None:
+            data["internal_context"] = internal_context
+
+        assert self._compose(data).status_code == status.HTTP_201_CREATED
+
+        ticket = Ticket.objects.get(team=self.team)
+        comments = Comment.objects.filter(team=self.team, scope="conversations_ticket", item_id=str(ticket.id))
+        assert comments.count() == 1
+        assert comments.get().item_context["is_private"] is False
+
+    def test_compose_with_context_opens_the_ticket_on_a_private_note(self, mock_on_commit):
+        context = "Raised at the user meetup, not through support."
+        assert (
+            self._compose(
+                {
+                    "recipient_email": "someone@test.com",
+                    "email_config_id": str(self.email_config.id),
+                    "message": "Hello!",
+                    "internal_context": context,
+                }
+            ).status_code
+            == status.HTTP_201_CREATED
+        )
+
+        ticket = Ticket.objects.get(team=self.team)
+        comments = Comment.objects.filter(team=self.team, scope="conversations_ticket", item_id=str(ticket.id))
+        note = comments.get(item_context__is_private=True)
+        outbound = comments.get(item_context__is_private=False)
+
+        assert note.item_context == {"author_type": "support", "is_private": True}
+        assert note.content == context
+        assert note.created_at < outbound.created_at
+
+        # Only the outbound message may be sent. If the note ever reaches the outbox, the
+        # composer's internal context is delivered to the recipient.
+        outbox = EmailOutboxMessage.objects.filter(team=self.team, ticket=ticket)
+        assert outbox.count() == 1
+        assert outbox.get().comment_id == outbound.id
+
+        # The note must stay out of the denormalized fields, or its text reaches the ticket list
+        # preview and the customer-facing widget's message count.
+        ticket.refresh_from_db()
+        assert ticket.message_count == 1
+        assert ticket.last_message_text == "Hello!"
 
 
 class TestTicketPersonalAPIKeyScopes(APIBaseTest):

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2123,6 +2123,7 @@ class TestComposeTicketAPI(APIBaseTest):
             message="Great idea, we logged it.",
             rich_content=None,
             distinct_id="pitch@test.com",
+            internal_context="",
         )
         assert fingerprint is not None
         # Another request holds the reservation and hasn't finished creating yet.

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2046,6 +2046,49 @@ class TestComposeTicketAPI(APIBaseTest):
         assert second.json() == first.json()
         assert Ticket.objects.filter(team=self.team).count() == 1
 
+    @parameterized.expand(
+        [
+            ("replay_without_context", False, None),
+            ("replay_with_context", False, "Asked for in the weekly sync"),
+            ("persisted_match_without_context", True, None),
+            ("persisted_match_with_context", True, "Asked for in the weekly sync"),
+        ]
+    )
+    def test_compose_stays_idempotent_when_a_private_note_lands_before_the_retry(
+        self, mock_on_commit, _name, lose_reservation, internal_context
+    ):
+        # Anyone can add a private note to a ticket, and AI triage does it unprompted. If the dedupe
+        # guard mistook that note for the compose's own, the retry would open a second ticket and
+        # email the recipient the same message twice.
+        payload = {
+            "recipient_email": "pitch@test.com",
+            "email_config_id": str(self.email_config.id),
+            "message": "Great idea, we logged it.",
+        }
+        if internal_context:
+            payload["internal_context"] = internal_context
+
+        first = self._compose(payload)
+        assert first.status_code == status.HTTP_201_CREATED
+
+        Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="conversations_ticket",
+            item_id=first.json()["id"],
+            content="Looping in billing on this one.",
+            item_context={"author_type": "support", "is_private": True},
+        )
+        if lose_reservation:
+            get_client().flushall()
+
+        second = self._compose(payload)
+
+        assert second.status_code == status.HTTP_200_OK
+        assert second.json() == first.json()
+        assert Ticket.objects.filter(team=self.team).count() == 1
+        assert EmailOutboxMessage.objects.filter(team=self.team).count() == 1
+
     def test_compose_distinct_messages_are_not_deduplicated(self, mock_on_commit):
         base = {
             "recipient_email": "pitch@test.com",
@@ -2153,7 +2196,7 @@ class TestComposeTicketAPI(APIBaseTest):
         assert comments.count() == 1
         assert comments.get().item_context["is_private"] is False
 
-    def test_compose_with_context_opens_the_ticket_on_a_private_note(self, mock_on_commit):
+    def test_compose_with_context_records_it_as_a_private_note(self, mock_on_commit):
         context = "Raised at the user meetup, not through support."
         assert (
             self._compose(
@@ -2174,7 +2217,9 @@ class TestComposeTicketAPI(APIBaseTest):
 
         assert note.item_context == {"author_type": "support", "is_private": True}
         assert note.content == context
-        assert note.created_at < outbound.created_at
+        # The outbound message stays the first comment, which is how the dedupe guard identifies
+        # the ticket. A note ahead of it would make a retry re-send the email.
+        assert outbound.created_at < note.created_at
 
         # Only the outbound message may be sent. If the note ever reaches the outbox, the
         # composer's internal context is delivered to the recipient.

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2053,6 +2053,38 @@ class TestComposeTicketAPI(APIBaseTest):
         assert first.json()["id"] != second.json()["id"]
         assert Ticket.objects.filter(team=self.team).count() == 2
 
+    def test_compose_same_message_to_different_persons_is_not_deduplicated(self, mock_on_commit):
+        # Two people can share one email address (person merging leaves this common). A compose to
+        # each — same subject and body, different recipient_distinct_id — is two distinct tickets,
+        # each linked to its own person. The fingerprint must not collapse them onto one.
+        _create_person(
+            team=self.team,
+            distinct_ids=["person-a"],
+            properties={"email": "shared@test.com"},
+            immediate=True,
+        )
+        _create_person(
+            team=self.team,
+            distinct_ids=["person-b"],
+            properties={"email": "shared@test.com"},
+            immediate=True,
+        )
+        base = {
+            "recipient_email": "shared@test.com",
+            "email_config_id": str(self.email_config.id),
+            "message": "Same body",
+        }
+
+        first = self._compose({**base, "recipient_distinct_id": "person-a"})
+        second = self._compose({**base, "recipient_distinct_id": "person-b"})
+
+        assert first.status_code == status.HTTP_201_CREATED
+        assert second.status_code == status.HTTP_201_CREATED
+        assert first.json()["id"] != second.json()["id"]
+        assert Ticket.objects.filter(team=self.team).count() == 2
+        assert Ticket.objects.get(pk=first.json()["id"]).distinct_id == "person-a"
+        assert Ticket.objects.get(pk=second.json()["id"]).distinct_id == "person-b"
+
     def test_compose_conflicts_while_an_identical_request_is_in_flight(self, mock_on_commit):
         payload = {
             "recipient_email": "pitch@test.com",
@@ -2066,6 +2098,7 @@ class TestComposeTicketAPI(APIBaseTest):
             email_subject="",
             message="Great idea, we logged it.",
             rich_content=None,
+            distinct_id="pitch@test.com",
         )
         assert fingerprint is not None
         # Another request holds the reservation and hasn't finished creating yet.

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2018,6 +2018,27 @@ class TestComposeTicketAPI(APIBaseTest):
         assert Ticket.objects.filter(team=self.team).count() == 1
         assert Comment.objects.filter(scope="conversations_ticket", item_id=first.json()["id"]).count() == 1
 
+    def test_compose_recovers_the_existing_ticket_when_the_reservation_is_lost(self, mock_on_commit):
+        # The Redis reservation can vanish (eviction, restart) after a ticket commits. A retry then
+        # reserves cleanly and must recover the existing ticket from the database — via
+        # find_persisted_match — instead of opening a second one and re-emailing the customer.
+        payload = {
+            "recipient_email": "pitch@test.com",
+            "email_config_id": str(self.email_config.id),
+            "email_subject": "Thanks for your pitch",
+            "message": "Great idea, we logged it.",
+        }
+
+        first = self._compose(payload)
+        assert first.status_code == status.HTTP_201_CREATED
+        get_client().flushall()
+
+        second = self._compose(payload)
+
+        assert second.status_code == status.HTTP_200_OK
+        assert second.json() == first.json()
+        assert Ticket.objects.filter(team=self.team).count() == 1
+
     def test_compose_distinct_messages_are_not_deduplicated(self, mock_on_commit):
         base = {
             "recipient_email": "pitch@test.com",
@@ -2047,8 +2068,9 @@ class TestComposeTicketAPI(APIBaseTest):
             rich_content=None,
         )
         assert fingerprint is not None
-        # Simulate another request that reserved the fingerprint and hasn't finished creating yet.
-        get_client().set(fingerprint.key, f"{reply_dedupe._IN_FLIGHT_VALUE_PREFIX}someone-else", nx=True, ex=30)
+        # Another request holds the reservation and hasn't finished creating yet.
+        held = reply_dedupe.reserve(fingerprint)
+        assert held.state is reply_dedupe.ReservationState.ACQUIRED
 
         response = self._compose(payload)
 

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -33,12 +33,18 @@ from posthog.test.persons import create_person
 
 from products.access_control.backend.models.access_control import AccessControl
 from products.access_control.backend.models.role import Role
+from products.conversations.backend import reply_dedupe
 from products.conversations.backend.api.ticket_filters import query_params_to_view_filters
 from products.conversations.backend.api.tickets import TicketReplyRequestSerializer
 from products.conversations.backend.models import EmailChannel, EmailChannelKind, Ticket, TicketAssignment, TicketView
 from products.conversations.backend.models.constants import Channel, ChannelDetail, Priority, Status
 from products.conversations.backend.person_lookup import PERSON_EMAIL_LOOKUP_QUERY, _get_persons_by_email
-from products.conversations.backend.reply_dedupe import REPLY_IN_PROGRESS_ERROR_TYPE, ReplyFingerprint, reserve
+from products.conversations.backend.reply_dedupe import (
+    REPLY_IN_PROGRESS_ERROR_TYPE,
+    ComposeFingerprint,
+    ReplyFingerprint,
+    reserve,
+)
 
 from ee.clickhouse.materialized_columns.columns import get_bloom_filter_lower_index_name
 
@@ -1836,6 +1842,9 @@ class TestComposeTicketAPI(APIBaseTest):
             domain_verified=True,
             inbound_token="test-token-compose",
         )
+        # fakeredis keeps one FakeServer per process, so dedupe reservations would otherwise leak
+        # between tests.
+        get_client().flushall()
 
     def _compose(self, data):
         return self.client.post(
@@ -1989,6 +1998,63 @@ class TestComposeTicketAPI(APIBaseTest):
         )
         assert search.status_code == status.HTTP_200_OK
         assert [t["id"] for t in search.json()["results"]] == [str(ticket.id)]
+
+    def test_compose_identical_request_is_idempotent(self, mock_on_commit):
+        # A caller that retries a slow compose (e.g. a workflow webhook whose fetch timed out) must
+        # get the same ticket back, not a second one — and the customer must not be emailed twice.
+        payload = {
+            "recipient_email": "pitch@test.com",
+            "email_config_id": str(self.email_config.id),
+            "email_subject": "Thanks for your pitch",
+            "message": "Great idea, we logged it.",
+        }
+
+        first = self._compose(payload)
+        second = self._compose(payload)
+
+        assert first.status_code == status.HTTP_201_CREATED
+        assert second.status_code == status.HTTP_200_OK
+        assert first.json() == second.json()
+        assert Ticket.objects.filter(team=self.team).count() == 1
+        assert Comment.objects.filter(scope="conversations_ticket", item_id=first.json()["id"]).count() == 1
+
+    def test_compose_distinct_messages_are_not_deduplicated(self, mock_on_commit):
+        base = {
+            "recipient_email": "pitch@test.com",
+            "email_config_id": str(self.email_config.id),
+        }
+
+        first = self._compose({**base, "message": "First idea"})
+        second = self._compose({**base, "message": "Second, different idea"})
+
+        assert first.status_code == status.HTTP_201_CREATED
+        assert second.status_code == status.HTTP_201_CREATED
+        assert first.json()["id"] != second.json()["id"]
+        assert Ticket.objects.filter(team=self.team).count() == 2
+
+    def test_compose_conflicts_while_an_identical_request_is_in_flight(self, mock_on_commit):
+        payload = {
+            "recipient_email": "pitch@test.com",
+            "email_config_id": str(self.email_config.id),
+            "message": "Great idea, we logged it.",
+        }
+        fingerprint = ComposeFingerprint.build(
+            team_id=self.team.id,
+            email_config_id=str(self.email_config.id),
+            recipient_email="pitch@test.com",
+            email_subject="",
+            message="Great idea, we logged it.",
+            rich_content=None,
+        )
+        assert fingerprint is not None
+        # Simulate another request that reserved the fingerprint and hasn't finished creating yet.
+        get_client().set(fingerprint.key, f"{reply_dedupe._IN_FLIGHT_VALUE_PREFIX}someone-else", nx=True, ex=30)
+
+        response = self._compose(payload)
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json()["error_type"] == reply_dedupe.COMPOSE_IN_PROGRESS_ERROR_TYPE
+        assert not Ticket.objects.filter(team=self.team).exists()
 
 
 class TestTicketPersonalAPIKeyScopes(APIBaseTest):

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -224,6 +224,15 @@ class ComposeTicketSerializer(serializers.Serializer):
         allow_null=True,
         help_text="TipTap rich content JSON for formatted messages.",
     )
+    internal_context = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=5000,
+        help_text=(
+            "Optional context about why the ticket is being opened. Becomes the private note that "
+            "starts the thread, so it is visible to the team and never sent to the recipient."
+        ),
+    )
 
     def validate_message(self, value: str) -> str:
         if not value or not value.strip():
@@ -1705,6 +1714,20 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
                     identity_verified=None,
                 )
 
+                # Created before the outbound message so the thread opens on it. Private, so it
+                # never reaches the recipient and never lands in the ticket's denormalized
+                # preview fields.
+                internal_context = data.get("internal_context", "").strip()
+                if internal_context:
+                    Comment.objects.create(
+                        team=team,
+                        created_by=request.user,
+                        scope="conversations_ticket",
+                        item_id=str(ticket.id),
+                        content=internal_context,
+                        item_context={"author_type": "support", "is_private": True},
+                    )
+
                 Comment.objects.create(
                     team=team,
                     created_by=request.user,
@@ -1726,6 +1749,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
             message=data["message"],
             rich_content=data.get("rich_content"),
             distinct_id=distinct_id,
+            internal_context=data.get("internal_context", ""),
         )
         assert fingerprint is not None
         guarded = reply_dedupe.create_ticket_deduplicated(fingerprint, create_ticket)

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -239,6 +239,11 @@ class ComposeTicketSerializer(serializers.Serializer):
             raise serializers.ValidationError("Message content is required.")
         return value.strip()
 
+    def validate_internal_context(self, value: str) -> str:
+        # Stripped here rather than at the point of use, so the note and the dedupe fingerprint
+        # that has to match it read the same value.
+        return value.strip()
+
     def validate_rich_content(self, value: object) -> object:
         if value is None:
             return value
@@ -1675,8 +1680,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
 
         recipient_email = data["recipient_email"]
         distinct_id = data.get("recipient_distinct_id", "") or recipient_email
-        # Stripped once, so the note and the fingerprint that has to match it agree.
-        internal_context = data.get("internal_context", "").strip()
+        internal_context = data.get("internal_context", "")
 
         person: Person | None = None
         if distinct_id != recipient_email:

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -229,8 +229,8 @@ class ComposeTicketSerializer(serializers.Serializer):
         allow_blank=True,
         max_length=5000,
         help_text=(
-            "Optional context about why the ticket is being opened. Becomes the private note that "
-            "starts the thread, so it is visible to the team and never sent to the recipient."
+            "Optional context about why the ticket is being opened. Saved as a private note on the "
+            "ticket, so the team can read it and the recipient never receives it."
         ),
     )
 
@@ -1716,18 +1716,6 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
                     identity_verified=None,
                 )
 
-                # Created before the outbound message so the thread opens on it. Private, so it
-                # never reaches the recipient.
-                if internal_context:
-                    Comment.objects.create(
-                        team=team,
-                        created_by=request.user,
-                        scope="conversations_ticket",
-                        item_id=str(ticket.id),
-                        content=internal_context,
-                        item_context={"author_type": "support", "is_private": True},
-                    )
-
                 Comment.objects.create(
                     team=team,
                     created_by=request.user,
@@ -1737,6 +1725,19 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
                     rich_content=data.get("rich_content"),
                     item_context={"author_type": "human", "is_private": False},
                 )
+
+                # Written after the outbound message, so the message stays the ticket's first
+                # comment and the dedupe guard keeps identifying the ticket by it. Private, so the
+                # note never reaches the recipient.
+                if internal_context:
+                    Comment.objects.create(
+                        team=team,
+                        created_by=request.user,
+                        scope="conversations_ticket",
+                        item_id=str(ticket.id),
+                        content=internal_context,
+                        item_context={"author_type": "support", "is_private": True},
+                    )
             return ticket
 
         # message, recipient_email, and email_config are all validated above, so build never

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1675,6 +1675,8 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
 
         recipient_email = data["recipient_email"]
         distinct_id = data.get("recipient_distinct_id", "") or recipient_email
+        # Stripped once, so the note and the fingerprint that has to match it agree.
+        internal_context = data.get("internal_context", "").strip()
 
         person: Person | None = None
         if distinct_id != recipient_email:
@@ -1715,9 +1717,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
                 )
 
                 # Created before the outbound message so the thread opens on it. Private, so it
-                # never reaches the recipient and never lands in the ticket's denormalized
-                # preview fields.
-                internal_context = data.get("internal_context", "").strip()
+                # never reaches the recipient.
                 if internal_context:
                     Comment.objects.create(
                         team=team,
@@ -1749,7 +1749,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
             message=data["message"],
             rich_content=data.get("rich_content"),
             distinct_id=distinct_id,
-            internal_context=data.get("internal_context", ""),
+            internal_context=internal_context,
         )
         assert fingerprint is not None
         guarded = reply_dedupe.create_ticket_deduplicated(fingerprint, create_ticket)

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1755,7 +1755,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
                 capture_exception(e, {"ticket_id": str(ticket.id)})
 
         return Response(
-            {"id": str(ticket.id), "ticket_number": ticket.ticket_number},
+            ComposeTicketResponseSerializer(ticket).data,
             status=drf_status.HTTP_201_CREATED if created else drf_status.HTTP_200_OK,
         )
 

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1608,8 +1608,16 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
     @extend_schema(
         request=ComposeTicketSerializer,
         responses={
-            201: OpenApiResponse(response=ComposeTicketResponseSerializer),
+            201: OpenApiResponse(response=ComposeTicketResponseSerializer, description="Ticket created."),
+            200: OpenApiResponse(
+                response=ComposeTicketResponseSerializer,
+                description="An identical compose was already handled; the existing ticket is returned.",
+            ),
             400: OpenApiResponse(response=TicketErrorSerializer),
+            409: OpenApiResponse(
+                response=TicketErrorSerializer,
+                description="An identical compose is still being created by another request.",
+            ),
         },
     )
     @action(
@@ -1619,7 +1627,12 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
         throttle_classes=[ComposeTicketBurstThrottle, ComposeTicketSustainedThrottle],
     )
     def compose(self, request, *args, **kwargs):
-        """Create a new outbound ticket and send the first message to the customer."""
+        """Create a new outbound ticket and send the first message to the customer.
+
+        Idempotent within a short window: an identical compose retried while the first is still
+        in flight returns 409, and one retried after it committed returns the same ticket with a
+        200. Only a genuinely new request creates a ticket and emails the customer.
+        """
         serializer = ComposeTicketSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
@@ -1673,48 +1686,77 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
                     status=drf_status.HTTP_400_BAD_REQUEST,
                 )
 
-        with transaction.atomic():
-            ticket = Ticket.objects.create_with_number(
-                team=team,
-                channel_source=Channel.EMAIL,
-                distinct_id=distinct_id,
-                status=Status.OPEN,
-                widget_session_id=str(uuid.uuid4()),
-                email_config=email_config,
-                email_from=recipient_email,
-                email_subject=data.get("email_subject", ""),
-                # Ticket search, the person display and restore-by-email all read the
-                # customer's address from traits, so outbound tickets must carry it too.
-                anonymous_traits={"email": recipient_email},
-                # The recipient hasn't proven control of this address — a team member just typed it —
-                # so leave identity unknown. It's promoted to verified if/when they reply and authenticate.
-                identity_verified=None,
-            )
+        def create_ticket() -> Ticket:
+            with transaction.atomic():
+                ticket = Ticket.objects.create_with_number(
+                    team=team,
+                    channel_source=Channel.EMAIL,
+                    distinct_id=distinct_id,
+                    status=Status.OPEN,
+                    widget_session_id=str(uuid.uuid4()),
+                    email_config=email_config,
+                    email_from=recipient_email,
+                    email_subject=data.get("email_subject", ""),
+                    # Ticket search, the person display and restore-by-email all read the
+                    # customer's address from traits, so outbound tickets must carry it too.
+                    anonymous_traits={"email": recipient_email},
+                    # The recipient hasn't proven control of this address — a team member just typed it —
+                    # so leave identity unknown. It's promoted to verified if/when they reply and authenticate.
+                    identity_verified=None,
+                )
 
-            Comment.objects.create(
-                team=team,
-                created_by=request.user,
-                scope="conversations_ticket",
-                item_id=str(ticket.id),
-                content=data["message"],
-                rich_content=data.get("rich_content"),
-                item_context={"author_type": "human", "is_private": False},
-            )
+                Comment.objects.create(
+                    team=team,
+                    created_by=request.user,
+                    scope="conversations_ticket",
+                    item_id=str(ticket.id),
+                    content=data["message"],
+                    rich_content=data.get("rich_content"),
+                    item_context={"author_type": "human", "is_private": False},
+                )
+            return ticket
 
-        try:
-            report_user_action(
-                request.user,
-                "support ticket composed",
-                {"channel_source": Channel.EMAIL},
-                team=team,
-                request=request,
-            )
-        except Exception as e:
-            capture_exception(e, {"ticket_id": str(ticket.id)})
+        fingerprint = reply_dedupe.ComposeFingerprint.build(
+            team_id=team.id,
+            email_config_id=str(email_config.id),
+            recipient_email=recipient_email,
+            email_subject=data.get("email_subject", ""),
+            message=data["message"],
+            rich_content=data.get("rich_content"),
+        )
+        if fingerprint is None:
+            ticket = create_ticket()
+            created = True
+        else:
+            guarded = reply_dedupe.create_ticket_deduplicated(fingerprint, create_ticket)
+            if guarded.outcome is reply_dedupe.CreateOutcome.CONFLICT:
+                return Response(
+                    {
+                        "detail": reply_dedupe.COMPOSE_IN_PROGRESS_DETAIL,
+                        "error_type": reply_dedupe.COMPOSE_IN_PROGRESS_ERROR_TYPE,
+                    },
+                    status=drf_status.HTTP_409_CONFLICT,
+                )
+            ticket = cast(Ticket, guarded.ticket)
+            created = guarded.outcome is reply_dedupe.CreateOutcome.CREATED
+
+        # A replay already reported this action and already emailed the customer, so only a genuine
+        # create repeats either.
+        if created:
+            try:
+                report_user_action(
+                    request.user,
+                    "support ticket composed",
+                    {"channel_source": Channel.EMAIL},
+                    team=team,
+                    request=request,
+                )
+            except Exception as e:
+                capture_exception(e, {"ticket_id": str(ticket.id)})
 
         return Response(
             {"id": str(ticket.id), "ticket_number": ticket.ticket_number},
-            status=drf_status.HTTP_201_CREATED,
+            status=drf_status.HTTP_201_CREATED if created else drf_status.HTTP_200_OK,
         )
 
 

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1725,6 +1725,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
             email_subject=data.get("email_subject", ""),
             message=data["message"],
             rich_content=data.get("rich_content"),
+            distinct_id=distinct_id,
         )
         assert fingerprint is not None
         guarded = reply_dedupe.create_ticket_deduplicated(fingerprint, create_ticket)

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -1716,6 +1716,8 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
                 )
             return ticket
 
+        # message, recipient_email, and email_config are all validated above, so build never
+        # returns None here.
         fingerprint = reply_dedupe.ComposeFingerprint.build(
             team_id=team.id,
             email_config_id=str(email_config.id),
@@ -1724,21 +1726,18 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
             message=data["message"],
             rich_content=data.get("rich_content"),
         )
-        if fingerprint is None:
-            ticket = create_ticket()
-            created = True
-        else:
-            guarded = reply_dedupe.create_ticket_deduplicated(fingerprint, create_ticket)
-            if guarded.outcome is reply_dedupe.CreateOutcome.CONFLICT:
-                return Response(
-                    {
-                        "detail": reply_dedupe.COMPOSE_IN_PROGRESS_DETAIL,
-                        "error_type": reply_dedupe.COMPOSE_IN_PROGRESS_ERROR_TYPE,
-                    },
-                    status=drf_status.HTTP_409_CONFLICT,
-                )
-            ticket = cast(Ticket, guarded.ticket)
-            created = guarded.outcome is reply_dedupe.CreateOutcome.CREATED
+        assert fingerprint is not None
+        guarded = reply_dedupe.create_ticket_deduplicated(fingerprint, create_ticket)
+        if guarded.outcome is reply_dedupe.CreateOutcome.CONFLICT:
+            return Response(
+                {
+                    "detail": reply_dedupe.COMPOSE_IN_PROGRESS_DETAIL,
+                    "error_type": reply_dedupe.COMPOSE_IN_PROGRESS_ERROR_TYPE,
+                },
+                status=drf_status.HTTP_409_CONFLICT,
+            )
+        ticket = cast(Ticket, guarded.ticket)
+        created = guarded.outcome is reply_dedupe.CreateOutcome.CREATED
 
         # A replay already reported this action and already emailed the customer, so only a genuine
         # create repeats either.

--- a/products/conversations/backend/reply_dedupe.py
+++ b/products/conversations/backend/reply_dedupe.py
@@ -379,7 +379,7 @@ def _classify_held_value(key: str, held: Any, token: str) -> Reservation:
 
 # Compose opens a brand-new outbound ticket, so it hashes into its own keyspace — a compose retry
 # must never collapse onto a reply, or vice versa. Bump the version when the contents below change.
-_COMPOSE_KEY_PREFIX = "conversations:compose_dedupe:v1:"
+_COMPOSE_KEY_PREFIX = "conversations:compose_dedupe:v2:"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -387,8 +387,8 @@ class ComposeFingerprint:
     """The immutable identity of an outbound compose request.
 
     Two requests with the same fingerprint open the same outbound ticket: same team, sending
-    channel, recipient, subject, and first message. ``build`` returns None for anything this guard
-    must not collapse.
+    channel, recipient, subject, first message, and resolved person link. ``build`` returns None
+    for anything this guard must not collapse.
     """
 
     team_id: int
@@ -397,6 +397,9 @@ class ComposeFingerprint:
     email_subject: str
     message: str
     rich_content: Any
+    # The resolved recipient person link the create writes onto the ticket. Two composes with the
+    # same body but a different recipient point at different people, so they must not collapse.
+    distinct_id: str
 
     @classmethod
     def build(
@@ -408,6 +411,7 @@ class ComposeFingerprint:
         email_subject: Any,
         message: Any,
         rich_content: Any,
+        distinct_id: Any,
     ) -> "ComposeFingerprint | None":
         if not email_config_id or not recipient_email or not isinstance(message, str) or not message:
             return None
@@ -418,6 +422,7 @@ class ComposeFingerprint:
             email_subject=str(email_subject or ""),
             message=message,
             rich_content=rich_content,
+            distinct_id=str(distinct_id or ""),
         )
 
     @property
@@ -430,6 +435,7 @@ class ComposeFingerprint:
                 "email_subject": self.email_subject,
                 "message": self.message,
                 "rich_content": self.rich_content,
+                "distinct_id": self.distinct_id,
             },
             sort_keys=True,
             separators=(",", ":"),
@@ -446,6 +452,7 @@ class ComposeFingerprint:
             or str(ticket.email_config_id or "") != self.email_config_id
             or (ticket.email_from or "") != self.recipient_email
             or (ticket.email_subject or "") != self.email_subject
+            or (ticket.distinct_id or "") != self.distinct_id
         ):
             return False
         # The first message lives on the ticket's opening comment, so confirm the body too: a

--- a/products/conversations/backend/reply_dedupe.py
+++ b/products/conversations/backend/reply_dedupe.py
@@ -5,6 +5,10 @@ the request within a second, and an operator whose send looks like it failed sen
 again. Dedupe on the validated request the server already has, so neither caller needs to supply
 an idempotency key.
 
+The same reservation protocol also guards outbound ``compose``. A caller that retries a slow
+compose — a workflow webhook whose fetch times out just as the server finishes — would otherwise
+open the same ticket, and email the customer, once per retry.
+
 Redis access goes through ``posthog.redis.get_client()`` rather than the Django cache. The default
 cache alias is replica-aware, so the ``GET`` that follows a lost ``SET NX`` could read a lagging
 replica and report a conflict for a reservation that already resolved. This client is bound to
@@ -19,7 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any
+from typing import Any, Protocol
 
 from django.utils import timezone
 
@@ -28,7 +32,15 @@ import structlog
 from posthog.models.comment import Comment
 from posthog.redis import get_client
 
+from products.conversations.backend.models import Channel, Ticket
+
 logger = structlog.get_logger(__name__)
+
+
+class _HasKey(Protocol):
+    @property
+    def key(self) -> str: ...
+
 
 # A reservation only has to outlive one request, and a worker killed mid-create self-heals this
 # many seconds later instead of blocking that exact message for the full replay window.
@@ -43,11 +55,16 @@ SUPPORT_AUTHOR_TYPE = "support"
 REPLY_IN_PROGRESS_ERROR_TYPE = "reply_in_progress"
 REPLY_IN_PROGRESS_DETAIL = "This message is already being sent. Check the thread before sending it again."
 
+COMPOSE_IN_PROGRESS_ERROR_TYPE = "compose_in_progress"
+COMPOSE_IN_PROGRESS_DETAIL = "This ticket is already being created. Check the inbox before composing it again."
+
 # Both endpoints hash into one keyspace, so a retry that switches paths still replays. Bump the
 # version when the fingerprint's contents change, so old entries can't be read under new rules.
 _KEY_PREFIX = "conversations:reply_dedupe:v1:"
 _IN_FLIGHT_VALUE_PREFIX = "inflight:"
-_COMMENT_VALUE_PREFIX = "comment:"
+# Marks a reservation value that holds the id of the created object — a comment for reply, a
+# ticket for compose. The key prefix keeps the two keyspaces apart, so the value prefix is shared.
+_STORED_VALUE_PREFIX = "comment:"
 
 # Compare the owner token before writing, so a creator that stalled past its own TTL cannot
 # overwrite or delete the reservation a later attempt has since taken.
@@ -82,7 +99,8 @@ class Reservation:
     key: str
     # Absent when we failed open, which makes publish and release no-ops.
     owner_token: str | None = None
-    comment_id: str | None = None
+    # Id of the created object (a comment for reply, a ticket for compose).
+    object_id: str | None = None
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -236,7 +254,7 @@ def create_deduplicated(fingerprint: ReplyFingerprint, create: Callable[[], Comm
     """
     reservation = reserve(fingerprint)
     if reservation.state is ReservationState.REPLAY:
-        replayed = fingerprint.load_replay_target(reservation.comment_id)
+        replayed = fingerprint.load_replay_target(reservation.object_id)
         if replayed is not None:
             return GuardedCreate(outcome=CreateOutcome.REPLAYED, comment=replayed)
         # A mapping we can't verify is treated as no mapping, rather than serving an unrelated row.
@@ -270,7 +288,7 @@ def _replay_window_start(attempted_at: datetime) -> datetime:
     return attempted_at - timedelta(seconds=REPLAY_WINDOW_SECONDS)
 
 
-def reserve(fingerprint: ReplyFingerprint) -> Reservation:
+def reserve(fingerprint: _HasKey) -> Reservation:
     """Claim the right to create this message, or report who got there first.
 
     Fails open (ACQUIRED without a token) once Redis has failed twice. That degrades to the caller's
@@ -299,11 +317,11 @@ def reserve(fingerprint: ReplyFingerprint) -> Reservation:
     return Reservation(state=ReservationState.ACQUIRED, key=key)
 
 
-def publish(reservation: Reservation, comment_id: Any) -> None:
-    """Point the reservation at the created message so later retries replay it."""
+def publish(reservation: Reservation, object_id: Any) -> None:
+    """Point the reservation at the created object so later retries replay it."""
     if reservation.owner_token is None:
         return
-    value = f"{_COMMENT_VALUE_PREFIX}{comment_id}"
+    value = f"{_STORED_VALUE_PREFIX}{object_id}"
     for attempt in range(2):
         try:
             get_client().eval(
@@ -333,13 +351,167 @@ def _classify_held_value(key: str, held: Any, token: str) -> Reservation:
     if value == token:
         # Our own SET landed even though its reply never reached us, so we still own the reservation.
         return Reservation(state=ReservationState.ACQUIRED, key=key, owner_token=token)
-    if value.startswith(_COMMENT_VALUE_PREFIX):
+    if value.startswith(_STORED_VALUE_PREFIX):
         return Reservation(
             state=ReservationState.REPLAY,
             key=key,
-            comment_id=value.removeprefix(_COMMENT_VALUE_PREFIX),
+            object_id=value.removeprefix(_STORED_VALUE_PREFIX),
         )
     if value.startswith(_IN_FLIGHT_VALUE_PREFIX):
         return Reservation(state=ReservationState.IN_FLIGHT, key=key)
     logger.warning("conversations_reply_dedupe_malformed_value", key=key)
     return Reservation(state=ReservationState.ACQUIRED, key=key)
+
+
+# Compose opens a brand-new outbound ticket, so it hashes into its own keyspace — a compose retry
+# must never collapse onto a reply, or vice versa. Bump the version when the contents below change.
+_COMPOSE_KEY_PREFIX = "conversations:compose_dedupe:v1:"
+
+
+@dataclass(frozen=True, kw_only=True)
+class ComposeFingerprint:
+    """The immutable identity of an outbound compose request.
+
+    Two requests with the same fingerprint open the same outbound ticket: same team, sending
+    channel, recipient, subject, and first message. ``build`` returns None for anything this guard
+    must not collapse.
+    """
+
+    team_id: int
+    email_config_id: str
+    recipient_email: str
+    email_subject: str
+    message: str
+    rich_content: Any
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        team_id: int,
+        email_config_id: Any,
+        recipient_email: Any,
+        email_subject: Any,
+        message: Any,
+        rich_content: Any,
+    ) -> "ComposeFingerprint | None":
+        if not email_config_id or not recipient_email or not isinstance(message, str) or not message:
+            return None
+        return cls(
+            team_id=team_id,
+            email_config_id=str(email_config_id),
+            recipient_email=str(recipient_email),
+            email_subject=str(email_subject or ""),
+            message=message,
+            rich_content=rich_content,
+        )
+
+    @property
+    def key(self) -> str:
+        canonical = json.dumps(
+            {
+                "team_id": self.team_id,
+                "email_config_id": self.email_config_id,
+                "recipient_email": self.recipient_email,
+                "email_subject": self.email_subject,
+                "message": self.message,
+                "rich_content": self.rich_content,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        # Only the digest reaches Redis, so no message content lands in a key.
+        return f"{_COMPOSE_KEY_PREFIX}{hashlib.sha256(canonical.encode()).hexdigest()}"
+
+    def matches(self, ticket: Ticket) -> bool:
+        """Whether this persisted outbound ticket is the one this request asked for."""
+        if (
+            ticket.team_id != self.team_id
+            or ticket.channel_source != Channel.EMAIL
+            or str(ticket.email_config_id or "") != self.email_config_id
+            or (ticket.email_from or "") != self.recipient_email
+            or (ticket.email_subject or "") != self.email_subject
+        ):
+            return False
+        # The first message lives on the ticket's opening comment, so confirm the body too: a
+        # second, different pitch to the same recipient in the window is a distinct ticket.
+        first = (
+            Comment.objects.filter(team_id=self.team_id, scope=SUPPORT_TICKET_SCOPE, item_id=str(ticket.id))
+            .order_by("created_at")
+            .first()
+        )
+        if first is None or first.deleted or first.content != self.message or first.rich_content != self.rich_content:
+            return False
+        return True
+
+    def find_persisted_match(self, *, created_after: datetime) -> Ticket | None:
+        """The outbound ticket this request would have opened, if an earlier attempt already did.
+
+        This closes the window where a create commits but its publication never lands: the
+        reservation is gone, so only the database can tell the retry that its ticket exists.
+        """
+        candidates = Ticket.objects.filter(
+            team_id=self.team_id,
+            channel_source=Channel.EMAIL,
+            email_config_id=self.email_config_id,
+            email_from=self.recipient_email,
+            created_at__gte=created_after,
+        ).order_by("-created_at")[:20]
+        return next((ticket for ticket in candidates if self.matches(ticket)), None)
+
+    def load_replay_target(self, ticket_id: str | None) -> Ticket | None:
+        """Re-verify a published mapping before serving it as a replay."""
+        if not ticket_id:
+            return None
+        ticket = Ticket.objects.filter(team_id=self.team_id, pk=ticket_id).first()
+        if ticket is None or not self.matches(ticket):
+            logger.warning("conversations_compose_dedupe_stale_mapping", ticket_id=ticket_id)
+            return None
+        return ticket
+
+
+@dataclass(frozen=True, kw_only=True)
+class GuardedTicketCreate:
+    outcome: CreateOutcome
+    ticket: Ticket | None = None
+
+
+def create_ticket_deduplicated(fingerprint: ComposeFingerprint, create: Callable[[], Ticket]) -> GuardedTicketCreate:
+    """Run ``create`` at most once per fingerprint, and report what happened.
+
+    Mirrors ``create_deduplicated`` for outbound compose. The caller owns the response shape: a
+    REPLAYED outcome is theirs to render as a 200 and a CONFLICT as a 409. This is what stops a
+    caller that retries a slow compose from opening the same ticket — and emailing the customer —
+    more than once. Exceptions from ``create`` propagate unchanged after the reservation is settled.
+    """
+    reservation = reserve(fingerprint)
+    if reservation.state is ReservationState.REPLAY:
+        replayed = fingerprint.load_replay_target(reservation.object_id)
+        if replayed is not None:
+            return GuardedTicketCreate(outcome=CreateOutcome.REPLAYED, ticket=replayed)
+        # A mapping we can't verify is treated as no mapping, rather than serving an unrelated row.
+    elif reservation.state is ReservationState.IN_FLIGHT:
+        return GuardedTicketCreate(outcome=CreateOutcome.CONFLICT)
+
+    attempted_at = timezone.now()
+    already_created = fingerprint.find_persisted_match(created_after=_replay_window_start(attempted_at))
+    if already_created is not None:
+        publish(reservation, already_created.id)
+        return GuardedTicketCreate(outcome=CreateOutcome.REPLAYED, ticket=already_created)
+
+    try:
+        ticket = create()
+    except Exception:
+        # post_save receivers (outbound send) run after the INSERT, so an exception does not mean
+        # the row is absent. Releasing blindly would make an already-sent ticket immediately
+        # repeatable.
+        recovered = fingerprint.find_persisted_match(created_after=attempted_at)
+        if recovered is not None:
+            publish(reservation, recovered.id)
+        else:
+            release(reservation)
+        raise
+
+    publish(reservation, ticket.id)
+    return GuardedTicketCreate(outcome=CreateOutcome.CREATED, ticket=ticket)

--- a/products/conversations/backend/reply_dedupe.py
+++ b/products/conversations/backend/reply_dedupe.py
@@ -37,9 +37,17 @@ from products.conversations.backend.models import Channel, Ticket
 logger = structlog.get_logger(__name__)
 
 
-class _HasKey(Protocol):
+class _DedupeFingerprint(Protocol):
+    """What the reservation protocol needs from any fingerprint: a key, and a way to find or
+    re-verify the object an earlier attempt created. ``ReplyFingerprint`` and ``ComposeFingerprint``
+    both satisfy it, over comments and tickets respectively."""
+
     @property
     def key(self) -> str: ...
+
+    def find_persisted_match(self, *, created_after: datetime) -> Any: ...
+
+    def load_replay_target(self, object_id: str | None) -> Any: ...
 
 
 # A reservation only has to outlive one request, and a worker killed mid-create self-heals this
@@ -245,34 +253,34 @@ class GuardedCreate:
     comment: Comment | None = None
 
 
-def create_deduplicated(fingerprint: ReplyFingerprint, create: Callable[[], Comment]) -> GuardedCreate:
-    """Run ``create`` at most once per fingerprint, and report what happened.
+def _run_deduplicated(fingerprint: _DedupeFingerprint, create: Callable[[], Any]) -> tuple[CreateOutcome, Any]:
+    """Run ``create`` at most once per fingerprint, and report the outcome plus the object.
 
-    Both support-message endpoints go through here so the protocol can't drift between them. The
-    caller owns the response shape: a REPLAYED outcome is theirs to render as a 200 and a CONFLICT
-    as a 409. Exceptions from ``create`` propagate unchanged after the reservation is settled.
+    The shared core for both create endpoints, so the reservation protocol can't drift between
+    them. The caller owns the response shape: a REPLAYED outcome is theirs to render as a 200 and a
+    CONFLICT as a 409. Exceptions from ``create`` propagate unchanged after the reservation is
+    settled. On CONFLICT the object is None.
     """
     reservation = reserve(fingerprint)
     if reservation.state is ReservationState.REPLAY:
         replayed = fingerprint.load_replay_target(reservation.object_id)
         if replayed is not None:
-            return GuardedCreate(outcome=CreateOutcome.REPLAYED, comment=replayed)
+            return CreateOutcome.REPLAYED, replayed
         # A mapping we can't verify is treated as no mapping, rather than serving an unrelated row.
     elif reservation.state is ReservationState.IN_FLIGHT:
-        return GuardedCreate(outcome=CreateOutcome.CONFLICT)
+        return CreateOutcome.CONFLICT, None
 
     attempted_at = timezone.now()
     already_created = fingerprint.find_persisted_match(created_after=_replay_window_start(attempted_at))
     if already_created is not None:
         publish(reservation, already_created.id)
-        return GuardedCreate(outcome=CreateOutcome.REPLAYED, comment=already_created)
+        return CreateOutcome.REPLAYED, already_created
 
     try:
-        comment = create()
+        created_object = create()
     except Exception:
-        # Mention fan-out and post_save receivers run after the INSERT, so an exception does not
-        # mean the row is absent. Releasing blindly would make an already-delivered message
-        # immediately repeatable.
+        # Receivers and mention fan-out run after the INSERT, so an exception does not mean the row
+        # is absent. Releasing blindly would make an already-delivered object immediately repeatable.
         recovered = fingerprint.find_persisted_match(created_after=attempted_at)
         if recovered is not None:
             publish(reservation, recovered.id)
@@ -280,15 +288,21 @@ def create_deduplicated(fingerprint: ReplyFingerprint, create: Callable[[], Comm
             release(reservation)
         raise
 
-    publish(reservation, comment.id)
-    return GuardedCreate(outcome=CreateOutcome.CREATED, comment=comment)
+    publish(reservation, created_object.id)
+    return CreateOutcome.CREATED, created_object
+
+
+def create_deduplicated(fingerprint: ReplyFingerprint, create: Callable[[], Comment]) -> GuardedCreate:
+    """Deduplicate a support-message create. See ``_run_deduplicated`` for the outcome contract."""
+    outcome, comment = _run_deduplicated(fingerprint, create)
+    return GuardedCreate(outcome=outcome, comment=comment)
 
 
 def _replay_window_start(attempted_at: datetime) -> datetime:
     return attempted_at - timedelta(seconds=REPLAY_WINDOW_SECONDS)
 
 
-def reserve(fingerprint: _HasKey) -> Reservation:
+def reserve(fingerprint: _DedupeFingerprint) -> Reservation:
     """Claim the right to create this message, or report who got there first.
 
     Fails open (ACQUIRED without a token) once Redis has failed twice. That degrades to the caller's
@@ -478,40 +492,10 @@ class GuardedTicketCreate:
 
 
 def create_ticket_deduplicated(fingerprint: ComposeFingerprint, create: Callable[[], Ticket]) -> GuardedTicketCreate:
-    """Run ``create`` at most once per fingerprint, and report what happened.
+    """Deduplicate an outbound compose. See ``_run_deduplicated`` for the outcome contract.
 
-    Mirrors ``create_deduplicated`` for outbound compose. The caller owns the response shape: a
-    REPLAYED outcome is theirs to render as a 200 and a CONFLICT as a 409. This is what stops a
-    caller that retries a slow compose from opening the same ticket — and emailing the customer —
-    more than once. Exceptions from ``create`` propagate unchanged after the reservation is settled.
+    This is what stops a caller that retries a slow compose from opening the same ticket — and
+    emailing the customer — more than once.
     """
-    reservation = reserve(fingerprint)
-    if reservation.state is ReservationState.REPLAY:
-        replayed = fingerprint.load_replay_target(reservation.object_id)
-        if replayed is not None:
-            return GuardedTicketCreate(outcome=CreateOutcome.REPLAYED, ticket=replayed)
-        # A mapping we can't verify is treated as no mapping, rather than serving an unrelated row.
-    elif reservation.state is ReservationState.IN_FLIGHT:
-        return GuardedTicketCreate(outcome=CreateOutcome.CONFLICT)
-
-    attempted_at = timezone.now()
-    already_created = fingerprint.find_persisted_match(created_after=_replay_window_start(attempted_at))
-    if already_created is not None:
-        publish(reservation, already_created.id)
-        return GuardedTicketCreate(outcome=CreateOutcome.REPLAYED, ticket=already_created)
-
-    try:
-        ticket = create()
-    except Exception:
-        # post_save receivers (outbound send) run after the INSERT, so an exception does not mean
-        # the row is absent. Releasing blindly would make an already-sent ticket immediately
-        # repeatable.
-        recovered = fingerprint.find_persisted_match(created_after=attempted_at)
-        if recovered is not None:
-            publish(reservation, recovered.id)
-        else:
-            release(reservation)
-        raise
-
-    publish(reservation, ticket.id)
-    return GuardedTicketCreate(outcome=CreateOutcome.CREATED, ticket=ticket)
+    outcome, ticket = _run_deduplicated(fingerprint, create)
+    return GuardedTicketCreate(outcome=outcome, ticket=ticket)

--- a/products/conversations/backend/reply_dedupe.py
+++ b/products/conversations/backend/reply_dedupe.py
@@ -400,8 +400,8 @@ class ComposeFingerprint:
     # The resolved recipient person link the create writes onto the ticket. Two composes with the
     # same body but a different recipient point at different people, so they must not collapse.
     distinct_id: str
-    # The private note the compose opens the ticket with. Two composes that send the same email but
-    # record different context are different requests, so they must not collapse either.
+    # The private note the compose opens the ticket with. The same email recorded with different
+    # context is a different request, so it must not collapse either.
     internal_context: str
 
     @classmethod
@@ -415,7 +415,7 @@ class ComposeFingerprint:
         message: Any,
         rich_content: Any,
         distinct_id: Any,
-        internal_context: Any = "",
+        internal_context: Any,
     ) -> "ComposeFingerprint | None":
         if not email_config_id or not recipient_email or not isinstance(message, str) or not message:
             return None
@@ -461,9 +461,9 @@ class ComposeFingerprint:
             or (ticket.distinct_id or "") != self.distinct_id
         ):
             return False
-        # A compose writes two comments: the private note it opens with, and the outbound message.
-        # Confirm both bodies. A second pitch to the same recipient in the window is a distinct
-        # ticket if either the message or the recorded context differs.
+        # A compose writes the outbound message, and the private note it opens with when there is
+        # one. Confirm both bodies: the same pitch recorded with different context is another
+        # ticket.
         opening = list(
             Comment.objects.filter(
                 team_id=self.team_id, scope=SUPPORT_TICKET_SCOPE, item_id=str(ticket.id), deleted=False

--- a/products/conversations/backend/reply_dedupe.py
+++ b/products/conversations/backend/reply_dedupe.py
@@ -379,7 +379,7 @@ def _classify_held_value(key: str, held: Any, token: str) -> Reservation:
 
 # Compose opens a brand-new outbound ticket, so it hashes into its own keyspace — a compose retry
 # must never collapse onto a reply, or vice versa. Bump the version when the contents below change.
-_COMPOSE_KEY_PREFIX = "conversations:compose_dedupe:v2:"
+_COMPOSE_KEY_PREFIX = "conversations:compose_dedupe:v3:"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -461,21 +461,29 @@ class ComposeFingerprint:
             or (ticket.distinct_id or "") != self.distinct_id
         ):
             return False
-        # A compose writes the outbound message, and the private note it opens with when there is
-        # one. Confirm both bodies: the same pitch recorded with different context is another
-        # ticket.
+        # A compose writes its outbound message first, then its private note. Read those rows by
+        # position and never scan for a private one: a note written later, by a teammate or by AI
+        # triage, would otherwise stop this request recognizing its own ticket, and the retry would
+        # email the recipient a second time. Soft deletion is ignored for the same reason — the
+        # ticket exists and the message went out, so a replay is still the safe answer.
         opening = list(
-            Comment.objects.filter(
-                team_id=self.team_id, scope=SUPPORT_TICKET_SCOPE, item_id=str(ticket.id), deleted=False
-            ).order_by("created_at")[:2]
+            Comment.objects.filter(team_id=self.team_id, scope=SUPPORT_TICKET_SCOPE, item_id=str(ticket.id)).order_by(
+                "created_at", "id"
+            )[:2]
         )
-        outbound = next((c for c in opening if not (c.item_context or {}).get("is_private")), None)
-        if outbound is None or outbound.content != self.message or outbound.rich_content != self.rich_content:
+        if not opening:
             return False
-        note = next((c for c in opening if (c.item_context or {}).get("is_private")), None)
-        if (note.content if note else "") != self.internal_context:
+        outbound = opening[0]
+        if outbound.content != self.message or outbound.rich_content != self.rich_content:
             return False
-        return True
+        if not self.internal_context:
+            return True
+        # Recorded context is part of the request, so the same pitch filed with different context
+        # is another ticket.
+        note = opening[1] if len(opening) > 1 else None
+        if note is None or (note.item_context or {}).get("is_private") is not True:
+            return False
+        return note.content == self.internal_context
 
     def find_persisted_match(self, *, created_after: datetime) -> Ticket | None:
         """The outbound ticket this request would have opened, if an earlier attempt already did.

--- a/products/conversations/backend/reply_dedupe.py
+++ b/products/conversations/backend/reply_dedupe.py
@@ -400,6 +400,9 @@ class ComposeFingerprint:
     # The resolved recipient person link the create writes onto the ticket. Two composes with the
     # same body but a different recipient point at different people, so they must not collapse.
     distinct_id: str
+    # The private note the compose opens the ticket with. Two composes that send the same email but
+    # record different context are different requests, so they must not collapse either.
+    internal_context: str
 
     @classmethod
     def build(
@@ -412,6 +415,7 @@ class ComposeFingerprint:
         message: Any,
         rich_content: Any,
         distinct_id: Any,
+        internal_context: Any = "",
     ) -> "ComposeFingerprint | None":
         if not email_config_id or not recipient_email or not isinstance(message, str) or not message:
             return None
@@ -423,6 +427,7 @@ class ComposeFingerprint:
             message=message,
             rich_content=rich_content,
             distinct_id=str(distinct_id or ""),
+            internal_context=str(internal_context or ""),
         )
 
     @property
@@ -436,6 +441,7 @@ class ComposeFingerprint:
                 "message": self.message,
                 "rich_content": self.rich_content,
                 "distinct_id": self.distinct_id,
+                "internal_context": self.internal_context,
             },
             sort_keys=True,
             separators=(",", ":"),
@@ -455,14 +461,19 @@ class ComposeFingerprint:
             or (ticket.distinct_id or "") != self.distinct_id
         ):
             return False
-        # The first message lives on the ticket's opening comment, so confirm the body too: a
-        # second, different pitch to the same recipient in the window is a distinct ticket.
-        first = (
-            Comment.objects.filter(team_id=self.team_id, scope=SUPPORT_TICKET_SCOPE, item_id=str(ticket.id))
-            .order_by("created_at")
-            .first()
+        # A compose writes two comments: the private note it opens with, and the outbound message.
+        # Confirm both bodies. A second pitch to the same recipient in the window is a distinct
+        # ticket if either the message or the recorded context differs.
+        opening = list(
+            Comment.objects.filter(
+                team_id=self.team_id, scope=SUPPORT_TICKET_SCOPE, item_id=str(ticket.id), deleted=False
+            ).order_by("created_at")[:2]
         )
-        if first is None or first.deleted or first.content != self.message or first.rich_content != self.rich_content:
+        outbound = next((c for c in opening if not (c.item_context or {}).get("is_private")), None)
+        if outbound is None or outbound.content != self.message or outbound.rich_content != self.rich_content:
+            return False
+        note = next((c for c in opening if (c.item_context or {}).get("is_private")), None)
+        if (note.content if note else "") != self.internal_context:
             return False
         return True
 

--- a/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
+++ b/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useRef } from 'react'
 
-import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
 
 import { RichContentEditorType } from 'lib/components/RichContentEditor/types'
 
@@ -18,9 +18,16 @@ export function ComposeTicketModal(): JSX.Element | null {
         emailConfigs,
         emailConfigsLoading,
         composingLoading,
+        internalContext,
     } = useValues(composeTicketLogic)
-    const { closeComposeModal, setRecipientEmail, setEmailSubject, setEmailConfigId, submitCompose } =
-        useActions(composeTicketLogic)
+    const {
+        closeComposeModal,
+        setRecipientEmail,
+        setEmailSubject,
+        setEmailConfigId,
+        setInternalContext,
+        submitCompose,
+    } = useActions(composeTicketLogic)
 
     const editorRef = useRef<RichContentEditorType | null>(null)
     const verifiedEmailConfigs = emailConfigs.filter((c) => c.domain_verified)
@@ -104,6 +111,25 @@ export function ComposeTicketModal(): JSX.Element | null {
                         onPressCmdEnter={handleSubmit}
                         minRows={5}
                     />
+                </div>
+
+                <div className="flex flex-col gap-1">
+                    <label className="font-semibold text-xs" htmlFor="compose-internal-context">
+                        Private note (optional)
+                    </label>
+                    <LemonTextArea
+                        id="compose-internal-context"
+                        value={internalContext}
+                        onChange={setInternalContext}
+                        placeholder="Where this request came from, and anything you promised"
+                        minRows={2}
+                        maxLength={5000}
+                    />
+                    {/* The guarantee stays on screen while someone types. In a placeholder it would
+                        disappear on the first keystroke, when they most need to read it. */}
+                    <span className="text-xs text-muted">
+                        Starts the ticket with a note only your team can see. The recipient never gets it.
+                    </span>
                 </div>
             </div>
         </LemonModal>

--- a/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
+++ b/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { useRef } from 'react'
 
 import { IconLock } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTag } from '@posthog/lemon-ui'
 
 import { RichContentEditorType } from 'lib/components/RichContentEditor/types'
 
@@ -19,18 +19,12 @@ export function ComposeTicketModal(): JSX.Element | null {
         emailConfigs,
         emailConfigsLoading,
         composingLoading,
-        internalContext,
     } = useValues(composeTicketLogic)
-    const {
-        closeComposeModal,
-        setRecipientEmail,
-        setEmailSubject,
-        setEmailConfigId,
-        setInternalContext,
-        submitCompose,
-    } = useActions(composeTicketLogic)
+    const { closeComposeModal, setRecipientEmail, setEmailSubject, setEmailConfigId, submitCompose } =
+        useActions(composeTicketLogic)
 
     const editorRef = useRef<RichContentEditorType | null>(null)
+    const noteEditorRef = useRef<RichContentEditorType | null>(null)
     const verifiedEmailConfigs = emailConfigs.filter((c) => c.domain_verified)
 
     const emailConfigOptions = verifiedEmailConfigs.map((c) => ({
@@ -46,7 +40,11 @@ export function ComposeTicketModal(): JSX.Element | null {
     const handleSubmit = (): void => {
         const richContent = editorRef.current?.getJSON() ?? null
         const content = richContent ? serializeToMarkdown(richContent) : ''
-        submitCompose(content, richContent as Record<string, unknown> | null)
+        // The note is stored as markdown only. The thread renders and re-edits markdown-only
+        // comments already, so it needs no rich content column of its own.
+        const noteRichContent = noteEditorRef.current?.getJSON() ?? null
+        const note = noteRichContent ? serializeToMarkdown(noteRichContent) : ''
+        submitCompose(content, richContent as Record<string, unknown> | null, note)
     }
 
     return (
@@ -115,18 +113,17 @@ export function ComposeTicketModal(): JSX.Element | null {
                 </div>
 
                 <div className="flex flex-col gap-1">
-                    <label className="font-semibold text-xs flex items-center gap-1" htmlFor="compose-internal-context">
+                    <label className="font-semibold text-xs flex items-center gap-1">
                         <IconLock className="text-sm" />
                         Private note (optional)
                     </label>
-                    <LemonTextArea
-                        id="compose-internal-context"
-                        value={internalContext}
-                        onChange={setInternalContext}
-                        onPressCmdEnter={handleSubmit}
+                    <SupportEditor
                         placeholder="Why you're reaching out, or anything the team should know"
+                        onCreate={(editor) => {
+                            noteEditorRef.current = editor
+                        }}
+                        onPressCmdEnter={handleSubmit}
                         minRows={2}
-                        aria-label="Private note. Only your team can see this. It is not sent to the recipient."
                     />
                     <span className="text-xs text-muted">
                         Only your team can see this. It is not sent to the recipient.

--- a/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
+++ b/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
@@ -1,6 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useRef } from 'react'
 
+import { IconLock } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
 
 import { RichContentEditorType } from 'lib/components/RichContentEditor/types'
@@ -114,18 +115,22 @@ export function ComposeTicketModal(): JSX.Element | null {
                 </div>
 
                 <div className="flex flex-col gap-1">
-                    <label className="font-semibold text-xs" htmlFor="compose-internal-context">
+                    <label className="font-semibold text-xs flex items-center gap-1" htmlFor="compose-internal-context">
+                        <IconLock className="text-sm" />
                         Private note (optional)
                     </label>
                     <LemonTextArea
                         id="compose-internal-context"
                         value={internalContext}
                         onChange={setInternalContext}
-                        placeholder="Where this request came from, and anything you promised"
+                        onPressCmdEnter={handleSubmit}
+                        placeholder="Why you're reaching out, or anything the team should know"
                         minRows={2}
-                        maxLength={5000}
+                        aria-label="Private note. Only your team can see this. It is not sent to the recipient."
                     />
-                    <span className="text-xs text-muted">Starts the ticket with a note only your team can see.</span>
+                    <span className="text-xs text-muted">
+                        Only your team can see this. It is not sent to the recipient.
+                    </span>
                 </div>
             </div>
         </LemonModal>

--- a/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
+++ b/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
@@ -125,11 +125,7 @@ export function ComposeTicketModal(): JSX.Element | null {
                         minRows={2}
                         maxLength={5000}
                     />
-                    {/* The guarantee stays on screen while someone types. In a placeholder it would
-                        disappear on the first keystroke, when they most need to read it. */}
-                    <span className="text-xs text-muted">
-                        Starts the ticket with a note only your team can see. The recipient never gets it.
-                    </span>
+                    <span className="text-xs text-muted">Starts the ticket with a note only your team can see.</span>
                 </div>
             </div>
         </LemonModal>

--- a/products/conversations/frontend/components/ComposeTicket/composeTicketLogic.ts
+++ b/products/conversations/frontend/components/ComposeTicket/composeTicketLogic.ts
@@ -16,7 +16,6 @@ export interface composeTicketLogicValues {
     emailConfigs: EmailConfigStatus[]
     emailConfigsLoading: boolean
     emailSubject: string
-    internalContext: string
     isOpen: boolean
     recipientDistinctId: string
     recipientEmail: string
@@ -64,9 +63,6 @@ export interface composeTicketLogicActions {
     setEmailSubject: (subject: string) => {
         subject: string
     }
-    setInternalContext: (context: string) => {
-        context: string
-    }
     setRecipientDistinctId: (distinctId: string) => {
         distinctId: string
     }
@@ -75,10 +71,12 @@ export interface composeTicketLogicActions {
     }
     submitCompose: (
         message: string,
-        richContent: Record<string, unknown> | null
+        richContent: Record<string, unknown> | null,
+        internalContext: string
     ) => {
         message: string
         richContent: Record<string, unknown> | null
+        internalContext: string
     }
     submitComposeFinished: () => {
         value: true
@@ -95,10 +93,13 @@ export const composeTicketLogic = kea<composeTicketLogicType>([
         setRecipientEmail: (email: string) => ({ email }),
         setRecipientDistinctId: (distinctId: string) => ({ distinctId }),
         setEmailSubject: (subject: string) => ({ subject }),
-        setInternalContext: (context: string) => ({ context }),
         setEmailConfigId: (configId: string, isManual: boolean = true) => ({ configId, isManual }),
         resetForm: true,
-        submitCompose: (message: string, richContent: Record<string, unknown> | null) => ({ message, richContent }),
+        submitCompose: (message: string, richContent: Record<string, unknown> | null, internalContext: string) => ({
+            message,
+            richContent,
+            internalContext,
+        }),
         submitComposeFinished: true,
     }),
     reducers({
@@ -130,14 +131,6 @@ export const composeTicketLogic = kea<composeTicketLogicType>([
             '',
             {
                 setEmailSubject: (_, { subject }) => subject,
-                openComposeModal: () => '',
-                resetForm: () => '',
-            },
-        ],
-        internalContext: [
-            '',
-            {
-                setInternalContext: (_, { context }) => context,
                 openComposeModal: () => '',
                 resetForm: () => '',
             },
@@ -207,8 +200,8 @@ export const composeTicketLogic = kea<composeTicketLogicType>([
                 actions.setEmailConfigId(defaultConfig.id, false)
             }
         },
-        submitCompose: async ({ message, richContent }) => {
-            const { recipientEmail, recipientDistinctId, emailSubject, emailConfigId, internalContext } = values
+        submitCompose: async ({ message, richContent, internalContext }) => {
+            const { recipientEmail, recipientDistinctId, emailSubject, emailConfigId } = values
 
             if (!message.trim()) {
                 lemonToast.error('Message is required.')

--- a/products/conversations/frontend/components/ComposeTicket/composeTicketLogic.ts
+++ b/products/conversations/frontend/components/ComposeTicket/composeTicketLogic.ts
@@ -16,6 +16,7 @@ export interface composeTicketLogicValues {
     emailConfigs: EmailConfigStatus[]
     emailConfigsLoading: boolean
     emailSubject: string
+    internalContext: string
     isOpen: boolean
     recipientDistinctId: string
     recipientEmail: string
@@ -63,6 +64,9 @@ export interface composeTicketLogicActions {
     setEmailSubject: (subject: string) => {
         subject: string
     }
+    setInternalContext: (context: string) => {
+        context: string
+    }
     setRecipientDistinctId: (distinctId: string) => {
         distinctId: string
     }
@@ -91,6 +95,7 @@ export const composeTicketLogic = kea<composeTicketLogicType>([
         setRecipientEmail: (email: string) => ({ email }),
         setRecipientDistinctId: (distinctId: string) => ({ distinctId }),
         setEmailSubject: (subject: string) => ({ subject }),
+        setInternalContext: (context: string) => ({ context }),
         setEmailConfigId: (configId: string, isManual: boolean = true) => ({ configId, isManual }),
         resetForm: true,
         submitCompose: (message: string, richContent: Record<string, unknown> | null) => ({ message, richContent }),
@@ -125,6 +130,14 @@ export const composeTicketLogic = kea<composeTicketLogicType>([
             '',
             {
                 setEmailSubject: (_, { subject }) => subject,
+                openComposeModal: () => '',
+                resetForm: () => '',
+            },
+        ],
+        internalContext: [
+            '',
+            {
+                setInternalContext: (_, { context }) => context,
                 openComposeModal: () => '',
                 resetForm: () => '',
             },
@@ -195,7 +208,7 @@ export const composeTicketLogic = kea<composeTicketLogicType>([
             }
         },
         submitCompose: async ({ message, richContent }) => {
-            const { recipientEmail, recipientDistinctId, emailSubject, emailConfigId } = values
+            const { recipientEmail, recipientDistinctId, emailSubject, emailConfigId, internalContext } = values
 
             if (!message.trim()) {
                 lemonToast.error('Message is required.')
@@ -223,6 +236,7 @@ export const composeTicketLogic = kea<composeTicketLogicType>([
                     ...(recipientDistinctId ? { recipient_distinct_id: recipientDistinctId } : {}),
                     ...(emailSubject ? { email_subject: emailSubject } : {}),
                     ...(richContent ? { rich_content: richContent } : {}),
+                    ...(internalContext.trim() ? { internal_context: internalContext.trim() } : {}),
                 })
 
                 lemonToast.success('Ticket created successfully.')

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -1091,6 +1091,11 @@ export interface ComposeTicketApi {
     message: string
     /** TipTap rich content JSON for formatted messages. */
     rich_content?: unknown
+    /**
+     * Optional context about why the ticket is being opened. Becomes the private note that starts the thread, so it is visible to the team and never sent to the recipient.
+     * @maxLength 5000
+     */
+    internal_context?: string
 }
 
 export interface ComposeTicketResponseApi {

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -1092,7 +1092,7 @@ export interface ComposeTicketApi {
     /** TipTap rich content JSON for formatted messages. */
     rich_content?: unknown
     /**
-     * Optional context about why the ticket is being opened. Becomes the private note that starts the thread, so it is visible to the team and never sent to the recipient.
+     * Optional context about why the ticket is being opened. Saved as a private note on the ticket, so the team can read it and the recipient never receives it.
      * @maxLength 5000
      */
     internal_context?: string

--- a/products/conversations/frontend/generated/api.ts
+++ b/products/conversations/frontend/generated/api.ts
@@ -595,6 +595,10 @@ export const getConversationsTicketsComposeCreateUrl = (projectId: string) => {
 
 /**
  * Create a new outbound ticket and send the first message to the customer.
+ *
+ * Idempotent within a short window: an identical compose retried while the first is still
+ * in flight returns 409, and one retried after it committed returns the same ticket with a
+ * 200. Only a genuinely new request creates a ticket and emails the customer.
  */
 export const conversationsTicketsComposeCreate = async (
     projectId: string,

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -410,6 +410,8 @@ export const conversationsTicketsComposeCreateBodyEmailSubjectMax = 500
 
 export const conversationsTicketsComposeCreateBodyMessageMax = 5000
 
+export const conversationsTicketsComposeCreateBodyInternalContextMax = 5000
+
 export const ConversationsTicketsComposeCreateBody = /* @__PURE__ */ zod.object({
     recipient_email: zod.email().describe('Recipient email address.'),
     recipient_distinct_id: zod
@@ -425,6 +427,13 @@ export const ConversationsTicketsComposeCreateBody = /* @__PURE__ */ zod.object(
     email_config_id: zod.uuid().describe('ID of the EmailChannel to send from.'),
     message: zod.string().max(conversationsTicketsComposeCreateBodyMessageMax).describe('Message content in markdown.'),
     rich_content: zod.unknown().optional().describe('TipTap rich content JSON for formatted messages.'),
+    internal_context: zod
+        .string()
+        .max(conversationsTicketsComposeCreateBodyInternalContextMax)
+        .optional()
+        .describe(
+            'Optional context about why the ticket is being opened. Becomes the private note that starts the thread, so it is visible to the team and never sent to the recipient.'
+        ),
 })
 
 export const conversationsViewsCreateBodyNameMax = 400

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -432,7 +432,7 @@ export const ConversationsTicketsComposeCreateBody = /* @__PURE__ */ zod.object(
         .max(conversationsTicketsComposeCreateBodyInternalContextMax)
         .optional()
         .describe(
-            'Optional context about why the ticket is being opened. Becomes the private note that starts the thread, so it is visible to the team and never sent to the recipient.'
+            'Optional context about why the ticket is being opened. Saved as a private note on the ticket, so the team can read it and the recipient never receives it.'
         ),
 })
 

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -399,6 +399,10 @@ export const ConversationsTicketsBulkUpdateTagsCreateBody = /* @__PURE__ */ zod.
 
 /**
  * Create a new outbound ticket and send the first message to the customer.
+ *
+ * Idempotent within a short window: an identical compose retried while the first is still
+ * in flight returns 409, and one retried after it committed returns the same ticket with a
+ * 200. Only a genuinely new request creates a ticket and emails the customer.
  */
 export const conversationsTicketsComposeCreateBodyRecipientDistinctIdMax = 400
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18410,6 +18410,11 @@ export namespace Schemas {
       message: string;
       /** TipTap rich content JSON for formatted messages. */
       rich_content?: unknown;
+      /**
+         * Optional context about why the ticket is being opened. Becomes the private note that starts the thread, so it is visible to the team and never sent to the recipient.
+         * @maxLength 5000
+         */
+      internal_context?: string;
     }
 
     export interface ComposeTicketResponse {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -18411,7 +18411,7 @@ export namespace Schemas {
       /** TipTap rich content JSON for formatted messages. */
       rich_content?: unknown;
       /**
-         * Optional context about why the ticket is being opened. Becomes the private note that starts the thread, so it is visible to the team and never sent to the recipient.
+         * Optional context about why the ticket is being opened. Saved as a private note on the ticket, so the team can read it and the recipient never receives it.
          * @maxLength 5000
          */
       internal_context?: string;


### PR DESCRIPTION
## Problem

A team member composing an outbound ticket has nowhere to say why they are sending it. The next person to open that ticket sees an email to a customer and no reason for it.

## Changes

- The compose modal gains a "Private note (optional)" field. What is typed there lands on the ticket under the outbound message, badged "Private note", and never reaches the recipient.
- The note uses the same editor as the message, so lists, links and code work in it. It is saved as markdown, which the thread already renders and re-opens for editing, so the note needs no column of its own.
- An empty field writes nothing: no note row, no workflow trigger, no text in the ticket list preview.
- The same email filed twice with different context now stays two tickets, because recorded context joins the compose dedupe fingerprint.
- `ComposeFingerprint.matches`, the guard deciding whether a retried compose already has a ticket, now reads the note by position instead of scanning for a private comment. Scanning let any later private note, a teammate's or one AI triage writes unprompted, make a retry stop recognizing its own ticket and email the recipient twice.
- The note is written after the outbound message, so the message stays the ticket's first comment and pods running the old code during a rollout read the ticket unchanged.
- Mechanical: `internal_context` added to the generated frontend and MCP types, dedupe key prefix bumped to `v3`.

![Compose modal with the optional private note field](https://raw.githubusercontent.com/PostHog/pr-assets/dd11339a1e3defd1fdfaa195f7e57ed4dda09759/2026/09/96ef41de-e991-4429-b28c-ec3542570d71.png)

The resulting thread. The note carries its formatting through markdown. "Failed to send" is the local dev stack having no email provider.

![Composed ticket showing the private note under the outbound message](https://raw.githubusercontent.com/PostHog/pr-assets/adc4cb7fe43d2ff463a92d7cfd25f2fcc4747402/2026/09/0e24f3c6-39cc-42e0-89a4-3b1f39485f56.png)

## How did you test this code?

Added to `test_tickets.py`, run locally:

- A private note landing before a compose retry keeps it idempotent. 4 cases over the Redis replay path and the database fallback. Against the previous commit these return 201 instead of 200: a second ticket and a second email.
- Composing with context writes one outbox row, for the message and not the note, and leaves `message_count` at 1, so the note stays out of the ticket list and the customer-facing widget.
- Composing without context writes one comment. The same message with different context is not deduplicated.

Checked in a browser against a local dev stack, which is where the screenshots come from: a bulleted note survives into the thread as a list, and a note typed then cancelled does not reappear on the next compose. Email delivery was not exercised, because this machine has no Mailgun key. Behavior under a real rolling deploy was not checked.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code in PostHog Desktop. Skills: `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/django-migrations`, `/stacking-prs`, `/writing-pr-descriptions`, and the `qa-team` multi-agent review.

Scope shrank during the session. An earlier design put an always-on provenance note and a thread banner on every composed ticket; that was cut so the only note that exists is one a person wrote. The `matches()` and write-ordering changes came from the `qa-team` review, which flagged the duplicate-email regression, four reviewers independently, one with a reproduction against this branch. The note started as a plain textarea and moved to the shared editor after review, which removed the kea state it needed. Two review findings were left alone: lifting the `is_private` predicate into a shared module, and the base PR's ambiguous send-failure toast, which belongs in that PR.

The originating investigation drew on production support tickets. Nothing from them reaches this diff; every string in the code, tests, and screenshots was invented from a list of properties each case had to exercise.
