### PR TITLE
feat(data-catalog): show the product empty state until a metric exists

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -68,6 +68,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Product analytics      | `frontend/src/scenes/saved-insights/SavedInsights.tsx`                              | on master             |
 | Notebooks              | `frontend/src/scenes/notebooks/NotebooksScene.tsx`                                  | on master             |
 | Alerts                 | `products/alerts/frontend/AlertsScene.tsx`                                          | on master             |
+| Data catalog           | `products/data_catalog/frontend/DataCatalogScene.tsx`                               | on master             |
 
 Only four products resolve their status at app boot, via a `setupProbe` in their manifest:
 LLM analytics, error tracking, MCP analytics, web analytics.
@@ -107,7 +108,7 @@ deeper, so the product is half-migrated.
 
 ### Tier 4: everything else
 
-Still on `ProductIntroduction`: subscriptions, pulse, data catalog, engineering analytics,
+Still on `ProductIntroduction`: subscriptions, pulse, engineering analytics,
 comments, ingestion warnings (v1 and v2),
 Max conversation history, and data pipelines destinations and transformations
 (`frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx` covers the last two).

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1788,6 +1788,10 @@ snapshots:
         hash: v1.k794b7964.b3a148d96ca0b54ca8929084054b91f4e52ae02160039f3a47ee04db7aeb62cc.SH8xd4Ro7F3Zuetn_B_qgVFVbWtT__aDzaW2YOr-Eac
     components-product-empty-state--dashboards-needs-setup--light:
         hash: v1.k794b7964.2782384906e9b2efb6153b3bf4b8135fc541639245f74f0abd3456a35023e641.vaJwGqX3KJ-_XLxP_slQ1vIyHx0QZ4fCXnrMtPJHnjg
+    components-product-empty-state--data-catalog-needs-setup--dark:
+        hash: v1.k794b7964.9ed4c29d6ca8589e87e45cd10ec459dab8a72d2daba5cae04d181ed6c0ae640c.pRHqmxDzmgJd4rkDZOPcDeN9Ye1aEvZYUD0p7FKCVuk
+    components-product-empty-state--data-catalog-needs-setup--light:
+        hash: v1.k794b7964.097d8cc7ffaf531a26fb0e1bf2ff8af8b47df93ca3cfb74f2649d39a290dfd50.WcTdtzYAhQD28lIYtcl9_uIdSxwz3VJFcxTZT8Y7pTA
     components-product-empty-state--data-warehouse-needs-setup--dark:
         hash: v1.k794b7964.3d7df6ce8c56af7c0c5200d0a381d5f28c885ad380cb370ea0e250266882d608.vwwreN_qibegkh3R21znmwi-Sp9TfdStRZyRxa-g69A
     components-product-empty-state--data-warehouse-needs-setup--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -16,6 +16,7 @@ import { cohortsEmptyState } from 'products/cohorts/frontend/emptyState/cohortsE
 import { supportEmptyState } from 'products/conversations/frontend/emptyState/supportEmptyState'
 import { customerAnalyticsEmptyState } from 'products/customer_analytics/frontend/emptyState/customerAnalyticsEmptyState'
 import { dashboardsEmptyState } from 'products/dashboards/frontend/emptyState/dashboardsEmptyState'
+import { dataCatalogEmptyState } from 'products/data_catalog/frontend/emptyState/dataCatalogEmptyState'
 import { dataWarehouseEmptyState } from 'products/data_warehouse/frontend/emptyState/dataWarehouseEmptyState'
 import { earlyAccessFeaturesEmptyState } from 'products/early_access_features/frontend/emptyState/earlyAccessFeaturesEmptyState'
 import { endpointsEmptyState } from 'products/endpoints/frontend/emptyState/endpointsEmptyState'
@@ -355,6 +356,13 @@ export const AlertsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(a
         },
     },
 })
