### PR TITLE
chore(ci): stop wiping the rust compile cache on every lockfile bump

### DIFF
--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -3,12 +3,18 @@ description: |
     Installs sccache and configures it as the Rust compiler wrapper.
     Uses actions/cache to avoid repeated downloads from GitHub's releases CDN.
     The sccache binary is pinned to a specific version for reproducibility.
+    Namespaces the remote cache on the native-library crate versions in Cargo.lock
+    (see cache-key-prefix.sh) and exports the prefix as SCCACHE_WEBDAV_KEY_PREFIX.
 
 inputs:
     version:
         description: 'sccache version to install (e.g. 0.14.0)'
         required: false
         default: '0.14.0'
+    cargo-lock:
+        description: 'Cargo.lock that keys the remote cache namespace, relative to the workspace'
+        required: false
+        default: 'rust/Cargo.lock'
 
 runs:
     using: composite
@@ -67,8 +73,14 @@ runs:
 
         - name: Configure sccache
           shell: bash
+          env:
+              CARGO_LOCK: ${{ inputs.cargo-lock }}
           run: |
               echo "$RUNNER_TEMP/sccache" >> "$GITHUB_PATH"
+              SCCACHE_WEBDAV_KEY_PREFIX=$(bash "$GITHUB_ACTION_PATH/cache-key-prefix.sh" "$GITHUB_WORKSPACE/$CARGO_LOCK")
+              export SCCACHE_WEBDAV_KEY_PREFIX
+              echo "SCCACHE_WEBDAV_KEY_PREFIX=$SCCACHE_WEBDAV_KEY_PREFIX" >> "$GITHUB_ENV"
+              echo "Remote cache key prefix: $SCCACHE_WEBDAV_KEY_PREFIX"
               for i in 1 2 3; do
                 if "$RUNNER_TEMP/sccache/sccache" --start-server; then
                   echo "sccache server started successfully"

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -3,7 +3,7 @@ description: |
     Installs sccache and configures it as the Rust compiler wrapper.
     Uses actions/cache to avoid repeated downloads from GitHub's releases CDN.
     The sccache binary is pinned to a specific version for reproducibility.
-    Namespaces the remote cache on the native-library crate versions in Cargo.lock
+    Namespaces the remote cache on the native-library crate versions in rust/Cargo.lock
     (see cache-key-prefix.sh) and exports the prefix as SCCACHE_WEBDAV_KEY_PREFIX.
 
 inputs:
@@ -11,10 +11,6 @@ inputs:
         description: 'sccache version to install (e.g. 0.14.0)'
         required: false
         default: '0.14.0'
-    cargo-lock:
-        description: 'Cargo.lock that keys the remote cache namespace, relative to the workspace'
-        required: false
-        default: 'rust/Cargo.lock'
 
 runs:
     using: composite
@@ -73,14 +69,11 @@ runs:
 
         - name: Configure sccache
           shell: bash
-          env:
-              CARGO_LOCK: ${{ inputs.cargo-lock }}
           run: |
               echo "$RUNNER_TEMP/sccache" >> "$GITHUB_PATH"
-              SCCACHE_WEBDAV_KEY_PREFIX=$(bash "$GITHUB_ACTION_PATH/cache-key-prefix.sh" "$GITHUB_WORKSPACE/$CARGO_LOCK")
+              SCCACHE_WEBDAV_KEY_PREFIX=$(bash "$GITHUB_ACTION_PATH/cache-key-prefix.sh" "$GITHUB_WORKSPACE/rust/Cargo.lock")
               export SCCACHE_WEBDAV_KEY_PREFIX
-              echo "SCCACHE_WEBDAV_KEY_PREFIX=$SCCACHE_WEBDAV_KEY_PREFIX" >> "$GITHUB_ENV"
-              echo "Remote cache key prefix: $SCCACHE_WEBDAV_KEY_PREFIX"
+              echo "SCCACHE_WEBDAV_KEY_PREFIX=$SCCACHE_WEBDAV_KEY_PREFIX" | tee -a "$GITHUB_ENV"
               for i in 1 2 3; do
                 if "$RUNNER_TEMP/sccache/sccache" --start-server; then
                   echo "sccache server started successfully"

