### PR TITLE
fix(frontend): a localStorage failure no longer blanks the scene

### DIFF
--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -16,6 +16,7 @@ import {
     removeProjectIdIfPresent,
     stripTrailingSlash,
 } from 'lib/utils/kea-router'
+import { safeStorageEngine } from 'lib/utils/safeStorageEngine'
 import { identifierToHuman } from 'lib/utils/strings'
 
 import { disposablesPlugin } from '~/kea-disposables'
@@ -100,7 +101,7 @@ export function initKea({
     const plugins = [
         ...(beforePlugins || []),
         disposablesPlugin,
-        localStoragePlugin(),
+        localStoragePlugin({ storageEngine: safeStorageEngine }),
         windowValuesPlugin({ window: window }),
         routerPlugin({
             history: routerHistory,

--- a/frontend/src/lib/utils/safeStorageEngine.test.ts
+++ b/frontend/src/lib/utils/safeStorageEngine.test.ts
@@ -48,4 +48,26 @@ describe('safeStorageEngine', () => {
 
         expect(engine['never.written']).toBeUndefined()
     })
+
+    it('reports a startup storage failure once, on first key access', () => {
+        // The memory fallback never throws, so a store blocked at startup would go
+        // unreported without deferring the capture to first access. Isolate the module
+        // to reset its once-per-session guard, and mock only this require's posthog-js.
+        jest.resetModules()
+        const capture = jest.fn()
+        jest.doMock('posthog-js', () => ({ __esModule: true, default: { capture } }))
+        const { createSafeStorageEngine: create } = require('lib/utils/safeStorageEngine')
+
+        const engine = create(undefined, new Error('NS_ERROR_FAILURE'))
+        // Deferred: nothing is reported until the engine is actually touched
+        expect(capture).not.toHaveBeenCalled()
+
+        expect(engine['first.access']).toBeUndefined()
+        engine['second.access'] = 'value'
+
+        expect(capture).toHaveBeenCalledTimes(1)
+        expect(capture).toHaveBeenCalledWith('kea_localstorage_unavailable', { error: 'Error: NS_ERROR_FAILURE' })
+
+        jest.dontMock('posthog-js')
+    })
 })

--- a/frontend/src/lib/utils/safeStorageEngine.test.ts
+++ b/frontend/src/lib/utils/safeStorageEngine.test.ts
@@ -1,0 +1,51 @@
+import { createSafeStorageEngine } from 'lib/utils/safeStorageEngine'
+
+describe('safeStorageEngine', () => {
+    // Firefox raises a bare NS_ERROR_FAILURE from storage access, and
+    // kea-localstorage touches the engine during render, so anything that
+    // escapes here blanks the whole scene
+    const throwingStorage = (): Storage => {
+        const fail = (): never => {
+            throw new Error('NS_ERROR_FAILURE')
+        }
+        return {
+            get length(): number {
+                return fail()
+            },
+            clear: fail,
+            getItem: fail,
+            key: fail,
+            removeItem: fail,
+            setItem: fail,
+        }
+    }
+
+    it('swallows a throwing backing store instead of propagating', () => {
+        const engine = createSafeStorageEngine(throwingStorage())
+
+        expect(() => {
+            engine['some.persisted.path'] = 'value'
+        }).not.toThrow()
+        expect(engine['some.persisted.path']).toBeUndefined()
+        expect(() => delete engine['some.persisted.path']).not.toThrow()
+        expect(() => engine.length).not.toThrow()
+        expect(() => engine.getItem('some.persisted.path')).not.toThrow()
+    })
+
+    it('falls back to memory when localStorage is unavailable', () => {
+        const engine = createSafeStorageEngine(undefined)
+
+        engine['some.persisted.path'] = 'value'
+
+        expect(engine['some.persisted.path']).toBe('value')
+    })
+
+    it('reads a missing key as undefined rather than null', () => {
+        // kea-localstorage branches on `typeof engine[path] !== 'undefined'`, so
+        // returning getItem's null would load null over every persisted
+        // reducer's coded default
+        const engine = createSafeStorageEngine(undefined)
+
+        expect(engine['never.written']).toBeUndefined()
+    })
+})

--- a/frontend/src/lib/utils/safeStorageEngine.test.ts
+++ b/frontend/src/lib/utils/safeStorageEngine.test.ts
@@ -1,24 +1,41 @@
-import { createSafeStorageEngine } from 'lib/utils/safeStorageEngine'
+import { createSafeStorageEngine, resolveLocalStorage } from 'lib/utils/safeStorageEngine'
 
 describe('safeStorageEngine', () => {
     // Firefox raises a bare NS_ERROR_FAILURE from storage access, and
     // kea-localstorage touches the engine during render, so anything that
     // escapes here blanks the whole scene
-    const throwingStorage = (): Storage => {
-        const fail = (): never => {
-            throw new Error('NS_ERROR_FAILURE')
-        }
-        return {
-            get length(): number {
-                return fail()
-            },
-            clear: fail,
-            getItem: fail,
-            key: fail,
-            removeItem: fail,
-            setItem: fail,
-        }
+    const fail = (): never => {
+        throw new Error('NS_ERROR_FAILURE')
     }
+
+    const throwingStorage = (): Storage => ({
+        get length(): number {
+            return fail()
+        },
+        clear: fail,
+        getItem: fail,
+        key: fail,
+        removeItem: fail,
+        setItem: fail,
+    })
+
+    // A store at quota rejects writes while its reads keep working
+    const readOnlyStorage = (seed: Record<string, string>): Storage => ({
+        length: Object.keys(seed).length,
+        clear: fail,
+        getItem: (key: string): string | null => seed[key] ?? null,
+        key: (index: number): string | null => Object.keys(seed)[index] ?? null,
+        removeItem: fail,
+        setItem: fail,
+    })
+
+    const realLocalStorage = Object.getOwnPropertyDescriptor(window, 'localStorage')
+
+    afterEach(() => {
+        if (realLocalStorage) {
+            Object.defineProperty(window, 'localStorage', realLocalStorage)
+        }
+    })
 
     it('swallows a throwing backing store instead of propagating', () => {
         const engine = createSafeStorageEngine(throwingStorage())
@@ -26,10 +43,29 @@ describe('safeStorageEngine', () => {
         expect(() => {
             engine['some.persisted.path'] = 'value'
         }).not.toThrow()
-        expect(engine['some.persisted.path']).toBeUndefined()
         expect(() => delete engine['some.persisted.path']).not.toThrow()
         expect(() => engine.length).not.toThrow()
         expect(() => engine.getItem('some.persisted.path')).not.toThrow()
+    })
+
+    it('keeps a store that only rejects writes', () => {
+        // A write probe would reject a store sitting at quota, and every one of
+        // the 227 persisted reducers would then load its default over readable
+        // saved state. Full storage is the case this guard exists for
+        const atQuota = readOnlyStorage({ 'dismissed.prompt': '"yes"' })
+        Object.defineProperty(window, 'localStorage', { value: atQuota, configurable: true })
+
+        expect(resolveLocalStorage().storage).toBe(atQuota)
+    })
+
+    it('reads saved values from a store that only rejects writes', () => {
+        const engine = createSafeStorageEngine(readOnlyStorage({ 'dismissed.prompt': '"yes"' }))
+
+        engine['new.value'] = 'written'
+
+        expect(engine['dismissed.prompt']).toBe('"yes"')
+        // The rejected write still holds for this session
+        expect(engine['new.value']).toBe('written')
     })
 
     it('falls back to memory when localStorage is unavailable', () => {

--- a/frontend/src/lib/utils/safeStorageEngine.ts
+++ b/frontend/src/lib/utils/safeStorageEngine.ts
@@ -96,29 +96,48 @@ function createStorageFacade(backing: Storage): Storage {
     }
 }
 
-export function createSafeStorageEngine(backing: Storage | undefined): Storage {
+export function createSafeStorageEngine(backing: Storage | undefined, startupError?: unknown): Storage {
     const facade = createStorageFacade(backing ?? createMemoryStorage())
+    // A store blocked at startup fails the probe and drops to the memory fallback, which never
+    // throws, so no facade catch can report it. resolveLocalStorage() also runs at module load,
+    // before posthog-js is initialized, so a capture there would be lost. Report on the first
+    // real key access instead - that runs during a logic mount, after posthog-js is up.
+    let startupPending = startupError !== undefined
+    const reportStartupFailureOnce = (): void => {
+        if (startupPending) {
+            startupPending = false
+            reportFailureOnce(startupError)
+        }
+    }
     return new Proxy(facade, {
-        get: (target, prop) =>
-            typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)
-                ? // Native property access yields undefined for a missing key while
-                  // getItem yields null, and kea-localstorage branches on
-                  // `typeof engine[path] !== 'undefined'`. Returning null here would
-                  // load null over every persisted reducer's coded default
-                  (target.getItem(prop) ?? undefined)
-                : Reflect.get(target, prop),
+        get: (target, prop) => {
+            if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
+                reportStartupFailureOnce()
+                // Native property access yields undefined for a missing key while
+                // getItem yields null, and kea-localstorage branches on
+                // `typeof engine[path] !== 'undefined'`. Returning null here would
+                // load null over every persisted reducer's coded default
+                return target.getItem(prop) ?? undefined
+            }
+            return Reflect.get(target, prop)
+        },
         set: (target, prop, value) => {
             if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
+                reportStartupFailureOnce()
                 target.setItem(prop, String(value))
             }
             return true
         },
-        has: (target, prop) =>
-            typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)
-                ? target.getItem(prop) !== null
-                : Reflect.has(target, prop),
+        has: (target, prop) => {
+            if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
+                reportStartupFailureOnce()
+                return target.getItem(prop) !== null
+            }
+            return Reflect.has(target, prop)
+        },
         deleteProperty: (target, prop) => {
             if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
+                reportStartupFailureOnce()
                 target.removeItem(prop)
             }
             return true
@@ -126,17 +145,19 @@ export function createSafeStorageEngine(backing: Storage | undefined): Storage {
     })
 }
 
-function resolveLocalStorage(): Storage | undefined {
+function resolveLocalStorage(): { storage: Storage | undefined; error?: unknown } {
     try {
         const probe = '__safe_storage_probe__'
         window.localStorage.setItem(probe, probe)
         window.localStorage.removeItem(probe)
-        return window.localStorage
-    } catch {
-        // Blocked outright, so fall back to memory and keep persistence
-        // working for the rest of the session
-        return undefined
+        return { storage: window.localStorage }
+    } catch (error) {
+        // Blocked outright, so fall back to memory and keep persistence working for the rest of
+        // the session. Keep the error so the first key access reports it - a full store, blocked
+        // site data, and Safari private mode all fail here, and those are the common causes
+        return { storage: undefined, error }
     }
 }
 
-export const safeStorageEngine = createSafeStorageEngine(resolveLocalStorage())
+const resolvedLocalStorage = resolveLocalStorage()
+export const safeStorageEngine = createSafeStorageEngine(resolvedLocalStorage.storage, resolvedLocalStorage.error)

--- a/frontend/src/lib/utils/safeStorageEngine.ts
+++ b/frontend/src/lib/utils/safeStorageEngine.ts
@@ -12,56 +12,63 @@ import posthog from 'posthog-js'
 // Read and written through the Proxy as real Storage members rather than as keys
 const STORAGE_MEMBERS = new Set(['length', 'clear', 'getItem', 'key', 'removeItem', 'setItem'])
 
-let failureReported = false
-
-// Once per session is enough to tell whether storage is failing in the wild.
-// Without it, degrading silently would also hide the problem from us
-function reportFailureOnce(error: unknown): void {
-    if (failureReported) {
-        return
-    }
-    failureReported = true
-    try {
-        posthog.capture('kea_localstorage_unavailable', { error: String(error) })
-    } catch {
-        // Telemetry must never be the thing that breaks a render
-    }
-}
-
-function createMemoryStorage(): Storage {
-    const values = new Map<string, string>()
-    return {
-        get length(): number {
-            return values.size
-        },
-        clear: (): void => values.clear(),
-        getItem: (key: string): string | null => values.get(key) ?? null,
-        key: (index: number): string | null => Array.from(values.keys())[index] ?? null,
-        removeItem: (key: string): void => void values.delete(key),
-        setItem: (key: string, value: string): void => void values.set(key, String(value)),
+// One report per engine is enough to tell whether storage is failing in the wild.
+// Per engine rather than per module, because the app and the toolbar each build
+// one and a module global would let the first silence the second for the session
+function createFailureReporter(): (error: unknown) => void {
+    let reported = false
+    return (error: unknown): void => {
+        if (reported) {
+            return
+        }
+        reported = true
+        try {
+            posthog.capture('kea_localstorage_unavailable', { error: String(error) })
+        } catch {
+            // Telemetry must never be the thing that breaks a render
+        }
     }
 }
 
 // Arrow functions close over `backing`, so the returned members stay callable
 // without rebinding, and no native call escapes a try/catch
-function createStorageFacade(backing: Storage): Storage {
+function createStorageFacade(backing: Storage | undefined, startupError: unknown): Storage {
+    const reportFailureOnce = createFailureReporter()
+    // A store at quota rejects writes while its reads keep returning the real
+    // values, so a failed write must not condemn the whole store. Failed writes
+    // land here and win on read, which keeps the session consistent while every
+    // untouched key still comes from the backing store
+    const overlay = new Map<string, string>()
+    // A store blocked before the engine was built has no failing call to report,
+    // because the overlay never throws. Report on first use, which also runs
+    // after posthog-js initializes
+    const reportUnavailable = (): void => reportFailureOnce(startupError)
+
     return {
         get length(): number {
             try {
-                return backing.length
+                return backing?.length ?? overlay.size
             } catch (error) {
                 reportFailureOnce(error)
-                return 0
+                return overlay.size
             }
         },
         clear: (): void => {
+            overlay.clear()
             try {
-                backing.clear()
+                backing?.clear()
             } catch (error) {
                 reportFailureOnce(error)
             }
         },
         getItem: (key: string): string | null => {
+            if (overlay.has(key)) {
+                return overlay.get(key) ?? null
+            }
+            if (!backing) {
+                reportUnavailable()
+                return null
+            }
             try {
                 return backing.getItem(key)
             } catch (error) {
@@ -71,73 +78,64 @@ function createStorageFacade(backing: Storage): Storage {
         },
         key: (index: number): string | null => {
             try {
-                return backing.key(index)
+                return backing?.key(index) ?? null
             } catch (error) {
                 reportFailureOnce(error)
                 return null
             }
         },
         removeItem: (key: string): void => {
+            overlay.delete(key)
             try {
-                backing.removeItem(key)
+                backing?.removeItem(key)
             } catch (error) {
                 reportFailureOnce(error)
             }
         },
         setItem: (key: string, value: string): void => {
+            const stored = String(value)
+            if (!backing) {
+                reportUnavailable()
+                overlay.set(key, stored)
+                return
+            }
             try {
-                backing.setItem(key, String(value))
+                backing.setItem(key, stored)
+                // The backing store holds the value now, so the overlay must stop
+                // shadowing it
+                overlay.delete(key)
             } catch (error) {
                 reportFailureOnce(error)
-                // A full or unavailable store means the value is not remembered.
-                // Losing persistence is the intended trade against losing the scene
+                // The value survives this session even though it never reaches disk
+                overlay.set(key, stored)
             }
         },
     }
 }
 
 export function createSafeStorageEngine(backing: Storage | undefined, startupError?: unknown): Storage {
-    const facade = createStorageFacade(backing ?? createMemoryStorage())
-    // A store blocked at startup fails the probe and drops to the memory fallback, which never
-    // throws, so no facade catch can report it. resolveLocalStorage() also runs at module load,
-    // before posthog-js is initialized, so a capture there would be lost. Report on the first
-    // real key access instead - that runs during a logic mount, after posthog-js is up.
-    let startupPending = startupError !== undefined
-    const reportStartupFailureOnce = (): void => {
-        if (startupPending) {
-            startupPending = false
-            reportFailureOnce(startupError)
-        }
-    }
+    const facade = createStorageFacade(backing, startupError)
     return new Proxy(facade, {
-        get: (target, prop) => {
-            if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
-                reportStartupFailureOnce()
-                // Native property access yields undefined for a missing key while
-                // getItem yields null, and kea-localstorage branches on
-                // `typeof engine[path] !== 'undefined'`. Returning null here would
-                // load null over every persisted reducer's coded default
-                return target.getItem(prop) ?? undefined
-            }
-            return Reflect.get(target, prop)
-        },
+        get: (target, prop) =>
+            typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)
+                ? // Native property access yields undefined for a missing key while
+                  // getItem yields null, and kea-localstorage branches on
+                  // `typeof engine[path] !== 'undefined'`. Returning null here would
+                  // load null over every persisted reducer's coded default
+                  (target.getItem(prop) ?? undefined)
+                : Reflect.get(target, prop),
         set: (target, prop, value) => {
             if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
-                reportStartupFailureOnce()
                 target.setItem(prop, String(value))
             }
             return true
         },
-        has: (target, prop) => {
-            if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
-                reportStartupFailureOnce()
-                return target.getItem(prop) !== null
-            }
-            return Reflect.has(target, prop)
-        },
+        has: (target, prop) =>
+            typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)
+                ? target.getItem(prop) !== null
+                : Reflect.has(target, prop),
         deleteProperty: (target, prop) => {
             if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
-                reportStartupFailureOnce()
                 target.removeItem(prop)
             }
             return true
@@ -145,16 +143,19 @@ export function createSafeStorageEngine(backing: Storage | undefined, startupErr
     })
 }
 
-function resolveLocalStorage(): { storage: Storage | undefined; error?: unknown } {
+export function resolveLocalStorage(): { storage: Storage | undefined; error?: unknown } {
     try {
-        const probe = '__safe_storage_probe__'
-        window.localStorage.setItem(probe, probe)
-        window.localStorage.removeItem(probe)
-        return { storage: window.localStorage }
+        const storage = window.localStorage
+        // Reading proves the object is usable. A write probe would reject a store
+        // sitting at quota, whose reads still return every saved value, and each
+        // persisted reducer would then load its default over readable state
+        void storage.length
+        return { storage }
     } catch (error) {
-        // Blocked outright, so fall back to memory and keep persistence working for the rest of
-        // the session. Keep the error so the first key access reports it - a full store, blocked
-        // site data, and Safari private mode all fail here, and those are the common causes
+        // Blocked outright, so every access falls back to the overlay and
+        // persistence still works for the rest of the session. Keep the error so
+        // the first key access reports it - a full store, blocked site data, and
+        // Safari private mode all fail here, and those are the common causes
         return { storage: undefined, error }
     }
 }

--- a/frontend/src/lib/utils/safeStorageEngine.ts
+++ b/frontend/src/lib/utils/safeStorageEngine.ts
@@ -1,0 +1,142 @@
+import posthog from 'posthog-js'
+
+// kea-localstorage reads and writes its engine with bare property access
+// (`engine[path]`), so guarding it needs a Proxy rather than a wrapper object. It
+// does that work while a logic mounts, which is during render, so a throw there
+// propagates into React and the scene error boundary replaces the whole page.
+// Firefox raises a bare NS_ERROR_FAILURE when its storage backend is unavailable,
+// so there is no error subtype to match on. Every access degrades instead.
+// Scoped to how kea-localstorage reads the engine: enumeration is not proxied, so
+// `Object.keys` returns the Storage members rather than the stored keys.
+
+// Read and written through the Proxy as real Storage members rather than as keys
+const STORAGE_MEMBERS = new Set(['length', 'clear', 'getItem', 'key', 'removeItem', 'setItem'])
+
+let failureReported = false
+
+// Once per session is enough to tell whether storage is failing in the wild.
+// Without it, degrading silently would also hide the problem from us
+function reportFailureOnce(error: unknown): void {
+    if (failureReported) {
+        return
+    }
+    failureReported = true
+    try {
+        posthog.capture('kea_localstorage_unavailable', { error: String(error) })
+    } catch {
+        // Telemetry must never be the thing that breaks a render
+    }
+}
+
+function createMemoryStorage(): Storage {
+    const values = new Map<string, string>()
+    return {
+        get length(): number {
+            return values.size
+        },
+        clear: (): void => values.clear(),
+        getItem: (key: string): string | null => values.get(key) ?? null,
+        key: (index: number): string | null => Array.from(values.keys())[index] ?? null,
+        removeItem: (key: string): void => void values.delete(key),
+        setItem: (key: string, value: string): void => void values.set(key, String(value)),
+    }
+}
+
+// Arrow functions close over `backing`, so the returned members stay callable
+// without rebinding, and no native call escapes a try/catch
+function createStorageFacade(backing: Storage): Storage {
+    return {
+        get length(): number {
+            try {
+                return backing.length
+            } catch (error) {
+                reportFailureOnce(error)
+                return 0
+            }
+        },
+        clear: (): void => {
+            try {
+                backing.clear()
+            } catch (error) {
+                reportFailureOnce(error)
+            }
+        },
+        getItem: (key: string): string | null => {
+            try {
+                return backing.getItem(key)
+            } catch (error) {
+                reportFailureOnce(error)
+                return null
+            }
+        },
+        key: (index: number): string | null => {
+            try {
+                return backing.key(index)
+            } catch (error) {
+                reportFailureOnce(error)
+                return null
+            }
+        },
+        removeItem: (key: string): void => {
+            try {
+                backing.removeItem(key)
+            } catch (error) {
+                reportFailureOnce(error)
+            }
+        },
+        setItem: (key: string, value: string): void => {
+            try {
+                backing.setItem(key, String(value))
+            } catch (error) {
+                reportFailureOnce(error)
+                // A full or unavailable store means the value is not remembered.
+                // Losing persistence is the intended trade against losing the scene
+            }
+        },
+    }
+}
+
+export function createSafeStorageEngine(backing: Storage | undefined): Storage {
+    const facade = createStorageFacade(backing ?? createMemoryStorage())
+    return new Proxy(facade, {
+        get: (target, prop) =>
+            typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)
+                ? // Native property access yields undefined for a missing key while
+                  // getItem yields null, and kea-localstorage branches on
+                  // `typeof engine[path] !== 'undefined'`. Returning null here would
+                  // load null over every persisted reducer's coded default
+                  (target.getItem(prop) ?? undefined)
+                : Reflect.get(target, prop),
+        set: (target, prop, value) => {
+            if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
+                target.setItem(prop, String(value))
+            }
+            return true
+        },
+        has: (target, prop) =>
+            typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)
+                ? target.getItem(prop) !== null
+                : Reflect.has(target, prop),
+        deleteProperty: (target, prop) => {
+            if (typeof prop === 'string' && !STORAGE_MEMBERS.has(prop)) {
+                target.removeItem(prop)
+            }
+            return true
+        },
+    })
+}
+
+function resolveLocalStorage(): Storage | undefined {
+    try {
+        const probe = '__safe_storage_probe__'
+        window.localStorage.setItem(probe, probe)
+        window.localStorage.removeItem(probe)
+        return window.localStorage
+    } catch {
+        // Blocked outright, so fall back to memory and keep persistence
+        // working for the rest of the session
+        return undefined
+    }
+}
+
+export const safeStorageEngine = createSafeStorageEngine(resolveLocalStorage())

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -1640,6 +1640,9 @@ describe('sessionRecordingsPlaylistLogic', () => {
 
     describe('getDefaultFilters', () => {
         beforeEach(() => {
+            // clearMocks resets calls but keeps implementations, so a spy set in
+            // one case would otherwise leak into the next
+            jest.restoreAllMocks()
             localStorage.clear()
         })
 
@@ -1658,6 +1661,18 @@ describe('sessionRecordingsPlaylistLogic', () => {
             localStorage.setItem('default_filter_test_accounts', 'false')
             const result = getDefaultFilters()
             expect(result.filter_test_accounts).toBe(false)
+        })
+
+        it('still returns defaults when reading localStorage throws', () => {
+            // Firefox raises a bare NS_ERROR_FAILURE when its storage backend is
+            // unavailable. This read runs while the recordings playlist mounts,
+            // so a throw here reached React and blanked the whole scene
+            jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+                throw new Error('NS_ERROR_FAILURE')
+            })
+
+            expect(() => getDefaultFilters()).not.toThrow()
+            expect(getDefaultFilters().filter_test_accounts).toBe(false)
         })
 
         it('returns date_from as -30d for person recordings', () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -174,8 +174,12 @@ export const MAX_SELECTED_RECORDINGS = 20
 export const DELETE_CONFIRMATION_TEXT = 'delete'
 
 const getDefaultFilterTestAccounts = (): boolean => {
-    const stored = localStorage.getItem('default_filter_test_accounts')
-    return stored === 'true'
+    try {
+        return localStorage.getItem('default_filter_test_accounts') === 'true'
+    } catch {
+        // Runs while the logic mounts, so a throw here would blank the scene
+        return false
+    }
 }
 
 // The sort the user explicitly picked in the list settings. It wins over the relevance

--- a/frontend/src/toolbar/index.tsx
+++ b/frontend/src/toolbar/index.tsx
@@ -12,6 +12,8 @@ import { windowValuesPlugin } from 'kea-window-values'
 import type { PostHog } from 'posthog-js'
 import { createRoot } from 'react-dom/client'
 
+import { safeStorageEngine } from 'lib/utils/safeStorageEngine'
+
 import { disposablesPlugin } from '~/kea-disposables'
 import { ToolbarApp } from '~/toolbar/ToolbarApp'
 import { canonicalizeApiHost } from '~/toolbar/toolbarConfigLogic'
@@ -33,7 +35,7 @@ const initKeaInToolbar = ({ routerHistory, routerLocation, beforePlugins }: Init
     const plugins = [
         ...(beforePlugins || []),
         disposablesPlugin,
-        localStoragePlugin(),
+        localStoragePlugin({ storageEngine: safeStorageEngine }),
         windowValuesPlugin({ window: window }),
         routerPlugin({
             history: routerHistory,


### PR DESCRIPTION
## Problem

Clicking the recordings tab on a person page replaced the whole page with "An error has occurred" for a user on Firefox.

- The scene error boundary caught a bare `NS_ERROR_FAILURE` that carried no message and no app frames.
- `kea-localstorage` reads and writes its storage engine with bare property access and no error handling.
- It does that work while a logic mounts, so during render, and the throw reached React.
- Firefox raises `NS_ERROR_FAILURE` when its storage backend is unavailable, so no error subtype identifies it.
- 227 persisted reducers use this path, so almost any scene can blank the same way.
- The toolbar builds its own kea context and mounts no error boundary, so the same failure costs the whole toolbar.

The [error tracking issue](https://us.posthog.com/project/2/error_tracking/01a04915-70c8-7af1-9fe4-2ea4e53f3989) holds 4 events from one user in one session, so it is rare today. The blast radius is the reason to fix it.

The reported frame looked unresolvable because the thrower is a vendor frame, and error tracking hides those behind its "app frames only" default.

## Changes

- A storage failure now costs a user their saved filters instead of the whole page.
- A store sitting at quota keeps serving every value it already holds. Its reads still work, so the engine acquires it with a read rather than a write probe.
- A write the store rejects still holds for the session. It lands in an overlay that wins on read, while untouched keys keep coming from disk.
- Both kea contexts get the engine, so the toolbar survives the same failure.
- The engine reports `kea_localstorage_unavailable` once per engine, on first use. That lands after posthog-js initializes, where a report at module load would be dropped.
- A missing key reads as `undefined`, not `null`, because `kea-localstorage` branches on `typeof engine[path] !== 'undefined'`.
- One read on the recordings mount path bypasses the engine and calls `localStorage` directly, so it gets its own guard.
- The defect is upstream, but the plugin accepts a `storageEngine`, so this needs no package patch.
- Nothing looks different while storage works, so there is no screenshot.

> [!NOTE]
> Known gap, left out on purpose. A person page mints three permanent `localStorage` keys per person visited, written on mount even with no interaction, and nothing removes them. That growth is the likely reason this user's storage failed. It stops being user-visible once a failure is survivable, so an eviction pass can wait for evidence that it recurs.

## How did you test this code?

Automated, all run locally:

- `safeStorageEngine.test.ts`, 6 cases. A backing store whose every member throws must not propagate. A store that only rejects writes must survive acquisition and keep serving saved values. An absent store must still round-trip. A missing key must read as `undefined`. A startup failure must report once, on first use.
- `keeps a store that only rejects writes` fails against the write probe it replaced, so it locks the regression rather than restating the fix.
- One case in `sessionRecordingsPlaylistLogic.test.ts` for the direct read. Reverting that guard makes it fail with `NS_ERROR_FAILURE`.
- The engine is also covered by the existing "resets a malformed persisted filters value to defaults on mount", which writes through the engine, finds the key in `localStorage`, then rehydrates from it.

Not checked:

- No manual Firefox run against a real filled or broken storage backend. The tests throw from a stub, so they prove the guard runs, not that it matches Firefox.
- No jsdom test can cover the unguarded `kea-localstorage` path end to end, because jsdom does not route `localStorage[key]` through `Storage.prototype`.
- No toolbar mount test. The toolbar change is the same one line as the app's, and the point above blocks a mount test there too.

<details>
<summary>Pre-existing flaky suite seen while checking blast radius</summary>

Three full frontend runs each failed a different suite on a 5s to 20s test timeout under 14-worker parallelism, including one run on the parent commit without this change. Each failing suite passes alone. Unrelated to this PR.

| Run | Code | Failed suite |
| --- | --- | --- |
| 1 | with fix | 3 suites |
| 2 | with fix | `RecordingsUniversalFilterAddFilterPopover` |
| 3 | parent, no fix | `TaxonomicPopover` |

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior is documented for this path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code in PostHog Desktop. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Resolving the unfiltered stack from error tracking named `kea-localstorage` as the thrower, which redirected the work away from the session replay code the report pointed at.

PostHog Review raised three findings. Its own fix flow landed the toolbar context and the startup report. The remaining one, a readable store discarded on a failed write probe, is fixed in b48afea00f7 on top of those two commits rather than in place of them.

Scope narrowed during the session. An earlier plan added LRU eviction for the per-person keys. That came out once non-fatal failures made the growth invisible to users, and it is recorded as a known gap above.

One test was written and then removed. It mounted the playlist logic against a spied `Storage.prototype` and still passed with the fix reverted, so it proved nothing.

The investigation read production error tracking data, including a customer project id and person identifiers. None of that reaches this diff, the tests, the comments, or this description. The committed test data is invented.