+
+// Data catalog detection counts metrics on mount - answer "none yet".
+export const DataCatalogNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    dataCatalogEmptyState,
+    'needs-setup',
+    { mocks: { get: { '/api/projects/:team_id/data_catalog/metrics/': [200, emptyEntityList] } } }
+)
 
 // Notebooks detection counts notebooks on mount - answer "none yet".
 export const NotebooksNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(notebooksEmptyState, 'needs-setup', {

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -343,6 +343,8 @@
     --color-product-customer-analytics-dark: rgb(85 199 211);
     --color-product-data-warehouse-light: rgb(133 103 255);
     --color-product-data-warehouse-dark: rgb(160 135 255);
+    --color-product-data-catalog-light: rgb(101 78 196);
+    --color-product-data-catalog-dark: rgb(139 118 232);
     --color-product-llm-analytics-light: rgb(182 42 217);
     --color-product-llm-analytics-dark: rgb(212 106 240);
     --color-product-llm-clusters-light: rgb(147 51 234);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2984,7 +2984,7 @@ importers:
     dependencies:
       '@posthog/brand':
         specifier: 'catalog:'
-        version: 0.10.0(react@18.3.1)
+        version: 0.11.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2982,6 +2982,9 @@ importers:
 
   products/data_catalog:
     dependencies:
+      '@posthog/brand':
+        specifier: 'catalog:'
+        version: 0.10.0(react@18.3.1)
       '@posthog/icons':
         specifier: 'catalog:'
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3022,6 +3025,9 @@ importers:
       '@testing-library/react':
         specifier: ^14.3.1
         version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      kea-test-utils:
+        specifier: 'catalog:'
+        version: 0.2.4(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))
 
   products/data_modeling:
     dependencies:

--- a/products/data_catalog/frontend/DataCatalogScene.tsx
+++ b/products/data_catalog/frontend/DataCatalogScene.tsx
@@ -18,6 +18,7 @@ import { certificationsLogic } from './certificationsLogic'
 import { NewMetricModal } from './components/NewMetricModal'
 import { buildDataCatalogAgentContext, DATA_CATALOG_AGENT_HEADLINES } from './dataCatalogAgentContext'
 import { DataCatalogTab, dataCatalogSceneLogic } from './dataCatalogSceneLogic'
+import { dataCatalogEmptyState } from './emptyState/dataCatalogEmptyState'
 import { metricsLogic } from './metricsLogic'
 import { relationshipsLogic } from './relationshipsLogic'
 import { CertificationsTab } from './tabs/CertificationsTab'
@@ -28,6 +29,7 @@ export const scene: SceneExport = {
     component: DataCatalogScene,
     logic: dataCatalogSceneLogic,
     productKey: ProductKey.DATA_CATALOG,
+    emptyState: dataCatalogEmptyState,
 }
 
 function TabLabel({ label, count }: { label: string; count: number }): JSX.Element {

--- a/products/data_catalog/frontend/emptyState/DataCatalogPreview.scss
+++ b/products/data_catalog/frontend/emptyState/DataCatalogPreview.scss
@@ -1,0 +1,208 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.CatalogPreview {
+    --catalog-preview-accent: var(--empty-state-accent, var(--color-product-data-catalog-light));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden approved state. A direct child of .CatalogPreview so `:checked ~` reaches all cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__panel,
+    &__definition {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Before/after pairs are stacked on one grid cell and crossfaded, so approving the
+    // metric never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-after {
+        @include preview-swap-hidden;
+    }
+
+    &__when-before {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    // Metric list
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+    }
+
+    &__row--focus {
+        cursor: pointer;
+        background: color-mix(in oklab, var(--catalog-preview-accent) 8%, transparent);
+    }
+
+    &__name {
+        overflow: hidden;
+        font-family: var(--font-mono);
+        font-size: 0.6875rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__unit {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+        white-space: nowrap;
+    }
+
+    &__pill {
+        padding: 0.125rem 0.375rem;
+        font-size: 0.5625rem;
+        font-weight: 600;
+        color: var(--color-text-tertiary);
+        white-space: nowrap;
+        background: var(--color-bg-fill-tertiary);
+        border-radius: 999px;
+    }
+
+    &__pill--approved {
+        background: color-mix(in oklab, var(--catalog-preview-accent) 16%, var(--color-bg-surface-primary));
+
+        @include preview-accent-text(var(--catalog-preview-accent));
+    }
+
+    // Definition card
+
+    &__body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        padding: 0.625rem 0.75rem 0.75rem;
+    }
+
+    &__desc {
+        margin: 0;
+        font-size: 0.625rem;
+        color: var(--color-text-secondary);
+    }
+
+    &__footer {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--catalog-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--catalog-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--catalog-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: CatalogPreview__trace 3.2s linear infinite;
+    }
+
+    // The value sits in the card head here, not above its own sparkline.
+    &__spark-value {
+        margin-top: 0;
+        font-size: 0.875rem;
+    }
+
+    @include preview-sparkline;
+}
+
+// Approved state (user approved the proposed metric)
+
+.CatalogPreview__checkbox:checked ~ * .CatalogPreview__when-after {
+    @include preview-swap-visible;
+}
+
+.CatalogPreview__checkbox:checked ~ * .CatalogPreview__when-before {
+    @include preview-swap-hidden;
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the row it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.CatalogPreview__checkbox:focus-visible ~ .CatalogPreview__panel .CatalogPreview__row--focus {
+    outline: 2px solid var(--catalog-preview-accent);
+    outline-offset: -2px;
+}
+
+// Nudge attention at the proposed metric until it's approved.
+.CatalogPreview:not(.CatalogPreview--static)
+    .CatalogPreview__checkbox:not(:checked)
+    ~ .CatalogPreview__panel
+    .CatalogPreview__row--focus
+    .CatalogPreview__pill {
+    animation: CatalogPreview__pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes CatalogPreview__pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 color-mix(in oklab, var(--catalog-preview-accent) 40%, transparent);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px color-mix(in oklab, var(--catalog-preview-accent) 16%, transparent);
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes CatalogPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; approving the metric
+// still certifies it (transitions only).
+@include preview-motion-guards('CatalogPreview');

--- a/products/data_catalog/frontend/emptyState/DataCatalogPreview.tsx
+++ b/products/data_catalog/frontend/emptyState/DataCatalogPreview.tsx
@@ -1,0 +1,98 @@
+import './DataCatalogPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored weekly series for the metric being reviewed.
+const LINE = 'M 0 26 L 14 24 L 28 27 L 42 20 L 56 22 L 70 15 L 84 13 L 100 8'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the data catalog empty state: a proposed metric and the
+ * definition behind it. Approving it certifies the definition and points the queries
+ * that use the number at it. One hidden checkbox drives it via `:checked ~` styles -
+ * no timers or state, per the preview rules in the `building-product-empty-states`
+ * skill. Before/after pairs share a `__swap` grid cell and crossfade, so no row moves.
+ */
+export function DataCatalogPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('CatalogPreview', isStatic && 'CatalogPreview--static')}>
+            {/* Approved state, before all cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="catalog-preview-approve" className="CatalogPreview__checkbox" />
+
+            <div className="CatalogPreview__panel">
+                <div className="CatalogPreview__head">
+                    <span className="CatalogPreview__title">Metrics</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="CatalogPreview__rows">
+                    <div className="CatalogPreview__row">
+                        <span className="CatalogPreview__name">revenue</span>
+                        <span className="CatalogPreview__unit">USD</span>
+                        <span className="CatalogPreview__pill CatalogPreview__pill--approved">Approved</span>
+                    </div>
+
+                    <label htmlFor="catalog-preview-approve" className="CatalogPreview__row CatalogPreview__row--focus">
+                        <span className="CatalogPreview__name">active_users</span>
+                        <span className="CatalogPreview__unit">people</span>
+                        <span className="CatalogPreview__state CatalogPreview__swap">
+                            <span className="CatalogPreview__pill CatalogPreview__when-before">Proposed</span>
+                            <span className="CatalogPreview__pill CatalogPreview__pill--approved CatalogPreview__when-after">
+                                Approved
+                            </span>
+                        </span>
+                    </label>
+
+                    <div className="CatalogPreview__row">
+                        <span className="CatalogPreview__name">signups</span>
+                        <span className="CatalogPreview__unit">people</span>
+                        <span className="CatalogPreview__pill CatalogPreview__pill--approved">Approved</span>
+                    </div>
+                </div>
+            </div>
+
+            <div className="CatalogPreview__definition">
+                <div className="CatalogPreview__head">
+                    <span className="CatalogPreview__title">active_users</span>
+                    <span className="CatalogPreview__spark-value">4,182</span>
+                </div>
+
+                <div className="CatalogPreview__body">
+                    <p className="CatalogPreview__desc">People with at least one event in the last 7 days.</p>
+
+                    <svg
+                        className="CatalogPreview__spark-svg"
+                        viewBox="0 0 100 40"
+                        preserveAspectRatio="none"
+                        aria-hidden="true"
+                    >
+                        <path className="CatalogPreview__spark-area" d={areaPath(LINE)} />
+                        <path className="CatalogPreview__spark-line" d={LINE} vectorEffect="non-scaling-stroke" />
+                        <path
+                            className="CatalogPreview__spark-trace"
+                            d={LINE}
+                            pathLength={100}
+                            vectorEffect="non-scaling-stroke"
+                        />
+                    </svg>
+
+                    <span className="CatalogPreview__footer CatalogPreview__swap">
+                        <span className="CatalogPreview__when-before">
+                            Proposed 2 days ago. Click the row above to approve it.
+                        </span>
+                        <span className="CatalogPreview__when-after">
+                            Approved. 12 insights and every SQL query now read this definition.
+                        </span>
+                    </span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/data_catalog/frontend/emptyState/DataCatalogPrimaryAction.tsx
+++ b/products/data_catalog/frontend/emptyState/DataCatalogPrimaryAction.tsx
@@ -1,0 +1,24 @@
+import { useActions } from 'kea'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+
+import { NewMetricModal } from '../components/NewMetricModal'
+import { metricsLogic } from '../metricsLogic'
+
+/**
+ * Create button for the data catalog empty state. Metrics are created in a modal that
+ * the scene normally renders, and the gate replaces the scene - so the empty state has
+ * to render the modal itself or the button would open nothing.
+ */
+export function DataCatalogPrimaryAction(): JSX.Element {
+    const { openNewMetricModal } = useActions(metricsLogic)
+
+    return (
+        <>
+            <LemonButton type="primary" onClick={openNewMetricModal} data-attr="data-catalog-new-metric-button">
+                Define your first metric
+            </LemonButton>
+            <NewMetricModal />
+        </>
+    )
+}

--- a/products/data_catalog/frontend/emptyState/dataCatalogEmptyState.tsx
+++ b/products/data_catalog/frontend/emptyState/dataCatalogEmptyState.tsx
@@ -1,0 +1,35 @@
+import * as stampApprovedPng from '@posthog/brand/hoggies/png/stamp-approved'
+import { IconBook } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { DataCatalogPreview } from './DataCatalogPreview'
+import { DataCatalogPrimaryAction } from './DataCatalogPrimaryAction'
+import { dataCatalogSetupLogic } from './dataCatalogSetupLogic'
+
+const HedgehogStampApproved = pngHoggie(stampApprovedPng)
+
+export const dataCatalogEmptyState: SceneProductEmptyState = {
+    statusLogic: dataCatalogSetupLogic,
+    config: {
+        productKey: ProductKey.DATA_CATALOG,
+        productName: 'Data catalog',
+        icon: <IconBook />,
+        accentColor: 'var(--color-product-data-catalog-light)',
+        accentColorDark: 'var(--color-product-data-catalog-dark)',
+        hedgehog: HedgehogStampApproved,
+        text: {
+            'needs-setup': {
+                headline: 'Settle what each number means, once',
+                lead: 'A catalog metric is one agreed definition of a number: its name, the query behind it, and who approved it. Define active users or revenue here, and everyone reads the same definition instead of rebuilding it slightly differently each time.',
+            },
+        },
+        PrimaryAction: DataCatalogPrimaryAction,
+        docsUrl: 'https://posthog.com/docs/semantic-layer',
+        previewLabel: 'Your catalog, once defined',
+        Preview: DataCatalogPreview,
+    },
+}

--- a/products/data_catalog/frontend/emptyState/dataCatalogSetupLogic.test.ts
+++ b/products/data_catalog/frontend/emptyState/dataCatalogSetupLogic.test.ts
@@ -1,0 +1,62 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { metricsLogic } from '../metricsLogic'
+import { dataCatalogSetupLogic } from './dataCatalogSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('dataCatalogSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(generatedApi, 'dataCatalogMetricsList')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [9, 'has-data'],
+    ])('pushes a metric count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, results: [] })
+        const logic = dataCatalogSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.DATA_CATALOG }).values.status).toBe(expected)
+    })
+
+    it('re-detects when a metric is created without leaving the scene', async () => {
+        let catalogSize = 0
+        listSpy.mockImplementation(async () => ({ count: catalogSize, results: [] }))
+        const logic = dataCatalogSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.DATA_CATALOG }).values.status).toBe('needs-setup')
+
+        // The empty state's modal creates the metric in place, so without the recheck
+        // wiring the gate would keep hiding it until the user re-entered the scene.
+        catalogSize = 1
+        metricsLogic.mount()
+        metricsLogic.actions.loadMetricsSuccess([])
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.DATA_CATALOG }).values.status).toBe('has-data')
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = dataCatalogSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.DATA_CATALOG }).values.status).toBe('unknown')
+    })
+})

