### PR TITLE
feat(replay-vision): widen rollout flags over the API for EU migration runs

### DIFF
--- a/products/feature_flags/backend/facade/api.py
+++ b/products/feature_flags/backend/facade/api.py
@@ -301,19 +301,33 @@ def add_group_to_flag_targeting(*, team: Team, key: str, group_key: str) -> bool
     flag = FeatureFlag.objects.filter(team=team, key=key, deleted=False).first()
     if flag is None:
         return False
+    outcome = widen_group_targeting(flag.filters or {}, group_key)
+    if outcome is None:
+        return False
+    if outcome == "added":
+        flag.save(update_fields=["filters"])
+    return True
+
+
+def widen_group_targeting(filters: dict, group_key: str) -> str | None:
+    """Add one group key to the first `$group_key` condition in a flag's filters, in place.
+
+    Returns "added" when the list was widened, "present" when the group is already targeted, and
+    None when the conditions carry no widenable `$group_key` list. Shared by the ORM path above and
+    callers that read and write the same filters shape over the REST API, so the two cannot drift.
+    """
     conditions = [
         prop
-        for group in (flag.filters or {}).get("groups") or []
+        for group in filters.get("groups") or []
         for prop in group.get("properties", [])
         if prop.get("key") == "$group_key"
     ]
     if not conditions:
-        return False
-    condition = conditions[0]
-    values = condition.get("value")
+        return None
+    values = conditions[0].get("value")
     if not isinstance(values, list):
-        return False
-    if group_key not in values:
-        values.append(group_key)
-        flag.save(update_fields=["filters"])
-    return True
+        return None
+    if group_key in values:
+        return "present"
+    values.append(group_key)
+    return "added"

--- a/products/feature_flags/backend/facade/api.py
+++ b/products/feature_flags/backend/facade/api.py
@@ -301,33 +301,19 @@ def add_group_to_flag_targeting(*, team: Team, key: str, group_key: str) -> bool
     flag = FeatureFlag.objects.filter(team=team, key=key, deleted=False).first()
     if flag is None:
         return False
-    outcome = widen_group_targeting(flag.filters or {}, group_key)
-    if outcome is None:
-        return False
-    if outcome == "added":
-        flag.save(update_fields=["filters"])
-    return True
-
-
-def widen_group_targeting(filters: dict, group_key: str) -> str | None:
-    """Add one group key to the first `$group_key` condition in a flag's filters, in place.
-
-    Returns "added" when the list was widened, "present" when the group is already targeted, and
-    None when the conditions carry no widenable `$group_key` list. Shared by the ORM path above and
-    callers that read and write the same filters shape over the REST API, so the two cannot drift.
-    """
     conditions = [
         prop
-        for group in filters.get("groups") or []
+        for group in (flag.filters or {}).get("groups") or []
         for prop in group.get("properties", [])
         if prop.get("key") == "$group_key"
     ]
     if not conditions:
-        return None
-    values = conditions[0].get("value")
+        return False
+    condition = conditions[0]
+    values = condition.get("value")
     if not isinstance(values, list):
-        return None
-    if group_key in values:
-        return "present"
-    values.append(group_key)
-    return "added"
+        return False
+    if group_key not in values:
+        values.append(group_key)
+        flag.save(update_fields=["filters"])
+    return True

--- a/products/replay_vision/backend/management/commands/migrate_vision_actions.py
+++ b/products/replay_vision/backend/management/commands/migrate_vision_actions.py
@@ -32,6 +32,7 @@ import structlog
 
 from posthog.models import Team, User
 
