### PR TITLE
chore(codeowners): hand tools/owners to team-devex

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,8 @@ posthog/hogql/database/test/__snapshots__/test_database.ambr
 # shadow stdlib/pyyaml for the privileged process — top-level modules (yaml.py),
 # shadow packages (yaml/__init__.py), and extension modules (yaml.so, *.pyd)
 # alike — so the whole directory is gated rather than enumerating suffixes.
-tools/owners/** @PostHog/team-security
+# DevEx maintains the resolver and reviews it with that risk in mind.
+tools/owners/** @PostHog/team-devex
 
 # And of course modifying this file can bring us problems so let's have the security team own it.
 # This does not affect the distributed owners.yaml files, which drive non-required reviewer


### PR DESCRIPTION
## Problem

- Changes under `tools/owners/` wait on a security approval, while DevEx wrote and maintains the resolver.
- A security reviewer proposed the handover on [add per-team test file census](https://github.com/PostHog/posthog/pull/92559#discussion_r3906427391).

## Changes

- `tools/owners/**` now requires a DevEx approval instead of a security one.
- The comment above the entry keeps the reason the directory is gated: it is the privileged sys.path root on `pull_request_target`.
- CODEOWNERS itself stays security-owned, so this PR still needs their approval.
- Nothing user-facing changes.

## How did you test this code?

- Not run: nothing to execute. Verified `PostHog/team-devex` exists via the GitHub API.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, acting on the linked review comment. Skills invoked: `/writing-pr-descriptions`.

https://claude.ai/code/session_0116YF8Si2qHvec3TS1zmAub
