### PR TITLE
fix(migrations): order the scim backfill before the idp config rename

### DIFF
--- a/ee/migrations/0058_backfill_scim_provisioned_user_config.py
+++ b/ee/migrations/0058_backfill_scim_provisioned_user_config.py
@@ -84,6 +84,11 @@ def backfill_scim_provisioned_user_config(apps: Any, schema_editor: Any) -> None
 class Migration(migrations.Migration):
     dependencies = [("ee", "0057_scim_records_identity_provider_config_indexes")]
 
+    # This backfill reads OrganizationDomain.identity_provider_config, which posthog.1316 renames in
+    # migration state. Without this edge the planner is free to apply 1316 first, and the backfill
+    # then fails on a fresh database with an unsupported-lookup FieldError.
+    run_before = [("posthog", "1316_deprecate_organization_domain_idp_config")]
+
     operations = [
         migrations.RunPython(
             backfill_scim_provisioned_user_config,


### PR DESCRIPTION
## Problem

Every commit merged to master since 17:27 UTC today fails Backend CI, so no one gets a green master. [Run 33538699249](https://github.com/PostHog/posthog/actions/runs/33538699249) is one of seven in a row.

- The `Validate migrations` job replays the whole migration history on an empty database and stops with `FieldError: Unsupported lookup 'identity_provider_config__isnull'`.
- `ee.0058_backfill_scim_provisioned_user_config` reads `OrganizationDomain.identity_provider_config`.
- `posthog.1316_deprecate_organization_domain_idp_config` renames that field to `_identity_provider_config` in migration state.
- Nothing ordered the two migrations, so the planner could apply 1316 first.
- `dashboards.0016_dashboardsavedview` depends on `posthog.1320`. The app label `dashboards` sorts before `ee`, which pulled 1316 ahead of the backfill.

A new database is also affected, so a fresh local setup hits the same error.

## Changes

- An empty database migrates to the end again, which unblocks master pushes and new local setups.
- `ee.0058` declares `run_before = [("posthog", "1316_deprecate_organization_domain_idp_config")]`. Django treats that as a hard graph edge, so no future migration can reorder the pair.
- The diff is five lines and changes no schema. `run_before` constrains the plan only.

The alternative was to rewrite the backfill against the renamed field. That trades one ordering assumption for the opposite one, so the ordering edge is the durable fix.

## How did you test this code?

- Rebuilt the migration state that `ee.0058` sees, then built its backfill query. Without this change the query raises the same `FieldError` as CI. With it the query builds.
- Ran `manage.py makemigrations --check --dry-run`: no state drift.
- Replayed the full migration history on an empty local Postgres database: 2328 migrations applied, no error. `ee.0058` now runs immediately before `posthog.1316`.

> [!NOTE]
> This PR's own CI cannot verify the fix. The `Validate migrations` job primes the database from a cached master schema dump, then applies only the migration files the PR adds. It never replays `ee.0058`. The post-merge master push run is the first place the ordering is exercised.

No test is added. `run_before` makes the failing order unrepresentable in the graph, so a test would assert something Django already enforces.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) diagnosed the red master and wrote the change. Skills invoked: `/debugging-ci-failures`, `/django-migrations`, `/writing-code-comments`, `/writing-pr-descriptions`.

The first attempt to attribute the plan flip bisected commits in a git worktree. That measured the main checkout instead, because `uv run` resolves the project at the working directory. Attribution came instead from reading the CI logs of one green and one red run, comparing where each applied `ee.0058` and `posthog.1316`, and then confirming the cause by pointing `dashboards.0016` at `posthog.1315` and watching the order return to normal.

Nothing in this PR comes from outside the repository and its public CI runs.


