### PR TITLE
feat(notebooks): show the product empty state until a notebook exists

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -66,6 +66,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Cohorts                | `frontend/src/scenes/cohorts/Cohorts.tsx`                                           | on master             |
 | Dashboards             | `frontend/src/scenes/dashboard/dashboards/Dashboards.tsx`                           | on master             |
 | Product analytics      | `frontend/src/scenes/saved-insights/SavedInsights.tsx`                              | on master             |
+| Notebooks              | `frontend/src/scenes/notebooks/NotebooksScene.tsx`                                  | on master             |
 
 Only four products resolve their status at app boot, via a `setupProbe` in their manifest:
 LLM analytics, error tracking, MCP analytics, web analytics.
@@ -114,7 +115,7 @@ Max conversation history, and data pipelines destinations and transformations
 Hand-rolled empty states: review hog, streamlit apps, groups (`GroupsIntroduction`), persons, and
 the LLM analytics sessions and evaluations tabs.
 
-Bare string or nothing: notebooks, the data warehouse overview scene, SQL editor, data modeling,
+Bare string or nothing: the data warehouse overview scene, SQL editor, data modeling,
 heatmaps, business knowledge, legal documents, MCP gateway, visual review, live debugger, batch
 exports, experiments shared metrics, skills community, and several LLM analytics sub-tabs.
 

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1872,6 +1872,10 @@ snapshots:
         hash: v1.k794b7964.e344a03ab4fb6bbef2cf88d2b89c12bccfe1b5307e5e80051e47ad6adec22d93.w4TEddGy6INFXoaPeIr201fD_4xWA6jG0Uugfke9ytM
     components-product-empty-state--not-empty-with-action--light:
         hash: v1.k794b7964.1500e8a17e5bfb2cdc59cea8794c8499622f0218ea6a7dc2bdde259d044d3235.IqteBA6dHdaJztqTmvDTi_IdMolu_vwld3w7xHahpvo
+    components-product-empty-state--notebooks-needs-setup--dark:
+        hash: v1.k794b7964.be9dec9126ce31f33d3c19f4cd94cbc7602c6d102365f841197dbbdc66dd6349.L9TQMe38uFWnpl9gSVpRkebTBH24Gpkxgug29h0eojo
+    components-product-empty-state--notebooks-needs-setup--light:
+        hash: v1.k794b7964.8faed3905cb11fc08ac70fb3e958effbb7d0f06af399336ce3d7d1b43152dd60.S8d2m0fiT_yzW6FkMhJrj2jrWo3HxZa4fHMqVawEJbE
     components-product-empty-state--product-analytics-needs-setup--dark:
         hash: v1.k794b7964.1ba74ff0bea7eef70d4faedf8160e9edd14b89ac74b23b98a1322f74f29c7188.eXqkpdeyPlzK4NAYg9xIMc73g54455Ng0wnqLkFqOCg
     components-product-empty-state--product-analytics-needs-setup--light:

--- a/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/defaultTree.tsx
@@ -218,6 +218,7 @@ const iconTypes: Record<FileSystemIconType, { icon: JSX.Element; iconColor?: Fil
     },
     notebook: {
         icon: <IconNotebook />,
+        iconColor: ['var(--color-product-notebooks-light)', 'var(--color-product-notebooks-dark)'],
     },
     live_debugger: {
         icon: <IconBug />,

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -26,6 +26,7 @@ import { logsEmptyState } from 'products/logs/frontend/emptyState/logsEmptyState
 import { marketingAnalyticsEmptyState } from 'products/marketing_analytics/frontend/emptyState/marketingAnalyticsEmptyState'
 import { mcpAnalyticsEmptyState } from 'products/mcp_analytics/frontend/emptyState/mcpAnalyticsEmptyState'
 import { metricsEmptyState } from 'products/metrics/frontend/emptyState/metricsEmptyState'
+import { notebooksEmptyState } from 'products/notebooks/frontend/emptyState/notebooksEmptyState'
 import { productAnalyticsEmptyState } from 'products/product_analytics/frontend/emptyState/productAnalyticsEmptyState'
 import { productToursEmptyState } from 'products/product_tours/frontend/emptyState/productToursEmptyState'
 import { sessionReplayEmptyState } from 'products/replay/frontend/emptyState/sessionReplayEmptyState'
@@ -343,6 +344,11 @@ export const WebVitalsWaitingForData: ProductEmptyStateStory = productEmptyState
     'waiting-for-data',
     { mocks: webVitalsMocks }
 )
