### PR TITLE
onboarding tweaks

### DIFF
--- a/products/canvas/backend/teaching.py
+++ b/products/canvas/backend/teaching.py
@@ -21,7 +21,7 @@ from products.canvas.backend.models import Canvas
 from products.canvas.backend.source import synthetic_source_project
 
 TEACHING_CANVAS_TEMPLATE_ID = "desktop-onboarding-teaching"
-TEACHING_CANVAS_NAME = "Start here"
+TEACHING_CANVAS_NAME = "Explore PostHog Desktop"
 
 # Template ids the create API refuses, so a user-created canvas can never be
 # mistaken for (or pre-claim and suppress) a PostHog-seeded one.
@@ -274,7 +274,7 @@ function HomeView({ onOpen, seen, seenCount, allSeen }) {
       <div className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1.5">
           <Heading size="2xl" render={<h1 />}>
-            How PostHog Desktop works
+            Explore PostHog Desktop
           </Heading>
           <Text variant="muted">A quick tour in five stops. Pick one.</Text>
         </div>
@@ -403,7 +403,7 @@ function DetailView({ topic, index, next, seen, onBack, onNext }) {
   );
 }
 
-export default function StartHere() {
+export default function ExploreDesktop() {
   const [topicId, setTopicId] = useState(null);
   const [seen, setSeen] = useState(null);
   useEffect(() => {

--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/show-actions.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/show-actions.ts
@@ -26,7 +26,10 @@ const SHOW_ACTIONS_TOOL_DESCRIPTION =
   "on its own. Pass `report_id` to open one report instead of the whole inbox. " +
   "Offer only what the person actually wants to do next, in the order they " +
   "would want it. Buttons that decorate an answer are noise, so skip the call " +
-  "entirely when there is nothing worth clicking.";
+  "entirely when there is nothing worth clicking. " +
+  "The buttons are drawn where you call the tool, so write the text they " +
+  "follow from first and call this after it. Calling it before the text puts " +
+  "the buttons above the message that explains them.";
 
 /**
  * Offers the user buttons; it does not press them. The handler only

--- a/products/desktop/packages/ui/src/features/onboarding/components/ConnectGitHubStep.tsx
+++ b/products/desktop/packages/ui/src/features/onboarding/components/ConnectGitHubStep.tsx
@@ -66,13 +66,13 @@ export function ConnectGitHubStep({ onNext, onBack }: ConnectGitHubStepProps) {
                 <Flex direction="column" gap="2">
                   <Flex align="center" gap="2">
                     <Text className="font-bold text-(--gray-12) text-2xl">
-                      Connect GitHub
+                      Connect your codebase
                     </Text>
                     <OptionalBadge />
                   </Flex>
                   <Text className="text-(--gray-11) text-sm">
-                    Allows agents to run tasks in the cloud, push branches, and
-                    open pull requests.
+                    Code access helps us understand your product, and helps you
+                    build.
                   </Text>
                 </Flex>
               </motion.div>

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -103,6 +103,7 @@ import { extractCustomInstructions } from "@posthog/ui/features/sessions/compone
 import {
   extractOnboardingBrief,
   ONBOARDING_BRIEF_LABEL,
+  ONBOARDING_BRIEF_TOOLTIP,
 } from "@posthog/ui/features/sessions/components/session-update/onboardingBrief";
 import {
   hasFileMentions,
@@ -626,8 +627,9 @@ function UserBubble({
               )}
               {onboardingBrief && (
                 <MentionChip
-                  icon={<FileText size={12} />}
+                  icon={<Robot size={12} />}
                   label={ONBOARDING_BRIEF_LABEL}
+                  tooltip={ONBOARDING_BRIEF_TOOLTIP}
                 />
               )}
               {showChannelContextTag && channelContext && (

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.stories.tsx
@@ -1,0 +1,38 @@
+import { UserMessage } from "@posthog/ui/features/sessions/components/session-update/UserMessage";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta: Meta<typeof UserMessage> = {
+  title: "Features/Sessions/UserMessage",
+  component: UserMessage,
+  decorators: [
+    (Story) => (
+      <div className="max-w-2xl p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof UserMessage>;
+
+const FIXED_TIMESTAMP = Date.parse("2026-07-01T10:30:00Z");
+
+export const Typed: Story = {
+  args: {
+    content: "What are our top errors this week?",
+    timestamp: FIXED_TIMESTAMP,
+    animate: false,
+  },
+};
+
+// The first-run session's whole prompt is an <onboarding_brief> block, so the bubble strips to
+// nothing and the chip is all the reader has while the agent's first turn streams.
+export const OnboardingBrief: Story = {
+  args: {
+    content:
+      "<onboarding_brief>\nWrite the first message someone sees in PostHog Desktop.\n</onboarding_brief>",
+    timestamp: FIXED_TIMESTAMP,
+    animate: false,
+  },
+};

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -24,6 +24,7 @@ import { extractCustomInstructions } from "./customInstructions";
 import {
   extractOnboardingBrief,
   ONBOARDING_BRIEF_LABEL,
+  ONBOARDING_BRIEF_TOOLTIP,
 } from "./onboardingBrief";
 import {
   hasFileMentions,
@@ -179,8 +180,9 @@ export const UserMessage = memo(function UserMessage({
               )}
               {onboardingBrief && (
                 <MentionChip
-                  icon={<FileText size={12} />}
+                  icon={<Robot size={12} />}
                   label={ONBOARDING_BRIEF_LABEL}
+                  tooltip={ONBOARDING_BRIEF_TOOLTIP}
                 />
               )}
               {showChannelContextTag && channelContext && (

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/onboardingBrief.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/onboardingBrief.ts
@@ -7,6 +7,9 @@ const ONBOARDING_BRIEF_REGEX =
 
 export const ONBOARDING_BRIEF_LABEL = "Getting started with PostHog Desktop";
 
+export const ONBOARDING_BRIEF_TOOLTIP =
+  "The agent is looking over your project to help set up the PostHog Desktop experience.";
+
 export function extractOnboardingBrief(
   content: string,
 ): { stripped: string } | null {

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/parseFileMentions.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/parseFileMentions.tsx
@@ -1,4 +1,5 @@
 import { File, Folder, Warning } from "@phosphor-icons/react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@posthog/quill";
 import { unescapeXmlAttr } from "@posthog/shared";
 import { Text } from "@radix-ui/themes";
 import type { ReactNode } from "react";
@@ -54,10 +55,12 @@ export function MentionChip({
   icon,
   label,
   onClick,
+  tooltip,
 }: {
   icon: ReactNode;
   label: string;
   onClick?: () => void;
+  tooltip?: string;
 }) {
   const style = { margin: "0 2px" };
 
@@ -68,23 +71,33 @@ export function MentionChip({
     </>
   );
 
-  if (onClick) {
-    return (
-      <button
-        type="button"
-        className={`${chipClass} cursor-pointer border-none text-[13px]`}
-        onClick={onClick}
-        style={style}
-      >
-        {content}
-      </button>
-    );
-  }
-
-  return (
-    <span className={`${chipClass} text-[13px]`} style={style}>
+  const chip = onClick ? (
+    <button
+      type="button"
+      className={`${chipClass} cursor-pointer border-none text-[13px]`}
+      onClick={onClick}
+      style={style}
+    >
+      {content}
+    </button>
+  ) : (
+    <span
+      className={`${chipClass} text-[13px]`}
+      style={style}
+      // A span takes no focus of its own, so a keyboard reader would never
+      // reach the tooltip that carries the chip's only explanation.
+      tabIndex={tooltip ? 0 : undefined}
+    >
       {content}
     </span>
+  );
+
+  if (!tooltip) return chip;
+  return (
+    <Tooltip>
+      <TooltipTrigger render={chip} />
+      <TooltipContent className="max-w-64">{tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/OnboardingTestToolsDialog.tsx
@@ -67,7 +67,7 @@ interface Draft {
 const DEFAULT_DRAFT: Draft = {
   joining: false,
   companyDomain: "posthog.com",
-  otherMembers: "Max, Lotte",
+  otherMembers: "Max, Lottie",
   situation: "nothing-connected",
   sourcesWatching: "errors, conversion drops",
 };
@@ -233,7 +233,7 @@ export function OnboardingTestToolsDialog({
               </QuestionnaireDescription>
               <TextAnswer
                 label="People already in the workspace"
-                placeholder="Max, Lotte"
+                placeholder="Max, Lottie"
                 value={draft.otherMembers}
                 onValueChange={(otherMembers) => patch({ otherMembers })}
               />

--- a/products/tasks/backend/facade/onboarding_brief.py
+++ b/products/tasks/backend/facade/onboarding_brief.py
@@ -178,7 +178,8 @@ def self_driving_line(reports: Sequence[InboxReportSummary]) -> str:
     line = (
         "Findings land in Self-driving, their inbox in the sidebar. When one comes up, offer a "
         "`show_actions` `open_inbox` button rather than describing where to look. That button "
-        "opens Self-driving on its own, or one report when you pass `report_id`."
+        "opens Self-driving on its own, or one report when you pass `report_id`. Write what you "
+        "have to say first, then call `show_actions`, so the button sits under the text."
     )
     if not reports:
         return line
@@ -198,8 +199,9 @@ def teaching_canvas_line(teaching: TeachingCanvas) -> str:
     return (
         f'A canvas named "{TEACHING_CANVAS_NAME}" is pinned in this space: a short tour of how '
         "the app works, and itself an example of a canvas. At a natural moment after your first "
-        "message, mention it in one sentence and offer it with a `show_actions` `open_canvas` "
-        f"button (channel_id `{teaching.channel_id}`, canvas_id `{teaching.canvas_id}`). "
+        "message, mention it in one sentence, then offer it with a `show_actions` `open_canvas` "
+        f"button (channel_id `{teaching.channel_id}`, canvas_id `{teaching.canvas_id}`). Write "
+        "the sentence before you make the call, so the button sits under it rather than above. "
         "You did not make it, so never claim it as your work."
     )
 

--- a/products/tasks/backend/facade/onboarding_prompt.py
+++ b/products/tasks/backend/facade/onboarding_prompt.py
@@ -120,7 +120,7 @@ Use the canonical `posthog:exec` tool for every PostHog operation. Follow its bu
 
 For questions about PostHog products, features, settings, SDKs, limits, how-to guidance, or pricing, use `docs-search` before answering. Ground your answer in what it returns, not in your memory.
 
-`show_actions` is how anything else gets done. When the next step is outside what you can reach, or points at something already in the workspace, offer the button rather than only describing the destination. Anything touching their code is a `compose` button with a prompt you write.
+`show_actions` is how anything else gets done. When the next step is outside what you can reach, or points at something already in the workspace, offer the button rather than only describing the destination. Anything touching their code is a `compose` button with a prompt you write. Buttons are drawn where you call the tool, so always write the text they explain first and call `show_actions` after it. A call that comes before the text puts the buttons above it, where they read as arriving out of nowhere.
 
 A `compose` button opens the composer filled in; it does not send. It is an offer they still have to accept, so nothing is underway until they do.
 


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

onboarding needs a lil polish

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- "Getting started with PostHog Desktop" chip now has a tooltip that says what is happening
- updated github connection step copy
- teaching canvas renamed "Start here" &rarr; "Explore PostHog Desktop"
- prompt updates to ensure buttons are placed below text

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

manually

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Voice: the subject of every sentence is the change, never its author. No "I", "me" or "my" anywhere in the body. "I (actually Claude)" is worse than either half: it hands the assignee an account of work they did not do. Authorship is one stated fact in the Agent context section below.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Flow and topology changes: include separate before-and-after Mermaid `flowchart` blocks with PostHog colors. This includes CI wiring, pipelines, state machines, and request paths. Use `/writing-pr-descriptions` for the palette and role mapping.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Simplify before opening: if your agent has a behavior-preserving cleanup pass (Claude Code: `/simplify`), run it on a non-trivial diff before final tests and preflight, since it edits the tree. Skip it for small mechanical changes.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
