### PR TITLE
chore(hogql): enforce property-restriction coverage for catalog tables

### DIFF
--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -195,7 +195,10 @@ Naming a column `properties` does not opt a table in.
 The printer checks the column name against `RESTRICTABLE_JSON_BLOB_COLUMNS` before it consults the dispatch, so a new table can pass that check on the name alone and still return its blob unmasked.
 A table that exposes person, event, or group properties has to be added to the dispatch when it is added to the catalog.
 
-`posthog/hogql/test/test_restricted_properties.py` enforces this: it walks the catalog and fails on a table that exposes one of those blob columns without a matching branch.
+`posthog/hogql/test/test_restricted_properties.py` enforces this: it walks the catalog and asserts that the set of tables exposing one of those blob columns with no matching branch equals a small allowlist of explicit exemptions.
+A table added to the catalog later without a branch is not on the allowlist, so it fails the test.
+The allowlist is not a statement of full coverage: `accounts.properties` and `pg_embeddings.properties` are name collisions masked nowhere by design, and `ai_events.properties` carries event properties but has no branch yet, so its blob is still returned unmasked.
+Covering a table means removing its exemption, so the list cannot keep a stale entry.
 
 ### No user: default rules apply
 

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -195,10 +195,13 @@ Naming a column `properties` does not opt a table in.
 The printer checks the column name against `RESTRICTABLE_JSON_BLOB_COLUMNS` before it consults the dispatch, so a new table can pass that check on the name alone and still return its blob unmasked.
 A table that exposes person, event, or group properties has to be added to the dispatch when it is added to the catalog.
 
-`posthog/hogql/test/test_restricted_properties.py` enforces this: it walks the catalog and asserts that the set of tables exposing one of those blob columns with no matching branch equals a small allowlist of explicit exemptions.
-A table added to the catalog later without a branch is not on the allowlist, so it fails the test.
-The allowlist is not a statement of full coverage: `accounts.properties` and `pg_embeddings.properties` are name collisions masked nowhere by design, and `ai_events.properties` carries event properties but has no branch yet, so its blob is still returned unmasked.
-Covering a table means removing its exemption, so the list cannot keep a stale entry.
+`posthog/hogql/test/test_restricted_properties.py` enforces this.
+It restricts one distinctly named key per property class, walks the catalog, and asserts the exact keys the dispatch masks in every blob column it reaches, with the exempt blobs mapped to no keys at all.
+The expected mapping is written out in the test rather than derived from `RESTRICTABLE_JSON_BLOB_COLUMNS`, so it holds the invariant in both directions: a table added to the catalog without a branch arrives masking nothing, and a column dropped from that set leaves its blob out of the walk entirely.
+Because each class restricts its own key, a table dispatched as the wrong class, or a group blob dispatched to the wrong group index, comes back carrying another class's key instead of passing on a non-empty result.
+
+The exemptions are not a statement of full coverage: `accounts.properties` and `pg_embeddings.properties` are name collisions masked nowhere by design, and `ai_events.properties` carries event properties but has no branch yet, so its blob is still returned unmasked.
+Covering a table means moving it out of the exemptions and into the expected mapping, so neither list can keep a stale entry.
 
 ### No user: default rules apply
 

--- a/posthog/hogql/ACCESS_CONTROL.md
+++ b/posthog/hogql/ACCESS_CONTROL.md
@@ -186,6 +186,17 @@ Group restrictions retain their group type index, so a same-named property on an
 
 The restriction set is loaded once per query in `prepare_ast_for_printing()` and cached per `(team_id, user_id)` for the request lifetime.
 
+### Coverage is per table, not per column name
+
+Both enforcement points ask `restricted_property_keys_for_table_type()` in `posthog/hogql/restricted_properties.py` which keys to mask, and it answers by matching the table's type.
+A table whose type it does not recognize gets an empty set, which reads as "nothing is restricted here" rather than as an error.
+
+Naming a column `properties` does not opt a table in.
+The printer checks the column name against `RESTRICTABLE_JSON_BLOB_COLUMNS` before it consults the dispatch, so a new table can pass that check on the name alone and still return its blob unmasked.
+A table that exposes person, event, or group properties has to be added to the dispatch when it is added to the catalog.
+
+`posthog/hogql/test/test_restricted_properties.py` enforces this: it walks the catalog and fails on a table that exposes one of those blob columns without a matching branch.
+
 ### No user: default rules apply
 
 When no user is present, only the team **default** rules apply instead of failing every query — see `get_restricted_properties_for_team()`.

