### PR TITLE
feat(subscriptions): show the product empty state until a subscription exists

### DIFF
--- a/docs/internal/product-empty-state-adoption.md
+++ b/docs/internal/product-empty-state-adoption.md
@@ -69,6 +69,7 @@ Rows marked "in review" are not on `master` yet. See "Regenerating the lists" fo
 | Notebooks              | `frontend/src/scenes/notebooks/NotebooksScene.tsx`                                  | on master             |
 | Alerts                 | `products/alerts/frontend/AlertsScene.tsx`                                          | on master             |
 | Data catalog           | `products/data_catalog/frontend/DataCatalogScene.tsx`                               | on master             |
+| Subscriptions          | `products/subscriptions/frontend/scenes/SubscriptionsScene.tsx`                     | on master             |
 
 Only four products resolve their status at app boot, via a `setupProbe` in their manifest:
 LLM analytics, error tracking, MCP analytics, web analytics.
@@ -108,7 +109,7 @@ deeper, so the product is half-migrated.
 
 ### Tier 4: everything else
 
-Still on `ProductIntroduction`: subscriptions, pulse, engineering analytics,
+Still on `ProductIntroduction`: pulse, engineering analytics,
 comments, ingestion warnings (v1 and v2),
 Max conversation history, and data pipelines destinations and transformations
 (`frontend/src/scenes/data-pipelines/DataPipelinesHogFunctions.tsx` covers the last two).

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1912,6 +1912,10 @@ snapshots:
         hash: v1.k794b7964.7fb1bfe531cab39785cf3d98edc3fed01122cbe04f2fc10b23054648455ed423.VhFzyJUt9ckAydjv1P6BL83AKLhlKl3NRrb5fL1o2M8
     components-product-empty-state--skills-needs-setup--light:
         hash: v1.k794b7964.6190af5d97300186be7d9edec9bb4139d2681ba6cfcb04961dca1f97d46181e2.puC3H-Nh82vaTwg0DxFehnS9abgqDzd_PW0XOv0QRGo
+    components-product-empty-state--subscriptions-needs-setup--dark:
+        hash: v1.k794b7964.bc7bc4e1e0b0bf5194f2409493a69fd0d630ccb95c240bc218e5a337d1079af1.04db5sSfCI3tTZ5yYWQ-JsVmhekakdoCsgO5LGzsynM
+    components-product-empty-state--subscriptions-needs-setup--light:
+        hash: v1.k794b7964.a5432f63afad30c6582ec786f219ceb409e1c117eabb71f1067fad83319742c6.SPizGdnHCfeluzxbsLLxTRKyrfoMhs0PntrnZ6cmkI8
     components-product-empty-state--support-needs-setup--dark:
         hash: v1.k794b7964.5f6d75f3dccda00b4931407c41fc8a2a3d11bbe477f53b938862867f9d96baad.sdnyT_ZwGyHUuOxOrOCN4oWyqPKe1dZ-iJN8f42ulAs
     components-product-empty-state--support-needs-setup--light:

--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.stories.tsx
@@ -34,6 +34,7 @@ import { productToursEmptyState } from 'products/product_tours/frontend/emptySta
 import { sessionReplayEmptyState } from 'products/replay/frontend/emptyState/sessionReplayEmptyState'
 import { replayVisionEmptyState } from 'products/replay_vision/frontend/emptyState/replayVisionEmptyState'
 import { llmSkillsEmptyState } from 'products/skills/frontend/emptyState/llmSkillsEmptyState'
+import { subscriptionsEmptyState } from 'products/subscriptions/frontend/emptyState/subscriptionsEmptyState'
 import { surveysEmptyState } from 'products/surveys/frontend/emptyState/surveysEmptyState'
 import { tracingEmptyState } from 'products/tracing/frontend/emptyState/tracingEmptyState'
 import { userInterviewsEmptyState } from 'products/user_interviews/frontend/emptyState/userInterviewsEmptyState'
@@ -356,6 +357,13 @@ export const AlertsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(a
         },
     },
 })
