### PR TITLE
fix(integrations): center the connect button on the landing page

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -8872,6 +8872,10 @@ snapshots:
         hash: v1.k794b7964.1a2abf46a5f43ec0e9bcf1f02115c68f3fab54fc8e8aec6f903e2481689d9a8c.oi6z4uOWfKTWAHVA_UhnCwGg-Zjal3CQ1Se4fDLVOMQ
     scenes-other-integration-landing-page--connected--light:
         hash: v1.k794b7964.3db01e8e2c1f2a9c6b622e06bd5ac66345cdd92961f70349829cdce36cddd2a9.BjXhubo71g8DdCf1Eih4H-AnYpXQnxwL48JtTfIjHWM
+    scenes-other-integration-landing-page--github-not-connected--dark:
+        hash: v1.k794b7964.bba0510987059cd3293c9cb521c38d7e02a18a8d9e63850279b49f725351ffa1.iZ6XagQWz90p8Mue7fhQ3nIgsiMZCggNaB8emk5ROck
+    scenes-other-integration-landing-page--github-not-connected--light:
+        hash: v1.k794b7964.201ce08c342863510e8bd4aaa577a87ed3be5edde701d14700495d8054e7ca12.dYCBsE5gXHBCzfvukpDRJFj3A5znqsR3KKFOrfgTXDY
     scenes-other-integration-landing-page--no-permission--dark:
         hash: v1.k794b7964.957e7be92050477838301517a8ebfdfd1f5b6c6ff3005dc35b505f553b6c58ea.CaFotiPrq8gJ5X6pzBmcsMuuURiBwLRHwihyFdPHZe8
     scenes-other-integration-landing-page--no-permission--light:
@@ -8880,6 +8884,10 @@ snapshots:
         hash: v1.k794b7964.957e7be92050477838301517a8ebfdfd1f5b6c6ff3005dc35b505f553b6c58ea.SoUeRmOD3bvKPv74k1UfUEArhSskLk6pVPDVlmUY_-g
     scenes-other-integration-landing-page--not-connected--light:
         hash: v1.k794b7964.1fe42b8b297343b0180998e98d5c4c68de32791266a856a07fcaf88765b71e93.Q-NV49-iLDmtzX4egP_H3Ks6sjTRd2NRMz_-OEJ7NWk
+    scenes-other-integration-landing-page--slack-not-configured--dark:
+        hash: v1.k794b7964.b8d633acb0b72d217732bfb6a85a0af99e3a8fd8be153158c311b59aa5be3fe1.UfxaT3QO-ESJ6CdUyAROsUAELLhYZ4tnnCIJDOK7Q4s
+    scenes-other-integration-landing-page--slack-not-configured--light:
+        hash: v1.k794b7964.a12f1b2e9bcce6e07f5dc5b8e07821599e77d131e6431727dd04da5f6613ec1c.LZ2zwIHu0AhggyqW-hnQaE1EO6dAgmDI9Xlu2eWTYKM
     scenes-other-onboarding-legacy--ai-observability-sdk-install--dark:
         hash: v1.k794b7964.0c82a4b8b276a3f51b42dd3a20aed7672fbfb5f096e4bd9da51221b6eb52bbdc.iXUjftr_vTAULjZ_soSDjZ9o_RG2YPlJBCG4ZSuNTS0
     scenes-other-onboarding-legacy--ai-observability-sdk-install--light:

--- a/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
@@ -9,7 +9,7 @@ import preflightJson from '~/mocks/fixtures/_preflight.json'
 import { mockIntegration } from '~/test/mocks'
 import { Realm } from '~/types'
 
-import { Slack } from './definitions'
+import { GitHub, Slack } from './definitions'
 import { IntegrationFullPage } from './IntegrationFullPage'
 
 const meta: Meta<typeof IntegrationFullPage> = {
@@ -41,6 +41,24 @@ export const NotConnected: Story = {
 
 export const Connected: Story = {
     decorators: [mswDecorator({ get: { '/api/environments/:id/integrations': { results: [mockIntegration] } } })],
+}
+
+// GitHub puts a helper paragraph next to its connect button, which stretches the section wider
+// than the button. Without the centered layout the button sits at that width's left edge.
+export const GithubNotConnected: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/environments/:id/integrations': { results: [] },
+                '/api/projects/:id/integrations/github/available_installations/': {
+                    installations: [],
+                    personal_github_connected: false,
+                },
+                '/api/users/@me/integrations/github/install_requests/': { results: [], install_url: null },
+            },
+        }),
+    ],
+    render: () => <IntegrationFullPage definition={GitHub} SettingsSection={GitHub.SettingsSection} />,
 }
 
 const memberTeam = { ...MOCK_DEFAULT_TEAM, effective_membership_level: OrganizationMembershipLevel.Member }

--- a/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.stories.tsx
@@ -43,6 +43,23 @@ export const Connected: Story = {
     decorators: [mswDecorator({ get: { '/api/environments/:id/integrations': { results: [mockIntegration] } } })],
 }
 