--- a/.github/actions/setup-sccache/cache-key-prefix.sh
+++ b/.github/actions/setup-sccache/cache-key-prefix.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
-# Prints the sccache remote cache namespace for a Cargo.lock.
-#
-# sccache keys every compile on rustc, the source files, the extern rlibs and
-# the static archives a crate bundles, so an ordinary dependency bump does not
-# need a fresh namespace. The namespace only rotates when a crate that builds
-# or binds a native library changes version, which is the one class of change
-# that has produced link errors against stale artifacts.
+# Prints the sccache remote cache namespace for a Cargo.lock: a hash of the
+# versions of the crates that build or bind native libraries. sccache keys each
+# compile on rustc, the sources and the extern rlibs, so a pure-Rust bump needs
+# no new namespace; only stale native artifacts have produced link errors.
 set -euo pipefail
 
 lock=${1:?usage: cache-key-prefix.sh <path/to/Cargo.lock>}
 
-native_crate_versions=$(
+native_crate_hash=$(
     grep -A1 -E '^name = "([^"]*-sys|openssl-src|ring)"$' "$lock" \
         | grep -E '^(name|version) = ' \
         | paste -d ' ' - - \
-        | sort
+        | LC_ALL=C sort \
+        | sha256sum \
+        | cut -c1-16
 )
 
-printf 'cargo-native-%s\n' "$(printf '%s\n' "$native_crate_versions" | sha256sum | cut -c1-16)"
+printf 'cargo-native-%s\n' "$native_crate_hash"

--- a/.github/actions/setup-sccache/cache-key-prefix.sh
+++ b/.github/actions/setup-sccache/cache-key-prefix.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Prints the sccache remote cache namespace for a Cargo.lock.
+#
+# sccache keys every compile on rustc, the source files, the extern rlibs and
+# the static archives a crate bundles, so an ordinary dependency bump does not
+# need a fresh namespace. The namespace only rotates when a crate that builds
+# or binds a native library changes version, which is the one class of change
+# that has produced link errors against stale artifacts.
+set -euo pipefail
+
+lock=${1:?usage: cache-key-prefix.sh <path/to/Cargo.lock>}
+
+native_crate_versions=$(
+    grep -A1 -E '^name = "([^"]*-sys|openssl-src|ring)"$' "$lock" \
+        | grep -E '^(name|version) = ' \
+        | paste -d ' ' - - \
+        | sort
+)
+
+printf 'cargo-native-%s\n' "$(printf '%s\n' "$native_crate_versions" | sha256sum | cut -c1-16)"

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -148,7 +148,14 @@ jobs:
               env:
                   IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
               run: |
-                  echo "cache-key-prefix=$(bash "$GITHUB_WORKSPACE/.github/actions/setup-sccache/cache-key-prefix.sh" Cargo.lock)" >> "$GITHUB_OUTPUT"
+                  script="$GITHUB_WORKSPACE/.github/actions/setup-sccache/cache-key-prefix.sh"
+                  if [ -f "$script" ]; then
+                      prefix=$(bash "$script" Cargo.lock)
+                  else
+                      # rust-smoke-test-build checks out head.sha, so a branch that predates the script must still get its own namespace.
+                      prefix="cargo-$(sha256sum Cargo.lock | cut -c1-16)"
+                  fi
+                  echo "cache-key-prefix=$prefix" >> "$GITHUB_OUTPUT"
                   if [ "$IS_FORK_PR" = "true" ]; then
                       echo "Fork PR — skipping sccache credentials (build runs without remote cache)"
                       exit 0

--- a/.github/workflows/_rust-build-images.yml
+++ b/.github/workflows/_rust-build-images.yml
@@ -109,6 +109,7 @@ jobs:
                   sparse-checkout: |
                       rust/
                       proto/
+                      .github/actions/setup-sccache/
                   sparse-checkout-cone-mode: false
 
             - name: Copy proto files into rust build context
@@ -147,7 +148,7 @@ jobs:
               env:
                   IS_FORK_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
               run: |
-                  echo "cache-key-prefix=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_OUTPUT"
+                  echo "cache-key-prefix=$(bash "$GITHUB_WORKSPACE/.github/actions/setup-sccache/cache-key-prefix.sh" Cargo.lock)" >> "$GITHUB_OUTPUT"
                   if [ "$IS_FORK_PR" = "true" ]; then
                       echo "Fork PR — skipping sccache credentials (build runs without remote cache)"
                       exit 0

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -174,9 +174,6 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
-
             - name: Install sccache
               uses: ./.github/actions/setup-sccache
 
@@ -238,9 +235,6 @@ jobs:
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
-
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
               uses: ./.github/actions/setup-sccache
@@ -367,9 +361,6 @@ jobs:
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
-
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
               uses: ./.github/actions/setup-sccache
@@ -671,9 +662,6 @@ jobs:
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
-
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
               uses: ./.github/actions/setup-sccache

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -290,9 +290,6 @@ jobs:
                     with:
                         toolchain: 1.91.1
 
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
-
             - name: Install sccache
               uses: ./.github/actions/setup-sccache
 
@@ -314,6 +311,10 @@ jobs:
                   echo "Building shard crates: ${crates[*]}"
                   cargo build "${crates[@]}" --locked --release
                   find target/release/ -maxdepth 1 -executable -type f -exec strip {} +
+
+            - name: Show sccache stats
+              if: ${{ !cancelled() }}
+              run: sccache --show-stats || true
 
     test:
         name: Test Rust (${{ matrix.packages }})
@@ -382,9 +383,6 @@ jobs:
 
             - name: Install protoc
               uses: ./.github/actions/setup-protoc
-
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
               uses: ./.github/actions/setup-sccache
@@ -546,6 +544,10 @@ jobs:
                       fi
                   done
 
+            - name: Show sccache stats
+              if: ${{ !cancelled() }}
+              run: sccache --show-stats || true
+
             # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
             # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
             # secret).
@@ -631,9 +633,6 @@ jobs:
             - name: Install protoc
               uses: ./.github/actions/setup-protoc
 
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
-
             - name: Install sccache
               uses: ./.github/actions/setup-sccache
 
@@ -649,6 +648,10 @@ jobs:
 
             - name: Build the personhog stack and harness
               run: cargo build -p personhog-replica -p personhog-router -p personhog-leader -p personhog-writer -p personhog-identity -p personhog-test-harness
+
+            - name: Show sccache stats
+              if: ${{ !cancelled() }}
+              run: sccache --show-stats || true
 
             # Unit tests for the harness's own verification logic — a
             # false-negative verifier would pass gates that lost data.
@@ -836,9 +839,6 @@ jobs:
                         toolchain: 1.91.1
                         components: clippy,rustfmt
 
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
-
             - name: Install sccache
               uses: ./.github/actions/setup-sccache
 
@@ -863,6 +863,10 @@ jobs:
                   # Use system OpenSSL instead of vendored to avoid assembly build issue (2026-01-13)
                   OPENSSL_NO_VENDOR: '1'
               run: cargo check --all-features
+
+            - name: Show sccache stats
+              if: ${{ !cancelled() }}
+              run: sccache --show-stats || true
 
             - name: Install cargo-binstall
               uses: cargo-bins/cargo-binstall@5cbf019d8cb9b9d5b086218c41458ea35d817691 # main


### PR DESCRIPTION
## Problem

- Rust CI throws away its whole compile cache on every `rust/Cargo.lock` change. After each one, every Rust job on every PR compiles cold until the cache refills.
- The cache namespace is the lockfile hash ([add SCCACHE_CACHE_KEY_PREFIX derived from Cargo.lock](https://github.com/PostHog/posthog/pull/62609)), added so a stale `openssl-sys` artifact cannot link against a newer vendored OpenSSL. That guard only needs to fire when a native-library crate changes version.

| Last 14 days on master | Lockfile-hash prefix (today) | Native-crate prefix (this PR) |
| --- | --- | --- |
| `rust/Cargo.lock` changes | 28 | 28 |
| Compile-cache wipes | 27 | 0 |

Cost of one wipe, measured on this PR:

| Run | `cargo build`, 8 Build jobs | sccache hits |
| --- | --- | --- |
| [cold](https://github.com/PostHog/posthog/actions/runs/33566976236) | 49 min total, 207 to 528 s each | 0% |
| [warm](https://github.com/PostHog/posthog/actions/runs/33631831949) | 11 min total, 59 to 146 s each | 94 to 100% |
| [after a pure-Rust `itoa` bump](https://github.com/PostHog/posthog/actions/runs/33632828300) | 155 to 289 s each | 66 to 87% (today's rule: 0%) |

The 8 Test jobs add 97 min of `cargo test` on a cold run; their warm time was not measured.

## Changes

- The namespace rotates only when a crate that builds or binds a native library changes version: `*-sys`, `openssl-src`, `ring`. sccache already keys on rustc, sources and extern rlibs, so pure-Rust bumps stay warm.
- One script in `setup-sccache` replaces six copied env steps. The Docker build reads the same script and falls back to a per-lockfile prefix on checkouts that predate it.
- Each Rust job prints `sccache --show-stats`.

## How did you test this code?

- The tables above. The wipe count comes from running the prefix script over each of the 28 lockfile versions. The `itoa` bump commit was removed after measuring. Not run locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Skills: /depot-github-runners, /writing-pr-descriptions, /code-review, /simplify. A subagent drafted the change; the session owner reviewed, committed and measured it.

https://claude.ai/code/session_012T7KBo5imZkY2LKzNjpqND
