### PR TITLE
refactor(workflows): make the trigger panel's schedule, goal and rate limit reusable

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -1,6 +1,6 @@
 import { Node } from '@xyflow/react'
 import { useActions, useValues } from 'kea'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import {
     IconBolt,
@@ -58,6 +58,8 @@ import { HogFlowEventFilters, WORKFLOW_OPERATOR_ALLOWLIST } from '../filters/Hog
 import { TriggerFrequencyOption, getRegisteredTriggerTypes } from '../registry/triggers/triggerTypeRegistry'
 import { HogFlowAction } from '../types'
 import { batchTriggerLogic, getAudienceDedupeKey, hogFlowSendsEmail } from './batchTriggerLogic'
+import { ConversionGoalEditor } from './components/ConversionGoalEditor'
+import { EmailSendingRateLimitPicker } from './components/EmailSendingRateLimitPicker'
 import { HogFlowFunctionConfiguration } from './components/HogFlowFunctionConfiguration'
 import { RecurringSchedulePicker } from './components/RecurringSchedulePicker'
 import { ScheduleStatusBadge } from './components/ScheduleStatusBadge'
@@ -372,7 +374,7 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
                         users, use a batch trigger instead.
                     </p>
                     <LemonField.Pure error={validationResult?.errors?.schedule}>
-                        <RecurringSchedulePicker />
+                        <WorkflowRecurringSchedulePicker />
                     </LemonField.Pure>
                 </div>
             ) : node.data.config.type === 'batch' ? (
@@ -515,6 +517,25 @@ function StepTriggerConfigurationManual(): JSX.Element {
     )
 }
 
+function WorkflowRecurringSchedulePicker(): JSX.Element {
+    const { scheduleState, scheduleStartsAt, scheduleTimezone, isScheduleRepeating } = useValues(workflowLogic)
+    const { setScheduleState, setScheduleStartsAtFromPicker, setScheduleTimezone, setScheduleRepeating } =
+        useActions(workflowLogic)
+
+    return (
+        <RecurringSchedulePicker
+            state={scheduleState}
+            startsAt={scheduleStartsAt}
+            timezone={scheduleTimezone}
+            repeating={isScheduleRepeating}
+            onStateChange={setScheduleState}
+            onStartsAtChange={setScheduleStartsAtFromPicker}
+            onTimezoneChange={setScheduleTimezone}
+            onRepeatingChange={setScheduleRepeating}
+        />
+    )
+}
+
 function StepTriggerAffectedUsers({ actionId, filters }: { actionId: string; filters: any }): JSX.Element | null {
     const { workflow } = useValues(workflowLogic)
     const isAccountAudience = filters?.audience_type === 'accounts'
@@ -580,7 +601,7 @@ function BatchScheduleSection(): JSX.Element {
         <>
             <LemonDivider />
             <LemonLabel showOptional>Schedule</LemonLabel>
-            <RecurringSchedulePicker />
+            <WorkflowRecurringSchedulePicker />
         </>
     )
 }