+
+// Subscriptions detection counts subscriptions on mount - answer "none yet".
+export const SubscriptionsNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(
+    subscriptionsEmptyState,
+    'needs-setup',
+    { mocks: { get: { '/api/projects/:team_id/subscriptions/': [200, emptyEntityList] } } }
+)
 
 // Data catalog detection counts metrics on mount - answer "none yet".
 export const DataCatalogNeedsSetup: ProductEmptyStateStory = productEmptyStateStory(

--- a/frontend/src/styles/base.scss
+++ b/frontend/src/styles/base.scss
@@ -372,6 +372,8 @@
     --color-product-early-access-features-dark: rgb(53 213 189);
     --color-product-support-light: rgb(243 84 84);
     --color-product-support-dark: rgb(247 165 1);
+    --color-product-subscriptions-light: rgb(20 144 232);
+    --color-product-subscriptions-dark: rgb(93 187 250);
     --color-product-visual-review-light: rgb(101 163 13);
     --color-product-visual-review-dark: rgb(163 230 53);
     --color-product-actions-light: rgb(47 128 250);

--- a/products/subscriptions/frontend/emptyState/SubscriptionsPreview.scss
+++ b/products/subscriptions/frontend/emptyState/SubscriptionsPreview.scss
@@ -1,0 +1,222 @@
+@import '../../../../frontend/src/lib/components/ProductEmptyState/previewMixins';
+
+.SubscriptionPreview {
+    --subscription-preview-accent: var(--empty-state-accent, var(--color-product-subscriptions-light));
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    // Hidden email state. A direct child of .SubscriptionPreview so `:checked ~` reaches all cards.
+    &__checkbox {
+        position: absolute;
+        width: 0;
+        height: 0;
+        pointer-events: none;
+        opacity: 0;
+    }
+
+    &__schedule,
+    &__delivery {
+        overflow: hidden;
+        background: var(--color-bg-surface-primary);
+        border: 1px solid var(--color-border-primary);
+        border-radius: var(--radius);
+    }
+
+    // Before/after pairs are stacked on one grid cell and crossfaded, so switching the
+    // destination never changes any element's size (no layout shift).
+    &__swap {
+        display: grid;
+    }
+
+    &__swap > * {
+        grid-area: 1 / 1;
+        min-width: 0;
+    }
+
+    &__when-after {
+        @include preview-swap-hidden;
+    }
+
+    &__when-before {
+        @include preview-swap-visible;
+    }
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+    }
+
+    // Schedule card
+
+    &__rows {
+        display: flex;
+        flex-direction: column;
+        padding: 0.25rem 0.5rem;
+    }
+
+    &__row {
+        display: grid;
+        grid-template-columns: 3rem minmax(0, 1fr) auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.375rem 0.5rem;
+        border-radius: var(--radius);
+    }
+
+    &__row--pick {
+        cursor: pointer;
+        background: color-mix(in oklab, var(--subscription-preview-accent) 8%, transparent);
+    }
+
+    &__label {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+
+    &__value {
+        overflow: hidden;
+        font-size: 0.6875rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__switch {
+        font-size: 0.5625rem;
+        text-align: right;
+        white-space: nowrap;
+
+        @include preview-accent-text(var(--subscription-preview-accent));
+    }
+
+    // Delivery card
+
+    &__delivery-head {
+        padding: 0.5rem 0.75rem;
+        border-bottom: 1px solid var(--color-border-primary);
+    }
+
+    &__delivery-head > span {
+        display: flex;
+        gap: 0.375rem;
+        align-items: center;
+    }
+
+    &__avatar {
+        width: 0.875rem;
+        height: 0.875rem;
+        background: var(--subscription-preview-accent);
+        border-radius: var(--radius);
+    }
+
+    &__sender {
+        font-size: 0.6875rem;
+        font-weight: 600;
+    }
+
+    &__meta {
+        overflow: hidden;
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    &__body {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        padding: 0.625rem 0.75rem 0.75rem;
+    }
+
+    &__snapshot-title {
+        font-size: 0.625rem;
+        color: var(--color-text-secondary);
+    }
+
+    &__footer {
+        font-size: 0.5625rem;
+        color: var(--color-text-tertiary);
+    }
+
+    &__spark-area {
+        fill: color-mix(in oklab, var(--subscription-preview-accent) 13%, transparent);
+        stroke: none;
+    }
+
+    &__spark-line {
+        fill: none;
+        stroke: color-mix(in oklab, var(--subscription-preview-accent) 32%, transparent);
+        stroke-width: 2;
+    }
+
+    // The moving bit: a short bright segment cycling along the line.
+    &__spark-trace {
+        fill: none;
+        stroke: var(--subscription-preview-accent);
+        stroke-dasharray: 16 84;
+        stroke-linecap: round;
+        stroke-width: 2;
+        animation: SubscriptionPreview__trace 3.2s linear infinite;
+    }
+
+    @include preview-sparkline;
+}
+
+// Email state (user switched the destination)
+
+.SubscriptionPreview__checkbox:checked ~ * .SubscriptionPreview__when-after {
+    @include preview-swap-visible;
+}
+
+.SubscriptionPreview__checkbox:checked ~ * .SubscriptionPreview__when-before {
+    @include preview-swap-hidden;
+}
+
+// The checkbox stays keyboard-focusable while visually hidden, so the row it labels
+// needs a visible focus indicator (WCAG 2.4.7).
+.SubscriptionPreview__checkbox:focus-visible ~ .SubscriptionPreview__schedule .SubscriptionPreview__row--pick {
+    outline: 2px solid var(--subscription-preview-accent);
+    outline-offset: -2px;
+}
+
+// Nudge attention at the destination until it's switched.
+.SubscriptionPreview:not(.SubscriptionPreview--static)
+    .SubscriptionPreview__checkbox:not(:checked)
+    ~ .SubscriptionPreview__schedule
+    .SubscriptionPreview__switch {
+    animation: SubscriptionPreview__pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes SubscriptionPreview__pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.4;
+    }
+}
+
+// pathLength is normalized to 100, so the dash offset loops cleanly regardless of length.
+@keyframes SubscriptionPreview__trace {
+    to {
+        stroke-dashoffset: -100;
+    }
+}
+
+// Storybook snapshots and reduced motion drop all ambient motion; switching the
+// destination still re-addresses the delivery (transitions only).
+@include preview-motion-guards('SubscriptionPreview');

--- a/products/subscriptions/frontend/emptyState/SubscriptionsPreview.tsx
+++ b/products/subscriptions/frontend/emptyState/SubscriptionsPreview.tsx
@@ -1,0 +1,94 @@
+import './SubscriptionsPreview.scss'
+
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { cn } from 'lib/utils/css-classes'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
+// Hand-authored weekly series for the snapshot that gets delivered.
+const LINE = 'M 0 28 L 14 25 L 28 27 L 42 20 L 56 22 L 70 14 L 84 12 L 100 7'
+
+function areaPath(line: string): string {
+    return `${line} L 100 40 L 0 40 Z`
+}
+
+/**
+ * Example-data preview for the subscriptions empty state: a scheduled dashboard and the
+ * message it sends. Switching the destination re-addresses the delivery below, which is
+ * the whole choice a subscription makes. One hidden checkbox drives it via `:checked ~`
+ * styles - no timers or state, per the preview rules in the `building-product-empty-states`
+ * skill. Before/after pairs share a `__swap` grid cell and crossfade, so nothing moves.
+ */
+export function SubscriptionsPreview(): JSX.Element {
+    const isStatic = inStorybook() || inStorybookTestRunner()
+
+    return (
+        <div className={cn('SubscriptionPreview', isStatic && 'SubscriptionPreview--static')}>
+            {/* Email state, before all cards so `:checked ~` can style them. */}
+            <input type="checkbox" id="subscription-preview-channel" className="SubscriptionPreview__checkbox" />
+
+            <div className="SubscriptionPreview__schedule">
+                <div className="SubscriptionPreview__head">
+                    <span className="SubscriptionPreview__title">Weekly metrics</span>
+                    <LemonTag size="small">example data</LemonTag>
+                </div>
+
+                <div className="SubscriptionPreview__rows">
+                    <div className="SubscriptionPreview__row">
+                        <span className="SubscriptionPreview__label">Sends</span>
+                        <span className="SubscriptionPreview__value">Every Monday at 9:00</span>
+                    </div>
+
+                    <label
+                        htmlFor="subscription-preview-channel"
+                        className="SubscriptionPreview__row SubscriptionPreview__row--pick"
+                    >
+                        <span className="SubscriptionPreview__label">To</span>
+                        <span className="SubscriptionPreview__value SubscriptionPreview__swap">
+                            <span className="SubscriptionPreview__when-before">Slack, #product-updates</span>
+                            <span className="SubscriptionPreview__when-after">Email, the growth team</span>
+                        </span>
+                        <span className="SubscriptionPreview__switch SubscriptionPreview__swap">
+                            <span className="SubscriptionPreview__when-before">Send by email instead</span>
+                            <span className="SubscriptionPreview__when-after">Send to Slack instead</span>
+                        </span>
+                    </label>
+                </div>
+            </div>
+
+            <div className="SubscriptionPreview__delivery">
+                <div className="SubscriptionPreview__delivery-head SubscriptionPreview__swap">
+                    <span className="SubscriptionPreview__when-before">
+                        <span className="SubscriptionPreview__avatar" aria-hidden="true" />
+                        <span className="SubscriptionPreview__sender">PostHog</span>
+                        <span className="SubscriptionPreview__meta">9:00 AM in #product-updates</span>
+                    </span>
+                    <span className="SubscriptionPreview__when-after">
+                        <span className="SubscriptionPreview__avatar" aria-hidden="true" />
+                        <span className="SubscriptionPreview__sender">Weekly metrics is ready</span>
+                        <span className="SubscriptionPreview__meta">to growth@example.com</span>
+                    </span>
+                </div>
+
+                <div className="SubscriptionPreview__body">
+                    <span className="SubscriptionPreview__snapshot-title">Sign-ups, last 7 days</span>
+                    <svg
+                        className="SubscriptionPreview__spark-svg"
+                        viewBox="0 0 100 40"
+                        preserveAspectRatio="none"
+                        aria-hidden="true"
+                    >
+                        <path className="SubscriptionPreview__spark-area" d={areaPath(LINE)} />
+                        <path className="SubscriptionPreview__spark-line" d={LINE} vectorEffect="non-scaling-stroke" />
+                        <path
+                            className="SubscriptionPreview__spark-trace"
+                            d={LINE}
+                            pathLength={100}
+                            vectorEffect="non-scaling-stroke"
+                        />
+                    </svg>
+                    <span className="SubscriptionPreview__footer">Next delivery in 3 days</span>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/products/subscriptions/frontend/emptyState/SubscriptionsPrimaryAction.tsx
+++ b/products/subscriptions/frontend/emptyState/SubscriptionsPrimaryAction.tsx
@@ -1,0 +1,29 @@
+import { useActions } from 'kea'
+import { router } from 'kea-router'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { urls } from 'scenes/urls'
+
+import { SubscriptionsSceneModal } from '../scenes/components/SubscriptionsSceneModal'
+
+/**
+ * Create button for the subscriptions empty state. The creation modal belongs to the
+ * scene the gate replaces, so the empty state renders it too - otherwise the button
+ * would change the URL and open nothing.
+ */
+export function SubscriptionsPrimaryAction(): JSX.Element {
+    const { push } = useActions(router)
+
+    return (
+        <>
+            <LemonButton
+                type="primary"
+                onClick={() => push(urls.subscriptionNew())}
+                data-attr="new-subscription-button"
+            >
+                Create your first subscription
+            </LemonButton>
+            <SubscriptionsSceneModal />
+        </>
+    )
+}

--- a/products/subscriptions/frontend/emptyState/subscriptionsEmptyState.tsx
+++ b/products/subscriptions/frontend/emptyState/subscriptionsEmptyState.tsx
@@ -1,0 +1,35 @@
+import * as townCrierPng from '@posthog/brand/hoggies/png/town-crier'
+import { IconLetter } from '@posthog/icons'
+
+import { pngHoggie } from 'lib/brand/hoggies'
+import type { SceneProductEmptyState } from 'lib/components/ProductEmptyState/types'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { SubscriptionsPreview } from './SubscriptionsPreview'
+import { SubscriptionsPrimaryAction } from './SubscriptionsPrimaryAction'
+import { subscriptionsSetupLogic } from './subscriptionsSetupLogic'
+
+const HedgehogTownCrier = pngHoggie(townCrierPng)
+
+export const subscriptionsEmptyState: SceneProductEmptyState = {
+    statusLogic: subscriptionsSetupLogic,
+    config: {
+        productKey: ProductKey.SUBSCRIPTIONS,
+        productName: 'Subscriptions',
+        icon: <IconLetter />,
+        accentColor: 'var(--color-product-subscriptions-light)',
+        accentColorDark: 'var(--color-product-subscriptions-dark)',
+        hedgehog: HedgehogTownCrier,
+        text: {
+            'needs-setup': {
+                headline: 'Send the numbers to the people who need them',
+                lead: 'A subscription re-runs an insight or a dashboard on a schedule and delivers the result to Slack or email. The people who read it never have to open PostHog, and you can ask for a written report from a prompt instead of a chart.',
+            },
+        },
+        PrimaryAction: SubscriptionsPrimaryAction,
+        docsUrl: 'https://posthog.com/docs/data/subscriptions',
+        previewLabel: 'A subscription, once scheduled',
+        Preview: SubscriptionsPreview,
+    },
+}

--- a/products/subscriptions/frontend/emptyState/subscriptionsSetupLogic.test.ts
+++ b/products/subscriptions/frontend/emptyState/subscriptionsSetupLogic.test.ts
@@ -1,0 +1,44 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { productSetupStatusLogic } from 'lib/components/ProductEmptyState/productSetupStatusLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import * as generatedApi from '../generated/api'
+import { subscriptionsSetupLogic } from './subscriptionsSetupLogic'
+
+// Guards the mapping into the app-wide setup-status layer: if it breaks, the scene
+// empty-state gate strands on its spinner or shows the wrong surface.
+describe('subscriptionsSetupLogic', () => {
+    let listSpy: jest.SpyInstance
+
+    beforeEach(() => {
+        listSpy = jest.spyOn(generatedApi, 'subscriptionsList')
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        listSpy.mockRestore()
+    })
+
+    it.each([
+        [0, 'needs-setup'],
+        [1, 'has-data'],
+        [12, 'has-data'],
+    ])('pushes a subscription count of %i as status %s', async (count, expected) => {
+        listSpy.mockResolvedValue({ count, results: [] })
+        const logic = subscriptionsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.SUBSCRIPTIONS }).values.status).toBe(expected)
+    })
+
+    it('fails open to unknown when the count query fails before any answer', async () => {
+        listSpy.mockRejectedValue(new Error('network down'))
+        const logic = subscriptionsSetupLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(productSetupStatusLogic({ productKey: ProductKey.SUBSCRIPTIONS }).values.status).toBe('unknown')
+    })
+})

--- a/products/subscriptions/frontend/emptyState/subscriptionsSetupLogic.ts
+++ b/products/subscriptions/frontend/emptyState/subscriptionsSetupLogic.ts
@@ -1,0 +1,24 @@
+import { createSetupDetectionLogic } from 'lib/components/ProductEmptyState/setupDetectionLogic'
+import { getCurrentTeamId } from 'lib/utils/getAppContext'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+
+import { subscriptionsList } from '../generated/api'
+import { subscriptionsSceneLogic } from '../scenes/subscriptionsSceneLogic'
+
+/**
+ * Setup detection for the subscriptions empty state. Subscriptions are a creation-first
+ * product, so "set up" means the project has at least one, whatever it sends.
+ */
+export const subscriptionsSetupLogic = createSetupDetectionLogic({
+    productKey: ProductKey.SUBSCRIPTIONS,
+    path: ['products', 'subscriptions', 'frontend', 'emptyState', 'subscriptionsSetupLogic'],
+    detect: async () => {
+        // limit=1 keeps the payload tiny; `count` reflects the full team total.
+        const response = await subscriptionsList(String(getCurrentTeamId()), { limit: 1 })
+        return (response.count ?? 0) > 0 ? 'has-data' : 'needs-setup'
+    },
+    // The empty state creates the first subscription in a modal, without leaving the scene,
+    // so no remount would re-run detection and the gate would keep hiding what was created.
+    recheckActionTypes: () => [subscriptionsSceneLogic.actionTypes.loadSubscriptionsSuccess],
+})

--- a/products/subscriptions/frontend/scenes/SubscriptionsScene.tsx
+++ b/products/subscriptions/frontend/scenes/SubscriptionsScene.tsx
@@ -1,13 +1,9 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import * as magnifyingGlassPng from '@posthog/brand/hoggies/png/magnifying-glass-1'
 import { IconEllipsis } from '@posthog/icons'
-import { LemonButton, LemonMenu, LemonModal } from '@posthog/lemon-ui'
+import { LemonButton, LemonMenu } from '@posthog/lemon-ui'
 
-import { pngHoggie } from 'lib/brand/hoggies'
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Spinner } from 'lib/lemon-ui/Spinner'
@@ -23,22 +19,16 @@ import { ProductKey } from '~/queries/schema/schema-general'
 
 import type { SubscriptionApi } from 'products/subscriptions/frontend/generated/api.schemas'
 
