### PR TITLE
fix(experiments): show live remaining time on the experiments list

### DIFF
--- a/products/experiments/frontend/components/RunningTimeCell.tsx
+++ b/products/experiments/frontend/components/RunningTimeCell.tsx
@@ -1,0 +1,67 @@
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+
+import { Experiment } from '~/types'
+
+import type { RunningTimeEstimateApi } from 'products/experiments/frontend/generated/api.schemas'
+
+export const RunningTimeCell = ({
+    experiment,
+    estimate,
+    loading,
+}: {
+    experiment: Experiment
+    estimate: RunningTimeEstimateApi | undefined
+    loading: boolean
+}): JSX.Element => {
+    if (loading && estimate === undefined) {
+        return <Spinner />
+    }
+
+    const remainingDays = estimate?.remaining_days
+    const targetSampleSize = estimate?.target_sample_size
+    const currentExposures = estimate?.current_exposures
+
+    // A negative estimate is not a real duration, so read it as "no estimate" rather than "~-N days".
+    if (remainingDays === undefined || remainingDays === null || remainingDays < 0) {
+        return (
+            <Tooltip title="Remaining time will be calculated once the experiment has enough data">
+                <div className="w-full">
+                    <LemonProgress percent={0} bgColor="var(--border)" strokeColor="var(--border)" />
+                </div>
+            </Tooltip>
+        )
+    }
+
+    if (remainingDays === 0) {
+        return (
+            <Tooltip title="Recommended sample size reached">
+                <div className="w-full">
+                    <LemonProgress percent={100} strokeColor="var(--success)" />
+                </div>
+            </Tooltip>
+        )
+    }
+
+    // Automatic mode reports live exposures, so progress is exposures toward the target. Manual mode has
+    // no exposures; measure progress by days elapsed against the total (elapsed + remaining) instead.
+    let progress = 0
+    if (currentExposures != null && targetSampleSize && targetSampleSize > 0) {
+        progress = Math.min((currentExposures / targetSampleSize) * 100, 100)
+    } else if (experiment.start_date) {
+        const daysElapsed = dayjs().diff(dayjs(experiment.start_date), 'day')
+        const totalDays = daysElapsed + remainingDays
+        progress = totalDays > 0 ? Math.min((daysElapsed / totalDays) * 100, 100) : 0
+    }
+
+    return (
+        <Tooltip title={`~${Math.ceil(remainingDays)} day${Math.ceil(remainingDays) !== 1 ? 's' : ''} remaining`}>
+            <div className="w-full">
+                <LemonProgress percent={progress} />
+            </div>
+        </Tooltip>
+    )
+}

--- a/products/experiments/frontend/scenes/ExperimentsScene.tsx
+++ b/products/experiments/frontend/scenes/ExperimentsScene.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { LemonInput, LemonSelect, LemonTag, Tooltip, lemonToast } from '@posthog/lemon-ui'
 
