### PR TITLE
feat(ingestion): extend merge distinct id histogram buckets to 1M

### DIFF
--- a/nodejs/src/common/utils/db/metrics.ts
+++ b/nodejs/src/common/utils/db/metrics.ts
@@ -19,7 +19,9 @@ export const pluginLogEntryCounter = new Counter({
 export const moveDistinctIdsCountHistogram = new Histogram({
     name: 'move_distinct_ids_count',
     help: 'Number of distinct IDs moved in merge operations',
-    buckets: [0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000],
+    buckets: [
+        0, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000,
+    ],
 })
 
 export const personPropertiesSizeHistogram = new Histogram({


### PR DESCRIPTION
## Problem

Ingestion operators cannot tell how large the biggest person merges are. The `move_distinct_ids_count` histogram tops out at 1000, so a merge that remaps 10k, 50k, or 100k distinct IDs lands in the same bucket as one that remaps 1001.

Wide merges are the ones that hit statement timeouts and wedge partitions, so the tail is exactly the part that matters.

## Changes

- Operators can now see how many distinct IDs a merge moved up to 1,000,000, with buckets at 2k, 5k, 10k, 20k, 50k, 100k, 200k, 500k, and 1M.
- Existing bucket boundaries are unchanged, so current dashboards and quantile queries keep working across the deploy.
- Nothing user-visible changes. The histogram has no labels, so this adds 9 series per pod.

## How did you test this code?

No tests changed. The diff is a bucket list on a `prom-client` histogram, and no test pins the bucket values. Not run: the Node.js test suite, because the change has no code path to exercise.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code located the histogram and both observe sites in the Postgres person repository, confirmed no move limit is configured by default so the full count reaches the metric, and extended the buckets. Skills invoked: /writing-pr-descriptions.

https://claude.ai/code/session_0172QaHYZYQQukn7dbTMwSUe