-import { subscriptionLogic } from '../components/Subscriptions/subscriptionLogic'
-import { SubscriptionWizard } from '../components/Subscriptions/SubscriptionWizard'
-import { requestSubscriptionWizardCancellation } from '../components/Subscriptions/utils'
-import { EditSubscription, SubscriptionFormSkeleton } from '../components/Subscriptions/views/EditSubscription'
-import { NewSubscriptionTarget } from './components/NewSubscriptionTarget'
+import { subscriptionsEmptyState } from '../emptyState/subscriptionsEmptyState'
 import { SubscriptionsFiltersBar } from './components/SubscriptionsFiltersBar'
+import { SubscriptionsSceneModal } from './components/SubscriptionsSceneModal'
 import {
     SubscriptionsTable,
     isSubscriptionEnabled,
     subscriptionEditHref,
     subscriptionName,
 } from './components/SubscriptionsTable'
-import { newSubscriptionTargetLogic } from './newSubscriptionTargetLogic'
 import { SubscriptionsTab, subscriptionsSceneLogic } from './subscriptionsSceneLogic'
-
-const HedgehogMagnifyingGlass = pngHoggie(magnifyingGlassPng)
 
 function SubscriptionEnabledSwitch({ sub }: { sub: SubscriptionApi }): JSX.Element {
     const { setSubscriptionEnabled } = useActions(subscriptionsSceneLogic)
@@ -114,53 +104,12 @@ export function SubscriptionsScene(): JSX.Element {
     const {
         subscriptions,
         subscriptionsLoading,
-        subscriptionsListAwaitingDebouncedFetch,
         pagination,
-        search,
-        createdByUuid,
         currentTab,
         subscriptionsSorting,
-        targetTypeFilter,
-        subscriptionModalId,
         aiSubscriptionsAvailable,
     } = useValues(subscriptionsSceneLogic)
-    const {
-        target: newSubscriptionTarget,
-        dashboard: newSubscriptionDashboard,
-        dashboardLoading: newSubscriptionDashboardLoading,
-    } = useValues(newSubscriptionTargetLogic)
-    const { reset: resetNewSubscriptionTarget } = useActions(newSubscriptionTargetLogic)
-    const subscriptionWizardExperimentEnabled = useFeatureFlag('SUBSCRIPTION_CREATION_WIZARD', 'test')
-    const isWizard = subscriptionModalId === 'new' && subscriptionWizardExperimentEnabled
-    const insightTarget = newSubscriptionTarget?.kind === 'insight' ? newSubscriptionTarget : null
-    const dashboardTargetPending = newSubscriptionTarget?.kind === 'dashboard' && !newSubscriptionDashboard
-    // A dashboard that failed to load leaves nothing to send, so the picker comes back.
-    const isPickingTarget =
-        subscriptionModalId === 'new' &&
-        (newSubscriptionTarget === null || (dashboardTargetPending && !newSubscriptionDashboardLoading))
-    const cancelWizard = (): void => {
-        resetNewSubscriptionTarget()
-        router.actions.push(urls.subscriptions())
-    }
-    const requestWizardCancel = (): void => {
-        const wizardForm = subscriptionLogic.findMounted({ id: 'new', creationSource: 'wizard' })
-        if (!wizardForm) {
-            cancelWizard()
-            return
-        }
-        requestSubscriptionWizardCancellation({
-            onCancel: cancelWizard,
-            resetSubscription: () => wizardForm.actions.resetSubscription(),
-            subscriptionChanged: wizardForm.values.subscriptionChanged,
-        })
-    }
     const { setCurrentTab, setSubscriptionsSorting } = useActions(subscriptionsSceneLogic)
-
-    const isFiltered =
-        Boolean(search.trim()) ||
-        createdByUuid !== null ||
-        targetTypeFilter !== null ||
-        currentTab !== SubscriptionsTab.All
 
     const subscriptionTabs: LemonTab<SubscriptionsTab>[] = [
         { key: SubscriptionsTab.All, label: 'All subscriptions' },
@@ -169,21 +118,6 @@ export function SubscriptionsScene(): JSX.Element {
         { key: SubscriptionsTab.Insight, label: 'Insight' },
         ...(aiSubscriptionsAvailable ? [{ key: SubscriptionsTab.AI, label: 'AI prompt' }] : []),
     ]
-    const showProductIntroduction =
-        subscriptions.length === 0 && !subscriptionsLoading && !isFiltered && !subscriptionsListAwaitingDebouncedFetch
-    const emptyStateDescription = aiSubscriptionsAvailable
-        ? 'Send scheduled dashboard and insight snapshots, or use an AI prompt to generate a recurring report. Deliver subscriptions to Slack or email.'
-        : 'Get recurring email or Slack digests, or scheduled exports from insights and dashboards. Use them for weekly rollups, stakeholder updates, or wiring metrics into your own systems.'
-    const emptyStateAction = (
-        <LemonButton
-            type="primary"
-            data-attr="new-subscription-button-empty-state"
-            onClick={() => router.actions.push(urls.subscriptionNew())}
-        >
-            New subscription
-        </LemonButton>
-    )
-
     return (
         <SceneContent>
             <SceneTitleSection
@@ -207,68 +141,18 @@ export function SubscriptionsScene(): JSX.Element {
                 sceneInset
             />
             <div className="py-8 flex-1 min-h-0 flex flex-col gap-4 max-w-full">
-                {showProductIntroduction ? (
-                    <ProductIntroduction
-                        productName="Subscriptions"
-                        productKey={ProductKey.SUBSCRIPTIONS}
-                        thingName="subscription"
-                        titleOverride="No subscriptions yet"
-                        description={emptyStateDescription}
-                        isEmpty
-                        customHog={HedgehogMagnifyingGlass}
-                        hogLayout="responsive"
-                        useMainContentContainerQueries
-                        docsURL="https://posthog.com/docs/user-guides/subscriptions"
-                        actionElementOverride={emptyStateAction}
-                    />
-                ) : (
-                    <>
-                        <SubscriptionsFiltersBar />
-                        <SubscriptionsTable
-                            dataSource={subscriptions}
-                            loading={subscriptionsLoading}
-                            pagination={pagination}
-                            sorting={subscriptionsSorting}
-                            onSort={setSubscriptionsSorting}
-                            renderRowActions={(sub) => <SubscriptionsRowActions sub={sub} />}
-                            renderEnabledToggle={(sub) => <SubscriptionEnabledSwitch sub={sub} />}
-                        />
-                    </>
-                )}
+                <SubscriptionsFiltersBar />
+                <SubscriptionsTable
+                    dataSource={subscriptions}
+                    loading={subscriptionsLoading}
+                    pagination={pagination}
+                    sorting={subscriptionsSorting}
+                    onSort={setSubscriptionsSorting}
+                    renderRowActions={(sub) => <SubscriptionsRowActions sub={sub} />}
+                    renderEnabledToggle={(sub) => <SubscriptionEnabledSwitch sub={sub} />}
+                />
             </div>
-            {subscriptionModalId !== null && (
-                <LemonModal
-                    isOpen
-                    onClose={isWizard && !isPickingTarget ? requestWizardCancel : cancelWizard}
-                    simple={isWizard && !isPickingTarget}
-                    width={isWizard && !isPickingTarget ? 720 : 650}
-                    title={isPickingTarget ? 'New subscription' : undefined}
-                >
-                    {isPickingTarget ? (
-                        <NewSubscriptionTarget
-                            aiSubscriptionsAvailable={aiSubscriptionsAvailable}
-                            onCancel={cancelWizard}
-                        />
-                    ) : dashboardTargetPending ? (
-                        <SubscriptionFormSkeleton />
-                    ) : isWizard ? (
-                        <SubscriptionWizard
-                            insightShortId={insightTarget?.shortId}
-                            insightName={insightTarget?.name}
-                            dashboard={newSubscriptionDashboard}
-                            onCancel={cancelWizard}
-                        />
-                    ) : (
-                        <EditSubscription
-                            id={subscriptionModalId}
-                            insightShortId={insightTarget?.shortId}
-                            dashboard={newSubscriptionDashboard}
-                            onCancel={cancelWizard}
-                            onDelete={cancelWizard}
-                        />
-                    )}
-                </LemonModal>
-            )}
+            <SubscriptionsSceneModal />
         </SceneContent>
     )
 }
@@ -276,4 +160,6 @@ export function SubscriptionsScene(): JSX.Element {
 export const scene: SceneExport = {
     component: SubscriptionsScene,
     logic: subscriptionsSceneLogic,
+    productKey: ProductKey.SUBSCRIPTIONS,
+    emptyState: subscriptionsEmptyState,
 }

--- a/products/subscriptions/frontend/scenes/components/SubscriptionsSceneModal.tsx
+++ b/products/subscriptions/frontend/scenes/components/SubscriptionsSceneModal.tsx
@@ -1,0 +1,91 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { LemonModal } from '@posthog/lemon-ui'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { urls } from 'scenes/urls'
+
+import { subscriptionLogic } from '../../components/Subscriptions/subscriptionLogic'
+import { SubscriptionWizard } from '../../components/Subscriptions/SubscriptionWizard'
+import { requestSubscriptionWizardCancellation } from '../../components/Subscriptions/utils'
+import { EditSubscription, SubscriptionFormSkeleton } from '../../components/Subscriptions/views/EditSubscription'
+import { newSubscriptionTargetLogic } from '../newSubscriptionTargetLogic'
+import { subscriptionsSceneLogic } from '../subscriptionsSceneLogic'
+import { NewSubscriptionTarget } from './NewSubscriptionTarget'
+
+/**
+ * The create and edit modal the subscriptions route opens over whatever is on screen.
+ * It renders from the URL alone, so the setup empty state can show it too - the scene
+ * behind it is not rendered while the gate is up.
+ */
+export function SubscriptionsSceneModal(): JSX.Element | null {
+    const { subscriptionModalId, aiSubscriptionsAvailable } = useValues(subscriptionsSceneLogic)
+    const {
+        target: newSubscriptionTarget,
+        dashboard: newSubscriptionDashboard,
+        dashboardLoading: newSubscriptionDashboardLoading,
+    } = useValues(newSubscriptionTargetLogic)
+    const { reset: resetNewSubscriptionTarget } = useActions(newSubscriptionTargetLogic)
+    const subscriptionWizardExperimentEnabled = useFeatureFlag('SUBSCRIPTION_CREATION_WIZARD', 'test')
+
+    const isWizard = subscriptionModalId === 'new' && subscriptionWizardExperimentEnabled
+    const insightTarget = newSubscriptionTarget?.kind === 'insight' ? newSubscriptionTarget : null
+    const dashboardTargetPending = newSubscriptionTarget?.kind === 'dashboard' && !newSubscriptionDashboard
+    // A dashboard that failed to load leaves nothing to send, so the picker comes back.
+    const isPickingTarget =
+        subscriptionModalId === 'new' &&
+        (newSubscriptionTarget === null || (dashboardTargetPending && !newSubscriptionDashboardLoading))
+
+    const cancel = (): void => {
+        resetNewSubscriptionTarget()
+        router.actions.push(urls.subscriptions())
+    }
+    const requestWizardCancel = (): void => {
+        const wizardForm = subscriptionLogic.findMounted({ id: 'new', creationSource: 'wizard' })
+        if (!wizardForm) {
+            cancel()
+            return
+        }
+        requestSubscriptionWizardCancellation({
+            onCancel: cancel,
+            resetSubscription: () => wizardForm.actions.resetSubscription(),
+            subscriptionChanged: wizardForm.values.subscriptionChanged,
+        })
+    }
+
+    if (subscriptionModalId === null) {
+        return null
+    }
+
+    return (
+        <LemonModal
+            isOpen
+            onClose={isWizard && !isPickingTarget ? requestWizardCancel : cancel}
+            simple={isWizard && !isPickingTarget}
+            width={isWizard && !isPickingTarget ? 720 : 650}
+            title={isPickingTarget ? 'New subscription' : undefined}
+        >
+            {isPickingTarget ? (
+                <NewSubscriptionTarget aiSubscriptionsAvailable={aiSubscriptionsAvailable} onCancel={cancel} />
+            ) : dashboardTargetPending ? (
+                <SubscriptionFormSkeleton />
+            ) : isWizard ? (
+                <SubscriptionWizard
+                    insightShortId={insightTarget?.shortId}
+                    insightName={insightTarget?.name}
+                    dashboard={newSubscriptionDashboard}
+                    onCancel={cancel}
+                />
+            ) : (
+                <EditSubscription
+                    id={subscriptionModalId}
+                    insightShortId={insightTarget?.shortId}
+                    dashboard={newSubscriptionDashboard}
+                    onCancel={cancel}
+                    onDelete={cancel}
+                />
+            )}
+        </LemonModal>
+    )
+}


### PR DESCRIPTION
## Problem

A user opening Subscriptions before creating one sees the deprecated intro card, which describes the product in one paragraph and shows nothing of it.

Part of the empty-state rollout tracked in [`docs/internal/product-empty-state-adoption.md`](https://github.com/PostHog/posthog/blob/master/docs/internal/product-empty-state-adoption.md), where subscriptions sat in tier 4. Stacks on #93040, which gives the page a create button that works for every team.

## Changes

- The subscriptions scene shows the shared setup empty state until the project has a subscription: what a subscription delivers, a "Create your first subscription" action, and an example schedule.
- The preview stages the product. Switching the destination between Slack and email re-addresses the delivery below it.
- The action opens the creation modal, which the empty state renders itself, because the gate replaces the scene that normally renders it.
- Detection counts subscriptions, and re-checks when the scene reloads its list, so a subscription created in the modal clears the gate.
- The `ProductIntroduction` card is deleted, along with the two descriptions and the link list it carried.
- Mechanical: the scene's modal block moves into `SubscriptionsSceneModal` so the scene and the empty state render one component, plus a `--color-product-subscriptions-*` token pair.

**Setup screen:**

![Subscriptions setup screen](https://raw.githubusercontent.com/PostHog/pr-assets/8f60e4aa97bf6103ae0cd4fa635c7e099d39c7b7/2026/09/51c6ec57-585e-4384-8336-7a959072b3c1.png)

**After switching the destination in the preview:**

![Subscriptions preview delivering by email](https://raw.githubusercontent.com/PostHog/pr-assets/354040c5168be078bf8b5eafb0436347d2586d87/2026/09/7e2eac3e-8b9a-42c9-adb0-7d6b25f87405.png)

## How did you test this code?

- New `subscriptionsSetupLogic.test.ts` guards the status mapping and the failure path that would otherwise strand the gate on its spinner.
- Rendered both preview states in a local Storybook through Chromium. The screenshots above are those runs.
- Not run: Playwright, and the app itself.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The adoption tracker moves subscriptions into the adopted table.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 5), directed by the assignee. Skills invoked: `/building-product-empty-states`, `/writing-ui-components`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`, `/stacking-prs`, `/writing-pr-descriptions`.

The empty state stays skippable. Behind the gate the scene's tabs and filters still work, and the create button sits in the scene header too.

The accent is a new token pair and wants a design blessing.