### PR TITLE
refactor(lib): add liquid render and resolve helpers next to parse

### DIFF
--- a/frontend/src/lib/utils/liquid.test.ts
+++ b/frontend/src/lib/utils/liquid.test.ts
@@ -1,0 +1,26 @@
+import { LiquidRenderer } from './liquid'
+
+describe('LiquidRenderer', () => {
+    const context = { person: { properties: { first_name: 'Ada', company: null } } }
+
+    it('renders a template the editor has escaped', () => {
+        // Unlayer stores `>` as `&gt;`, so a renderer that skips the decode step compares the
+        // literal entity and silently takes the wrong branch.
+        const template =
+            '{% if person.properties.first_name != &quot;&quot; %}Hi {{ person.properties.first_name }}{% endif %}'
+        expect(LiquidRenderer.render(template, context)).toBe('Hi Ada')
+    })
+
+    it.each([
+        ['person.properties.first_name', true],
+        ['person.properties.company', false],
+        ['person.properties.missing', false],
+        ['person.properties.first_name | upcase', true],
+    ])('resolves(%s) is %s', (expression, expected) => {
+        expect(LiquidRenderer.resolves(expression, context)).toBe(expected)
+    })
+
+    it('treats an unparseable expression as unresolved rather than throwing', () => {
+        expect(LiquidRenderer.resolves('person.properties[', context)).toBe(false)
+    })
+})

--- a/frontend/src/lib/utils/liquid.ts
+++ b/frontend/src/lib/utils/liquid.ts
@@ -11,23 +11,48 @@ export class LiquidRenderer {
         if (!this._liquid) {
             this._liquid = new Liquid({
                 outputEscape: 'escape',
+                // Render partials from an in-memory map only: this disables LiquidJS's filesystem-backed
+                // partial loading, so user-controlled templates can't read local files via include/render/layout.
+                templates: {},
             })
         }
         return this._liquid
     }
 
-    public static parse(template: string): Template[] {
-        // TRICKY: Unlayer replaces all liquid's elements like > for example with &gt;
-        // We need to decode these but _only_ for the liquid elements i.e. content within {{ }} or {% %}
-        const decodedTemplate = template.replace(LIQUID_REGEX, (match) => {
-            return match
-                .replace(/&lt;/g, '<')
-                .replace(/&gt;/g, '>')
-                .replace(/&quot;/g, '"')
-                .replace(/&#x27;/g, "'")
-                .replace(/&amp;/g, '&') // NOTE: This should always be last
-        })
+    private static decodeEntities(source: string): string {
+        return source
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .replace(/&quot;/g, '"')
+            .replace(/&#x27;/g, "'")
+            .replace(/&amp;/g, '&') // NOTE: This should always be last
+    }
 
-        return this.liquid.parse(decodedTemplate)
+    // TRICKY: Unlayer replaces all liquid's elements like > for example with &gt;
+    // We need to decode these but _only_ for the liquid elements i.e. content within {{ }} or {% %}
+    private static decode(template: string): string {
+        return template.replace(LIQUID_REGEX, (match) => this.decodeEntities(match))
+    }
+
+    public static parse(template: string): Template[] {
+        return this.liquid.parse(this.decode(template))
+    }
+
+    /** Render a template the way the worker does at send time. Throws on an unparseable template. */
+    public static render(template: string, context: Record<string, any>): string {
+        return this.liquid.parseAndRenderSync(this.decode(template), context)
+    }
+
+    /**
+     * Whether an expression such as `person.properties.email` has a value in this context. Takes
+     * the expression as it appears in the template, so it decodes the editor's escaping first.
+     */
+    public static resolves(expression: string, context: Record<string, any>): boolean {
+        try {
+            const value = this.liquid.evalValueSync(this.decodeEntities(expression), context)
+            return value !== undefined && value !== null
+        } catch {
+            return false
+        }
     }
 }


### PR DESCRIPTION
## Problem

- Nothing changes for a person today. This adds shared-library capability that a second surface needs.
- `LiquidRenderer` can parse an email template but not render one, so no frontend surface can show what a template produces for a given person.
- The broadcasts wizard in #82343 previews an email before it sends. That preview needs both a render and a way to tell an unfilled variable from a filled one.
- Landing this in a workflows prototype would put a `frontend/src/lib` change in front of workflows reviewers rather than the shared-library owners.

## Changes

- `LiquidRenderer.render` renders a template against a context, mirroring what the worker does at send time.
- `LiquidRenderer.resolves` reports whether an expression such as `person.properties.email` has a value, so a caller can flag a variable that would render empty.
- Both decode the editor's HTML escaping first, which `parse` already did inline. That decoding moves into a shared private helper.
- The Liquid instance now sets `templates: {}`, which pins partial loading to an in-memory map. This is defense in depth, not a live fix, since the class only runs in the browser.

> [!NOTE]
> `render` and `resolves` land with no caller in this repo. #82343 is their first consumer.

## How did you test this code?

- Added `frontend/src/lib/utils/liquid.test.ts`, six cases, no existing coverage for this class.
- The render case catches a caller skipping the decode step: Unlayer stores `>` as `&gt;`, so an undecoded template compares the literal entity and takes the wrong branch. Deleting `this.decode(...)` from `render` fails that case and only that case.
- The `resolves` cases separate a present value from `null`, from a missing key, and from a filtered expression. Without them, a broadcast could ship an unfilled `{{ person.properties.first_name }}`.
- Not checked: whether `render` agrees with the plugin-server worker's Liquid output. The two configurations match by inspection, not by a test that runs both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code split this out of #82343 at the author's request. `frontend/src/lib` has different owners than `products/workflows`, which is the reason to separate it rather than its size.

Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-pr-descriptions`.

The test was added here rather than left to #82343 because these two methods would otherwise reach master unused and uncovered.
