### PR TITLE
fix(insights): keep long funnel step names inside their column

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.scss
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.scss
@@ -184,7 +184,11 @@
         font-weight: 500;
 
         &:first-child {
+            // `fit-content` keeps the row hugging a short name, but it cannot go below the
+            // longest unbreakable word. Cap it, and let a long event name break anywhere, so it
+            // stays inside its step column instead of running over the next step's name.
             width: fit-content;
+            max-width: 100%;
             margin-top: 0;
             font-weight: 600;
             white-space: normal;
@@ -194,7 +198,7 @@
                 -webkit-line-clamp: 5;
                 -webkit-box-orient: vertical;
                 overflow: hidden;
-                overflow-wrap: break-word;
+                overflow-wrap: anywhere;
             }
         }
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/StepHeader.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/StepHeader.tsx
@@ -23,7 +23,8 @@ export function StepHeader({ step, stepIndex, previousStep, isUnordered, isOptio
     return (
         <div className={clsx('flex flex-wrap items-center justify-between leading-5', isOptional && 'opacity-60')}>
             <div className="flex items-center max-w-full grow">
-                <div className="overflow-hidden font-bold break-words whitespace-normal">
+                {/* `wrap-anywhere`, so an event name with no spaces wraps instead of getting cut off. */}
+                <div className="overflow-hidden font-bold wrap-anywhere whitespace-normal">
                     {isUnordered ? (
                         <span>Completed {step.order + 1} steps</span>
                     ) : (


### PR DESCRIPTION
## Problem

Someone building a funnel on events with long, unspaced names — `user_completed_onboarding_checklist`, a URL, most `snake_case` events — sees the first step's name run over the top of the next step's name in the steps bar chart. The names overlap, so neither is readable.

The step legend row is sized `width: fit-content`. That cannot shrink below the widest unbreakable word, and `overflow-wrap: break-word` does not create a break opportunity for intrinsic sizing. So a one-word name makes the row wider than its step column, and nothing clips it.

## Changes

- Long step names now wrap inside their own column in the funnel steps bar chart, instead of overlapping the next step. Short names still hug their text as before, so nothing else moves. The name still clamps to five lines with an ellipsis, and hovering shows the full name.
- In the horizontal funnel chart, a long unspaced name now wraps instead of being cut off mid-word at the header's edge.

Both changes are one declaration each: cap the legend row at `max-width: 100%`, and swap `overflow-wrap: break-word` for `anywhere` (`wrap-anywhere` in the Tailwind case), which is the version that actually lowers the intrinsic minimum width.

Breaking mid-word is not pretty, but it is the only option once a name has no break opportunity in it, and it beats hiding the name or covering the neighbouring one. Truncating to one line was the alternative and it loses more: these names differ near the end (`..._step_two` vs `..._step_three`), which is exactly the part a single-line ellipsis eats.

## How did you test this code?

I did not run the app. Storybook and the dev stack were not available in this environment, so I verified the CSS mechanism directly instead: a standalone page reproducing the funnel footer's grid, `.StepLegend`, and `LemonRow` rules, rendered in headless Chromium. Before the change the first step's name paints across the second step's name; after it, each name wraps inside its own column. That confirms the cause and the fix, but it is not the real component — worth a look in the app before merge.

No tests added: this is a CSS sizing fix with no behavior a unit test can assert meaningfully.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Code) from a Slack report. No repo skills were invoked; the work was locating the rule, reproducing the overflow in headless Chromium, and changing two declarations.

The first guess was that the five-line clamp was at fault. It is not — the clamp works. The cause is intrinsic sizing: `fit-content` floors at the min-content width, and `break-word` (unlike `anywhere`) is explicitly excluded from min-content calculation. That is why the fix is `anywhere` rather than any clamp or truncation change.

Nothing in this PR carries material from the session that is not already public. The event names in this description are invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1788295004876549?thread_ts=1788295004.876549&cid=C0ACRAMJUAG)*
