### PR TITLE
feat(desktop): choose onboarding test session model

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -3390,6 +3390,7 @@ export class PostHogAPIClient {
     sources_enabled: string[];
     sources_watching: string[];
     sources_newly_enabled: boolean;
+    model?: string | null;
   }): Promise<{ task_id: string; channel_id: string }> {
     const teamId = await this.getTeamId();
     const urlPath = `/api/projects/${teamId}/task_channels/onboarding_session_test/`;

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.test.tsx
@@ -1,0 +1,141 @@
+import type { GatewayModel } from "@posthog/shared";
+import type { ModelRolloutFlags } from "@posthog/ui/features/sessions/modelOptionFilters";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  availableOnboardingTestModels,
+  OnboardingTestToolsDialog,
+} from "./OnboardingTestToolsDialog";
+
+const mocks = vi.hoisted(() => ({
+  getCloudTaskGatewayModels: vi.fn(),
+  startOnboardingTestSession: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/auth/authClient", () => ({
+  useAuthenticatedClient: () => mocks,
+}));
+
+vi.mock("@posthog/ui/features/sessions/useModelRolloutFlags", () => ({
+  useModelRolloutFlags: () => rolloutFlags,
+}));
+
+vi.mock("@posthog/ui/features/settings/hooks/useOpenSettings", () => ({
+  leaveSettings: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/primitives/toast", () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("@posthog/ui/router/navigationBridge", () => ({
+  navigateToChannelTask: vi.fn(),
+}));
+
+const model = (id: string, owned_by: string, allowed = true): GatewayModel => ({
+  id,
+  owned_by,
+  context_window: 200000,
+  supports_streaming: true,
+  supports_vision: false,
+  allowed,
+});
+
+const rolloutFlags: ModelRolloutFlags = {
+  deepseek: true,
+  glm: true,
+  glm53: true,
+  glm53Flash: true,
+  kimi: true,
+};
+
+describe("availableOnboardingTestModels", () => {
+  beforeEach(() => {
+    mocks.getCloudTaskGatewayModels.mockReset();
+    mocks.startOnboardingTestSession.mockReset();
+  });
+
+  it("keeps each supported, plan-available desktop model", () => {
+    const options = availableOnboardingTestModels(
+      [
+        model("claude-opus-4-8", "anthropic"),
+        model("@cf/zai-org/glm-5.2", "cloudflare"),
+        model("gpt-5.5", "openai"),
+        model("claude-fable-5", "anthropic", false),
+        model("titan-express", "bedrock"),
+      ],
+      rolloutFlags,
+    );
+
+    expect(options.map((option) => option.value)).toEqual([
+      "claude-opus-4-8",
+      "@cf/zai-org/glm-5.2",
+      "gpt-5.5",
+    ]);
+  });
+
+  it.each([
+    ["deepseek", "deepseek-ai/deepseek-v4-flash-0731", "openai"],
+    ["glm", "zai-org/glm-4.6", "anthropic"],
+    ["glm53", "zai-org/glm-5.3", "anthropic"],
+    ["glm53Flash", "zai-org/glm-5.3-flash", "anthropic"],
+    ["kimi", "moonshotai/kimi-k3", "anthropic"],
+  ] as const)(
+    "hides %s models when their rollout is disabled",
+    (flag, gatedModel, owner) => {
+      const options = availableOnboardingTestModels(
+        [
+          model("@cf/zai-org/glm-5.2", "cloudflare"),
+          model("claude-opus-4-8", "anthropic"),
+          model(gatedModel, owner),
+        ],
+        { ...rolloutFlags, [flag]: false },
+      );
+
+      expect(options.map((option) => option.value)).toEqual(
+        flag === "glm"
+          ? ["claude-opus-4-8"]
+          : ["claude-opus-4-8", "@cf/zai-org/glm-5.2"],
+      );
+    },
+  );
+
+  it("does not create fallback choices for missing adapter models", () => {
+    expect(
+      availableOnboardingTestModels(
+        [model("claude-opus-4-8", "anthropic")],
+        rolloutFlags,
+      ),
+    ).toEqual([expect.objectContaining({ value: "claude-opus-4-8" })]);
+    expect(availableOnboardingTestModels([], rolloutFlags)).toEqual([]);
+  });
+
+  it("submits a loaded model selection", async () => {
+    mocks.getCloudTaskGatewayModels.mockResolvedValue([
+      model("claude-opus-4-8", "anthropic"),
+    ]);
+    mocks.startOnboardingTestSession.mockResolvedValue({
+      channel_id: "channel",
+      task_id: "task",
+    });
+
+    render(<OnboardingTestToolsDialog open onOpenChange={vi.fn()} />);
+
+    await waitFor(() =>
+      expect(document.querySelector("input[name='model']")).toHaveValue(
+        "claude-opus-4-8",
+      ),
+    );
+    const form = document.querySelector<HTMLFormElement>(
+      "form[data-slot='questionnaire']",
+    );
+    if (form === null) throw new Error("Questionnaire form is missing");
+    fireEvent.submit(form);
+
+    await waitFor(() =>
+      expect(mocks.startOnboardingTestSession).toHaveBeenCalledWith(
+        expect.objectContaining({ model: "claude-opus-4-8" }),
+      ),
+    );
+  });
+});

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
@@ -20,8 +20,24 @@ import {
   QuestionnaireProgress,
   QuestionnaireSubmit,
   QuestionnaireTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@posthog/quill";
+import {
+  buildCloudTaskConfigOptions,
+  type CloudTaskConfigSelectOption,
+  type GatewayModel,
+  isRestrictedModelOption,
+} from "@posthog/shared";
 import { useAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
+import {
+  type ModelRolloutFlags,
+  stripDisabledModelOption,
+} from "@posthog/ui/features/sessions/modelOptionFilters";
+import { useModelRolloutFlags } from "@posthog/ui/features/sessions/useModelRolloutFlags";
 import { leaveSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 import { toast } from "@posthog/ui/primitives/toast";
 import { navigateToChannelTask } from "@posthog/ui/router/navigationBridge";
@@ -30,6 +46,7 @@ import {
   type ComponentProps,
   type FormEvent,
   type ReactElement,
+  useEffect,
   useState,
 } from "react";
 
@@ -38,6 +55,9 @@ const ALREADY_WATCHING = ["error tracking", "web analytics"];
 
 /** What "findings are waiting" stands for, so that answer needs no input. */
 const FINDINGS_WAITING = 3;
+
+const DEFAULT_PAID_MODEL = "claude-opus-4-8";
+const DEFAULT_FREE_MODEL = "@cf/zai-org/glm-5.2";
 
 function commaSeparated(value: string): string[] {
   return value
@@ -62,6 +82,7 @@ interface Draft {
   otherMembers: string;
   situation: Situation;
   sourcesWatching: string;
+  model: string | null;
 }
 
 const DEFAULT_DRAFT: Draft = {
@@ -70,6 +91,7 @@ const DEFAULT_DRAFT: Draft = {
   otherMembers: "Max, Lottie",
   situation: "nothing-connected",
   sourcesWatching: "errors, conversion drops",
+  model: null,
 };
 
 function toRequest(draft: Draft) {
@@ -87,7 +109,46 @@ function toRequest(draft: Draft) {
         ? commaSeparated(draft.sourcesWatching)
         : [],
     sources_newly_enabled: draft.situation === "just-switched-on",
+    model: draft.model,
   };
+}
+
+export function availableOnboardingTestModels(
+  models: GatewayModel[],
+  rolloutFlags: ModelRolloutFlags,
+): CloudTaskConfigSelectOption[] {
+  const gatewayModelIds = new Set(models.map((model) => model.id));
+  const options = new Map<string, CloudTaskConfigSelectOption>();
+  for (const adapter of ["claude", "codex"] as const) {
+    const unfilteredModelOption = buildCloudTaskConfigOptions(
+      models,
+      adapter,
+    ).find((option) => option.category === "model");
+    const modelOption = unfilteredModelOption
+      ? stripDisabledModelOption(unfilteredModelOption, rolloutFlags)
+      : undefined;
+    if (modelOption?.type !== "select") continue;
+    for (const option of modelOption.options) {
+      if (
+        gatewayModelIds.has(option.value) &&
+        !isRestrictedModelOption(option._meta)
+      ) {
+        options.set(option.value, option);
+      }
+    }
+  }
+  return [...options.values()];
+}
+
+function defaultOnboardingTestModel(
+  options: CloudTaskConfigSelectOption[],
+): string | null {
+  return (
+    options.find((option) => option.value === DEFAULT_PAID_MODEL)?.value ??
+    options.find((option) => option.value === DEFAULT_FREE_MODEL)?.value ??
+    options[0]?.value ??
+    null
+  );
 }
 
 /** A question answered by typing, so it wears a plain field instead of a choice row. */
@@ -129,11 +190,42 @@ export function OnboardingTestToolsDialog({
   onOpenChange: (open: boolean) => void;
 }): ReactElement {
   const client = useAuthenticatedClient();
+  const modelRolloutFlags = useModelRolloutFlags();
   const [draft, setDraft] = useState<Draft>(DEFAULT_DRAFT);
   const [starting, setStarting] = useState(false);
+  const [modelOptions, setModelOptions] = useState<
+    CloudTaskConfigSelectOption[]
+  >([]);
 
   const patch = (values: Partial<Draft>): void =>
     setDraft((current) => ({ ...current, ...values }));
+
+  useEffect(() => {
+    if (!open) return;
+
+    let active = true;
+    setModelOptions([]);
+    setDraft((current) => ({ ...current, model: null }));
+    void client
+      .getCloudTaskGatewayModels()
+      .then((models) => {
+        if (!active) return;
+        const options = availableOnboardingTestModels(
+          models,
+          modelRolloutFlags,
+        );
+        setModelOptions(options);
+        setDraft((current) => ({
+          ...current,
+          model: defaultOnboardingTestModel(options),
+        }));
+      })
+      .catch(() => undefined);
+
+    return () => {
+      active = false;
+    };
+  }, [client, modelRolloutFlags, open]);
 
   const startSession = async (): Promise<void> => {
     setStarting(true);
@@ -158,6 +250,7 @@ export function OnboardingTestToolsDialog({
     { name: "members", disabled: !draft.joining },
     { name: "situation" },
     { name: "watching", disabled: draft.situation !== "just-switched-on" },
+    ...(modelOptions.length > 0 ? [{ name: "model" }] : []),
   ];
 
   return (
@@ -307,6 +400,43 @@ export function OnboardingTestToolsDialog({
                 onValueChange={(sourcesWatching) => patch({ sourcesWatching })}
               />
             </QuestionnaireItem>
+
+            {modelOptions.length > 0 && (
+              <QuestionnaireItem name="model">
+                <QuestionnaireTitle>
+                  Which model should run this test?
+                </QuestionnaireTitle>
+                <QuestionnaireChoices>
+                  <QuestionnaireInput
+                    aria-label="Model"
+                    value={draft.model ?? ""}
+                    onChange={() => undefined}
+                    render={(inputProps: ComponentProps<"input">) => (
+                      <input {...inputProps} type="hidden" aria-hidden="true" />
+                    )}
+                  />
+                  <Select
+                    value={draft.model}
+                    onValueChange={(model: string | null) => patch({ model })}
+                    items={modelOptions.map((option) => ({
+                      value: option.value,
+                      label: option.name,
+                    }))}
+                  >
+                    <SelectTrigger aria-label="Model" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {modelOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </QuestionnaireChoices>
+              </QuestionnaireItem>
+            )}
           </DialogBody>
 
           <DialogFooter>

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
@@ -29,6 +29,7 @@ import {
 import {
   buildCloudTaskConfigOptions,
   type CloudTaskConfigSelectOption,
+  flattenSelectOptions,
   type GatewayModel,
   isRestrictedModelOption,
 } from "@posthog/shared";
@@ -128,12 +129,17 @@ export function availableOnboardingTestModels(
       ? stripDisabledModelOption(unfilteredModelOption, rolloutFlags)
       : undefined;
     if (modelOption?.type !== "select") continue;
-    for (const option of modelOption.options) {
+    for (const option of flattenSelectOptions(modelOption.options)) {
       if (
         gatewayModelIds.has(option.value) &&
-        !isRestrictedModelOption(option._meta)
+        !isRestrictedModelOption(option._meta ?? undefined)
       ) {
-        options.set(option.value, option);
+        options.set(option.value, {
+          value: option.value,
+          name: option.name,
+          description: option.description ?? undefined,
+          _meta: option._meta ?? undefined,
+        });
       }
     }
   }


### PR DESCRIPTION
## Problem

- Onboarding testers cannot choose an account-available model when they start a first-run session.

## Changes

- Testers can select an available model in the existing onboarding test dialog.
- The dialog reuses the task composer rollout rules and hides models restricted by the account plan.
- The client sends the selected model to the backend layer in [#94258](https://github.com/PostHog/posthog/pull/94258).

## How did you test this code?

- Added a UI regression test for model filtering and submission.
- Ran the scoped Desktop Vitest, Biome, and TypeScript checks.
- Not run: manual UI validation.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update. This feature-flagged staff test tool uses the existing settings workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Created with PostHog Desktop.
- Skills used: posthog-desktop, debugging-ci-failures, and writing-pr-descriptions.
- This layer now shares the model picker logic with the main task composer.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*