### PR TITLE
feat(desktop): track inbox action outcomes

### DIFF
--- a/products/desktop/packages/core/src/inbox/engagement.test.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.test.ts
@@ -79,25 +79,23 @@ describe("buildBulkActionEvents", () => {
     expect(events.every((e) => e.dismissal_reason === undefined)).toBe(true);
   });
 
-  it("attaches dismissal reason/note only for dismiss, truncating the note", () => {
-    const longNote = "x".repeat(600);
+  it("attaches only the dismissal category for dismiss", () => {
     const [dismissed] = buildBulkActionEvents({
       reports: [fakeReport({ id: "a" })],
       actionType: "dismiss",
       surface: "toolbar",
-      dismissal: { reason: "not_relevant", note: longNote },
+      dismissalReason: "not_relevant",
     });
     expect(dismissed.dismissal_reason).toBe("not_relevant");
-    expect(dismissed.dismissal_note).toHaveLength(500);
+    expect(dismissed).not.toHaveProperty("dismissal_note");
 
     const [snoozed] = buildBulkActionEvents({
       reports: [fakeReport({ id: "a" })],
       actionType: "snooze",
       surface: "toolbar",
-      dismissal: { reason: "not_relevant", note: longNote },
+      dismissalReason: "not_relevant",
     });
     expect(snoozed.dismissal_reason).toBeUndefined();
-    expect(snoozed.dismissal_note).toBeUndefined();
   });
 });
 

--- a/products/desktop/packages/core/src/inbox/engagement.ts
+++ b/products/desktop/packages/core/src/inbox/engagement.ts
@@ -58,8 +58,10 @@ export interface BuildBulkActionEventsInput {
   reports: SignalReport[];
   actionType: InboxBulkActionType;
   surface: InboxReportActionSurface;
-  /** Dismissal metadata, only meaningful for `dismiss`. Note is truncated to 500 chars. */
-  dismissal?: { reason?: string; note?: string };
+  triageId?: string;
+  bulkSize?: number;
+  /** Dismissal category, only meaningful for `dismiss`. */
+  dismissalReason?: string;
 }
 
 /**
@@ -74,12 +76,11 @@ export interface BuildBulkActionEventsInput {
 export function buildBulkActionEvents(
   input: BuildBulkActionEventsInput,
 ): InboxReportActionProperties[] {
-  const { reports, actionType, surface, dismissal } = input;
-  const bulkSize = reports.length;
+  const { reports, actionType, surface, triageId, dismissalReason } = input;
+  const bulkSize = input.bulkSize ?? reports.length;
   const isBulk = bulkSize > 1;
   return reports.map((report) => ({
     report_id: report.id,
-    report_title: report.title ?? null,
     report_age_hours: reportAgeHours(report.created_at),
     priority: report.priority ?? null,
     actionability: report.actionability ?? null,
@@ -89,11 +90,9 @@ export function buildBulkActionEvents(
     bulk_size: bulkSize,
     rank: 0,
     list_size: 0,
-    ...(actionType === "dismiss" && dismissal?.reason
-      ? { dismissal_reason: dismissal.reason }
-      : {}),
-    ...(actionType === "dismiss" && dismissal?.note
-      ? { dismissal_note: dismissal.note.slice(0, 500) }
+    ...(triageId ? { triage_id: triageId } : {}),
+    ...(actionType === "dismiss" && dismissalReason
+      ? { dismissal_reason: dismissalReason }
       : {}),
   }));
 }

--- a/products/desktop/packages/core/src/inbox/reportActionEvents.test.ts
+++ b/products/desktop/packages/core/src/inbox/reportActionEvents.test.ts
@@ -24,13 +24,14 @@ function fakeReport(overrides: Partial<SignalReport> = {}): SignalReport {
 }
 
 describe("snapshotReportList", () => {
-  it("captures rank, title, and list size per report", () => {
+  it("captures rank and list size per report without report content", () => {
     const snapshot = snapshotReportList([
       fakeReport({ id: "a", title: "A" }),
       fakeReport({ id: "b", title: "B" }),
     ]);
     expect(snapshot.listSize).toBe(2);
-    expect(snapshot.byId.get("b")).toMatchObject({ rank: 1, title: "B" });
+    expect(snapshot.byId.get("b")).toMatchObject({ rank: 1 });
+    expect(snapshot.byId.get("b")).not.toHaveProperty("title");
   });
 });
 
@@ -61,7 +62,6 @@ describe("buildBulkActionEvents", () => {
       is_bulk: false,
       bulk_size: 1,
       rank: -1,
-      report_title: null,
       priority: null,
     });
   });
@@ -76,12 +76,12 @@ describe("buildDetailActionEvent", () => {
     );
     expect(event).toMatchObject({
       report_id: "x",
-      report_title: "X",
       action_type: "expand_why",
       surface: "detail_pane",
       is_bulk: false,
       bulk_size: 1,
       why_field: "priority",
     });
+    expect(event).not.toHaveProperty("report_title");
   });
 });

--- a/products/desktop/packages/core/src/inbox/reportActionEvents.ts
+++ b/products/desktop/packages/core/src/inbox/reportActionEvents.ts
@@ -4,7 +4,6 @@ import { reportAgeHours } from "./engagement";
 
 export interface ReportListSnapshotEntry {
   rank: number;
-  title: string | null;
   createdAt: string | null;
   priority: string | null;
   actionability: string | null;
@@ -26,7 +25,6 @@ export function snapshotReportList(
             report.id,
             {
               rank: index,
-              title: report.title,
               createdAt: report.created_at,
               priority: report.priority ?? null,
               actionability: report.actionability ?? null,
@@ -48,7 +46,6 @@ export function buildBulkActionEvents(
     const entry = snapshot.byId.get(reportId);
     return {
       report_id: reportId,
-      report_title: entry?.title ?? null,
       report_age_hours: reportAgeHours(entry?.createdAt),
       action_type: actionType,
       surface: "toolbar",
@@ -66,7 +63,6 @@ export type DetailActionExtra = Partial<
   Omit<
     InboxReportActionProperties,
     | "report_id"
-    | "report_title"
     | "report_age_hours"
     | "action_type"
     | "surface"
@@ -92,7 +88,6 @@ export function buildDetailActionEvent(
 ): DetailActionEvent {
   return {
     report_id: report.id,
-    report_title: report.title,
     report_age_hours: reportAgeHours(report.created_at),
     action_type: actionType,
     surface: "detail_pane",

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -715,9 +715,25 @@ export type InboxReportActionSurface =
   | "list_row"
   | "triage";
 
+export type InboxReportActionOutcome = "succeeded" | "failed";
+
+export type InboxReportActionFailureCode =
+  | "offline"
+  | "missing_repository"
+  | "missing_integration"
+  | "signed_out"
+  | "missing_model"
+  | "usage_limit"
+  | "existing_task"
+  | "request_failed"
+  | "task_creation_failed"
+  | "unexpected_error";
+
 export type InboxReviewerScope = "for-you" | "entire-project" | "teammate";
 
 export interface InboxTriageStartedProperties {
+  /** Correlates one Desktop triage run across its start, actions, and end. */
+  triage_id?: string;
   queue_size: number;
   scope: InboxReviewerScope;
   has_active_filters: boolean;
