### PR TITLE
fix(workflows): warn before discarding an uncreated workflow

### DIFF
--- a/products/workflows/frontend/Workflows/workflowLogic.autosave.test.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.autosave.test.ts
@@ -1,3 +1,4 @@
+import { getRouterContext } from 'kea-router/lib/router'
 import { expectLogic } from 'kea-test-utils'
 
 import { useMocks } from '~/mocks/jest'
@@ -45,6 +46,10 @@ const makeWorkflow = (overrides: Partial<HogFlow> = {}): HogFlow => ({
     ...overrides,
 })
 
+// Asks the router the same question it asks before it lets a navigation through.
+const warnsBeforeLeaving = (): boolean =>
+    Array.from(getRouterContext().beforeUnloadInterceptors).some((interceptor) => interceptor.enabled())
+
 describe('workflowLogic auto-save', () => {
     let logic: ReturnType<typeof workflowLogic.build>
     let updateCalls: number
@@ -62,6 +67,9 @@ describe('workflowLogic auto-save', () => {
                     updateCalls += 1
                     return [200, workflow]
                 },
+            },
+            post: {
+                '/api/environments/:team_id/hog_flows/': () => [200, makeWorkflow({ id: 'wf-created-1' })],
             },
         })
     })
@@ -795,18 +803,39 @@ describe('workflowLogic auto-save', () => {
             expect(updateCalls).toBe(0)
         })
 
-        it('does not warn on navigation for new workflows', async () => {
-            // The beforeUnload guard skips when id is 'new', even if
-            // the form has unsaved changes (e.g. freshly created draft).
+        // A workflow that was never created has no row to auto-save into, so the create scene
+        // needs the leave prompt more than a saved workflow does.
+        it.each([
+            ['does not warn when leaving an untouched new workflow', false, false],
+            ['warns when leaving a new workflow carrying unsaved changes', true, true],
+        ] as [string, boolean, boolean][])('%s', async (_name, edited, expected) => {
+            initKeaTests()
+            logic = workflowLogic({ id: 'new' })
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
+
+            if (edited) {
+                logic.actions.setWorkflowValue('name', 'My new workflow')
+            }
+            expect(logic.values.hasUnsavedChanges).toBe(edited)
+            expect(warnsBeforeLeaving()).toBe(expected)
+        })
+
+        it('does not prompt on the redirect that completes the create', async () => {
+            // The form is only rebaselined after the redirect, so it is still dirty when the
+            // navigation fires. Without the opt-out, every successful create shows a leave prompt.
+            const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true)
             initKeaTests()
             logic = workflowLogic({ id: 'new' })
             logic.mount()
             await expectLogic(logic).toDispatchActions(['loadWorkflowSuccess'])
 
             logic.actions.setWorkflowValue('name', 'My new workflow')
-            expect(logic.values.hasUnsavedChanges).toBe(true)
-            // Guard condition: props.id === 'new' → skip
-            expect(logic.props.id).toBe('new')
+            logic.actions.submitWorkflow()
+            await expectLogic(logic).toDispatchActions(['saveWorkflowSuccess'])
+
+            expect(confirmSpy).not.toHaveBeenCalled()
+            confirmSpy.mockRestore()
         })
     })
 })

--- a/products/workflows/frontend/Workflows/workflowLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowLogic.ts
@@ -4079,6 +4079,10 @@ export const workflowLogic = kea<workflowLogicType>([
                     // doesn't see the create yet doesn't leave the user staring at a list without
                     // the workflow they just made.
                     actions.workflowCreated(originalWorkflow)
+                    // The form is still dirty here: it is rebaselined further down this listener,
+                    // after the redirect. Without this the create scene's own leave prompt would
+                    // fire on the navigation that completes the save.
+                    cache.disabledBeforeUnload = true
                     router.actions.replace(
                         urls.workflow(
                             originalWorkflow.id,
@@ -4318,7 +4322,13 @@ export const workflowLogic = kea<workflowLogicType>([
     }),
     beforeUnload((logic) => ({
         enabled: (newLocation) => {
-            if (!logic.props.id || logic.props.id === 'new') {
+            if (!logic.props.id) {
+                return false
+            }
+            // A workflow that has never been created has no row to auto-save into, so leaving the
+            // create scene discards the whole canvas. That scene needs the prompt more than a saved
+            // one does, not less. Its own redirect to the saved workflow opts out through this flag.
+            if (logic.cache.disabledBeforeUnload) {
                 return false
             }
             if (logic.props.editTemplateId) {


### PR DESCRIPTION
## Problem

Everything you configure on the new-workflow canvas is discarded without a prompt if you navigate away before pressing "Create as draft".

- Auto-save deliberately skips a workflow with no row yet, and the leave-confirmation was disabled for that same scene. So the create scene had neither guard, while every saved workflow has both.
- Someone who learns that an existing workflow saves itself has no reason to expect the create scene not to. The browser back button is enough to lose the work.
- The `id === 'new'` skip existed to dodge a real problem: the create scene's own redirect to the saved workflow fires while the form is still dirty, so the prompt would have appeared on every successful create. This PR keeps that redirect quiet a narrower way.

Stacked on #92851, which fixes two unrelated stale reads in the same product. That PR touches the same region of `saveWorkflowSuccess`, so this one sits on top of it rather than conflicting.

## Changes

- Navigating away from an unsaved new workflow now asks before discarding it, the same prompt a saved workflow already shows.
- Creating a workflow stays silent. The redirect that completes the save opts out through `cache.disabledBeforeUnload`, the pattern `hogFunctionConfigurationLogic` already uses.
- An untouched create scene never prompts, so abandoning an empty canvas costs nothing.

The alternative was auto-saving the new workflow into a real row. That trades silent data loss for junk drafts on every abandoned canvas, and it changes what "Create as draft" means, so the prompt won.

> [!NOTE]
> No visual change. This adds a browser confirm dialog on a navigation that previously had none.

## How did you test this code?

Automated only. This sandbox has no dev stack, so the gesture was not performed in a browser.

Each new case was confirmed to fail on its own, against a tree with only its half of the fix reverted:

- Reverting the guard fails "warns when leaving a new workflow carrying unsaved changes".
- Reverting only the opt-out fails "does not prompt on the redirect that completes the create". That failure also confirms the old skip really was dodging this redirect, rather than being an arbitrary exclusion.

The two cases assert through the router. `warnsBeforeLeaving()` reads `beforeUnloadInterceptors` from the router context and calls the same `enabled()` predicate the router calls before it lets a navigation through, and the redirect case spies on `window.confirm`, which is what the router invokes to show the prompt.

This replaces a test that asserted only `props.id === 'new'` and documented the old behavior, so it could not have caught this.

Verified against `kea-router@3.4.1`: `router.js` calls `preventUnload()` from the `popstate` handler, so the guard covers the browser back button and not only in-app links.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Desktop). This started as the first hypothesis for a different report, that a created workflow went missing from the index. That turned out to be a stale list read, fixed in #92851, and the person who filed it confirmed their workflow had saved. This scene's missing guard was a real bug found along the way, and was held back until it could be raised on its own.

Skills invoked: `/writing-tests`, which is why the two cases are a `test.each` rather than separate near-duplicates, and why they assert through the router rather than reading `cache` directly.

Public artifact: nothing in this PR carries material from the originating session. No customer name, project data, or operational figure appears in the code, the test fixtures, or this description.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
