### PR TITLE
fix(desktop): show app shell while booting

### DIFF
--- a/products/desktop/apps/code/index.html
+++ b/products/desktop/apps/code/index.html
@@ -9,7 +9,40 @@
 </head>
 
 <body class="bg-(--color-background) text-(--gray-12)">
-  <div id="root"></div>
+  <div id="root">
+    <output aria-label="PostHog is starting" class="flex min-h-screen w-full bg-(--color-background)" data-testid="app-loading-shell">
+      <aside class="flex w-64 shrink-0 flex-col border-(--gray-5) border-r bg-(--gray-2) px-3 pb-3 pt-12">
+        <div class="mb-5 h-7 w-28 rounded bg-(--gray-a4)"></div>
+        <div class="flex flex-col gap-2">
+          <div class="h-7 w-full rounded bg-(--gray-a4)"></div>
+          <div class="h-7 w-[88%] rounded bg-(--gray-a4)"></div>
+          <div class="h-7 w-[72%] rounded bg-(--gray-a4)"></div>
+        </div>
+        <div class="mt-7 flex flex-col gap-2">
+          <div class="h-3 w-20 rounded bg-(--gray-a4)"></div>
+          <div class="h-7 w-full rounded bg-(--gray-a4)"></div>
+          <div class="h-7 w-[92%] rounded bg-(--gray-a4)"></div>
+          <div class="h-7 w-[84%] rounded bg-(--gray-a4)"></div>
+          <div class="h-7 w-[96%] rounded bg-(--gray-a4)"></div>
+        </div>
+      </aside>
+      <main class="flex min-w-0 flex-1 flex-col">
+        <div class="flex h-12 shrink-0 items-center border-(--gray-5) border-b px-4">
+          <div class="h-6 w-36 rounded bg-(--gray-a4)"></div>
+        </div>
+        <div class="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-5 px-8 py-10">
+          <div class="h-8 w-56 rounded bg-(--gray-a4)"></div>
+          <div class="h-4 w-[62%] rounded bg-(--gray-a4)"></div>
+          <div class="mt-3 flex flex-col gap-3">
+            <div class="h-14 w-full rounded bg-(--gray-a4)"></div>
+            <div class="h-14 w-full rounded bg-(--gray-a4)"></div>
+            <div class="h-14 w-full rounded bg-(--gray-a4)"></div>
+            <div class="h-14 w-full rounded bg-(--gray-a4)"></div>
+          </div>
+        </div>
+      </main>
+    </output>
+  </div>
   <script type="module" src="/src/renderer/main.tsx"></script>
 </body>
 