+// An instance without Slack configured shows staff the instructions button instead of the connect
+// button. That branch ignores ``centered``, so it relies on the page for its centered layout.
+export const SlackNotConfigured: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/_preflight': {
+                    ...preflightJson,
+                    realm: Realm.Cloud,
+                    slack_service: { available: false, client_id: null },
+                },
+                '/api/environments/:id/integrations': { results: [] },
+            },
+        }),
+    ],
+}
+
 // GitHub puts a helper paragraph next to its connect button, which stretches the section wider
 // than the button. Without the centered layout the button sits at that width's left edge.
 export const GithubNotConnected: Story = {

--- a/frontend/src/scenes/integrations/IntegrationFullPage.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.tsx
@@ -102,7 +102,7 @@ function ConnectView({
                 <RequestAccessSection definition={definition} />
             ) : (
                 // onClickCapture fires before the connect button triggers its OAuth redirect
-                <div className="w-full" onClickCapture={onConnectClick}>
+                <div onClickCapture={onConnectClick}>
                     <SettingsSection next={urls.integration(definition.slug)} centered />
                 </div>
             )}

--- a/frontend/src/scenes/integrations/IntegrationFullPage.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.tsx
@@ -102,7 +102,7 @@ function ConnectView({
                 <RequestAccessSection definition={definition} />
             ) : (
                 // onClickCapture fires before the connect button triggers its OAuth redirect
-                <div onClickCapture={onConnectClick}>
+                <div className="w-full" onClickCapture={onConnectClick}>
                     <SettingsSection next={urls.integration(definition.slug)} centered />
                 </div>
             )}

--- a/frontend/src/scenes/integrations/components/GithubIntegration.tsx
+++ b/frontend/src/scenes/integrations/components/GithubIntegration.tsx
@@ -10,6 +10,7 @@ import { githubInstallRequestsLogic } from 'lib/integrations/githubInstallReques
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import type { IntegrationConnectSurface } from 'lib/integrations/utils'
 import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
+import { cn } from 'lib/utils/css-classes'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -20,12 +21,14 @@ import { Integration, useIntegrations } from './Integration'
 
 export function GithubIntegration({
     next,
+    centered = false,
     connectSurface,
     connectText = 'Connect account',
     emphasizeConnect = false,
     showPersonalConnectionHelp = true,
 }: {
     next?: string
+    centered?: boolean
     connectText?: string
     emphasizeConnect?: boolean
     showPersonalConnectionHelp?: boolean
@@ -75,7 +78,7 @@ export function GithubIntegration({
     }
 
     return (
-        <Integration kind="github">
+        <Integration kind="github" centered={centered}>
             {/* w-full because Integration drops its children into a bare flex row, which would
                 otherwise size the banner to its longest word. */}
             <div className="flex flex-col gap-y-4 w-full">
@@ -135,7 +138,7 @@ export function GithubIntegration({
                         </p>
                     </div>
                 ) : (
-                    <div className="flex flex-wrap gap-2">
+                    <div className={cn('flex flex-wrap gap-2', centered && 'justify-center')}>
                         {/* This leaves PostHog entirely, and a GitHub App installs at most once per
                             account, so GitHub offers install where it's missing and configure where it
                             isn't. "Connect account" matches the Linear and Jira cards, which name the
@@ -151,7 +154,7 @@ export function GithubIntegration({
                     </div>
                 )}
                 {isConnected && (
-                    <p className="text-secondary text-xs mb-0">
+                    <p className={cn('text-secondary text-xs mb-0', centered && 'text-center')}>
                         Add the PostHog app to another GitHub account, or change which repositories it can see.
                     </p>
                 )}
@@ -159,7 +162,7 @@ export function GithubIntegration({
                     !isConnected &&
                     installations.length === 0 &&
                     githubPersonalConnected === false && (
-                        <p className="text-secondary text-xs mb-0">
+                        <p className={cn('text-secondary text-xs mb-0', centered && 'text-center')}>
                             Already installed the PostHog GitHub App but don't see it here? Connect your GitHub account
                             under <Link to={urls.settings('user-personal-integrations')}>Personal integrations</Link> so
                             PostHog can find it.

--- a/frontend/src/scenes/integrations/components/Integration.tsx
+++ b/frontend/src/scenes/integrations/components/Integration.tsx
@@ -3,10 +3,15 @@ import { PropsWithChildren, useMemo } from 'react'
 
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { IntegrationView } from 'lib/integrations/IntegrationView'
+import { cn } from 'lib/utils/css-classes'
 
 import { IntegrationKind, IntegrationType } from '~/types'
 
-export function Integration({ kind, children }: PropsWithChildren<{ kind: IntegrationKind }>): JSX.Element {
+export function Integration({
+    kind,
+    centered,
+    children,
+}: PropsWithChildren<{ kind: IntegrationKind; centered?: boolean }>): JSX.Element {
     const integrations = useIntegrations(kind)
 
     return (
@@ -15,7 +20,7 @@ export function Integration({ kind, children }: PropsWithChildren<{ kind: Integr
                 {integrations.map((integration) => (
                     <IntegrationView key={integration.id} integration={integration} />
                 ))}
-                <div className="flex">{children}</div>
+                <div className={cn('flex', centered && 'justify-center')}>{children}</div>
             </div>
         </div>
     )

--- a/frontend/src/scenes/integrations/components/Integrations.tsx
+++ b/frontend/src/scenes/integrations/components/Integrations.tsx
@@ -14,10 +14,10 @@ import { Integration } from './Integration'
 
 export { GithubIntegration, GitHubInstallationLink } from './GithubIntegration'
 
-export function GitLabIntegration(): JSX.Element {
+export function GitLabIntegration({ centered }: { centered?: boolean } = {}): JSX.Element {
     const [isOpen, setIsOpen] = useState<boolean>(false)
     return (
-        <Integration kind="gitlab">
+        <Integration kind="gitlab" centered={centered}>
             <LemonButton type="secondary" onClick={() => setIsOpen(true)}>
                 Connect project
             </LemonButton>
@@ -26,22 +26,24 @@ export function GitLabIntegration(): JSX.Element {
     )
 }
 
-export function LinearIntegration({ next }: { next?: string }): JSX.Element {
-    return <OAuthIntegration kind="linear" connectText="Connect workspace" next={next} />
+export function LinearIntegration({ next, centered }: { next?: string; centered?: boolean }): JSX.Element {
+    return <OAuthIntegration kind="linear" connectText="Connect workspace" next={next} centered={centered} />
 }
 
-export function JiraIntegration({ next }: { next?: string }): JSX.Element {
-    return <OAuthIntegration kind="jira" connectText="Connect site" next={next} />
+export function JiraIntegration({ next, centered }: { next?: string; centered?: boolean }): JSX.Element {
+    return <OAuthIntegration kind="jira" connectText="Connect site" next={next} centered={centered} />
 }
 
 const OAuthIntegration = ({
     kind,
     connectText,
     next,
+    centered,
 }: {
     kind: IntegrationKind
     connectText: string
     next?: string
+    centered?: boolean
 }): JSX.Element => {
     const { currentTeam } = useValues(teamLogic)
     const settingsPath = next ?? urls.settings('environment-integrations')
@@ -51,7 +53,7 @@ const OAuthIntegration = ({
     })
 
     return (
-        <Integration kind={kind}>
+        <Integration kind={kind} centered={centered}>
             <LemonButton type="secondary" disableClientSideRouting to={authorizationUrl}>
                 {connectText}
             </LemonButton>


### PR DESCRIPTION
## Problem

Anyone opening the GitHub integration landing page saw "Connect account" jammed against the left edge of the card, while the logo, title, description, and "Learn more" link were all centered. The page reads as broken before the user has done anything.

The landing page already passes a `centered` flag to each integration's connect section, but only Slack honored it. GitHub's section stretches to the width of the helper paragraph under the button, so the button landed at the left edge of that row.

## Changes

- The connect button and its helper copy now sit in the middle of the card on the GitHub landing page.
- GitLab, Linear, and Jira landing pages get the same treatment, since they shared the same wrapper.
- Mechanical: `Integration`, `GithubIntegration`, and the OAuth section accept `centered` and pass it down.
- Added GitHub and unconfigured-Slack stories to `IntegrationFullPage.stories.tsx` so visual review catches this layout again.

GitHub, before and after:

| Before | After |
| --- | --- |
| ![gh-before](https://raw.githubusercontent.com/PostHog/pr-assets/1972752cfde17e9d680b68a4816b537752addd19/2026/09/b79e20b6-ff19-4801-b9ce-e073342ca84d.png) | ![gh-after](https://raw.githubusercontent.com/PostHog/pr-assets/406a6f146adf17788bfab7fb54ebb50e67c7735d/2026/09/845bde3a-6a14-4995-96db-c3c14157c2b8.png) |

## How did you test this code?

Rendered the affected stories in a local Storybook and screenshotted each one with and without the change. The existing `src/scenes/integrations` Jest suites still pass locally.

`tsgo --noEmit` was killed by the OOM killer in this sandbox on an unmodified tree too, so the full TypeScript check is left to CI. The change only adds optional boolean props.

No new assertions were added: the regression here is visual, and the two new stories are what a snapshot can catch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code in a PostHog Desktop cloud task. Skills invoked: `/writing-pr-descriptions`.

An earlier revision also forced the section wrapper to full width. That fixed GitHub but left-aligned any section that does not read `centered` itself, which showed up on an instance with Slack unconfigured: the instructions button moved to the left edge. Screenshotting that branch caught it, so the wrapper went back to shrinking to fit and the `centered` flag does all the work. The unconfigured-Slack story exists to keep that branch under review.

Nothing in this diff comes from outside the repository.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
