### PR TITLE
fix(mcp-analytics): stop the interval picker reading the day of month

### DIFF
--- a/products/mcp_analytics/frontend/timeBuckets.test.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.test.ts
@@ -143,35 +143,53 @@ describe('timeBuckets', () => {
         })
     })
 
-    describe('resolveInterval', () => {
-        // A pin outlives the window it was set on, so it has to give way once the window outgrows it:
-        // charting a year hour by hour also runs past the query's row limit, which drops the newest
-        // buckets. A pin that still fits has to beat the auto-choice — that's the point of pinning.
-        it.each([
-            ['-14d', 'hour', 'hour'], // 337 hourly buckets: fits
-            ['-1y', 'hour', 'month'], // 8761 hourly buckets: back to the auto-choice
-            ['-7d', 'month', 'day'], // shorter than one month: back to the auto-choice
-            ['-1y', 'day', 'day'], // 367 daily buckets: fits, and beats the auto-choice
-            ['-1y', null, 'month'], // nothing pinned: the auto-choice
-        ])('groups a %s window pinned to %s by %s', (dateFrom, pinned, expected) => {
-            expect(resolveInterval(dateFrom, null, 'UTC', pinned as IntervalType | null)).toBe(expected)
+    // Both judgements below resolve a relative window against the real clock, and where that window
+    // falls in the calendar moves with the date: -7d sits inside one month on the 15th and straddles
+    // two on the 1st. Run both anchors so the picker cannot answer by the day of the month, which
+    // would fail this suite for the first week of every month and pass it for the rest.
+    describe.each([
+        ['mid-month', '2026-06-18T12:00:00Z'],
+        ['across a month boundary', '2026-09-01T12:00:00Z'],
+    ])('with now %s', (_, now) => {
+        beforeEach(() => {
+            jest.useFakeTimers().setSystemTime(new Date(now))
         })
-    })
 
-    describe('intervalOptionsForWindow', () => {
-        it('disables the intervals that would smear or collapse the window', () => {
-            expect(intervalOptionsForWindow('-1y', null, 'UTC')).toEqual([
-                { value: 'hour', label: 'Hour', disabledReason: 'Range too long' },
-                { value: 'day', label: 'Day', disabledReason: null },
-                { value: 'week', label: 'Week', disabledReason: null },
-                { value: 'month', label: 'Month', disabledReason: null },
-            ])
-            expect(intervalOptionsForWindow('-7d', null, 'UTC')).toEqual([
-                { value: 'hour', label: 'Hour', disabledReason: null },
-                { value: 'day', label: 'Day', disabledReason: null },
-                { value: 'week', label: 'Week', disabledReason: null },
-                { value: 'month', label: 'Month', disabledReason: 'Range too short' },
-            ])
+        afterEach(() => {
+            jest.useRealTimers()
+        })
+
+        describe('resolveInterval', () => {
+            // A pin outlives the window it was set on, so it has to give way once the window outgrows
+            // it: charting a year hour by hour also runs past the query's row limit, which drops the
+            // newest buckets. A pin that still fits has to beat the auto-choice — that's the point of
+            // pinning.
+            it.each([
+                ['-14d', 'hour', 'hour'], // a few hundred hourly buckets: fits
+                ['-1y', 'hour', 'month'], // thousands of hourly buckets: back to the auto-choice
+                ['-7d', 'month', 'day'], // under one whole month: back to the auto-choice
+                ['-1y', 'day', 'day'], // a year of daily buckets: fits, and beats the auto-choice
+                ['-1y', null, 'month'], // nothing pinned: the auto-choice
+            ])('groups a %s window pinned to %s by %s', (dateFrom, pinned, expected) => {
+                expect(resolveInterval(dateFrom, null, 'UTC', pinned as IntervalType | null)).toBe(expected)
+            })
+        })
+
+        describe('intervalOptionsForWindow', () => {
+            it('disables the intervals that would smear or collapse the window', () => {
+                expect(intervalOptionsForWindow('-1y', null, 'UTC')).toEqual([
+                    { value: 'hour', label: 'Hour', disabledReason: 'Range too long' },
+                    { value: 'day', label: 'Day', disabledReason: null },
+                    { value: 'week', label: 'Week', disabledReason: null },
+                    { value: 'month', label: 'Month', disabledReason: null },
+                ])
+                expect(intervalOptionsForWindow('-7d', null, 'UTC')).toEqual([
+                    { value: 'hour', label: 'Hour', disabledReason: null },
+                    { value: 'day', label: 'Day', disabledReason: null },
+                    { value: 'week', label: 'Week', disabledReason: null },
+                    { value: 'month', label: 'Month', disabledReason: 'Range too short' },
+                ])
+            })
         })
     })
 })

--- a/products/mcp_analytics/frontend/timeBuckets.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.ts
@@ -91,9 +91,10 @@ export function parseIntervalParam(raw: unknown): IntervalType | null {
     return SELECTABLE_INTERVALS.find((interval) => interval === raw) ?? null
 }
 
-// How many buckets a window spans at an interval, without materializing every key. Approximate by
-// design: month lengths and DST shifts move the count by one, which never changes the judgement it
-// feeds.
+// How many buckets a window spans at an interval, without materializing every key. Counts the
+// buckets the window touches, so the result moves with the calendar: the same 7 days touch one month
+// bucket mid-month and two across a month boundary. That fits a density judgement, which depends on
+// the points actually drawn. For a judgement that must not move with the date, use intervalsSpanned.
 export function approximateBucketCount(
     dateFrom: string | null,
     dateTo: string | null,
@@ -104,6 +105,19 @@ export function approximateBucketCount(
     return Math.max(1, Math.floor(end.diff(startOfBucket(start, interval), interval, true)) + 1)
 }
 
+// How much of an interval the window covers, as a fraction. A 7-day window is about 0.25 of a month.
+// Measures the window itself rather than truncated bucket edges, so calendar alignment does not move
+// the result.
+function intervalsSpanned(
+    dateFrom: string | null,
+    dateTo: string | null,
+    timezone: string,
+    interval: IntervalType
+): number {
+    const { start, end } = resolveWindow(dateFrom, dateTo, timezone)
+    return end.diff(start, interval, true)
+}
+
 // The picker's options for a window, with the intervals that would draw an unreadable line or
 // collapse the range to a single point marked disabled.
 export function intervalOptionsForWindow(
@@ -112,11 +126,16 @@ export function intervalOptionsForWindow(
     timezone: string
 ): IntervalOption[] {
     return SELECTABLE_INTERVALS.map((value) => {
-        const buckets = approximateBucketCount(dateFrom, dateTo, timezone, value)
+        // Two separate questions. Density depends on the points drawn, so it counts buckets. Whether
+        // the range is worth grouping at all depends on the window's own length, so it measures the
+        // span, because a window under one whole interval can only chart partial buckets. One bucket
+        // count for both would make "Range too short" depend on the day of the month.
+        const tooLong = approximateBucketCount(dateFrom, dateTo, timezone, value) > MAX_BUCKETS
+        const tooShort = intervalsSpanned(dateFrom, dateTo, timezone, value) < 1
         return {
             value,
             label: INTERVAL_LABELS[value] ?? value,
-            disabledReason: buckets > MAX_BUCKETS ? 'Range too long' : buckets < 2 ? 'Range too short' : null,
+            disabledReason: tooLong ? 'Range too long' : tooShort ? 'Range too short' : null,
         }
     })
 }


### PR DESCRIPTION
> [!WARNING]
> Needs a rebase and a rescope. [#92557](https://github.com/PostHog/posthog/pull/92557) landed a mid-month clock pin on the same tests, so the test half of this PR is redundant and now conflicts. The production fix below is still unlanded. See the correction note at the bottom.

## Problem

The MCP analytics interval picker answers by the day of the month. A 7-day window offers Month grouping on the 1st and disables it on the 15th.

- `intervalOptionsForWindow` judges "Range too short" by counting the buckets a window touches. The same 7 days touch one month bucket mid-month and two across a month boundary.
- Two `timeBuckets` tests inherit that sensitivity, so they fail for the first seven days of every month.
- The tests landed on 2026-08-12 in [#81367](https://github.com/PostHog/posthog/pull/81367). 2026-09-01 was the first month boundary they met.
- [#92557](https://github.com/PostHog/posthog/pull/92557) pinned those tests to a mid-month clock. That stops the CI failure and leaves the picker's behavior unchanged.

## Changes

- Month is now disabled for a 7-day window on every day of the month, using the existing "Range too short" reason. The picker offered it on the first seven days before.
- "Range too short" now measures how much of the interval the window covers. Density still counts buckets, because that is what the query's row limit depends on.
- The two affected tests run at a mid-month anchor and a month-boundary anchor. This part overlaps [#92557](https://github.com/PostHog/posthog/pull/92557) and needs rework on top of it.

The only difference a person sees is one grouping option greyed out in the picker during the first seven days of a month, with a reason string that already exists. No screenshot is attached, because rendering it needs the dev stack plus MCP analytics data.

> [!NOTE]
> A 30-day window still resolves differently in February than in March, because 30 days is longer than one month and shorter than the next. That edge predates this change and stays open.

## How did you test this code?

- Reverting only `timeBuckets.ts` fails the month-boundary anchor and passes the mid-month one. That is the regression the added anchor catches.
- A throwaway sweep froze the clock on 425 consecutive days and compared the picker's output for 12 relative windows. Master produced 21 distinct behaviors, this branch produces 2, and both remaining ones come from the 30-day edge above. The sweep is not committed.
- The `mcp_analytics` Jest suite passes locally, and a 20-run loop of the changed file passed every run.
- Frontend typecheck reports the same error count on this branch as on master, all from the unbuilt `@posthog/quill` workspace. This diff adds none.
- Not run: the backend suites and Playwright. This diff touches neither.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow covers the picker's disabled reasons.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread asking why two PRs sat blocked in the merge queue.

Skills invoked: `/triaging-merge-queue-failures`, `/fixing-flaky-tests`, `/writing-tests`, `/announcing-behavior-changes`, `/writing-code-comments`, `/writing-pr-descriptions`.

**Correction to the original description.** The first version of this body claimed Frontend CI was red on master for every PR from the start of 2026-09-01. That was wrong, and a reviewer pushed back on the timeline. The two tests did fail on every `Jest test (EE - 4)` run from 00:00 UTC, but Trunk's quarantine gate absorbed them and the job reported success: "All test failures were quarantined, overriding exit code to be exit_success (0)". Master only turned red at 13:04 UTC, when the same two failures came back unquarantined. So the queue kicks in that window had several distinct causes, and this one accounted for a subset rather than all of them.

Public artifact: nothing in this PR carries material from the agent session that is not already public. The diff, the comments, and this description come from the repository and from GitHub Actions run data.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1788273155103269)*