+
+// Notebooks detection counts notebooks on mount - answer "none yet".
+export const NotebooksNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(notebooksEmptyState, 'needs-setup', {
+    mocks: { get: { '/api/projects/:team_id/notebooks/': [200, { count: 0, results: [] }] } },
+})
 
 // Data warehouse detection lists sources and tables on mount - answer "none yet".
 export const DataWarehouseNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(

--- a/frontend/src/scenes/notebooks/NotebooksScene.tsx
+++ b/frontend/src/scenes/notebooks/NotebooksScene.tsx
@@ -17,12 +17,15 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+import { notebooksEmptyState } from 'products/notebooks/frontend/emptyState/notebooksEmptyState'
+
 import { NotebooksTable } from './NotebooksTable/NotebooksTable'
 
 export const scene: SceneExport = {
     component: NotebooksScene,
     logic: notebooksTableLogic,
     productKey: ProductKey.NOTEBOOKS,
+    emptyState: notebooksEmptyState,
 }
 
 export function NotebooksScene(): JSX.Element {

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -304,6 +304,7 @@ export const sceneConfigurations: Record<Scene | string, SceneConfig> = {
         description: 'Notebooks are a way to organize your work and share it with others.',
         activityScope: ActivityScope.NOTEBOOK,
         docsHref: 'https://posthog.com/docs/notebooks',
+        iconType: 'notebook',
     },
     [Scene.OAuthAuthorize]: {
         name: 'Authorize',

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -352,6 +352,8 @@
     --color-product-mcp-analytics-dark: rgb(229 105 205);
     --color-product-links-light: rgb(143 7 255);
     --color-product-links-dark: rgb(178 92 255);
+    --color-product-notebooks-light: rgb(26 137 173);
+    --color-product-notebooks-dark: rgb(43 179 223);
     --color-product-tracing-light: rgb(6 182 212);
     --color-product-tracing-dark: rgb(34 211 238);
     --color-product-metrics-light: rgb(234 88 12);

--- a/playwright/page-models/notebookPage.ts
+++ b/playwright/page-models/notebookPage.ts
@@ -19,13 +19,23 @@ export class NotebookPage {
         this.titleHeading = page.locator('.MarkdownNotebook__text-block--title')
     }
 
-    async goToList(): Promise<void> {
+    /**
+     * Open /notebooks. A project with no notebooks lands on the setup empty state
+     * instead of the table, and both screens carry the "New notebook" action.
+     */
+    async goToScene(): Promise<void> {
         await this.page.goto('/notebooks', { waitUntil: 'domcontentloaded' })
+        await expect(this.newNotebookButton).toBeVisible({ timeout: 15000 })
+    }
+
+    /** Open the notebooks table. Reaches it only once the project has a notebook. */
+    async goToList(): Promise<void> {
+        await this.goToScene()
         await expect(this.notebooksTable).toBeVisible({ timeout: 15000 })
     }
 
     async createNew(name?: string): Promise<void> {
-        await this.goToList()
+        await this.goToScene()
         await this.newNotebookButton.click()
         await expect(this.editor).toBeVisible({ timeout: 10000 })
         await this.page.waitForURL(/\/notebooks\/(?!new)/, { timeout: 15000 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3968,6 +3968,9 @@ importers:
 
   products/notebooks:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.10.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5049,7 +5052,7 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.3)(vite@7.3.5(@types/node@22.18.8)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@8.1.3(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(less@4.2.2)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.6(@types/node@22.18.8)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.18.8)(typescript@6.0.3))(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -5095,7 +5098,7 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.3)(vite@8.1.3(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(less@4.2.2)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@7.3.5(@types/node@22.18.8)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.6(@types/node@22.18.8)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.18.8)(typescript@6.0.3))(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -22608,8 +22611,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.477.0:
-    resolution: {integrity: sha512-9FGVO9JJwaPkPP2lLhoPz8qt58Vy41XgygNBtkw2dBGKnn8Bi6WldOqhwqNMsWHsTbDorFJkn9v8ACng11hdBw==}
+  unlayer-types@1.471.0:
+    resolution: {integrity: sha512-f3FNjzFPhBAe2nxy7Jc2bKp8gIpD7QbhOpR/A/Ce8cc2NBV3ehfjVLINjng2j2AMQZPGE6VtcbGU03Dg7kcwTw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -43060,7 +43063,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.477.0
+      unlayer-types: 1.471.0
 
   react-grid-layout@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -45375,7 +45378,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.477.0: {}
+  unlayer-types@1.471.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3970,7 +3970,7 @@ importers:
     dependencies:
       '@posthog/brand':
         specifier: 'catalog:'
-        version: 0.10.0(react@18.3.1)
+        version: 0.11.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5052,7 +5052,7 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.3)(vite@8.1.3(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(less@4.2.2)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@7.3.5(@types/node@22.18.8)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.6(@types/node@22.18.8)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.18.8)(typescript@6.0.3))(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -5098,7 +5098,7 @@ importers:
         version: 6.0.3
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@6.0.3)(vite@7.3.5(@types/node@22.18.8)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@8.1.3(@types/node@22.18.8)(esbuild@0.25.12)(jiti@2.6.1)(less@4.2.2)(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.6(@types/node@22.18.8)(happy-dom@20.9.0)(jiti@2.6.1)(jsdom@20.0.3)(less@4.2.2)(lightningcss@1.32.0)(msw@2.14.6(@types/node@22.18.8)(typescript@6.0.3))(sass-embedded@1.70.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -22611,8 +22611,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.471.0:
-    resolution: {integrity: sha512-f3FNjzFPhBAe2nxy7Jc2bKp8gIpD7QbhOpR/A/Ce8cc2NBV3ehfjVLINjng2j2AMQZPGE6VtcbGU03Dg7kcwTw==}
+  unlayer-types@1.477.0:
+    resolution: {integrity: sha512-9FGVO9JJwaPkPP2lLhoPz8qt58Vy41XgygNBtkw2dBGKnn8Bi6WldOqhwqNMsWHsTbDorFJkn9v8ACng11hdBw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -43063,7 +43063,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.471.0
+      unlayer-types: 1.477.0
 
   react-grid-layout@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -45378,7 +45378,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.471.0: {}
+  unlayer-types@1.477.0: {}
 
   unpipe@1.0.0: {}
 

--- a/products/notebooks/frontend/emptyState/NotebooksPreview.scss
+++ b/products/notebooks/frontend/emptyState/NotebooksPreview.scss
@@ -1,0 +1,270 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.NotebookPreview {
+    --notebook-preview-accent: var(--empty-state-accent, var(--color-product-notebooks-light));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    // Hidden inserted state. A direct child of .NotebookPreview so `:checked ~` reaches all cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__page {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Before/after pairs are stacked on one grid cell and crossfaded, so inserting the
+    // block never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-after {
+        @include preview-swap-hidden;
+    }
+
+    &__when-before {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        overflow: hidden;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    // The page body
+
+    &__doc {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 0.75rem;
+    }
+
+    &__para {
+        margin: 0;
+        font-size: 0.6875rem;
+        line-height: 1.4;
+        color: var(--color-text-secondary);
+    }
+
+    &__para--muted {
+        color: var(--color-text-tertiary);
+    }
+
+    // Blinking insertion point, so the page reads as one being written right now.
+    &__caret {
+        display: inline-block;
+        width: 1px;
+        height: 0.75rem;
+        margin-left: 2px;
+        vertical-align: text-bottom;
+        background: var(--notebook-preview-accent);
+        animation: NotebookPreview__caret 1.1s step-end infinite;
+    }
+
+    // Both halves of the swap sit in this slot, which is tall enough for either.
+    &__slot {
+        min-height: 6.25rem;
+    }
+
+    &__menu,
+    &__block {
+        cursor: pointer;
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    &__menu {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem;
+        background: var(--color-bg-surface-primary);
+        box-shadow: 0 2px 6px rgb(0 0 0 / 10%);
+    }
+
+    &__menu-head {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        color: var(--color-text-tertiary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    &__menu-row {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.6875rem;
+        border-radius: var(--radius);
+    }
+
+    &__menu-row svg {
+        font-size: 0.875rem;
+        color: var(--notebook-preview-accent);
+    }
+
+    &__menu-row--lead {
+        background: color-mix(in oklab, var(--notebook-preview-accent) 10%, transparent);
+
+        @include preview-accent-text(var(--notebook-preview-accent));
+    }
+
+    // The inserted insight
+
+    &__block {
+        padding: 0.5rem 0.625rem;
+        background: color-mix(in oklab, var(--notebook-preview-accent) 6%, var(--color-bg-surface-primary));
+    }
+
+    &__block-head {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+    }
+
+    &__block-title {
+        font-size: 0.6875rem;
+        font-weight: 600;
+    }
+
+    &__block-meta {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--notebook-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--notebook-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--notebook-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: NotebookPreview__trace 3.2s linear infinite;
+    }
+
+    // Footer
+
+    &__footer {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 0.25rem;
+    }
+
+    &__count {
+        font-size: 0.625rem;
+        font-weight: 600;
+        font-variant-numeric: tabular-nums;
+        color: var(--color-text-secondary);
+        white-space: nowrap;
+    }
+
+    &__hint {
+        font-size: 0.625rem;
+        color: var(--color-text-tertiary);
+        text-align: right;
+    }
+
+    @include preview-sparkline;
+}
+
+// Inserted state (user picked a block)
+
+.NotebookPreview__checkbox:checked ~ * .NotebookPreview__when-after {
+    @include preview-swap-visible;
+}
+
+.NotebookPreview__checkbox:checked ~ * .NotebookPreview__when-before {
+    @include preview-swap-hidden;
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the menu it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.NotebookPreview__checkbox:focus-visible ~ .NotebookPreview__page .NotebookPreview__slot > * {
+    outline: 2px solid var(--notebook-preview-accent);
+    outline-offset: 2px;
+}
+
+// Nudge attention at the block that inserts, until it's picked.
+.NotebookPreview:not(.NotebookPreview--static)
+    .NotebookPreview__checkbox:not(:checked)
+    ~ .NotebookPreview__page
+    .NotebookPreview__menu-row--lead {
+    animation: NotebookPreview__pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes NotebookPreview__pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--notebook-preview-accent) 40%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--notebook-preview-accent) 16%, transparent);
+    }
+}
+
+@keyframes NotebookPreview__caret {
+    0%,
+    45% {
+        opacity: 1;
+    }
+
+    50%,
+    95% {
+        opacity: 0;
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes NotebookPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; picking a block
+// still inserts it (transitions only).
+@include preview-motion-guards('NotebookPreview');

--- a/products/notebooks/frontend/emptyState/NotebooksPreview.tsx
+++ b/products/notebooks/frontend/emptyState/NotebooksPreview.tsx
@@ -1,0 +1,115 @@
+import './NotebooksPreview.scss'
+
+import { IconGraph, IconRewindPlay, IconToggle } from '@posthog/icons'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored weekly sign-up series: a dip in the middle, then a recovery.
+const LINE = 'M 0 14 L 14 12 L 28 15 L 42 27 L 56 25 L 70 18 L 84 12 L 100 8'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the notebooks empty state: a notebook page mid-write,
+ * with the block menu open where the cursor sits. Picking the trends block drops a
+ * live insight into the page and the block count follows. One hidden checkbox drives
+ * it via `:checked ~` styles - no timers or state, per the preview rules in the
+ * `building-product-empty-states` skill. Both halves label the same checkbox, so the
+ * inserted block clicks back out. Before/after pairs share a `__swap` grid cell and
+ * crossfade, so the page never reflows.
+ */
+export function NotebooksPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('NotebookPreview', isStatic && 'NotebookPreview--static')}>
+            {/* Inserted state, before all cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="notebook-preview-insert" className="NotebookPreview__checkbox" />
+
+            <div className="NotebookPreview__page">
+                <div className="NotebookPreview__head">
+                    <span className="NotebookPreview__title">Why sign-ups dipped in March</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="NotebookPreview__doc">
+                    <p className="NotebookPreview__para">
+                        Sign-ups fell the week the new pricing page shipped.
+                        <span className="NotebookPreview__caret" aria-hidden="true" />
+                    </p>
+
+                    <div className="NotebookPreview__slot NotebookPreview__swap">
+                        <label
+                            htmlFor="notebook-preview-insert"
+                            className="NotebookPreview__menu NotebookPreview__when-before"
+                        >
+                            <span className="NotebookPreview__menu-head">Add a block</span>
+                            <span className="NotebookPreview__menu-row NotebookPreview__menu-row--lead">
+                                <IconGraph />
+                                Trends insight
+                            </span>
+                            <span className="NotebookPreview__menu-row">
+                                <IconRewindPlay />
+                                Session replay
+                            </span>
+                            <span className="NotebookPreview__menu-row">
+                                <IconToggle />
+                                Feature flag
+                            </span>
+                        </label>
+
+                        <label
+                            htmlFor="notebook-preview-insert"
+                            className="NotebookPreview__block NotebookPreview__when-after"
+                        >
+                            <span className="NotebookPreview__block-head">
+                                <span className="NotebookPreview__block-title">Weekly sign-ups</span>
+                                <span className="NotebookPreview__block-meta">Last 90 days</span>
+                            </span>
+                            <svg
+                                className="NotebookPreview__spark-svg"
+                                viewBox="0 0 100 40"
+                                preserveAspectRatio="none"
+                                aria-hidden="true"
+                            >
+                                <path className="NotebookPreview__spark-area" d={areaPath(LINE)} />
+                                <path
+                                    className="NotebookPreview__spark-line"
+                                    d={LINE}
+                                    vectorEffect="non-scaling-stroke"
+                                />
+                                <path
+                                    className="NotebookPreview__spark-trace"
+                                    d={LINE}
+                                    pathLength={100}
+                                    vectorEffect="non-scaling-stroke"
+                                />
+                            </svg>
+                        </label>
+                    </div>
+
+                    <p className="NotebookPreview__para NotebookPreview__para--muted">
+                        Retention held steady, so the drop is on acquisition.
+                    </p>
+                </div>
+            </div>
+
+            <div className="NotebookPreview__footer">
+                <span className="NotebookPreview__count NotebookPreview__swap">
+                    <span className="NotebookPreview__when-before">3 blocks</span>
+                    <span className="NotebookPreview__when-after">4 blocks</span>
+                </span>
+                <span className="NotebookPreview__hint NotebookPreview__swap">
+                    <span className="NotebookPreview__when-before">Pick a block to drop it into the page.</span>
+                    <span className="NotebookPreview__when-after">
+                        The block re-runs its query each time the page opens. Click it to remove.
+                    </span>
+                </span>
+            </div>
+        </div>
+    )
+}

--- a/products/notebooks/frontend/emptyState/notebooksEmptyState.tsx
+++ b/products/notebooks/frontend/emptyState/notebooksEmptyState.tsx
@@ -1,0 +1,44 @@
+import * as readingPng from '@posthog/brand/hoggies/png/reading'
+import { IconNotebook } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import { NotebooksPreview } from './NotebooksPreview'
+import { notebooksSetupLogic } from './notebooksSetupLogic'
+
+const HedgehogReading = pngHoggie(readingPng)
+
+export const notebooksEmptyState: SceneProductEmptyState = {
+    statusLogic: notebooksSetupLogic,
+    config: {
+        productKey: ProductKey.NOTEBOOKS,
+        productName: 'Notebooks',
+        icon: <IconNotebook />,
+        accentColor: 'var(--color-product-notebooks-light)',
+        accentColorDark: 'var(--color-product-notebooks-dark)',
+        hedgehog: HedgehogReading,
+        text: {
+            'needs-setup': {
+                headline: 'Write up what you found, next to the data you found it in',
+                lead: 'A notebook holds your writing and live PostHog data in one page: insights, session replays, feature flags, and events. Every block re-runs its query when someone opens the notebook, so the analysis you share stays current instead of freezing into a screenshot.',
+            },
+        },
+        primaryAction: {
+            label: 'Create your first notebook',
+            to: urls.notebook('new'),
+            dataAttr: 'new-notebook',
+            accessControl: {
+                resourceType: AccessControlResourceType.Notebook,
+                minAccessLevel: AccessControlLevel.Editor,
+            },
+        },
+        docsUrl: 'https://posthog.com/docs/notebooks',
+        previewLabel: 'A notebook, once written',
+        Preview: NotebooksPreview,
+    },
+}

--- a/products/notebooks/frontend/emptyState/notebooksSetupLogic.test.ts
+++ b/products/notebooks/frontend/emptyState/notebooksSetupLogic.test.ts
@@ -1,0 +1,44 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { notebooksSetupLogic } from './notebooksSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('notebooksSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(generatedApi, 'notebooksList')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [23, 'has-data'],
+    ])('pushes a notebook count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, results: [] })
+        const logic = notebooksSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.NOTEBOOKS }).values.status).toBe(expected)
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = notebooksSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.NOTEBOOKS }).values.status).toBe('unknown')
+    })
+})

--- a/products/notebooks/frontend/emptyState/notebooksSetupLogic.ts
+++ b/products/notebooks/frontend/emptyState/notebooksSetupLogic.ts
@@ -1,0 +1,21 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { notebooksList } from '../generated/api'
+
+/**
+ * Setup detection for the notebooks empty state. Notebooks are a creation-first
+ * product, so "set up" means the project has at least one notebook. Templates the
+ * table lists alongside them are local, so they never count as a notebook.
+ */
+export const notebooksSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.NOTEBOOKS,
+    path: ['products', 'notebooks', 'frontend', 'emptyState', 'notebooksSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await notebooksList(projectId, { limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+})

--- a/products/notebooks/package.json
+++ b/products/notebooks/package.json
@@ -14,6 +14,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",


### PR DESCRIPTION
## Problem

A user opening Notebooks before writing one sees a table that reads "No notebooks matching your filters!", with no filters set and nothing that says what a notebook is for.

Part of the empty-state rollout tracked in [`docs/internal/product-empty-state-adoption.md`](https://github.com/PostHog/posthog/blob/master/docs/internal/product-empty-state-adoption.md), where notebooks sat under "Bare string or nothing".

## Changes

- The notebooks scene shows the shared setup empty state until the project has a notebook: a "Create your first notebook" action, docs, and an example notebook page.
- The preview stages the product. Picking a block from the menu drops a live insight into the page, and the block count follows.
- The escape hatch stays. Behind the gate the table still lists the notebook templates, so skipping reveals something.
- Detection counts notebooks through the generated `notebooksList` client, so no event data is involved.
- Mechanical: a `--color-product-notebooks-*` token pair, the notebook tree icon takes that color, and the Notebooks scene config gains `iconType`.

**Setup screen:**

![Notebooks setup screen](https://raw.githubusercontent.com/PostHog/pr-assets/2927a513d487fe92110e3070c9162b7da8c33680/2026/09/3f3283ab-cb72-46b9-adb5-947b5faa5a51.png)

**After picking the trends block in the preview:**

![Notebooks preview after inserting a block](https://raw.githubusercontent.com/PostHog/pr-assets/b8a602ddf47477c2642d2a2a9143c6156111515d/2026/09/90342d53-7dd9-4353-8114-6d382663fb16.png)

## How did you test this code?

- New `notebooksSetupLogic.test.ts`: the count cases catch a detection change that hides a project's existing notebooks, and the failure case catches a stranded spinner when the count query fails.
- Rendered both preview states in a local Storybook through Chromium, in light and dark mode. The screenshots above are those runs.
- Not run: Playwright, and the app itself. The new story carries the visual-regression coverage.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The adoption tracker moves notebooks from "Bare string or nothing" into the adopted table.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 5), directed by the assignee. Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/adopting-generated-api-types`, `/stacking-prs`, `/writing-pr-descriptions`.

The scene's "Welcome to Notebooks" banner stays. It is dismissible and shows however many notebooks exist, so it is not an empty state and its templates link is the reason skipping is worth allowing here.

The accent is a new token pair taken from the brand palette (corn blue) and wants a design blessing.