### PR TITLE
feat(flags): monitor flag_evaluations parity against events

### DIFF
--- a/nodejs/src/ingestion/common/steps/event-processing/fork-flag-evaluations-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/fork-flag-evaluations-step.ts
@@ -129,12 +129,14 @@ export function createForkFlagEvaluationsStep<T extends ForkFlagEvaluationsStepI
             const settled = ack.then(
                 () => {
                     flagEvaluationsPendingAcks.dec(messages.length)
+                    // Observe latency only on a real ack. A failed produce, especially a
+                    // local reject like MessageSizeTooLarge, settles before any broker
+                    // round trip, so timing it would pull the ack-latency signal down.
                     stopAckTimer()
                     flagEvaluationsEventsTotal.labels('dual_written').inc(messages.length)
                 },
                 (error: unknown) => {
                     flagEvaluationsPendingAcks.dec(messages.length)
-                    stopAckTimer()
                     if (error instanceof MessageSizeTooLarge) {
                         // An oversized row is a property of the row, not of the broker, so
                         // it gets its own outcome and no warning: retrying or alerting on

--- a/nodejs/src/ingestion/common/steps/event-processing/fork-flag-evaluations-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/fork-flag-evaluations-step.ts
@@ -1,4 +1,4 @@
-import { Counter, Gauge } from 'prom-client'
+import { Counter, Gauge, Histogram } from 'prom-client'
 
 import { FLAG_EVALUATIONS_OUTPUT, FlagEvaluationsOutput } from '~/common/outputs'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
@@ -32,6 +32,18 @@ export const flagEvaluationsEventsTotal = new Counter({
 export const flagEvaluationsPendingAcks = new Gauge({
     name: 'ingestion_flag_evaluations_pending_acks',
     help: 'flag_evaluations produces queued but not yet acknowledged; sustained non-zero means the fork is holding up batches',
+})
+
+/**
+ * How long a produce takes to be acknowledged. The pending-acks gauge above only
+ * separates "stalled" from "not stalled", so it moves once the lane is already
+ * holding up offset commits. This shows the lane slowing down while it still
+ * works, which is what gates widening the fork onto a lane other teams share.
+ */
+export const flagEvaluationsAckDuration = new Histogram({
+    name: 'ingestion_flag_evaluations_ack_duration_seconds',
+    help: 'Time from queueing a flag_evaluations produce to the broker acknowledging it',
+    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
 })
 
 export const flagEvaluationsSetPropsTotal = new Counter({
@@ -106,6 +118,7 @@ export function createForkFlagEvaluationsStep<T extends ForkFlagEvaluationsStepI
             })
             const ack = outputs.queueMessages(FLAG_EVALUATIONS_OUTPUT, messages)
             flagEvaluationsPendingAcks.inc(messages.length)
+            const stopAckTimer = flagEvaluationsAckDuration.startTimer()
             // Count on the ack, not the enqueue, so a failed produce is not reported as
             // dual-written.
             //
@@ -116,10 +129,12 @@ export function createForkFlagEvaluationsStep<T extends ForkFlagEvaluationsStepI
             const settled = ack.then(
                 () => {
                     flagEvaluationsPendingAcks.dec(messages.length)
+                    stopAckTimer()
                     flagEvaluationsEventsTotal.labels('dual_written').inc(messages.length)
                 },
                 (error: unknown) => {
                     flagEvaluationsPendingAcks.dec(messages.length)
+                    stopAckTimer()
                     if (error instanceof MessageSizeTooLarge) {
                         // An oversized row is a property of the row, not of the broker, so
                         // it gets its own outcome and no warning: retrying or alerting on

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -187,10 +187,15 @@ def parity_alert_lines(results: ParityResults) -> list[str] | None:
     if not deficits and not results.teams_truncated:
         return None
 
+    # A team the query covered but that had no rows on the day emits no result row, so
+    # len(checked) counts only teams with rows. Report the queried count so this does not
+    # understate coverage or contradict the truncation line below.
+    queried = results.teams_enabled - results.teams_truncated
     excess_total = sum(team.only_in_flag_evaluations for team in results.checked)
     lines = [
         f"*flag_evaluations parity* for `{results.day}`",
-        f"Checked {len(results.checked)} of {results.teams_enabled} enabled teams. Excess rows: {excess_total:,}.",
+        f"Checked {queried} of {results.teams_enabled} enabled teams "
+        f"({len(results.checked)} had rows on the day). Excess rows: {excess_total:,}.",
     ]
     if results.teams_truncated:
         lines.append(f"{results.teams_truncated} enabled teams were not checked; raise `max_teams`.")
@@ -214,7 +219,8 @@ def report_flag_evaluations_parity(
     context.add_output_metadata(
         {
             "day": str(results.day),
-            "teams_checked": len(results.checked),
+            "teams_checked": results.teams_enabled - results.teams_truncated,
+            "teams_with_rows": len(results.checked),
             "teams_enabled": results.teams_enabled,
             "deficit_rows": sum(team.only_in_events for team in results.checked),
             "excess_rows": sum(team.only_in_flag_evaluations for team in results.checked),

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -163,9 +163,13 @@ def measure_flag_evaluations_parity(
                         FROM {settings.CLICKHOUSE_DATABASE}.events
                         WHERE team_id IN %(teams)s AND toDate(timestamp) = %(day)s
                           AND event = %(event)s
-                          -- Same predicate the fork applies before it writes: an event
-                          -- without a non-empty string $feature_flag never produces a row,
-                          -- so counting it here would read as a false deficit.
+                          -- The fork writes a row only when $feature_flag is a non-empty string,
+                          -- and lets every other $feature_flag_called event continue to the events
+                          -- table untouched. Without the same condition here, each one reads as a
+                          -- lost row. JSONExtractString on its own is not that condition, because
+                          -- it renders a number, boolean, object or array as its text, so
+                          -- JSONType has to reject those types before the empty-string check.
+                          AND JSONType(properties, '$feature_flag') = 'String'
                           AND JSONExtractString(properties, '$feature_flag') != ''
                     )
                     GROUP BY team_id, uuid
@@ -199,14 +203,25 @@ def parity_alert_lines(results: ParityResults) -> list[str] | None:
     """The Slack message for a run, or None when there is nothing to say.
 
     Only a deficit and an uncovered team are worth waking someone for. Excess is reported as
-    context but never triggers the alert on its own: flag_evaluations carries a permanent
-    surplus of a fraction of a percent, because clients re-send event uuids and its plain
-    MergeTree cannot collapse them while the ReplacingMergeTree behind events does. Alerting
-    on any difference would fire every day for every team and teach everyone to ignore it.
+    context but never triggers the alert on its own. It counts uuids the fork wrote that the
+    events table has no row for. Over the week to 2026-08-31 in prod-US it stayed at or below
+    0.09 percent of the uuids the fork wrote, and was zero on four of the seven days. Re-sent
+    uuids are not what it counts: the comparison groups by (team_id, uuid), so the duplicate
+    rows that flag_evaluations keeps and the ReplacingMergeTree behind events collapses fold
+    into one entry per side before anything is counted, and a re-sent uuid that reached both
+    tables lands in in_both.
 
     There is no threshold on the deficit for the opposite reason: it has measured zero on
     every day checked so far, so any non-zero value is a regression a threshold would hide.
     """
+
+    # No enabled team means the fork wrote nothing anywhere for the whole lookback window, which
+    # a rolled-back allowlist produces. Staying quiet here would report it as a clean run.
+    if not results.teams_enabled:
+        return [
+            f"*flag_evaluations parity* for `{results.day}`",
+            "No team wrote a flag_evaluations row in the lookback window, so nothing was compared.",
+        ]
 
     deficits = sorted(
         (team for team in results.checked if team.only_in_events > 0),
@@ -260,6 +275,10 @@ def report_flag_evaluations_parity(
     if lines is None:
         context.log.info(f"Parity holds for {len(results.checked)} teams on {results.day}")
         return
+
+    # A Slack failure is logged and swallowed below, and the per-team deficit lines exist
+    # nowhere else, so record them before the post is attempted.
+    context.log.warning("\n".join(lines))
 
     if not settings.CLOUD_DEPLOYMENT:
         context.log.info("Skipping Slack notification in non-prod environment")

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -126,6 +126,10 @@ def measure_flag_evaluations_parity(
                         FROM {settings.CLICKHOUSE_DATABASE}.events
                         WHERE team_id IN %(teams)s AND toDate(timestamp) = %(day)s
                           AND event = %(event)s
+                          -- Same predicate the fork applies before it writes: an event
+                          -- without a non-empty string $feature_flag never produces a row,
+                          -- so counting it here would read as a false deficit.
+                          AND JSONExtractString(properties, '$feature_flag') != ''
                     )
                     GROUP BY team_id, uuid
                 )

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -8,7 +8,7 @@ from clickhouse_driver import Client
 
 from posthog import settings
 from posthog.clickhouse.cluster import ClickhouseCluster
-from posthog.dags.common import JobOwners, settings_with_log_comment
+from posthog.dags.common import JobOwners, settings_with_log_comment, skip_if_already_running
 from posthog.models.flag_evaluations.sql import FLAG_EVALUATIONS_SOURCE_EVENT, FLAG_EVALUATIONS_TABLE
 
 FLAG_EVALUATIONS_SLACK_CHANNEL = "#alerts-ingestion"
@@ -272,10 +272,16 @@ def flag_evaluations_parity():
     report_flag_evaluations_parity(measure_flag_evaluations_parity())
 
 
-flag_evaluations_parity_schedule = dagster.ScheduleDefinition(
+@dagster.schedule(
     job=flag_evaluations_parity,
     # After the previous UTC day is complete and its merges have settled.
     cron_schedule="0 4 * * *",
     execution_timezone="UTC",
     name="flag_evaluations_parity_schedule",
 )
+@skip_if_already_running
+def flag_evaluations_parity_schedule(context: dagster.ScheduleEvaluationContext) -> dagster.RunRequest:
+    # Skip while a previous run is still active so catch-up ticks after an outage do not run
+    # several comparisons at once against the shared events cluster and post duplicate alerts
+    # for the same day.
+    return dagster.RunRequest()

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -111,6 +111,23 @@ def measure_flag_evaluations_parity(
             + (f", skipped {skipped_activation} activated that day" if skipped_activation else "")
         )
 
+        # The shared cluster resource disables both ceilings (max_execution_time and
+        # max_memory_usage are "0"), so this comparison must cap itself: it runs on the
+        # cluster that serves customer queries and its group-by state grows with the
+        # $feature_flag_called uuids of the largest teams for a whole day. A per-query memory
+        # breach reports "for query", which the retry policy leaves alone -- unlike a total
+        # server breach or a socket timeout, which it retries up to 8 times -- so a heavy
+        # batch fails once instead of repeating at full cost. distributed_aggregation_memory_efficient
+        # streams each shard's (team_id, uuid) states rather than merging them all in the
+        # initiator. The ceilings are generous guardrails for a batch of teams_per_query
+        # teams; lower teams_per_query if a batch reaches them.
+        comparison_settings = {
+            **query_settings,
+            "max_execution_time": "600",
+            "max_memory_usage": str(100 * 1024**3),
+            "distributed_aggregation_memory_efficient": "1",
+        }
+
         checked: list[TeamParity] = []
         for start in range(0, len(teams), config.teams_per_query):
             batch = teams[start : start + config.teams_per_query]
@@ -144,7 +161,7 @@ def measure_flag_evaluations_parity(
                 GROUP BY team_id
                 """,
                 {"teams": batch, "day": day, "event": FLAG_EVALUATIONS_SOURCE_EVENT},
-                settings=query_settings,
+                settings=comparison_settings,
             )
             checked.extend(
                 TeamParity(

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -42,6 +42,13 @@ class FlagEvaluationsParityConfig(dagster.Config):
             "never silent, because a truncated run otherwise reads as full coverage."
         ),
     )
+    target_day: str | None = pydantic.Field(
+        default=None,
+        description=(
+            "Day to check as YYYY-MM-DD. Defaults to yesterday (UTC). Set it on a manual run to "
+            "re-check the day a past alert named."
+        ),
+    )
 
 
 @dataclass(frozen=True)
@@ -64,6 +71,11 @@ def _target_day() -> date:
     return (datetime.now(tz=UTC) - timedelta(days=1)).date()
 
 
+def _resolve_target_day(target_day: str | None) -> date:
+    """The day to check: an explicit YYYY-MM-DD override, else yesterday (UTC)."""
+    return date.fromisoformat(target_day) if target_day else _target_day()
+
+
 @dagster.op
 def measure_flag_evaluations_parity(
     context: dagster.OpExecutionContext,
@@ -79,7 +91,7 @@ def measure_flag_evaluations_parity(
     Only comparing the two tables catches that.
     """
 
-    day = _target_day()
+    day = _resolve_target_day(config.target_day)
 
     def run_queries(client: Client) -> ParityResults:
         query_settings = settings_with_log_comment(context)

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -269,10 +269,14 @@ def report_flag_evaluations_parity(
     # must name the deployment that lost the rows.
     lines.append(f"Environment: {settings.CLOUD_DEPLOYMENT}")
 
+    # text is the notification and accessibility fallback, and what Slack shows if it rejects
+    # the rich blocks. It carries the same lines, so the truncation clause survives that reject.
+    message = "\n".join(lines)
     try:
         slack.get_client().chat_postMessage(
             channel=FLAG_EVALUATIONS_SLACK_CHANNEL,
-            blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}}],
+            text=message,
+            blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": message}}],
         )
     except Exception as e:
         context.log.exception(f"Failed to send Slack notification: {e}")

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -1,0 +1,242 @@
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+
+import dagster
+import pydantic
+import dagster_slack
+from clickhouse_driver import Client
+
+from posthog import settings
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.dags.common import JobOwners, settings_with_log_comment
+from posthog.models.flag_evaluations.sql import FLAG_EVALUATIONS_SOURCE_EVENT, FLAG_EVALUATIONS_TABLE
+
+FLAG_EVALUATIONS_SLACK_CHANNEL = "#alerts-ingestion"
+
+JOB_NAME = "flag_evaluations_parity"
+
+
+class FlagEvaluationsParityConfig(dagster.Config):
+    """Configuration for the flag_evaluations parity check."""
+
+    enabled_team_lookback_days: int = pydantic.Field(
+        default=7,
+        description=(
+            "How far back to look for teams with flag_evaluations rows. A team enabled at any "
+            "point in this window is checked, so a day where the fork wrote nothing at all "
+            "reads as a total deficit rather than as the team not being enabled."
+        ),
+    )
+    teams_per_query: int = pydantic.Field(
+        default=20,
+        description=(
+            "Teams compared per query. The comparison groups by uuid, so its memory scales with "
+            "the rows in the batch, not with the team count. Lower this if a batch containing a "
+            "high-volume team runs out of memory."
+        ),
+    )
+    max_teams: int = pydantic.Field(
+        default=500,
+        description=(
+            "Cap on teams checked in one run, highest volume first. Reaching it is reported, "
+            "never silent, because a truncated run otherwise reads as full coverage."
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class TeamParity:
+    team_id: int
+    only_in_events: int
+    only_in_flag_evaluations: int
+    in_both: int
+
+
+@dataclass(frozen=True)
+class ParityResults:
+    day: date
+    checked: list[TeamParity]
+    teams_enabled: int
+    teams_truncated: int
+
+
+def _target_day() -> date:
+    return (datetime.now(tz=UTC) - timedelta(days=1)).date()
+
+
+@dagster.op
+def measure_flag_evaluations_parity(
+    context: dagster.OpExecutionContext,
+    config: FlagEvaluationsParityConfig,
+    cluster: dagster.ResourceParam[ClickhouseCluster],
+) -> ParityResults:
+    """Compare flag_evaluations against events for every team the fork is writing for.
+
+    The produce-side counters answer "did we hand the row to Kafka", which is not the
+    question. Everything past the ack -- the Kafka engine table, the MV, the writable
+    Distributed, the shard -- is unobserved, and kafka_flag_evaluations sets
+    kafka_skip_broken_messages, so a malformed row is discarded after a successful produce.
+    Only comparing the two tables catches that.
+    """
+
+    day = _target_day()
+
+    def run_queries(client: Client) -> ParityResults:
+        query_settings = settings_with_log_comment(context)
+
+        # The enabled set comes from the data rather than from a mirror of the charts
+        # allowlist, so the two cannot drift.
+        enabled_rows = client.execute(
+            f"""
+            SELECT team_id, count() AS rows
+            FROM {settings.CLICKHOUSE_DATABASE}.{FLAG_EVALUATIONS_TABLE}
+            WHERE toDate(timestamp) >= %(lookback_start)s AND toDate(timestamp) <= %(day)s
+            GROUP BY team_id
+            ORDER BY rows DESC
+            """,
+            {"lookback_start": day - timedelta(days=config.enabled_team_lookback_days), "day": day},
+            settings=query_settings,
+        )
+
+        ranked_teams = [int(row[0]) for row in enabled_rows]
+        teams = ranked_teams[: config.max_teams]
+        truncated = len(ranked_teams) - len(teams)
+        context.log.info(f"{len(ranked_teams)} teams enabled, checking {len(teams)} for {day}")
+
+        checked: list[TeamParity] = []
+        for start in range(0, len(teams), config.teams_per_query):
+            batch = teams[start : start + config.teams_per_query]
+            rows = client.execute(
+                f"""
+                SELECT
+                    team_id,
+                    countIf(in_ev > 0 AND in_fe = 0) AS only_in_events,
+                    countIf(in_fe > 0 AND in_ev = 0) AS only_in_flag_evaluations,
+                    countIf(in_fe > 0 AND in_ev > 0) AS in_both
+                FROM (
+                    SELECT team_id, uuid, max(is_fe) AS in_fe, max(is_ev) AS in_ev
+                    FROM (
+                        SELECT team_id, uuid, 1 AS is_fe, 0 AS is_ev
+                        FROM {settings.CLICKHOUSE_DATABASE}.{FLAG_EVALUATIONS_TABLE}
+                        WHERE team_id IN %(teams)s AND toDate(timestamp) = %(day)s
+
+                        UNION ALL
+
+                        SELECT team_id, uuid, 0 AS is_fe, 1 AS is_ev
+                        FROM {settings.CLICKHOUSE_DATABASE}.events
+                        WHERE team_id IN %(teams)s AND toDate(timestamp) = %(day)s
+                          AND event = %(event)s
+                    )
+                    GROUP BY team_id, uuid
+                )
+                GROUP BY team_id
+                """,
+                {"teams": batch, "day": day, "event": FLAG_EVALUATIONS_SOURCE_EVENT},
+                settings=query_settings,
+            )
+            checked.extend(
+                TeamParity(
+                    team_id=int(row[0]),
+                    only_in_events=int(row[1]),
+                    only_in_flag_evaluations=int(row[2]),
+                    in_both=int(row[3]),
+                )
+                for row in rows
+            )
+
+        return ParityResults(
+            day=day,
+            checked=checked,
+            teams_enabled=len(ranked_teams),
+            teams_truncated=truncated,
+        )
+
+    return cluster.any_host(run_queries).result()
+
+
+def parity_alert_lines(results: ParityResults) -> list[str] | None:
+    """The Slack message for a run, or None when there is nothing to say.
+
+    Only a deficit and an uncovered team are worth waking someone for. Excess is reported as
+    context but never triggers the alert on its own: flag_evaluations carries a permanent
+    surplus of a fraction of a percent, because clients re-send event uuids and its plain
+    MergeTree cannot collapse them while the ReplacingMergeTree behind events does. Alerting
+    on any difference would fire every day for every team and teach everyone to ignore it.
+
+    There is no threshold on the deficit for the opposite reason: it has measured zero on
+    every day checked so far, so any non-zero value is a regression a threshold would hide.
+    """
+
+    deficits = sorted(
+        (team for team in results.checked if team.only_in_events > 0),
+        key=lambda team: team.only_in_events,
+        reverse=True,
+    )
+    if not deficits and not results.teams_truncated:
+        return None
+
+    excess_total = sum(team.only_in_flag_evaluations for team in results.checked)
+    lines = [
+        f"*flag_evaluations parity* for `{results.day}`",
+        f"Checked {len(results.checked)} of {results.teams_enabled} enabled teams. Excess rows: {excess_total:,}.",
+    ]
+    if results.teams_truncated:
+        lines.append(f"{results.teams_truncated} enabled teams were not checked; raise `max_teams`.")
+    lines.extend(
+        f"Team `{team.team_id}`: {team.only_in_events:,} rows in events with no flag_evaluations row"
+        for team in deficits[:10]
+    )
+    if len(deficits) > 10:
+        lines.append(f"…and {len(deficits) - 10} more teams with a deficit")
+    return lines
+
+
+@dagster.op
+def report_flag_evaluations_parity(
+    context: dagster.OpExecutionContext,
+    results: ParityResults,
+    slack: dagster.ResourceParam[dagster_slack.SlackResource],
+) -> None:
+    """Post the parity result to Slack when it needs attention."""
+
+    context.add_output_metadata(
+        {
+            "day": str(results.day),
+            "teams_checked": len(results.checked),
+            "teams_enabled": results.teams_enabled,
+            "deficit_rows": sum(team.only_in_events for team in results.checked),
+            "excess_rows": sum(team.only_in_flag_evaluations for team in results.checked),
+        }
+    )
+
+    lines = parity_alert_lines(results)
+    if lines is None:
+        context.log.info(f"Parity holds for {len(results.checked)} teams on {results.day}")
+        return
+
+    if not settings.CLOUD_DEPLOYMENT:
+        context.log.info("Skipping Slack notification in non-prod environment")
+        return
+
+    try:
+        slack.get_client().chat_postMessage(
+            channel=FLAG_EVALUATIONS_SLACK_CHANNEL,
+            blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": "\n".join(lines)}}],
+        )
+    except Exception as e:
+        context.log.exception(f"Failed to send Slack notification: {e}")
+
+
+@dagster.job(tags={"owner": JobOwners.TEAM_INGESTION.value})
+def flag_evaluations_parity():
+    """Check that every row the flag-evaluations fork wrote also reached the events table."""
+    report_flag_evaluations_parity(measure_flag_evaluations_parity())
+
+
+flag_evaluations_parity_schedule = dagster.ScheduleDefinition(
+    job=flag_evaluations_parity,
+    # After the previous UTC day is complete and its merges have settled.
+    cron_schedule="0 4 * * *",
+    execution_timezone="UTC",
+    name="flag_evaluations_parity_schedule",
+)

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -222,6 +222,10 @@ def report_flag_evaluations_parity(
         context.log.info("Skipping Slack notification in non-prod environment")
         return
 
+    # Both regions post to the same channel and team ids are per-region, so the alert
+    # must name the deployment that lost the rows.
+    lines.append(f"Environment: {settings.CLOUD_DEPLOYMENT}")
+
     try:
         slack.get_client().chat_postMessage(
             channel=FLAG_EVALUATIONS_SLACK_CHANNEL,

--- a/posthog/dags/flag_evaluations_parity.py
+++ b/posthog/dags/flag_evaluations_parity.py
@@ -88,7 +88,7 @@ def measure_flag_evaluations_parity(
         # allowlist, so the two cannot drift.
         enabled_rows = client.execute(
             f"""
-            SELECT team_id, count() AS rows
+            SELECT team_id, count() AS rows, min(toDate(timestamp)) AS first_day
             FROM {settings.CLICKHOUSE_DATABASE}.{FLAG_EVALUATIONS_TABLE}
             WHERE toDate(timestamp) >= %(lookback_start)s AND toDate(timestamp) <= %(day)s
             GROUP BY team_id
@@ -98,10 +98,18 @@ def measure_flag_evaluations_parity(
             settings=query_settings,
         )
 
-        ranked_teams = [int(row[0]) for row in enabled_rows]
+        # A team whose earliest row in the lookback window falls on the checked day was
+        # switched on that day. Its events from before the allowlist reached the pods have
+        # no fork row, so comparing it would report a deficit for a fork that works. Skip it;
+        # its first full day is checked on the next run.
+        ranked_teams = [int(row[0]) for row in enabled_rows if row[2] < day]
+        skipped_activation = len(enabled_rows) - len(ranked_teams)
         teams = ranked_teams[: config.max_teams]
         truncated = len(ranked_teams) - len(teams)
-        context.log.info(f"{len(ranked_teams)} teams enabled, checking {len(teams)} for {day}")
+        context.log.info(
+            f"{len(ranked_teams)} teams enabled, checking {len(teams)} for {day}"
+            + (f", skipped {skipped_activation} activated that day" if skipped_activation else "")
+        )
 
         checked: list[TeamParity] = []
         for start in range(0, len(teams), config.teams_per_query):

--- a/posthog/dags/locations/ingestion.py
+++ b/posthog/dags/locations/ingestion.py
@@ -4,6 +4,7 @@ from posthog.dags import (
     delete_persons_from_trigger_log,
     detach_distinct_id,
     distinct_id_usage,
+    flag_evaluations_parity,
     ingestion_assets,
     person_property_reconciliation,
     persondistinctids_without_person_cleanup,
@@ -21,6 +22,7 @@ defs = dagster.Definitions(
         delete_persons_from_trigger_log.delete_persons_from_trigger_log_job,
         detach_distinct_id.detach_distinct_id_job,
         distinct_id_usage.distinct_id_usage_monitoring,
+        flag_evaluations_parity.flag_evaluations_parity,
         person_property_reconciliation.person_property_reconciliation_job,
         persondistinctids_without_person_cleanup.persondistinctids_without_person_cleanup_job,
         persons_new_backfill.persons_new_backfill_job,
@@ -28,6 +30,7 @@ defs = dagster.Definitions(
     ],
     schedules=[
         distinct_id_usage.distinct_id_usage_monitoring_schedule,
+        flag_evaluations_parity.flag_evaluations_parity_schedule,
     ],
     sensors=[
         person_property_reconciliation.person_property_reconciliation_scheduler,

--- a/posthog/dags/owners.yaml
+++ b/posthog/dags/owners.yaml
@@ -3,6 +3,8 @@ owners: []
 rules:
     - match:
           - '/detach_distinct_id.py'
+          - '/flag_evaluations_parity.py'
+          - '/tests/test_flag_evaluations_parity.py'
           - '/fix_missing_person_overrides.py'
           - '/fix_person_id_overrides.py'
           - '/person_property_reconciliation.py'

--- a/posthog/dags/tests/test_flag_evaluations_parity.py
+++ b/posthog/dags/tests/test_flag_evaluations_parity.py
@@ -56,9 +56,10 @@ class TestParityAlertLines:
 @pytest.mark.django_db
 def test_measure_attributes_deficit_and_excess_to_the_right_team(cluster: ClickhouseCluster) -> None:
     day = (datetime.now(tz=UTC) - timedelta(days=1)).replace(hour=12, minute=0, second=0, microsecond=0)
+    earlier = day - timedelta(days=1)
     matched, also_matched, events_only, fork_only = UUID(int=1), UUID(int=2), UUID(int=3), UUID(int=4)
     person = UUID(int=99)
-    clean_team, deficit_team, excess_team = 8001, 8002, 8003
+    clean_team, deficit_team, excess_team, activation_team = 8001, 8002, 8003, 8004
 
     def insert_events(client: Client) -> None:
         flag_props = '{"$feature_flag": "my-flag"}'
@@ -79,6 +80,10 @@ def test_measure_attributes_deficit_and_excess_to_the_right_team(cluster: Clickh
                 (deficit_team, "$feature_flag_called", "d", person, UUID(int=8), day, '{"$feature_flag": 5}'),
                 # A different event with a uuid the fork never sees must not read as a deficit.
                 (excess_team, "$pageview", "d", person, UUID(int=5), day, ""),
+                # activation_team is switched on during the checked day: this earlier event
+                # has no fork row, so checking the team would read as a deficit. The op must
+                # skip the team instead.
+                (activation_team, "$feature_flag_called", "d", person, UUID(int=9), day, flag_props),
             ],
         )
 
@@ -87,17 +92,25 @@ def test_measure_attributes_deficit_and_excess_to_the_right_team(cluster: Clickh
         partial(
             insert_flag_evaluations,
             [
+                # A row before the checked day marks each team as one the fork was already
+                # writing for, so it stays in the enabled set and is compared on the day.
+                (clean_team, "d", person, UUID(int=10), earlier),
+                (deficit_team, "d", person, UUID(int=11), earlier),
+                (excess_team, "d", person, UUID(int=12), earlier),
                 (clean_team, "d", person, matched, day),
                 # Enabled, so the op checks it, but one of its two events never arrived.
                 (deficit_team, "d", person, also_matched, day),
                 # Two rows for one uuid: a duplicate is excess, and excess is not a deficit.
                 (excess_team, "d", person, fork_only, day),
                 (excess_team, "d", person, fork_only, day),
+                # activation_team's first-ever row is on the checked day, so it was switched
+                # on that day and must be skipped rather than compared.
+                (activation_team, "d", person, UUID(int=13), day),
             ],
         )
     ).result()
 
-    # Two teams per query, three teams enabled, so the batching loop runs more than once.
+    # Two teams per query and three teams compared, so the batching loop runs more than once.
     config = FlagEvaluationsParityConfig(teams_per_query=2)
     results = measure_flag_evaluations_parity(dagster.build_op_context(), config, cluster)
 
@@ -105,3 +118,5 @@ def test_measure_attributes_deficit_and_excess_to_the_right_team(cluster: Clickh
     assert by_team[clean_team] == TeamParity(clean_team, only_in_events=0, only_in_flag_evaluations=0, in_both=1)
     assert by_team[deficit_team] == TeamParity(deficit_team, only_in_events=1, only_in_flag_evaluations=0, in_both=1)
     assert by_team[excess_team] == TeamParity(excess_team, only_in_events=0, only_in_flag_evaluations=1, in_both=0)
+    # Switched on during the checked day, so it is skipped rather than reported as a deficit.
+    assert activation_team not in by_team

--- a/posthog/dags/tests/test_flag_evaluations_parity.py
+++ b/posthog/dags/tests/test_flag_evaluations_parity.py
@@ -52,6 +52,20 @@ class TestParityAlertLines:
         assert lines is not None
         assert any(expected in line for line in lines)
 
+    def test_summary_counts_queried_teams_not_only_teams_with_rows(self) -> None:
+        # Ten teams were queried but only one had rows on the day. The summary must report the
+        # queried count, not len(checked), or it understates coverage and contradicts the
+        # truncation line.
+        results = ParityResults(
+            day=datetime.now(tz=UTC).date(),
+            checked=[TeamParity(1, 5, 0, 0)],
+            teams_enabled=10,
+            teams_truncated=0,
+        )
+        lines = parity_alert_lines(results)
+        assert lines is not None
+        assert any("Checked 10 of 10 enabled teams (1 had rows on the day)" in line for line in lines)
+
 
 @pytest.mark.django_db
 def test_measure_attributes_deficit_and_excess_to_the_right_team(cluster: ClickhouseCluster) -> None:

--- a/posthog/dags/tests/test_flag_evaluations_parity.py
+++ b/posthog/dags/tests/test_flag_evaluations_parity.py
@@ -61,16 +61,24 @@ def test_measure_attributes_deficit_and_excess_to_the_right_team(cluster: Clickh
     clean_team, deficit_team, excess_team = 8001, 8002, 8003
 
     def insert_events(client: Client) -> None:
+        flag_props = '{"$feature_flag": "my-flag"}'
         client.execute(
-            """INSERT INTO writable_events (team_id, event, distinct_id, person_id, uuid, timestamp)
+            """INSERT INTO writable_events (team_id, event, distinct_id, person_id, uuid, timestamp, properties)
             VALUES
             """,
             [
-                (clean_team, "$feature_flag_called", "d", person, matched, day),
-                (deficit_team, "$feature_flag_called", "d", person, also_matched, day),
-                (deficit_team, "$feature_flag_called", "d", person, events_only, day),
+                (clean_team, "$feature_flag_called", "d", person, matched, day, flag_props),
+                (deficit_team, "$feature_flag_called", "d", person, also_matched, day, flag_props),
+                (deficit_team, "$feature_flag_called", "d", person, events_only, day, flag_props),
+                # The fork only writes for a non-empty string $feature_flag, so a
+                # $feature_flag_called event without one has no flag_evaluations row by
+                # design and must not read as a deficit. Missing, empty, and non-string
+                # all match the fork's typeof-string check.
+                (deficit_team, "$feature_flag_called", "d", person, UUID(int=6), day, "{}"),
+                (deficit_team, "$feature_flag_called", "d", person, UUID(int=7), day, '{"$feature_flag": ""}'),
+                (deficit_team, "$feature_flag_called", "d", person, UUID(int=8), day, '{"$feature_flag": 5}'),
                 # A different event with a uuid the fork never sees must not read as a deficit.
-                (excess_team, "$pageview", "d", person, UUID(int=5), day),
+                (excess_team, "$pageview", "d", person, UUID(int=5), day, ""),
             ],
         )
 

--- a/posthog/dags/tests/test_flag_evaluations_parity.py
+++ b/posthog/dags/tests/test_flag_evaluations_parity.py
@@ -58,6 +58,14 @@ class TestParityAlertLines:
         assert lines is not None
         assert any(expected in line for line in lines)
 
+    def test_alerts_when_no_team_is_enabled(self) -> None:
+        # A cleared allowlist leaves no enabled team, which produces no deficit. Reporting that
+        # as a clean run would hide the fork having stopped writing everywhere.
+        results = ParityResults(day=datetime.now(tz=UTC).date(), checked=[], teams_enabled=0, teams_truncated=0)
+        lines = parity_alert_lines(results)
+        assert lines is not None
+        assert any("No team wrote a flag_evaluations row in the lookback window" in line for line in lines)
+
     def test_summary_counts_queried_teams_not_only_teams_with_rows(self) -> None:
         # Ten teams were queried but only one had rows on the day. The summary must report the
         # queried count, not len(checked), or it understates coverage and contradicts the
@@ -140,3 +148,11 @@ def test_measure_attributes_deficit_and_excess_to_the_right_team(cluster: Clickh
     assert by_team[excess_team] == TeamParity(excess_team, only_in_events=0, only_in_flag_evaluations=1, in_both=0)
     # Switched on during the checked day, so it is skipped rather than reported as a deficit.
     assert activation_team not in by_team
+
+    # A run capped by max_teams has to report the teams it left out, or it reads as full
+    # coverage. Only the counts are asserted, because ORDER BY count() DESC does not settle
+    # which of the equally-sized teams the cap drops.
+    capped = measure_flag_evaluations_parity(
+        dagster.build_op_context(), FlagEvaluationsParityConfig(max_teams=2), cluster
+    )
+    assert (capped.teams_enabled, capped.teams_truncated) == (3, 1)

--- a/posthog/dags/tests/test_flag_evaluations_parity.py
+++ b/posthog/dags/tests/test_flag_evaluations_parity.py
@@ -1,0 +1,99 @@
+from datetime import UTC, datetime, timedelta
+from functools import partial
+from uuid import UUID
+
+import pytest
+
+import dagster
+from clickhouse_driver import Client
+from parameterized import parameterized
+
+from posthog.clickhouse.cluster import ClickhouseCluster
+from posthog.dags.flag_evaluations_parity import (
+    FlagEvaluationsParityConfig,
+    ParityResults,
+    TeamParity,
+    measure_flag_evaluations_parity,
+    parity_alert_lines,
+)
+from posthog.dags.tests.conftest import insert_flag_evaluations
+
+
+def _results(checked: list[TeamParity], teams_truncated: int = 0) -> ParityResults:
+    return ParityResults(
+        day=datetime.now(tz=UTC).date(),
+        checked=checked,
+        teams_enabled=len(checked) + teams_truncated,
+        teams_truncated=teams_truncated,
+    )
+
+
+class TestParityAlertLines:
+    @parameterized.expand(
+        [
+            ("clean", [TeamParity(1, 0, 0, 100)], 0),
+            # The permanent duplicate surplus must never alert on its own, or the job fires
+            # every day for every team and stops being read.
+            ("excess_only", [TeamParity(1, 0, 250, 100)], 0),
+        ]
+    )
+    def test_stays_quiet(self, _name: str, checked: list[TeamParity], truncated: int) -> None:
+        assert parity_alert_lines(_results(checked, truncated)) is None
+
+    @parameterized.expand(
+        [
+            ("deficit", [TeamParity(1, 3, 0, 100)], 0, "3 rows in events"),
+            # A capped run must not read as full coverage.
+            ("truncated_without_deficit", [TeamParity(1, 0, 0, 100)], 5, "5 enabled teams were not checked"),
+        ]
+    )
+    def test_alerts(self, _name: str, checked: list[TeamParity], truncated: int, expected: str) -> None:
+        lines = parity_alert_lines(_results(checked, truncated))
+        assert lines is not None
+        assert any(expected in line for line in lines)
+
+
+@pytest.mark.django_db
+def test_measure_attributes_deficit_and_excess_to_the_right_team(cluster: ClickhouseCluster) -> None:
+    day = (datetime.now(tz=UTC) - timedelta(days=1)).replace(hour=12, minute=0, second=0, microsecond=0)
+    matched, also_matched, events_only, fork_only = UUID(int=1), UUID(int=2), UUID(int=3), UUID(int=4)
+    person = UUID(int=99)
+    clean_team, deficit_team, excess_team = 8001, 8002, 8003
+
+    def insert_events(client: Client) -> None:
+        client.execute(
+            """INSERT INTO writable_events (team_id, event, distinct_id, person_id, uuid, timestamp)
+            VALUES
+            """,
+            [
+                (clean_team, "$feature_flag_called", "d", person, matched, day),
+                (deficit_team, "$feature_flag_called", "d", person, also_matched, day),
+                (deficit_team, "$feature_flag_called", "d", person, events_only, day),
+                # A different event with a uuid the fork never sees must not read as a deficit.
+                (excess_team, "$pageview", "d", person, UUID(int=5), day),
+            ],
+        )
+
+    cluster.any_host(insert_events).result()
+    cluster.any_host(
+        partial(
+            insert_flag_evaluations,
+            [
+                (clean_team, "d", person, matched, day),
+                # Enabled, so the op checks it, but one of its two events never arrived.
+                (deficit_team, "d", person, also_matched, day),
+                # Two rows for one uuid: a duplicate is excess, and excess is not a deficit.
+                (excess_team, "d", person, fork_only, day),
+                (excess_team, "d", person, fork_only, day),
+            ],
+        )
+    ).result()
+
+    # Two teams per query, three teams enabled, so the batching loop runs more than once.
+    config = FlagEvaluationsParityConfig(teams_per_query=2)
+    results = measure_flag_evaluations_parity(dagster.build_op_context(), config, cluster)
+
+    by_team = {team.team_id: team for team in results.checked}
+    assert by_team[clean_team] == TeamParity(clean_team, only_in_events=0, only_in_flag_evaluations=0, in_both=1)
+    assert by_team[deficit_team] == TeamParity(deficit_team, only_in_events=1, only_in_flag_evaluations=0, in_both=1)
+    assert by_team[excess_team] == TeamParity(excess_team, only_in_events=0, only_in_flag_evaluations=1, in_both=0)

--- a/posthog/dags/tests/test_flag_evaluations_parity.py
+++ b/posthog/dags/tests/test_flag_evaluations_parity.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from functools import partial
 from uuid import UUID
 
@@ -13,6 +13,7 @@ from posthog.dags.flag_evaluations_parity import (
     FlagEvaluationsParityConfig,
     ParityResults,
     TeamParity,
+    _resolve_target_day,
     measure_flag_evaluations_parity,
     parity_alert_lines,
 )
@@ -26,6 +27,11 @@ def _results(checked: list[TeamParity], teams_truncated: int = 0) -> ParityResul
         teams_enabled=len(checked) + teams_truncated,
         teams_truncated=teams_truncated,
     )
+
+
+def test_resolve_target_day_uses_the_override_when_set() -> None:
+    # An operator rerunning to re-check a past alert's date must get that date, not yesterday.
+    assert _resolve_target_day("2026-08-31") == date(2026, 8, 31)
 
 
 class TestParityAlertLines:


### PR DESCRIPTION
## Problem

Nothing tells us when a row the flag-evaluations fork wrote never reaches the events table.

- The fork's counters increment on the Kafka ack, so they see nothing past it. That leaves the Kafka engine table, the materialized view, the writable Distributed table, and the shard unobserved.
- `kafka_flag_evaluations` sets `kafka_skip_broken_messages`, so a malformed row is discarded after a successful produce.
- The first-team rollout had a two-day window where rows landed in this table and not in events. The produce counters stayed clean through it.
- This blocks widening the fork past the first team. Each new team is meant to be gated on a parity result, and today that result comes from running a query by hand.

## Changes

- A daily job posts to `#alerts-ingestion` when an enabled team has an event with no matching flag_evaluations row.
- The alert names the deployment, because prod-US and prod-EU post to the same channel and team ids are per-region.
- The events side now requires `$feature_flag` to be a non-empty JSON string, matching the fork's own condition.
- `JSONExtractString` alone did not do that. It renders a number, boolean, object or array as its text, so `123` returned `'123'` and passed an empty-string check.
- `JSONType` rejects those types before the empty-string check.
- The job reads its team list from flag_evaluations rather than a copy of the deployment allowlist, so the two cannot drift.
- A lookback window keeps a team in that list after a day where the fork wrote nothing. A total outage then reads as a deficit, not as the team not being enabled.
- The job skips a team on the day it is switched on. Its events from before the allowlist reached the pods have no fork row. Checking it would report a deficit for a fork that is working.
- A run where no team is enabled alerts too, rather than reporting the day as clean. A rolled-back allowlist stops the fork writing, and after the lookback window those teams leave the query entirely.
- A deficit alerts at any size. It has measured zero on every day checked, so a threshold would only hide a regression.
- Excess never alerts on its own. It stayed at or below 0.09% in prod-US over the week to 2026-08-31, and was zero on four days.
- The fork gains an ack-latency histogram, timed on successful acks only. A failed produce settles before any broker round trip, so timing it would pull the signal down.
- Teams are compared in batches, so query memory scales with the rows in a batch rather than with a whole day.

A deficit alert reads like this:

```text
*flag_evaluations parity* for `2026-08-31`
Checked 12 of 14 enabled teams (11 had rows on the day). Excess rows: 1,204.
Team `12345`: 37 rows in events with no flag_evaluations row
Environment: US
```

The job alerts through Slack rather than a metric because `posthog/dags/` has no metrics-push path. The one `prometheus_client` counter there is documented as dying with its pod.

## How did you test this code?

Automated tests in `posthog/dags/tests/test_flag_evaluations_parity.py`, each aimed at a named regression:

- Two cases hold the alert quiet on a clean run and on an excess-only run. They catch a change that alerts on any difference between the tables.
- Two cases hold the alert firing on a deficit, and on a capped run with no deficit. The second catches truncation reading as full coverage.
- One case holds the alert firing when no team is enabled, which otherwise reports a stopped fork as a clean day.
- One case holds the summary reporting the queried team count, not the count of teams with rows. An idle team otherwise reads as uncovered.
- One ClickHouse-backed case checks per-team attribution across the batching loop. It covers four ways the two sides count different populations: a `$feature_flag` that is missing, empty, or a number, and a team switched on mid-day. It also asserts the `max_teams` counts.

Deleting the `JSONType` line makes that case report two deficit rows where one is correct, so the numeric row covers the regression.

The excess figure comes from a 7-day prod-US query, grouped by `(team_id, uuid)` with the job's own filter.

<details>
<summary>Excess and deficit by day, prod-US</summary>

| day | in_both | excess | deficit | excess % |
| --- | --- | --- | --- | --- |
| 2026-08-25 | 125 | 0 | 9,924,961 | 0.0000 |
| 2026-08-26 | 7,333,874 | 2,127 | 2,358,365 | 0.0290 |
| 2026-08-27 | 9,395,897 | 8,404 | 0 | 0.0894 |
| 2026-08-28 | 8,197,488 | 626 | 0 | 0.0076 |
| 2026-08-29 | 4,293,160 | 0 | 0 | 0.0000 |
| 2026-08-30 | 4,433,857 | 0 | 0 | 0.0000 |
| 2026-08-31 | 9,682,943 | 0 | 0 | 0.0000 |

The two large deficits are the fork's own rollout. The job skips a team on its enable day.

</details>

> [!NOTE]
> That same query read 3.44 TiB and peaked at 30.7 GiB on one coordinating host, against a 40 GB cap. It covered 7 days and every team at once where the job covers 1 day in batches of 20, so a real run is smaller. Whether the comparison should instead run shard-local is still open.

Not run: repo-wide mypy, and the wider `posthog/dags` suites. No manual testing.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code in PostHog Desktop. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`, `/review-code`, `/explain-open`, and `/metabase-prod-query`.

The first plan put a `team_id` label on the fork's outcome counter. That was dropped: the rollout ends with the allowlist set to `*`, which would make the label roughly nine thousand teams wide per pod. The parity job answers per-team questions instead.

A review pass found the events branch counted every `$feature_flag_called` row. The first fix used `JSONExtractString(...) != ''`, which still kept non-string values. Measuring against ClickHouse 26.6.2.158 showed only `null`, `""` and a missing key return `''`. The same pass found the stated reason for ignoring excess did not survive the query's own `GROUP BY uuid`.

Two branches of this work ran in parallel and reached several of the same fixes independently. This branch keeps both, with the duplicate work merged rather than force-pushed over.

Nothing in this PR carries material from the session that is not already public. The tests use invented team IDs and UUIDs.
