### PR TITLE
fix(mcp-analytics): stop guessing why a failure has no error message

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { IconArrowLeft, IconArrowRight, IconCopy } from '@posthog/icons'
+import { IconArrowLeft, IconArrowRight, IconCopy, IconInfo } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonModal, LemonSkeleton, Tooltip } from '@posthog/lemon-ui'
 import {
     type ChartTheme,
@@ -786,9 +786,11 @@ function FailureOccurrencesModal({ toolName }: { toolName: string }): JSX.Elemen
                                     {String(r[2])}
                                 </span>
                             ) : (
-                                <span className="text-muted text-xs">
-                                    Not captured (event predates error message capture)
-                                </span>
+                                <Tooltip title="This event carries no $mcp_error_message. Check that the MCP server sends it on failed tool calls.">
+                                    <span className="text-muted text-xs whitespace-nowrap">
+                                        Not captured <IconInfo />
+                                    </span>
+                                </Tooltip>
                             ),
                     },
                     {

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -786,7 +786,7 @@ function FailureOccurrencesModal({ toolName }: { toolName: string }): JSX.Elemen
                                     {String(r[2])}
                                 </span>
                             ) : (
-                                <Tooltip title="This event carries no $mcp_error_message. Check that the MCP server sends it on failed tool calls.">
+                                <Tooltip title="No $mcp_error_message on this event. Check that your MCP server sends it on failed tool calls.">
                                     <span className="text-muted text-xs whitespace-nowrap">
                                         Not captured <IconInfo />
                                     </span>

--- a/products/mcp_analytics/frontend/tool-quality/errorContext.test.ts
+++ b/products/mcp_analytics/frontend/tool-quality/errorContext.test.ts
@@ -46,7 +46,7 @@ describe('formatErrorContext', () => {
             toolName: 'query_run',
             errorType: 'internal',
         })
-        expect(out).toContain('Error message: not captured (this event carries no $mcp_error_message).')
+        expect(out).toContain('Error message: not captured (no $mcp_error_message on this event).')
         expect(out).not.toContain('predates')
     })
 