@@ -927,8 +948,6 @@ function ConversionGoalSection(): JSX.Element {
     const { setWorkflowValue } = useActions(workflowLogic)
     const { workflow } = useValues(workflowLogic)
 
-    const conversionEventFilters = workflow.conversion?.events?.[0]?.filters ?? {}
-
     return (
         <div className="flex flex-col py-2 w-full">
             <span className="flex gap-1 items-center">
@@ -943,41 +962,11 @@ function ConversionGoalSection(): JSX.Element {
                 considered converted.
             </p>
 
-            <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-1 items-start">
-                    <LemonLabel>Detect conversion from property changes</LemonLabel>
-                    <PropertyFilters
-                        buttonText="Add property conversion"
-                        buttonClassName="grow-0"
-                        propertyFilters={workflow.conversion?.filters ?? []}
-                        taxonomicGroupTypes={[
-                            TaxonomicFilterGroupType.PersonProperties,
-                            TaxonomicFilterGroupType.HogQLExpression,
-                        ]}
-                        onChange={(filters) => setWorkflowValue('conversion', { ...workflow.conversion, filters })}
-                        pageKey="workflow-conversion-properties"
-                        hideBehavioralCohorts
-                        operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
-                        logicalRowDivider
-                    />
-                </div>
-
-                <div className="flex flex-col gap-1 items-start w-full">
-                    <LemonLabel>Detect conversion from events</LemonLabel>
-                    <HogFlowEventFilters
-                        filtersKey="workflow-conversion-events"
-                        filters={conversionEventFilters}
-                        setFilters={(newFilters) =>
-                            setWorkflowValue('conversion', {
-                                ...workflow.conversion,
-                                events: newFilters ? [{ filters: newFilters }] : undefined,
-                            })
-                        }
-                        typeKey="workflow-conversion-event"
-                        buttonCopy="Add event"
-                    />
-                </div>
-            </div>
+            <ConversionGoalEditor
+                conversion={workflow.conversion}
+                onChange={(conversion) => setWorkflowValue('conversion', conversion)}
+                pageKey="workflow-conversion"
+            />
         </div>
     )
 }
@@ -987,12 +976,6 @@ function SendingRateLimitSection(): JSX.Element | null {
     const { workflow } = useValues(workflowLogic)
 
     const rateLimit = workflow.email_sending_rate_limit ?? null
-    // Mirror the count locally so clearing the field doesn't snap back to the committed value
-    // mid-edit; reconcile when the stored value changes externally (toggle, another editor).
-    const [displayCount, setDisplayCount] = useState<number | undefined>(rateLimit?.count)
-    useEffect(() => {
-        setDisplayCount(rateLimit?.count)
-    }, [rateLimit?.count])
 
     const hasEmailAction = workflow.actions.some((action) => action.type === 'function_email')
     // Stay visible while a limit is set even without an email step, so it can still be removed.
@@ -1003,72 +986,10 @@ function SendingRateLimitSection(): JSX.Element | null {
     return (
         <>
             <LemonDivider />
-            <div className="flex flex-col w-full py-2 gap-2">
-                <span className="flex gap-1 items-center">
-                    <IconClock className="text-lg" />
-                    <span className="text-md font-semibold">Email sending rate limit (optional)</span>
-                    <Tooltip title="Sending a large volume too quickly can hurt deliverability. Emails over the limit are delayed until capacity frees up, not dropped.">
-                        <IconInfo className="text-secondary" />
-                    </Tooltip>
-                </span>
-                <p className="mb-0">Spread this workflow's emails out over time instead of sending all at once.</p>
-                <LemonCheckbox
-                    checked={!!rateLimit}
-                    onChange={(checked) =>
-                        setWorkflowValue('email_sending_rate_limit', checked ? { count: 100, period: 'minute' } : null)
-                    }
-                    label="Limit sending rate"
-                    data-attr="workflow-email-rate-limit-toggle"
-                />
-                {rateLimit ? (
-                    <div className="flex items-center gap-2">
-                        <span>Send at most</span>
-                        <LemonInput
-                            type="number"
-                            size="small"
-                            className="w-24"
-                            min={1}
-                            // Mirror the API's accepted range (min_value=1, max_value=1_000_000) so an
-                            // out-of-range entry is clamped here instead of failing the workflow save.
-                            max={1_000_000}
-                            aria-label="Maximum emails per period"
-                            value={displayCount ?? NaN}
-                            onChange={(count) => {
-                                if (count == null || !Number.isFinite(count)) {
-                                    setDisplayCount(undefined)
-                                    return
-                                }
-                                const next = Math.min(1_000_000, Math.max(1, Math.floor(count)))
-                                setDisplayCount(next)
-                                setWorkflowValue('email_sending_rate_limit', { ...rateLimit, count: next })
-                            }}
-                            onBlur={() =>
-                                displayCount === undefined
-                                    ? setDisplayCount(rateLimit.count)
-                                    : setWorkflowValue('email_sending_rate_limit', {
-                                          ...rateLimit,
-                                          count: displayCount,
-                                      })
-                            }
-                            data-attr="workflow-email-rate-limit-count"
-                        />
-                        <span>emails per</span>
-                        <LemonSelect
-                            size="small"
-                            aria-label="Rate limit period"
-                            value={rateLimit.period}
-                            options={[
-                                { value: 'minute' as const, label: 'minute' },
-                                { value: 'hour' as const, label: 'hour' },
-                            ]}
-                            onChange={(period) =>
-                                setWorkflowValue('email_sending_rate_limit', { ...rateLimit, period })
-                            }
-                            data-attr="workflow-email-rate-limit-period"
-                        />
-                    </div>
-                ) : null}
-            </div>
+            <EmailSendingRateLimitPicker
+                value={rateLimit}
+                onChange={(value) => setWorkflowValue('email_sending_rate_limit', value)}
+            />
         </>
     )
 }

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/ConversionGoalEditor.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/ConversionGoalEditor.tsx
@@ -1,0 +1,66 @@
+import { LemonLabel } from '@posthog/lemon-ui'
+
+import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+import { HogFlowEventFilters, WORKFLOW_OPERATOR_ALLOWLIST } from '../../filters/HogFlowFilters'
+
+// Structural shape of a workflow conversion goal, compatible with both the frontend HogFlow
+// type and the generated HogFlowConversionApi type.
+export interface ConversionGoalValue {
+    window_minutes?: number | null
+    filters?: any
+    events?: { filters?: any; name?: string }[]
+    bytecode?: unknown
+}
+
+export interface ConversionGoalEditorProps {
+    conversion: ConversionGoalValue | null | undefined
+    onChange: (conversion: ConversionGoalValue) => void
+    /** Unique key for the filter pickers, so multiple editors on one page don't share state. */
+    pageKey: string
+}
+
+export function ConversionGoalEditor({ conversion, onChange, pageKey }: ConversionGoalEditorProps): JSX.Element {
+    const conversionEventFilters = conversion?.events?.[0]?.filters ?? {}
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1 items-start">
+                <LemonLabel>Detect conversion from property changes</LemonLabel>
+                <PropertyFilters
+                    buttonText="Add property conversion"
+                    buttonClassName="grow-0"
+                    propertyFilters={conversion?.filters ?? []}
+                    taxonomicGroupTypes={[
+                        TaxonomicFilterGroupType.PersonProperties,
+                        TaxonomicFilterGroupType.HogQLExpression,
+                    ]}
+                    onChange={(filters) => onChange({ window_minutes: null, ...conversion, filters })}
+                    pageKey={`${pageKey}-properties`}
+                    hideBehavioralCohorts
+                    operatorAllowlist={WORKFLOW_OPERATOR_ALLOWLIST}
+                    logicalRowDivider
+                />
+            </div>
+
+            <div className="flex flex-col gap-1 items-start w-full">
+                <LemonLabel>Detect conversion from events</LemonLabel>
+                <HogFlowEventFilters
+                    filtersKey={`${pageKey}-events`}
+                    filters={conversionEventFilters}
+                    setFilters={(newFilters) =>
+                        onChange({
+                            window_minutes: null,
+                            filters: [],
+                            ...conversion,
+                            events: newFilters ? [{ filters: newFilters }] : undefined,
+                        })
+                    }
+                    typeKey={`${pageKey}-event`}
+                    buttonCopy="Add event"
+                />
+            </div>
+        </div>
+    )
+}

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/EmailSendingRateLimitPicker.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/EmailSendingRateLimitPicker.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react'
+
+import { IconClock, IconInfo } from '@posthog/icons'
+import { LemonCheckbox, LemonInput, LemonSelect, Tooltip } from '@posthog/lemon-ui'
+
+import type { HogFlowEmailSendingRateLimitApi } from 'products/workflows/frontend/generated/api.schemas'
+
+const DEFAULT_RATE_LIMIT: HogFlowEmailSendingRateLimitApi = { count: 100, period: 'minute' }
+
+export interface EmailSendingRateLimitPickerProps {
+    value: HogFlowEmailSendingRateLimitApi | null
+    onChange: (value: HogFlowEmailSendingRateLimitApi | null) => void
+}
+
+/**
+ * Editor for a flow's email pacing, shared by the workflow trigger panel and the broadcast wizard.
+ * Callers decide when to show it, because the conditions differ: a workflow needs an email step
+ * before pacing means anything, while a broadcast always has one.
+ */
+export function EmailSendingRateLimitPicker({ value, onChange }: EmailSendingRateLimitPickerProps): JSX.Element {
+    // Mirror the count locally so clearing the field doesn't snap back to the committed value
+    // mid-edit; reconcile when the stored value changes externally (toggle, another editor).
+    const [displayCount, setDisplayCount] = useState<number | undefined>(value?.count)
+    useEffect(() => {
+        setDisplayCount(value?.count)
+    }, [value?.count])
+
+    return (
+        <div className="flex flex-col w-full py-2 gap-2">
+            <span className="flex gap-1 items-center">
+                <IconClock className="text-lg" />
+                <span className="text-md font-semibold">Email sending rate limit (optional)</span>
+                <Tooltip title="Sending a large volume too quickly can hurt deliverability. Emails over the limit are delayed until capacity frees up, not dropped.">
+                    <IconInfo className="text-secondary" />
+                </Tooltip>
+            </span>
+            <p className="mb-0">Spread the emails out over time instead of sending all at once.</p>
+            <LemonCheckbox
+                checked={!!value}
+                onChange={(checked) => onChange(checked ? DEFAULT_RATE_LIMIT : null)}
+                label="Limit sending rate"
+                data-attr="workflow-email-rate-limit-toggle"
+            />
+            {value ? (
+                <div className="flex items-center gap-2">
+                    <span>Send at most</span>
+                    <LemonInput
+                        type="number"
+                        size="small"
+                        className="w-24"
+                        min={1}
+                        // Mirror the API's accepted range (min_value=1, max_value=1_000_000) so an
+                        // out-of-range entry is clamped here instead of failing the save.
+                        max={1_000_000}
+                        aria-label="Maximum emails per period"
+                        value={displayCount ?? NaN}
+                        onChange={(count) => {
+                            if (count == null || !Number.isFinite(count)) {
+                                setDisplayCount(undefined)
+                                return
+                            }
+                            const next = Math.min(1_000_000, Math.max(1, Math.floor(count)))
+                            setDisplayCount(next)
+                            onChange({ ...value, count: next })
+                        }}
+                        onBlur={() =>
+                            displayCount === undefined
+                                ? setDisplayCount(value.count)
+                                : onChange({ ...value, count: displayCount })
+                        }
+                        data-attr="workflow-email-rate-limit-count"
+                    />
+                    <span>emails per</span>
+                    <LemonSelect
+                        size="small"
+                        aria-label="Rate limit period"
+                        value={value.period}
+                        options={[
+                            { value: 'minute' as const, label: 'minute' },
+                            { value: 'hour' as const, label: 'hour' },
+                        ]}
+                        onChange={(period) => onChange({ ...value, period })}
+                        data-attr="workflow-email-rate-limit-period"
+                    />
+                </div>
+            ) : null}
+        </div>
+    )
+}

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/RecurringSchedulePicker.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/RecurringSchedulePicker.tsx
@@ -1,4 +1,4 @@
-import { useActions, useValues } from 'kea'
+import { useValues } from 'kea'
 import { useCallback, useMemo, useState } from 'react'
 
 import { IconCalendar } from '@posthog/icons'
@@ -15,7 +15,6 @@ import { dayjs } from 'lib/dayjs'
 import { timeZoneLabel } from 'lib/utils/timezones'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 
-import { workflowLogic } from '../../../workflowLogic'
 import { OccurrencesList } from './OccurrencesList'
 import {
     buildSummary,
@@ -320,11 +319,28 @@ function NaturalLanguageScheduleInput({
     )
 }
 
-export function RecurringSchedulePicker(): JSX.Element {
-    const { scheduleState, scheduleStartsAt, scheduleTimezone, isScheduleRepeating } = useValues(workflowLogic)
-    const { setScheduleState, setScheduleStartsAtFromPicker, setScheduleTimezone, setScheduleRepeating } =
-        useActions(workflowLogic)
+export interface RecurringSchedulePickerProps {
+    state: ScheduleState
+    startsAt: string | null
+    timezone: string
+    repeating: boolean
+    onStateChange: (state: ScheduleState, source?: 'picker' | 'natural_language') => void
+    /** Receives the picker's browser-local ISO datetime (or null when cleared). */
+    onStartsAtChange: (pickerDate: string | null) => void
+    onTimezoneChange: (timezone: string, previousTimezone: string) => void
+    onRepeatingChange: (repeating: boolean) => void
+}
 
+export function RecurringSchedulePicker({
+    state: scheduleState,
+    startsAt: scheduleStartsAt,
+    timezone: scheduleTimezone,
+    repeating: isScheduleRepeating,
+    onStateChange: setScheduleState,
+    onStartsAtChange: setScheduleStartsAtFromPicker,
+    onTimezoneChange: setScheduleTimezone,
+    onRepeatingChange: setScheduleRepeating,
+}: RecurringSchedulePickerProps): JSX.Element {
     const previewOccurrences = useMemo(() => {
         if (!isScheduleRepeating || !scheduleStartsAt) {
             return []


### PR DESCRIPTION
## Problem

- Nothing changes for a person using the workflow editor. This is preparation for a second surface.
- The trigger panel builds its schedule picker, conversion goal and email rate limit inline against `workflowLogic`.
- A surface that is not the workflow editor cannot use any of the three, because each reads its state from that logic directly.
- The broadcasts wizard in #82343 needs all three. Extracting them there buried the only behavior-changing part of that PR under 2800 lines of new files.

## Changes

- `RecurringSchedulePicker` takes its state and callbacks as props instead of reading `workflowLogic`.
- `StepTrigger` keeps a small `WorkflowRecurringSchedulePicker` wrapper that supplies those props, so the editor behaves as before.
- The conversion goal editor moves to `ConversionGoalEditor`, taking `conversion` and `onChange`.
- The email rate limit control moves to `EmailSendingRateLimitPicker`, taking `value` and `onChange`.
- All of it is mechanical. No user-visible change, and `StepTrigger` drops 79 lines net.

Nothing looks different, so there are no screenshots.

## How did you test this code?

- No tests added. The diff moves code between files without changing behavior, so a new test would assert what the existing trigger panel tests already cover.
- Typecheck and lint pass locally on this branch alone.
- Not checked: the workflow editor in a browser. The three components render the same JSX against the same values, but nobody clicked through the trigger panel on this branch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code split this out of #82343 at the author's request, after a review of that PR's diff found the extractions were its riskiest part and were landing unreviewed alongside a large prototype.

Skills invoked: `/stacking-prs`, `/writing-tests` (which gated out adding tests here), `/writing-pr-descriptions`.

The extraction is taken verbatim from #82343 rather than rewritten, so the two stay identical until that PR rebases onto master.