+from products.feature_flags.backend.facade.api import add_group_to_flag_targeting, widen_group_targeting
 from products.replay_vision.backend.alert_destinations import (
     EVENT_KIND_CONFIG,
     MATCH_EVENT_KINDS,
@@ -68,52 +69,67 @@ class _FlagsApiTargeting:
     """Widens org targeting on flags that live on another PostHog instance.
 
     EU evaluates the rollout flags against the US instance (`posthog.ph_client` self-capture), so a
-    migration run on EU must widen the US flags. Mirrors `add_group_to_flag_targeting`: returns False
-    when the flag, its `$group_key` condition, or the write is missing, so the org is not counted.
+    migration run on EU must widen the US flags. Each widen re-reads the flag before the PATCH: the
+    run is long, and writing back a cached filters document would revert any concurrent flag edit.
     """
 
     def __init__(self, host: str, project_id: int, api_key: str) -> None:
-        self._base = f"{host.rstrip('/')}/api/projects/{project_id}/feature_flags"
+        self._host = host.rstrip("/")
+        self._base = f"{self._host}/api/projects/{project_id}/feature_flags"
         self._session = requests.Session()
         self._session.headers["Authorization"] = f"Bearer {api_key}"
-        self._flags: dict[str, dict[str, Any]] = {}
+        self._flag_ids: dict[str, int] = {}
 
-    def _fetch(self, key: str) -> dict[str, Any] | None:
-        response = self._session.get(self._base, params={"search": key}, timeout=15)
-        response.raise_for_status()
-        for flag in response.json().get("results", []):
-            if flag.get("key") == key and not flag.get("deleted"):
-                return {"id": flag["id"], "filters": flag.get("filters") or {}}
-        return None
+    @property
+    def where(self) -> str:
+        return self._host
 
-    def add_group(self, key: str, group_key: str) -> bool:
-        try:
-            flag = self._flags.get(key) or self._fetch(key)
-            if flag is None:
-                return False
-            self._flags[key] = flag
-            conditions = [
-                prop
-                for group in flag["filters"].get("groups") or []
-                for prop in group.get("properties", [])
-                if prop.get("key") == "$group_key"
-            ]
-            if not conditions:
-                return False
-            values = conditions[0].get("value")
-            if not isinstance(values, list):
-                return False
-            if group_key in values:
-                return True
-            values.append(group_key)
-            response = self._session.patch(f"{self._base}/{flag['id']}/", json={"filters": flag["filters"]}, timeout=15)
+    def preflight(self, keys: tuple[str, ...]) -> None:
+        """Resolve flag ids so a wrong host, key, or missing flag fails before any row is migrated."""
+        for key in keys:
+            response = self._session.get(self._base, params={"key": key}, timeout=15)
             response.raise_for_status()
-            return True
+            results = response.json().get("results", [])
+            flag = next((f for f in results if f.get("key") == key and not f.get("deleted")), None)
+            if flag is None or flag.get("id") is None:
+                raise CommandError(f"flag {key}: not found via {self._base}")
+            self._flag_ids[key] = flag["id"]
+
+    def add_group(self, key: str, group_key: str) -> str | None:
+        """Widen one flag's org targeting. Returns a problem description, or None on success."""
+        url = f"{self._base}/{self._flag_ids[key]}/"
+        try:
+            response = self._session.get(url, timeout=15)
+            response.raise_for_status()
+            filters = response.json().get("filters") or {}
+            outcome = widen_group_targeting(filters, group_key)
+            if outcome is None:
+                return "no organization targeting to widen"
+            if outcome == "added":
+                self._session.patch(url, json={"filters": filters}, timeout=15).raise_for_status()
+            return None
         except requests.RequestException as error:
-            # Drop the cached copy so the next org re-reads instead of replaying a stale list.
-            self._flags.pop(key, None)
             logger.exception("vision_action_migration.flags_api_failed", key=key, error=str(error))
-            return False
+            return f"API request failed ({error})"
+
+
+class _LocalFlagTargeting:
+    """The same widen contract over this instance's own flags project."""
+
+    def __init__(self, team: Team) -> None:
+        self._team = team
+
+    @property
+    def where(self) -> str:
+        return f"team {self._team.id}"
+
+    def add_group(self, key: str, group_key: str) -> str | None:
+        if add_group_to_flag_targeting(team=self._team, key=key, group_key=group_key):
+            return None
+        return "no organization targeting to widen"
+
+
+_FlagTargeting = _FlagsApiTargeting | _LocalFlagTargeting
 
 
 @dataclass(frozen=False)
@@ -209,12 +225,22 @@ class Command(BaseCommand):
             raise CommandError("--flags-api-host and --flags-api-project must be passed together.")
         if api_mode == (options["flag_team_id"] is not None):
             raise CommandError("Pass exactly one of --flag-team-id or --flags-api-host/--flags-api-project.")
-        self._flags_api: _FlagsApiTargeting | None = None
+        targeting: _FlagTargeting
         if api_mode:
             api_key = os.environ.get(FLAGS_API_KEY_ENV)
             if not api_key:
                 raise CommandError(f"--flags-api-host requires a personal API key in ${FLAGS_API_KEY_ENV}.")
-            self._flags_api = _FlagsApiTargeting(options["flags_api_host"], options["flags_api_project"], api_key)
+            if not options["flags_api_host"].startswith("https://"):
+                raise CommandError("--flags-api-host must be https:// — the API key crosses the network.")
+            api_targeting = _FlagsApiTargeting(options["flags_api_host"], options["flags_api_project"], api_key)
+            try:
+                # Runs in dry-run mode too, so a rehearsal validates the host, key, and flags.
+                api_targeting.preflight((ALERTS_FLAG_KEY, SCOUTS_FLAG_KEY))
+            except requests.RequestException as error:
+                raise CommandError(f"flags API preflight failed: {error}")
+            targeting = api_targeting
+        else:
+            targeting = _LocalFlagTargeting(Team.objects.get(id=options["flag_team_id"]))
         report = _Report()
 
         actions = (
@@ -235,7 +261,7 @@ class Command(BaseCommand):
             orgs = orgs[: options["limit_orgs"]]
 
         for org_id, org_actions in orgs:
-            self._migrate_org(org_id, org_actions, execute, options["flag_team_id"], report)
+            self._migrate_org(org_id, org_actions, execute, targeting, report)
 
         mode = "EXECUTED" if execute else "DRY RUN"
         self.stdout.write(
@@ -249,7 +275,7 @@ class Command(BaseCommand):
             raise CommandError(f"{len(report.problems)} rows need manual attention; see above.")
 
     def _migrate_org(
-        self, org_id: Any, org_actions: list[VisionAction], execute: bool, flag_team_id: int | None, report: _Report
+        self, org_id: Any, org_actions: list[VisionAction], execute: bool, targeting: _FlagTargeting, report: _Report
     ) -> None:
         # "This org has migrated rows", not "this run migrated something": an interrupted run that
         # already moved the rows must still be able to flag the org on a re-run, or its users sit on
@@ -300,7 +326,7 @@ class Command(BaseCommand):
             report.problems.append(f"org {org_id}: not flagged, {org_problems} row(s) need attention")
             return
         if migrated_any:
-            self._flag_org(org_id, execute, flag_team_id, report)
+            self._flag_org(org_id, execute, targeting, report)
 
     def _plan(self, action: VisionAction) -> str:
         """What this row becomes. Shared by the check and the write so they cannot disagree."""
@@ -494,26 +520,16 @@ class Command(BaseCommand):
         action.save(update_fields=["synthesis_config", "enabled", "updated_at"])
         return True
 
-    def _flag_org(self, org_id: Any, execute: bool, flag_team_id: int | None, report: _Report) -> None:
-        from products.feature_flags.backend.facade.api import (  # noqa: PLC0415 — keeps the flags API surface off the command's import path
-            add_group_to_flag_targeting,
-        )
-
-        team = Team.objects.get(id=flag_team_id) if self._flags_api is None else None
+    def _flag_org(self, org_id: Any, execute: bool, targeting: _FlagTargeting, report: _Report) -> None:
         widened = True
         for key in (ALERTS_FLAG_KEY, SCOUTS_FLAG_KEY):
             if not execute:
                 continue
-            if self._flags_api is not None:
-                took = self._flags_api.add_group(key, str(org_id))
-                where = "the flags API instance"
-            else:
-                took = add_group_to_flag_targeting(team=cast(Team, team), key=key, group_key=str(org_id))
-                where = f"team {flag_team_id}"
-            if not took:
-                report.problems.append(f"flag {key}: no organization targeting to widen on {where}")
+            problem = targeting.add_group(key, str(org_id))
+            if problem is not None:
+                report.problems.append(f"flag {key}: {problem} on {targeting.where}")
                 widened = False
-        # Counting an org as flagged when the flag never took would report a rollout that did not
+        # Counting the org as flagged when a flag never took would report a rollout that did not
         # happen, and its users would sit on the legacy surface with their rows already migrated.
         if widened:
             report.orgs_flagged += 1

--- a/products/replay_vision/backend/management/commands/migrate_vision_actions.py
+++ b/products/replay_vision/backend/management/commands/migrate_vision_actions.py
@@ -32,7 +32,6 @@ import structlog
 
 from posthog.models import Team, User
 
-from products.feature_flags.backend.facade.api import add_group_to_flag_targeting, widen_group_targeting
 from products.replay_vision.backend.alert_destinations import (
     EVENT_KIND_CONFIG,
     MATCH_EVENT_KINDS,
@@ -102,10 +101,20 @@ class _FlagsApiTargeting:
             response = self._session.get(url, timeout=15)
             response.raise_for_status()
             filters = response.json().get("filters") or {}
-            outcome = widen_group_targeting(filters, group_key)
-            if outcome is None:
+            # Mirrors add_group_to_flag_targeting in the feature flags facade; keep in sync.
+            conditions = [
+                prop
+                for group in filters.get("groups") or []
+                for prop in group.get("properties", [])
+                if prop.get("key") == "$group_key"
+            ]
+            if not conditions:
                 return "no organization targeting to widen"
-            if outcome == "added":
+            values = conditions[0].get("value")
+            if not isinstance(values, list):
+                return "no organization targeting to widen"
+            if group_key not in values:
+                values.append(group_key)
                 self._session.patch(url, json={"filters": filters}, timeout=15).raise_for_status()
             return None
         except requests.RequestException as error:
@@ -124,6 +133,10 @@ class _LocalFlagTargeting:
         return f"team {self._team.id}"
 
     def add_group(self, key: str, group_key: str) -> str | None:
+        from products.feature_flags.backend.facade.api import (  # noqa: PLC0415 — keeps the flags API surface off the command's import path
+            add_group_to_flag_targeting,
+        )
+
         if add_group_to_flag_targeting(team=self._team, key=key, group_key=group_key):
             return None
         return "no organization targeting to widen"

--- a/products/replay_vision/backend/management/commands/migrate_vision_actions.py
+++ b/products/replay_vision/backend/management/commands/migrate_vision_actions.py
@@ -17,6 +17,7 @@ Every touched row is stamped with a `migrated_to` pointer (or `retired`), which
 makes the command idempotent and the cutover scriptably reversible.
 """
 
+import os
 import re
 from dataclasses import dataclass, field
 from types import SimpleNamespace
@@ -26,6 +27,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils import timezone
 
+import requests
 import structlog
 
 from posthog.models import Team, User
@@ -57,6 +59,61 @@ SCOUTS_FLAG_KEY = "replay-vision-scout-digests"
 # Legacy on_breach alerts were evaluated at their action's schedule cadence; the new
 # scheduler takes a minute interval instead.
 _FREQ_TO_MINUTES = {"MINUTELY": 15, "HOURLY": 60, "DAILY": 1440, "WEEKLY": 10080}
+
+
+FLAGS_API_KEY_ENV = "POSTHOG_FLAGS_API_KEY"
+
+
+class _FlagsApiTargeting:
+    """Widens org targeting on flags that live on another PostHog instance.
+
+    EU evaluates the rollout flags against the US instance (`posthog.ph_client` self-capture), so a
+    migration run on EU must widen the US flags. Mirrors `add_group_to_flag_targeting`: returns False
+    when the flag, its `$group_key` condition, or the write is missing, so the org is not counted.
+    """
+
+    def __init__(self, host: str, project_id: int, api_key: str) -> None:
+        self._base = f"{host.rstrip('/')}/api/projects/{project_id}/feature_flags"
+        self._session = requests.Session()
+        self._session.headers["Authorization"] = f"Bearer {api_key}"
+        self._flags: dict[str, dict[str, Any]] = {}
+
+    def _fetch(self, key: str) -> dict[str, Any] | None:
+        response = self._session.get(self._base, params={"search": key}, timeout=15)
+        response.raise_for_status()
+        for flag in response.json().get("results", []):
+            if flag.get("key") == key and not flag.get("deleted"):
+                return {"id": flag["id"], "filters": flag.get("filters") or {}}
+        return None
+
+    def add_group(self, key: str, group_key: str) -> bool:
+        try:
+            flag = self._flags.get(key) or self._fetch(key)
+            if flag is None:
+                return False
+            self._flags[key] = flag
+            conditions = [
+                prop
+                for group in flag["filters"].get("groups") or []
+                for prop in group.get("properties", [])
+                if prop.get("key") == "$group_key"
+            ]
+            if not conditions:
+                return False
+            values = conditions[0].get("value")
+            if not isinstance(values, list):
+                return False
+            if group_key in values:
+                return True
+            values.append(group_key)
+            response = self._session.patch(f"{self._base}/{flag['id']}/", json={"filters": flag["filters"]}, timeout=15)
+            response.raise_for_status()
+            return True
+        except requests.RequestException as error:
+            # Drop the cached copy so the next org re-reads instead of replaying a stale list.
+            self._flags.pop(key, None)
+            logger.exception("vision_action_migration.flags_api_failed", key=key, error=str(error))
+            return False
 
 
 @dataclass(frozen=False)
@@ -127,13 +184,37 @@ class Command(BaseCommand):
         parser.add_argument(
             "--flag-team-id",
             type=int,
-            required=True,
-            help="Team id of this instance's internal flags project (US: 2).",
+            default=None,
+            help="Team id of this instance's internal flags project (US: 2). Mutually exclusive with --flags-api-host.",
+        )
+        parser.add_argument(
+            "--flags-api-host",
+            default=None,
+            help="Widen the rollout flags over the REST API of this PostHog instance instead of the local ORM. "
+            "Use from EU: the flags live on the US instance. Requires --flags-api-project and "
+            f"a personal API key with feature flag write scope in ${FLAGS_API_KEY_ENV}.",
+        )
+        parser.add_argument(
+            "--flags-api-project",
+            type=int,
+            default=None,
+            help="Project id holding the rollout flags on --flags-api-host (US: 2).",
         )
         parser.add_argument("--limit-orgs", type=int, default=None, help="Stop after this many organizations.")
 
     def handle(self, *args: Any, **options: Any) -> None:
         execute: bool = options["execute"]
+        api_mode = options["flags_api_host"] is not None or options["flags_api_project"] is not None
+        if api_mode and (options["flags_api_host"] is None or options["flags_api_project"] is None):
+            raise CommandError("--flags-api-host and --flags-api-project must be passed together.")
+        if api_mode == (options["flag_team_id"] is not None):
+            raise CommandError("Pass exactly one of --flag-team-id or --flags-api-host/--flags-api-project.")
+        self._flags_api: _FlagsApiTargeting | None = None
+        if api_mode:
+            api_key = os.environ.get(FLAGS_API_KEY_ENV)
+            if not api_key:
+                raise CommandError(f"--flags-api-host requires a personal API key in ${FLAGS_API_KEY_ENV}.")
+            self._flags_api = _FlagsApiTargeting(options["flags_api_host"], options["flags_api_project"], api_key)
         report = _Report()
 
         actions = (
@@ -168,7 +249,7 @@ class Command(BaseCommand):
             raise CommandError(f"{len(report.problems)} rows need manual attention; see above.")
 
     def _migrate_org(
-        self, org_id: Any, org_actions: list[VisionAction], execute: bool, flag_team_id: int, report: _Report
+        self, org_id: Any, org_actions: list[VisionAction], execute: bool, flag_team_id: int | None, report: _Report
     ) -> None:
         # "This org has migrated rows", not "this run migrated something": an interrupted run that
         # already moved the rows must still be able to flag the org on a re-run, or its users sit on
@@ -413,18 +494,24 @@ class Command(BaseCommand):
         action.save(update_fields=["synthesis_config", "enabled", "updated_at"])
         return True
 
-    def _flag_org(self, org_id: Any, execute: bool, flag_team_id: int, report: _Report) -> None:
+    def _flag_org(self, org_id: Any, execute: bool, flag_team_id: int | None, report: _Report) -> None:
         from products.feature_flags.backend.facade.api import (  # noqa: PLC0415 — keeps the flags API surface off the command's import path
             add_group_to_flag_targeting,
         )
 
-        team = Team.objects.get(id=flag_team_id)
+        team = Team.objects.get(id=flag_team_id) if self._flags_api is None else None
         widened = True
         for key in (ALERTS_FLAG_KEY, SCOUTS_FLAG_KEY):
             if not execute:
                 continue
-            if not add_group_to_flag_targeting(team=team, key=key, group_key=str(org_id)):
-                report.problems.append(f"flag {key}: no organization targeting to widen on team {flag_team_id}")
+            if self._flags_api is not None:
+                took = self._flags_api.add_group(key, str(org_id))
+                where = "the flags API instance"
+            else:
+                took = add_group_to_flag_targeting(team=cast(Team, team), key=key, group_key=str(org_id))
+                where = f"team {flag_team_id}"
+            if not took:
+                report.problems.append(f"flag {key}: no organization targeting to widen on {where}")
                 widened = False
         # Counting an org as flagged when the flag never took would report a rollout that did not
         # happen, and its users would sit on the legacy surface with their rows already migrated.

--- a/products/replay_vision/backend/tests/test_migrate_vision_actions.py
+++ b/products/replay_vision/backend/tests/test_migrate_vision_actions.py
@@ -1,7 +1,8 @@
+import os
 from typing import Any
 
 from posthog.test.base import APIBaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -10,7 +11,12 @@ from django.test import SimpleTestCase
 from parameterized import parameterized
 
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
-from products.replay_vision.backend.management.commands.migrate_vision_actions import rrule_to_cron
+from products.replay_vision.backend.management.commands.migrate_vision_actions import (
+    ALERTS_FLAG_KEY,
+    SCOUTS_FLAG_KEY,
+    _FlagsApiTargeting,
+    rrule_to_cron,
+)
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerType
 from products.replay_vision.backend.models.vision_action import ActionMode, TriggerType, VisionAction
 from products.replay_vision.backend.models.vision_alert import VisionAlertConfiguration, VisionAlertKind
@@ -281,6 +287,59 @@ class TestMigrateVisionActions(APIBaseTest):
             flag = FeatureFlag.objects.get(team=self.team, key=key)
             assert flag.filters["groups"][0]["properties"][0]["value"] == []
 
+    def test_flag_mode_arguments_are_validated(self) -> None:
+        with self.assertRaises(CommandError):
+            call_command("migrate_vision_actions")
+        with self.assertRaises(CommandError):
+            call_command(
+                "migrate_vision_actions",
+                "--flag-team-id",
+                "2",
+                "--flags-api-host",
+                "https://example.com",
+                "--flags-api-project",
+                "2",
+            )
+        with patch.dict(os.environ), self.assertRaises(CommandError):
+            os.environ.pop("POSTHOG_FLAGS_API_KEY", None)
+            call_command(
+                "migrate_vision_actions", "--flags-api-host", "https://example.com", "--flags-api-project", "2"
+            )
+
+    def test_flags_api_mode_widens_remote_flags(self) -> None:
+        action = self._make_action(alert_config={"frequency": "every_match"}, selection={})
+        results = [
+            {
+                "id": 5,
+                "key": ALERTS_FLAG_KEY,
+                "filters": {"groups": [{"properties": [{"key": "$group_key", "value": []}]}]},
+            },
+            {
+                "id": 6,
+                "key": SCOUTS_FLAG_KEY,
+                "filters": {"groups": [{"properties": [{"key": "$group_key", "value": []}]}]},
+            },
+        ]
+        session = MagicMock()
+        session.get.return_value.json.return_value = {"results": results}
+        with (
+            patch(f"{_CMD}.requests.Session", return_value=session),
+            patch(f"{_CMD}.Command._create_destinations"),
+            patch.dict(os.environ, {"POSTHOG_FLAGS_API_KEY": "phx_test"}),
+        ):
+            call_command(
+                "migrate_vision_actions",
+                "--execute",
+                "--flags-api-host",
+                "https://example.com",
+                "--flags-api-project",
+                "2",
+            )
+        assert session.patch.call_count == 2
+        for call in session.patch.call_args_list:
+            values = call.kwargs["json"]["filters"]["groups"][0]["properties"][0]["value"]
+            assert str(action.team.organization_id) in values
+
 
 class TestComposeDigestScoutBody(SimpleTestCase):
     def test_legacy_narrowing_shapes(self) -> None:
@@ -294,3 +353,22 @@ class TestComposeDigestScoutBody(SimpleTestCase):
 
         malformed = compose_digest_scout_body("sid", selection={"window_days": "7"}, prompt_guide=None)
         assert "fall back to the last 24 hours" in malformed
+
+
+class TestFlagsApiTargeting(SimpleTestCase):
+    def _client_with(self, results: list[dict]) -> tuple[_FlagsApiTargeting, MagicMock]:
+        session = MagicMock()
+        session.get.return_value.json.return_value = {"results": results}
+        with patch(f"{_CMD}.requests.Session", return_value=session):
+            return _FlagsApiTargeting("https://example.com/", 2, "phx_test"), session
+
+    def test_add_group_is_idempotent_and_fails_closed(self) -> None:
+        filters = {"groups": [{"properties": [{"key": "$group_key", "value": ["org-a"]}]}]}
+        client, session = self._client_with([{"id": 5, "key": "k", "filters": filters}])
+        assert client.add_group("k", "org-a") is True
+        session.patch.assert_not_called()
+        assert client.add_group("k", "org-b") is True
+        session.patch.assert_called_once()
+        assert client.add_group("missing", "org-a") is False
+        client2, _ = self._client_with([{"id": 6, "key": "k", "filters": {"groups": []}}])
+        assert client2.add_group("k", "org-a") is False

--- a/products/replay_vision/backend/tests/test_migrate_vision_actions.py
+++ b/products/replay_vision/backend/tests/test_migrate_vision_actions.py
@@ -8,6 +8,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import SimpleTestCase
 
+import requests
 from parameterized import parameterized
 
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
@@ -300,28 +301,47 @@ class TestMigrateVisionActions(APIBaseTest):
                 "--flags-api-project",
                 "2",
             )
+        with self.assertRaises(CommandError):
+            call_command("migrate_vision_actions", "--flags-api-project", "2")
         with patch.dict(os.environ), self.assertRaises(CommandError):
             os.environ.pop("POSTHOG_FLAGS_API_KEY", None)
             call_command(
                 "migrate_vision_actions", "--flags-api-host", "https://example.com", "--flags-api-project", "2"
             )
+        with patch.dict(os.environ, {"POSTHOG_FLAGS_API_KEY": "phx_test"}), self.assertRaises(CommandError):
+            call_command("migrate_vision_actions", "--flags-api-host", "http://example.com", "--flags-api-project", "2")
 
-    def test_flags_api_mode_widens_remote_flags(self) -> None:
-        action = self._make_action(alert_config={"frequency": "every_match"}, selection={})
-        results = [
-            {
+    def _api_session(self) -> MagicMock:
+        flags = {
+            ALERTS_FLAG_KEY: {
                 "id": 5,
                 "key": ALERTS_FLAG_KEY,
                 "filters": {"groups": [{"properties": [{"key": "$group_key", "value": []}]}]},
             },
-            {
+            SCOUTS_FLAG_KEY: {
                 "id": 6,
                 "key": SCOUTS_FLAG_KEY,
                 "filters": {"groups": [{"properties": [{"key": "$group_key", "value": []}]}]},
             },
-        ]
+        }
+
+        def get(url: str, params: dict | None = None, timeout: int | None = None) -> MagicMock:
+            assert "/api/projects/2/feature_flags" in url
+            response = MagicMock()
+            if params is not None:
+                response.json.return_value = {"results": [flags[params["key"]]]}
+            else:
+                flag_id = int(url.rstrip("/").rsplit("/", 1)[-1])
+                response.json.return_value = next(f for f in flags.values() if f["id"] == flag_id)
+            return response
+
         session = MagicMock()
-        session.get.return_value.json.return_value = {"results": results}
+        session.get.side_effect = get
+        return session
+
+    def test_flags_api_mode_widens_remote_flags(self) -> None:
+        action = self._make_action(alert_config={"frequency": "every_match"}, selection={})
+        session = self._api_session()
         with (
             patch(f"{_CMD}.requests.Session", return_value=session),
             patch(f"{_CMD}.Command._create_destinations"),
@@ -335,10 +355,29 @@ class TestMigrateVisionActions(APIBaseTest):
                 "--flags-api-project",
                 "2",
             )
+        session.headers.__setitem__.assert_any_call("Authorization", "Bearer phx_test")
         assert session.patch.call_count == 2
+        patched_urls = {call.args[0] for call in session.patch.call_args_list}
+        assert patched_urls == {
+            "https://example.com/api/projects/2/feature_flags/5/",
+            "https://example.com/api/projects/2/feature_flags/6/",
+        }
         for call in session.patch.call_args_list:
             values = call.kwargs["json"]["filters"]["groups"][0]["properties"][0]["value"]
             assert str(action.team.organization_id) in values
+
+    def test_flags_api_dry_run_preflights_but_never_patches(self) -> None:
+        self._make_action(alert_config={"frequency": "every_match"}, selection={})
+        session = self._api_session()
+        with (
+            patch(f"{_CMD}.requests.Session", return_value=session),
+            patch.dict(os.environ, {"POSTHOG_FLAGS_API_KEY": "phx_test"}),
+        ):
+            call_command(
+                "migrate_vision_actions", "--flags-api-host", "https://example.com", "--flags-api-project", "2"
+            )
+        assert session.get.call_count == 2
+        session.patch.assert_not_called()
 
 
 class TestComposeDigestScoutBody(SimpleTestCase):
@@ -356,19 +395,44 @@ class TestComposeDigestScoutBody(SimpleTestCase):
 
 
 class TestFlagsApiTargeting(SimpleTestCase):
-    def _client_with(self, results: list[dict]) -> tuple[_FlagsApiTargeting, MagicMock]:
+    def _client_with(self, flag: dict) -> tuple[_FlagsApiTargeting, MagicMock]:
         session = MagicMock()
-        session.get.return_value.json.return_value = {"results": results}
+        session.get.return_value.json.return_value = {"results": [flag], **flag}
         with patch(f"{_CMD}.requests.Session", return_value=session):
-            return _FlagsApiTargeting("https://example.com/", 2, "phx_test"), session
+            client = _FlagsApiTargeting("https://example.com/", 2, "phx_test")
+        client.preflight((flag["key"],))
+        return client, session
+
+    def test_preflight_rejects_missing_flag(self) -> None:
+        session = MagicMock()
+        session.get.return_value.json.return_value = {"results": []}
+        with patch(f"{_CMD}.requests.Session", return_value=session):
+            client = _FlagsApiTargeting("https://example.com", 2, "phx_test")
+        with self.assertRaises(CommandError):
+            client.preflight(("missing",))
 
     def test_add_group_is_idempotent_and_fails_closed(self) -> None:
-        filters = {"groups": [{"properties": [{"key": "$group_key", "value": ["org-a"]}]}]}
-        client, session = self._client_with([{"id": 5, "key": "k", "filters": filters}])
-        assert client.add_group("k", "org-a") is True
+        flag = {
+            "id": 5,
+            "key": "k",
+            "filters": {"groups": [{"properties": [{"key": "$group_key", "value": ["org-a"]}]}]},
+        }
+        client, session = self._client_with(flag)
+        assert client.add_group("k", "org-a") is None
         session.patch.assert_not_called()
-        assert client.add_group("k", "org-b") is True
+        assert client.add_group("k", "org-b") is None
         session.patch.assert_called_once()
-        assert client.add_group("missing", "org-a") is False
-        client2, _ = self._client_with([{"id": 6, "key": "k", "filters": {"groups": []}}])
-        assert client2.add_group("k", "org-a") is False
+
+        unwidenable = {"id": 6, "key": "k", "filters": {"groups": []}}
+        client2, _ = self._client_with(unwidenable)
+        assert client2.add_group("k", "org-a") == "no organization targeting to widen"
+
+    def test_request_failure_fails_closed(self) -> None:
+        flag = {"id": 5, "key": "k", "filters": {"groups": [{"properties": [{"key": "$group_key", "value": []}]}]}}
+        client, session = self._client_with(flag)
+        session.patch.side_effect = requests.ConnectionError("boom")
+        problem = client.add_group("k", "org-a")
+        assert problem is not None and "API request failed" in problem
+        session.patch.side_effect = None
+        session.patch.return_value = MagicMock()
+        assert client.add_group("k", "org-b") is None


### PR DESCRIPTION
## Problem

The vision-actions migration cannot roll out EU organizations.

- Every region evaluates the two rollout flags against the US instance: the self-capture client is pinned to the US internal project in `posthog/apps.py`.
- `_flag_org` widens flags through the local ORM. On EU the flags do not exist locally, so every org would fail with "no organization targeting to widen".
- Skipping the flag step instead would break the per-org lockstep between data migration and surface switch.

## Changes

- An EU run can now widen the US flags in lockstep: `--flags-api-host` and `--flags-api-project` route each org's flag widening to that instance's REST API instead of the local ORM.
- The API key comes from `POSTHOG_FLAGS_API_KEY` (a personal API key with feature flag write scope on the target project).
- The command requires exactly one of `--flag-team-id` or the API pair. US runs are unchanged.
- A failed widen still lands in `problems` with the cause and host named, leaves the org uncounted, and a re-run repairs it, same as the local path.
- API mode preflights both flags in `handle()`, dry run included, so a wrong host, key, or missing flag fails before any row is migrated.
- Each widen re-reads the flag before the PATCH, so a long run cannot revert a concurrent flag edit.
- The API client's widening logic mirrors the flags facade's `add_group_to_flag_targeting`, with a keep-in-sync comment; the facade itself is untouched.
- Both modes now go through one targeting adapter passed down from `handle()`; the ORM path stops re-fetching the flags team per org. Mechanical: signatures thread the adapter instead of `flag_team_id`.

## How did you test this code?

`hogli test products/replay_vision/backend/tests/test_migrate_vision_actions.py` and repo-wide `uv run mypy --cache-fine-grained .`.

New tests: mode validation (missing key, both modes, no mode, half a pair, non-https host), an executed API-mode run patching both flags with the org id and auth header, a dry run that preflights but never PATCHes, preflight rejection of a missing flag, and the client's idempotence and request-failure fail-closed paths.

Not run: no live API call; the request layer is mocked at the session boundary.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. Design picked over a data-only `--skip-flags` mode to keep the per-org data/flag lockstep the command was built around. Review applied: per-widen re-read instead of a cached filters document, preflight, exact `key=` lookup. Not applied: keyless API-mode dry runs (a rehearsal should validate the credentials it will run with).