--- a/products/mcp_analytics/frontend/tool-quality/errorContext.test.ts
+++ b/products/mcp_analytics/frontend/tool-quality/errorContext.test.ts
@@ -37,6 +37,19 @@ describe('formatErrorContext', () => {
         expect(out).not.toMatch(/^## (injected|New|bare)/m)
     })
 
+    // An absent $mcp_error_message has several causes (an SDK that doesn't emit it, a
+    // dispatcher that never passes the error, autocapture off, a blank message), and this
+    // text is prefilled into a coding agent's task description — so it names the missing
+    // property and stops there rather than asserting one of them.
+    it('names the missing property when the event carries no error message', () => {
+        const out = formatErrorContext({
+            toolName: 'query_run',
+            errorType: 'internal',
+        })
+        expect(out).toContain('Error message: not captured (this event carries no $mcp_error_message).')
+        expect(out).not.toContain('predates')
+    })
+
     it('collapses newlines in inline telemetry fields so they stay on their list line', () => {
         const out = formatErrorContext({
             toolName: 'query_run',

--- a/products/mcp_analytics/frontend/tool-quality/errorContext.ts
+++ b/products/mcp_analytics/frontend/tool-quality/errorContext.ts
@@ -62,7 +62,7 @@ export function formatErrorContext(ctx: MCPErrorContext): string {
     if (ctx.errorMessage) {
         lines.push('', 'Error message:', '', ...indentedBlock(ctx.errorMessage))
     } else {
-        lines.push('', 'Error message: not captured (this event carries no $mcp_error_message).')
+        lines.push('', 'Error message: not captured (no $mcp_error_message on this event).')
     }
     lines.push('', `Tool report: ${absoluteUrl(urls.mcpAnalyticsTool(ctx.toolName))}`)
     if (ctx.sessionId) {

--- a/products/mcp_analytics/frontend/tool-quality/errorContext.ts
+++ b/products/mcp_analytics/frontend/tool-quality/errorContext.ts
@@ -62,7 +62,7 @@ export function formatErrorContext(ctx: MCPErrorContext): string {
     if (ctx.errorMessage) {
         lines.push('', 'Error message:', '', ...indentedBlock(ctx.errorMessage))
     } else {
-        lines.push('', 'Error message: not captured (event predates error message capture).')
+        lines.push('', 'Error message: not captured (this event carries no $mcp_error_message).')
     }
     lines.push('', `Tool report: ${absoluteUrl(urls.mcpAnalyticsTool(ctx.toolName))}`)
     if (ctx.sessionId) {


### PR DESCRIPTION
## Problem

In the failure occurrences modal (`/mcp-analytics/tool-quality/<toolName>` → click a failure bucket), a row with no `$mcp_error_message` rendered:

> Not captured (event predates error message capture)

The cell's only check is `r[2] ? … : …` — whether the string is truthy. It has no access to the event's age, so it asserted a cause it cannot establish.

And that cause is usually the wrong one. A server can be on the current SDK and still send no message:

- a custom dispatcher that never passes `error=` to `capture_tool_call`
- exception autocapture switched off
- a genuinely blank message

All three land in the same branch. A user running a Python-backed MCP server hit this on *every* row and went looking at dates and retention windows, when the actual fix was on the server side.

## Change

Two surfaces, same correction — state the one fact the row has, and stop.

**1. The table cell** (`MCPAnalyticsToolDetail.tsx`) — the long sentence is replaced by a short label plus a tooltip, so it no longer stretches the row:

| | Rendered |
|---|---|
| Before | `Not captured (event predates error message capture)` |
| After | `Not captured ⓘ` — hover: *"This event carries no `$mcp_error_message`. Check that the MCP server sends it on failed tool calls."* |

This is the same `<Tooltip title=…><span>…</span></Tooltip>` shape already used at line 343 of this file, which likewise names a `$mcp_*` property in its prose. `Tooltip` was already imported; only `IconInfo` is new.

**2. The copied agent context** (`errorContext.ts`):

| | Text |
|---|---|
| Before | `Error message: not captured (event predates error message capture).` |
| After | `Error message: not captured (this event carries no $mcp_error_message).` |

That second one is why this was worth fixing rather than leaving. `formatErrorContext` feeds two things: the row's copy button ("Copy error context for a coding agent") and the prefilled **description** on **Create fix task**, whose dialog says *"The task starts a coding agent with this context."* So the invented cause was being handed to an agent as a premise about why data was missing.

## Deliberately not included

An earlier draft keyed the message off `$lib`/`$lib_version` to say "posthog-python 7.38 doesn't emit this, upgrade to ≥7.41". Dropped, because:

- the version floors need updating every SDK release and rot silently
- it tells a manual implementer on the latest version that their SDK is fine — a second wrong answer

No link in the tooltip either; *how* to emit the property depends on the setup (upgrade, pass `error=`, re-enable autocapture) and belongs in the docs. The Python side of that is PostHog/posthog.com#19880.

## Testing

- **New test** for the branch this PR changes. `errorContext.test.ts` had three cases and all of them pass an `errorMessage`, so the `else` branch had no coverage. The new case pins the property-naming wording and asserts the text makes no claim about the event's age. I verified it fails against the old copy (`Expected substring: "…this event carries no $mcp_error_message."`) before restoring the fix — a guard that can't fail isn't one. 4/4 pass.
- `tsc --noEmit` clean.
- No other reference to the old string remains (`grep` across `.ts`/`.tsx`/`.py`/`.json`).

**No screenshots.** The modal has no Storybook story and no seeded fixture, so capturing a hover state would mean either a new story with msw mocks for the nine query kinds this scene fires plus a `play` function (larger than the fix, and new `snapshots.yml` visual-regression surface), or booting the full stack with seeded MCP failure events. Both cost more than they'd tell a reviewer here, since the rendering is fully determined by `Tooltip` + `IconInfo`. The exact before/after strings are in the tables above. Happy to add the story separately if the failure modal is worth visual coverage on its own merits — it currently has none.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