--- a/products/data_catalog/frontend/emptyState/dataCatalogSetupLogic.ts
+++ b/products/data_catalog/frontend/emptyState/dataCatalogSetupLogic.ts
@@ -1,0 +1,25 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { dataCatalogMetricsList } from '../generated/api'
+import { metricsLogic } from '../metricsLogic'
+
+/**
+ * Setup detection for the data catalog empty state. The catalog is built around
+ * metrics: certifications and relationships describe warehouse tables the product
+ * did not create, so a project with no metric has nothing catalogued yet.
+ */
+export const dataCatalogSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.DATA_CATALOG,
+    path: ['products', 'data_catalog', 'frontend', 'emptyState', 'dataCatalogSetupLogic'],
+    detect: async () => {
+        const projectId = String(projectLogic.findMounted()?.values.currentProjectId)
+        const response = await dataCatalogMetricsList(projectId, { limit: 1 })
+        return response.count > 0 ? 'has-data' : 'needs-setup'
+    },
+    // The empty state creates the first metric in a modal, without leaving the scene,
+    // so no remount would re-run detection and the gate would keep hiding what was created.
+    recheckActionTypes: () => [metricsLogic.actionTypes.loadMetricsSuccess],
+})

--- a/products/data_catalog/frontend/tabs/MetricsTab.tsx
+++ b/products/data_catalog/frontend/tabs/MetricsTab.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { IconRefresh } from '@posthog/icons'
 import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
