### PR TITLE
fix(workflows): save to the tab's project, not the account's current one

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -164,6 +164,38 @@ describe('API helper', () => {
         })
     })
 
+    describe('workflow endpoints', () => {
+        // These must carry the team id of the tab that issues them. `@current` resolves server-side to
+        // the account's last-switched project, so a second tab on another project makes every save 404.
+        it.each([
+            [
+                'hogFlows.updateHogFlow',
+                () => api.hogFlows.updateHogFlow('flow-1', {}),
+                '/api/environments/2/hog_flows/flow-1/',
+            ],
+            ['hogFlows.createHogFlow', () => api.hogFlows.createHogFlow({}), '/api/environments/2/hog_flows/'],
+            [
+                'messaging.updateTemplate',
+                () => api.messaging.updateTemplate('template-1', {}),
+                '/api/environments/2/messaging_templates/template-1/',
+            ],
+            [
+                'messaging.getCategory',
+                () => api.messaging.getCategory('category-1'),
+                '/api/environments/2/messaging_categories/category-1/',
+            ],
+            [
+                'messaging.generateMessagingPreferencesLink',
+                () => api.messaging.generateMessagingPreferencesLink(),
+                '/api/environments/2/messaging_preferences/generate_link/',
+            ],
+        ])("%s targets the tab's team, not @current", async (_name, request, expected) => {
+            await request()
+
+            expect(fakeFetch.mock.calls[0][0]).toEqual(expected)
+        })
+    })
+
     describe('getting URLs', () => {
         const testCases = [
             {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1945,7 +1945,7 @@ export class ApiRequest {
     }
 
     public messagingTemplates(): ApiRequest {
-        return this.environments().current().addPathComponent('messaging_templates')
+        return this.environmentsDetail().addPathComponent('messaging_templates')
     }
 
     public messagingTemplate(templateId: MessageTemplate['id']): ApiRequest {
@@ -1953,7 +1953,7 @@ export class ApiRequest {
     }
 
     public messagingCategories(): ApiRequest {
-        return this.environments().current().addPathComponent('messaging_categories')
+        return this.environmentsDetail().addPathComponent('messaging_categories')
     }
 
     public messagingCategory(categoryId: string): ApiRequest {
@@ -1989,29 +1989,23 @@ export class ApiRequest {
     }
 
     public messagingPreferences(): ApiRequest {
-        return this.environments().current().addPathComponent('messaging_preferences')
+        return this.environmentsDetail().addPathComponent('messaging_preferences')
     }
 
     public messagingPreferencesLink(): ApiRequest {
-        return this.environments().current().addPathComponent('messaging_preferences').addPathComponent('generate_link')
+        return this.messagingPreferences().addPathComponent('generate_link')
     }
 
     public messagingPreferencesExportOptOutsCsv(): ApiRequest {
-        return this.environments()
-            .current()
-            .addPathComponent('messaging_preferences')
-            .addPathComponent('export_opt_outs_csv')
+        return this.messagingPreferences().addPathComponent('export_opt_outs_csv')
     }
 
     public messagingPreferencesBulkAddOptOuts(): ApiRequest {
-        return this.environments()
-            .current()
-            .addPathComponent('messaging_preferences')
-            .addPathComponent('bulk_add_opt_outs')
+        return this.messagingPreferences().addPathComponent('bulk_add_opt_outs')
     }
 
     public hogFlows(): ApiRequest {
-        return this.environments().current().addPathComponent('hog_flows')
+        return this.environmentsDetail().addPathComponent('hog_flows')
     }
 
     public hogFlow(hogFlowId: HogFlow['id']): ApiRequest {
@@ -2019,7 +2013,7 @@ export class ApiRequest {
     }
 
     public hogFlowTemplates(): ApiRequest {
-        return this.environments().current().addPathComponent('hog_flow_templates')
+        return this.environmentsDetail().addPathComponent('hog_flow_templates')
     }
 
     public hogFlowTemplate(hogFlowTemplateId: HogFlowTemplate['id']): ApiRequest {


### PR DESCRIPTION
## Problem

Saving a workflow fails with `Save workflow failed: Not found.` for anyone who has two PostHog projects open at once, and the message gives no hint why. Every subsequent save fails the same way until the page is reloaded, so the work looks unsaveable rather than misrouted.

The workflow and messaging paths in `ApiRequest` were built from the `@current` alias, which the server resolves per request to `request.user.team` (`posthog/api/routing.py`). That value is one per account, not one per tab. Switching project in any other tab moves it, so the workflow editor starts addressing a project that does not hold the workflow, and the API correctly answers 404.

Two things made this hard to spot: it needs a second tab to reproduce, and a bare `Not found.` reads as a missing workflow rather than a wrong project.

## Changes

- Saving, publishing, and loading a workflow now stay on the project the tab is showing, so a second tab on another project no longer breaks saves. The paths take the team id already held in the tab's own state instead of re-resolving `@current` on each request.
- Email templates, message categories, and opt-out preferences get the same fix. They are reachable from the workflow editor and shared the identical alias.
- The three `messaging_preferences` sub-paths now build on `messagingPreferences()` rather than repeating the prefix. Mechanical, no behavior change.

`addProductIntent` still uses `@current`. It is fire-and-forget telemetry, and changing which project it attributes to belongs in its own PR.

> [!NOTE]
> The fix is that the team id is now sampled once at page load rather than on every request, which is what stops another tab from retargeting this one. It is not read out of the URL: `ApiConfig._currentTeamId` is set from `api/environments/@current` at bootstrap, and `addProjectIdUnlessPresent` then writes that same value *into* the URL. The `/project/<id>/` segment is generated from the team id, never an input to it.

> [!WARNING]
> `environmentsDetail()` throws when no team id is loaded, where `@current` did not. Every caller of these paths is an in-project scene that mounts after bootstrap — verified across the workflows, messaging, and email-templater logics, and no unauthenticated page reaches them — but this is the part of the diff most likely to bite, and the part worth a reviewer's attention.

This is a targeted fix, not the end state. Request scoping here is ambient: which project a call hits comes from account-global state, while the project the user believes they are in is the URL. Any divergence between those two produces this bug class, and a cross-project read that *succeeds* would be worse than a 404. The generated `hog_flows` functions already take a required `projectId`, which removes the ambiguity properly; moving these call sites onto them is the real follow-up.

## How did you test this code?

Added five `it.each` rows in `frontend/src/lib/api.test.ts` asserting the built URL carries the team id. They catch a revert to `@current` on the workflow save path, which no existing test covered — `api.test.ts` had no workflow URL coverage at all.

Confirmed the guard actually bites: reverting `hogFlows()` alone turns the suite red with `Expected "/api/environments/2/hog_flows/"` / `Received "/api/environments/@current/hog_flows/"`.

<details>
<summary>What ran, and what did not</summary>

- `jest src/lib/api.test.ts` — full file green.
- `pnpm --filter=@posthog/frontend fix` — clean.
- Repo security rules over both changed files — 0 findings.
- Whole-app `tsgo --noEmit` could not finish in the sandbox: it is SIGKILLed on memory once the nested quill and hogvm workspaces are built. An earlier completed run reported errors only in unrelated unbuilt-module files, and a full classic `tsc` pass reports none in either changed file. CI runs the real gate.
- No manual browser check. The two-tab reproduction was not exercised by hand, so the claim that this fixes it rests on the code path, not on observed behavior.

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (PostHog Desktop) after a support report that saving a workflow failed repeatedly with `Not found.`. Error tracking showed the same message across a run of consecutive save attempts in one session, ending in a real validation error once a deploy forced a page reload — the reload resyncing the team id is what pointed at the alias. The same message recurs daily across unrelated users, so this is not a one-off.

An earlier draft of this description claimed the fix makes requests follow the tab's URL. That was wrong, and reviewing the assumption is what surfaced it: nothing reads the project id out of the URL. The description now states the actual mechanism, because the wrong version would have given a reviewer a false model of the change.

Skills invoked: `/adopting-generated-api-types`, `/writing-tests`, `/writing-pr-descriptions` (all repo-provided). That first skill is why the fix follows explicit scoping rather than adding another alias, and why the call-site migration is named as follow-up rather than attempted here.

No customer data, session content, or ticket material is included in this branch.
