### PR TITLE
fix(feature-flags): clamp variant rollouts that sum over 100

### DIFF
--- a/posthog/management/migration_analysis/atomic_false_acknowledged_migrations.txt
+++ b/posthog/management/migration_analysis/atomic_false_acknowledged_migrations.txt
@@ -29,3 +29,6 @@ warehouse_sources_queue.0009_sourcebatch_job_id_idx
 # on the table the flags API writes to. Re-running is a no-op: the transform is idempotent and
 # each swap only matches rows still holding the pre-clean value.
 feature_flags.0014_clean_flag_filters_inert_violations
+# Same shape as 0014: scans every flag but writes only the few that need clamping, each as its
+# own compare-and-swap. Re-running is a no-op, since a clamped set already sums to 100.
+feature_flags.0015_clamp_rollout_percentages_over_100

--- a/products/feature_flags/backend/migrations/0015_clamp_rollout_percentages_over_100.py
+++ b/products/feature_flags/backend/migrations/0015_clamp_rollout_percentages_over_100.py
@@ -20,7 +20,7 @@ def _clamped(rollouts: list[float]) -> list[float] | None:
     already 40/40/20. Verified against the Rust server, plus the Python, Go, .NET and JS SDKs.
     Whole numbers stay ints because the .NET and Java SDKs deserialize rollout percentages as
     integers (#84957)."""
-    if any(isinstance(r, bool) or not isinstance(r, int | float) for r in rollouts):
+    if any(isinstance(r, bool) or not isinstance(r, int | float) or r < 0 for r in rollouts):
         return None
     total = sum(rollouts)
     if total <= 100 + VARIANT_ROLLOUT_SUM_TOLERANCE:
@@ -30,7 +30,9 @@ def _clamped(rollouts: list[float]) -> list[float] | None:
     used: float = 0
     for rollout in rollouts:
         headroom = 100 - used
-        value = rollout if rollout <= headroom else max(headroom, 0)
+        # Rounded because `used` accumulates in binary floating point: without it a set like
+        # 10.1/20.2/30.3/50.5 leaves a remainder of 39.400000000000006 in the stored filters.
+        value = rollout if rollout <= headroom else round(max(headroom, 0), 10)
         if float(value).is_integer():
             value = int(value)
         clamped.append(value)
@@ -89,6 +91,12 @@ def clamp_rollout_percentages_over_100(apps, schema_editor):
     can return: an over-100 flag still matched its last variant there, and a clamped one returns
     no variant, exactly as a correctly summing flag always has. Odds are 1 in 2^60.
 
+    Two places do see a difference, both of them corrections. The experiment sample-ratio check
+    and the uneven-split warning build their expected counts from these stored percentages, so a
+    40/40/40 flag stops reporting a mismatch it never really had. And `.update()` fires no
+    post_save, so the flag-definitions cache serves the pre-clamp payload until the hypercache
+    verification task repairs the drift; both values pick the same variant meanwhile.
+
     A sum under 100 is left alone, because the shortfall is a slice of users who match the flag
     and get no variant, and handing it to someone is the customer's call.
 
@@ -108,7 +116,11 @@ def clamp_rollout_percentages_over_100(apps, schema_editor):
     while True:
         # _base_manager documents that soft-deleted rows are in scope (a historical model's
         # manager is plain anyway). Nothing here touches payloads, so encrypted flags are in scope.
-        rows = list(FeatureFlag._base_manager.filter(id__gt=last_id).order_by("id").only("id", "filters")[:BATCH_SIZE])
+        rows = list(
+            FeatureFlag._base_manager.filter(id__gt=last_id)
+            .order_by("id")
+            .only("id", "filters", "ensure_experience_continuity")[:BATCH_SIZE]
+        )
         if not rows:
             break
         last_id = rows[-1].id

--- a/products/feature_flags/backend/migrations/0015_clamp_rollout_percentages_over_100.py
+++ b/products/feature_flags/backend/migrations/0015_clamp_rollout_percentages_over_100.py
@@ -2,11 +2,13 @@ from django.db import migrations
 
 import structlog
 
-from products.feature_flags.backend.variant_rollout import VARIANT_ROLLOUT_SUM_TOLERANCE
-
 logger = structlog.get_logger(__name__)
 
 BATCH_SIZE = 500
+
+# Frozen copy of variant_rollout.VARIANT_ROLLOUT_SUM_TOLERANCE: migrations must stay
+# self-contained, so a later rename or retune cannot change what this one already did.
+VARIANT_ROLLOUT_SUM_TOLERANCE = 1e-9
 
 
 def _clamped(rollouts: list[float]) -> list[float] | None:
@@ -16,7 +18,8 @@ def _clamped(rollouts: list[float]) -> list[float] | None:
     first whose running total passes the hash, which never exceeds 1.0. So a variant starting at
     or beyond 100 is unreachable and one straddling it only serves the remainder: 40/40/40 is
     already 40/40/20. Verified against the Rust server, plus the Python, Go, .NET and JS SDKs.
-    Whole numbers stay ints so the wire format keeps the shape #84957 restored."""
+    Whole numbers stay ints because the .NET and Java SDKs deserialize rollout percentages as
+    integers (#84957)."""
     if any(isinstance(r, bool) or not isinstance(r, int | float) for r in rollouts):
         return None
     total = sum(rollouts)
@@ -35,7 +38,24 @@ def _clamped(rollouts: list[float]) -> list[float] | None:
     return clamped
 
 
-def _clamp_filters(filters: dict) -> dict | None:
+def _flips_hash_dependence(rollouts: list) -> bool:
+    """Whether clamping would change how the Rust evaluator classifies this flag.
+
+    has_hash_dependent_variants (rust/feature-flags/src/flags/flag_operations.rs) returns false
+    when any variant sits at 100, even where an earlier smaller variant still takes the low
+    hashes. Clamping removes the 100 and flips it to true, which starts the experience-continuity
+    override lookup and can change which identifier is hashed. Only matters when continuity is
+    on: get_hash picks the override branch on has_experience_continuity, so with it off both
+    classifications hash the current distinct_id and the flag is safe to clamp."""
+    seen_partial = False
+    for rollout in rollouts:
+        if rollout >= 100:
+            return seen_partial
+        seen_partial = True
+    return False
+
+
+def _clamp_filters(filters: dict, has_continuity: bool) -> dict | None:
     """Idempotent transform; None means the flag is untouched."""
     variants = (
         (filters.get("multivariate") or {}).get("variants") if isinstance(filters.get("multivariate"), dict) else None
@@ -45,8 +65,11 @@ def _clamp_filters(filters: dict) -> dict | None:
     if any(not isinstance(variant, dict) for variant in variants):
         return None
 
-    clamped = _clamped([variant.get("rollout_percentage") for variant in variants])
+    rollouts = [variant.get("rollout_percentage") for variant in variants]
+    clamped = _clamped(rollouts)
     if clamped is None:
+        return None
+    if has_continuity and _flips_hash_dependence(rollouts):
         return None
 
     new_filters = dict(filters)
@@ -61,9 +84,13 @@ def _clamp_filters(filters: dict) -> dict | None:
 def clamp_rollout_percentages_over_100(apps, schema_editor):
     """One-time cleanup of multivariate flags whose variant percentages sum over 100 (#50084).
 
-    Only the over-100 case: the evaluators truncate it already, so rewriting it changes nothing
-    anyone can observe. A sum under 100 is left alone, because the shortfall is a slice of users
-    who match the flag and get no variant, and handing it to someone is the customer's call.
+    Only the over-100 case: the evaluators truncate it already, so rewriting it serves the same
+    variant for every hash below 1.0. The exception is a hash of exactly 1.0, which calculate_hash
+    can return: an over-100 flag still matched its last variant there, and a clamped one returns
+    no variant, exactly as a correctly summing flag always has. Odds are 1 in 2^60.
+
+    A sum under 100 is left alone, because the shortfall is a slice of users who match the flag
+    and get no variant, and handing it to someone is the customer's call.
 
     Percentages live in nested arrays that jsonb prefilters can't select cheaply, so this scans
     all flags read-only and writes only the ones that change. Soft-deleted and inactive flags
@@ -89,7 +116,7 @@ def clamp_rollout_percentages_over_100(apps, schema_editor):
         for flag in rows:
             if not isinstance(flag.filters, dict):
                 continue
-            new_filters = _clamp_filters(flag.filters)
+            new_filters = _clamp_filters(flag.filters, bool(flag.ensure_experience_continuity))
             if new_filters is None:
                 continue
             # Compare-and-swap on the value we read: a flag edited between the batch select and

--- a/products/feature_flags/backend/migrations/0015_clamp_rollout_percentages_over_100.py
+++ b/products/feature_flags/backend/migrations/0015_clamp_rollout_percentages_over_100.py
@@ -1,0 +1,123 @@
+from django.db import migrations
+
+import structlog
+
+from products.feature_flags.backend.variant_rollout import VARIANT_ROLLOUT_SUM_TOLERANCE
+
+logger = structlog.get_logger(__name__)
+
+BATCH_SIZE = 500
+
+
+def _clamped(rollouts: list[float]) -> list[float] | None:
+    """Rewrite percentages summing over 100 as what the evaluators already serve, or None.
+
+    Every implementation walks the variants in order accumulating percentages and returns the
+    first whose running total passes the hash, which never exceeds 1.0. So a variant starting at
+    or beyond 100 is unreachable and one straddling it only serves the remainder: 40/40/40 is
+    already 40/40/20. Verified against the Rust server, plus the Python, Go, .NET and JS SDKs.
+    Whole numbers stay ints so the wire format keeps the shape #84957 restored."""
+    if any(isinstance(r, bool) or not isinstance(r, int | float) for r in rollouts):
+        return None
+    total = sum(rollouts)
+    if total <= 100 + VARIANT_ROLLOUT_SUM_TOLERANCE:
+        return None
+
+    clamped: list[float] = []
+    used: float = 0
+    for rollout in rollouts:
+        headroom = 100 - used
+        value = rollout if rollout <= headroom else max(headroom, 0)
+        if float(value).is_integer():
+            value = int(value)
+        clamped.append(value)
+        used += value
+    return clamped
+
+
+def _clamp_filters(filters: dict) -> dict | None:
+    """Idempotent transform; None means the flag is untouched."""
+    variants = (
+        (filters.get("multivariate") or {}).get("variants") if isinstance(filters.get("multivariate"), dict) else None
+    )
+    if not isinstance(variants, list) or not variants:
+        return None
+    if any(not isinstance(variant, dict) for variant in variants):
+        return None
+
+    clamped = _clamped([variant.get("rollout_percentage") for variant in variants])
+    if clamped is None:
+        return None
+
+    new_filters = dict(filters)
+    new_multivariate = dict(filters["multivariate"])
+    new_multivariate["variants"] = [
+        {**variant, "rollout_percentage": value} for variant, value in zip(variants, clamped)
+    ]
+    new_filters["multivariate"] = new_multivariate
+    return new_filters
+
+
+def clamp_rollout_percentages_over_100(apps, schema_editor):
+    """One-time cleanup of multivariate flags whose variant percentages sum over 100 (#50084).
+
+    Only the over-100 case: the evaluators truncate it already, so rewriting it changes nothing
+    anyone can observe. A sum under 100 is left alone, because the shortfall is a slice of users
+    who match the flag and get no variant, and handing it to someone is the customer's call.
+
+    Percentages live in nested arrays that jsonb prefilters can't select cheaply, so this scans
+    all flags read-only and writes only the ones that change. Soft-deleted and inactive flags
+    included: their filters are blanked in the cached payload, but restoring or re-enabling a
+    flag would put the stored value straight back in play."""
+    FeatureFlag = apps.get_model("feature_flags", "FeatureFlag")
+
+    updated_rows = 0
+    skipped_concurrent = 0
+
+    # Keyset pagination instead of .iterator(): server-side cursors are disabled when migrations
+    # run through pgbouncer (DISABLE_SERVER_SIDE_CURSORS), which would make .iterator() buffer the
+    # whole table client-side. id-range batches are memory-bounded however the connection is pooled.
+    last_id = 0
+    while True:
+        # _base_manager documents that soft-deleted rows are in scope (a historical model's
+        # manager is plain anyway). Nothing here touches payloads, so encrypted flags are in scope.
+        rows = list(FeatureFlag._base_manager.filter(id__gt=last_id).order_by("id").only("id", "filters")[:BATCH_SIZE])
+        if not rows:
+            break
+        last_id = rows[-1].id
+
+        for flag in rows:
+            if not isinstance(flag.filters, dict):
+                continue
+            new_filters = _clamp_filters(flag.filters)
+            if new_filters is None:
+                continue
+            # Compare-and-swap on the value we read: a flag edited between the batch select and
+            # this write keeps the newer filters instead of being reverted to our snapshot.
+            written = FeatureFlag._base_manager.filter(id=flag.id, filters=flag.filters).update(filters=new_filters)
+            if not written:
+                skipped_concurrent += 1
+                continue
+            updated_rows += 1
+
+    logger.info(
+        "clamped_rollout_percentages_over_100",
+        updated_rows=updated_rows,
+        skipped_concurrent=skipped_concurrent,
+    )
+
+
+class Migration(migrations.Migration):
+    # Non-atomic so each row's UPDATE commits as it goes. The default wrapping transaction would
+    # stay open across the whole scan, holding an xmin autovacuum cannot advance past on the table
+    # the flags API writes to. Safe to resume: every compare-and-swap is independently correct and
+    # the transform is idempotent, so a partial run leaves a consistent table.
+    atomic = False
+
+    dependencies = [
+        ("feature_flags", "0014_clean_flag_filters_inert_violations"),
+    ]
+
+    operations = [
+        migrations.RunPython(clamp_rollout_percentages_over_100, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/feature_flags/backend/migrations/max_migration.txt
+++ b/products/feature_flags/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0014_clean_flag_filters_inert_violations
+0015_clamp_rollout_percentages_over_100

--- a/products/feature_flags/backend/test/test_migration_0015_clamp_rollouts.py
+++ b/products/feature_flags/backend/test/test_migration_0015_clamp_rollouts.py
@@ -4,6 +4,8 @@ from posthog.test.base import BaseTest, TestMigrations
 from unittest.mock import patch
 
 from django.apps import apps as global_apps
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 
 def variants(*percentages: Any) -> dict:
@@ -225,3 +227,38 @@ class ClampRolloutCompareAndSwapTest(BaseTest):
 
         flag.refresh_from_db()
         assert flag.filters == edited
+
+
+class ClampRolloutQueryCountTest(BaseTest):
+    """The scan reads `ensure_experience_continuity`, so it has to be in the `.only()`. Without
+    it Django refetches the column once per row, and the field has silently dropped out once."""
+
+    def test_the_scan_does_not_query_per_row(self) -> None:
+        from importlib import import_module
+
+        from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+        migration = import_module("products.feature_flags.backend.migrations.0015_clamp_rollout_percentages_over_100")
+        for i in range(25):
+            FeatureFlag.objects.create(
+                team=self.team,
+                created_by=self.user,
+                key=f"counted-{i}",
+                filters={
+                    "groups": [],
+                    "multivariate": {
+                        "variants": [
+                            {"key": "a", "name": "", "rollout_percentage": 60},
+                            {"key": "b", "name": "", "rollout_percentage": 60},
+                        ]
+                    },
+                },
+            )
+
+        with CaptureQueriesContext(connection) as captured:
+            migration.clamp_rollout_percentages_over_100(global_apps, None)
+
+        selects = [q["sql"] for q in captured.captured_queries if q["sql"].lstrip().upper().startswith("SELECT")]
+        # One batch of up to 500, then one empty batch that ends the loop. A per-row refetch
+        # would add one SELECT for every flag scanned.
+        assert len(selects) == 2, "\n".join(selects)

--- a/products/feature_flags/backend/test/test_migration_0015_clamp_rollouts.py
+++ b/products/feature_flags/backend/test/test_migration_0015_clamp_rollouts.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+from posthog.test.base import TestMigrations
+
+
+def variants(*percentages: Any) -> dict:
+    return {"variants": [{"key": f"v{i}", "name": "", "rollout_percentage": p} for i, p in enumerate(percentages)]}
+
+
+def rollouts(filters: dict) -> list:
+    return [variant["rollout_percentage"] for variant in filters["multivariate"]["variants"]]
+
+
+class ClampRolloutPercentagesMigrationTest(TestMigrations):
+    migrate_from = "0014_clean_flag_filters_inert_violations"
+    migrate_to = "0015_clamp_rollout_percentages_over_100"
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    @property
+    def app(self) -> str:
+        return "feature_flags"
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        Organization = apps.get_model("posthog", "Organization")
+        Project = apps.get_model("posthog", "Project")
+        Team = apps.get_model("posthog", "Team")
+        FeatureFlag = apps.get_model("feature_flags", "FeatureFlag")
+
+        org = Organization.objects.create(name="Test Organization")
+        project = Project.objects.create(id=999994, organization=org, name="Test Project")
+        team = Team.objects.create(organization=org, project=project, name="Test Team")
+
+        def make_flag(key: str, filters: dict, **kwargs: Any) -> Any:
+            return FeatureFlag.objects.create(team=team, created_by=None, key=key, filters=filters, **kwargs)
+
+        self.straddling_id = make_flag("straddling", {"groups": [], "multivariate": variants(40, 40, 40)}).id
+        self.two_over_id = make_flag("two-over", {"groups": [], "multivariate": variants(60, 60)}).id
+        self.first_takes_all_id = make_flag("first-takes-all", {"groups": [], "multivariate": variants(150, 10)}).id
+        self.unreachable_id = make_flag("unreachable", {"groups": [], "multivariate": variants(50, 50, 50)}).id
+        self.fractional_id = make_flag("fractional", {"groups": [], "multivariate": variants(33.33, 33.33, 50)}).id
+        self.soft_deleted_id = make_flag(
+            "soft-deleted", {"groups": [], "multivariate": variants(70, 70)}, deleted=True
+        ).id
+        self.inactive_id = make_flag("inactive", {"groups": [], "multivariate": variants(70, 70)}, active=False).id
+        self.encrypted_id = make_flag(
+            "encrypted", {"groups": [], "multivariate": variants(60, 60)}, has_encrypted_payloads=True
+        ).id
+
+        # Left alone: already correct, or a shortfall only the customer can resolve.
+        self.exact_id = make_flag("exact", {"groups": [], "multivariate": variants(40, 40, 20)}).id
+        self.under_id = make_flag("under", {"groups": [], "multivariate": variants(30, 30)}).id
+        self.drifting_id = make_flag("drifting", {"groups": [], "multivariate": variants(0.01, 64.04, 35.95)}).id
+
+        # Shapes the scan must skip rather than raise on.
+        self.junk_ids = [
+            make_flag("junk-multivariate-list", {"groups": [], "multivariate": ["nope"]}).id,
+            make_flag("junk-variants-not-list", {"groups": [], "multivariate": {"variants": {}}}).id,
+            make_flag("junk-variant-entry", {"groups": [], "multivariate": {"variants": ["nope"]}}).id,
+            make_flag("junk-rollout-string", {"groups": [], "multivariate": variants("60", "60")}).id,
+            make_flag("no-multivariate", {"groups": []}).id,
+        ]
+
+    def _filters(self, flag_id: int) -> dict:
+        assert self.apps is not None
+        FeatureFlag = self.apps.get_model("feature_flags", "FeatureFlag")
+        return FeatureFlag.objects.get(id=flag_id).filters
+
+    def test_clamps_a_straddling_variant_to_the_remainder(self) -> None:
+        assert rollouts(self._filters(self.straddling_id)) == [40, 40, 20]
+        assert rollouts(self._filters(self.two_over_id)) == [60, 40]
+
+    def test_zeroes_variants_the_evaluator_can_never_reach(self) -> None:
+        assert rollouts(self._filters(self.first_takes_all_id)) == [100, 0]
+        assert rollouts(self._filters(self.unreachable_id)) == [50, 50, 0]
+
+    def test_keeps_whole_numbers_as_integers(self) -> None:
+        # A float here would re-break the .NET and Java SDKs that #84957 fixed.
+        assert [type(r) for r in rollouts(self._filters(self.straddling_id))] == [int, int, int]
+
+    def test_keeps_real_decimals(self) -> None:
+        assert rollouts(self._filters(self.fractional_id)) == [33.33, 33.33, 33.34]
+
+    def test_covers_soft_deleted_inactive_and_encrypted_flags(self) -> None:
+        assert rollouts(self._filters(self.soft_deleted_id)) == [70, 30]
+        assert rollouts(self._filters(self.inactive_id)) == [70, 30]
+        assert rollouts(self._filters(self.encrypted_id)) == [60, 40]
+
+    def test_leaves_correct_and_short_sums_alone(self) -> None:
+        assert rollouts(self._filters(self.exact_id)) == [40, 40, 20]
+        assert rollouts(self._filters(self.under_id)) == [30, 30]
+        assert rollouts(self._filters(self.drifting_id)) == [0.01, 64.04, 35.95]
+
+    def test_skips_malformed_filters_without_raising(self) -> None:
+        # Reaching any assertion here means the scan completed; these rows stay as they were.
+        assert self._filters(self.junk_ids[0])["multivariate"] == ["nope"]
+        assert self._filters(self.junk_ids[2])["multivariate"]["variants"] == ["nope"]
+        assert rollouts(self._filters(self.junk_ids[3])) == ["60", "60"]
+        assert "multivariate" not in self._filters(self.junk_ids[4])

--- a/products/feature_flags/backend/test/test_migration_0015_clamp_rollouts.py
+++ b/products/feature_flags/backend/test/test_migration_0015_clamp_rollouts.py
@@ -54,6 +54,14 @@ class ClampRolloutPercentagesMigrationTest(TestMigrations):
             },
         ).id
         self.two_over_id = make_flag("two-over", {"groups": [], "multivariate": variants(60, 60)}).id
+        # Decimal inputs whose remainder lands whole: the only shape where the int conversion
+        # changes the stored value, 33.0 without it and 33 with it.
+        self.whole_remainder_id = make_flag(
+            "whole-remainder", {"groups": [], "multivariate": variants(33.5, 33.5, 50)}
+        ).id
+        self.drifting_remainder_id = make_flag(
+            "drifting-remainder", {"groups": [], "multivariate": variants(10.1, 20.2, 30.3, 50.5)}
+        ).id
         self.first_takes_all_id = make_flag("first-takes-all", {"groups": [], "multivariate": variants(150, 10)}).id
         self.unreachable_id = make_flag("unreachable", {"groups": [], "multivariate": variants(50, 50, 50)}).id
         self.fractional_id = make_flag("fractional", {"groups": [], "multivariate": variants(33.33, 33.33, 50)}).id
@@ -150,8 +158,15 @@ class ClampRolloutPercentagesMigrationTest(TestMigrations):
         assert rollouts(self._filters(self.unreachable_id)) == [50, 50, 0]
 
     def test_keeps_whole_numbers_as_integers(self) -> None:
-        # A float here would re-break the .NET and Java SDKs that #84957 fixed.
+        # A float here would re-break the .NET and Java SDKs that #84957 fixed. The decimal
+        # fixture is the one that pins the conversion: its remainder is whole, so without it
+        # the stored value would be 33.0.
         assert [type(r) for r in rollouts(self._filters(self.straddling_id))] == [int, int, int]
+        assert rollouts(self._filters(self.whole_remainder_id)) == [33.5, 33.5, 33]
+        assert [type(r) for r in rollouts(self._filters(self.whole_remainder_id))] == [float, float, int]
+
+    def test_rounds_the_remainder_instead_of_storing_a_float_artifact(self) -> None:
+        assert rollouts(self._filters(self.drifting_remainder_id)) == [10.1, 20.2, 30.3, 39.4]
 
     def test_keeps_real_decimals(self) -> None:
         assert rollouts(self._filters(self.fractional_id)) == [33.33, 33.33, 33.34]

--- a/products/feature_flags/backend/test/test_migration_0015_clamp_rollouts.py
+++ b/products/feature_flags/backend/test/test_migration_0015_clamp_rollouts.py
@@ -1,6 +1,9 @@
 from typing import Any
 
-from posthog.test.base import TestMigrations
+from posthog.test.base import BaseTest, TestMigrations
+from unittest.mock import patch
+
+from django.apps import apps as global_apps
 
 
 def variants(*percentages: Any) -> dict:
@@ -35,6 +38,21 @@ class ClampRolloutPercentagesMigrationTest(TestMigrations):
             return FeatureFlag.objects.create(team=team, created_by=None, key=key, filters=filters, **kwargs)
 
         self.straddling_id = make_flag("straddling", {"groups": [], "multivariate": variants(40, 40, 40)}).id
+        self.annotated_id = make_flag(
+            "annotated",
+            {
+                "groups": [{"properties": [], "rollout_percentage": 100, "variant": None}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "v0", "name": "First", "rollout_percentage": 40},
+                        {"key": "v1", "name": "Second", "rollout_percentage": 40},
+                        {"key": "v2", "name": "Third", "rollout_percentage": 40},
+                    ],
+                    "some_unrelated_key": "kept",
+                },
+                "payloads": {"v0": "1"},
+            },
+        ).id
         self.two_over_id = make_flag("two-over", {"groups": [], "multivariate": variants(60, 60)}).id
         self.first_takes_all_id = make_flag("first-takes-all", {"groups": [], "multivariate": variants(150, 10)}).id
         self.unreachable_id = make_flag("unreachable", {"groups": [], "multivariate": variants(50, 50, 50)}).id
@@ -52,19 +70,76 @@ class ClampRolloutPercentagesMigrationTest(TestMigrations):
         self.under_id = make_flag("under", {"groups": [], "multivariate": variants(30, 30)}).id
         self.drifting_id = make_flag("drifting", {"groups": [], "multivariate": variants(0.01, 64.04, 35.95)}).id
 
+        # Clamping a [40, 100] shape flips has_hash_dependent_variants, which starts the
+        # continuity override lookup and can change which identifier is hashed.
+        self.risky_with_continuity_id = make_flag(
+            "risky-with-continuity",
+            {"groups": [], "multivariate": variants(40, 100)},
+            ensure_experience_continuity=True,
+        ).id
+        self.risky_without_continuity_id = make_flag(
+            "risky-without-continuity", {"groups": [], "multivariate": variants(40, 100)}
+        ).id
+        self.leading_full_with_continuity_id = make_flag(
+            "leading-full-with-continuity",
+            {"groups": [], "multivariate": variants(100, 40)},
+            ensure_experience_continuity=True,
+        ).id
+
+        # Past the first 500-row batch, so keyset pagination is actually exercised.
+        for i in range(505):
+            make_flag(f"filler-{i}", {"groups": [], "multivariate": variants(50, 50)})
+        self.last_batch_id = make_flag("last-batch", {"groups": [], "multivariate": variants(80, 80)}).id
+
         # Shapes the scan must skip rather than raise on.
-        self.junk_ids = [
-            make_flag("junk-multivariate-list", {"groups": [], "multivariate": ["nope"]}).id,
-            make_flag("junk-variants-not-list", {"groups": [], "multivariate": {"variants": {}}}).id,
-            make_flag("junk-variant-entry", {"groups": [], "multivariate": {"variants": ["nope"]}}).id,
-            make_flag("junk-rollout-string", {"groups": [], "multivariate": variants("60", "60")}).id,
-            make_flag("no-multivariate", {"groups": []}).id,
-        ]
+        self.junk = {
+            "filters-not-dict": make_flag("junk-filters-not-dict", {}).id,
+            "multivariate-list": make_flag("junk-multivariate-list", {"groups": [], "multivariate": ["nope"]}).id,
+            "variants-not-list": make_flag(
+                "junk-variants-not-list", {"groups": [], "multivariate": {"variants": {}}}
+            ).id,
+            "variant-entry": make_flag("junk-variant-entry", {"groups": [], "multivariate": {"variants": ["nope"]}}).id,
+            "rollout-string": make_flag("junk-rollout-string", {"groups": [], "multivariate": variants("60", "60")}).id,
+            "no-multivariate": make_flag("no-multivariate", {"groups": []}).id,
+            "rollout-bool": make_flag("junk-rollout-bool", {"groups": [], "multivariate": variants(True, 100)}).id,
+        }
+        # A whole `filters` value that is not a dict at all; the model default blocks it on create.
+        FeatureFlag.objects.filter(id=self.junk["filters-not-dict"]).update(filters=["nope"])
+
+    def _raw_filters(self, flag_id: int) -> Any:
+        assert self.apps is not None
+        FeatureFlag = self.apps.get_model("feature_flags", "FeatureFlag")
+        return FeatureFlag.objects.get(id=flag_id).filters
 
     def _filters(self, flag_id: int) -> dict:
         assert self.apps is not None
         FeatureFlag = self.apps.get_model("feature_flags", "FeatureFlag")
         return FeatureFlag.objects.get(id=flag_id).filters
+
+    def test_preserves_every_other_field_while_clamping(self) -> None:
+        assert self._filters(self.annotated_id) == {
+            "groups": [{"properties": [], "rollout_percentage": 100, "variant": None}],
+            "multivariate": {
+                "variants": [
+                    {"key": "v0", "name": "First", "rollout_percentage": 40},
+                    {"key": "v1", "name": "Second", "rollout_percentage": 40},
+                    {"key": "v2", "name": "Third", "rollout_percentage": 20},
+                ],
+                "some_unrelated_key": "kept",
+            },
+            "payloads": {"v0": "1"},
+        }
+
+    def test_skips_only_the_shape_that_flips_hash_dependence_with_continuity(self) -> None:
+        # Continuity on plus a 100 after a smaller variant: the one shape that can move a user.
+        assert rollouts(self._filters(self.risky_with_continuity_id)) == [40, 100]
+        # Same shape without continuity hashes the distinct_id either way, so it is safe.
+        assert rollouts(self._filters(self.risky_without_continuity_id)) == [40, 60]
+        # The 100 comes first, so nothing smaller precedes it and the classification is unchanged.
+        assert rollouts(self._filters(self.leading_full_with_continuity_id)) == [100, 0]
+
+    def test_clamps_rows_past_the_first_batch(self) -> None:
+        assert rollouts(self._filters(self.last_batch_id)) == [80, 20]
 
     def test_clamps_a_straddling_variant_to_the_remainder(self) -> None:
         assert rollouts(self._filters(self.straddling_id)) == [40, 40, 20]
@@ -93,7 +168,45 @@ class ClampRolloutPercentagesMigrationTest(TestMigrations):
 
     def test_skips_malformed_filters_without_raising(self) -> None:
         # Reaching any assertion here means the scan completed; these rows stay as they were.
-        assert self._filters(self.junk_ids[0])["multivariate"] == ["nope"]
-        assert self._filters(self.junk_ids[2])["multivariate"]["variants"] == ["nope"]
-        assert rollouts(self._filters(self.junk_ids[3])) == ["60", "60"]
-        assert "multivariate" not in self._filters(self.junk_ids[4])
+        assert self._raw_filters(self.junk["filters-not-dict"]) == ["nope"]
+        assert self._filters(self.junk["multivariate-list"])["multivariate"] == ["nope"]
+        assert self._filters(self.junk["variants-not-list"])["multivariate"]["variants"] == {}
+        assert self._filters(self.junk["variant-entry"])["multivariate"]["variants"] == ["nope"]
+        assert rollouts(self._filters(self.junk["rollout-string"])) == ["60", "60"]
+        assert "multivariate" not in self._filters(self.junk["no-multivariate"])
+        # True is an int in Python, so without the bool guard this would become [1, 99].
+        assert rollouts(self._filters(self.junk["rollout-bool"])) == [True, 100]
+
+
+class ClampRolloutCompareAndSwapTest(BaseTest):
+    """The `filters=flag.filters` predicate is what stops a stale snapshot overwriting a newer
+    edit, and only a write landing mid-scan exercises it."""
+
+    def test_a_write_landing_mid_scan_survives(self) -> None:
+        from importlib import import_module
+
+        from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+        migration = import_module("products.feature_flags.backend.migrations.0015_clamp_rollout_percentages_over_100")
+        flag = FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key="raced",
+            filters={"groups": [], "multivariate": variants(60, 60)},
+        )
+        edited = {"groups": [], "multivariate": variants(25, 25)}
+
+        original_clamp = migration._clamp_filters
+
+        def clamp_then_race(filters: dict, has_continuity: bool) -> dict | None:
+            result = original_clamp(filters, has_continuity)
+            if result is not None:
+                # Stand in for a user saving between the batch SELECT and the UPDATE.
+                FeatureFlag.objects.filter(id=flag.id).update(filters=edited)
+            return result
+
+        with patch.object(migration, "_clamp_filters", clamp_then_race):
+            migration.clamp_rollout_percentages_over_100(global_apps, None)
+
+        flag.refresh_from_db()
+        assert flag.filters == edited


