### PR TITLE
feat(logs): expose pattern-based alert triggers through the API

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -608,6 +608,9 @@ SPECTACULAR_SETTINGS = {
         # (`OriginProductEnumApi`) so naming it doesn't rename the type its consumers import.
         "OriginProductEnum": "products.tasks.backend.models.Task.OriginProduct",
         "TicketStatusEnum": "products.conversations.backend.models.constants.Status",
+        # Shared by LogsAlertConfiguration.trigger_type, LogsAlertConfigurationDetail.trigger_type,
+        # and LogsAlertSimulateRequest.trigger_type.
+        "TriggerTypeEnum": "products.logs.backend.models.LogsAlertConfiguration.TriggerType",
         "EmailChannelKindEnum": "products.conversations.backend.models.team_conversations_email_config.EmailChannelKind",
         "EmailThreadMessageDirectionEnum": "products.conversations.backend.models.email_thread.EmailThreadMessageDirection",
         "EmailThreadParticipantKindEnum": "products.conversations.backend.models.email_thread.EmailThreadParticipantKind",

--- a/products/logs/backend/pattern_alert_check_query.py
+++ b/products/logs/backend/pattern_alert_check_query.py
@@ -25,13 +25,23 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.clickhouse.client.connection import Workload
 from posthog.models import Team
 
-from products.logs.backend.alert_check_query import AlertCheckQuery, _tag_alert_query, build_alert_where_expr
+from products.logs.backend.alert_check_query import (
+    AlertCheckQuery,
+    _tag_alert_query,
+    build_alert_where_expr,
+    is_projection_eligible,
+)
 from products.logs.backend.models import LogsAlertConfiguration
 
 # Per-check cap on distinct (service_name, pattern) groups. Past this, the alert's
 # filters are too broad for per-fingerprint semantics and the check errors with an
 # actionable message instead of silently dropping groups.
 MAX_PATTERN_GROUPS = 1_000
+
+# Per-simulation cap on total (bucket, group) rows. A simulate preview covers up to
+# MAX_SIMULATE_LOOKBACK_DAYS of history, so this bounds query cost independently of
+# the per-bucket MAX_PATTERN_GROUPS cap.
+MAX_SIMULATE_PATTERN_ROWS = 50_000
 
 
 @dataclass(frozen=True)
@@ -54,6 +64,21 @@ class PatternGroupsResult:
 class StampingProbeResult:
     total: int
     stamped: int
+    query_duration_ms: int
+
+
+@dataclass(frozen=True)
+class BucketedPatternGroups:
+    timestamp: dt.datetime
+    groups: list[PatternGroupCount]
+
+
+@dataclass(frozen=True)
+class BucketedPatternGroupsResult:
+    buckets: list[BucketedPatternGroups]
+    # True when the query hit its row cap and dropped groups. The caller decides how
+    # to surface it (the simulate preview reports this as a warning, not an error).
+    truncated: bool
     query_duration_ms: int
 
 
@@ -117,6 +142,71 @@ class GroupedPatternCheckQuery:
             for row in rows[:limit]
         ]
         return PatternGroupsResult(groups=groups, truncated=truncated, query_duration_ms=duration_ms)
