### PR TITLE
chore(auth): split the passkey login completion handler

### DIFF
--- a/posthog/api/test/test_webauthn.py
+++ b/posthog/api/test/test_webauthn.py
@@ -182,25 +182,41 @@ class TestWebAuthnLogin(APIBaseTest):
         response = self.client.post("/api/webauthn/login/complete/", {})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_login_complete_without_user_handle_fails(self):
+    @parameterized.expand(
+        [
+            (
+                "missing_user_handle",
+                {"authenticatorData": "data", "clientDataJSON": "data", "signature": "sig"},
+                "some-raw-id",
+                "userHandle",
+            ),
+            (
+                "missing_raw_id",
+                {"authenticatorData": "data", "clientDataJSON": "data", "signature": "sig", "userHandle": "handle"},
+                None,
+                "credential ID",
+            ),
+            (
+                "missing_signature",
+                {"authenticatorData": "data", "clientDataJSON": "data", "userHandle": "handle"},
+                "some-raw-id",
+                "Missing required fields",
+            ),
+        ]
+    )
+    def test_login_complete_with_unreadable_assertion_fails(
+        self, _name: str, response_data: dict, raw_id: str | None, expected_error: str
+    ):
         self.client.post("/api/webauthn/login/begin/")
 
-        response = self.client.post(
-            "/api/webauthn/login/complete/",
-            {
-                "id": "some-id",
-                "rawId": "some-raw-id",
-                "type": "public-key",
-                "response": {
-                    "authenticatorData": "data",
-                    "clientDataJSON": "data",
-                    "signature": "sig",
-                },
-            },
-            format="json",
-        )
+        payload = {"id": "some-id", "type": "public-key", "response": response_data}
+        if raw_id is not None:
+            payload["rawId"] = raw_id
+
+        response = self.client.post("/api/webauthn/login/complete/", payload, format="json")
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("userHandle", response.json()["error"])
+        self.assertIn(expected_error, response.json()["error"])
 
     @patch("posthog.auth.verify_passkey_authentication_response")
     def test_login_complete_success(self, mock_verify):

--- a/posthog/api/webauthn.py
+++ b/posthog/api/webauthn.py
@@ -264,7 +264,8 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
 
         # Validate request data format
         response_data: dict[str, Any] = request.data.get("response", {})
-        if payload_error := self._assertion_payload_error(request, response_data):
+        credential_id: str = request.data.get("rawId") or ""
+        if payload_error := self._assertion_payload_error(credential_id, response_data):
             return _login_error(payload_error)
 
         # Type the response data
@@ -280,7 +281,7 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
 
         try:
             verified_user = self._verify_login_assertion(
-                request, credential_id=request.data["rawId"], challenge=challenge, typed_response=typed_response
+                request, credential_id=credential_id, challenge=challenge, typed_response=typed_response
             )
             self._enforce_login_policy(request, verified_user)
 
@@ -312,12 +313,12 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-    def _assertion_payload_error(self, request: Request, response_data: dict[str, Any]) -> str | None:
+    def _assertion_payload_error(self, credential_id: str, response_data: dict[str, Any]) -> str | None:
         """Reject an assertion the verification step cannot read, before any cryptographic work."""
         if not response_data.get("userHandle"):
             return "No userHandle in response. Make sure you're using a discoverable credential."
 
-        if not request.data.get("rawId"):
+        if not credential_id:
             return "No credential ID in response."
 
         # Validate response structure

--- a/posthog/api/webauthn.py
+++ b/posthog/api/webauthn.py
@@ -53,6 +53,18 @@ WEBAUTHN_LOGIN_CHALLENGE_KEY = "webauthn_login_challenge"
 WEBAUTHN_2FA_CHALLENGE_KEY = "webauthn_2fa_challenge"
 
 
+class _LoginRejected(Exception):
+    """Carries the response that ends a passkey login attempt short of a session."""
+
+    def __init__(self, response: Response | JsonResponse) -> None:
+        super().__init__()
+        self.response = response
+
+
+def _login_error(message: str) -> Response:
+    return Response({"error": message}, status=status.HTTP_400_BAD_REQUEST)
+
+
 def user_uuid_to_handle(user_uuid: uuid.UUID) -> bytes:
     """Convert a user's UUID to bytes for use as a WebAuthn user handle."""
     return user_uuid.bytes
@@ -248,124 +260,29 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
         request.session.save()
 
         if not challenge:
