### PR TITLE
feat(ci): publish OCI index annotations from the remaining image builds

### DIFF
--- a/.github/workflows/cd-agent-proxy-image.yml
+++ b/.github/workflows/cd-agent-proxy-image.yml
@@ -60,6 +60,7 @@ jobs:
                   push: ${{ github.ref == 'refs/heads/master' }}
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 

--- a/.github/workflows/cd-integration-service-image.yml
+++ b/.github/workflows/cd-integration-service-image.yml
@@ -60,6 +60,7 @@ jobs:
                   push: ${{ github.ref == 'refs/heads/master' }}
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 

--- a/.github/workflows/cd-llm-analytics-image.yml
+++ b/.github/workflows/cd-llm-analytics-image.yml
@@ -91,6 +91,43 @@ jobs:
               id: aws-ecr
               uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
+            - name: Docker meta
+              id: docker-meta
+              continue-on-error: true
+              uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+              env:
+                  DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+              with:
+                  images: ${{ steps.aws-ecr.outputs.registry }}/${{ env.ECR_IMAGE }}
+
+            - name: Add commit annotations
+              id: image-annotations
+              continue-on-error: true
+              shell: bash
+              env:
+                  EVENT_AUTHOR: ${{ github.event.head_commit.author.username }}
+                  EVENT_COMMITTER: ${{ github.event.head_commit.committer.username }}
+                  LC_ALL: C.UTF-8
+                  METADATA_ANNOTATIONS: ${{ steps.docker-meta.outputs.annotations }}
+              run: |
+                  set -euo pipefail
+                  subject="$(git log -1 --format=%s)"
+                  author="${EVENT_AUTHOR:-$(git log -1 --format=%an)}"
+                  committer="${EVENT_COMMITTER:-$(git log -1 --format=%cn)}"
+                  timestamp="$(TZ=UTC git show -s --date=format-local:%Y-%m-%dT%H:%M:%SZ --format=%cd HEAD)"
+                  if [ "${#subject}" -gt 160 ]; then
+                    subject="${subject:0:157}..."
+                  fi
+                  {
+                    echo "value<<ANNOTATIONS_EOF"
+                    printf '%s\n' "$METADATA_ANNOTATIONS"
+                    printf 'index:com.posthog.image.author=%s\n' "$author"
+                    printf 'index:com.posthog.image.committer=%s\n' "$committer"
+                    printf 'index:com.posthog.image.message=%s\n' "$subject"
+                    printf 'index:com.posthog.image.commit-timestamp=%s\n' "$timestamp"
+                    echo "ANNOTATIONS_EOF"
+                  } >> "$GITHUB_OUTPUT"
+
             - name: Build and push container image
               id: build
               uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
@@ -100,6 +137,7 @@ jobs:
                   buildx-fallback: false
                   push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
                   tags: ${{ github.ref == 'refs/heads/master' && format('{0}/{1}:master,{0}/{1}:{2}', steps.aws-ecr.outputs.registry, env.ECR_IMAGE, github.sha) || format('{0}/{1}:{2}', steps.aws-ecr.outputs.registry, env.ECR_IMAGE, github.sha) }}
+                  annotations: ${{ steps.docker-meta.outcome == 'success' && steps.image-annotations.outcome == 'success' && steps.image-annotations.outputs.value || '' }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 
@@ -140,3 +178,7 @@ jobs:
                         "labels": ${{ steps.labels.outputs.labels }},
                         "timestamp": "${{ github.event.head_commit.timestamp }}"
                       }
+
+            - name: Warn when image annotations are missing
+              if: ${{ always() && (steps.docker-meta.outcome != 'success' || steps.image-annotations.outcome != 'success' || steps.image-annotations.outputs.value == '') }}
+              run: echo "::warning::OCI image annotations are missing because annotation generation did not complete successfully."

