### PR TITLE
feat(data-quality): focus first check creation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3040,6 +3040,9 @@ importers:
 
   products/data_quality:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.10.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/products/data_quality/frontend/overview/DataQualityOverview.test.tsx
+++ b/products/data_quality/frontend/overview/DataQualityOverview.test.tsx
@@ -212,7 +212,7 @@ describe('DataQualityOverview', () => {
         expect(screen.getAllByText('orders').length).toBeGreaterThan(0)
     })
 
-    it('opens the subject picker from the first-use state', async () => {
+    it('shows only the creation path from the illustrated first-use state', async () => {
         ;(dataQualityChecksList as jest.Mock).mockResolvedValue({ results: [] })
         ;(dataQualityChecksHealthList as jest.Mock).mockResolvedValue([])
         render(<DataQualityOverview />)
@@ -220,6 +220,8 @@ describe('DataQualityOverview', () => {
         expect(await screen.findByText('No checks yet')).toBeTruthy()
         expect(screen.queryByText('No checks match these filters.')).toBeNull()
         expect(document.querySelector('[data-attr="data-quality-overview-new-check"]')).not.toBeNull()
+        expect(document.querySelector('[data-attr="data-quality-overview-browse"]')).toBeNull()
+        expect(document.querySelector('[data-attr="data-quality-overview-empty-state"] img')).not.toBeNull()
 
         fireEvent.click(document.querySelector('[data-attr="data-quality-overview-first-check"]')!)
 

--- a/products/data_quality/frontend/overview/DataQualityOverview.tsx
+++ b/products/data_quality/frontend/overview/DataQualityOverview.tsx
@@ -1,5 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
+import * as scientistPng from '@posthog/brand/hoggies/png/scientist'
 import { IconChevronRight, IconEllipsis } from '@posthog/icons'
 import {
     LemonBanner,
@@ -14,8 +15,8 @@ import {
     Spinner,
 } from '@posthog/lemon-ui'
 
+import { pngHoggie } from 'lib/brand/hoggies'
 import { TZLabel } from 'lib/components/TZLabel'
-import { urls } from 'scenes/urls'
 
 import { CheckEditorModal } from '../CheckEditorModal'
 import { CheckRunsTable } from '../CheckRunsTable'
@@ -25,7 +26,7 @@ import { DataQualityCheckEditorLogicProps, dataQualityCheckEditorLogic } from '.
 import type { DataQualityOverviewCheckApi } from '../generated/api.schemas'
 import { DataQualityGateToggle } from './DataQualityGateToggle'
 import {
-    BROWSE_ACTION_ID,
+    NEW_CHECK_ACTION_ID,
     OverviewStatusFilter,
     SubjectGroup,
     dataQualityOverviewLogic,
@@ -41,7 +42,7 @@ const STATUS_FILTERS: { value: OverviewStatusFilter; label: string }[] = [
     { value: 'never_run', label: 'Not run yet' },
 ]
 
-const NEW_CHECK_ACTION_ID = 'data-quality-overview-new-check'
+const HedgehogScientist = pngHoggie(scientistPng)
 
 function focusFirstAvailable(elementIds: string[]): void {
     // Runs after the removed row has left the DOM, so the first id that still resolves wins.
@@ -209,20 +210,17 @@ export function DataQualityOverview(): JSX.Element {
 
 function NoChecksYet({ onAddCheck }: { onAddCheck: () => void }): JSX.Element {
     return (
-        <div className="border rounded p-4 flex flex-col items-start gap-2">
-            <h4 className="mb-0">No checks yet</h4>
-            <p className="mb-0 text-secondary">Add a check here, or browse tables and views first.</p>
+        <div
+            data-attr="data-quality-overview-empty-state"
+            className="border rounded px-4 py-8 flex flex-col items-center text-center mx-auto"
+        >
+            <HedgehogScientist width="128" height="128" className="mb-4" />
+            <h2 className="text-xl leading-tight">No checks yet</h2>
+            <p className="mb-4 text-sm text-balance text-tertiary">
+                Create a check to spot issues in your data before they affect your analysis.
+            </p>
             <LemonButton type="primary" size="small" onClick={onAddCheck} data-attr="data-quality-overview-first-check">
                 Add your first check
-            </LemonButton>
-            <LemonButton
-                id={BROWSE_ACTION_ID}
-                type="secondary"
-                size="small"
-                to={urls.database()}
-                data-attr="data-quality-overview-browse"
-            >
-                Browse tables and views
             </LemonButton>
         </div>
     )

--- a/products/data_quality/frontend/overview/dataQualityOverviewLogic.test.ts
+++ b/products/data_quality/frontend/overview/dataQualityOverviewLogic.test.ts
@@ -20,6 +20,7 @@ import type {
 } from 'products/data_quality/frontend/generated/api.schemas'
 
 import {
+    NEW_CHECK_ACTION_ID,
     dataQualityOverviewLogic,
     focusCandidatesAfterDelete,
     rowActionsId,
@@ -531,7 +532,7 @@ describe('dataQualityOverviewLogic', () => {
 
         const candidates = focusCandidatesAfterDelete(logic.values.subjectGroups, 'view:uuid-customers', 'check-3')
 
-        expect(candidates).toEqual([subjectDisclosureId('view:uuid-orders'), 'data-quality-browse-subjects'])
+        expect(candidates).toEqual([subjectDisclosureId('view:uuid-orders'), NEW_CHECK_ACTION_ID])
     })
 
     async function drainListeners(): Promise<void> {

--- a/products/data_quality/frontend/overview/dataQualityOverviewLogic.ts
+++ b/products/data_quality/frontend/overview/dataQualityOverviewLogic.ts
@@ -90,7 +90,7 @@ export function subjectDetailUrl(check: DataQualityOverviewCheckApi): string | n
 
 export const ROW_ACTIONS_ID_PREFIX = 'data-quality-check-actions-'
 export const SUBJECT_DISCLOSURE_ID_PREFIX = 'data-quality-subject-disclosure-'
-export const BROWSE_ACTION_ID = 'data-quality-browse-subjects'
+export const NEW_CHECK_ACTION_ID = 'data-quality-overview-new-check'
 
 export function rowActionsId(checkId: string): string {
     return `${ROW_ACTIONS_ID_PREFIX}${checkId}`
@@ -120,7 +120,7 @@ export function focusCandidatesAfterDelete(groups: SubjectGroup[], subjectKey: s
         ...(siblings.length ? [subjectDisclosureId(subjectKey)] : []),
         ...(groups[groupIndex + 1] ? [subjectDisclosureId(groups[groupIndex + 1].subjectKey)] : []),
         ...(groupIndex > 0 ? [subjectDisclosureId(groups[groupIndex - 1].subjectKey)] : []),
-        BROWSE_ACTION_ID,
+        NEW_CHECK_ACTION_ID,
     ]
 }
 

--- a/products/data_quality/package.json
+++ b/products/data_quality/package.json
@@ -14,6 +14,7 @@
         "@testing-library/react": "^14.3.1"
     },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",


### PR DESCRIPTION
## Problem

Data Quality users saw two competing first-use paths instead of a focused way to create their first check.

## Changes

- New users see a centered scientist Hoggie and one primary creation action
- The persistent New check control now receives focus after the last check is deleted
- Mechanical: declares the bundled brand asset dependency

![data-quality-empty-state-final](https://raw.githubusercontent.com/PostHog/pr-assets/7b70da9bfe6edc81769f5e3c0634f64d8ad4dd06/2026/09/683a57e8-e4e5-48ee-b600-91a92dcce0e7.png)

## How did you test this code?

- Focused overview and focus-recovery Jest tests
- Frontend lint, format check, and TypeScript check
- Live empty-state check in a temporary local project

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no matching Data Quality document exists under `docs/`

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex authored the change from the requested first-use behavior
- Skills: `/building-product-empty-states`, `/writing-tests`, `/browse`, `/writing-pr-descriptions`, `/ce-commit-push-pr`
