### PR TITLE
fix(agent): inspect catalog metrics before queries

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -5232,6 +5232,9 @@ describe("AgentServer HTTP Mode", () => {
           "Task-Id: test-task-id",
           "canonical `posthog:exec` tool",
           "`posthog:read-data-schema`",
+          "`posthog:metric-list`",
+          "`posthog:metric-describe`",
+          "`posthog:data-catalog-metric-run`",
         ],
         shouldNotContain: [
           "gh repo clone",
@@ -5248,6 +5251,9 @@ describe("AgentServer HTTP Mode", () => {
           "You may make local edits in a repository cloned with `clone_repo`",
           "Do NOT create branches, commits, push changes, or open pull requests in this run",
           "canonical `posthog:exec` tool",
+          "`posthog:metric-list`",
+          "`posthog:metric-describe`",
+          "`posthog:data-catalog-metric-run`",
         ],
         shouldNotContain: [
           "open a draft pull request",

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -4442,6 +4442,7 @@ When the user asks about analytics, data, metrics, events, funnels, dashboards, 
 - Use the canonical \`posthog:exec\` tool to query data, search insights, and provide real answers
 - Follow its built-in instructions to discover and invoke inner tools
 - Do NOT tell the user to check an external analytics platform — you ARE the analytics platform
+- For a named business or telemetry metric, inspect the complete governed catalog with \`posthog:metric-list\`, inspect a candidate with \`posthog:metric-describe\`, then run an approved match with \`posthog:data-catalog-metric-run\` before a typed domain tool or raw query
 - Inner tools include \`posthog:read-data-schema\`, \`posthog:execute-sql\`, \`posthog:insight-query\`, and the typed query tools
 
 When the user asks for code changes or software engineering tasks:


### PR DESCRIPTION
## Problem

- Cloud task agents need the governed-metric workflow before selecting typed or raw data tools.

## Changes

- Adds a no-repository prompt hint to list metrics, describe candidates, and run approved matches.
- Updates cloud-agent prompt assertions; the test update is mechanical.

## How did you test this code?

- Ran `pnpm --dir products/desktop/packages/agent exec vitest run src/server/agent-server.test.ts`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This changes internal cloud-agent instruction assembly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex updated the cloud-agent hint and regression assertions.
- Skills used: `/stacking-prs` and `/writing-pr-descriptions`.
- No non-public session material is included.
