### PR TITLE
fix(personhog): cache missing freeze-quorum record w/ short ttl

### DIFF
--- a/rust/personhog-coordination/src/store.rs
+++ b/rust/personhog-coordination/src/store.rs
@@ -91,30 +91,12 @@ pub struct PersonhogStore {
     /// plan's handoffs share one id, so this turns a few hundred reads
     /// per reconcile pass into one.
     freeze_quorums: Arc<StdMutex<HashMap<String, Vec<String>>>>,
-    /// When each id was last read and found missing. A remembered
-    /// absence answers resolutions from memory until it expires
-    /// (`absent_freeze_quorum_ttl`) or `apply_plan` re-puts the
-    /// record, but never for good: the sweep can delete a record a
-    /// later chunk re-creates, and a pinned absence would hold every
-    /// later resolution on the every-live-router fallback.
+    /// When each id was last read and found missing.
     absent_freeze_quorums: Arc<StdMutex<HashMap<String, Instant>>>,
-    /// See [`DEFAULT_ABSENT_FREEZE_QUORUM_TTL`].
     absent_freeze_quorum_ttl: Duration,
 }
 
-/// How long a remembered absence answers without a re-read. The
-/// reconcile pass resolves every Freezing handoff each tick and a
-/// plan's handoffs share one id, so an unremembered absence costs one
-/// etcd read and one warn per Freezing handoff per pass. `apply_plan`
-/// invalidates when it re-puts a record, so the expiry only bounds how
-/// long a record written by another coordinator process goes unseen.
-/// An unseen record widens the requirement to every live router, which
-/// delays a handoff rather than advancing it early, so the expiry must
-/// stay small against the freeze phase deadline. Kept below the
-/// reconcile interval (default 5s): an expiry at or above the interval
-/// would let an absence cached in one pass carry the next whole pass,
-/// which defers the re-read to the pass after and doubles how long a
-/// re-created record goes unseen.
+/// How long a remembered absence answers without a re-read.
 const DEFAULT_ABSENT_FREEZE_QUORUM_TTL: Duration = Duration::from_secs(4);
 
 /// Counts store calls by the method that made them. The shared etcd
@@ -228,11 +210,7 @@ impl PersonhogStore {
         }
     }
 