### PR DESCRIPTION
Multivariate flags whose variant percentages add up to more than 100 now store what the evaluators already serve. `40/40/40` becomes `40/40/20`, `150/10` becomes `100/0`.

**Why the assignment does not change**

Every evaluator walks the variants in order adding up the percentages, and returns the first one whose running total passes the user's hash. That hash never goes above 1.0, so a variant starting at or beyond 100 can never be picked, and one that straddles it only serves the remainder. Checked against the Rust server and the Python, Go, .NET and JS SDKs. The Java SDK does not do local evaluation at all.

**Where it is visible anyway**

Three carve-outs, all of them corrections rather than regressions:

- A hash of exactly 1.0. `calculate_hash` can return it, and a clamped flag then returns no variant, which is what a correctly summing flag has always done. Odds are 1 in 2^60.
- The experiment sample-ratio check and the uneven-split warning build their expected counts from these stored percentages, so a `40/40/40` flag stops reporting a mismatch it never really had.
- The flag definitions cache serves the pre-clamp payload until the verification task repairs the drift, since `.update()` fires no `post_save`. Both values pick the same variant meanwhile.

**What it leaves alone**

- Sums under 100. There the shortfall is real: those users match the flag and get no variant. Handing that slice to someone is the customer's decision.
- Flags where a variant at 100 follows a smaller one **and** experience continuity is on. Clamping flips `has_hash_dependent_variants`, which starts the continuity override lookup and can change which identifier is hashed. Zero flags in either region currently have both, so nothing is skipped today.
- Negative percentages, which would lift headroom above 100. Also zero in both regions.
- Whole numbers stay whole numbers. A float here would re-break the .NET and Java clients the way #84957 did.

**How it runs**

- Batches of 500 with keyset pagination, since server side cursors are off behind pgbouncer.
- Base manager, so soft deleted flags are included. Encrypted flags are in scope too, because nothing here touches payloads.
- A compare and swap per row, so a flag edited mid scan keeps the newer value.
- Non atomic, so each write commits instead of holding one transaction open across the whole table.
- Only the rows that actually change get written, and running it twice does nothing the second time.

**Tests**

Cover the straddling and unreachable cases, integers and decimals including a remainder that lands whole, the float artifact in the remainder, the continuity guard in all three of its states, rows past the first batch, a write landing mid scan against the compare and swap, whole `filters` preservation, and the malformed shapes it has to skip rather than raise on.
