### PR TITLE
fix(cdp): key rust hogvm batches by bytecode content, not array identity

### DIFF
--- a/nodejs/src/cdp/hog-transformations/rust-vm-batch-scheduler.test.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-batch-scheduler.test.ts
@@ -18,20 +18,27 @@ describe('RustVmBatchScheduler', () => {
         )
     })
 
-    it('coalesces same-program executions from one tick into a single call, mapping results back in order', async () => {
-        const scheduler = new RustVmBatchScheduler(runBatch)
-        const bytecode = ['_H', 1, 38]
+    it.each([
+        ['one array instance', (bytecode: unknown[]) => bytecode],
+        // Each team's hog function holds its own array of the same template bytecode.
+        ['distinct array instances with equal content', (bytecode: unknown[]) => [...bytecode]],
+    ])(
+        'coalesces same-program executions from one tick into a single call, mapping results back in order (%s)',
+        async (_label, instance) => {
+            const scheduler = new RustVmBatchScheduler(runBatch)
+            const bytecode = ['_H', 1, 38]
 
-        const results = await Promise.all([
-            scheduler.execute(bytecode, { event: 'a' }),
-            scheduler.execute(bytecode, { event: 'b' }),
-            scheduler.execute(bytecode, { event: 'c' }),
-        ])
+            const results = await Promise.all([
+                scheduler.execute(instance(bytecode), { event: 'a' }),
+                scheduler.execute(instance(bytecode), { event: 'b' }),
+                scheduler.execute(instance(bytecode), { event: 'c' }),
+            ])
 
-        expect(runBatch).toHaveBeenCalledTimes(1)
-        expect(runBatch).toHaveBeenCalledWith(bytecode, [{ event: 'a' }, { event: 'b' }, { event: 'c' }])
-        expect(results.map((r) => r.result)).toEqual(['result-0', 'result-1', 'result-2'])
-    })
+            expect(runBatch).toHaveBeenCalledTimes(1)
+            expect(runBatch).toHaveBeenCalledWith(bytecode, [{ event: 'a' }, { event: 'b' }, { event: 'c' }])
+            expect(results.map((r) => r.result)).toEqual(['result-0', 'result-1', 'result-2'])
+        }
+    )
 
     it('keeps different programs in separate batches', async () => {
         const scheduler = new RustVmBatchScheduler(runBatch)

--- a/nodejs/src/cdp/hog-transformations/rust-vm-batch-scheduler.ts
+++ b/nodejs/src/cdp/hog-transformations/rust-vm-batch-scheduler.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { Histogram } from 'prom-client'
 
 import { RustExecResult } from './rust-vm'
@@ -16,6 +17,12 @@ interface QueueEntry {
     reject: (error: unknown) => void
 }
 
+interface ProgramQueue {
+    // The first array instance seen for this program; any instance with the same content will do.
+    bytecode: unknown[]
+    entries: QueueEntry[]
+}
+
 // Above this many queued invocations a program's queue is dispatched immediately instead of
 // waiting for the tick to end, bounding how much converted-event memory a single batch holds
 // and how long the first waiter sits in the queue. The Rust side derives its rayon chunk size
@@ -26,16 +33,22 @@ export const DEFAULT_MAX_BATCH_SIZE = 500
  * Coalesces individual transformation executions into per-program `executeBatch` calls.
  *
  * Callers `execute(bytecode, globals)` and await their own result; invocations that arrive within
- * the same event-loop tick for the same program (keyed by bytecode reference — stable while the
- * hog function manager caches the function, and a new version's new array simply starts its own
- * batch) are flushed together on the next `setImmediate` as one FFI crossing, executed off the JS
- * thread. Batch sizes therefore track how many events are concurrently at the transform step.
+ * the same event-loop tick for the same program are flushed together on the next `setImmediate`
+ * as one FFI crossing, executed off the JS thread. Batch sizes therefore track how many events
+ * are concurrently at the transform step.
+ *
+ * "Same program" means same bytecode content, not the same array instance. Every team has its own
+ * HogFunction row, so one template (GeoIP on thousands of teams) arrives as thousands of distinct
+ * arrays with identical content; keying by instance would keep each team in its own batch.
  *
  * A batch-level failure rejects every waiter in that batch — the caller decides what a rejection
  * means (the executor treats it like a boundary throw and falls back to the Node VM).
  */
 export class RustVmBatchScheduler {
-    private queues = new Map<unknown[], QueueEntry[]>()
+    private queues = new Map<string, ProgramQueue>()
+    // Content hash per array instance. The hog function manager hands out one cached array per
+    // function, so this is computed once per function, not once per invocation.
+    private programKeys = new WeakMap<unknown[], string>()
     private flushScheduled = false
 
     constructor(
@@ -45,16 +58,17 @@ export class RustVmBatchScheduler {
 
     public execute(bytecode: unknown[], globals: unknown): Promise<RustExecResult> {
         return new Promise((resolve, reject) => {
-            let queue = this.queues.get(bytecode)
+            const key = this.programKey(bytecode)
+            let queue = this.queues.get(key)
             if (!queue) {
-                queue = []
-                this.queues.set(bytecode, queue)
+                queue = { bytecode, entries: [] }
+                this.queues.set(key, queue)
             }
-            queue.push({ globals, resolve, reject })
+            queue.entries.push({ globals, resolve, reject })
 
-            if (queue.length >= this.maxBatchSize) {
-                this.queues.delete(bytecode)
-                this.dispatch(bytecode, queue)
+            if (queue.entries.length >= this.maxBatchSize) {
+                this.queues.delete(key)
+                this.dispatch(queue)
                 return
             }
 
@@ -65,16 +79,25 @@ export class RustVmBatchScheduler {
         })
     }
 
+    private programKey(bytecode: unknown[]): string {
+        let key = this.programKeys.get(bytecode)
+        if (key === undefined) {
+            key = createHash('sha256').update(JSON.stringify(bytecode)).digest('base64')
+            this.programKeys.set(bytecode, key)
+        }
+        return key
+    }
+
     private flush(): void {
         this.flushScheduled = false
         const queues = this.queues
         this.queues = new Map()
-        for (const [bytecode, entries] of queues) {
-            this.dispatch(bytecode, entries)
+        for (const queue of queues.values()) {
+            this.dispatch(queue)
         }
     }
 
-    private dispatch(bytecode: unknown[], entries: QueueEntry[]): void {
+    private dispatch({ bytecode, entries }: ProgramQueue): void {
         hogvmRustBatchFlushSize.observe(entries.length)
         this.runBatch(
             bytecode,


### PR DESCRIPTION
## Problem

- Turning on batch execution for Rust HogVM transformations (`CDP_HOG_RUST_VM_BATCH_EXECUTION_ENABLED`, #74536) buys almost no batching in production: nearly every `executeBatch` call carries one invocation.
- Each event still pays the async hop and the thread-pool dispatch of the batch path, without the amortization the batch path exists for.
- The scheduler keys its queues by the bytecode array instance. Each team owns its own hog function row, so one template (GeoIP on every team) arrives as one array per team, and teams never share a batch.
- A main-lane batch spans many teams with one event each, so instance keying makes a batch of one the normal case.

## Changes

- Invocations whose bytecode has the same content now share one `executeBatch` call, whatever team they belong to. Transformation results do not change and nothing is user-visible.
- The scheduler keys queues by a SHA-256 of the bytecode JSON. A `WeakMap` caches the hash per array instance, so each cached hog function is hashed once and each invocation costs one lookup.
- `executeBatch` still receives a real bytecode array, the first instance seen for that key.
- After deploy, `hogvm_rust_batch_flush_size` is the metric to watch on lanes with the flag on; it should move off 1.

## How did you test this code?

- `rust-vm-batch-scheduler.test.ts`: the coalescing test now runs as two cases, one array instance and distinct instances with equal content. The second case fails under instance keying and is the regression this PR fixes.
- The scheduler and executor suites ran locally; CI reports the rest.
- Not run on this branch: the database-backed transformer suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Claude Fable 5). Tools: Grafana MCP for the batch flush size histogram, PostHog tracing MCP for per-batch team composition, jest.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Before this change, a local experiment fired eight same-team events concurrently through the real transformer service and got one `executeBatch` call of eight, which ruled out the service path and left the key as the cause.
- Running a group's transformations concurrently in the ingestion pipeline would also raise batch sizes, but cross-team fragmentation dominates, so that is left for a follow-up.