-    /// Test hook: the expiry cannot be exercised against a mocked
-    /// clock (`Instant` is real time), so tests shrink it instead.
-    /// Production code keeps the default: the caches are shared
-    /// across clones but the expiry is per-clone, so divergent values
-    /// would judge the same entry differently.
+    /// Test hook
     #[doc(hidden)]
     pub fn with_absent_freeze_quorum_ttl(mut self, ttl: Duration) -> Self {
         self.absent_freeze_quorum_ttl = ttl;
@@ -931,12 +909,6 @@ impl PersonhogStore {
             Ok(application)
         }
         .await;
-        // On every return, errors included: an earlier chunk can have
-        // re-put the record before a later chunk failed. Ordered after
-        // the writes because a resolve that read absence before a
-        // chunk's re-put can remember it again afterwards; the entry's
-        // expiry repairs that within one window, as it repairs a task
-        // abort mid-plan, which skips this cleanup entirely.
         if let Some((id, _)) = freeze_quorum {
             self.absent_freeze_quorums
                 .lock()
@@ -1094,10 +1066,6 @@ impl PersonhogStore {
                 if let Some(members) = cached {
                     return Ok(Some(members));
                 }
-                // A fresh miss answers from memory too, so a missing
-                // record costs about one read and one warn per expiry
-                // window (racing resolves can each read once), not one
-                // per Freezing handoff per reconcile pass.
                 let recently_absent = self
                     .absent_freeze_quorums
                     .lock()
@@ -1111,8 +1079,6 @@ impl PersonhogStore {
                 let members = self.get_freeze_quorum(id).await?;
                 match &members {
                     Some(recorded) => {
-                        // The record is back, so a remembered absence
-                        // is stale.
                         self.absent_freeze_quorums
                             .lock()
                             .expect("freeze quorum absence cache lock poisoned")
@@ -1143,12 +1109,6 @@ impl PersonhogStore {
                             .absent_freeze_quorums
                             .lock()
                             .expect("freeze quorum absence cache lock poisoned");
-                        // Bounded like the membership cache. Refreshing
-                        // a present id does not grow the map, so it
-                        // evicts nothing; a growing insert evicts the
-                        // stalest entry, which the recorded instant
-                        // names directly. An evicted absence only
-                        // costs the next resolution a re-read.
                         if absent.len() >= 32 && !absent.contains_key(id) {
                             if let Some(stalest) = absent
                                 .iter()

--- a/rust/personhog-coordination/src/store.rs
+++ b/rust/personhog-coordination/src/store.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::str::from_utf8;
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 
 use assignment_coordination::store::EtcdStore;
 use etcd_client::{Compare, CompareOp, DeleteOptions, PutOptions, Txn, TxnOp, WatchStream};
@@ -88,10 +89,33 @@ pub struct PersonhogStore {
     /// names one immutable value (a chunked plan re-puts it only
     /// byte-identically), so a recorded membership cannot go stale; a
     /// plan's handoffs share one id, so this turns a few hundred reads
-    /// per reconcile pass into one. Absence is never cached — the
-    /// sweep can delete a record a later chunk re-creates.
+    /// per reconcile pass into one.
     freeze_quorums: Arc<StdMutex<HashMap<String, Vec<String>>>>,
+    /// When each id was last read and found missing. A remembered
+    /// absence answers resolutions from memory until it expires
+    /// (`absent_freeze_quorum_ttl`) or `apply_plan` re-puts the
+    /// record, but never for good: the sweep can delete a record a
+    /// later chunk re-creates, and a pinned absence would hold every
+    /// later resolution on the every-live-router fallback.
+    absent_freeze_quorums: Arc<StdMutex<HashMap<String, Instant>>>,
+    /// See [`DEFAULT_ABSENT_FREEZE_QUORUM_TTL`].
+    absent_freeze_quorum_ttl: Duration,
 }
+
+/// How long a remembered absence answers without a re-read. The
+/// reconcile pass resolves every Freezing handoff each tick and a
+/// plan's handoffs share one id, so an unremembered absence costs one
+/// etcd read and one warn per Freezing handoff per pass. `apply_plan`
+/// invalidates when it re-puts a record, so the expiry only bounds how
+/// long a record written by another coordinator process goes unseen.
+/// An unseen record widens the requirement to every live router, which
+/// delays a handoff rather than advancing it early, so the expiry must
+/// stay small against the freeze phase deadline. Kept below the
+/// reconcile interval (default 5s): an expiry at or above the interval
+/// would let an absence cached in one pass carry the next whole pass,
+/// which defers the re-read to the pass after and doubles how long a
+/// re-created record goes unseen.
+const DEFAULT_ABSENT_FREEZE_QUORUM_TTL: Duration = Duration::from_secs(4);
 
 /// Counts store calls by the method that made them. The shared etcd
 /// layer labels by primitive — `get`, `list_with_revision` — which is
@@ -199,7 +223,20 @@ impl PersonhogStore {
         Self {
             inner,
             freeze_quorums: Arc::new(StdMutex::new(HashMap::new())),
+            absent_freeze_quorums: Arc::new(StdMutex::new(HashMap::new())),
+            absent_freeze_quorum_ttl: DEFAULT_ABSENT_FREEZE_QUORUM_TTL,
         }
+    }
+
+    /// Test hook: the expiry cannot be exercised against a mocked
+    /// clock (`Instant` is real time), so tests shrink it instead.
+    /// Production code keeps the default: the caches are shared
+    /// across clones but the expiry is per-clone, so divergent values
+    /// would judge the same entry differently.
+    #[doc(hidden)]
+    pub fn with_absent_freeze_quorum_ttl(mut self, ttl: Duration) -> Self {
+        self.absent_freeze_quorum_ttl = ttl;
+        self
     }
 
     pub fn inner(&self) -> &EtcdStore {
@@ -846,49 +883,67 @@ impl PersonhogStore {
         let ranges = plan_chunk_ranges(&costs, max_txn_ops, reserve_ops);
         metrics::histogram!("personhog_coordination_plan_chunks").record(ranges.len() as f64);
 
-        let mut application = PlanApplication::default();
-        for range in ranges {
-            let chunk = &units[range];
-            match self.apply_units(chunk, &quorum).await {
-                Ok(true) => {
-                    application
-                        .applied
-                        .extend(chunk.iter().map(|u| u.partition));
-                    continue;
-                }
-                Ok(false) => {}
-                // The server's effective --max-txn-ops can sit below the
-                // configured budget (values drift, a member not yet
-                // restarted with a raised flag). Degrade to the per-unit
-                // path — under any workable server limit — instead of
-                // handing back a rejection the planner retries forever.
-                Err(e) if chunk.len() > 1 && is_txn_too_large(&e) => {
-                    application.over_budget_chunks += 1;
-                    metrics::counter!("personhog_coordination_plan_chunk_over_server_budget_total")
+        let result = async {
+            let mut application = PlanApplication::default();
+            for range in ranges {
+                let chunk = &units[range];
+                match self.apply_units(chunk, &quorum).await {
+                    Ok(true) => {
+                        application
+                            .applied
+                            .extend(chunk.iter().map(|u| u.partition));
+                        continue;
+                    }
+                    Ok(false) => {}
+                    // The server's effective --max-txn-ops can sit below the
+                    // configured budget (values drift, a member not yet
+                    // restarted with a raised flag). Degrade to the per-unit
+                    // path — under any workable server limit — instead of
+                    // handing back a rejection the planner retries forever.
+                    Err(e) if chunk.len() > 1 && is_txn_too_large(&e) => {
+                        application.over_budget_chunks += 1;
+                        metrics::counter!(
+                            "personhog_coordination_plan_chunk_over_server_budget_total"
+                        )
                         .increment(1);
-                    tracing::warn!(
-                        units = chunk.len(),
-                        max_txn_ops,
-                        error = %e,
-                        "plan chunk exceeds the server txn budget; applying per unit"
-                    );
+                        tracing::warn!(
+                            units = chunk.len(),
+                            max_txn_ops,
+                            error = %e,
+                            "plan chunk exceeds the server txn budget; applying per unit"
+                        );
+                    }
+                    Err(e) => return Err(e),
                 }
-                Err(e) => return Err(e),
-            }
-            // A failed guard names no key, so retry the chunk one
-            // partition at a time: the concurrent write that broke the
-            // chunk stands down only the units it actually touched.
-            for u in chunk {
-                if self.apply_units(std::slice::from_ref(u), &quorum).await? {
-                    application.applied.push(u.partition);
-                } else {
-                    metrics::counter!("personhog_coordination_plan_units_conflicted_total")
-                        .increment(1);
-                    application.conflicted.push(u.partition);
+                // A failed guard names no key, so retry the chunk one
+                // partition at a time: the concurrent write that broke the
+                // chunk stands down only the units it actually touched.
+                for u in chunk {
+                    if self.apply_units(std::slice::from_ref(u), &quorum).await? {
+                        application.applied.push(u.partition);
+                    } else {
+                        metrics::counter!("personhog_coordination_plan_units_conflicted_total")
+                            .increment(1);
+                        application.conflicted.push(u.partition);
+                    }
                 }
             }
+            Ok(application)
         }
-        Ok(application)
+        .await;
+        // On every return, errors included: an earlier chunk can have
+        // re-put the record before a later chunk failed. Ordered after
+        // the writes because a resolve that read absence before a
+        // chunk's re-put can remember it again afterwards; the entry's
+        // expiry repairs that within one window, as it repairs a task
+        // abort mid-plan, which skips this cleanup entirely.
+        if let Some((id, _)) = freeze_quorum {
+            self.absent_freeze_quorums
+                .lock()
+                .expect("freeze quorum absence cache lock poisoned")
+                .remove(id);
+        }
+        result
     }
 
     /// One plan chunk as one transaction: the units' guards and ops,
@@ -1039,9 +1094,29 @@ impl PersonhogStore {
                 if let Some(members) = cached {
                     return Ok(Some(members));
                 }
+                // A fresh miss answers from memory too, so a missing
+                // record costs about one read and one warn per expiry
+                // window (racing resolves can each read once), not one
+                // per Freezing handoff per reconcile pass.
+                let recently_absent = self
+                    .absent_freeze_quorums
+                    .lock()
+                    .expect("freeze quorum absence cache lock poisoned")
+                    .get(id)
+                    .is_some_and(|at| at.elapsed() < self.absent_freeze_quorum_ttl);
+                if recently_absent {
+                    crate::util::record_unresolved_freeze_quorum();
+                    return Ok(None);
+                }
                 let members = self.get_freeze_quorum(id).await?;
                 match &members {
                     Some(recorded) => {
+                        // The record is back, so a remembered absence
+                        // is stale.
+                        self.absent_freeze_quorums
+                            .lock()
+                            .expect("freeze quorum absence cache lock poisoned")
+                            .remove(id);
                         let mut cache = self
                             .freeze_quorums
                             .lock()
@@ -1057,10 +1132,6 @@ impl PersonhogStore {
                         }
                         cache.insert(id.clone(), recorded.clone());
                     }
-                    // Never cached: a chunked plan's re-puts can
-                    // re-create a swept record, so absence is not
-                    // permanent — and pinning it would hold every later
-                    // resolution on the every-live-router fallback.
                     None => {
                         crate::util::record_unresolved_freeze_quorum();
                         tracing::warn!(
@@ -1068,6 +1139,26 @@ impl PersonhogStore {
                             quorum_id = %id,
                             "freeze quorum record is missing; requiring every live router"
                         );
+                        let mut absent = self
+                            .absent_freeze_quorums
+                            .lock()
+                            .expect("freeze quorum absence cache lock poisoned");
+                        // Bounded like the membership cache. Refreshing
+                        // a present id does not grow the map, so it
+                        // evicts nothing; a growing insert evicts the
+                        // stalest entry, which the recorded instant
+                        // names directly. An evicted absence only
+                        // costs the next resolution a re-read.
+                        if absent.len() >= 32 && !absent.contains_key(id) {
+                            if let Some(stalest) = absent
+                                .iter()
+                                .min_by_key(|(_, at)| **at)
+                                .map(|(k, _)| k.clone())
+                            {
+                                absent.remove(&stalest);
+                            }
+                        }
+                        absent.insert(id.clone(), Instant::now());
                     }
                 }
                 Ok(members)

--- a/rust/personhog-coordination/tests/protocol_hardening.rs
+++ b/rust/personhog-coordination/tests/protocol_hardening.rs
@@ -5852,14 +5852,22 @@ async fn a_swept_quorum_delete_loses_to_a_concurrent_re_put() {
     );
 }
 
-/// A missing membership record is not remembered as missing: a chunked
-/// plan can re-create a swept record, and a pinned absence would hold
-/// every later resolution on the every-live-router fallback.
+/// A missing membership record is remembered as missing, so the
+/// reconcile pass costs one read per expiry window instead of one per
+/// Freezing handoff, and a plan's re-put drops the remembered absence
+/// so the record it re-creates resolves on the next look. A pinned
+/// absence would hold every later resolution on the every-live-router
+/// fallback.
 #[tokio::test]
 async fn a_missing_membership_is_resolved_again_once_written() {
     use personhog_coordination::types::AssignmentPrecondition;
 
-    let store = test_store("quorum-absence-not-cached").await;
+    // A generous expiry, so a stalled runner cannot expire the
+    // remembered absence mid-test: the final assertion must exercise
+    // apply_plan's invalidation, not the expiry.
+    let store = (*test_store("quorum-absence-remembered").await)
+        .clone()
+        .with_absent_freeze_quorum_ttl(Duration::from_secs(3600));
     let quorum_id = "late-written";
     let quorum = vec!["router-0".to_string()];
     let handoff = HandoffState {
@@ -5882,6 +5890,27 @@ async fn a_missing_membership_is_resolved_again_once_written() {
         .unwrap()
         .is_none());
 
+    // A record written outside apply_plan stays behind the remembered
+    // absence until it expires: the resolution must answer from
+    // memory, without a read per Freezing handoff per pass.
+    store
+        .inner()
+        .put(
+            &format!("{}freeze_quorums/{quorum_id}", store.inner().prefix()),
+            &quorum,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        store
+            .resolve_freeze_quorum(&handoff)
+            .await
+            .unwrap()
+            .is_none(),
+        "a fresh absence must answer from memory, not from a re-read"
+    );
+
     store
         .apply_plan(
             &[],
@@ -5898,6 +5927,57 @@ async fn a_missing_membership_is_resolved_again_once_written() {
         store.resolve_freeze_quorum(&handoff).await.unwrap(),
         Some(quorum),
         "a record written after a miss must resolve on the next look"
+    );
+}
+
+/// A remembered absence expires. A record written by another
+/// coordinator process gets no local apply_plan invalidation, so the
+/// expiry is what bounds how long that record goes unseen: a stale
+/// absence delays a handoff by at most one window, and never wedges
+/// it. A zero TTL stands in for an elapsed window because the expiry
+/// runs on real time.
+#[tokio::test]
+async fn a_remembered_absence_expires() {
+    let store = test_store("quorum-absence-expires").await;
+    let store = (*store)
+        .clone()
+        .with_absent_freeze_quorum_ttl(Duration::ZERO);
+    let quorum_id = "written-elsewhere";
+    let quorum = vec!["router-0".to_string()];
+    let handoff = HandoffState {
+        partition: 0,
+        old_owner: None,
+        new_owner: "pod-new".to_string(),
+        new_owner_address: None,
+        phase: HandoffPhase::Freezing,
+        started_at: 0,
+        handoff_id: "handoff-elsewhere".to_string(),
+        freeze_quorum: None,
+        freeze_quorum_ref: Some(quorum_id.to_string()),
+        created_at_ms: 0,
+        phase_entered_at_ms: 0,
+    };
+
+    assert!(store
+        .resolve_freeze_quorum(&handoff)
+        .await
+        .unwrap()
+        .is_none());
+
+    store
+        .inner()
+        .put(
+            &format!("{}freeze_quorums/{quorum_id}", store.inner().prefix()),
+            &quorum,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.resolve_freeze_quorum(&handoff).await.unwrap(),
+        Some(quorum),
+        "an expired absence must re-read and see the record"
     );
 }
 

--- a/rust/personhog-coordination/tests/protocol_hardening.rs
+++ b/rust/personhog-coordination/tests/protocol_hardening.rs
@@ -5862,9 +5862,6 @@ async fn a_swept_quorum_delete_loses_to_a_concurrent_re_put() {
 async fn a_missing_membership_is_resolved_again_once_written() {
     use personhog_coordination::types::AssignmentPrecondition;
 
-    // A generous expiry, so a stalled runner cannot expire the
-    // remembered absence mid-test: the final assertion must exercise
-    // apply_plan's invalidation, not the expiry.
     let store = (*test_store("quorum-absence-remembered").await)
         .clone()
         .with_absent_freeze_quorum_ttl(Duration::from_secs(3600));
@@ -5890,9 +5887,6 @@ async fn a_missing_membership_is_resolved_again_once_written() {
         .unwrap()
         .is_none());
 
-    // A record written outside apply_plan stays behind the remembered
-    // absence until it expires: the resolution must answer from
-    // memory, without a read per Freezing handoff per pass.
     store
         .inner()
         .put(


### PR DESCRIPTION
## Problem

While a freeze-quorum membership record is missing, the coordinator reads etcd and logs a warning for every Freezing handoff, on every reconcile pass and every freeze-ack watch event.
A mass cancellation across a plan's partitions turns that into tens of identical reads and warn lines per second, aimed at etcd while it is already under strain.

The resolve path caches memberships it finds but never absence, because a chunked plan can re-create a record the sweep deleted, and a permanently pinned absence would hold every later resolution on the every-live-router fallback.

## Changes

Nothing user-visible changes. The operational effect is that a missing record now costs about one etcd read and one warn line per 4-second window, instead of one of each per Freezing handoff per pass.

- `resolve_freeze_quorum` remembers a record it read and found missing, and answers later resolutions from memory until the memory expires.
- The expiry (4s) sits below the default reconcile interval (5s), so each pass re-reads a missing record at most once.
- `apply_plan` drops the remembered absence whenever it re-puts the record, on every return path, so a record a plan chunk re-creates resolves on the next look.
- The expiry bounds every race the invalidation cannot see, including a record written by another coordinator process.

> [!NOTE]
> A stale remembered absence only widens the freeze requirement to every live router. That is the protocol's existing stricter fallback: it can delay a handoff by up to one 4-second window, and never advances one early.

Mechanical: `apply_plan`'s chunk loop moved into an inner async block so the invalidation also runs on its error returns.

## How did you test this code?

- Extended `a_missing_membership_is_resolved_again_once_written`: a record written behind the cache's back stays hidden (catches a removed or broken absence cache), then an `apply_plan` re-put resolves on the next look (catches a dropped invalidation).
- Added `a_remembered_absence_expires` with a zero expiry via a test hook: an expired absence re-reads and sees the record (catches a pinned absence, the wedge the old code avoided by never caching).
- Each mechanism was disabled in turn to confirm its test fails for the predicted reason, then restored.
- Full `personhog-coordination` suite ran locally against a real etcd.
- Not run: the e2e harness gates. The change touches no decision logic, phase, or ack semantics, so the stateright model is untouched.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The crate README's freeze-quorum sections describe the record lifecycle and sweep, which are unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code implemented a review suggestion on the resolve path's read amplification, combining its two proposed variants (write-path invalidation plus a bounded expiry) because each covers the other's blind spot.
Skills invoked: `/reviewing-personhog-protocol`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
Per the protocol review skill, two cold-context adversarial review passes ran on the diff; the first surfaced the error-path invalidation gap, the expiry-equals-interval coincidence, and the untested expiry, all fixed and re-reviewed as closed.
Accepted residuals, each bounded to one expiry window in the delaying direction: the below-the-interval invariant is comment-enforced against a configurable interval, and cancellation attribution can briefly read a cached absence.

https://claude.ai/code/session_01Bz3RMwiuhvFW16z7S8wBiE