--- a/posthog/hogql/test/test_restricted_properties.py
+++ b/posthog/hogql/test/test_restricted_properties.py
@@ -1,0 +1,90 @@
+import re
+from collections.abc import Iterator
+
+from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import _construct_database_root_node
+from posthog.hogql.database.models import StringJSONDatabaseField, Table, TableNode
+from posthog.hogql.property_access_types import RestrictedProperty
+from posthog.hogql.restricted_properties import RESTRICTABLE_JSON_BLOB_COLUMNS, restricted_property_keys_for_table_type
+
+from posthog.constants import GROUP_TYPES_LIMIT
+
+from products.event_definitions.backend.models.property_definition import PropertyDefinition
+
+_GROUP_PROPERTIES_COLUMN = re.compile(r"group(\d+)_properties")
+
+# Blob columns the dispatch returns no keys for. `properties` is a common column name, so most of
+# these are a name collision: the contents are not a property class property-level access control
+# knows about. Adding a branch for one means removing its entry here.
+_UNCOVERED_BLOB_COLUMNS = {
+    # CRM account attributes, not person/event/group properties. Gated separately by the object-level
+    # `access_scope="account"` on the table.
+    ("accounts", "properties"),
+    # Metadata attached to an embedded item.
+    ("pg_embeddings", "properties"),
+    # Carries event properties, so unlike the two above this one is owed a branch. Tracked with
+    # team-ai-observability, who own the table.
+    ("ai_events", "properties"),
+}
+
+
+def _restrictions_covering_every_property_class() -> set[RestrictedProperty]:
+    restrictions = {
+        RestrictedProperty(name="secret", property_type=PropertyDefinition.Type.EVENT),
+        RestrictedProperty(name="secret", property_type=PropertyDefinition.Type.PERSON),
+    }
+    restrictions |= {
+        RestrictedProperty(name="secret", property_type=PropertyDefinition.Type.GROUP, group_type_index=index)
+        for index in range(GROUP_TYPES_LIMIT)
+    }
+    return restrictions
+
+
+def _tables_in_node(node: TableNode) -> Iterator[Table]:
+    if isinstance(node.table, Table):
+        yield node.table
+    for child in node.children.values():
+        yield from _tables_in_node(child)
+
+
+def _with_nested_tables(table: Table) -> Iterator[Table]:
+    yield table
+    for field in table.fields.values():
+        if isinstance(field, Table):
+            yield from _with_nested_tables(field)
+
+
+def _restrictable_blob_columns(table: Table) -> set[str]:
+    return {
+        field.name
+        for field in table.fields.values()
+        if isinstance(field, StringJSONDatabaseField) and field.name in RESTRICTABLE_JSON_BLOB_COLUMNS
+    }
+
+
+def test_every_restrictable_blob_column_is_covered_by_a_dispatch_branch():
+    # The printer wraps a JSON blob in JSONDropKeys only when the column name is in
+    # RESTRICTABLE_JSON_BLOB_COLUMNS *and* restricted_property_keys_for_table_type returns keys for
+    # the table. The first half matches on a column name, the second on a table type. So a table
+    # that copies the events blob names without being added to the dispatch reads the blob
+    # unscrubbed, and nothing says so: the query compiles and returns the restricted values.
+    #
+    # Asserting the exact set rather than a subset means covering one of these has to remove its
+    # entry below, instead of leaving a stale claim behind.
+    context = HogQLContext(team_id=1, restricted_properties=_restrictions_covering_every_property_class())
+
+    unscrubbed: set[tuple[str, str]] = set()
+    for table in _tables_in_node(_construct_database_root_node(include_posthog_tables=True)):
+        for candidate in _with_nested_tables(table):
+            for column in _restrictable_blob_columns(candidate):
+                group_match = _GROUP_PROPERTIES_COLUMN.fullmatch(column)
+                keys = restricted_property_keys_for_table_type(
+                    ast.TableType(table=candidate),
+                    context,
+                    group_type_index=int(group_match.group(1)) if group_match else None,
+                )
+                if not keys:
+                    unscrubbed.add((candidate.to_printed_hogql(), column))
+
+    assert unscrubbed == _UNCOVERED_BLOB_COLUMNS

--- a/posthog/hogql/test/test_restricted_properties.py
+++ b/posthog/hogql/test/test_restricted_properties.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.database import _construct_database_root_node
+from posthog.hogql.database.database import build_database_root_node
 from posthog.hogql.database.models import StringJSONDatabaseField, Table, TableNode
 from posthog.hogql.property_access_types import RestrictedProperty
 from posthog.hogql.restricted_properties import RESTRICTABLE_JSON_BLOB_COLUMNS, restricted_property_keys_for_table_type
@@ -75,7 +75,7 @@ def test_every_restrictable_blob_column_is_covered_by_a_dispatch_branch():
     context = HogQLContext(team_id=1, restricted_properties=_restrictions_covering_every_property_class())
 
     unscrubbed: set[tuple[str, str]] = set()
