### PR TITLE
fix(desktop): clean up hedgehog mode listeners

### DIFF
--- a/products/desktop/patches/@posthog__hedgehog-mode@0.0.53.patch
+++ b/products/desktop/patches/@posthog__hedgehog-mode@0.0.53.patch
@@ -1,0 +1,47 @@
+diff --git a/dist/index-C7xcW2m7.js b/dist/index-C7xcW2m7.js
+index e800d29ab4bd72f9cdf9aa17dc2f38dfc63c4a63..520f3037654e4974cb9b94f3889e7a5b5193d604 100644
+--- a/dist/index-C7xcW2m7.js
++++ b/dist/index-C7xcW2m7.js
+@@ -18244,7 +18244,7 @@ class Tx {
+ }
+ class Ax {
+   constructor(t) {
+-    this.actor = t, this.setupKeyboardListeners();
++    this.actor = t, this.destroyControls = this.setupKeyboardListeners();
+   }
+   setupKeyboardListeners() {
+     const t = /* @__PURE__ */ new Set(), r = {
+@@ -18338,8 +18338,11 @@ class Ax {
+       t.has(y) && (t.delete(y), (m = f[y]) == null || m.off(c));
+     };
+     return window.addEventListener("keydown", h), window.addEventListener("keyup", d), () => {
+-      window.removeEventListener("keydown", h), window.removeEventListener("keyup", d);
++      clearInterval(n), n = void 0, window.removeEventListener("keydown", h), window.removeEventListener("keyup", d);
+     };
++  }
++  destroy() {
++    this.destroyControls();
+   }
+ }
+ const iu = [
+@@ -19217,7 +19220,7 @@ class pn extends br {
+   }
+   beforeUnload() {
+     var t;
+-    (t = this.ability) == null || t.destroy(), this.ai.enable(!1), Object.values(this.accessorySprites).forEach((r) => {
++    this.controls.destroy(), (t = this.ability) == null || t.destroy(), this.ai.enable(!1), Object.values(this.accessorySprites).forEach((r) => {
+       this.game.app.stage.removeChild(r);
+     });
+   }
+@@ -19662,7 +19665,10 @@ class sv {
+     this.options = t, this.elements = [], this.totalElapsedTime = 0, this.pointerEventsEnabled = !1, this.isDebugging = !1, this.spritesManager = new bx(t), this.setupDebugListeners();
+   }
+   destroy() {
+-    this.syncPlatformsInterval && clearInterval(this.syncPlatformsInterval), ut.Runner.stop(this.runner), this.app.destroy({
++    this.syncPlatformsInterval && clearInterval(this.syncPlatformsInterval), this.elements.forEach((t) => {
++      var r;
++      (r = t.beforeUnload) == null || r.call(t);
++    }), ut.Runner.stop(this.runner), this.app.destroy({
+       removeView: !0
+     }), this.debugRender && (ut.Render.stop(this.debugRender), ke.World.clear(this.engine.world, !1), ke.Engine.clear(this.engine), this.debugRender.canvas.remove(), this.debugRender.canvas = document.createElement("canvas"), this.debugRender.context = this.debugRender.canvas.getContext("2d"), this.debugRender.textures = {});
+   }

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -109,6 +109,9 @@ overrides:
   smol-toml: 1.6.1
 
 patchedDependencies:
+  '@posthog/hedgehog-mode@0.0.53':
+    hash: 8f02616a171a2131f9da0239d756a9c7037a2fe033cbdd9d15d14846bded50ab
+    path: patches/@posthog__hedgehog-mode@0.0.53.patch
   app-builder-lib@26.15.3:
     hash: 4688f96749e3d76cf27bc535d874470bf264610a331db13644df7715d699acf1
     path: patches/app-builder-lib@26.15.3.patch

--- a/products/desktop/pnpm-workspace.yaml
+++ b/products/desktop/pnpm-workspace.yaml
@@ -144,6 +144,7 @@ onlyBuiltDependencies:
     - tree-sitter-cli
 
 patchedDependencies:
+    '@posthog/hedgehog-mode@0.0.53': patches/@posthog__hedgehog-mode@0.0.53.patch
     app-builder-lib@26.15.3: patches/app-builder-lib@26.15.3.patch
     node-pty: patches/node-pty.patch
     react-hotkeys-hook: patches/react-hotkeys-hook.patch


### PR DESCRIPTION
## Problem

- People who close Hedgehog Mode can later trigger renderer errors when they use the keyboard.
- The game keeps its global keyboard listeners after it destroys its canvas.

## Changes

- Hedgehog Mode now removes keyboard listeners and clears active fire timers during game teardown.
- The game now cleans up each actor before Pixi destroys the canvas.

```mermaid
flowchart LR
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  Open[Open Hedgehog Mode] --> Close[Close Hedgehog Mode]
  Close --> Stale[Keyboard listener stays active]
  Stale --> Error[Later keypress triggers renderer error]
  class Open,Close phBlue;
  class Stale,Error phRed;
```

```mermaid
flowchart LR
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
  Open[Open Hedgehog Mode] --> Close[Close Hedgehog Mode]
  Close --> Cleanup[Clear timers and remove listeners]
  Cleanup --> Safe[Later keypress stays in the app]
  class Open,Close,Cleanup phBlue;
  class Safe phYellow;
```

- The package-manager entries only apply the dependency patch.

## How did you test this code?

- Verified local Electron behavior with real key-down and key-up input after opening and closing Hedgehog Mode.
- Checked that repeated input no longer creates the destroyed-canvas renderer error.
- Ran `pnpm typecheck` and `pnpm lint`.
- No new automated test covers this dependency patch. The live Electron check exercises the listener lifecycle.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. The change prevents an error and does not change the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: Codex and local Electron CDP.
- Skills: `posthog-desktop`, `test-electron-app`, `writing-tests`, and `writing-pr-descriptions`.
- The patch fixes the dependency lifecycle because the dependency owns the global listeners.
- The diff contains no task, log, account, or customer data.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