@@ -767,7 +783,6 @@ export interface InboxViewedProperties {
 
 export interface InboxReportOpenedProperties {
   report_id: string;
-  report_title: string | null;
   report_age_hours: number;
   status: string | null;
   priority: string | null;
@@ -781,7 +796,6 @@ export interface InboxReportOpenedProperties {
 
 export interface InboxReportClosedProperties {
   report_id: string;
-  report_title: string | null;
   report_age_hours: number;
   priority: string | null;
   actionability: string | null;
@@ -792,7 +806,6 @@ export interface InboxReportClosedProperties {
 
 export interface InboxReportScrolledProperties {
   report_id: string;
-  report_title: string | null;
   report_age_hours: number;
   priority: string | null;
   actionability: string | null;
@@ -826,7 +839,6 @@ export interface SpendAnalysisTaskOpenedProperties {
 
 export interface InboxReportActionProperties {
   report_id: string;
-  report_title: string | null;
   report_age_hours: number;
   priority: string | null;
   actionability: string | null;
@@ -836,26 +848,30 @@ export interface InboxReportActionProperties {
   bulk_size: number;
   rank: number;
   list_size: number;
+  triage_id?: string;
   dismissal_reason?: string;
-  dismissal_note?: string;
   signal_id?: string;
   signal_source_product?: string;
   signal_source_type?: string;
   signal_section?: "relevant_code" | "data_queried";
   why_field?: "priority" | "actionability";
   task_section?: "research" | "implementation";
-  suggested_reviewer_login?: string;
-  suggested_reviewer_uuid?: string;
   // True when the user submitted Discuss with a first question via the popover.
   has_question?: boolean;
-  // The first question text the user typed before hitting Discuss. Truncated to
-  // 500 chars to keep event payloads bounded.
-  question_text?: string;
   // True when the user submitted Create PR with extra feedback via the popover.
   has_feedback?: boolean;
-  // The feedback text the user typed before hitting Create PR. Truncated to
-  // 500 chars to keep event payloads bounded.
-  feedback_text?: string;
+}
+
+export interface InboxReportActionResultProperties {
+  report_id: string;
+  action_type: InboxReportActionType;
+  surface: InboxReportActionSurface;
+  outcome: InboxReportActionOutcome;
+  duration_ms: number;
+  is_bulk: boolean;
+  bulk_size: number;
+  triage_id?: string;
+  failure_code?: InboxReportActionFailureCode;
 }
 
 /**
@@ -865,8 +881,7 @@ export interface InboxReportActionProperties {
  * against, so it carries the same report classification as the impression and
  * open events. Mirrors cloud's `Inbox report feedback`
  * (`frontend/src/scenes/inbox/inboxAnalytics.ts`) so the clients are
- * comparable in one PostHog project. `note` is optional — the thumbs submit on
- * one click, with no note.
+ * comparable in one PostHog project.
  */
 export interface InboxReportFeedbackProperties {
   report_id: string;
@@ -877,13 +892,10 @@ export interface InboxReportFeedbackProperties {
   /** Whether the report already has an implementation PR. */
   has_pr: boolean;
   surface: InboxReportActionSurface;
-  // Optional free-text note, truncated to keep event payloads bounded. Present
-  // only on the rare path where the rating and note submit together.
-  note?: string;
 }
 
 /**
- * Optional free-text note, offered only once a rating is already recorded. It
+ * Optional note metadata, offered only once a rating is already recorded. It
  * rides on its own event rather than re-firing {@link InboxReportFeedbackProperties}
  * so sentiment stays exactly one event per rating; join back to the rating on
  * `report_id`. Carries `sentiment` too so a note can be read without that join.
@@ -896,8 +908,7 @@ export interface InboxReportFeedbackNoteProperties {
   sentiment: InboxReportFeedbackSentiment;
   has_pr: boolean;
   surface: InboxReportActionSurface;
-  /** Truncated to keep event payloads bounded. */
-  note: string;
+  note_length: number;
 }
 
 // Scout events
@@ -1613,6 +1624,7 @@ export const ANALYTICS_EVENTS = {
   INBOX_REPORT_OPENED: "Inbox report opened",
   INBOX_REPORT_CLOSED: "Inbox report closed",
   INBOX_REPORT_ACTION: "Inbox report action",
+  INBOX_REPORT_ACTION_RESULT: "Inbox report action result",
   INBOX_REPORT_SCROLLED: "Inbox report scrolled",
   INBOX_REPORT_FEEDBACK: "Inbox report feedback",
   INBOX_REPORT_FEEDBACK_NOTE: "Inbox report feedback note",
@@ -1819,6 +1831,7 @@ export type EventPropertyMap = {
   [ANALYTICS_EVENTS.INBOX_REPORT_OPENED]: InboxReportOpenedProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_CLOSED]: InboxReportClosedProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_ACTION]: InboxReportActionProperties;
+  [ANALYTICS_EVENTS.INBOX_REPORT_ACTION_RESULT]: InboxReportActionResultProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_SCROLLED]: InboxReportScrolledProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK]: InboxReportFeedbackProperties;
   [ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK_NOTE]: InboxReportFeedbackNoteProperties;
@@ -1907,9 +1920,12 @@ const INBOX_ANALYTICS_EVENT_NAMES: ReadonlySet<string> = new Set([
   ANALYTICS_EVENTS.INBOX_REPORT_OPENED,
   ANALYTICS_EVENTS.INBOX_REPORT_CLOSED,
   ANALYTICS_EVENTS.INBOX_REPORT_ACTION,
+  ANALYTICS_EVENTS.INBOX_REPORT_ACTION_RESULT,
   ANALYTICS_EVENTS.INBOX_REPORT_SCROLLED,
   ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK,
   ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK_NOTE,
+  ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED,
+  ANALYTICS_EVENTS.INBOX_TRIAGE_ENDED,
   ANALYTICS_EVENTS.SIGNAL_SOURCE_CONNECTED,
 ]);
 

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportChatSidebar.tsx
@@ -8,6 +8,7 @@ import {
   textToContent,
 } from "@posthog/core/message-editor/content";
 import { Button, Spinner, Textarea } from "@posthog/quill";
+import type { InboxReportActionSurface } from "@posthog/shared";
 import type { SignalReport } from "@posthog/shared/types";
 import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useDiscussReport } from "@posthog/ui/features/inbox/hooks/useDiscussReport";
@@ -32,6 +33,8 @@ const isMac =
 
 interface ReportChatSidebarProps {
   report: SignalReport;
+  surface?: InboxReportActionSurface;
+  triageId?: string;
 }
 
 /**
@@ -43,7 +46,11 @@ interface ReportChatSidebarProps {
  * to the existing discussion; only the first question on a task-less report
  * creates one. The full task page stays one click away in the header.
  */
-export function ReportChatSidebar({ report }: ReportChatSidebarProps) {
+export function ReportChatSidebar({
+  report,
+  surface = "detail_pane",
+  triageId,
+}: ReportChatSidebarProps) {
   const width = useReportChatPanelStore((s) => s.width);
   const setWidth = useReportChatPanelStore((s) => s.setWidth);
   const setOpen = useReportChatPanelStore((s) => s.setOpen);
@@ -119,7 +126,11 @@ export function ReportChatSidebar({ report }: ReportChatSidebarProps) {
               <Spinner />
             </div>
           ) : (
-            <ReportChatStarter report={report} />
+            <ReportChatStarter
+              report={report}
+              surface={surface}
+              triageId={triageId}
+            />
           )}
         </div>
       </div>
@@ -182,9 +193,17 @@ function ReportChatConversation({
 
 // The report has no conversation yet: one question starts it, with the full
 // report and its evidence inlined as the agent's context.
-function ReportChatStarter({ report }: { report: SignalReport }) {
+function ReportChatStarter({
+  report,
+  surface,
+  triageId,
+}: {
+  report: SignalReport;
+  surface: InboxReportActionSurface;
+  triageId?: string;
+}) {
   const queryClient = useQueryClient();
-  const fireAction = useReportActionTracker(report);
+  const fireAction = useReportActionTracker(report, surface, triageId);
   const rememberStartedTask = useReportChatPanelStore(
     (s) => s.rememberStartedTask,
   );
@@ -220,6 +239,8 @@ function ReportChatStarter({ report }: { report: SignalReport }) {
     report,
     channelId: taskChannelId,
     redirectOnSuccess: false,
+    surface,
+    triageId,
     onTaskCreated: (task) => {
       // Seed the detail cache with the task we already hold so the panel's
       // useQuery resolves from cache instead of firing a GET that can 404 while

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportReviewersHeader.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportReviewersHeader.tsx
@@ -29,7 +29,10 @@ import {
   useInboxReportArtefacts,
   useUpdateSuggestedReviewers,
 } from "@posthog/ui/features/inbox/hooks/useInboxReports";
-import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
+import {
+  useReportActionResultTracker,
+  useReportActionTracker,
+} from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
 import { useDeferredValue, useMemo, useState } from "react";
 
 function reviewerMatchesAvailable(
@@ -54,6 +57,7 @@ function reviewerMatchesAvailable(
 export function ReportReviewersHeader({ report }: { report: SignalReport }) {
   const client = useOptionalAuthenticatedClient();
   const fireAction = useReportActionTracker(report);
+  const trackResult = useReportActionResultTracker(report);
   const { data: currentUser } = useCurrentUser({ client, enabled: !!client });
   const { data: artefactsResp } = useInboxReportArtefacts(report.id);
   const artefact = selectSuggestedReviewersArtefact(
@@ -96,15 +100,26 @@ export function ReportReviewersHeader({ report }: { report: SignalReport }) {
     const existing = reviewers.find((r) => reviewerMatchesAvailable(r, option));
     if (existing) {
       const next = reviewers.filter((r) => r !== existing);
-      fireAction("remove_suggested_reviewer", {
-        suggested_reviewer_login: existing.github_login || undefined,
-        suggested_reviewer_uuid: existing.user?.uuid,
-      });
-      updateReviewers({
-        artefactId: artefact.id,
-        content: toSuggestedReviewerWriteContent(next),
-        optimisticReviewers: next,
-      });
+      const startedAt = Date.now();
+      fireAction("remove_suggested_reviewer");
+      updateReviewers(
+        {
+          artefactId: artefact.id,
+          content: toSuggestedReviewerWriteContent(next),
+          optimisticReviewers: next,
+        },
+        {
+          onSuccess: () =>
+            trackResult("remove_suggested_reviewer", "succeeded", startedAt),
+          onError: () =>
+            trackResult(
+              "remove_suggested_reviewer",
+              "failed",
+              startedAt,
+              "request_failed",
+            ),
+        },
+      );
       return;
     }
     const optimisticEntry: SuggestedReviewer = {
@@ -119,18 +134,29 @@ export function ReportReviewersHeader({ report }: { report: SignalReport }) {
         last_name: "",
       },
     };
-    fireAction("add_suggested_reviewer", {
-      suggested_reviewer_login: option.github_login || undefined,
-      suggested_reviewer_uuid: option.uuid,
-    });
-    updateReviewers({
-      artefactId: artefact.id,
-      content: [
-        ...toSuggestedReviewerWriteContent(reviewers),
-        { user_uuid: option.uuid },
-      ],
-      optimisticReviewers: [...reviewers, optimisticEntry],
-    });
+    const startedAt = Date.now();
+    fireAction("add_suggested_reviewer");
+    updateReviewers(
+      {
+        artefactId: artefact.id,
+        content: [
+          ...toSuggestedReviewerWriteContent(reviewers),
+          { user_uuid: option.uuid },
+        ],
+        optimisticReviewers: [...reviewers, optimisticEntry],
+      },
+      {
+        onSuccess: () =>
+          trackResult("add_suggested_reviewer", "succeeded", startedAt),
+        onError: () =>
+          trackResult(
+            "add_suggested_reviewer",
+            "failed",
+            startedAt,
+            "request_failed",
+          ),
+      },
+    );
   };
 
   return (

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -101,7 +101,9 @@ export function ReportTriageFocus({
   const [expanded, setExpanded] = useState(false);
   const chatOpen = useReportChatPanelStore((state) => state.open);
   const setChatOpen = useReportChatPanelStore((state) => state.setOpen);
+  const triageIdRef = useRef(crypto.randomUUID());
   const sessionContextRef = useRef({
+    triage_id: triageIdRef.current,
     queue_size: reports.length,
     scope: inboxReviewerScopeValue(scope),
     has_active_filters: hasActiveFilters,
@@ -187,6 +189,7 @@ export function ReportTriageFocus({
     allReports,
     report?.id ?? null,
     "triage",
+    triageIdRef.current,
   );
   const dismissPending = bulkActions.isSuppressing || bulkActions.isSnoozing;
 
@@ -299,10 +302,15 @@ export function ReportTriageFocus({
               variant="triage-actions"
               prHotkey={dismissOpen || !prShortcut ? undefined : "c"}
               surface="triage"
+              triageId={triageIdRef.current}
             />
           }
           reviewers={
-            <SuggestedReviewerAvatarStack report={report} surface="triage" />
+            <SuggestedReviewerAvatarStack
+              report={report}
+              surface="triage"
+              triageId={triageIdRef.current}
+            />
           }
           onExit={handleExit}
           onPrevious={goPrev}
@@ -322,7 +330,13 @@ export function ReportTriageFocus({
           />
         )}
       </div>
-      {chatOpen && <ReportChatSidebar report={report} />}
+      {chatOpen && (
+        <ReportChatSidebar
+          report={report}
+          surface="triage"
+          triageId={triageIdRef.current}
+        />
+      )}
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportVerdictBanner.tsx
@@ -71,6 +71,7 @@ interface ReportVerdictBannerProps {
   onEngaged?: () => void;
   /** Analytics and behavior context for actions rendered in this banner. */
   surface?: InboxReportActionSurface;
+  triageId?: string;
 }
 
 /**
@@ -85,6 +86,7 @@ export function ReportVerdictBanner({
   initialEngagementOnly = false,
   onEngaged,
   surface = "detail_pane",
+  triageId,
 }: ReportVerdictBannerProps) {
   const compact = variant === "header-actions";
   const triageActions = variant === "triage-actions";
@@ -138,7 +140,7 @@ export function ReportVerdictBanner({
 
   const verdict = deriveReportVerdict(report, { hasExistingPr });
 
-  const fireAction = useReportActionTracker(report, surface);
+  const fireAction = useReportActionTracker(report, surface, triageId);
   const openTask = useOpenTask();
   const queryClient = useQueryClient();
   const [prOpen, setPrOpen] = useState(false);
@@ -176,6 +178,8 @@ export function ReportVerdictBanner({
     reportId: report.id,
     reportTitle: report.title ?? null,
     cloudRepository,
+    surface,
+    triageId,
     // The dock binds to the new task the moment it exists — and only then does
     // the view advance. A failed create (offline, missing repo/integration/
     // model, API error) never reaches here, so the report and its actions stay
@@ -186,6 +190,8 @@ export function ReportVerdictBanner({
     report,
     channelId: taskChannelId,
     redirectOnSuccess: false,
+    surface,
+    triageId,
     onTaskCreated: handleTaskCreated,
   });
 
@@ -195,7 +201,7 @@ export function ReportVerdictBanner({
   // right there). Running reports keep it out of the banner because the header's
   // Dismiss covers that rare case.
   const { dialog: dismissDialog, openDialog: openDismissDialog } =
-    useInboxReportDismissAction(report, surface);
+    useInboxReportDismissAction(report, surface, triageId);
   const canArchiveHere =
     report.status === "ready" ||
     report.status === "failed" ||
@@ -205,7 +211,6 @@ export function ReportVerdictBanner({
     const trimmed = prFeedback.trim();
     fireAction("create_pr", {
       has_feedback: trimmed.length > 0,
-      ...(trimmed ? { feedback_text: trimmed.slice(0, 500) } : {}),
     });
     setPrFeedback("");
     setPrOpen(false);

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   currentUserUuid: "user-me",
   mutate: vi.fn(),
   trackAction: vi.fn(),
+  trackResult: vi.fn(),
   lastSurface: undefined as string | undefined,
 }));
 
@@ -35,6 +36,7 @@ vi.mock("@posthog/ui/features/inbox/hooks/useReportActionTracker", () => ({
     mocks.lastSurface = surface;
     return mocks.trackAction;
   },
+  useReportActionResultTracker: () => mocks.trackResult,
 }));
 
 import { SuggestedReviewerAvatarStack } from "./SuggestedReviewerAvatarStack";
@@ -151,18 +153,18 @@ describe("SuggestedReviewerAvatarStack", () => {
     await user.click(button);
 
     expect(onCardClick).not.toHaveBeenCalled();
-    expect(mocks.mutate).toHaveBeenCalledWith({
-      artefactId: "reviewers-1",
-      content: [{ github_login: "bob" }],
-      optimisticReviewers: [teammate],
-    });
-    expect(mocks.trackAction).toHaveBeenCalledWith(
-      "remove_suggested_reviewer",
+    expect(mocks.mutate).toHaveBeenCalledWith(
       {
-        suggested_reviewer_login: "alice",
-        suggested_reviewer_uuid: "user-me",
+        artefactId: "reviewers-1",
+        content: [{ github_login: "bob" }],
+        optimisticReviewers: [teammate],
       },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
     );
+    expect(mocks.trackAction).toHaveBeenCalledWith("remove_suggested_reviewer");
     document.removeEventListener("click", onCardClick);
   });
 

--- a/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SuggestedReviewerAvatarStack.tsx
@@ -25,7 +25,10 @@ import {
   useInboxReportArtefacts,
   useUpdateSuggestedReviewers,
 } from "@posthog/ui/features/inbox/hooks/useInboxReports";
-import { useReportActionTracker } from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
+import {
+  useReportActionResultTracker,
+  useReportActionTracker,
+} from "@posthog/ui/features/inbox/hooks/useReportActionTracker";
 
 const MAX_VISIBLE = 4;
 // Keep this stable because autocapture insights and UI tests can depend on it.
@@ -38,12 +41,14 @@ interface SuggestedReviewerAvatarStackProps {
   /** Analytics surface for the remove-self action; the stack lives on list
    * cards by default, but the detail header reuses it. */
   surface?: InboxReportActionSurface;
+  triageId?: string;
 }
 
 export function SuggestedReviewerAvatarStack({
   report,
   artefacts,
   surface = "list_row",
+  triageId,
 }: SuggestedReviewerAvatarStackProps) {
   const client = useOptionalAuthenticatedClient();
   const { data: currentUser } = useCurrentUser({ client, enabled: !!client });
@@ -55,7 +60,8 @@ export function SuggestedReviewerAvatarStack({
   const { mutate: updateReviewers, isPending } = useUpdateSuggestedReviewers(
     report.id,
   );
-  const fireAction = useReportActionTracker(report, surface);
+  const fireAction = useReportActionTracker(report, surface, triageId);
+  const trackResult = useReportActionResultTracker(report, surface, triageId);
   const reviewerArtefact = selectSuggestedReviewersArtefact(
     artefacts?.results ?? data?.results ?? [],
   );
@@ -96,15 +102,26 @@ export function SuggestedReviewerAvatarStack({
     const nextReviewers = reviewerArtefact.content.filter(
       (reviewer) => reviewer.user?.uuid !== currentUser?.uuid,
     );
-    fireAction("remove_suggested_reviewer", {
-      suggested_reviewer_login: currentReviewer.github_login,
-      suggested_reviewer_uuid: currentReviewer.user?.uuid,
-    });
-    updateReviewers({
-      artefactId: reviewerArtefact.id,
-      content: toSuggestedReviewerWriteContent(nextReviewers),
-      optimisticReviewers: nextReviewers,
-    });
+    const startedAt = Date.now();
+    fireAction("remove_suggested_reviewer");
+    updateReviewers(
+      {
+        artefactId: reviewerArtefact.id,
+        content: toSuggestedReviewerWriteContent(nextReviewers),
+        optimisticReviewers: nextReviewers,
+      },
+      {
+        onSuccess: () =>
+          trackResult("remove_suggested_reviewer", "succeeded", startedAt),
+        onError: () =>
+          trackResult(
+            "remove_suggested_reviewer",
+            "failed",
+            startedAt,
+            "request_failed",
+          ),
+      },
+    );
   };
 
   return (

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/ReportFeedbackFooter.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/ReportFeedbackFooter.test.tsx
@@ -96,7 +96,7 @@ describe("ReportFeedbackFooter", () => {
         sentiment: "negative",
         has_pr: false,
         surface: "detail_footer",
-        note: "some detail",
+        note_length: 11,
       },
     );
     expect(screen.getByText("Note added")).toBeInTheDocument();

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useCreateCanvasReport.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useCreateCanvasReport.ts
@@ -84,6 +84,10 @@ export function useCreateCanvasReport({
   const { run, isRunning } = useInboxCloudTaskRunner({
     reportId,
     reportTitle,
+    reportAction: {
+      action_type: "create_canvas",
+      surface: "detail_pane",
+    },
     cloudRepository,
     // The server resolves the repo from the report itself, same as Discuss; no
     // client-side repo gate applies to building a canvas.

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useCreatePrReport.ts
@@ -1,6 +1,7 @@
 import { buildCreatePrReportPrompt } from "@posthog/core/inbox/reportActions";
 import { buildPostHogUrl } from "@posthog/core/settings/posthogUrl";
 import type { TaskCreationInput } from "@posthog/core/task-detail/taskService";
+import type { InboxReportActionSurface } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
@@ -14,6 +15,8 @@ interface UseCreatePrReportOptions {
   reportId: string;
   reportTitle: string | null;
   cloudRepository: string | null;
+  surface?: InboxReportActionSurface;
+  triageId?: string;
   /** Fires once the implementation task exists (the chat dock binds to it). */
   onTaskCreated?: (task: Task) => void;
 }
@@ -47,6 +50,8 @@ export function useCreatePrReport({
   reportId,
   reportTitle,
   cloudRepository,
+  surface = "detail_pane",
+  triageId,
   onTaskCreated,
 }: UseCreatePrReportOptions): UseCreatePrReportReturn {
   const { data: teamConfig } = useSignalTeamConfig();
@@ -115,6 +120,11 @@ export function useCreatePrReport({
   const { run, isRunning } = useInboxCloudTaskRunner({
     reportId,
     reportTitle,
+    reportAction: {
+      action_type: "create_pr",
+      surface,
+      ...(triageId ? { triage_id: triageId } : {}),
+    },
     cloudRepository,
     loggerScope: "create-pr-report",
     copy: {

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useDiscussReport.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useDiscussReport.ts
@@ -1,6 +1,7 @@
 import { buildDiscussReportPrompt } from "@posthog/core/inbox/reportActions";
 import { buildReportPromptContext } from "@posthog/core/inbox/reportPromptContext";
 import type { TaskCreationInput } from "@posthog/core/task-detail/taskService";
+import type { InboxReportActionSurface } from "@posthog/shared/analytics-events";
 import type { SignalReport, Task } from "@posthog/shared/types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
@@ -23,6 +24,8 @@ interface UseDiscussReportOptions {
   redirectOnSuccess?: boolean;
   /** Called with the created task, before any navigation. */
   onTaskCreated?: (task: Task) => void;
+  surface?: InboxReportActionSurface;
+  triageId?: string;
 }
 
 interface UseDiscussReportReturn {
@@ -56,6 +59,8 @@ export function useDiscussReport({
   channelId,
   redirectOnSuccess,
   onTaskCreated,
+  surface = "detail_pane",
+  triageId,
 }: UseDiscussReportOptions): UseDiscussReportReturn {
   const queryClient = useQueryClient();
   const client = useOptionalAuthenticatedClient();
@@ -108,6 +113,11 @@ export function useDiscussReport({
   const { run, isRunning } = useInboxCloudTaskRunner({
     reportId: report.id,
     reportTitle: report.title ?? null,
+    reportAction: {
+      action_type: "discuss",
+      surface,
+      ...(triageId ? { triage_id: triageId } : {}),
+    },
     // The server resolves the repo from the report itself; no client-side repo
     // or GitHub-integration gate applies to starting a discussion.
     cloudRepository: null,

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBulkActions.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBulkActions.ts
@@ -51,23 +51,33 @@ interface BulkActionResult {
   successCount: number;
   failureCount: number;
   succeededIds: string[];
+  failedIds: string[];
+  durationMs: number;
+  totalCount: number;
 }
 
 async function runBulkAction(
   reportIds: string[],
   perItem: (reportId: string) => Promise<unknown>,
 ): Promise<BulkActionResult> {
+  const startedAt = Date.now();
   const results = await Promise.allSettled(reportIds.map(perItem));
   const succeededIds: string[] = [];
+  const failedIds: string[] = [];
   for (let i = 0; i < results.length; i += 1) {
     if (results[i].status === "fulfilled") {
       succeededIds.push(reportIds[i]);
+    } else {
+      failedIds.push(reportIds[i]);
     }
   }
   return {
     successCount: succeededIds.length,
-    failureCount: results.length - succeededIds.length,
+    failureCount: failedIds.length,
     succeededIds,
+    failedIds,
+    durationMs: Date.now() - startedAt,
+    totalCount: reportIds.length,
   };
 }
 
@@ -220,6 +230,7 @@ export function useInboxBulkActions(
   reports: SignalReport[],
   selection: InboxBulkSelection,
   surface: InboxReportActionSurface = "toolbar",
+  triageId?: string,
 ) {
   const queryClient = useQueryClient();
   const client = useOptionalAuthenticatedClient();
@@ -243,25 +254,50 @@ export function useInboxBulkActions(
       result: BulkActionResult,
       dismissal?: DismissReportDialogResult,
     ) => {
-      if (result.successCount === 0) return;
       const byId = new Map(reports.map((report) => [report.id, report]));
       const succeeded = result.succeededIds
         .map((id) => byId.get(id))
         .filter((report): report is SignalReport => report !== undefined);
-      if (succeeded.length === 0) return;
-      const events = buildBulkActionEvents({
-        reports: succeeded,
-        actionType,
-        surface,
-        dismissal: dismissal
-          ? { reason: dismissal.reason, note: dismissal.note }
-          : undefined,
-      });
-      for (const event of events) {
-        track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION, event);
+      if (succeeded.length > 0) {
+        const events = buildBulkActionEvents({
+          reports: succeeded,
+          actionType,
+          surface,
+          triageId,
+          bulkSize: result.totalCount,
+          dismissalReason: dismissal?.reason,
+        });
+        for (const event of events) {
+          track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION, event);
+        }
+      }
+      for (const reportId of result.succeededIds) {
+        track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION_RESULT, {
+          report_id: reportId,
+          action_type: actionType,
+          surface,
+          outcome: "succeeded",
+          duration_ms: result.durationMs,
+          is_bulk: result.totalCount > 1,
+          bulk_size: result.totalCount,
+          ...(triageId ? { triage_id: triageId } : {}),
+        });
+      }
+      for (const reportId of result.failedIds) {
+        track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION_RESULT, {
+          report_id: reportId,
+          action_type: actionType,
+          surface,
+          outcome: "failed",
+          failure_code: "request_failed",
+          duration_ms: result.durationMs,
+          is_bulk: result.totalCount > 1,
+          bulk_size: result.totalCount,
+          ...(triageId ? { triage_id: triageId } : {}),
+        });
       }
     },
-    [reports, surface],
+    [reports, surface, triageId],
   );
 
   /**

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -16,6 +16,11 @@ import {
   defaultEligibleModel,
   getCloudUrlFromRegion,
 } from "@posthog/shared";
+import type {
+  InboxReportActionFailureCode,
+  InboxReportActionSurface,
+  InboxReportActionType,
+} from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { showOfflineToast } from "@posthog/ui/features/connectivity/connectivityToast";
@@ -79,6 +84,11 @@ export interface UseInboxCloudTaskRunnerOptions {
   /** Backing signal report, when the task is report-scoped (Create PR, Discuss). */
   reportId?: string;
   reportTitle?: string | null;
+  reportAction?: {
+    action_type: InboxReportActionType;
+    surface: InboxReportActionSurface;
+    triage_id?: string;
+  };
   cloudRepository: string | null;
   /**
    * When true, a missing repository is not an error: the task is created
@@ -121,6 +131,7 @@ export interface UseInboxCloudTaskRunnerReturn {
 export function useInboxCloudTaskRunner({
   reportId,
   reportTitle,
+  reportAction,
   cloudRepository,
   allowMissingRepository = false,
   copy,
@@ -142,14 +153,36 @@ export function useInboxCloudTaskRunner({
   const run = useCallback(async () => {
     if (isRunning) return;
     const log = logger.scope(loggerScope);
+    const startedAt = Date.now();
+    const trackActionResult = (
+      outcome: "succeeded" | "failed",
+      failureCode?: InboxReportActionFailureCode,
+    ) => {
+      if (!reportId || !reportAction) return;
+      track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION_RESULT, {
+        report_id: reportId,
+        action_type: reportAction.action_type,
+        surface: reportAction.surface,
+        outcome,
+        duration_ms: Date.now() - startedAt,
+        is_bulk: false,
+        bulk_size: 1,
+        ...(reportAction.triage_id
+          ? { triage_id: reportAction.triage_id }
+          : {}),
+        ...(failureCode ? { failure_code: failureCode } : {}),
+      });
+    };
 
     if (!isOnline) {
       showOfflineToast();
+      trackActionResult("failed", "offline");
       return;
     }
 
     if (!cloudRepository && !allowMissingRepository) {
       toast.error(copy.errorTitle, { description: copy.missingRepository });
+      trackActionResult("failed", "missing_repository");
       return;
     }
 
@@ -160,11 +193,13 @@ export function useInboxCloudTaskRunner({
       : null;
     if (cloudRepository && !githubUserIntegrationId) {
       toast.error(copy.errorTitle, { description: copy.missingIntegration });
+      trackActionResult("failed", "missing_integration");
       return;
     }
 
     if (!cloudRegion) {
       toast.error(copy.errorTitle, { description: copy.signedOut });
+      trackActionResult("failed", "signed_out");
       return;
     }
 
@@ -195,6 +230,7 @@ export function useInboxCloudTaskRunner({
       toast.dismiss(toastId);
       toast.error(copy.errorTitle, { description: copy.missingModel });
       setIsRunning(false);
+      trackActionResult("failed", "missing_model");
       return;
     }
 
@@ -240,6 +276,7 @@ export function useInboxCloudTaskRunner({
       });
 
       if (result.success) {
+        trackActionResult("succeeded");
         toast.dismiss(toastId);
         if (!redirectOnSuccess) {
           const task = createdTask;
@@ -271,6 +308,14 @@ export function useInboxCloudTaskRunner({
           ...analyticsExtras,
         });
       } else {
+        const failureCode: InboxReportActionFailureCode = isUsageLimitResult(
+          result,
+        )
+          ? "usage_limit"
+          : reportId && isSignalReportTaskCapError(result.error)
+            ? "existing_task"
+            : "task_creation_failed";
+        trackActionResult("failed", failureCode);
         toast.dismiss(toastId);
         // Usage-limit blocks already show the upgrade modal; don't double-toast.
         if (!isUsageLimitResult(result)) {
@@ -302,6 +347,7 @@ export function useInboxCloudTaskRunner({
         }
       }
     } catch (error) {
+      trackActionResult("failed", "unexpected_error");
       toast.dismiss(toastId);
       toastError(copy.errorTitle, error);
       log.error("Unexpected error during cloud-task creation", {
@@ -320,6 +366,7 @@ export function useInboxCloudTaskRunner({
     cloudRegion,
     reportId,
     reportTitle,
+    reportAction,
     getUserIntegrationIdForRepo,
     invalidateTasks,
     queryClient,

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReportDismissAction.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxReportDismissAction.tsx
@@ -22,6 +22,7 @@ const EMPTY_REPORTS: SignalReport[] = [];
 export function useInboxReportDismissAction(
   report: SignalReport,
   surface: InboxReportActionSurface = "detail_pane",
+  triageId?: string,
 ): {
   actionButton: ReactElement;
   dialog: ReactElement | null;
@@ -40,6 +41,7 @@ export function useInboxReportDismissAction(
     reportsForActions,
     open ? report.id : null,
     surface,
+    triageId,
   );
 
   const isPending = bulkActions.isSuppressing || bulkActions.isSnoozing;

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportActionTracker.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportActionTracker.ts
@@ -1,4 +1,6 @@
 import type {
+  InboxReportActionFailureCode,
+  InboxReportActionOutcome,
   InboxReportActionProperties,
   InboxReportActionSurface,
   InboxReportActionType,
@@ -12,7 +14,6 @@ type Extras = Partial<
   Omit<
     InboxReportActionProperties,
     | "report_id"
-    | "report_title"
     | "report_age_hours"
     | "priority"
     | "actionability"
@@ -38,12 +39,12 @@ function reportAgeHours(report: SignalReport): number {
 export function useReportActionTracker(
   report: SignalReport,
   surface: InboxReportActionSurface = "detail_pane",
+  triageId?: string,
 ) {
   return useCallback(
     (action: InboxReportActionType, extras: Extras = {}) => {
       track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION, {
         report_id: report.id,
-        report_title: report.title ?? null,
         report_age_hours: reportAgeHours(report),
         priority: report.priority ?? null,
         actionability: report.actionability ?? null,
@@ -53,9 +54,38 @@ export function useReportActionTracker(
         bulk_size: 1,
         rank: 0,
         list_size: 0,
+        ...(triageId ? { triage_id: triageId } : {}),
         ...extras,
       });
     },
-    [report, surface],
+    [report, surface, triageId],
+  );
+}
+
+export function useReportActionResultTracker(
+  report: SignalReport,
+  surface: InboxReportActionSurface = "detail_pane",
+  triageId?: string,
+) {
+  return useCallback(
+    (
+      action: InboxReportActionType,
+      outcome: InboxReportActionOutcome,
+      startedAt: number,
+      failureCode?: InboxReportActionFailureCode,
+    ) => {
+      track(ANALYTICS_EVENTS.INBOX_REPORT_ACTION_RESULT, {
+        report_id: report.id,
+        action_type: action,
+        surface,
+        outcome,
+        duration_ms: Date.now() - startedAt,
+        is_bulk: false,
+        bulk_size: 1,
+        ...(triageId ? { triage_id: triageId } : {}),
+        ...(failureCode ? { failure_code: failureCode } : {}),
+      });
+    },
+    [report.id, surface, triageId],
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportFeedbackTracker.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportFeedbackTracker.ts
@@ -8,7 +8,7 @@ import type { SignalReport } from "@posthog/shared/types";
 import { track } from "@posthog/ui/shell/analytics";
 import { useCallback, useMemo } from "react";
 
-/** Bounded to keep the note within the analytics client's per-property limit. */
+/** Input bound; analytics captures only the note length, never its contents. */
 export const FEEDBACK_NOTE_MAX_LENGTH = 4000;
 
 /**
@@ -46,7 +46,7 @@ export function useReportFeedbackTracker(
       track(ANALYTICS_EVENTS.INBOX_REPORT_FEEDBACK_NOTE, {
         ...base,
         sentiment,
-        note: text.slice(0, FEEDBACK_NOTE_MAX_LENGTH),
+        note_length: text.length,
       });
     },
     [base],

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportOpenTracker.ts
@@ -97,7 +97,6 @@ export function useReportOpenTracker(
 
     track(ANALYTICS_EVENTS.INBOX_REPORT_OPENED, {
       report_id: opened.id,
-      report_title: opened.title ?? null,
       report_age_hours: reportAgeHours(opened.created_at),
       status: opened.status ?? null,
       priority: opened.priority ?? null,
@@ -113,7 +112,6 @@ export function useReportOpenTracker(
     return () => {
       track(ANALYTICS_EVENTS.INBOX_REPORT_CLOSED, {
         report_id: opened.id,
-        report_title: opened.title ?? null,
         report_age_hours: reportAgeHours(opened.created_at),
         priority: opened.priority ?? null,
         actionability: opened.actionability ?? null,

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.test.ts
@@ -179,6 +179,23 @@ describe("track", () => {
     );
   });
 
+  it("stamps inbox_client on triage events", async () => {
+    const { initializePostHog, track } = await loadAnalytics();
+    initializePostHog();
+
+    track(ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED, {
+      triage_id: "triage-1",
+      queue_size: 3,
+      scope: "for-you",
+      has_active_filters: false,
+    });
+
+    expect(mockPosthog.capture).toHaveBeenCalledWith(
+      ANALYTICS_EVENTS.INBOX_TRIAGE_STARTED,
+      expect.objectContaining({ inbox_client: "code" }),
+    );
+  });
+
   it("does not stamp inbox_client on non-inbox events", async () => {
     const { initializePostHog, track } = await loadAnalytics();
     initializePostHog();


### PR DESCRIPTION
## Problem

Desktop Inbox analytics records action intent but cannot distinguish successful work from failures. Triage events also cannot be correlated as one run.

Several events include report text or reviewer identifiers that behavioral analysis does not need.

## Changes

- Desktop Inbox mutations now emit a result event with outcome, duration, and a stable failure category.
- Triage starts, actions, and endings share a run ID and carry the Desktop client discriminator.
- Analytics keeps categorical context while removing report titles, free text, dismissal notes, and reviewer identities.
- Nothing changes visually.

## How did you test this code?

- Extended Inbox analytics tests to guard privacy-safe payloads and Desktop client tagging.
- Ran the focused Core and UI Inbox tests.
- Verified the shared contract across every Desktop package and host.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing documentation changes are needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the change using PostHog product data and the existing Desktop analytics contract.

Skills used: `/instrument-product-analytics`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The committed fixtures and event fields come from the public repository. No private production values are included.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*