-            return Response(
-                {"error": "No login challenge found. Please start login again."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+            return _login_error("No login challenge found. Please start login again.")
 
         # Validate request data format
         response_data: dict[str, Any] = request.data.get("response", {})
-        user_handle_b64 = response_data.get("userHandle")
-
-        if not user_handle_b64:
-            return Response(
-                {"error": "No userHandle in response. Make sure you're using a discoverable credential."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        credential_id = request.data.get("rawId")
-        if not credential_id:
-            return Response(
-                {"error": "No credential ID in response."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Validate response structure
-        if not all(key in response_data for key in ("authenticatorData", "clientDataJSON", "signature")):
-            return Response(
-                {"error": "Invalid response structure. Missing required fields."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if payload_error := self._assertion_payload_error(request, response_data):
+            return _login_error(payload_error)
 
         # Type the response data
         typed_response: WebAuthnAuthenticationResponse = {
             "authenticatorData": response_data["authenticatorData"],
             "clientDataJSON": response_data["clientDataJSON"],
             "signature": response_data["signature"],
-            "userHandle": user_handle_b64,
+            "userHandle": response_data["userHandle"],
         }
 
         # Track if user was already authenticated (for re-auth detection)
-        was_authenticated_before_login_attempt = request.user is not None and request.user.is_authenticated
+        was_authenticated_before_login_attempt = bool(getattr(request.user, "is_authenticated", False))
 
         try:
-            # Perform cryptographic verification first — this is the only trustworthy
-            # source of user identity. The client-provided userHandle is NOT part of the
-            # signed assertion and can be freely spoofed.
-            authenticated_user = authenticate(
-                request=request,
-                credential_id=credential_id,
-                challenge=challenge,
-                response=typed_response,
-                backend=WebauthnBackend,  # no reason to use password or social auth backends
+            verified_user = self._verify_login_assertion(
+                request, credential_id=request.data["rawId"], challenge=challenge, typed_response=typed_response
             )
-
-            if not authenticated_user:
-                # Try to extract user from userHandle for axes failure recording.
-                # This is best-effort — the userHandle may be spoofed, but recording
-                # failures against the claimed identity is acceptable for rate limiting.
-                claimed_user = self._extract_user_from_user_handle(user_handle_b64)
-                if lockout_response := self._handle_authentication_failure(request, claimed_user):
-                    return lockout_response
-
-                return Response(
-                    {"error": "Authentication failed. Please check your passkey and try again."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            # Cast to our User model — WebauthnBackend.authenticate() always returns
-            # posthog.models.User, but Django's authenticate() stub returns _User.
-            verified_user = cast(User, authenticated_user)
-
-            # Verify the userHandle matches the authenticated user. The userHandle
-            # is not signed, so we must confirm it wasn't spoofed before trusting
-            # any pre-authentication context derived from it.
-            claimed_user = self._extract_user_from_user_handle(user_handle_b64)
-            if not claimed_user or claimed_user.pk != verified_user.pk:
-                logger.warning(
-                    "webauthn_login_user_handle_mismatch",
-                    claimed_user_id=claimed_user.pk if claimed_user else None,
-                    authenticated_user_id=verified_user.pk,
-                )
-                # Record failure against the verified user so repeated
-                # mismatch attempts trigger axes rate limiting.
-                if lockout_response := self._handle_authentication_failure(request, verified_user):
-                    return lockout_response
-
-                return Response(
-                    {"error": "Authentication failed."},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            # All policy checks run against the cryptographically verified user
-            evaluate_auth_attempt(
-                request=request._request,
-                email=verified_user.email,
-                action=RadarAction.SIGNIN,
-                auth_method=RadarAuthMethod.PASSKEY,
-                user_id=str(verified_user.distinct_id),
-            )
-
-            # Check axes lockout against the verified user
-            if lockout_response := self._check_axes_lockout(request, verified_user):
-                return lockout_response
-
-            # Check SSO enforcement against the verified user
-            if sso_enforcement_response := self._check_sso_enforcement(verified_user):
-                return sso_enforcement_response
-
-            # Domain enforcement: refuse blocked members — blocked admins still get a gated session.
-            if not resolve_login_organization(verified_user):
-                return Response(
-                    {"error": VERIFIED_DOMAIN_REQUIRED_ERROR},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            if not is_email_verified_for_login(verified_user):
-                # The passkey assertion is verified at this point, so the uuid is safe to return:
-                # the password path returns the same uuid after a correct password. The frontend
-                # uses the uuid to route to /verify_email/<uuid>.
-                raise EmailVerificationPending(str(verified_user.uuid))
+            self._enforce_login_policy(request, verified_user)
 
             # Login the user with the WebauthnBackend
             login(request, verified_user, backend="posthog.auth.WebauthnBackend")
@@ -380,6 +297,8 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
 
             return Response({"success": True})
 
+        except _LoginRejected as rejected:
+            return rejected.response
         except AxesBackendPermissionDenied:
             return axes_locked_out(request)
         except EmailVerificationPending:
@@ -392,6 +311,106 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
                 {"error": f"Login failed"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
+
+    def _assertion_payload_error(self, request: Request, response_data: dict[str, Any]) -> str | None:
+        """Reject an assertion the verification step cannot read, before any cryptographic work."""
+        if not response_data.get("userHandle"):
+            return "No userHandle in response. Make sure you're using a discoverable credential."
+
+        if not request.data.get("rawId"):
+            return "No credential ID in response."
+
+        # Validate response structure
+        if not all(key in response_data for key in ("authenticatorData", "clientDataJSON", "signature")):
+            return "Invalid response structure. Missing required fields."
+
+        return None
+
+    def _verify_login_assertion(
+        self,
+        request: Request,
+        credential_id: str,
+        challenge: str,
+        typed_response: WebAuthnAuthenticationResponse,
+    ) -> User:
+        """Return the user the assertion cryptographically proves.
+
+        Raises `_LoginRejected` carrying the response to send when it proves no one.
+        """
+        # Perform cryptographic verification first — this is the only trustworthy
+        # source of user identity. The client-provided userHandle is NOT part of the
+        # signed assertion and can be freely spoofed.
+        authenticated_user = authenticate(
+            request=request,
+            credential_id=credential_id,
+            challenge=challenge,
+            response=typed_response,
+            backend=WebauthnBackend,  # no reason to use password or social auth backends
+        )
+        user_handle_b64 = typed_response["userHandle"]
+
+        if not authenticated_user:
+            # Try to extract user from userHandle for axes failure recording.
+            # This is best-effort — the userHandle may be spoofed, but recording
+            # failures against the claimed identity is acceptable for rate limiting.
+            claimed_user = self._extract_user_from_user_handle(user_handle_b64)
+            raise _LoginRejected(
+                self._handle_authentication_failure(request, claimed_user)
+                or _login_error("Authentication failed. Please check your passkey and try again.")
+            )
+
+        # Cast to our User model — WebauthnBackend.authenticate() always returns
+        # posthog.models.User, but Django's authenticate() stub returns _User.
+        verified_user = cast(User, authenticated_user)
+
+        # Verify the userHandle matches the authenticated user. The userHandle
+        # is not signed, so we must confirm it wasn't spoofed before trusting
+        # any pre-authentication context derived from it.
+        claimed_user = self._extract_user_from_user_handle(user_handle_b64)
+        if not claimed_user or claimed_user.pk != verified_user.pk:
+            logger.warning(
+                "webauthn_login_user_handle_mismatch",
+                claimed_user_id=claimed_user.pk if claimed_user else None,
+                authenticated_user_id=verified_user.pk,
+            )
+            # Record failure against the verified user so repeated
+            # mismatch attempts trigger axes rate limiting.
+            raise _LoginRejected(
+                self._handle_authentication_failure(request, verified_user) or _login_error("Authentication failed.")
+            )
+
+        return verified_user
+
+    def _enforce_login_policy(self, request: Request, verified_user: User) -> None:
+        """Run the policy checks that gate a session, all against the verified user.
+
+        Raises `_LoginRejected` carrying the response to send when one refuses the login.
+        """
+        evaluate_auth_attempt(
+            request=request._request,
+            email=verified_user.email,
+            action=RadarAction.SIGNIN,
+            auth_method=RadarAuthMethod.PASSKEY,
+            user_id=str(verified_user.distinct_id),
+        )
+
+        # Check axes lockout against the verified user
+        if lockout_response := self._check_axes_lockout(request, verified_user):
+            raise _LoginRejected(lockout_response)
+
+        # Check SSO enforcement against the verified user
+        if sso_enforcement_response := self._check_sso_enforcement(verified_user):
+            raise _LoginRejected(sso_enforcement_response)
+
+        # Domain enforcement: refuse blocked members — blocked admins still get a gated session.
+        if not resolve_login_organization(verified_user):
+            raise _LoginRejected(_login_error(VERIFIED_DOMAIN_REQUIRED_ERROR))
+
+        if not is_email_verified_for_login(verified_user):
+            # The passkey assertion is verified at this point, so the uuid is safe to return:
+            # the password path returns the same uuid after a correct password. The frontend
+            # uses the uuid to route to /verify_email/<uuid>.
+            raise EmailVerificationPending(str(verified_user.uuid))
 
     def _extract_user_from_user_handle(self, user_handle_b64: str) -> User | None:
         """Extract user from base64url-encoded userHandle (UUID bytes)."""

--- a/posthog/api/webauthn.py
+++ b/posthog/api/webauthn.py
@@ -53,14 +53,6 @@ WEBAUTHN_LOGIN_CHALLENGE_KEY = "webauthn_login_challenge"
 WEBAUTHN_2FA_CHALLENGE_KEY = "webauthn_2fa_challenge"
 
 
-class _LoginRejected(Exception):
-    """Carries the response that ends a passkey login attempt short of a session."""
-
-    def __init__(self, response: Response | JsonResponse) -> None:
-        super().__init__()
-        self.response = response
-
-
 def _login_error(message: str) -> Response:
     return Response({"error": message}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -283,7 +275,10 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
             verified_user = self._verify_login_assertion(
                 request, credential_id=credential_id, challenge=challenge, typed_response=typed_response
             )
-            self._enforce_login_policy(request, verified_user)
+            if not isinstance(verified_user, User):
+                return verified_user
+            if policy_response := self._enforce_login_policy(request, verified_user):
+                return policy_response
 
             # Login the user with the WebauthnBackend
             login(request, verified_user, backend="posthog.auth.WebauthnBackend")
@@ -298,8 +293,6 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
 
             return Response({"success": True})
 
-        except _LoginRejected as rejected:
-            return rejected.response
         except AxesBackendPermissionDenied:
             return axes_locked_out(request)
         except EmailVerificationPending:
@@ -333,10 +326,10 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
         credential_id: str,
         challenge: str,
         typed_response: WebAuthnAuthenticationResponse,
-    ) -> User:
+    ) -> User | Response | JsonResponse:
         """Return the user the assertion cryptographically proves.
 
-        Raises `_LoginRejected` carrying the response to send when it proves no one.
+        Returns the response to send instead when it proves no one.
         """
         # Perform cryptographic verification first — this is the only trustworthy
         # source of user identity. The client-provided userHandle is NOT part of the
@@ -355,9 +348,8 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
             # This is best-effort — the userHandle may be spoofed, but recording
             # failures against the claimed identity is acceptable for rate limiting.
             claimed_user = self._extract_user_from_user_handle(user_handle_b64)
-            raise _LoginRejected(
-                self._handle_authentication_failure(request, claimed_user)
-                or _login_error("Authentication failed. Please check your passkey and try again.")
+            return self._handle_authentication_failure(request, claimed_user) or _login_error(
+                "Authentication failed. Please check your passkey and try again."
             )
 
         # Cast to our User model — WebauthnBackend.authenticate() always returns
@@ -376,16 +368,16 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
             )
             # Record failure against the verified user so repeated
             # mismatch attempts trigger axes rate limiting.
-            raise _LoginRejected(
-                self._handle_authentication_failure(request, verified_user) or _login_error("Authentication failed.")
-            )
+            return self._handle_authentication_failure(request, verified_user) or _login_error("Authentication failed.")
 
         return verified_user
 
-    def _enforce_login_policy(self, request: Request, verified_user: User) -> None:
+    def _enforce_login_policy(self, request: Request, verified_user: User) -> Response | JsonResponse | None:
         """Run the policy checks that gate a session, all against the verified user.
 
-        Raises `_LoginRejected` carrying the response to send when one refuses the login.
+        Returns the response to send when a check refuses the login, or None when all of them
+        pass. Email verification is the exception: it raises, so the DRF handler formats the 401
+        the password path also returns.
         """
         evaluate_auth_attempt(
             request=request._request,
@@ -397,21 +389,23 @@ class WebAuthnLoginViewSet(viewsets.ViewSet):
 
         # Check axes lockout against the verified user
         if lockout_response := self._check_axes_lockout(request, verified_user):
-            raise _LoginRejected(lockout_response)
+            return lockout_response
 
         # Check SSO enforcement against the verified user
         if sso_enforcement_response := self._check_sso_enforcement(verified_user):
-            raise _LoginRejected(sso_enforcement_response)
+            return sso_enforcement_response
 
         # Domain enforcement: refuse blocked members — blocked admins still get a gated session.
         if not resolve_login_organization(verified_user):
-            raise _LoginRejected(_login_error(VERIFIED_DOMAIN_REQUIRED_ERROR))
+            return _login_error(VERIFIED_DOMAIN_REQUIRED_ERROR)
 
         if not is_email_verified_for_login(verified_user):
             # The passkey assertion is verified at this point, so the uuid is safe to return:
             # the password path returns the same uuid after a correct password. The frontend
             # uses the uuid to route to /verify_email/<uuid>.
             raise EmailVerificationPending(str(verified_user.uuid))
+
+        return None
 
     def _extract_user_from_user_handle(self, user_handle_b64: str) -> User | None:
         """Extract user from base64url-encoded userHandle (UUID bytes)."""


### PR DESCRIPTION
## Problem

Passkey login is the one place that decides whether a browser assertion becomes a session. Everything that decision depends on sits in one 140-line method: payload shape checks, the cryptographic verification, the spoofed-userHandle comparison, axes lockout recording, SSO enforcement, domain enforcement, and email verification. A reviewer auditing any one of those has to hold the other six.

Ruff scores `WebAuthnLoginViewSet.complete` at 16 against the configured C901 limit of 10.

## Changes

- Nothing changes for someone signing in with a passkey: same status codes, same error strings, same order of checks.
- `complete` now reads as verify, enforce, log in. It scores 8.
- `_verify_login_assertion` holds the identity half: `authenticate`, the failed-attempt recording, and the userHandle match against the verified user.
- `_enforce_login_policy` holds the policy half, so the four gates between a verified user and a session sit in one place a reviewer can read top to bottom.
- `_assertion_payload_error` returns the message for a malformed payload, replacing three near-identical 400 blocks.
- The two helpers return the response that ends the attempt, matching the `if x := self._check_...(): return x` idiom the rest of this viewset already uses.
- The credential id is read once, next to the check that guarantees it, rather than by subscript inside the try block.
- Endpoint contract is untouched. This PR adds no schema annotations to the viewset; the login actions still lack them.

> [!NOTE]
> This is an authentication path. The refactor preserves the ordering that matters: verification runs before anything reads the client-supplied `userHandle`, and every policy check still runs against the verified user rather than the claimed one.

## How did you test this code?

Ran `posthog/api/test/test_webauthn.py`. It covers a failed assertion, the userHandle mismatch, axes lockout, SSO enforcement, and the email verification path.

Two cases added, as parameterized rows on the existing malformed-payload test: a request with no `rawId`, and one missing a required response field. Only the missing-`userHandle` branch was covered before, so dropping either of the other two checks would have passed the suite while turning a specific 400 into a generic one.

Also ran `ruff` and `mypy` over the file. Not run: the rest of the authentication suites, and a real passkey login in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from Slack after a Signals scout report listed C901 hotspots, with the ask limited to the ones scoring above 15. This is one of three separate PRs from that list.

Written by the PostHog Slack app (Claude Code). Skills invoked: `/improving-drf-endpoints` before touching the viewset, `/writing-tests` before adding the cases, `/writing-pr-descriptions` for this body, `rs-pr-shepherd` and its `rs-review-swarm` self-review afterwards. The endpoint contract was left alone on purpose: annotating these actions changes the generated OpenAPI surface for auth, which belongs in its own PR.

The self-review ran four independent lenses, including a security pass that tried to construct a bypass of each gate and found none.

An earlier revision carried the rejection response out of the helpers on a private `_LoginRejected` exception, on the assumption that plain return-and-check was what had put the method at 16 in the first place. That assumption was wrong and got measured rather than argued: with the checks already moved into helpers, the caller needs two checks, not ten, so return-and-check scores 8 against the limit of 10. The exception bought one complexity point in exchange for a bespoke type, so it is gone.

Nothing in this diff comes from the agent session. The scout report is derived from this repository's own source.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BG1186CQL/p1788296871844319?thread_ts=1788296871.844319&cid=C0BG1186CQL)*


