### PR TITLE
fix(tasks): truncate hogland box tags to hogland's 64-char limit

### DIFF
--- a/products/tasks/backend/logic/services/hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/hogland_sandbox.py
@@ -82,6 +82,10 @@ HOGLAND_GOLDEN_DISK_GB = 64.0
 # the server enforces the real per-call budgets.
 _HTTP_TIMEOUT = httpx.Timeout(30 * 60, connect=15)
 
+# hogland rejects any box tag longer than this (the create() API 400s with
+# "tag[i] must be <= 64 chars").
+_HOGLAND_MAX_TAG_CHARS = 64
+
 # Static container env the Modal image carries as Dockerfile ENVs. The golden image
 # bakes them into /etc/environment too; passing them per-box keeps a restore that
 # predates a bake change consistent with this backend.
@@ -221,7 +225,10 @@ class HoglandSandbox(AgentServerLaunchMixin):
         config.image_fallback = None
 
         env = {**_STATIC_BOX_ENV, **(config.environment_variables or {})}
-        tags = [f"{key}={value}" for key, value in (config.metadata or {}).items()]
+        # hogland caps each box tag at 64 chars; the Modal-shaped metadata overflows it
+        # (workflow_id is `task-processing-<task_id>-<run_id>`, ~100 chars), so truncate.
+        # task_id and task_run_id are separate, within-limit tags, so tracing survives.
+        tags = [f"{key}={value}"[:_HOGLAND_MAX_TAG_CHARS] for key, value in (config.metadata or {}).items()]
 
         try:
             client = get_hogland_client()

--- a/products/tasks/backend/logic/services/tests/test_hogland_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_hogland_sandbox.py
@@ -92,6 +92,19 @@ class TestHoglandSandboxCreate:
         assert sandbox.id == "box-abc123def456"
         assert config.snapshot_restored is False
 
+    def test_create_truncates_tags_over_the_hogland_64_char_limit(self):
+        # hogland 400s any box tag longer than 64 chars; the Modal-shaped workflow_id tag
+        # (`task-processing-<task_id>-<run_id>`, ~90 chars) overflows it, so create() must
+        # truncate. Without truncation this run fails with "tag[i] must be <= 64 chars".
+        workflow_id = "task-processing-" + "a" * 36 + "-" + "b" * 36
+        config = SandboxConfig(name="s", metadata={"workflow_id": workflow_id, "task_id": "t1"})
+        _, client = self._create(config)
+
+        tags = client.create.call_args.kwargs["tags"]
+        assert all(len(t) <= 64 for t in tags)
+        assert f"workflow_id={workflow_id}"[:64] in tags
+        assert "task_id=t1" in tags
+
     def test_create_records_the_read_back_box_shape_for_the_ledger(self):
         # The box ignores per-task overrides, so the ledger must reflect the shape the box
         # actually delivered, read back from box.view.spec — not the requested override and


### PR DESCRIPTION
## Problem

A task that routes to hogland fails to create the box with `APIError: tag[4] must be <= 64 chars`. hogland caps each box tag at 64 characters, but the worker forwards its Modal-shaped metadata as `key=value` tags, and the `workflow_id` tag (`task-processing-<task_id>-<run_id>`, ~100 chars) overflows the limit. So the `POST /v1/hogboxes` call 400s and the run fails.

This is the last blocker in routing tasks to hogland: auth and provisioning now reach hogland, and the box create fails only on this tag length.

## Changes

- Truncate each hogland box tag to 64 characters in `HoglandSandbox.create()`. `task_id` and `task_run_id` are separate tags that stay within the limit, so tracing survives the truncation. Modal is unaffected (it has no such limit).

## How did you test this code?

I am an agent (Claude Code). Automated:

- Added `test_create_truncates_tags_over_the_hogland_64_char_limit`: a >64-char metadata value produces a tag truncated to <=64, and short tags pass through — guards the exact 400. Full `test_hogland_sandbox.py` suite passes (39); `ruff` clean.

Not run locally: the ClickHouse-backed suites (no ClickHouse here); they run in CI.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent-authored (Claude Code), directed by Tom Owers. Found live: after the hogplane JWKS-discovery fix landed, the worker's token verifies and box creation proceeds far enough to hit hogland's 64-char tag limit on the `workflow_id` tag. Truncation is the minimal fix; the fully-qualified `task_id` and `task_run_id` tags remain for tracing.