@@ -17,7 +17,6 @@ import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
-import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { atColumn, createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
@@ -50,6 +49,7 @@ import {
 import { CopyExperimentToProjectModal } from 'products/experiments/frontend/components/CopyExperimentToProjectModal'
 import { DuplicateExperimentModal } from 'products/experiments/frontend/components/DuplicateExperimentModal'
 import { ExperimentVelocityStats } from 'products/experiments/frontend/components/ExperimentVelocityStats'
+import { RunningTimeCell } from 'products/experiments/frontend/components/RunningTimeCell'
 import { StatusTag } from 'products/experiments/frontend/components/StatusTag'
 import { CONCLUSION_DISPLAY_CONFIG } from 'products/experiments/frontend/constants'
 import { experimentsEmptyState } from 'products/experiments/frontend/emptyState/experimentsEmptyState'
@@ -213,8 +213,16 @@ const ExperimentsTable = ({
     openSurveyModal: (experiment: Experiment) => void
     openCopyToProjectModal: (experiment: Experiment) => void
 }): JSX.Element => {
-    const { currentProjectId, experiments, experimentsLoading, filters, count, pagination } =
-        useValues(experimentsLogic)
+    const {
+        currentProjectId,
+        experiments,
+        experimentsLoading,
+        filters,
+        count,
+        pagination,
+        runningTimeEstimates,
+        runningTimeEstimatesLoading,
+    } = useValues(experimentsLogic)
     const { loadExperiments, archiveExperiment, unarchiveExperiment, setExperimentsFilters } =
         useActions(experimentsLogic)
     const { currentOrganization } = useValues(organizationLogic)
@@ -224,289 +232,269 @@ const ExperimentsTable = ({
     const startCount = count === 0 ? 0 : (page - 1) * EXPERIMENTS_PER_PAGE + 1
     const endCount = page * EXPERIMENTS_PER_PAGE < count ? page * EXPERIMENTS_PER_PAGE : count
 
-    const columns: LemonTableColumns<Experiment> = [
-        {
-            title: 'Name',
-            dataIndex: 'name',
-            className: 'ph-no-capture',
-            sticky: true,
-            width: '40%',
-            render: function Render(_, experiment: Experiment) {
-                return (
-                    <LemonTableLink
-                        to={experiment.id ? urls.experiment(experiment.id) : undefined}
-                        title={
-                            <>
-                                {stringWithWBR(experiment.name, 17)}
-                                {experiment.type === 'web' && (
-                                    <LemonTag type="default" className="ml-1">
-                                        No-code
-                                    </LemonTag>
-                                )}
-                                {experiment.is_legacy && (
-                                    <Tooltip
-                                        title="This experiment uses the legacy engine, so some features and improvements may be missing."
-                                        docLink="https://posthog.com/docs/experiments/new-experimentation-engine"
-                                    >
-                                        <LemonTag type="warning" className="ml-1">
-                                            Legacy
-                                        </LemonTag>
-                                    </Tooltip>
-                                )}
-                                {isSingleVariantShipped(experiment) && (
-                                    <Tooltip
-                                        title={`Variant "${getShippedVariantKey(experiment)}" has been rolled out to 100% of users`}
-                                    >
-                                        <LemonTag type="completion" className="ml-1">
-                                            <b className="uppercase">100% rollout</b>
-                                        </LemonTag>
-                                    </Tooltip>
-                                )}
-                            </>
-                        }
-                        description={
-                            experiment.description ? (
-                                // Hypotheses can run many paragraphs, so clamp to keep list rows compact
-                                <LemonMarkdown className="max-w-[30rem] line-clamp-2" lowKeyHeadings disableImages>
-                                    {experiment.description}
-                                </LemonMarkdown>
-                            ) : undefined
-                        }
-                    />
-                )
-            },
-        },
-        createdByColumn<Experiment>() as LemonTableColumn<Experiment, keyof Experiment | undefined>,
-        createdAtColumn<Experiment>() as LemonTableColumn<Experiment, keyof Experiment | undefined>,
-        atColumn('start_date', 'Started') as LemonTableColumn<Experiment, keyof Experiment | undefined>,
-        {
-            title: 'Duration',
-            key: 'duration',
-            render: function Render(_, experiment: Experiment) {
-                const duration = getExperimentDuration(experiment)
-
-                return <div>{duration !== undefined ? `${duration} day${duration !== 1 ? 's' : ''}` : '—'}</div>
-            },
-            sorter: (a, b) => {
-                const durationA = getExperimentDuration(a) ?? -1
-                const durationB = getExperimentDuration(b) ?? -1
-                return durationA > durationB ? 1 : -1
-            },
-            align: 'right',
-        },
-        {
-            title: 'Remaining',
-            key: 'remaining_time',
-            width: 80,
-            render: function Render(_, experiment: Experiment) {
-                const remainingDays = experiment.running_time_calculation?.recommended_running_time
-                const daysElapsed = experiment.start_date
-                    ? dayjs().diff(dayjs(experiment.start_date), 'day')
-                    : undefined
-
-                // A negative stored estimate isn't a real duration, so read it as "no estimate"
-                // rather than "~-N days remaining" (records saved before the persist guard can still hold one).
-                if (remainingDays === undefined || remainingDays === null || remainingDays < 0) {
+    // A fresh columns array every render defeats LemonTable's TableRow React.memo, re-rendering all rows
+    // whenever the running-time estimates load. Memoize so only the changed cells re-render.
+    const columns: LemonTableColumns<Experiment> = useMemo(
+        () => [
+            {
+                title: 'Name',
+                dataIndex: 'name',
+                className: 'ph-no-capture',
+                sticky: true,
+                width: '40%',
+                render: function Render(_, experiment: Experiment) {
                     return (
-                        <Tooltip title="Remaining time will be calculated once the experiment has enough data">
-                            <div className="w-full">
-                                <LemonProgress percent={0} bgColor="var(--border)" strokeColor="var(--border)" />
+                        <LemonTableLink
+                            to={experiment.id ? urls.experiment(experiment.id) : undefined}
+                            title={
+                                <>
+                                    {stringWithWBR(experiment.name, 17)}
+                                    {experiment.type === 'web' && (
+                                        <LemonTag type="default" className="ml-1">
+                                            No-code
+                                        </LemonTag>
+                                    )}
+                                    {experiment.is_legacy && (
+                                        <Tooltip
+                                            title="This experiment uses the legacy engine, so some features and improvements may be missing."
+                                            docLink="https://posthog.com/docs/experiments/new-experimentation-engine"
+                                        >
+                                            <LemonTag type="warning" className="ml-1">
+                                                Legacy
+                                            </LemonTag>
+                                        </Tooltip>
+                                    )}
+                                    {isSingleVariantShipped(experiment) && (
+                                        <Tooltip
+                                            title={`Variant "${getShippedVariantKey(experiment)}" has been rolled out to 100% of users`}
+                                        >
+                                            <LemonTag type="completion" className="ml-1">
+                                                <b className="uppercase">100% rollout</b>
+                                            </LemonTag>
+                                        </Tooltip>
+                                    )}
+                                </>
+                            }
+                            description={
+                                experiment.description ? (
+                                    // Hypotheses can run many paragraphs, so clamp to keep list rows compact
+                                    <LemonMarkdown className="max-w-[30rem] line-clamp-2" lowKeyHeadings disableImages>
+                                        {experiment.description}
+                                    </LemonMarkdown>
+                                ) : undefined
+                            }
+                        />
+                    )
+                },
+            },
+            createdByColumn<Experiment>() as LemonTableColumn<Experiment, keyof Experiment | undefined>,
+            createdAtColumn<Experiment>() as LemonTableColumn<Experiment, keyof Experiment | undefined>,
+            atColumn('start_date', 'Started') as LemonTableColumn<Experiment, keyof Experiment | undefined>,
+            {
+                title: 'Duration',
+                key: 'duration',
+                render: function Render(_, experiment: Experiment) {
+                    const duration = getExperimentDuration(experiment)
+
+                    return <div>{duration !== undefined ? `${duration} day${duration !== 1 ? 's' : ''}` : '—'}</div>
+                },
+                sorter: (a, b) => {
+                    const durationA = getExperimentDuration(a) ?? -1
+                    const durationB = getExperimentDuration(b) ?? -1
+                    return durationA > durationB ? 1 : -1
+                },
+                align: 'right',
+            },
+            {
+                title: 'Remaining',
+                key: 'remaining_time',
+                width: 80,
+                render: function Render(_, experiment: Experiment) {
+                    return (
+                        <RunningTimeCell
+                            experiment={experiment}
+                            estimate={runningTimeEstimates[String(experiment.id)]}
+                            loading={runningTimeEstimatesLoading}
+                        />
+                    )
+                },
+            },
+            {
+                title: 'Status',
+                key: 'status',
+                render: function Render(_, experiment: Experiment) {
+                    return <StatusTag status={getExperimentStatus(experiment)} />
+                },
+                align: 'center',
+                sorter: (a, b) => {
+                    const statusA = getExperimentStatus(a)
+                    const statusB = getExperimentStatus(b)
+
+                    const score: Record<ExperimentStatus, number> = {
+                        [ExperimentStatus.Draft]: 1,
+                        [ExperimentStatus.Running]: 2,
+                        [ExperimentStatus.Paused]: 3,
+                        [ExperimentStatus.ExposureFrozen]: 4,
+                        [ExperimentStatus.Stopped]: 5,
+                    }
+                    return score[statusA] > score[statusB] ? 1 : -1
+                },
+            },
+            {
+                title: 'Result',
+                key: 'conclusion',
+                render: function Render(_, experiment: Experiment) {
+                    if (!experiment.conclusion) {
+                        return <span className="text-secondary">—</span>
+                    }
+                    const config = CONCLUSION_DISPLAY_CONFIG[experiment.conclusion]
+                    const tooltip = experiment.conclusion_comment
+                        ? `${config.description} — ${experiment.conclusion_comment}`
+                        : config.description
+                    return (
+                        <Tooltip title={tooltip}>
+                            <div className="flex items-center gap-2 cursor-default">
+                                <div className={clsx('w-2 h-2 rounded-full', config.color)} />
+                                <span className="font-medium">{config.title}</span>
                             </div>
                         </Tooltip>
                     )
-                }
-
-                if (remainingDays === 0) {
+                },
+                align: 'left',
+                sorter: (a, b) => {
+                    const conclusionScore: Record<ExperimentConclusion, number> = {
+                        [ExperimentConclusion.Won]: 1,
+                        [ExperimentConclusion.Lost]: 2,
+                        [ExperimentConclusion.Inconclusive]: 3,
+                        [ExperimentConclusion.StoppedEarly]: 4,
+                        [ExperimentConclusion.Invalid]: 5,
+                    }
+                    const aScore = a.conclusion ? conclusionScore[a.conclusion] : 6
+                    const bScore = b.conclusion ? conclusionScore[b.conclusion] : 6
+                    return aScore - bScore
+                },
+            },
+            {
+                width: 0,
+                render: function Render(_, experiment: Experiment) {
                     return (
-                        <Tooltip title="Recommended sample size reached">
-                            <div className="w-full">
-                                <LemonProgress percent={100} strokeColor="var(--success)" />
-                            </div>
-                        </Tooltip>
-                    )
-                }
-
-                const totalEstimatedDays = (daysElapsed ?? 0) + remainingDays
-                const progress = totalEstimatedDays > 0 ? ((daysElapsed ?? 0) / totalEstimatedDays) * 100 : 0
-
-                return (
-                    <Tooltip
-                        title={`~${Math.ceil(remainingDays)} day${Math.ceil(remainingDays) !== 1 ? 's' : ''} remaining`}
-                    >
-                        <div className="w-full">
-                            <LemonProgress percent={progress} />
-                        </div>
-                    </Tooltip>
-                )
-            },
-        },
-        {
-            title: 'Status',
-            key: 'status',
-            render: function Render(_, experiment: Experiment) {
-                return <StatusTag status={getExperimentStatus(experiment)} />
-            },
-            align: 'center',
-            sorter: (a, b) => {
-                const statusA = getExperimentStatus(a)
-                const statusB = getExperimentStatus(b)
-
-                const score: Record<ExperimentStatus, number> = {
-                    [ExperimentStatus.Draft]: 1,
-                    [ExperimentStatus.Running]: 2,
-                    [ExperimentStatus.Paused]: 3,
-                    [ExperimentStatus.ExposureFrozen]: 4,
-                    [ExperimentStatus.Stopped]: 5,
-                }
-                return score[statusA] > score[statusB] ? 1 : -1
-            },
-        },
-        {
-            title: 'Result',
-            key: 'conclusion',
-            render: function Render(_, experiment: Experiment) {
-                if (!experiment.conclusion) {
-                    return <span className="text-secondary">—</span>
-                }
-                const config = CONCLUSION_DISPLAY_CONFIG[experiment.conclusion]
-                const tooltip = experiment.conclusion_comment
-                    ? `${config.description} — ${experiment.conclusion_comment}`
-                    : config.description
-                return (
-                    <Tooltip title={tooltip}>
-                        <div className="flex items-center gap-2 cursor-default">
-                            <div className={clsx('w-2 h-2 rounded-full', config.color)} />
-                            <span className="font-medium">{config.title}</span>
-                        </div>
-                    </Tooltip>
-                )
-            },
-            align: 'left',
-            sorter: (a, b) => {
-                const conclusionScore: Record<ExperimentConclusion, number> = {
-                    [ExperimentConclusion.Won]: 1,
-                    [ExperimentConclusion.Lost]: 2,
-                    [ExperimentConclusion.Inconclusive]: 3,
-                    [ExperimentConclusion.StoppedEarly]: 4,
-                    [ExperimentConclusion.Invalid]: 5,
-                }
-                const aScore = a.conclusion ? conclusionScore[a.conclusion] : 6
-                const bScore = b.conclusion ? conclusionScore[b.conclusion] : 6
-                return aScore - bScore
-            },
-        },
-        {
-            width: 0,
-            render: function Render(_, experiment: Experiment) {
-                return (
-                    <More
-                        overlay={
-                            <>
-                                <LemonButton to={urls.experiment(`${experiment.id}`)} size="small" fullWidth>
-                                    View
-                                </LemonButton>
-                                <LemonButton
-                                    onClick={() => openDuplicateModal(experiment)}
-                                    size="small"
-                                    fullWidth
-                                    disabledReason={
-                                        experiment.is_legacy
-                                            ? 'Not supported for experiments using legacy metrics. Please recreate the experiment manually.'
-                                            : undefined
-                                    }
-                                >
-                                    Duplicate
-                                </LemonButton>
-                                {hasMultipleProjects && (
+                        <More
+                            overlay={
+                                <>
+                                    <LemonButton to={urls.experiment(`${experiment.id}`)} size="small" fullWidth>
+                                        View
+                                    </LemonButton>
                                     <LemonButton
-                                        onClick={() => openCopyToProjectModal(experiment)}
+                                        onClick={() => openDuplicateModal(experiment)}
                                         size="small"
                                         fullWidth
                                         disabledReason={
                                             experiment.is_legacy
-                                                ? 'Copying is not supported for experiments using legacy metrics.'
+                                                ? 'Not supported for experiments using legacy metrics. Please recreate the experiment manually.'
                                                 : undefined
                                         }
                                     >
-                                        Copy to project
+                                        Duplicate
                                     </LemonButton>
-                                )}
-                                <ExperimentSurveyButton
-                                    experiment={experiment}
-                                    onOpenModal={() => {
-                                        openSurveyModal(experiment)
-                                        void addProductIntentForCrossSell({
-                                            from: ProductKey.EXPERIMENTS,
-                                            to: ProductKey.SURVEYS,
-                                            intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
-                                        })
-                                    }}
-                                />
-                                {canArchiveExperiment(experiment) && (
-                                    <AccessControlAction
-                                        resourceType={AccessControlResourceType.Experiment}
-                                        minAccessLevel={AccessControlLevel.Editor}
-                                        userAccessLevel={experiment.user_access_level}
-                                    >
+                                    {hasMultipleProjects && (
                                         <LemonButton
-                                            onClick={() =>
-                                                confirmArchiveExperiment(experiment, (disableFlag) =>
-                                                    archiveExperiment({
-                                                        id: experiment.id as number,
-                                                        disableFeatureFlag: disableFlag,
-                                                    })
-                                                )
+                                            onClick={() => openCopyToProjectModal(experiment)}
+                                            size="small"
+                                            fullWidth
+                                            disabledReason={
+                                                experiment.is_legacy
+                                                    ? 'Copying is not supported for experiments using legacy metrics.'
+                                                    : undefined
                                             }
-                                            data-attr={`experiment-${experiment.id}-dropdown-archive`}
-                                            fullWidth
                                         >
-                                            Archive experiment
+                                            Copy to project
                                         </LemonButton>
-                                    </AccessControlAction>
-                                )}
-                                {experiment.archived && (
+                                    )}
+                                    <ExperimentSurveyButton
+                                        experiment={experiment}
+                                        onOpenModal={() => {
+                                            openSurveyModal(experiment)
+                                            void addProductIntentForCrossSell({
+                                                from: ProductKey.EXPERIMENTS,
+                                                to: ProductKey.SURVEYS,
+                                                intent_context: ProductIntentContext.QUICK_SURVEY_STARTED,
+                                            })
+                                        }}
+                                    />
+                                    {canArchiveExperiment(experiment) && (
+                                        <AccessControlAction
+                                            resourceType={AccessControlResourceType.Experiment}
+                                            minAccessLevel={AccessControlLevel.Editor}
+                                            userAccessLevel={experiment.user_access_level}
+                                        >
+                                            <LemonButton
+                                                onClick={() =>
+                                                    confirmArchiveExperiment(experiment, (disableFlag) =>
+                                                        archiveExperiment({
+                                                            id: experiment.id as number,
+                                                            disableFeatureFlag: disableFlag,
+                                                        })
+                                                    )
+                                                }
+                                                data-attr={`experiment-${experiment.id}-dropdown-archive`}
+                                                fullWidth
+                                            >
+                                                Archive experiment
+                                            </LemonButton>
+                                        </AccessControlAction>
+                                    )}
+                                    {experiment.archived && (
+                                        <AccessControlAction
+                                            resourceType={AccessControlResourceType.Experiment}
+                                            minAccessLevel={AccessControlLevel.Editor}
+                                            userAccessLevel={experiment.user_access_level}
+                                        >
+                                            <LemonButton
+                                                onClick={() => unarchiveExperiment(experiment.id as number)}
+                                                data-attr={`experiment-${experiment.id}-dropdown-unarchive`}
+                                                fullWidth
+                                            >
+                                                Unarchive experiment
+                                            </LemonButton>
+                                        </AccessControlAction>
+                                    )}
+                                    <LemonDivider />
                                     <AccessControlAction
                                         resourceType={AccessControlResourceType.Experiment}
                                         minAccessLevel={AccessControlLevel.Editor}
                                         userAccessLevel={experiment.user_access_level}
                                     >
                                         <LemonButton
-                                            onClick={() => unarchiveExperiment(experiment.id as number)}
-                                            data-attr={`experiment-${experiment.id}-dropdown-unarchive`}
+                                            status="danger"
+                                            onClick={() =>
+                                                confirmDeleteExperiment({
+                                                    projectId: currentProjectId,
+                                                    experiment,
+                                                    onDelete: () => loadExperiments(),
+                                                })
+                                            }
+                                            data-attr={`experiment-${experiment.id}-dropdown-remove`}
                                             fullWidth
                                         >
-                                            Unarchive experiment
+                                            Delete experiment
                                         </LemonButton>
                                     </AccessControlAction>
-                                )}
-                                <LemonDivider />
-                                <AccessControlAction
-                                    resourceType={AccessControlResourceType.Experiment}
-                                    minAccessLevel={AccessControlLevel.Editor}
-                                    userAccessLevel={experiment.user_access_level}
-                                >
-                                    <LemonButton
-                                        status="danger"
-                                        onClick={() =>
-                                            confirmDeleteExperiment({
-                                                projectId: currentProjectId,
-                                                experiment,
-                                                onDelete: () => loadExperiments(),
-                                            })
-                                        }
-                                        data-attr={`experiment-${experiment.id}-dropdown-remove`}
-                                        fullWidth
-                                    >
-                                        Delete experiment
-                                    </LemonButton>
-                                </AccessControlAction>
-                            </>
-                        }
-                    />
-                )
+                                </>
+                            }
+                        />
+                    )
+                },
             },
-        },
-    ]
+        ],
+        [
+            openDuplicateModal,
+            openSurveyModal,
+            openCopyToProjectModal,
+            hasMultipleProjects,
+            runningTimeEstimates,
+            runningTimeEstimatesLoading,
+        ]
+    )
 
     return (
         <SceneContent>

--- a/products/experiments/frontend/scenes/experimentsLogic.ts
+++ b/products/experiments/frontend/scenes/experimentsLogic.ts
@@ -27,6 +27,10 @@ import {
 import type { AvailableFeature, UserType } from '~/types'
 import type { TeamPublicType, TeamType } from '~/types'
 
+import { getExperimentStatus } from 'products/experiments/frontend/experimentStatus'
+import { experimentsRunningTimeEstimatesRetrieve } from 'products/experiments/frontend/generated/api'
+import type { RunningTimeEstimatesResponseApiResults } from 'products/experiments/frontend/generated/api.schemas'
+
 export const EXPERIMENTS_PER_PAGE = 100
 
 export interface ExperimentsResult extends CountedPaginatedResponse<Experiment> {
@@ -181,6 +185,8 @@ export interface experimentsLogicValues {
         search?: string | undefined
         status?: ExperimentStatus | 'all' | undefined
     }
+    runningTimeEstimates: RunningTimeEstimatesResponseApiResults
+    runningTimeEstimatesLoading: boolean
     sidePanelContext: SidePanelSceneContext
     tab: ExperimentsTabs
     unavailableFeatureFlagKeys: Set<string>
@@ -398,6 +404,21 @@ export interface experimentsLogicActions {
         }
         payload?: void
     }
+    loadRunningTimeEstimates: (experimentIds: number[]) => number[]
+    loadRunningTimeEstimatesFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadRunningTimeEstimatesSuccess: (
+        runningTimeEstimates: RunningTimeEstimatesResponseApiResults,
+        payload?: number[]
+    ) => {
+        runningTimeEstimates: RunningTimeEstimatesResponseApiResults
+        payload?: number[]
+    }
     openFeatureFlagModal: () => {
         value: true
     }
@@ -590,6 +611,15 @@ export const experimentsLogic = kea<experimentsLogicType>([
             }
             actions.loadExperiments()
         },
+        loadExperimentsSuccess: ({ experiments }) => {
+            // Remaining time is estimated on demand, not stored, so fetch it for the running rows on this page.
+            // Running experiments are persisted, so their id is always numeric (never 'new'/'web').
+            const runningIds = experiments.results
+                .filter((experiment) => getExperimentStatus(experiment) === ExperimentStatus.Running)
+                .map((experiment) => experiment.id)
+                .filter((id): id is number => typeof id === 'number')
+            actions.loadRunningTimeEstimates(runningIds)
+        },
         setFeatureFlagModalFilters: async (_, breakpoint) => {
             await breakpoint(300)
             actions.loadFeatureFlagModalFeatureFlags()
@@ -719,6 +749,20 @@ export const experimentsLogic = kea<experimentsLogicType>([
                         results: values.experiments.results.map((exp) => (exp.id === experiment.id ? experiment : exp)),
                         count: values.experiments.count,
                     }
+                },
+            },
+        ],
+        runningTimeEstimates: [
+            {} as RunningTimeEstimatesResponseApiResults,
+            {
+                loadRunningTimeEstimates: async (experimentIds: number[]) => {
+                    if (experimentIds.length === 0) {
+                        return {}
+                    }
+                    const response = await experimentsRunningTimeEstimatesRetrieve(String(values.currentProjectId), {
+                        ids: experimentIds.join(','),
+                    })
+                    return response.results
                 },
             },
         ],


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

The experiments list showed each running experiment's remaining time from a value the detail page persisted back onto the experiment on every exposure refresh. That number went stale, and the list often showed no progress at all. This is the frontend half of moving remaining time onto the on-demand endpoint.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

This PR points the experiments list at the running-time estimate endpoint added in the base PR, so the "Remaining" column reflects current data and progress. It is stacked on `experiments/experiment-running-time-endpoint`.

### Batch load per page

After the list loads, `experimentsLogic` fetches estimates for the running rows in one request, keyed by experiment id. It filters to running experiments, so drafts and finished ones make no call. This follows the surveys `responses_count` pattern.

- `products/experiments/frontend/scenes/experimentsLogic.ts`

### The cell

A new `RunningTimeCell` renders the "Remaining" column from the estimate: a spinner while loading, a progress bar with a "~N days remaining" tooltip, and distinct empty and complete states. Progress is exposures toward the target when live exposures exist, and elapsed days against the total otherwise.

- `products/experiments/frontend/components/RunningTimeCell.tsx`

### List wiring

The "Remaining" column now renders `RunningTimeCell` instead of reading the stored `recommended_running_time`. The columns array is memoized so an estimate load re-renders only the changed cells, not all rows. The rest of the column diff is a mechanical re-indent from wrapping the array in `useMemo`.

- `products/experiments/frontend/scenes/ExperimentsScene.tsx`

_Screenshot pending: the local preview is being rebuilt on this branch. A list screenshot showing the live remaining-time progress bars will be added here._

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->

Verified in the running app that the list "Remaining" column matches the detail page for the same experiment, and that the progress bar reflects exposures toward the target.

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/c0fc4189-122a-48f4-bdff-2551ad32f2d8)

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

None.

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /brainstorming (superpowers)
- /writing-ui-components (local)
- /writing-kea-logics (local)
- /adopting-generated-api-types (local)

Relevant decisions:

- Batch loader plus a dumb `RunningTimeCell`, not a per-row logic component, so the whole page loads in one request against the batch endpoint rather than N single-id calls.
- Fired the estimate load from a new `loadExperimentsSuccess` listener, filtered to running experiments, since remaining time only applies to them.
- Memoized the columns array because a fresh array each render defeats `LemonTable`'s per-row `React.memo`, so an estimate load would otherwise re-render every row.