@@ -15,8 +14,6 @@ import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { urls } from 'scenes/urls'
-
-import { ProductKey } from '~/queries/schema/schema-general'
 
 import { METRIC_BULK_MAX, humanizeDefinitionKind, metricCount } from '../common'
 import type { DataCatalogMetricApi } from '../generated/api.schemas'
@@ -75,7 +72,6 @@ export function MetricsTab(): JSX.Element {
         approveMetric,
         refreshMetricFromInsight,
         deleteMetric,
-        openNewMetricModal,
         bulkApproveMetrics,
         bulkDeleteMetrics,
     } = useActions(metricsLogic)
@@ -135,19 +131,6 @@ export function MetricsTab(): JSX.Element {
             },
             secondaryButton: { children: 'Cancel', type: 'tertiary' },
         })
-    }
-
-    if (!allMetricsLoading && allMetrics.length === 0) {
-        return (
-            <ProductIntroduction
-                productName="Data catalog"
-                productKey={ProductKey.DATA_CATALOG}
-                thingName="metric"
-                description="Metrics give your team one canonical definition for a number. Define one from SQL, an insight, or written instructions."
-                isEmpty
-                action={openNewMetricModal}
-            />
-        )
     }
 
     const columns: LemonTableColumns<DataCatalogMetricApi> = [
@@ -277,7 +260,7 @@ export function MetricsTab(): JSX.Element {
                 columns={columns}
                 loading={allMetricsLoading}
                 pagination={{ pageSize: 20 }}
-                emptyState="No metrics match your filters."
+                emptyState={allMetrics.length === 0 ? 'No metrics defined yet.' : 'No metrics match your filters.'}
                 nouns={['metric', 'metrics']}
                 bulkSelection={{
                     // Key on the stable id, not the name: a name is freed for reuse when a metric is

--- a/products/data_catalog/package.json
+++ b/products/data_catalog/package.json
@@ -12,9 +12,11 @@
     "devDependencies": {
         "@storybook/react": "catalog:",
         "@testing-library/jest-dom": "^5.17.0",
-        "@testing-library/react": "^14.3.1"
+        "@testing-library/react": "^14.3.1",
+        "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
+        "@posthog/brand": "catalog:",
         "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",


### PR DESCRIPTION
## Problem

A user opening Data catalog before defining a metric sees a one-line intro card on the metrics tab, and nothing that shows what a governed metric looks like once it exists.

Part of the empty-state rollout tracked in [`docs/internal/product-empty-state-adoption.md`](https://github.com/PostHog/posthog/blob/master/docs/internal/product-empty-state-adoption.md), where data catalog sat in tier 4.

## Changes

- The data catalog scene shows the shared setup empty state until the project has a metric: what a catalog metric settles, a "Define your first metric" action, and an example catalog.
- The preview stages the product. Approving the proposed metric certifies its definition, and the footer says what now reads from it.
- The action opens the New metric modal, which the empty state renders itself. The gate replaces the scene that normally renders it, so the button would otherwise open nothing.
- Detection counts metrics, and re-checks when the modal creates one, because that happens without leaving the scene.
- The metrics tab's `ProductIntroduction` is deleted. Its table now says "No metrics defined yet." when nothing is filtered, which is what a user who skips the setup screen sees.
- Mechanical: a `--color-product-data-catalog-*` token pair.

**Setup screen:**

![Data catalog setup screen](https://raw.githubusercontent.com/PostHog/pr-assets/ee0ca1bc579d7ad259b1cbae7bdbfb1ffe247e65/2026/09/1067b24c-ee2d-44a6-a87b-cf3a5b86127c.png)

**After approving the metric in the preview:**

![Data catalog preview after approval](https://raw.githubusercontent.com/PostHog/pr-assets/5ff867fc6b636f41f2560d9d1d99671ed594123f/2026/09/b065a862-669e-49ba-855e-496249098bb9.png)

## How did you test this code?

- New `dataCatalogSetupLogic.test.ts`. The recheck case catches the gate hiding a metric the user just created in the modal, which is the failure this adoption introduces; the count and failure cases guard the status mapping.
- Rendered both preview states in a local Storybook through Chromium. The screenshots above are those runs.
- Not run: Playwright, and the app itself.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The adoption tracker moves data catalog into the adopted table.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 5), directed by the assignee. Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/adopting-generated-api-types`, `/stacking-prs`, `/writing-pr-descriptions`.

Detection counts metrics only. Certifications and relationships describe warehouse tables the product did not create, so they do not prove a project has catalogued anything.

The accent is a new token pair and wants a design blessing.