### PR TITLE
feat(logs): add pattern_message_keys to team logs settings

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -817,6 +817,7 @@ export interface LogsSettings {
     capture_console_logs?: boolean
     json_parse_logs?: boolean
     pii_scrub_logs?: boolean
+    pattern_message_keys?: string[]
     retention_days?: number
     retention_last_updated?: string
 }

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -257,6 +257,7 @@ export interface LogsSettings {
     capture_console_logs?: boolean
     json_parse_logs?: boolean
     pii_scrub_logs?: boolean
+    pattern_message_keys?: string[]
     retention_days?: number
     retention_last_updated?: string
 }

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1684,10 +1684,27 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
         return value
 
     VALID_RETENTION_DAYS = {14, 30}
+    MAX_PATTERN_MESSAGE_KEYS = 20
+
+    @staticmethod
+    def _validate_pattern_message_keys(value: object) -> None:
+        if not isinstance(value, list) or not all(isinstance(key, str) for key in value):
+            raise exceptions.ValidationError("pattern_message_keys must be a list of strings")
+        if len(value) > TeamSerializer.MAX_PATTERN_MESSAGE_KEYS:
+            raise exceptions.ValidationError(
+                f"pattern_message_keys must contain at most {TeamSerializer.MAX_PATTERN_MESSAGE_KEYS} keys"
+            )
+        if any(not key.strip() for key in value):
+            raise exceptions.ValidationError("pattern_message_keys must not contain empty keys")
+        if len(set(value)) != len(value):
+            raise exceptions.ValidationError("pattern_message_keys must not contain duplicate keys")
 
     def validate_logs_settings(self, value: dict | None) -> dict | None:
         if value is None:
             return value
+
+        if "pattern_message_keys" in value:
+            TeamSerializer._validate_pattern_message_keys(value["pattern_message_keys"])
 
         new_retention = value.get("retention_days")
         if new_retention is not None and new_retention not in TeamSerializer.VALID_RETENTION_DAYS:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1831,6 +1831,42 @@ def team_api_test_factory():
                 )
                 assert "retention_days must be one of" in response.json()["detail"]
 
+        @parameterized.expand(
+            [
+                ("not_a_list", "message", "must be a list of strings"),
+                ("non_string_member", ["message", 3], "must be a list of strings"),
+                ("empty_string", ["message", ""], "must not contain empty keys"),
+                ("whitespace_only", ["message", "  "], "must not contain empty keys"),
+                ("duplicates", ["message", "msg", "message"], "must not contain duplicate keys"),
+                ("over_cap", [f"key_{index}" for index in range(21)], "at most 20 keys"),
+            ]
+        )
+        def test_logs_settings_pattern_message_keys_invalid(self, _name, keys, expected_error):
+            response = self.client.patch(
+                "/api/environments/@current/",
+                {"logs_settings": {"pattern_message_keys": keys}},
+            )
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            assert expected_error in response.json()["detail"]
+
+        @parameterized.expand(
+            [
+                ("absent", None),
+                ("empty_list", []),
+                ("single_key", ["message"]),
+                ("ordered_keys", ["message", "msg", "event"]),
+                ("at_cap", [f"key_{index}" for index in range(20)]),
+            ]
+        )
+        def test_logs_settings_pattern_message_keys_valid(self, _name, keys):
+            logs_settings = {} if keys is None else {"pattern_message_keys": keys}
+            response = self.client.patch(
+                "/api/environments/@current/",
+                {"logs_settings": logs_settings},
+            )
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json()["logs_settings"] == logs_settings
+
         def test_logs_settings_retention_requires_matching_feature(self):
             response = self.client.patch(
                 "/api/environments/@current/",


### PR DESCRIPTION
## Problem

A team whose logs carry the message under an unexpected key gets no message extraction in log patterns. Pattern derivation reads the message from a fixed list of `message`, `msg`, `event`. Supporting one more key means shipping a release, and we cannot guess every key a customer uses.

This PR stores the per-team list. It does not yet read it.

## Changes

- Nothing is different for anyone yet. No UI writes the setting, and ingestion does not read it.
- `logs_settings` accepts `pattern_message_keys`, an ordered list of JSON keys.
- Validation rejects a non-list, a non-string member, a blank key, a duplicate, and more than 20 keys.
- An empty list is valid. It will mean message extraction is off.
- The cap of 20 is a guardrail, not a contract. Derivation will scan the list per log record, so an unbounded list buys a per-record cost on a hot path.
- No migration. `logs_settings` is an existing `JSONField` on `Team`, so this adds a key to a blob rather than a column to a hot table.
- Mechanical: the two hand-written `LogsSettings` declarations gain the field.

The name is `pattern_message_keys` rather than anything with "masking" in it. Mask rules stay identical for every team, and the keys only choose which text gets masked.

> [!NOTE]
> The field does not reach generated frontend types. `logs_settings` is an untyped `JSONField`, so drf-spectacular emits `logs_settings?: unknown`, which is why `LogsSettings` is hand-declared in two places. Typing the whole blob would change the generated shape of the five existing keys, so it wants its own PR.

## How did you test this code?

Eleven parameterized cases sit next to the existing `logs_settings` retention tests. Six assert a 400 and the specific message. Five assert a 200 and that the stored blob round-trips: absent, empty, one key, ordered keys, and exactly 20.

They catch a list reaching pattern derivation with a non-string member, a duplicate, or an unbounded length. No existing test touches this key.

The cases live in `team_api_test_factory()`, so the team and project suites each run all eleven. That is what confirms the project serializer inherits the validation rather than needing its own copy.

Not tested by hand, and no UI exists to test.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None. The setting has no UI and no reader yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code implemented this from a spike that worked out where a per-team key list should live and how it reaches the ingestion consumer. Skills invoked: `improving-drf-endpoints`, `writing-tests`, `writing-pr-descriptions`.

The spike ruled out a Team extension model, which was the starting assumption. The repo bans new columns on `posthog_team` because an `ALTER TABLE` there takes an `ACCESS EXCLUSIVE` lock, but a new key in an existing JSON blob is not an `ALTER`, so no migration is needed at all.

A boolean toggle was also considered and rejected. The plumbing is identical and only the UI differs, and a boolean would mean shipping code every time a customer logs to a key we did not guess.

No content from any session source reached this diff. The code, tests, and this description come from the repository alone.
