### PR TITLE
fix(aio): explain the trace root empty state in plain language

### DIFF
--- a/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
@@ -1736,14 +1736,22 @@ const EventContent = React.memo(
                                         <>
                                             {isTopLevelTraceWithoutContent ? (
                                                 <InsightEmptyState
-                                                    heading="No top-level trace event"
+                                                    heading="This trace doesn't have its own input and output"
                                                     detail={
                                                         <>
-                                                            This trace doesn't have an associated <code>$ai_trace</code>{' '}
-                                                            event.
+                                                            This trace groups the events in the tree, and the content is
+                                                            on those events. Select an event to view its input and
+                                                            output.
                                                             <br />
-                                                            Click on individual generations in the tree to view their
-                                                            content.
+                                                            To record an input and output for the whole trace, capture a{' '}
+                                                            <Link
+                                                                to="https://posthog.com/docs/ai-observability/installation/manual-capture"
+                                                                target="_blank"
+                                                            >
+                                                                <code>$ai_trace</code> event
+                                                            </Link>{' '}
+                                                            with <code>$ai_input_state</code> and{' '}
+                                                            <code>$ai_output_state</code> properties.
                                                         </>
                                                     }
                                                 />

--- a/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityTraceScene.tsx
@@ -1736,16 +1736,15 @@ const EventContent = React.memo(
                                         <>
                                             {isTopLevelTraceWithoutContent ? (
                                                 <InsightEmptyState
-                                                    heading="This trace doesn't have its own input and output"
+                                                    heading="No trace-level input and output captured"
                                                     detail={
                                                         <>
-                                                            This trace groups the events in the tree, and the content is
-                                                            on those events. Select an event to view its input and
-                                                            output.
+                                                            This trace's content is on the events in the tree. Select an
+                                                            event to view its input and output.
                                                             <br />
-                                                            To record an input and output for the whole trace, capture a{' '}
+                                                            To show a conversation here, capture a{' '}
                                                             <Link
-                                                                to="https://posthog.com/docs/ai-observability/installation/manual-capture"
+                                                                to="https://posthog.com/docs/ai-observability/traces"
                                                                 target="_blank"
                                                             >
                                                                 <code>$ai_trace</code> event


### PR DESCRIPTION
## Problem

Users who click a trace's root row can hit "No top-level trace event", while the page around it visibly renders a full trace.

- Most SDK integrations send only generation and span events, so nothing is captured at the trace level itself. The root row still shows a name, latency, and cost, so it invites the click.
- The old message reads like data loss, and its explanation only makes sense to a reader who knows the AI event taxonomy.
- It is also inaccurate for projects that do send a `$ai_trace` event but without the state properties; they hit the same empty state.
- Session replays of the trace view showed users hitting this state repeatedly, right after other selection friction.

## Changes

- The empty state heading now names the cause: no input and output were captured at the trace level. The trace still has content through its child events, and the body points to selecting one.
- A second line says how to record trace-level input and output, and links the [traces docs](https://posthog.com/docs/ai-observability/traces) for the `$ai_trace` event.
- The copy says "captured" rather than "no `$ai_trace` event", because sending the event without `$ai_input_state` and `$ai_output_state` lands in this state too.
- Copy only, no logic or layout changes, so no screenshot: the strings are the whole visual diff.

| | Before | After |
|---|---|---|
| Heading | No top-level trace event | No trace-level input and output captured |
| Body | This trace doesn't have an associated `$ai_trace` event. Click on individual generations in the tree to view their content. | This trace's content is on the events in the tree. Select an event to view its input and output. To show a conversation here, capture a [`$ai_trace` event](https://posthog.com/docs/ai-observability/traces) with `$ai_input_state` and `$ai_output_state` properties. |

## How did you test this code?

- No test added: a string assertion on this copy catches no realistic regression.
- Ran oxfmt, oxlint on the file, and `hogli ci:preflight --fix` (0 failures; the complexity warnings are pre-existing, in functions this PR does not touch).
- The docs link resolves, and that page documents `$ai_trace`, `$ai_input_state`, and `$ai_output_state`.
- Not run: the app itself, so the rendered state was not eyeballed. The change sits inside an existing `InsightEmptyState` that already accepted JSX.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the new copy links existing docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code, running as a PostHog Desktop cloud task.
- Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- The session diagnosed the confusion from session replays and autocapture of the trace view, then the requester chose the minimal fix from a larger option list. Deferred options: rendering fallback content at the pseudo-trace root, and closing the full-screen timeline modal on bar selection.
- Revised after review feedback: the first heading implied the trace had no input and output at all, which is wrong since child events carry content. The revision names the missing trace-level capture instead, and adopts the suggested traces docs link. Event data confirmed `$ai_trace` events are sometimes sent without the state properties, so the copy names the properties, not the event.
- Public artifact: the copy is written fresh; no session material is in the diff.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
