### PR TITLE
perf(logs): skip the json parse for bodies that cannot be json

### DIFF
--- a/nodejs/src/logs/log-body-parse.test.ts
+++ b/nodejs/src/logs/log-body-parse.test.ts
@@ -30,4 +30,31 @@ describe('log-body-parse', () => {
         const raw = 'not json {'
         expect(parseLogBodyForIngestion(raw)).toEqual({ kind: 'invalid_json', raw })
     })
+
+    // A body that cannot start a JSON document never reaches `parseJSON`. Each row here starts a
+    // valid document, so a narrower skip would misreport it as `invalid_json`.
+    it.each([
+        ['object', '{"a":1}', { kind: 'json_object_or_array', value: { a: 1 } }],
+        ['object behind leading whitespace', ' \r\n\t{"a":1}', { kind: 'json_object_or_array', value: { a: 1 } }],
+        ['array behind leading whitespace', '\n[1,2]', { kind: 'json_object_or_array', value: [1, 2] }],
+        ['string', '"hi"', { kind: 'json_string', value: 'hi' }],
+        ['negative number', '-7', { kind: 'json_primitive', parsed: -7 }],
+        ['true', 'true', { kind: 'json_primitive', parsed: true }],
+        ['false', 'false', { kind: 'json_primitive', parsed: false }],
+        ['null', 'null', { kind: 'json_primitive', parsed: null }],
+    ])('decodes a body that starts with %s', (_name, body, expected) => {
+        expect(parseLogBodyForIngestion(body)).toEqual(expected)
+    })
+
+    // The skip is a pre-filter, not a verdict. These bodies pass it and still fail the parse.
+    it.each([
+        ['null pointer at line 4'],
+        ['true and false both reported'],
+        ['-- person processing disabled'],
+        ['404 not found'],
+        ['   '],
+        [''],
+    ])('returns invalid_json for %p', (raw) => {
+        expect(parseLogBodyForIngestion(raw)).toEqual({ kind: 'invalid_json', raw })
+    })
 })

--- a/nodejs/src/logs/log-body-parse.ts
+++ b/nodejs/src/logs/log-body-parse.ts
@@ -11,9 +11,44 @@ export type LogBodyParseResult =
     | { kind: 'json_string'; value: string }
     | { kind: 'json_primitive'; parsed: number | boolean | null }
 
+// JSON allows only these four characters between the start of the document and the value.
+const isJsonWhitespace = (code: number): boolean => code === 0x20 || code === 0x09 || code === 0x0a || code === 0x0d
+
+/**
+ * True when the first non-whitespace character is one a JSON document can begin with:
+ * `{`, `[`, `"`, `-`, a digit, or the first letter of `true`, `false`, or `null`.
+ *
+ * The set holds all eight starts on purpose. A `{`/`[` check would send top-level JSON strings
+ * and bare scalars down the `invalid_json` branch, which changes the pattern they produce.
+ */
+function canStartJsonDocument(body: string): boolean {
+    for (let index = 0; index < body.length; index++) {
+        const code = body.charCodeAt(index)
+        if (isJsonWhitespace(code)) {
+            continue
+        }
+        return (
+            code === 0x7b || // {
+            code === 0x5b || // [
+            code === 0x22 || // "
+            code === 0x2d || // -
+            (code >= 0x30 && code <= 0x39) || // 0-9
+            code === 0x74 || // t, for true
+            code === 0x66 || // f, for false
+            code === 0x6e // n, for null
+        )
+    }
+    return false
+}
+
 export function parseLogBodyForIngestion(body: string | null): LogBodyParseResult {
     if (body === null) {
         return { kind: 'empty' }
+    }
+    // Plaintext log lines are a large share of the traffic and every one of them makes `parseJSON`
+    // build and throw an error. The scan reaches the same result without paying for the throw.
+    if (!canStartJsonDocument(body)) {
+        return { kind: 'invalid_json', raw: body }
     }
     try {
         const parsed = parseJSON(body)

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -172,6 +172,8 @@ describe('log-pattern-mask', () => {
             ['json string', '"quoted 7"', 'json_string', 'quoted <N>'],
             ['json number primitive', '42', 'primitive', '<N>'],
             ['prose body', 'plain text 3', 'plaintext', 'plain text <N>'],
+            ['json object behind leading whitespace', ' \n\t{"msg":"hi 9"}', 'json_object_or_array', 'hi <N>'],
+            ['prose body that opens like JSON', 'null pointer at line 4', 'plaintext', 'null pointer at line <N>'],
         ])('body kind %s', (_name, body, expectedKind, expectedPattern) => {
             const result = computeLogPattern(body)
             expect(result.bodyKind).toEqual(expectedKind)


### PR DESCRIPTION
## Problem

Nobody sees a difference. This removes wasted work in the logs ingestion path, so headroom goes to log volume rather than to failed parses.

- Every log body goes through `parseJSON` before pattern masking classifies it.
- Plaintext log lines are a large share of the traffic, and none of them are JSON.
- Each one makes V8 build a `SyntaxError` and throw it, which the caller then discards.

## Changes

- `parseLogBodyForIngestion` scans for the first non-whitespace character and returns `invalid_json` at once when that character cannot start a JSON document.
- The accepted set is all eight JSON value starts: `{`, `[`, `"`, `-`, a digit, `t`, `f`, and `n`. A `{`/`[` check would reroute top-level JSON strings and bare scalars to the plaintext branch and change the patterns they produce.
- The skipped whitespace is JSON's own set of space, tab, line feed, and carriage return, which matches what `JSON.parse` accepts before a value.
- The scan sits in the shared parse helper, so `extractJsonAttributesFromBody` and `scrubBodyField` get it too. It is neutral for them because a rejected body returns the same `{ kind: 'invalid_json', raw }` the catch block returned.
- `PATTERN_VERSION` stays 3, and the stored shape digests are untouched.

> [!NOTE]
> The scan is a pre-filter, not a verdict. A body that starts with `n` still goes to `parseJSON`, which still decides.

## How did you test this code?

The shape ratchet added in #92255 is the neutrality proof. It hashes the masking inputs together with the patterns a fixed corpus produces, keyed by `PATTERN_VERSION`. The version-3 digest did not move, and no digest was edited.

New cases:

- `log-body-parse.test.ts` gains a table over every accepted start character, including leading whitespace before `{` and `[`. It catches a narrowed scan that stops decoding strings, negative numbers, `true`, `false`, or `null`.
- The same file gains a table of bodies that pass the scan and still fail the parse, such as `null pointer at line 4`. It catches a scan that is treated as a verdict.
- `log-pattern-mask.test.ts` gains two rows on the existing body-kind table, for a JSON object behind leading whitespace and for prose that opens like JSON. They catch the same two regressions at the pattern level, where the digest cannot see them.

A differential run over 3,000,000 random short strings found no body that `JSON.parse` accepts and the scan rejects. That script was scratch work and is not in the diff.

<details>
<summary>Local jest run</summary>

```
Test Suites: 21 passed, 21 total
Tests:       545 passed, 545 total
Ran all test suites matching nodejs/src/logs.
```

</details>

Not checked: nothing ran against real ingestion traffic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5). Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

Two decisions during the session:

- The scan went into the shared `parseLogBodyForIngestion` rather than into `computeLogPattern`. The tagged union it returns is identical either way, so the other two callers gain the same saving with no behavior change.
- The character matrix went into the parse helper's own test file rather than the pattern test, because the scan lives there and serves callers that never reach `computeLogPattern`. The pattern test took only the two rows the digest cannot cover.

Nothing in this PR carries material from the session that is not already public. The test bodies are invented.
