### PR TITLE
fix(sentry): classify rate-limit errors as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/source.py
@@ -134,13 +134,16 @@ class SentrySource(ResumableSource[SentrySourceConfig, SentryResumeConfig]):
         }
 
     def get_retryable_errors(self) -> set[str]:
-        # `_request_with_retry` (sentry.py) already retries a dropped connection, read timeout, or
-        # persistent 429/5xx before re-raising once that budget is exhausted. urllib3 wraps all of
-        # those as "... Max retries exceeded with url: ..." regardless of the underlying cause, so
-        # match that stable prefix rather than the per-request URL or nested error detail. Temporal
-        # then retries the whole activity, so the failure is transient and self-recovering. Mirrors
-        # Close's equivalent case.
-        return {"Max retries exceeded with url"}
+        # `_request_with_retry` (sentry.py) retries dropped connections and read timeouts at the
+        # urllib3 level; once that budget is exhausted, urllib3 re-raises with the stable "Max
+        # retries exceeded with url" prefix regardless of the underlying cause.
+        #
+        # HTTP 429s are retried by tenacity (respecting X-Sentry-Rate-Limit-Reset); when that
+        # budget is exhausted, `raise_for_status()` raises `HTTPError: 429 Client Error: Too Many
+        # Requests`, which does NOT contain the "Max retries exceeded" phrase. Match the stable
+        # status-line prefix so persistent rate-limiting lets Temporal retry instead of being
+        # reported to error tracking as a bug.
+        return {"Max retries exceeded with url", "429 Client Error"}
 
     def get_required_parent_schemas(self, schema_name: str) -> list[str]:
         # issue_tag_values fans out over issues through its custom two-level iterator, so it

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -436,6 +436,14 @@ class TestSentrySourceValidation:
 
         assert any(pattern in error_msg for pattern in SentrySource().get_retryable_errors())
 
+    def test_retryable_errors_match_exhausted_rate_limit_retries(self) -> None:
+        # tenacity retries 429s (reading X-Sentry-Rate-Limit-Reset); once exhausted, raise_for_status
+        # raises HTTPError with the status line "429 Client Error: Too Many Requests for url: ...".
+        # This does NOT contain "Max retries exceeded", so it must be matched separately.
+        error_msg = "429 Client Error: Too Many Requests for url: https://sentry.io/api/0/organizations/acme/trace-items/attributes/?dataset=logs"
+
+        assert any(pattern in error_msg for pattern in SentrySource().get_retryable_errors())
+
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry.rest_api_resource")
     def test_sentry_source_builds_response(self, mock_rest_api_resource) -> None:
         mock_resource = Mock()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -442,7 +442,7 @@ class TestSentrySourceValidation:
         # This does NOT contain "Max retries exceeded", so it must be matched separately.
         error_msg = "429 Client Error: Too Many Requests for url: https://sentry.io/api/0/organizations/acme/trace-items/attributes/?dataset=logs"
 
-        assert any(pattern in error_msg for pattern in SentrySource().get_retryable_errors())
+        assert error_message_matches(error_msg, SentrySource().get_retryable_errors())
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry.rest_api_resource")
     def test_sentry_source_builds_response(self, mock_rest_api_resource) -> None:


### PR DESCRIPTION
## Problem

Sentry source syncs hit Sentry's API rate limit (HTTP 429) and report the failure to PostHog error tracking as a bug on each Temporal retry attempt. The error is transient -- the activity retries correctly -- but the noise in error tracking misrepresents it as a code defect.

The root cause is a gap in the retryable-error classification. The `get_retryable_errors` comment stated that persistent 429s (after `_request_with_retry`'s tenacity budget is exhausted) would produce the "Max retries exceeded with url" phrase. That phrase comes only from urllib3 for network-level failures. A 429 that exhausts tenacity's budget is returned as a response, and the subsequent `raise_for_status()` raises `HTTPError: 429 Client Error: Too Many Requests` -- which does not contain "Max retries exceeded", so it was not matched.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/01a05d98-02f2-7c30-a568-0890995df81c

## Changes

- Sentry syncs that exhaust the 429 retry budget now log a warning and let Temporal retry, instead of being reported to error tracking.
- `"429 Client Error"` added to `SentrySource.get_retryable_errors()` alongside the existing "Max retries exceeded" entry.
- Comment corrected to distinguish urllib3's network-retry phrase from tenacity's HTTP-retry path.
- Mechanical: added one test asserting the new pattern is matched.

## How did you test this code?

- `test_retryable_errors_match_exhausted_rate_limit_retries`: asserts that `"429 Client Error: Too Many Requests for url: ..."` is matched by `get_retryable_errors()`. This catches a regression where the 429 pattern is removed or the matching logic changes -- no existing test covered it.
- `test_retryable_errors_match_exhausted_connection_retries` (pre-existing): still passes, confirming the "Max retries exceeded" path is unaffected.
- Full DB-backed suites: not run (no DB in this sandbox); the change touches no query or model code.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated the [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a05d98-02f2-7c30-a568-0890995df81c) via MCP tools, read the full stack trace, and traced the 429 path through `_request_with_retry` → `raise_for_status()` → `_iter_rows_tolerating_unavailable` → `_handle_import_error`. Confirmed the 429 is already retried in-process by tenacity (with `X-Sentry-Rate-Limit-Reset` backoff) before reaching the activity error handler, making this a transient retryable error rather than a code bug or a non-retryable customer configuration issue.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*