+
+    def execute_bucketed_groups(
+        self, *, interval_minutes: int, limit: int = MAX_SIMULATE_PATTERN_ROWS
+    ) -> BucketedPatternGroupsResult:
+        """Occurrence counts per (bucket, service_name, pattern) across the window, for
+        the simulate preview. Buckets with no stamped rows are omitted; the caller fills
+        gaps the same way `AlertCheckQuery.execute_bucketed` does for count triggers.
+
+        Buckets are ASC (oldest-first), matching `execute_bucketed`'s contract.
+        """
+        self._tag()
+        time_field = (
+            ast.Call(name="toStartOfMinute", args=[ast.Field(chain=["timestamp"])])
+            if is_projection_eligible(self.alert.filters)
+            else ast.Field(chain=["timestamp"])
+        )
+        query = parse_select(
+            """
+            SELECT
+                toStartOfInterval({time_field}, toIntervalMinute({bucket_minutes})) AS bucket,
+                service_name,
+                pattern,
+                max(pattern_version) AS pattern_version,
+                count() AS occurrences
+            FROM logs
+            WHERE {where} AND pattern != ''
+            GROUP BY bucket, service_name, pattern
+            ORDER BY bucket ASC
+            LIMIT {row_limit}
+            """,
+            placeholders={
+                "time_field": time_field,
+                "bucket_minutes": ast.Constant(value=interval_minutes),
+                "where": self.where_expr,
+                # +1 so the caller can tell "exactly limit rows" from "truncated".
+                "row_limit": ast.Constant(value=limit + 1),
+            },
+        )
+
+        start_ms = time.monotonic_ns() // 1_000_000
+        response = self._run_query(query)
+        duration_ms = time.monotonic_ns() // 1_000_000 - start_ms
+
+        rows = response.results or []
+        truncated = len(rows) > limit
+        rows = rows[:limit]
+
+        buckets: list[BucketedPatternGroups] = []
+        current_bucket: dt.datetime | None = None
+        current_groups: list[PatternGroupCount] = []
+        for bucket, service_name, pattern, pattern_version, occurrences in rows:
+            if bucket != current_bucket:
+                if current_bucket is not None:
+                    buckets.append(BucketedPatternGroups(timestamp=current_bucket, groups=current_groups))
+                current_bucket = bucket
+                current_groups = []
+            current_groups.append(
+                PatternGroupCount(
+                    service_name=service_name, pattern=pattern, pattern_version=pattern_version, occurrences=occurrences
+                )
+            )
+        if current_bucket is not None:
+            buckets.append(BucketedPatternGroups(timestamp=current_bucket, groups=current_groups))
+
+        return BucketedPatternGroupsResult(buckets=buckets, truncated=truncated, query_duration_ms=duration_ms)
 
     def execute_stamping_probe(self) -> StampingProbeResult:
         """Total vs pattern-stamped row counts for the window.

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -9,6 +9,7 @@ from django.db.models import F, OuterRef, Prefetch, Q, QuerySet, Subquery
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
+import posthoganalytics
 from drf_spectacular.utils import extend_schema, extend_schema_field, extend_schema_view
 from pydantic import ValidationError as PydanticValidationError
 from rest_framework import serializers, viewsets
@@ -68,6 +69,13 @@ from products.logs.backend.alert_state_machine import (
 )
 from products.logs.backend.facade.api import next_allowed_check_at
 from products.logs.backend.models import MAX_EVALUATION_PERIODS, LogsAlertConfiguration, LogsAlertEvent
+from products.logs.backend.pattern_alert_check_query import (
+    MAX_SIMULATE_PATTERN_ROWS,
+    BucketedPatternGroups,
+    GroupedPatternCheckQuery,
+    PatternGroupCount,
+)
+from products.logs.backend.pattern_alert_evaluator import DEFAULT_SEED_LOOKBACK_DAYS, MAX_SEED_LOOKBACK_DAYS
 
 ALLOWED_WINDOW_MINUTES = {5, 10, 15, 30, 60}
 MAX_ALERTS_PER_TEAM = 20
@@ -79,6 +87,14 @@ LOGS_ALERT_EVENT_IDS: Final = tuple(spec.event_id for spec in EVENT_KIND_CONFIG.
 # not in this set.
 UNCAPPED_ALERT_TEAM_IDS: frozenset[int] = frozenset(
     int(t) for x in os.environ.get("LOGS_ALERTS_UNCAPPED_TEAM_IDS", "").split(",") if (t := x.strip()).isdigit()
+)
+LOGS_PATTERN_ALERTS_FEATURE_FLAG = "logs-pattern-alerts"
+# Same env var the Node ingestion worker reads (nodejs/src/logs/config.ts) to decide
+# whether it stamps `pattern`/`pattern_version` on a team's logs. A pattern-trigger
+# alert can never fire for a team outside this allowlist, so creation is gated on it
+# here too. Coordinate both services' argocd config when growing the allowlist.
+PATTERN_MASKING_ENABLED_TEAM_IDS: frozenset[int] = frozenset(
+    int(t) for x in os.environ.get("LOGS_PATTERN_MASKING_ENABLED_TEAMS", "").split(",") if (t := x.strip()).isdigit()
 )
 MAX_SIMULATE_LOOKBACK_DAYS = 30
 MAX_SIMULATE_BUCKETS = 15_000
@@ -161,6 +177,36 @@ class ScheduleRestrictionField(serializers.JSONField):
     pass
 
 
+class LogsAlertTriggerConfigSerializer(serializers.Serializer):
+    seed_lookback_days = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=MAX_SEED_LOOKBACK_DAYS,
+        default=DEFAULT_SEED_LOOKBACK_DAYS,
+        help_text=(
+            "Only used with trigger_type=new_pattern. Days of history the alert's first check scans "
+            "to seed its seen-set before it starts alerting, so pre-existing error shapes never fire."
+        ),
+    )
+
+
+@extend_schema_field(LogsAlertTriggerConfigSerializer)
+class LogsAlertTriggerConfigField(serializers.JSONField):
+    """JSONField typed against `LogsAlertTriggerConfigSerializer`.
+
+    Only meaningful for trigger_type=new_pattern; cross-field consistency with
+    trigger_type is enforced in `LogsAlertConfigurationSerializer.validate`.
+    """
+
+    def to_internal_value(self, data: dict | list) -> dict:
+        value = super().to_internal_value(data)
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Must be a JSON object.")
+        config_serializer = LogsAlertTriggerConfigSerializer(data=value)
+        config_serializer.is_valid(raise_exception=True)
+        return config_serializer.validated_data
+
+
 class LogsAlertDestinationResponseSerializer(serializers.Serializer):
     hog_function_ids = serializers.ListField(child=serializers.UUIDField())
 
@@ -203,10 +249,28 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
         "severityLevels (list of severity strings), serviceNames (list of service name strings), "
         "or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).",
     )
+    trigger_type = serializers.ChoiceField(
+        choices=LogsAlertConfiguration.TriggerType.choices,
+        default=LogsAlertConfiguration.TriggerType.COUNT,
+        help_text=(
+            "What the alert evaluates. 'count': threshold_count matching logs in the window (the "
+            "default). 'new_pattern': the first time a distinct (service, pattern) error shape "
+            "appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences "
+            "in the window. The pattern trigger types require log pattern stamping to be enabled for "
+            "this team, and force evaluation_periods and datapoints_to_alarm to 1."
+        ),
+    )
+    trigger_config = LogsAlertTriggerConfigField(
+        required=False,
+        allow_null=True,
+        help_text="Trigger-specific settings. Only used with trigger_type=new_pattern.",
+    )
     threshold_count = serializers.IntegerField(
         min_value=0,
         default=100,
-        help_text="Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.",
+        help_text="Number of matching log entries (or, for a pattern trigger, occurrences of one error "
+        "shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. "
+        "Use 0 with the 'above' operator to fire on any match.",
     )
     first_enabled_at = serializers.DateTimeField(
         read_only=True,
@@ -444,6 +508,8 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
             "name",
             "enabled",
             "filters",
+            "trigger_type",
+            "trigger_config",
             "threshold_count",
             "threshold_operator",
             "window_minutes",
@@ -498,6 +564,25 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
         window = attrs.get("window_minutes", getattr(self.instance, "window_minutes", None))
         if window is not None and window not in ALLOWED_WINDOW_MINUTES:
             raise ValidationError({"window_minutes": f"Must be one of {sorted(ALLOWED_WINDOW_MINUTES)}."})
+
+        trigger_type = attrs.get(
+            "trigger_type", getattr(self.instance, "trigger_type", LogsAlertConfiguration.TriggerType.COUNT)
+        )
+        is_pattern_trigger = trigger_type != LogsAlertConfiguration.TriggerType.COUNT
+
+        trigger_config = attrs.get("trigger_config", _SENTINEL)
+        if trigger_config not in (_SENTINEL, None) and trigger_type != LogsAlertConfiguration.TriggerType.NEW_PATTERN:
+            raise ValidationError({"trigger_config": "Only used with trigger_type=new_pattern."})
+
+        if is_pattern_trigger:
+            # Pattern triggers evaluate 1-of-1: a fingerprint is new, or breaches, exactly
+            # once per check, so an N-of-M rolling window has no meaning for them.
+            attrs["evaluation_periods"] = 1
+            attrs["datapoints_to_alarm"] = 1
+
+            previous_trigger_type = getattr(self.instance, "trigger_type", LogsAlertConfiguration.TriggerType.COUNT)
+            if previous_trigger_type != trigger_type:
+                _validate_pattern_trigger_allowed(self.context["get_team"]())
 
         evaluation_periods = attrs.get("evaluation_periods", getattr(self.instance, "evaluation_periods", 1))
         datapoints_to_alarm = attrs.get("datapoints_to_alarm", getattr(self.instance, "datapoints_to_alarm", 1))
@@ -638,6 +723,35 @@ def _validate_filters(filters: dict) -> None:
         )
 
 
+def _validate_pattern_trigger_allowed(team: Team) -> None:
+    """Gate turning an alert into a pattern trigger (new_pattern / pattern_threshold).
+
+    Only checked on the transition into a pattern trigger, not on every save of an
+    alert that already has one. An alert already using a pattern trigger keeps
+    working, and can still be edited, if the flag or allowlist changes later.
+    """
+    if not posthoganalytics.feature_enabled(
+        LOGS_PATTERN_ALERTS_FEATURE_FLAG,
+        str(team.uuid),
+        groups={"organization": str(team.organization_id)},
+        group_properties={
+            "organization": {
+                "id": str(team.organization_id),
+                "created_at": team.organization.created_at,
+            }
+        },
+        send_feature_flag_events=False,
+    ):
+        raise ValidationError({"trigger_type": "Pattern-based alerting is not enabled for this team."})
+    if team.id not in PATTERN_MASKING_ENABLED_TEAM_IDS:
+        raise ValidationError(
+            {
+                "trigger_type": "Pattern-based alerting requires log pattern stamping, which is not "
+                "enabled for this team. Contact support to enable it."
+            }
+        )
+
+
 class LogsAlertConfigurationDetailSerializer(LogsAlertConfigurationSerializer):
     """One alert, with the destinations attached to it. The list endpoint leaves them out:
     reading a destination pulls its stored inputs, which run to several KB per row."""
@@ -688,17 +802,42 @@ class LogsAlertEventSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class LogsAlertSimulateBreachingPatternSerializer(serializers.Serializer):
+    service_name = serializers.CharField(help_text="Service the breaching log pattern belongs to.")
+    pattern = serializers.CharField(help_text="The masked log pattern template that breached.")
+    occurrences = serializers.IntegerField(help_text="Occurrences of this pattern counted toward the breach.")
+
+
 class LogsAlertSimulateBucketSerializer(serializers.Serializer):
     timestamp = serializers.DateTimeField(help_text="Bucket start timestamp.")
-    count = serializers.IntegerField(help_text="Number of matching logs in this bucket.")
+    count = serializers.IntegerField(
+        help_text="Number of matching logs in this bucket (count trigger), or the number of breaching "
+        "patterns (pattern trigger)."
+    )
     threshold_breached = serializers.BooleanField(help_text="Whether the count crossed the threshold in this bucket.")
     state = serializers.CharField(help_text="Alert state after evaluating this bucket.")
     notification = serializers.CharField(help_text="Notification action: none, fire, or resolve.")
     reason = serializers.CharField(help_text="Human-readable explanation of the state transition.")
+    breaching_patterns = LogsAlertSimulateBreachingPatternSerializer(
+        many=True,
+        required=False,
+        help_text="Patterns that breached in this bucket. Only populated for a pattern trigger.",
+    )
 
 
 class LogsAlertSimulateRequestSerializer(serializers.Serializer):
     filters = LogsAlertFiltersField(help_text="Filter criteria — same format as LogsAlertConfiguration.filters.")
+    trigger_type = serializers.ChoiceField(
+        choices=LogsAlertConfiguration.TriggerType.choices,
+        default=LogsAlertConfiguration.TriggerType.COUNT,
+        help_text="Same meaning as LogsAlertConfiguration.trigger_type. Forces evaluation_periods and "
+        "datapoints_to_alarm to 1 for a pattern trigger.",
+    )
+    trigger_config = LogsAlertTriggerConfigField(
+        required=False,
+        allow_null=True,
+        help_text="Same meaning as LogsAlertConfiguration.trigger_config. Only used with trigger_type=new_pattern.",
+    )
     threshold_count = serializers.IntegerField(
         min_value=0,
         help_text="Threshold count to evaluate against.",
@@ -757,6 +896,13 @@ class LogsAlertSimulateRequestSerializer(serializers.Serializer):
         return value
 
     def validate(self, attrs: dict) -> dict:
+        if (
+            attrs.get("trigger_type", LogsAlertConfiguration.TriggerType.COUNT)
+            != LogsAlertConfiguration.TriggerType.COUNT
+        ):
+            # Same 1-of-1 override as LogsAlertConfigurationSerializer.
+            attrs["evaluation_periods"] = 1
+            attrs["datapoints_to_alarm"] = 1
         if attrs.get("datapoints_to_alarm", 1) > attrs.get("evaluation_periods", 1):
             raise ValidationError({"datapoints_to_alarm": "Cannot exceed evaluation_periods."})
         if attrs["check_interval_minutes"] > attrs["window_minutes"]:
@@ -775,6 +921,12 @@ class LogsAlertSimulateResponseSerializer(serializers.Serializer):
     total_buckets = serializers.IntegerField(help_text="Total number of buckets in the simulation window.")
     threshold_count = serializers.IntegerField(help_text="Threshold count used for evaluation.")
     threshold_operator = serializers.CharField(help_text="Threshold operator used for evaluation.")
+    approximate = serializers.BooleanField(
+        default=False,
+        help_text="True for a new_pattern trigger: the seen-set this preview builds only covers the "
+        "simulated range, unlike the real evaluator's persisted seen-set, so early buckets can "
+        "under- or over-count new patterns relative to production.",
+    )
 
 
 class LogsAlertCreateDestinationSerializer(serializers.Serializer):
@@ -902,6 +1054,79 @@ def _fill_empty_buckets(
             result.append(BucketedCount(timestamp=cursor, count=0))
         cursor += interval
     return result
+
+
+def _fill_empty_pattern_buckets(
+    sparse: list[BucketedPatternGroups],
+    date_from: datetime,
+    date_to: datetime,
+    interval_minutes: int,
+) -> list[BucketedPatternGroups]:
+    """Pattern-trigger analog of `_fill_empty_buckets`: fills gaps with empty group lists."""
+    if interval_minutes <= 0:
+        return sparse
+
+    expected_buckets = int((date_to - date_from).total_seconds() / (interval_minutes * 60)) + 1
+    if expected_buckets > MAX_SIMULATE_BUCKETS:
+        raise ValidationError(
+            f"Simulation would produce {expected_buckets} buckets (max {MAX_SIMULATE_BUCKETS}). "
+            "Use a shorter date range or larger window."
+        )
+
+    existing = {(b.timestamp.replace(tzinfo=UTC) if b.timestamp.tzinfo is None else b.timestamp): b for b in sparse}
+    interval = dt.timedelta(minutes=interval_minutes)
+
+    epoch = datetime(2000, 1, 1, tzinfo=UTC)
+    seconds = int((date_from - epoch).total_seconds())
+    interval_seconds = interval_minutes * 60
+    aligned_seconds = (seconds // interval_seconds) * interval_seconds
+    cursor = epoch + dt.timedelta(seconds=aligned_seconds)
+
+    result: list[BucketedPatternGroups] = []
+    while cursor <= date_to:
+        if cursor in existing:
+            result.append(existing[cursor])
+        elif cursor >= date_from:
+            result.append(BucketedPatternGroups(timestamp=cursor, groups=[]))
+        cursor += interval
+    return result
+
+
+def _rolling_group_totals(
+    buckets: list[BucketedPatternGroups], buckets_per_window: int, i: int
+) -> dict[tuple[str, str, int], int]:
+    """Sum occurrences per (service_name, pattern, pattern_version) across the
+    `buckets_per_window` cadence buckets ending just before bucket `i`. This is the
+    pattern analog of the count trigger's rolling sum in `simulate()`. Bucket `i`
+    itself is excluded because it holds data at-or-after the simulated check time.
+    """
+    totals: dict[tuple[str, str, int], int] = {}
+    window_start = max(0, i - buckets_per_window)
+    for bucket in buckets[window_start:i]:
+        for group in bucket.groups:
+            key = (group.service_name, group.pattern, group.pattern_version)
+            totals[key] = totals.get(key, 0) + group.occurrences
+    return totals
+
+
+def _build_pattern_reason(outcome: AlertCheckOutcome, breaching: list[PatternGroupCount]) -> str:
+    """Human-readable explanation of a simulated pattern-trigger check, analogous to
+    `_build_reason` for count triggers."""
+    if breaching:
+        names = ", ".join(f"{g.service_name}: {g.pattern}" for g in breaching[:3])
+        if len(breaching) > 3:
+            names += f", and {len(breaching) - 3} more"
+        desc = f"{len(breaching)} breaching pattern(s): {names}"
+    else:
+        desc = "no breaching patterns"
+
+    if outcome.notification == NotificationAction.FIRE:
+        return f"{desc}, fired"
+    if outcome.notification == NotificationAction.RESOLVE:
+        return f"{desc}, resolved"
+    if outcome.new_state == AlertState.FIRING:
+        return f"{desc}, still firing"
+    return desc
 
 
 @extend_schema_view(list=extend_schema(parameters=[LogsAlertListQuerySerializer]))
@@ -1174,6 +1399,11 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
+        trigger_type = data.get("trigger_type", LogsAlertConfiguration.TriggerType.COUNT)
+        if trigger_type != LogsAlertConfiguration.TriggerType.COUNT:
+            response_data = self._simulate_pattern_trigger(data, trigger_type)
+            return Response(LogsAlertSimulateResponseSerializer(response_data).data)
+
         date_from_dt = relative_date_parse(data["date_from"], ZoneInfo("UTC"))
         date_to_dt = datetime.now(UTC)
         window_minutes = data["window_minutes"]
@@ -1302,10 +1532,132 @@ class LogsAlertViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             "total_buckets": len(result_buckets),
             "threshold_count": threshold,
             "threshold_operator": data["threshold_operator"],
+            "approximate": False,
         }
 
         response_serializer = LogsAlertSimulateResponseSerializer(response_data)
         return Response(response_serializer.data)
+
+    def _simulate_pattern_trigger(self, data: dict, trigger_type: str) -> dict:
+        """Pattern-trigger counterpart of the count-trigger simulation above.
+
+        `pattern_threshold` runs the same grouped query the real evaluator uses,
+        bucketed and rolled up the same way the count path rolls up `AlertCheckQuery`
+        buckets. `new_pattern` is an approximation: it seeds from a lookback window
+        like the real evaluator, then re-derives its own seen-set as it walks the
+        simulated range, instead of reading the alert's actual persisted seen-set
+        (this alert does not exist yet, or the caller is previewing a change).
+        """
+        date_from_dt = relative_date_parse(data["date_from"], ZoneInfo("UTC"))
+        date_to_dt = datetime.now(UTC)
+        window_minutes = data["window_minutes"]
+        cadence_minutes = data["check_interval_minutes"]
+        threshold = data["threshold_count"]
+        cooldown_minutes = data.get("cooldown_minutes", 0)
+
+        fake_alert = LogsAlertConfiguration(
+            team=self.team,
+            filters=data["filters"],
+            threshold_count=threshold,
+            window_minutes=window_minutes,
+            trigger_type=trigger_type,
+        )
+
+        seen: set[tuple[str, str, int]] = set()
+        if trigger_type == LogsAlertConfiguration.TriggerType.NEW_PATTERN:
+            seed_lookback_days = (data.get("trigger_config") or {}).get(
+                "seed_lookback_days", DEFAULT_SEED_LOOKBACK_DAYS
+            )
+            seed_from = date_from_dt - dt.timedelta(days=seed_lookback_days)
+            seed_result = GroupedPatternCheckQuery(
+                team=self.team, alert=fake_alert, date_from=seed_from, date_to=date_from_dt
+            ).execute_groups(limit=MAX_SIMULATE_PATTERN_ROWS)
+            seen = {(g.service_name, g.pattern, g.pattern_version) for g in seed_result.groups}
+
+        bucketed = GroupedPatternCheckQuery(
+            team=self.team, alert=fake_alert, date_from=date_from_dt, date_to=date_to_dt
+        ).execute_bucketed_groups(interval_minutes=cadence_minutes, limit=MAX_SIMULATE_PATTERN_ROWS)
+        cadence_buckets = _fill_empty_pattern_buckets(bucketed.buckets, date_from_dt, date_to_dt, cadence_minutes)
+
+        # ALLOWED_WINDOW_MINUTES is bounded below by the configured cadence, so
+        # integer division here is always >= 1 (same contract as the count path).
+        buckets_per_window = window_minutes // cadence_minutes
+
+        snapshot = AlertSnapshot(
+            state=AlertState.NOT_FIRING,
+            evaluation_periods=1,
+            datapoints_to_alarm=1,
+            cooldown_minutes=cooldown_minutes,
+            last_notified_at=None,
+            snooze_until=None,
+            consecutive_failures=0,
+            recent_events_breached=(),
+        )
+
+        result_buckets = []
+        fire_count = 0
+        resolve_count = 0
+
+        for i, bucket in enumerate(cadence_buckets):
+            totals = _rolling_group_totals(cadence_buckets, buckets_per_window, i)
+
+            if trigger_type == LogsAlertConfiguration.TriggerType.NEW_PATTERN:
+                new_keys = [key for key in totals if key not in seen]
+                seen.update(new_keys)
+                breaching_keys = [key for key in new_keys if totals[key] >= threshold]
+            else:
+                breaching_keys = [key for key, total in totals.items() if total >= threshold]
+
+            breaching = [
+                PatternGroupCount(service_name=key[0], pattern=key[1], pattern_version=key[2], occurrences=totals[key])
+                for key in breaching_keys
+            ]
+            window_count = len(breaching)
+            breached = window_count > 0
+
+            check = CheckResult(result_count=window_count, threshold_breached=breached)
+            outcome: AlertCheckOutcome = evaluate_alert_check(snapshot, check, bucket.timestamp)
+
+            if outcome.notification == NotificationAction.FIRE:
+                fire_count += 1
+            elif outcome.notification == NotificationAction.RESOLVE:
+                resolve_count += 1
+
+            result_buckets.append(
+                {
+                    "timestamp": bucket.timestamp.isoformat(),
+                    "count": window_count,
+                    "threshold_breached": breached,
+                    "state": outcome.new_state.value,
+                    "notification": outcome.notification.value,
+                    "reason": _build_pattern_reason(outcome, breaching),
+                    "breaching_patterns": [
+                        {"service_name": g.service_name, "pattern": g.pattern, "occurrences": g.occurrences}
+                        for g in breaching
+                    ],
+                }
+            )
+
+            snapshot = AlertSnapshot(
+                state=outcome.new_state,
+                evaluation_periods=1,
+                datapoints_to_alarm=1,
+                cooldown_minutes=cooldown_minutes,
+                last_notified_at=bucket.timestamp if outcome.update_last_notified_at else snapshot.last_notified_at,
+                snooze_until=None,
+                consecutive_failures=outcome.consecutive_failures,
+                recent_events_breached=(breached,),
+            )
+
+        return {
+            "buckets": result_buckets,
+            "fire_count": fire_count,
+            "resolve_count": resolve_count,
+            "total_buckets": len(result_buckets),
+            "threshold_count": threshold,
+            "threshold_operator": data["threshold_operator"],
+            "approximate": trigger_type == LogsAlertConfiguration.TriggerType.NEW_PATTERN,
+        }
 
     def _track(self, action: Literal["created", "updated", "deleted"], instance: LogsAlertConfiguration) -> None:
         report_user_action(

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -2516,3 +2516,206 @@ class TestLogsAlertAPIPersonalAPIKeyScopes(APIBaseTest):
         url = f"{self.base_url}{uuid4()}/reset/"
         response = self.client.post(url, {}, format="json", **self._auth(key))
         assert response.status_code == 403, response.json()
+
+
+class TestPatternTriggerValidation(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.base_url = f"/api/projects/{self.team.pk}/logs/alerts/"
+        self._ff_patcher = patch("posthoganalytics.feature_enabled", return_value=True)
+        self._ff_patcher.start()
+        self.addCleanup(self._ff_patcher.stop)
+        self._masking_patcher = patch(
+            "products.logs.backend.presentation.views.alerts_api.PATTERN_MASKING_ENABLED_TEAM_IDS",
+            frozenset({self.team.id}),
+        )
+        self._masking_patcher.start()
+        self.addCleanup(self._masking_patcher.stop)
+
+    def _payload(self, **overrides) -> dict:
+        defaults: dict[str, Any] = {
+            "name": "New pattern alert",
+            "trigger_type": "new_pattern",
+            "threshold_count": 1,
+            "filters": {"severityLevels": ["error"]},
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_create_pattern_trigger_requires_feature_flag(self):
+        with patch("posthoganalytics.feature_enabled", return_value=False):
+            response = self.client.post(self.base_url, self._payload(), format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["attr"] == "trigger_type"
+        assert "not enabled for this team" in response.json()["detail"]
+
+    def test_create_pattern_trigger_requires_stamping_allowlist(self):
+        with patch("products.logs.backend.presentation.views.alerts_api.PATTERN_MASKING_ENABLED_TEAM_IDS", frozenset()):
+            response = self.client.post(self.base_url, self._payload(), format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert "pattern stamping" in response.json()["detail"]
+
+    def test_create_pattern_trigger_succeeds_when_flag_and_allowlist_pass(self):
+        response = self.client.post(self.base_url, self._payload(), format="json")
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["trigger_type"] == "new_pattern"
+
+    def test_create_pattern_trigger_forces_evaluation_periods_and_datapoints_to_one(self):
+        response = self.client.post(
+            self.base_url, self._payload(evaluation_periods=5, datapoints_to_alarm=3), format="json"
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["evaluation_periods"] == 1
+        assert response.json()["datapoints_to_alarm"] == 1
+
+    def test_create_pattern_threshold_trigger_rejects_trigger_config(self):
+        response = self.client.post(
+            self.base_url,
+            self._payload(trigger_type="pattern_threshold", trigger_config={"seed_lookback_days": 3}),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["attr"] == "trigger_config"
+
+    def test_count_trigger_rejects_trigger_config(self):
+        response = self.client.post(
+            self.base_url,
+            {
+                "name": "count alert",
+                "threshold_count": 5,
+                "filters": {"severityLevels": ["error"]},
+                "trigger_config": {"seed_lookback_days": 3},
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+        assert response.json()["attr"] == "trigger_config"
+
+    def test_create_new_pattern_accepts_trigger_config(self):
+        response = self.client.post(
+            self.base_url, self._payload(trigger_config={"seed_lookback_days": 3}), format="json"
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+        assert response.json()["trigger_config"]["seed_lookback_days"] == 3
+
+    def test_updating_an_existing_pattern_trigger_alert_is_not_regated(self):
+        created = self.client.post(self.base_url, self._payload(), format="json").json()
+
+        with (
+            patch("posthoganalytics.feature_enabled", return_value=False),
+            patch("products.logs.backend.presentation.views.alerts_api.PATTERN_MASKING_ENABLED_TEAM_IDS", frozenset()),
+        ):
+            response = self.client.patch(f"{self.base_url}{created['id']}/", {"name": "renamed"}, format="json")
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["name"] == "renamed"
+
+    def test_converting_a_count_trigger_to_a_pattern_trigger_is_gated(self):
+        created = self.client.post(
+            self.base_url,
+            {"name": "count alert", "threshold_count": 5, "filters": {"severityLevels": ["error"]}},
+            format="json",
+        ).json()
+
+        with patch("posthoganalytics.feature_enabled", return_value=False):
+            response = self.client.patch(
+                f"{self.base_url}{created['id']}/", {"trigger_type": "new_pattern"}, format="json"
+            )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+
+
+class TestSimulatePatternTrigger(ClickhouseTestMixin, APIBaseTest):
+    BASE_TIME = datetime(2025, 6, 1, 0, 0, 0, tzinfo=UTC)
+    SERVICE = "pattern_simulate_service"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.base_url = f"/api/projects/{self.team.pk}/logs/alerts/"
+        self._ff_patcher = patch("posthoganalytics.feature_enabled", return_value=True)
+        self._ff_patcher.start()
+        self.addCleanup(self._ff_patcher.stop)
+
+    def _insert(self, rows: list[dict]) -> None:
+        sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+    def _stamped_row(self, *, ts: datetime, pattern: str, row_uuid: str) -> dict:
+        row = _make_log_row(team_id=self.team.id, service=self.SERVICE, uuid=row_uuid, ts=ts, body=pattern)
+        row["pattern"] = pattern
+        row["pattern_version"] = 3
+        return row
+
+    @freeze_time("2025-06-01T01:00:00Z")
+    def test_pattern_threshold_simulate_reports_a_breaching_bucket(self) -> None:
+        # 5 occurrences of the same pattern within one 5-minute bucket, comfortably
+        # inside the "-2h" simulate range.
+        rows = [
+            self._stamped_row(
+                ts=self.BASE_TIME + timedelta(minutes=30, seconds=i * 10),
+                pattern="Error in Foo.bar",
+                row_uuid=f"pt-{i}",
+            )
+            for i in range(5)
+        ]
+        self._insert(rows)
+
+        response = self.client.post(
+            f"{self.base_url}simulate/",
+            {
+                "filters": {"serviceNames": [self.SERVICE]},
+                "trigger_type": "pattern_threshold",
+                "threshold_count": 3,
+                "threshold_operator": "above",
+                "window_minutes": 5,
+                "check_interval_minutes": 5,
+                "date_from": "-2h",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        data = response.json()
+        assert data["approximate"] is False
+
+        breaching_buckets = [b for b in data["buckets"] if b["threshold_breached"]]
+        assert len(breaching_buckets) == 1
+        assert breaching_buckets[0]["breaching_patterns"] == [
+            {"service_name": self.SERVICE, "pattern": "Error in Foo.bar", "occurrences": 5}
+        ]
+        assert data["fire_count"] == 1
+
+    @freeze_time("2025-06-01T01:00:00Z")
+    def test_new_pattern_simulate_only_flags_the_fingerprint_outside_the_seed_window(self) -> None:
+        # Seeded well before the simulated range: never breaches.
+        self._insert(
+            [self._stamped_row(ts=self.BASE_TIME - timedelta(days=1), pattern="Known error", row_uuid="seed-1")]
+        )
+        # Inside the simulated range, and not in the seed window: flagged as new.
+        self._insert(
+            [
+                self._stamped_row(
+                    ts=self.BASE_TIME + timedelta(minutes=40), pattern="Panic in Checkout.pay", row_uuid="novel-1"
+                )
+            ]
+        )
+
+        response = self.client.post(
+            f"{self.base_url}simulate/",
+            {
+                "filters": {"serviceNames": [self.SERVICE]},
+                "trigger_type": "new_pattern",
+                "trigger_config": {"seed_lookback_days": 3},
+                "threshold_count": 1,
+                "threshold_operator": "above",
+                "window_minutes": 5,
+                "check_interval_minutes": 5,
+                "date_from": "-2h",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        data = response.json()
+        assert data["approximate"] is True
+
+        breaching_buckets = [b for b in data["buckets"] if b["threshold_breached"]]
+        assert len(breaching_buckets) == 1
+        assert breaching_buckets[0]["breaching_patterns"] == [
+            {"service_name": self.SERVICE, "pattern": "Panic in Checkout.pay", "occurrences": 1}
+        ]

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -393,6 +393,28 @@ export interface LogsAlertFiltersApi {
 }
 
 /**
+ * * `count` - Count threshold
+ * * `new_pattern` - New pattern
+ * * `pattern_threshold` - Pattern threshold
+ */
+export type TriggerTypeEnumApi = (typeof TriggerTypeEnumApi)[keyof typeof TriggerTypeEnumApi]
+
+export const TriggerTypeEnumApi = {
+    Count: 'count',
+    NewPattern: 'new_pattern',
+    PatternThreshold: 'pattern_threshold',
+} as const
+
+export interface LogsAlertTriggerConfigApi {
+    /**
+     * Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire.
+     * @minimum 1
+     * @maximum 30
+     */
+    seed_lookback_days?: number
+}
+
+/**
  * * `above` - Above
  * * `below` - Below
  */
@@ -537,8 +559,16 @@ export interface LogsAlertConfigurationApi {
     enabled?: boolean
     /** Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
     filters?: LogsAlertFiltersApi
+    /** What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.
+     *
+     * * `count` - Count threshold
+     * * `new_pattern` - New pattern
+     * * `pattern_threshold` - Pattern threshold */
+    trigger_type?: TriggerTypeEnumApi
+    /** Trigger-specific settings. Only used with trigger_type=new_pattern. */
+    trigger_config?: LogsAlertTriggerConfigApi | null
     /**
-     * Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.
+     * Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.
      * @minimum 0
      */
     threshold_count?: number
@@ -666,8 +696,16 @@ export interface LogsAlertConfigurationDetailApi {
     enabled?: boolean
     /** Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
     filters?: LogsAlertFiltersApi
+    /** What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.
+     *
+     * * `count` - Count threshold
+     * * `new_pattern` - New pattern
+     * * `pattern_threshold` - Pattern threshold */
+    trigger_type?: TriggerTypeEnumApi
+    /** Trigger-specific settings. Only used with trigger_type=new_pattern. */
+    trigger_config?: LogsAlertTriggerConfigApi | null
     /**
-     * Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.
+     * Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.
      * @minimum 0
      */
     threshold_count?: number
@@ -768,8 +806,16 @@ export interface PatchedLogsAlertConfigurationApi {
     enabled?: boolean
     /** Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
     filters?: LogsAlertFiltersApi
+    /** What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.
+     *
+     * * `count` - Count threshold
+     * * `new_pattern` - New pattern
+     * * `pattern_threshold` - Pattern threshold */
+    trigger_type?: TriggerTypeEnumApi
+    /** Trigger-specific settings. Only used with trigger_type=new_pattern. */
+    trigger_config?: LogsAlertTriggerConfigApi | null
     /**
-     * Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.
+     * Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.
      * @minimum 0
      */
     threshold_count?: number
@@ -935,6 +981,14 @@ export interface PaginatedLogsAlertEventListApi {
 export interface LogsAlertSimulateRequestApi {
     /** Filter criteria — same format as LogsAlertConfiguration.filters. */
     filters: LogsAlertFiltersApi
+    /** Same meaning as LogsAlertConfiguration.trigger_type. Forces evaluation_periods and datapoints_to_alarm to 1 for a pattern trigger.
+     *
+     * * `count` - Count threshold
+     * * `new_pattern` - New pattern
+     * * `pattern_threshold` - Pattern threshold */
+    trigger_type?: TriggerTypeEnumApi
+    /** Same meaning as LogsAlertConfiguration.trigger_config. Only used with trigger_type=new_pattern. */
+    trigger_config?: LogsAlertTriggerConfigApi | null
     /**
      * Threshold count to evaluate against.
      * @minimum 0
@@ -974,10 +1028,19 @@ export interface LogsAlertSimulateRequestApi {
     date_from: string
 }
 
+export interface LogsAlertSimulateBreachingPatternApi {
+    /** Service the breaching log pattern belongs to. */
+    service_name: string
+    /** The masked log pattern template that breached. */
+    pattern: string
+    /** Occurrences of this pattern counted toward the breach. */
+    occurrences: number
+}
+
 export interface LogsAlertSimulateBucketApi {
     /** Bucket start timestamp. */
     timestamp: string
-    /** Number of matching logs in this bucket. */
+    /** Number of matching logs in this bucket (count trigger), or the number of breaching patterns (pattern trigger). */
     count: number
     /** Whether the count crossed the threshold in this bucket. */
     threshold_breached: boolean
@@ -987,6 +1050,8 @@ export interface LogsAlertSimulateBucketApi {
     notification: string
     /** Human-readable explanation of the state transition. */
     reason: string
+    /** Patterns that breached in this bucket. Only populated for a pattern trigger. */
+    breaching_patterns?: LogsAlertSimulateBreachingPatternApi[]
 }
 
 export interface LogsAlertSimulateResponseApi {
@@ -1002,6 +1067,8 @@ export interface LogsAlertSimulateResponseApi {
     threshold_count: number
     /** Threshold operator used for evaluation. */
     threshold_operator: string
+    /** True for a new_pattern trigger: the seen-set this preview builds only covers the simulated range, unlike the real evaluator's persisted seen-set, so early buckets can under- or over-count new patterns relative to production. */
+    approximate?: boolean
 }
 
 export interface _ScanDateRangeApi {

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -12,6 +12,10 @@ import * as zod from 'zod'
 export const logsAlertsCreateBodyNameMax = 255
 
 export const logsAlertsCreateBodyEnabledDefault = true
+export const logsAlertsCreateBodyTriggerTypeDefault = `count`
+export const logsAlertsCreateBodyTriggerConfigOneSeedLookbackDaysDefault = 7
+export const logsAlertsCreateBodyTriggerConfigOneSeedLookbackDaysMax = 30
+
 export const logsAlertsCreateBodyThresholdCountDefault = 100
 export const logsAlertsCreateBodyThresholdCountMin = 0
 
@@ -62,12 +66,37 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).'
         ),
+    trigger_type: zod
+        .enum(['count', 'new_pattern', 'pattern_threshold'])
+        .describe(
+            '\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        )
+        .default(logsAlertsCreateBodyTriggerTypeDefault)
+        .describe(
+            "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold"
+        ),
+    trigger_config: zod
+        .union([
+            zod.object({
+                seed_lookback_days: zod
+                    .number()
+                    .min(1)
+                    .max(logsAlertsCreateBodyTriggerConfigOneSeedLookbackDaysMax)
+                    .default(logsAlertsCreateBodyTriggerConfigOneSeedLookbackDaysDefault)
+                    .describe(
+                        "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire."
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Trigger-specific settings. Only used with trigger_type=new_pattern.'),
     threshold_count: zod
         .number()
         .min(logsAlertsCreateBodyThresholdCountMin)
         .default(logsAlertsCreateBodyThresholdCountDefault)
         .describe(
-            "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log."
+            "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match."
         ),
     threshold_operator: zod
         .enum(['above', 'below'])
@@ -134,6 +163,10 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
 export const logsAlertsUpdateBodyNameMax = 255
 
 export const logsAlertsUpdateBodyEnabledDefault = true
+export const logsAlertsUpdateBodyTriggerTypeDefault = `count`
+export const logsAlertsUpdateBodyTriggerConfigOneSeedLookbackDaysDefault = 7
+export const logsAlertsUpdateBodyTriggerConfigOneSeedLookbackDaysMax = 30
+
 export const logsAlertsUpdateBodyThresholdCountDefault = 100
 export const logsAlertsUpdateBodyThresholdCountMin = 0
 
@@ -184,12 +217,37 @@ export const LogsAlertsUpdateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).'
         ),
+    trigger_type: zod
+        .enum(['count', 'new_pattern', 'pattern_threshold'])
+        .describe(
+            '\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        )
+        .default(logsAlertsUpdateBodyTriggerTypeDefault)
+        .describe(
+            "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold"
+        ),
+    trigger_config: zod
+        .union([
+            zod.object({
+                seed_lookback_days: zod
+                    .number()
+                    .min(1)
+                    .max(logsAlertsUpdateBodyTriggerConfigOneSeedLookbackDaysMax)
+                    .default(logsAlertsUpdateBodyTriggerConfigOneSeedLookbackDaysDefault)
+                    .describe(
+                        "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire."
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Trigger-specific settings. Only used with trigger_type=new_pattern.'),
     threshold_count: zod
         .number()
         .min(logsAlertsUpdateBodyThresholdCountMin)
         .default(logsAlertsUpdateBodyThresholdCountDefault)
         .describe(
-            "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log."
+            "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match."
         ),
     threshold_operator: zod
         .enum(['above', 'below'])
@@ -256,6 +314,10 @@ export const LogsAlertsUpdateBody = /* @__PURE__ */ zod.object({
 export const logsAlertsPartialUpdateBodyNameMax = 255
 
 export const logsAlertsPartialUpdateBodyEnabledDefault = true
+export const logsAlertsPartialUpdateBodyTriggerTypeDefault = `count`
+export const logsAlertsPartialUpdateBodyTriggerConfigOneSeedLookbackDaysDefault = 7
+export const logsAlertsPartialUpdateBodyTriggerConfigOneSeedLookbackDaysMax = 30
+
 export const logsAlertsPartialUpdateBodyThresholdCountDefault = 100
 export const logsAlertsPartialUpdateBodyThresholdCountMin = 0
 
@@ -306,12 +368,37 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).'
         ),
+    trigger_type: zod
+        .enum(['count', 'new_pattern', 'pattern_threshold'])
+        .describe(
+            '\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        )
+        .default(logsAlertsPartialUpdateBodyTriggerTypeDefault)
+        .describe(
+            "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold"
+        ),
+    trigger_config: zod
+        .union([
+            zod.object({
+                seed_lookback_days: zod
+                    .number()
+                    .min(1)
+                    .max(logsAlertsPartialUpdateBodyTriggerConfigOneSeedLookbackDaysMax)
+                    .default(logsAlertsPartialUpdateBodyTriggerConfigOneSeedLookbackDaysDefault)
+                    .describe(
+                        "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire."
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Trigger-specific settings. Only used with trigger_type=new_pattern.'),
     threshold_count: zod
         .number()
         .min(logsAlertsPartialUpdateBodyThresholdCountMin)
         .default(logsAlertsPartialUpdateBodyThresholdCountDefault)
         .describe(
-            "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log."
+            "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match."
         ),
     threshold_operator: zod
         .enum(['above', 'below'])
@@ -406,6 +493,10 @@ export const LogsAlertsDestinationsDeleteCreateBody = /* @__PURE__ */ zod.object
 /**
  * Simulate a logs alert on historical data using the full state machine. Read-only — no alert check records are created.
  */
+export const logsAlertsSimulateCreateBodyTriggerTypeDefault = `count`
+export const logsAlertsSimulateCreateBodyTriggerConfigOneSeedLookbackDaysDefault = 7
+export const logsAlertsSimulateCreateBodyTriggerConfigOneSeedLookbackDaysMax = 30
+
 export const logsAlertsSimulateCreateBodyThresholdCountMin = 0
 
 export const logsAlertsSimulateCreateBodyCheckIntervalMinutesDefault = 5
@@ -444,6 +535,31 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                 .optional(),
         })
         .describe('Filter criteria — same format as LogsAlertConfiguration.filters.'),
+    trigger_type: zod
+        .enum(['count', 'new_pattern', 'pattern_threshold'])
+        .describe(
+            '\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        )
+        .default(logsAlertsSimulateCreateBodyTriggerTypeDefault)
+        .describe(
+            'Same meaning as LogsAlertConfiguration.trigger_type. Forces evaluation_periods and datapoints_to_alarm to 1 for a pattern trigger.\n\n\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        ),
+    trigger_config: zod
+        .union([
+            zod.object({
+                seed_lookback_days: zod
+                    .number()
+                    .min(1)
+                    .max(logsAlertsSimulateCreateBodyTriggerConfigOneSeedLookbackDaysMax)
+                    .default(logsAlertsSimulateCreateBodyTriggerConfigOneSeedLookbackDaysDefault)
+                    .describe(
+                        "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire."
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Same meaning as LogsAlertConfiguration.trigger_config. Only used with trigger_type=new_pattern.'),
     threshold_count: zod
         .number()
         .min(logsAlertsSimulateCreateBodyThresholdCountMin)

--- a/products/logs/mcp/tools.yaml
+++ b/products/logs/mcp/tools.yaml
@@ -20,8 +20,11 @@ tools:
             idempotent: false
         title: Create log alert
         description: >
-            Create a threshold-based alert on log streams. The alert periodically counts log entries matching the given
-            filters and fires when the count crosses the threshold. Maximum 20 alerts per project.
+            Create an alert on log streams. The default trigger_type "count" periodically counts log entries matching
+            the given filters and fires when the count crosses the threshold. Two pattern-based trigger types are also
+            available: "new_pattern" fires the first time a distinct (service, error shape) fingerprint appears;
+            "pattern_threshold" fires when a single error shape reaches threshold_count occurrences. Pattern triggers
+            require log pattern stamping to be enabled for the team. Maximum 20 alerts per project.
         exclude_params:
             - id
             - state
@@ -40,6 +43,8 @@ tools:
                 - enabled
                 - state
                 - filters
+                - trigger_type
+                - trigger_config
                 - threshold_count
                 - threshold_operator
                 - window_minutes
@@ -151,14 +156,16 @@ tools:
         list: true
         title: List log alerts
         description: >
-            List log alert configurations in the current project, newest first. Returns alert name, state, threshold,
-            filters, and scheduling details. Use this to review existing alerts before creating or modifying them.
+            List log alert configurations in the current project, newest first. Returns alert name, state, trigger
+            type, threshold, and scheduling details. Use this to review existing alerts before creating or modifying
+            them.
         response:
             include:
                 - id
                 - name
                 - enabled
                 - state
+                - trigger_type
                 - threshold_count
                 - threshold_operator
                 - window_minutes
@@ -177,7 +184,8 @@ tools:
         title: Update log alert
         description: >
             Update a log alert configuration by ID. Only the fields you provide are changed. Use this to adjust
-            thresholds, filters, quiet hours, enable/disable alerts, or snooze them.
+            thresholds, filters, quiet hours, trigger_type, enable/disable alerts, or snooze them. Switching
+            trigger_type to a pattern-based type requires log pattern stamping to be enabled for the team.
         exclude_params:
             - id
             - state
@@ -196,6 +204,8 @@ tools:
                 - enabled
                 - state
                 - filters
+                - trigger_type
+                - trigger_config
                 - threshold_count
                 - threshold_operator
                 - window_minutes
@@ -226,8 +236,8 @@ tools:
             idempotent: true
         title: Get log alert
         description: >
-            Get a log alert configuration by ID. Returns full details including current state, threshold settings,
-            filters, and scheduling information.
+            Get a log alert configuration by ID. Returns full details including current state, trigger type,
+            threshold settings, filters, and scheduling information.
         response:
             include:
                 - id
@@ -235,6 +245,8 @@ tools:
                 - enabled
                 - state
                 - filters
+                - trigger_type
+                - trigger_config
                 - threshold_count
                 - threshold_operator
                 - window_minutes
@@ -263,9 +275,12 @@ tools:
         title: Simulate log alert
         description: >
             Run a draft alert configuration against historical logs and return per-bucket results from the full state
-            machine — count, threshold_breached, state, notification (none/fire/resolve), reason. Use to validate
-            threshold + N-of-M settings before creating an alert. Read-only; no alert records are written. Aim for
-            fire_count between 0 and 3 over a `-7d` lookback for a healthy threshold.
+            machine — count, threshold_breached, state, notification (none/fire/resolve), reason. For a pattern-based
+            trigger_type, count is the number of breaching error shapes and each bucket lists them under
+            breaching_patterns. new_pattern simulations are approximate: the response's approximate field is true,
+            since the seen-set is rebuilt from the simulated range rather than read from a persisted alert. Use to
+            validate settings before creating an alert. Read-only; no alert records are written. Aim for fire_count
+            between 0 and 3 over a `-7d` lookback for a healthy threshold.
         response:
             include:
                 - buckets
@@ -274,6 +289,7 @@ tools:
                 - total_buckets
                 - threshold_count
                 - threshold_operator
+                - approximate
     logs-alerts-update:
         operation: logs_alerts_update
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6930,7 +6930,7 @@
         }
     },
     "logs-alerts-create": {
-        "description": "Create a threshold-based alert on log streams. The alert periodically counts log entries matching the given filters and fires when the count crosses the threshold. Maximum 20 alerts per project.",
+        "description": "Create an alert on log streams. The default trigger_type \"count\" periodically counts log entries matching the given filters and fires when the count crosses the threshold. Two pattern-based trigger types are also available: \"new_pattern\" fires the first time a distinct (service, error shape) fingerprint appears; \"pattern_threshold\" fires when a single error shape reaches threshold_count occurrences. Pattern triggers require log pattern stamping to be enabled for the team. Maximum 20 alerts per project.",
         "category": "Logs",
         "feature": "logs",
         "summary": "Create log alert",
@@ -7000,7 +7000,7 @@
         }
     },
     "logs-alerts-list": {
-        "description": "List log alert configurations in the current project, newest first. Returns alert name, state, threshold, filters, and scheduling details. Use this to review existing alerts before creating or modifying them.",
+        "description": "List log alert configurations in the current project, newest first. Returns alert name, state, trigger type, threshold, and scheduling details. Use this to review existing alerts before creating or modifying them.",
         "category": "Logs",
         "feature": "logs",
         "summary": "List log alerts",
@@ -7014,7 +7014,7 @@
         }
     },
     "logs-alerts-partial-update": {
-        "description": "Update a log alert configuration by ID. Only the fields you provide are changed. Use this to adjust thresholds, filters, quiet hours, enable/disable alerts, or snooze them.",
+        "description": "Update a log alert configuration by ID. Only the fields you provide are changed. Use this to adjust thresholds, filters, quiet hours, trigger_type, enable/disable alerts, or snooze them. Switching trigger_type to a pattern-based type requires log pattern stamping to be enabled for the team.",
         "category": "Logs",
         "feature": "logs",
         "summary": "Update log alert",
@@ -7028,7 +7028,7 @@
         }
     },
     "logs-alerts-retrieve": {
-        "description": "Get a log alert configuration by ID. Returns full details including current state, threshold settings, filters, and scheduling information.",
+        "description": "Get a log alert configuration by ID. Returns full details including current state, trigger type, threshold settings, filters, and scheduling information.",
         "category": "Logs",
         "feature": "logs",
         "summary": "Get log alert",
@@ -7042,7 +7042,7 @@
         }
     },
     "logs-alerts-simulate-create": {
-        "description": "Run a draft alert configuration against historical logs and return per-bucket results from the full state machine — count, threshold_breached, state, notification (none/fire/resolve), reason. Use to validate threshold + N-of-M settings before creating an alert. Read-only; no alert records are written. Aim for fire_count between 0 and 3 over a `-7d` lookback for a healthy threshold.",
+        "description": "Run a draft alert configuration against historical logs and return per-bucket results from the full state machine — count, threshold_breached, state, notification (none/fire/resolve), reason. For a pattern-based trigger_type, count is the number of breaching error shapes and each bucket lists them under breaching_patterns. new_pattern simulations are approximate: the response's approximate field is true, since the seen-set is rebuilt from the simulated range rather than read from a persisted alert. Use to validate settings before creating an alert. Read-only; no alert records are written. Aim for fire_count between 0 and 3 over a `-7d` lookback for a healthy threshold.",
         "category": "Logs",
         "feature": "logs",
         "summary": "Simulate log alert",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -7309,7 +7309,7 @@
         }
     },
     "logs-alerts-create": {
-        "description": "Create a threshold-based alert on log streams. The alert periodically counts log entries matching the given filters and fires when the count crosses the threshold. Maximum 20 alerts per project.",
+        "description": "Create an alert on log streams. The default trigger_type \"count\" periodically counts log entries matching the given filters and fires when the count crosses the threshold. Two pattern-based trigger types are also available: \"new_pattern\" fires the first time a distinct (service, error shape) fingerprint appears; \"pattern_threshold\" fires when a single error shape reaches threshold_count occurrences. Pattern triggers require log pattern stamping to be enabled for the team. Maximum 20 alerts per project.",
         "category": "Logs",
         "feature": "logs",
         "summary": "Create log alert",
@@ -7379,7 +7379,7 @@
         }
     },
     "logs-alerts-list": {
-        "description": "List log alert configurations in the current project, newest first. Returns alert name, state, threshold, filters, and scheduling details. Use this to review existing alerts before creating or modifying them.",
+        "description": "List log alert configurations in the current project, newest first. Returns alert name, state, trigger type, threshold, and scheduling details. Use this to review existing alerts before creating or modifying them.",
         "category": "Logs",
         "feature": "logs",
         "summary": "List log alerts",
@@ -7393,7 +7393,7 @@
         }
     },
     "logs-alerts-partial-update": {
-        "description": "Update a log alert configuration by ID. Only the fields you provide are changed. Use this to adjust thresholds, filters, quiet hours, enable/disable alerts, or snooze them.",
+        "description": "Update a log alert configuration by ID. Only the fields you provide are changed. Use this to adjust thresholds, filters, quiet hours, trigger_type, enable/disable alerts, or snooze them. Switching trigger_type to a pattern-based type requires log pattern stamping to be enabled for the team.",
         "category": "Logs",
         "feature": "logs",
         "summary": "Update log alert",
@@ -7407,7 +7407,7 @@
         }
     },
     "logs-alerts-retrieve": {
-        "description": "Get a log alert configuration by ID. Returns full details including current state, threshold settings, filters, and scheduling information.",
+        "description": "Get a log alert configuration by ID. Returns full details including current state, trigger type, threshold settings, filters, and scheduling information.",
         "category": "Logs",
         "feature": "logs",
         "summary": "Get log alert",
@@ -7421,7 +7421,7 @@
         }
     },
     "logs-alerts-simulate-create": {
-        "description": "Run a draft alert configuration against historical logs and return per-bucket results from the full state machine — count, threshold_breached, state, notification (none/fire/resolve), reason. Use to validate threshold + N-of-M settings before creating an alert. Read-only; no alert records are written. Aim for fire_count between 0 and 3 over a `-7d` lookback for a healthy threshold.",
+        "description": "Run a draft alert configuration against historical logs and return per-bucket results from the full state machine — count, threshold_breached, state, notification (none/fire/resolve), reason. For a pattern-based trigger_type, count is the number of breaching error shapes and each bucket lists them under breaching_patterns. new_pattern simulations are approximate: the response's approximate field is true, since the seen-set is rebuilt from the simulated range rather than read from a persisted alert. Use to validate settings before creating an alert. Read-only; no alert records are written. Aim for fire_count between 0 and 3 over a `-7d` lookback for a healthy threshold.",
         "category": "Logs",
         "feature": "logs",
         "summary": "Simulate log alert",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -47865,6 +47865,29 @@ export namespace Schemas {
     }
 
     /**
+     * * `count` - Count threshold
+     * * `new_pattern` - New pattern
+     * * `pattern_threshold` - Pattern threshold
+     */
+    export type TriggerTypeEnum = typeof TriggerTypeEnum[keyof typeof TriggerTypeEnum];
+
+
+    export const TriggerTypeEnum = {
+      Count: 'count',
+      NewPattern: 'new_pattern',
+      PatternThreshold: 'pattern_threshold',
+    } as const;
+
+    export interface LogsAlertTriggerConfig {
+      /**
+         * Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire.
+         * @minimum 1
+         * @maximum 30
+         */
+      seed_lookback_days?: number;
+    }
+
+    /**
      * * `above` - Above
      * * `below` - Below
      */
@@ -47926,8 +47949,16 @@ export namespace Schemas {
       enabled?: boolean;
       /** Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
       filters?: LogsAlertFilters;
+      /** What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.
+       *
+       * * `count` - Count threshold
+       * * `new_pattern` - New pattern
+       * * `pattern_threshold` - Pattern threshold */
+      trigger_type?: TriggerTypeEnum;
+      /** Trigger-specific settings. Only used with trigger_type=new_pattern. */
+      trigger_config?: LogsAlertTriggerConfig | null;
       /**
-         * Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.
+         * Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.
          * @minimum 0
          */
       threshold_count?: number;
@@ -48046,8 +48077,16 @@ export namespace Schemas {
       enabled?: boolean;
       /** Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
       filters?: LogsAlertFilters;
+      /** What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.
+       *
+       * * `count` - Count threshold
+       * * `new_pattern` - New pattern
+       * * `pattern_threshold` - Pattern threshold */
+      trigger_type?: TriggerTypeEnum;
+      /** Trigger-specific settings. Only used with trigger_type=new_pattern. */
+      trigger_config?: LogsAlertTriggerConfig | null;
       /**
-         * Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.
+         * Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.
          * @minimum 0
          */
       threshold_count?: number;
@@ -48204,10 +48243,19 @@ export namespace Schemas {
       readonly query_duration_ms: number | null;
     }
 
+    export interface LogsAlertSimulateBreachingPattern {
+      /** Service the breaching log pattern belongs to. */
+      service_name: string;
+      /** The masked log pattern template that breached. */
+      pattern: string;
+      /** Occurrences of this pattern counted toward the breach. */
+      occurrences: number;
+    }
+
     export interface LogsAlertSimulateBucket {
       /** Bucket start timestamp. */
       timestamp: string;
-      /** Number of matching logs in this bucket. */
+      /** Number of matching logs in this bucket (count trigger), or the number of breaching patterns (pattern trigger). */
       count: number;
       /** Whether the count crossed the threshold in this bucket. */
       threshold_breached: boolean;
@@ -48217,11 +48265,21 @@ export namespace Schemas {
       notification: string;
       /** Human-readable explanation of the state transition. */
       reason: string;
+      /** Patterns that breached in this bucket. Only populated for a pattern trigger. */
+      breaching_patterns?: LogsAlertSimulateBreachingPattern[];
     }
 
     export interface LogsAlertSimulateRequest {
       /** Filter criteria — same format as LogsAlertConfiguration.filters. */
       filters: LogsAlertFilters;
+      /** Same meaning as LogsAlertConfiguration.trigger_type. Forces evaluation_periods and datapoints_to_alarm to 1 for a pattern trigger.
+       *
+       * * `count` - Count threshold
+       * * `new_pattern` - New pattern
+       * * `pattern_threshold` - Pattern threshold */
+      trigger_type?: TriggerTypeEnum;
+      /** Same meaning as LogsAlertConfiguration.trigger_config. Only used with trigger_type=new_pattern. */
+      trigger_config?: LogsAlertTriggerConfig | null;
       /**
          * Threshold count to evaluate against.
          * @minimum 0
@@ -48274,6 +48332,8 @@ export namespace Schemas {
       threshold_count: number;
       /** Threshold operator used for evaluation. */
       threshold_operator: string;
+      /** True for a new_pattern trigger: the seen-set this preview builds only covers the simulated range, unlike the real evaluator's persisted seen-set, so early buckets can under- or over-count new patterns relative to production. */
+      approximate?: boolean;
     }
 
     export type LogsAlertStateChangeSignalExtraFilters = { [key: string]: unknown };
@@ -63493,8 +63553,16 @@ export namespace Schemas {
       enabled?: boolean;
       /** Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false). */
       filters?: LogsAlertFilters;
+      /** What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.
+       *
+       * * `count` - Count threshold
+       * * `new_pattern` - New pattern
+       * * `pattern_threshold` - Pattern threshold */
+      trigger_type?: TriggerTypeEnum;
+      /** Trigger-specific settings. Only used with trigger_type=new_pattern. */
+      trigger_config?: LogsAlertTriggerConfig | null;
       /**
-         * Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.
+         * Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.
          * @minimum 0
          */
       threshold_count?: number;

--- a/services/mcp/src/generated/logs/api.ts
+++ b/services/mcp/src/generated/logs/api.ts
@@ -65,6 +65,10 @@ export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwo
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
 export const logsAlertsCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault = `behavioral`
+export const logsAlertsCreateBodyTriggerTypeDefault = `count`
+export const logsAlertsCreateBodyTriggerConfigOneSeedLookbackDaysDefault = 7
+export const logsAlertsCreateBodyTriggerConfigOneSeedLookbackDaysMax = 30
+
 export const logsAlertsCreateBodyThresholdCountDefault = 100
 export const logsAlertsCreateBodyThresholdCountMin = 0
 
@@ -1735,12 +1739,37 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).'
         ),
+    trigger_type: zod
+        .enum(['count', 'new_pattern', 'pattern_threshold'])
+        .describe(
+            '\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        )
+        .default(logsAlertsCreateBodyTriggerTypeDefault)
+        .describe(
+            "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold"
+        ),
+    trigger_config: zod
+        .union([
+            zod.object({
+                seed_lookback_days: zod
+                    .number()
+                    .min(1)
+                    .max(logsAlertsCreateBodyTriggerConfigOneSeedLookbackDaysMax)
+                    .default(logsAlertsCreateBodyTriggerConfigOneSeedLookbackDaysDefault)
+                    .describe(
+                        "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire."
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Trigger-specific settings. Only used with trigger_type=new_pattern.'),
     threshold_count: zod
         .number()
         .min(logsAlertsCreateBodyThresholdCountMin)
         .default(logsAlertsCreateBodyThresholdCountDefault)
         .describe(
-            "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log."
+            "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match."
         ),
     threshold_operator: zod
         .enum(['above', 'below'])
@@ -1856,6 +1885,9 @@ export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValues
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
 export const logsAlertsPartialUpdateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault = `behavioral`
+export const logsAlertsPartialUpdateBodyTriggerConfigOneSeedLookbackDaysDefault = 7
+export const logsAlertsPartialUpdateBodyTriggerConfigOneSeedLookbackDaysMax = 30
+
 export const logsAlertsPartialUpdateBodyThresholdCountMin = 0
 
 export const logsAlertsPartialUpdateBodyEvaluationPeriodsMax = 10
@@ -3520,12 +3552,37 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
         .describe(
             'Filter criteria — subset of LogsViewerFilters. Must contain at least one of: severityLevels (list of severity strings), serviceNames (list of service name strings), or filterGroup (property filter group object). May be empty on draft alerts (enabled=false).'
         ),
+    trigger_type: zod
+        .enum(['count', 'new_pattern', 'pattern_threshold'])
+        .describe(
+            '\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        )
+        .optional()
+        .describe(
+            "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold"
+        ),
+    trigger_config: zod
+        .union([
+            zod.object({
+                seed_lookback_days: zod
+                    .number()
+                    .min(1)
+                    .max(logsAlertsPartialUpdateBodyTriggerConfigOneSeedLookbackDaysMax)
+                    .default(logsAlertsPartialUpdateBodyTriggerConfigOneSeedLookbackDaysDefault)
+                    .describe(
+                        "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire."
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Trigger-specific settings. Only used with trigger_type=new_pattern.'),
     threshold_count: zod
         .number()
         .min(logsAlertsPartialUpdateBodyThresholdCountMin)
         .optional()
         .describe(
-            "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log."
+            "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match."
         ),
     threshold_operator: zod
         .enum(['above', 'below'])
@@ -3703,6 +3760,10 @@ export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValue
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFourTypeDefault = `feature`
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveEventFiltersOneItemFiveTypeDefault = `hogql`
 export const logsAlertsSimulateCreateBodyFiltersOneFilterGroupOneValuesItemValuesItemTwofiveTypeDefault = `behavioral`
+export const logsAlertsSimulateCreateBodyTriggerTypeDefault = `count`
+export const logsAlertsSimulateCreateBodyTriggerConfigOneSeedLookbackDaysDefault = 7
+export const logsAlertsSimulateCreateBodyTriggerConfigOneSeedLookbackDaysMax = 30
+
 export const logsAlertsSimulateCreateBodyThresholdCountMin = 0
 
 export const logsAlertsSimulateCreateBodyCheckIntervalMinutesDefault = 5
@@ -5361,6 +5422,31 @@ export const LogsAlertsSimulateCreateBody = /* @__PURE__ */ zod.object({
                 .optional(),
         })
         .describe('Filter criteria — same format as LogsAlertConfiguration.filters.'),
+    trigger_type: zod
+        .enum(['count', 'new_pattern', 'pattern_threshold'])
+        .describe(
+            '\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        )
+        .default(logsAlertsSimulateCreateBodyTriggerTypeDefault)
+        .describe(
+            'Same meaning as LogsAlertConfiguration.trigger_type. Forces evaluation_periods and datapoints_to_alarm to 1 for a pattern trigger.\n\n\* `count` - Count threshold\n\* `new_pattern` - New pattern\n\* `pattern_threshold` - Pattern threshold'
+        ),
+    trigger_config: zod
+        .union([
+            zod.object({
+                seed_lookback_days: zod
+                    .number()
+                    .min(1)
+                    .max(logsAlertsSimulateCreateBodyTriggerConfigOneSeedLookbackDaysMax)
+                    .default(logsAlertsSimulateCreateBodyTriggerConfigOneSeedLookbackDaysDefault)
+                    .describe(
+                        "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire."
+                    ),
+            }),
+            zod.null(),
+        ])
+        .optional()
+        .describe('Same meaning as LogsAlertConfiguration.trigger_config. Only used with trigger_type=new_pattern.'),
     threshold_count: zod
         .number()
         .min(logsAlertsSimulateCreateBodyThresholdCountMin)

--- a/services/mcp/src/tools/generated/logs.ts
+++ b/services/mcp/src/tools/generated/logs.ts
@@ -48,6 +48,12 @@ const logsAlertsCreate = (): ToolBase<typeof LogsAlertsCreateSchema, Schemas.Log
         if (params.filters !== undefined) {
             body['filters'] = params.filters
         }
+        if (params.trigger_type !== undefined) {
+            body['trigger_type'] = params.trigger_type
+        }
+        if (params.trigger_config !== undefined) {
+            body['trigger_config'] = params.trigger_config
+        }
         if (params.threshold_count !== undefined) {
             body['threshold_count'] = params.threshold_count
         }
@@ -83,6 +89,8 @@ const logsAlertsCreate = (): ToolBase<typeof LogsAlertsCreateSchema, Schemas.Log
             'enabled',
             'state',
             'filters',
+            'trigger_type',
+            'trigger_config',
             'threshold_count',
             'threshold_operator',
             'window_minutes',
@@ -262,6 +270,7 @@ const logsAlertsList = (): ToolBase<
                     'name',
                     'enabled',
                     'state',
+                    'trigger_type',
                     'threshold_count',
                     'threshold_operator',
                     'window_minutes',
@@ -293,6 +302,12 @@ const logsAlertsPartialUpdate = (): ToolBase<typeof LogsAlertsPartialUpdateSchem
         }
         if (params.filters !== undefined) {
             body['filters'] = params.filters
+        }
+        if (params.trigger_type !== undefined) {
+            body['trigger_type'] = params.trigger_type
+        }
+        if (params.trigger_config !== undefined) {
+            body['trigger_config'] = params.trigger_config
         }
         if (params.threshold_count !== undefined) {
             body['threshold_count'] = params.threshold_count
@@ -329,6 +344,8 @@ const logsAlertsPartialUpdate = (): ToolBase<typeof LogsAlertsPartialUpdateSchem
             'enabled',
             'state',
             'filters',
+            'trigger_type',
+            'trigger_config',
             'threshold_count',
             'threshold_operator',
             'window_minutes',
@@ -367,6 +384,8 @@ const logsAlertsRetrieve = (): ToolBase<typeof LogsAlertsRetrieveSchema, Schemas
             'enabled',
             'state',
             'filters',
+            'trigger_type',
+            'trigger_config',
             'threshold_count',
             'threshold_operator',
             'window_minutes',
@@ -401,6 +420,12 @@ const logsAlertsSimulateCreate = (): ToolBase<
         const body: Record<string, unknown> = {}
         if (params.filters !== undefined) {
             body['filters'] = params.filters
+        }
+        if (params.trigger_type !== undefined) {
+            body['trigger_type'] = params.trigger_type
+        }
+        if (params.trigger_config !== undefined) {
+            body['trigger_config'] = params.trigger_config
         }
         if (params.threshold_count !== undefined) {
             body['threshold_count'] = params.threshold_count
@@ -438,6 +463,7 @@ const logsAlertsSimulateCreate = (): ToolBase<
             'total_buckets',
             'threshold_count',
             'threshold_operator',
+            'approximate',
         ]) as typeof result
         return filtered
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-create.json
@@ -2924,7 +2924,7 @@
         },
         "threshold_count": {
             "default": 100,
-            "description": "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.",
+            "description": "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.",
             "minimum": 0,
             "type": "number"
         },
@@ -2932,6 +2932,32 @@
             "default": "above",
             "description": "Whether the alert fires when the count is above or below the threshold.\n\n* `above` - Above\n* `below` - Below",
             "enum": ["above", "below"],
+            "type": "string"
+        },
+        "trigger_config": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "seed_lookback_days": {
+                            "default": 7,
+                            "description": "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire.",
+                            "maximum": 30,
+                            "minimum": 1,
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Trigger-specific settings. Only used with trigger_type=new_pattern."
+        },
+        "trigger_type": {
+            "default": "count",
+            "description": "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n* `count` - Count threshold\n* `new_pattern` - New pattern\n* `pattern_threshold` - Pattern threshold",
+            "enum": ["count", "new_pattern", "pattern_threshold"],
             "type": "string"
         },
         "window_minutes": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-partial-update.json
@@ -2923,13 +2923,38 @@
             "description": "ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze."
         },
         "threshold_count": {
-            "description": "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.",
+            "description": "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.",
             "minimum": 0,
             "type": "number"
         },
         "threshold_operator": {
             "description": "Whether the alert fires when the count is above or below the threshold.\n\n* `above` - Above\n* `below` - Below",
             "enum": ["above", "below"],
+            "type": "string"
+        },
+        "trigger_config": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "seed_lookback_days": {
+                            "default": 7,
+                            "description": "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire.",
+                            "maximum": 30,
+                            "minimum": 1,
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Trigger-specific settings. Only used with trigger_type=new_pattern."
+        },
+        "trigger_type": {
+            "description": "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n* `count` - Count threshold\n* `new_pattern` - New pattern\n* `pattern_threshold` - Pattern threshold",
+            "enum": ["count", "new_pattern", "pattern_threshold"],
             "type": "string"
         },
         "window_minutes": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-simulate-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-simulate-create.json
@@ -2888,6 +2888,32 @@
             "enum": ["above", "below"],
             "type": "string"
         },
+        "trigger_config": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "seed_lookback_days": {
+                            "default": 7,
+                            "description": "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire.",
+                            "maximum": 30,
+                            "minimum": 1,
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Same meaning as LogsAlertConfiguration.trigger_config. Only used with trigger_type=new_pattern."
+        },
+        "trigger_type": {
+            "default": "count",
+            "description": "Same meaning as LogsAlertConfiguration.trigger_type. Forces evaluation_periods and datapoints_to_alarm to 1 for a pattern trigger.\n\n* `count` - Count threshold\n* `new_pattern` - New pattern\n* `pattern_threshold` - Pattern threshold",
+            "enum": ["count", "new_pattern", "pattern_threshold"],
+            "type": "string"
+        },
         "window_minutes": {
             "description": "Window size in minutes — determines bucket interval.",
             "type": "number"


### PR DESCRIPTION
## Problem

[#92982](https://github.com/PostHog/posthog/pull/92982) adds the model and evaluation engine for pattern-based logs alert triggers, but a team can't actually create one: the alert API only accepts a count threshold, and the simulate preview has no way to test a pattern trigger before turning it on.

## Changes

- `trigger_type` and `trigger_config` are now writable on `LogsAlertConfiguration`, alongside the existing threshold fields. `trigger_type` defaults to `count`, so every existing alert and API caller is unaffected.
- Turning an alert into a pattern trigger for the first time requires the `logs-pattern-alerts` feature flag and the team being on the same pattern-stamping allowlist the log ingestion worker uses. An alert already on a pattern trigger keeps working, and can still be edited, if either is later turned off.
- Setting a pattern trigger forces `evaluation_periods` and `datapoints_to_alarm` to 1, since a pattern breach is a one-shot event with no rolling N-of-M window.
- The simulate endpoint now accepts `trigger_type`. A `pattern_threshold` preview runs the same grouped query the real evaluator uses; a `new_pattern` preview is approximate (it rebuilds its own seen-set from the simulated range rather than reading an alert's persisted one), and the response says so via a new `approximate` field.
- Mechanical: regenerates OpenAPI types, frontend API types, and MCP tool schemas for the new fields; adds an `ENUM_NAME_OVERRIDES` entry for the `trigger_type` enum shared across three components; updates the `logs-alerts-*` MCP tool descriptions to mention pattern triggers.
- Also included: a one-line fix to `posthog/models/activity_logging/activity_log.py`, excluding the new `LogsAlertSeenPattern` reverse relation from activity-log diffing. Without it, saving any `LogsAlertConfiguration` raised `TeamScopeError`, since that relation reads through a fail-closed manager with no team context at signal-handling time. This surfaced only once the full `products/logs/backend/test/` suite ran; #92982 will need the same fix landed independently, and this PR is stacked on top of it.

## How did you test this code?

- Added tests in `test_alerts_api.py`: the feature-flag gate, the stamping-allowlist gate, that an existing pattern-trigger alert survives an unrelated edit after the gates are turned off, that a count-to-pattern conversion re-checks the gates, that `evaluation_periods`/`datapoints_to_alarm` are forced to 1, and that `trigger_config` is rejected outside `new_pattern`.
- Added two ClickHouse-backed simulate tests: one confirms `pattern_threshold` reports a breaching bucket with the expected `breaching_patterns` payload, the other confirms `new_pattern` only flags a fingerprint that falls outside its seed window.
- Ran the full `products/logs/backend/test/` suite plus `posthog/models/activity_logging/`: all pass except one pre-existing, unrelated flake in `test_series_bands.py` (a missing `team_id` filter in `series_bands.py`'s ClickHouse query, which aggregates across teams once enough historical rows accumulate in a long-lived local database) — not touched by this PR.
- `ruff check`/`ruff format`: clean. `uv run mypy --cache-fine-grained .` (repo-wide): no issues in 19547 source files.
- Not run: `pnpm --filter=@posthog/mcp exec tsc --noEmit`, which fails on pre-existing `@posthog/quill` module-resolution errors in unrelated MCP UI apps (the nested quill workspace isn't built in this sandbox); none of the errors touch a logs file.
- Not run: any manual or browser verification, since this PR has no frontend UI surface (that's the next PR in the stack).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None yet: the alert creation UI doesn't expose these trigger types until the frontend PR lands, so there's nothing yet for a user to read docs about.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Continuation of the work on [#92982](https://github.com/PostHog/posthog/pull/92982): this PR is the second of a planned four-layer stack (model/evaluator, API, frontend, an independent absence-alerts rider), reconstructed from a hung cloud task-run's own approved plan, then implemented fresh since the API layer was never actually written in that session.

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`, `/writing-code-comments`, `/stacking-prs`.

Public artifact: nothing in this PR carries material from the agent session that is not already public. No customer conversation, ticket, or internal thread informed any file, fixture, or comment.
