### PR TITLE
chore(ci): drop dead dagster durations restore

### DIFF
--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -358,10 +358,10 @@ jobs:
             - name: Download the last published durations
               # The selector's full-run cutoff and shard sizing read .test_durations,
               # which is not in the repo. The timing workflow saves it to the Actions
-              # cache from a Depot runner, and GitHub-hosted jobs like this one read
-              # a separate cache store, so a cache restore here can never hit. Take
-              # the artifact the timing workflow publishes instead; if that is gone
-              # too, the selector estimates without durations until the next timing run.
+              # cache from a Depot runner. GitHub-hosted jobs like this one read a
+              # separate cache store, so a cache restore here can never hit. Take the
+              # artifact the timing workflow publishes instead; if that is gone too,
+              # the selector estimates without durations until the next timing run.
               continue-on-error: true
               env:
                   GH_TOKEN: ${{ github.token }}
@@ -369,7 +369,7 @@ jobs:
                   run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow ci-backend-update-test-timing.yml \
                       --branch master --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')
                   if [ -z "$run_id" ]; then
-                      echo "::warning::No successful timing run to fall back to, sharding without durations"
+                      echo "::warning::No successful timing run, sharding without durations"
                       exit 0
                   fi
                   gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name test-durations --dir . \

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -355,25 +355,13 @@ jobs:
               with:
                   version: '0.11.28'
 
-            - name: Restore test durations from cache
+            - name: Download the last published durations
               # The selector's full-run cutoff and shard sizing read .test_durations,
-              # which is not in the repo. This job runs on a GitHub-hosted runner, so
-              # the Depot-side cache misses and the fallback below is the usual path.
-              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-              with:
-                  path: .test_durations
-                  key: posthog-test-durations-${{ github.run_id }}
-                  restore-keys: |
-                      posthog-test-durations-
-
-            - name: Fall back to the last published durations
-              # .test_durations is not in the repo. The timing workflow refreshes the
-              # cache several times a day and publishes the same files as an artifact
-              # of its own runs. On a cache miss (retention lapsed, timing workflow
-              # down for two weeks) take the newest artifact; if that is gone too,
-              # pytest-split splits by count and turbo-discover sizes from file counts
-              # until the next timing run.
-              if: ${{ hashFiles('.test_durations') == '' }}
+              # which is not in the repo. The timing workflow saves it to the Actions
+              # cache from a Depot runner, and GitHub-hosted jobs like this one read
+              # a separate cache store, so a cache restore here can never hit. Take
+              # the artifact the timing workflow publishes instead; if that is gone
+              # too, the selector estimates without durations until the next timing run.
               continue-on-error: true
               env:
                   GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Problem

- The Dagster test selector runs on a GitHub-hosted runner and restores `.test_durations` from the Actions cache on every PR. It can never hit: the timing workflow saves that key from a Depot runner, and the two runner classes use separate cache stores.

| Evidence | Result |
| --- | --- |
| [run 1](https://github.com/PostHog/posthog/actions/runs/33555123832/job/100014238278), [run 2](https://github.com/PostHog/posthog/actions/runs/33554444064/job/100011746132), [run 3](https://github.com/PostHog/posthog/actions/runs/33547168659/job/99987500714) | `Cache not found`, then the artifact download |
| GitHub cache API, `posthog-test-durations-*` | 0 entries |

## Changes

- The selector downloads the timing artifact directly and skips the restore. Same file, same fallback when no artifact exists. About 1 s per run, so this is hygiene.
- Rejected: mirroring the key into GitHub's cache, or moving the job to a paid runner, to save that second.

## How did you test this code?

- [Selector job on this PR](https://github.com/PostHog/posthog/actions/runs/33556192775/job/100017569135) runs without the restore and passes. `hogli lint:workflows` and actionlint pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Skills: /authoring-ci-workflows, /writing-code-comments, /writing-pr-descriptions, /code-review, /simplify. From an audit of every `actions/cache` key for keys saved in one store and restored from the other; this was the only dead cross-store restore.

https://claude.ai/code/session_012T7KBo5imZkY2LKzNjpqND
