### PR TITLE
fix(tasks): stop silent and canceling runs promptly

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -346,15 +346,12 @@ def _should_signal_workflow_heartbeat(
         return False
     if last_workflow_signal is not None and (now - last_workflow_signal[0]) < HEARTBEAT_INTERVAL_SECONDS:
         return False
-    # An in-flight turn can be legitimately quiet for minutes (a long tool call
-    # emits no session events), so a short per-run idle window (loop runs: 2
-    # minutes) must not starve keep-alives mid-turn and let the workflow tear
-    # the sandbox down under the agent. Floor the freshness guard at the
-    # background default; that still bounds how long a turn that hung without
-    # an end_of_turn can pin the sandbox, and the short window keeps applying
-    # to post-turn idleness because agent_active is false there.
-    event_freshness_seconds = max(inactivity_timeout_seconds, INACTIVITY_TIMEOUT_DEFAULT_SECONDS)
-    return (now - last_event_time[0]) < event_freshness_seconds
+    # The workflow starts a full inactivity timer after the final heartbeat.
+    # Subtract that timer so event silence never exceeds the larger idle window.
+    heartbeat_budget_seconds = (
+        max(inactivity_timeout_seconds, INACTIVITY_TIMEOUT_DEFAULT_SECONDS) - inactivity_timeout_seconds
+    )
+    return heartbeat_budget_seconds > 0 and (now - last_event_time[0]) < heartbeat_budget_seconds
 
 
 async def _relay_loop(

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -307,11 +307,16 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
         # background-mode runs hang until the inactivity timeout because
         raise ApplicationError(f"send_followup failed: {error_msg}", non_retryable=True)
 
+    if (task_run.state or {}).get("cancel_requested_at"):
+        if peer_message_id is not None:
+            _mark_peer_delivery_outcome(
+                peer_message_id, AgentPeerMessage.Outcome.DELIVERY_FAILED, "run_stopping", RUN_STOPPING_MESSAGE
+            )
+            raise ApplicationError(f"peer message delivery failed: {RUN_STOPPING_MESSAGE}", non_retryable=True)
+        raise ApplicationError(RUN_STOPPING_MESSAGE, non_retryable=True)
+
     if peer_message_id is not None:
         return _deliver_peer_message(input, task_run, peer_message_id)
-
-    if (task_run.state or {}).get("cancel_requested_at"):
-        raise ApplicationError(RUN_STOPPING_MESSAGE, non_retryable=True)
 
     # Resolve credentials against this message's sender, not the run-state
     # actor a concurrent follow-up may have overwritten since queueing. Local

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -307,7 +307,11 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
         # background-mode runs hang until the inactivity timeout because
         raise ApplicationError(f"send_followup failed: {error_msg}", non_retryable=True)
 
-    if (task_run.state or {}).get("cancel_requested_at"):
+    # Reject the marker written by user-initiated cancel, and the bare CANCELLED status that
+    # loop overlap and lifecycle cancellation set without that marker (loop_runs.py,
+    # loop_lifecycle.py). Either means the run is winding down, so no follow-up should rebind
+    # credentials or reach the sandbox.
+    if (task_run.state or {}).get("cancel_requested_at") or task_run.status == TaskRun.Status.CANCELLED:
         if peer_message_id is not None:
             _mark_peer_delivery_outcome(
                 peer_message_id, AgentPeerMessage.Outcome.DELIVERY_FAILED, "run_stopping", RUN_STOPPING_MESSAGE

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -83,6 +83,7 @@ REFRESH_RETRY_DELAY_SECONDS = 0.5
 SANDBOX_STOPPED_MESSAGE = (
     "This run's sandbox has stopped, so your message wasn't delivered. Start a new run to continue."
 )
+RUN_STOPPING_MESSAGE = "This run is stopping, so your message wasn't delivered. Start a new run to continue."
 PEER_SANDBOX_STOPPED_MESSAGE = "The recipient run's sandbox has stopped"
 DENIED_PERMISSION_STOP_MESSAGE = (
     "Stopped after the denied action. Send a new message to continue with a different approach."
@@ -308,6 +309,9 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
 
     if peer_message_id is not None:
         return _deliver_peer_message(input, task_run, peer_message_id)
+
+    if (task_run.state or {}).get("cancel_requested_at"):
+        raise ApplicationError(RUN_STOPPING_MESSAGE, non_retryable=True)
 
     # Resolve credentials against this message's sender, not the run-state
     # actor a concurrent follow-up may have overwritten since queueing. Local

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_relay_sandbox_events.py
@@ -1293,20 +1293,22 @@ class TestShouldSignalWorkflowHeartbeat:
             # Loop runs carry a 2-minute idle window; a quiet in-flight turn past that
             # window must still keep the workflow alive (the mid-turn teardown bug).
             ("mid_turn_quiet_past_short_run_window", True, 300.0, 120.0, True),
-            # The floor is the background default, not unbounded: a turn that hung
-            # without an end_of_turn stops pinning the sandbox past that window.
+            # Leave the workflow's short inactivity timer enough time to expire at
+            # the background default instead of after another full short window.
             (
-                "mid_turn_quiet_past_default_window",
+                "mid_turn_quiet_past_heartbeat_budget",
                 True,
-                float(INACTIVITY_TIMEOUT_DEFAULT_SECONDS) + 60.0,
+                float(INACTIVITY_TIMEOUT_DEFAULT_SECONDS) - 60.0,
                 120.0,
                 False,
             ),
             # Idle after end_of_turn: the short loop window applies and the run winds down.
             ("idle_agent_stale_events", False, 300.0, 120.0, False),
             ("mid_turn_fresh_events", True, 30.0, 120.0, True),
-            # Runs with a window above the default keep their longer window mid-turn.
-            ("mid_turn_long_window_still_fresh", True, float(INACTIVITY_TIMEOUT_DEFAULT_SECONDS) + 60.0, 3600.0, True),
+            # Default and longer windows rely on the event-driven heartbeat, then
+            # let their own inactivity timer measure the full silence window.
+            ("mid_turn_default_window_uses_event_heartbeat", True, 30.0, 1800.0, False),
+            ("mid_turn_long_window_uses_event_heartbeat", True, 30.0, 3600.0, False),
         ]
     )
     def test_freshness_gating(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_send_followup_to_sandbox.py
@@ -89,6 +89,7 @@ class TestSendFollowupToSandbox(BaseTest):
         self, mock_task_run_objects, mock_send_user_message, mock_publish
     ):
         task_run = MagicMock()
+        task_run.state = {}
         task_run.task.created_by = None
         mock_task_run_objects.select_related.return_value.get.return_value = task_run
         mock_send_user_message.return_value = MagicMock(

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -1313,6 +1313,24 @@ class TestPeerDeliveryMode:
         assert _patches["mark"].call_args.args == (self._PEER_ID, "delivery_failed")
         assert _patches["mark"].call_args.kwargs["failure_phase"] == "credential_identity"
 
+    def test_stopping_run_rejects_before_peer_delivery(self, _patches):
+        _patches["task_run"].state = {"cancel_requested_at": "2026-01-01T00:00:00+00:00"}
+
+        with pytest.raises(ApplicationError) as excinfo:
+            send_followup_to_sandbox(
+                SendFollowupToSandboxInput(
+                    run_id="run-1", message="peer ping", message_id="m-1", context=self._peer_context()
+                )
+            )
+
+        assert excinfo.value.non_retryable is True
+        _patches["conn_token"].assert_not_called()
+        _patches["refresh_mcp"].assert_not_called()
+        _patches["refresh_github"].assert_not_called()
+        _patches["user_msg"].assert_not_called()
+        assert _patches["mark"].call_args.args == (self._PEER_ID, "delivery_failed")
+        assert _patches["mark"].call_args.kwargs["failure_phase"] == "run_stopping"
+
     @pytest.mark.parametrize("refresh_key", ["refresh_mcp", "refresh_github"])
     def test_refresh_failure_marks_row_without_stream_sentinels(self, _patches, refresh_key):
         _patches["bound_actor"].return_value = (MagicMock(id=42, distinct_id="u42"), "")

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -777,6 +777,22 @@ class TestSendFollowupActivityRefreshOrdering:
         _patches["refresh_github"].assert_not_called()
         _patches["user_msg"].assert_not_called()
 
+    def test_a_cancelled_status_run_rejects_before_rebinding_credentials(self, _patches):
+        # Loop overlap and lifecycle cancellation set CANCELLED without the cancel marker,
+        # so the status alone must reject the follow-up.
+        _patches["task_run"].state = {}
+        _patches["task_run"].status = _patches["task_run_cls"].Status.CANCELLED
+
+        with pytest.raises(ApplicationError) as excinfo:
+            send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-1", message="hi"))
+
+        assert str(excinfo.value) == RUN_STOPPING_MESSAGE
+        assert excinfo.value.non_retryable
+        _patches["conn_token"].assert_not_called()
+        _patches["refresh"].assert_not_called()
+        _patches["refresh_github"].assert_not_called()
+        _patches["user_msg"].assert_not_called()
+
     def test_stopped_sandbox_says_so_once_instead_of_retrying(self, _patches):
         _patches["refresh_github"].return_value = SandboxRebindFailure.SANDBOX_NOT_RUNNING
 

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -11,6 +11,7 @@ from products.tasks.backend.logic.services.agent_command import CommandResult
 from products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox import (
     DENIED_PERMISSION_STOP_MESSAGE,
     REFRESH_RETRY_DELAY_SECONDS,
+    RUN_STOPPING_MESSAGE,
     SANDBOX_STOPPED_MESSAGE,
     SEND_FOLLOWUP_MAX_ATTEMPTS,
     STEER_DECLINED_OUTCOME,
@@ -761,6 +762,19 @@ class TestSendFollowupActivityRefreshOrdering:
         assert str(excinfo.value) == SANDBOX_STOPPED_MESSAGE
         assert excinfo.value.non_retryable
         _patches["refresh"].assert_not_called()
+        _patches["user_msg"].assert_not_called()
+
+    def test_a_stopping_run_rejects_before_rebinding_credentials(self, _patches):
+        _patches["task_run"].state = {"cancel_requested_at": "2026-01-01T00:00:00+00:00"}
+
+        with pytest.raises(ApplicationError) as excinfo:
+            send_followup_to_sandbox(SendFollowupToSandboxInput(run_id="run-1", message="hi"))
+
+        assert str(excinfo.value) == RUN_STOPPING_MESSAGE
+        assert excinfo.value.non_retryable
+        _patches["conn_token"].assert_not_called()
+        _patches["refresh"].assert_not_called()
+        _patches["refresh_github"].assert_not_called()
         _patches["user_msg"].assert_not_called()
 
     def test_stopped_sandbox_says_so_once_instead_of_retrying(self, _patches):


### PR DESCRIPTION
## Problem

Silent task runs could remain active beyond their configured inactivity window because relay heartbeats consumed a full timeout before the workflow started another. Follow-ups could also enter a run after cancellation began.

**Why:** People should be able to trust that a stalled or canceled run stops promptly and gives them a clear next step.

## Changes

Background heartbeats now leave enough time for the workflow inactivity timer, bounding total event silence to the configured window. Canceling runs reject follow-ups before credential rebinding and ask the person to start a new run.

Before:

```mermaid
flowchart LR
    A[Silent run] --> B[Heartbeat for full idle window] --> C[Wait another idle window] --> D[Stop]
    classDef task fill:#F9BD2B,stroke:#1D4AFF,color:#000
    class A,B,C,D task
```

After:

```mermaid
flowchart LR
    A[Silent run] --> B[Heartbeat within remaining budget] --> C[Workflow timer completes total window] --> D[Stop]
    classDef task fill:#F9BD2B,stroke:#1D4AFF,color:#000
    class A,B,C,D task
```

## How did you test this code?

Added regression coverage for heartbeat budgeting and rejecting follow-ups before credential rebinding. The focused task activity suites pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed; this is a backend behavior fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Desktop with Codex implemented the change using the writing tests, code comments, user-facing copy, and PR description skills. Test fixtures use invented values.

---

*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*