-    for table in _tables_in_node(_construct_database_root_node(include_posthog_tables=True)):
+    for table in _tables_in_node(build_database_root_node(include_posthog_tables=True)):
         for candidate in _with_nested_tables(table):
             for column in _restrictable_blob_columns(candidate):
                 group_match = _GROUP_PROPERTIES_COLUMN.fullmatch(column)

--- a/posthog/hogql/test/test_restricted_properties.py
+++ b/posthog/hogql/test/test_restricted_properties.py
@@ -14,28 +14,55 @@ from products.event_definitions.backend.models.property_definition import Proper
 
 _GROUP_PROPERTIES_COLUMN = re.compile(r"group(\d+)_properties")
 
-# Blob columns the dispatch returns no keys for. `properties` is a common column name, so most of
-# these are a name collision: the contents are not a property class property-level access control
-# knows about. Adding a branch for one means removing its entry here.
-_UNCOVERED_BLOB_COLUMNS = {
-    # CRM account attributes, not person/event/group properties. Gated separately by the object-level
-    # `access_scope="account"` on the table.
-    ("accounts", "properties"),
-    # Metadata attached to an embedded item.
-    ("pg_embeddings", "properties"),
-    # Carries event properties, so unlike the two above this one is owed a branch. Tracked with
-    # team-ai-observability, who own the table.
-    ("ai_events", "properties"),
+# A distinct restricted key per property class, so a table dispatched to the wrong class, or a group blob
+# dispatched to the wrong index, comes back carrying the wrong key instead of passing on a non-empty set.
+_EVENT_KEY = "restricted_event_property"
+_PERSON_KEY = "restricted_person_property"
+_GROUP_KEYS = tuple(f"restricted_group_{index}_property" for index in range(GROUP_TYPES_LIMIT))
+
+# Every catalog blob the printer masks, and the keys it drops from each. Written out rather than derived
+# from RESTRICTABLE_JSON_BLOB_COLUMNS, so that dropping a column name from that set fails here instead of
+# quietly shrinking the walk below.
+_MASKED_BLOBS: dict[str, frozenset[str]] = {
+    "events.properties (EventsTable)": frozenset({_EVENT_KEY}),
+    "events.person_properties (EventsPersonSubTable)": frozenset({_PERSON_KEY}),
+    **{
+        f"events.group{index}_properties (EventsGroupSubTable)": frozenset({_GROUP_KEYS[index]})
+        for index in range(GROUP_TYPES_LIMIT)
+    },
+    "persons.properties (PersonsTable)": frozenset({_PERSON_KEY}),
+    "raw_persons.properties (RawPersonsTable)": frozenset({_PERSON_KEY}),
+    # The groups tables hold every group type, with the index in a column rather than in the blob's name, so
+    # a read of one row's blob has to drop the restricted keys of all of them.
+    "groups.group_properties (GroupsTable)": frozenset(_GROUP_KEYS),
+    "raw_groups.group_properties (RawGroupsTable)": frozenset(_GROUP_KEYS),
+    "groups.group_properties (PostgresTable)": frozenset(_GROUP_KEYS),
 }
+
+# Blob columns the dispatch returns no keys for. `properties` is a common column name, so most of these are
+# a name collision: the contents are not a property class property-level access control knows about. Adding
+# a branch for one means moving its entry into _MASKED_BLOBS.
+_UNMASKED_BLOBS: frozenset[str] = frozenset(
+    {
+        # CRM account attributes, not person/event/group properties. Gated separately by the object-level
+        # `access_scope="account"` on the table.
+        "accounts.properties (PostgresTable)",
+        # Metadata attached to an embedded item.
+        "pg_embeddings.properties (PgEmbeddingsTable)",
+        # Carries event properties, so unlike the two above this one is owed a branch. Tracked with
+        # team-ai-observability, who own the table.
+        "ai_events.properties (AiEventsTable)",
+    }
+)
 
 
 def _restrictions_covering_every_property_class() -> set[RestrictedProperty]:
     restrictions = {
-        RestrictedProperty(name="secret", property_type=PropertyDefinition.Type.EVENT),
-        RestrictedProperty(name="secret", property_type=PropertyDefinition.Type.PERSON),
+        RestrictedProperty(name=_EVENT_KEY, property_type=PropertyDefinition.Type.EVENT),
+        RestrictedProperty(name=_PERSON_KEY, property_type=PropertyDefinition.Type.PERSON),
     }
     restrictions |= {
-        RestrictedProperty(name="secret", property_type=PropertyDefinition.Type.GROUP, group_type_index=index)
+        RestrictedProperty(name=_GROUP_KEYS[index], property_type=PropertyDefinition.Type.GROUP, group_type_index=index)
         for index in range(GROUP_TYPES_LIMIT)
     }
     return restrictions
@@ -63,28 +90,36 @@ def _restrictable_blob_columns(table: Table) -> set[str]:
     }
 
 