--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -83,6 +83,7 @@ jobs:
                   push: ${{ github.ref == 'refs/heads/master' && vars.CD_DEPLOY_ENABLED == 'true' }}
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 

--- a/.github/workflows/ci-ml-mirror-image-scrub-container.yml
+++ b/.github/workflows/ci-ml-mirror-image-scrub-container.yml
@@ -157,6 +157,7 @@ jobs:
                   file: Dockerfile.ml-mirror-image-scrub
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   # Both arches: the charts-side Karpenter NodePool defaults to arm64 (Graviton), and an
                   # amd64-only manifest fails there with "no match for platform in manifest".
                   platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -148,6 +148,7 @@ jobs:
                   file: Dockerfile.node
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
                   build-args: |
                       COMMIT_HASH=${{ github.sha }}

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -153,6 +153,7 @@ jobs:
                   file: Dockerfile.recording-rasterizer
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/amd64
                   build-args: |
                       COMMIT_HASH=${{ github.sha }}

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -89,6 +89,7 @@ jobs:
                   platforms: linux/amd64,linux/arm64
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   project: '87b1ch2t7h'
 
     deploy:

--- a/.github/workflows/llm-gateway-cd.yml
+++ b/.github/workflows/llm-gateway-cd.yml
@@ -61,6 +61,7 @@ jobs:
                   platforms: linux/amd64,linux/arm64
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   project: 90mkjhdrjz # llm-gateway depot project
 
     deploy:


### PR DESCRIPTION
## Problem

Most of our container images deploy through the charts state-file flow, but only the main posthog image publishes OCI index annotations (`org.opencontainers.image.revision`, `org.opencontainers.image.source`, and the `com.posthog.image.*` commit fields). The platform tooling that maps a running image back to its source commit relies on those annotations, and today eight image builds compute them and then drop them, while the LLM analytics build never computes them at all.

## Changes

- The agent-proxy, MCP, node, recording-rasterizer, LLM gateway, livestream, ML mirror image-scrub, and integration-service builds now pass the annotations their existing docker-meta step already computes into the build, so their published images carry the same index-level revision, source, and commit metadata the main posthog image has published since the ordered-alias work. One added line per build step; tags, labels, logins, push conditions, and step ordering are untouched.
- The LLM analytics image build gains a self-contained annotation pair: a metadata step computing the standard OCI fields for its ECR image, and a small step appending the commit author, committer, message, and timestamp fields in the same format the shared docker-meta action emits. Both steps are fail-soft (`continue-on-error`, with the build receiving an empty annotations value if either fails), so annotation trouble degrades to an un-annotated image plus a workflow warning instead of failing a build that ships today. Its hand-rolled tag expression is byte-identical to before.

## How did you test this code?

I'm an agent; no images were built or pushed from this branch. Checks actually run: actionlint 1.7.12 over all nine workflows (zero new findings; the pre-existing ShellCheck notes in three files reproduce identically at the base commit), Ruby YAML parse of every touched file, a diff audit confirming 50 pure insertions and zero deletions or reordering, and an independent cold review that read the pinned upstream action manifests, confirmed the fail-soft expression against GitHub's steps-context semantics, and inspected the already-annotated `posthog/posthog:master` index with `docker buildx imagetools` as the live reference. Post-merge, each image's annotations should be verified on the published index at the digest its state file records.

## Rollback

- Revert this PR. Annotations are additive metadata; no consumer behavior depends on them yet.

## 🤖 Agent context

Authored by an agent pipeline (Claude Code boss session coordinating a Codex implementation worker and independent Codex reviewers). The remediation shape (per-workflow wiring rather than a shared composite) was chosen deliberately after adversarial review showed a step-collapsing composite could not preserve failure-path login ordering across these heterogeneous workflows; the review corpus is retained internally for any future composite refactor. The LLM analytics fail-soft design exists because that workflow lacks the credentials the shared metadata action assumes, and a fail-closed metadata step would have added a new way for its build to go red.