--- a/products/desktop/apps/code/src/main/index.ts
+++ b/products/desktop/apps/code/src/main/index.ts
@@ -386,7 +386,7 @@ async function boot(): Promise<void> {
   const wsServer = container.get<WorkspaceServerService>(
     WORKSPACE_SERVER_SERVICE,
   );
-  await wsServer.start().catch((error: unknown) => {
+  const workspaceServerStart = wsServer.start().catch((error: unknown) => {
     log.error("workspace-server failed to start", error);
   });
   // The workspace-server child respawns on a new port/secret after a crash;
@@ -451,6 +451,8 @@ async function boot(): Promise<void> {
   // The hidden quick-ask panel must not keep the app alive after the main
   // window closes.
   onMainWindowClosed(destroyQuickAskWindow);
+  await workspaceServerStart;
+  if (shutdownStarted) return;
   await initializeServices();
   initializeDeepLinks();
 

--- a/products/desktop/apps/code/src/main/services/auth/port-adapters.test.ts
+++ b/products/desktop/apps/code/src/main/services/auth/port-adapters.test.ts
@@ -1,0 +1,43 @@
+import type { WorkspaceClient } from "@posthog/workspace-client/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  WorkspaceServerEvent,
+  WorkspaceServerService,
+  WorkspaceServerStatus,
+} from "../workspace-server/service";
+import { ConnectivityPortAdapter } from "./port-adapters";
+
+describe("ConnectivityPortAdapter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("waits for the workspace server before subscribing", () => {
+    const unsubscribe = vi.fn();
+    const subscribe = vi.fn(() => ({ unsubscribe }));
+    const getStatus = vi.fn().mockResolvedValue({ isOnline: true });
+    const workspace = {
+      connectivity: {
+        onStatusChange: { subscribe },
+        getStatus: { query: getStatus },
+      },
+    } as unknown as WorkspaceClient;
+    const workspaceServer = new WorkspaceServerService();
+
+    const adapter = new ConnectivityPortAdapter(workspace, workspaceServer);
+
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(getStatus).not.toHaveBeenCalled();
+
+    workspaceServer.emit(WorkspaceServerEvent.StatusChanged, {
+      status: WorkspaceServerStatus.Ready,
+      attempt: 0,
+    });
+
+    expect(subscribe).toHaveBeenCalledOnce();
+    expect(getStatus).toHaveBeenCalledOnce();
+
+    adapter.dispose();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/products/desktop/apps/code/src/main/services/auth/port-adapters.ts
+++ b/products/desktop/apps/code/src/main/services/auth/port-adapters.ts
@@ -170,7 +170,6 @@ export class ConnectivityPortAdapter implements IAuthConnectivity {
     @inject(WORKSPACE_SERVER_SERVICE)
     private readonly workspaceServer: WorkspaceServerService,
   ) {
-    this.subscribe();
     // The workspace-server child respawns on a new port after a crash; the
     // old SSE subscription keeps retrying the dead port forever, so re-
     // establish it against the current connection once the server is healthy.
@@ -178,6 +177,9 @@ export class ConnectivityPortAdapter implements IAuthConnectivity {
       WorkspaceServerEvent.StatusChanged,
       this.onServerStatusChanged,
     );
+    if (this.workspaceServer.getStatus() === WorkspaceServerStatus.Ready) {
+      this.subscribe();
+    }
   }
 
   dispose(): void {

--- a/products/desktop/apps/code/tests/e2e/tests/smoke.spec.ts
+++ b/products/desktop/apps/code/tests/e2e/tests/smoke.spec.ts
@@ -16,7 +16,7 @@ test.describe("Smoke Tests", () => {
     await window.waitForSelector("#root > *", { timeout: 30000 });
 
     await window
-      .locator('[data-testid="app-loading-logo"]')
+      .locator('[data-testid="app-loading-shell"]')
       .waitFor({ state: "hidden", timeout: 30000 })
       .catch(() => {});
 

--- a/products/desktop/apps/code/tests/e2e/tests/visual.spec.ts
+++ b/products/desktop/apps/code/tests/e2e/tests/visual.spec.ts
@@ -7,7 +7,7 @@ test.describe("Visual Stability", () => {
   }) => {
     await window.waitForSelector("#root > *", { timeout: 30000 });
     await window
-      .locator('[data-testid="app-loading-logo"]')
+      .locator('[data-testid="app-loading-shell"]')
       .waitFor({ state: "hidden", timeout: 30000 })
       .catch(() => {});
 

--- a/products/desktop/packages/ui/src/shell/AppLoadingScreen.test.tsx
+++ b/products/desktop/packages/ui/src/shell/AppLoadingScreen.test.tsx
@@ -29,20 +29,21 @@ describe("AppLoadingScreen", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the loading logo immediately", () => {
+  it("renders the app shell immediately", () => {
     renderScreen();
-    expect(screen.getByTestId("app-loading-logo")).toBeInTheDocument();
+    expect(screen.getByTestId("app-loading-shell")).toBeInTheDocument();
+    expect(screen.queryByTestId("app-loading-logo")).not.toBeInTheDocument();
     expect(
       screen.queryByText("PostHog is taking longer than expected to start"),
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the logo until just before the stall timeout", () => {
+  it("keeps the app shell until just before the stall timeout", () => {
     renderScreen();
     act(() => {
       vi.advanceTimersByTime(STALL_TIMEOUT_MS - 1);
     });
-    expect(screen.getByTestId("app-loading-logo")).toBeInTheDocument();
+    expect(screen.getByTestId("app-loading-shell")).toBeInTheDocument();
   });
 
   it("swaps to the stalled screen after the timeout", () => {
@@ -57,7 +58,7 @@ describe("AppLoadingScreen", () => {
     expect(
       screen.getByRole("button", { name: "Get support" }),
     ).toBeInTheDocument();
-    expect(screen.queryByTestId("app-loading-logo")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("app-loading-shell")).not.toBeInTheDocument();
   });
 
   it("clears the stall timer on unmount", () => {

--- a/products/desktop/packages/ui/src/shell/AppLoadingScreen.tsx
+++ b/products/desktop/packages/ui/src/shell/AppLoadingScreen.tsx
@@ -1,14 +1,54 @@
+import { Skeleton } from "@posthog/quill";
 import { EXTERNAL_LINKS } from "@posthog/shared";
 import { Button } from "@posthog/ui/primitives/Button";
-import { LoadingScreen } from "@posthog/ui/primitives/LoadingScreen";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
-import { Flex, Text } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
 
 // The gate spans bootstrap (20s deadline in core auth), the access check and
 // the initial route load, so this sits well above all three combined before
 // declaring boot stuck.
 const STALL_TIMEOUT_MS = 30_000;
+
+function AppBootShell(): React.ReactNode {
+  return (
+    <output
+      aria-label="PostHog is starting"
+      className="flex min-h-screen w-full bg-(--color-background)"
+      data-testid="app-loading-shell"
+    >
+      <aside className="flex w-64 shrink-0 flex-col border-(--gray-5) border-r bg-(--gray-2) px-3 pt-12 pb-3">
+        <Skeleton className="mb-5 h-7 w-28" />
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-7 w-full" />
+          <Skeleton className="h-7 w-[88%]" />
+          <Skeleton className="h-7 w-[72%]" />
+        </div>
+        <div className="mt-7 flex flex-col gap-2">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-7 w-full" />
+          <Skeleton className="h-7 w-[92%]" />
+          <Skeleton className="h-7 w-[84%]" />
+          <Skeleton className="h-7 w-[96%]" />
+        </div>
+      </aside>
+      <main className="flex min-w-0 flex-1 flex-col">
+        <div className="flex h-12 shrink-0 items-center border-(--gray-5) border-b px-4">
+          <Skeleton className="h-6 w-36" />
+        </div>
+        <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-5 px-8 py-10">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-4 w-[62%]" />
+          <div className="mt-3 flex flex-col gap-3">
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+          </div>
+        </div>
+      </main>
+    </output>
+  );
+}
 
 export function AppLoadingScreen(): React.ReactNode {
   const [stalled, setStalled] = useState(false);
@@ -19,22 +59,19 @@ export function AppLoadingScreen(): React.ReactNode {
   }, []);
 
   if (!stalled) {
-    return <LoadingScreen className="min-h-screen" />;
+    return <AppBootShell />;
   }
 
   return (
-    <Flex align="center" justify="center" minHeight="100vh">
-      <Flex
-        direction="column"
-        align="center"
-        gap="4"
-        className="max-w-[360px] text-center"
-      >
-        <Text size="4" weight="bold">
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="flex max-w-[360px] flex-col items-center gap-4 text-center">
+        <p className="font-bold text-lg">
           PostHog is taking longer than expected to start
-        </Text>
-        <Text color="gray">This usually clears up with a restart.</Text>
-        <Flex gap="3">
+        </p>
+        <p className="text-(--gray-11)">
+          This usually clears up with a restart.
+        </p>
+        <div className="flex gap-3">
           <Button onClick={() => window.location.reload()}>Retry</Button>
           <Button
             variant="soft"
@@ -42,8 +79,8 @@ export function AppLoadingScreen(): React.ReactNode {
           >
             Get support
           </Button>
-        </Flex>
-      </Flex>
-    </Flex>
+        </div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

Desktop users see an empty window and logo while workspace-server blocks the first renderer load.

## Changes

- Desktop opens the renderer while workspace-server starts.
- Startup shows an app-shaped shell instead of the logo splash.

Before:

```mermaid
flowchart LR
    A[Desktop starts] --> B[Workspace server ready] --> C[Renderer opens]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,C phYellow;
    class B phBlue;
```

After:

```mermaid
flowchart LR
    A[Desktop starts] --> B[Workspace server starts]
    A --> C[Renderer opens]
    B --> D[Services initialize]
    C --> D
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,D phYellow;
    class B,C phBlue;
```