-def test_every_restrictable_blob_column_is_covered_by_a_dispatch_branch():
+def _blob_label(table: Table, column: str) -> str:
+    return f"{table.to_printed_hogql()}.{column} ({type(table).__name__})"
+
+
+def test_every_restrictable_blob_column_is_masked_with_the_keys_of_its_property_class():
     # The printer wraps a JSON blob in JSONDropKeys only when the column name is in
-    # RESTRICTABLE_JSON_BLOB_COLUMNS *and* restricted_property_keys_for_table_type returns keys for
-    # the table. The first half matches on a column name, the second on a table type. So a table
-    # that copies the events blob names without being added to the dispatch reads the blob
-    # unscrubbed, and nothing says so: the query compiles and returns the restricted values.
+    # RESTRICTABLE_JSON_BLOB_COLUMNS *and* restricted_property_keys_for_table_type returns keys for the
+    # table. The first half matches on a column name, the second on a table type, so either half can stop
+    # covering a blob the other still covers, and the query still compiles and returns the restricted values.
     #
-    # Asserting the exact set rather than a subset means covering one of these has to remove its
-    # entry below, instead of leaving a stale claim behind.
+    # Comparing whole mappings holds both halves: a missing entry means a column left the name set, an entry
+    # masking nothing means a catalog table has no dispatch branch, and a wrong value means a table reached
+    # the wrong property class or group index.
     context = HogQLContext(team_id=1, restricted_properties=_restrictions_covering_every_property_class())
 
-    unscrubbed: set[tuple[str, str]] = set()
+    masked: dict[str, frozenset[str]] = {}
     for table in _tables_in_node(build_database_root_node(include_posthog_tables=True)):
         for candidate in _with_nested_tables(table):
             for column in _restrictable_blob_columns(candidate):
                 group_match = _GROUP_PROPERTIES_COLUMN.fullmatch(column)
-                keys = restricted_property_keys_for_table_type(
-                    ast.TableType(table=candidate),
-                    context,
-                    group_type_index=int(group_match.group(1)) if group_match else None,
+                keys = frozenset(
+                    restricted_property_keys_for_table_type(
+                        ast.TableType(table=candidate),
+                        context,
+                        group_type_index=int(group_match.group(1)) if group_match else None,
+                    )
                 )
-                if not keys:
-                    unscrubbed.add((candidate.to_printed_hogql(), column))
+                # The catalog reaches most tables by more than one path, so tables sharing a label have to
+                # agree on what is masked for the assertion below to speak for both.
+                label = _blob_label(candidate, column)
+                assert masked.setdefault(label, keys) == keys, f"{label} names blobs that mask different keys"
 
-    assert unscrubbed == _UNCOVERED_BLOB_COLUMNS
+    assert masked == {**_MASKED_BLOBS, **dict.fromkeys(_UNMASKED_BLOBS, frozenset())}


### PR DESCRIPTION
## Problem

Property-level access control masks a JSON blob column only when a table's type matches a branch in `restricted_property_keys_for_table_type()`. The name check (`properties`, `person_properties`, `group{n}_properties`) and the type dispatch are separate gates, and nothing keeps them in sync. A new catalog table can pass the name check and still get no masking, if it is missing from the dispatch. Nothing errors; the query just compiles and returns the unmasked value.

## Changes

- Adds a test that walks the HogQL catalog and asserts every table exposing one of those blob columns has a matching branch in the dispatch. A table added later without one now fails this test instead of shipping unmasked.
- The test found one table not yet covered, `ai_events.properties`. That's tracked separately with the owning team rather than fixed here.
- Two other flagged columns are name collisions, not gaps: `accounts.properties` holds CRM data under its own access scope, and `pg_embeddings.properties` holds embedding metadata. Both are recorded as expected exemptions.
- Documents the per-table-type coverage requirement in `posthog/hogql/ACCESS_CONTROL.md`, since neither enforcement point states it today.

## How did you test this code?

Ran the new test locally against the current catalog; it passes with exactly the three exemptions above and fails if any is removed without a dispatch branch to match. Not run: CI, since this branch has not been pushed yet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`posthog/hogql/ACCESS_CONTROL.md` is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written while adding a HogQL table for `flag_evaluations` in a stacked PR on top of this one. That work hit the same coverage gap this test now catches. The user asked to split the guard into its own base layer, so it lands ahead of the table it protects. Skills invoked: `/writing-tests` to gate whether the test earned its place, `/plain-writing` and `/writing-pr-descriptions` for this description, `/stacking-prs` for the split.
