### PR TITLE
fix(desktop): disable own-plan billing for cloud tasks

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -566,6 +566,7 @@ export const ChannelHomeComposer = forwardRef<
                 workspaceMode,
               )}
               showBillingMenu
+              workspaceMode={workspaceMode}
               disabled={isBusy}
               isLoading={isLoading}
             />

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
@@ -1,4 +1,8 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import {
+  subscriptionModelAccess,
+  type WorkspaceModeForAccess,
+} from "@posthog/ui/features/settings/adapterSubscription";
 import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ReactElement, useState } from "react";
@@ -101,7 +105,11 @@ function contextWindowOption(): SessionConfigOption {
   } as unknown as SessionConfigOption;
 }
 
-function Harness(): ReactElement {
+function Harness({
+  workspaceMode,
+}: {
+  workspaceMode?: WorkspaceModeForAccess;
+}): ReactElement {
   const [adapter, setAdapter] = useState<AgentAdapter>("claude");
   const [model, setModel] = useState("claude-opus-5");
   const [effort, setEffort] = useState("medium");
@@ -121,6 +129,26 @@ function Harness(): ReactElement {
           setModel(nextModel);
         }}
         onConfigOptionChange={() => {}}
+        showBillingMenu={workspaceMode !== undefined}
+        workspaceMode={workspaceMode}
+        // Logged out in Storybook (the status query never resolves), so the
+        // submenu shows the PostHog-checked state with the provider disabled.
+        modelAccess={
+          workspaceMode === undefined
+            ? undefined
+            : subscriptionModelAccess(
+                {
+                  flagEnabled: true,
+                  subscriptionOn: false,
+                  status: undefined,
+                  loggedIn: false,
+                  loginState: "unknown",
+                  needsConnection: false,
+                  setSubscriptionOn: () => {},
+                },
+                workspaceMode,
+              )
+        }
       />
     </div>
   );
@@ -147,5 +175,52 @@ export const GroupedModelSubmenu: Story = {
     );
     await userEvent.hover(await body.findByText("Model"));
     await body.findByText("GPT-5.6 Sol");
+  },
+};
+
+async function openBillingSubmenu(
+  canvas: ReturnType<typeof within>,
+  canvasElement: HTMLElement,
+  userEvent: {
+    click: (el: HTMLElement) => Promise<void>;
+    hover: (el: HTMLElement) => Promise<void>;
+  },
+): Promise<void> {
+  const body = within(canvasElement.ownerDocument.body);
+  await userEvent.click(
+    canvas.getByRole("button", { name: /Model and reasoning/ }),
+  );
+  await userEvent.click(await body.findByRole("button", { name: "Advanced" }));
+  await userEvent.click(await body.findByRole("menuitem", { name: /Billing/ }));
+}
+
+function BillingHarnessLocal(): ReactElement {
+  return <Harness workspaceMode="local" />;
+}
+
+function BillingHarnessCloud(): ReactElement {
+  return <Harness workspaceMode="cloud" />;
+}
+
+export const LocalBilling: StoryObj<typeof BillingHarnessLocal> = {
+  render: () => <BillingHarnessLocal />,
+  play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
+    await openBillingSubmenu(canvas, canvasElement, userEvent);
+    const body = within(canvasElement.ownerDocument.body);
+    await body.findByRole("menuitemradio", { name: "PostHog" });
+    await body.findByRole("menuitemradio", { name: "Anthropic" });
+  },
+};
+
+export const CloudBilling: StoryObj<typeof BillingHarnessCloud> = {
+  render: () => <BillingHarnessCloud />,
+  play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
+    await openBillingSubmenu(canvas, canvasElement, userEvent);
+    const body = within(canvasElement.ownerDocument.body);
+    const provider = await body.findByRole("menuitemradio", {
+      name: "Anthropic",
+    });
+    await userEvent.hover(provider);
+    await body.findByText(/Anthropic billing only works/);
   },
 };

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
@@ -3,7 +3,10 @@ import {
   subscriptionModelAccess,
   type WorkspaceModeForAccess,
 } from "@posthog/ui/features/settings/adapterSubscription";
-import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
+import {
+  type AgentAdapter,
+  useSettingsStore,
+} from "@posthog/ui/features/settings/settingsStore";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ReactElement, useState } from "react";
 import { within } from "storybook/test";
@@ -117,6 +120,14 @@ function Harness({
   const [model, setModel] = useState("claude-opus-5");
   const [effort, setEffort] = useState("medium");
 
+  // The submenu reads the real useAdapterSubscription hook, which reads the
+  // settings store; the modelAccess prop below only gates the model list.
+  useSettingsStore
+    .getState()
+    .setClaudeModelAccess(
+      subscriptionOn ? "own-subscription" : "posthog-gateway",
+    );
+
   return (
     <div className="flex h-[520px] items-end p-2">
       <ReasoningLevelSelector
@@ -134,8 +145,9 @@ function Harness({
         onConfigOptionChange={() => {}}
         showBillingMenu={workspaceMode !== undefined}
         workspaceMode={workspaceMode}
-        // Logged out in Storybook (the status query never resolves); the
-        // login note shows only when the provider is the picked billing.
+        // Storybook never resolves the subscription status query, so the
+        // provider counts as not logged in; the store write above picks the
+        // billing shown in the submenu.
         modelAccess={
           workspaceMode === undefined
             ? undefined

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
@@ -131,8 +131,8 @@ function Harness({
         onConfigOptionChange={() => {}}
         showBillingMenu={workspaceMode !== undefined}
         workspaceMode={workspaceMode}
-        // Logged out in Storybook (the status query never resolves), so the
-        // submenu shows the PostHog-checked state with the provider disabled.
+        // Logged out in Storybook (the status query never resolves) with
+        // PostHog selected, so the login note stays hidden.
         modelAccess={
           workspaceMode === undefined
             ? undefined

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
@@ -111,29 +111,38 @@ function contextWindowOption(): SessionConfigOption {
 function Harness({
   workspaceMode,
   subscriptionOn = false,
+  billingAdapter = "claude",
 }: {
   workspaceMode?: WorkspaceModeForAccess;
   /** Provider picked in the Billing menu; true reveals the logged-out login note. */
   subscriptionOn?: boolean;
+  /** Adapter whose Billing submenu is shown. */
+  billingAdapter?: AgentAdapter;
 }): ReactElement {
-  const [adapter, setAdapter] = useState<AgentAdapter>("claude");
+  const [, setAdapter] = useState<AgentAdapter>("claude");
   const [model, setModel] = useState("claude-opus-5");
   const [effort, setEffort] = useState("medium");
 
   // The submenu reads the real useAdapterSubscription hook, which reads the
   // settings store; the modelAccess prop below only gates the model list.
-  useSettingsStore
-    .getState()
-    .setClaudeModelAccess(
-      subscriptionOn ? "own-subscription" : "posthog-gateway",
-    );
+  const store = useSettingsStore.getState();
+  store.setClaudeModelAccess(
+    billingAdapter === "claude" && subscriptionOn
+      ? "own-subscription"
+      : "posthog-gateway",
+  );
+  store.setCodexModelAccess(
+    billingAdapter === "codex" && subscriptionOn
+      ? "own-subscription"
+      : "posthog-gateway",
+  );
 
   return (
     <div className="flex h-[520px] items-end p-2">
       <ReasoningLevelSelector
         thoughtOption={effortOption(effort)}
         modelOption={groupedModelOption(model)}
-        adapter={adapter}
+        adapter={billingAdapter}
         contextWindowOption={contextWindowOption()}
         onChange={setEffort}
         onModelChange={setModel}
@@ -205,7 +214,11 @@ async function openBillingSubmenu(
   await userEvent.click(
     canvas.getByRole("button", { name: /Model and reasoning/ }),
   );
-  await userEvent.click(await body.findByRole("button", { name: "Advanced" }));
+  // An off-ladder combo opens straight on the Advanced view, with no toggle.
+  const advanced = body.queryByRole("button", { name: "Advanced" });
+  if (advanced) {
+    await userEvent.click(advanced);
+  }
   await userEvent.click(await body.findByRole("menuitem", { name: /Billing/ }));
 }
 
@@ -236,8 +249,34 @@ export const LoginPromptBilling: StoryObj<typeof BillingHarnessLoginPrompt> = {
   play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
     await openBillingSubmenu(canvas, canvasElement, userEvent);
     const body = within(canvasElement.ownerDocument.body);
-    await body.findByText(/Log in to Claude Code to use Anthropic billing/);
-    await body.findByRole("button", { name: "Log in" });
+    await body.findByRole("button", { name: "Log in to Claude Code" });
+    await body.findByText(
+      (_, element) =>
+        element?.textContent ===
+        "Log in to Claude Code to use Anthropic billing.",
+    );
+  },
+};
+
+function BillingHarnessCodexLoginPrompt(): ReactElement {
+  return (
+    <Harness workspaceMode="local" subscriptionOn billingAdapter="codex" />
+  );
+}
+
+export const LoginPromptBillingCodex: StoryObj<
+  typeof BillingHarnessCodexLoginPrompt
+> = {
+  render: () => <BillingHarnessCodexLoginPrompt />,
+  play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
+    await openBillingSubmenu(canvas, canvasElement, userEvent);
+    const body = within(canvasElement.ownerDocument.body);
+    await body.findByRole("menuitemradio", { name: "OpenAI" });
+    await body.findByRole("button", { name: "Connect ChatGPT" });
+    await body.findByText(
+      (_, element) =>
+        element?.textContent === "Connect ChatGPT to use OpenAI billing.",
+    );
   },
 };
 

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.stories.tsx
@@ -107,8 +107,11 @@ function contextWindowOption(): SessionConfigOption {
 
 function Harness({
   workspaceMode,
+  subscriptionOn = false,
 }: {
   workspaceMode?: WorkspaceModeForAccess;
+  /** Provider picked in the Billing menu; true reveals the logged-out login note. */
+  subscriptionOn?: boolean;
 }): ReactElement {
   const [adapter, setAdapter] = useState<AgentAdapter>("claude");
   const [model, setModel] = useState("claude-opus-5");
@@ -131,19 +134,19 @@ function Harness({
         onConfigOptionChange={() => {}}
         showBillingMenu={workspaceMode !== undefined}
         workspaceMode={workspaceMode}
-        // Logged out in Storybook (the status query never resolves) with
-        // PostHog selected, so the login note stays hidden.
+        // Logged out in Storybook (the status query never resolves); the
+        // login note shows only when the provider is the picked billing.
         modelAccess={
           workspaceMode === undefined
             ? undefined
             : subscriptionModelAccess(
                 {
                   flagEnabled: true,
-                  subscriptionOn: false,
+                  subscriptionOn,
                   status: undefined,
                   loggedIn: false,
                   loginState: "unknown",
-                  needsConnection: false,
+                  needsConnection: subscriptionOn,
                   setSubscriptionOn: () => {},
                 },
                 workspaceMode,
@@ -202,6 +205,10 @@ function BillingHarnessCloud(): ReactElement {
   return <Harness workspaceMode="cloud" />;
 }
 
+function BillingHarnessLoginPrompt(): ReactElement {
+  return <Harness workspaceMode="local" subscriptionOn />;
+}
+
 export const LocalBilling: StoryObj<typeof BillingHarnessLocal> = {
   render: () => <BillingHarnessLocal />,
   play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
@@ -209,6 +216,16 @@ export const LocalBilling: StoryObj<typeof BillingHarnessLocal> = {
     const body = within(canvasElement.ownerDocument.body);
     await body.findByRole("menuitemradio", { name: "PostHog" });
     await body.findByRole("menuitemradio", { name: "Anthropic" });
+  },
+};
+
+export const LoginPromptBilling: StoryObj<typeof BillingHarnessLoginPrompt> = {
+  render: () => <BillingHarnessLoginPrompt />,
+  play: async ({ canvas, canvasElement, userEvent }): Promise<void> => {
+    await openBillingSubmenu(canvas, canvasElement, userEvent);
+    const body = within(canvasElement.ownerDocument.body);
+    await body.findByText(/Log in to Claude Code to use Anthropic billing/);
+    await body.findByRole("button", { name: "Log in" });
   },
 };
 

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -955,10 +955,15 @@ describe("ReasoningLevelSelector", () => {
     await openAdvanced(user);
     await openSub(user, /^Billing/);
     expect(
-      await screen.findByText(
-        "Log in to Claude Code to use Anthropic billing.",
+      await screen.findByRole("button", { name: "Log in to Claude Code" }),
+    ).toBeInTheDocument();
+    // One sentence, no separate "Log in" row: the link carries the whole note.
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.textContent ===
+          "Log in to Claude Code to use Anthropic billing.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Log in" })).toBeInTheDocument();
   }, 20000);
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -6,6 +6,7 @@ import {
 import { Theme } from "@radix-ui/themes";
 import { configure, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { cloneElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ReasoningLevelSelector } from "./ReasoningLevelSelector";
 
@@ -18,6 +19,66 @@ vi.mock("@posthog/ui/utils/browser", () => ({ openUrlInBrowser }));
 vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
   useFeatureFlag: () => true,
 }));
+
+const useAdapterSubscription = vi.hoisted(() => vi.fn());
+vi.mock(
+  "@posthog/ui/features/settings/adapterSubscription",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@posthog/ui/features/settings/adapterSubscription")
+      >();
+    return {
+      ...actual,
+      useAdapterSubscription,
+    };
+  },
+);
+
+// Base UI tooltips never open under jsdom's zero layout, so render their
+// content unconditionally and assert on it directly (see TaskHeaderActions
+// tests for the same trick). Triggers keep honoring their `render` prop —
+// children are merged into the rendered element, as real Base UI does.
+vi.mock("@posthog/quill", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@posthog/quill")>();
+  const passthrough = ({ children }: { children: React.ReactNode }) => children;
+  const renderPassthrough = ({
+    children,
+    render,
+  }: {
+    children?: React.ReactNode;
+    render?: React.ReactElement;
+  }) =>
+    render && children
+      ? cloneElement(render, undefined, children)
+      : (render ?? children);
+  return {
+    ...actual,
+    TooltipProvider: passthrough,
+    Tooltip: passthrough,
+    TooltipTrigger: renderPassthrough,
+    TooltipContent: passthrough,
+  };
+});
+
+function subscriptionState(
+  overrides?: Partial<{
+    flagEnabled: boolean;
+    subscriptionOn: boolean;
+    loggedIn: boolean;
+  }>,
+) {
+  return {
+    flagEnabled: true,
+    subscriptionOn: true,
+    loggedIn: true,
+    status: { loginState: "logged-in" as const },
+    loginState: "logged-in" as const,
+    needsConnection: false,
+    setSubscriptionOn: () => {},
+    ...overrides,
+  };
+}
 
 const ultracodeDocsUrl = "https://code.claude.com/docs/en/workflows";
 
@@ -787,5 +848,59 @@ describe("ReasoningLevelSelector", () => {
     );
 
     expect(onModelChange).toHaveBeenCalledWith("@cf/zai-org/glm-5.2");
+  }, 20000);
+
+  it.each([
+    ["claude", "Your Claude plan", "Your Claude plan"],
+    ["codex", "Your ChatGPT plan", "Your ChatGPT plan"],
+  ] as const)(
+    "disables the %s plan option for cloud tasks and names the reason",
+    async (adapter, planLabel, reasonPrefix) => {
+      useAdapterSubscription.mockReturnValue(subscriptionState());
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      render(
+        <Theme>
+          <ReasoningLevelSelector
+            thoughtOption={thoughtOption()}
+            adapter={adapter}
+            showBillingMenu
+            workspaceMode="cloud"
+          />
+        </Theme>,
+      );
+
+      await openAdvanced(user);
+      await openSub(user, /^Billing/);
+      const planItem = screen.getByRole("menuitemradio", {
+        name: planLabel,
+      });
+      expect(planItem).toHaveAttribute("aria-disabled", "true");
+
+      await expect(
+        screen.findByText(new RegExp(`^${reasonPrefix} only works`)),
+      ).resolves.toBeInTheDocument();
+    },
+    20000,
+  );
+
+  it("keeps the plan option selectable for local tasks", async () => {
+    useAdapterSubscription.mockReturnValue(subscriptionState());
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption()}
+          adapter="claude"
+          showBillingMenu
+          workspaceMode="local"
+        />
+      </Theme>,
+    );
+
+    await openAdvanced(user);
+    await openSub(user, /^Billing/);
+    expect(
+      screen.getByRole("menuitemradio", { name: "Your Claude plan" }),
+    ).not.toHaveAttribute("aria-disabled", "true");
   }, 20000);
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@posthog/ui/features/feature-flags/useFeatureFlag", () => ({
 }));
 
 const useAdapterSubscription = vi.hoisted(() => vi.fn());
+const applyModelAccess = vi.hoisted(() => vi.fn());
 vi.mock(
   "@posthog/ui/features/settings/adapterSubscription",
   async (importOriginal) => {
@@ -31,6 +32,10 @@ vi.mock(
     return {
       ...actual,
       useAdapterSubscription,
+      // The real one writes the settings store and resolves the analytics
+      // service, which no test container provides; the click path only needs
+      // the menu to keep rendering.
+      applyModelAccess,
     };
   },
 );
@@ -68,7 +73,7 @@ function subscriptionState(
     loggedIn: boolean;
   }>,
 ) {
-  return {
+  const state = {
     flagEnabled: true,
     subscriptionOn: true,
     loggedIn: true,
@@ -78,6 +83,10 @@ function subscriptionState(
     setSubscriptionOn: () => {},
     ...overrides,
   };
+  // Mirror the real hook: the connection is only "needed" once the
+  // subscription is picked while logged out.
+  state.needsConnection = state.subscriptionOn && !state.loggedIn;
+  return state;
 }
 
 const ultracodeDocsUrl = "https://code.claude.com/docs/en/workflows";
@@ -902,5 +911,54 @@ describe("ReasoningLevelSelector", () => {
     expect(
       screen.getByRole("menuitemradio", { name: "Anthropic" }),
     ).not.toHaveAttribute("aria-disabled", "true");
+    // Logged in, so the login note stays hidden.
+    expect(screen.queryByText(/Log in to Claude Code/)).not.toBeInTheDocument();
+  }, 20000);
+
+  it("shows the login note only when the logged-out billing pick needs it", async () => {
+    // Persisted billing is PostHog, account is logged out: no login prompt.
+    useAdapterSubscription.mockReturnValue(
+      subscriptionState({ subscriptionOn: false, loggedIn: false }),
+    );
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { unmount } = render(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption()}
+          adapter="claude"
+          showBillingMenu
+          workspaceMode="local"
+        />
+      </Theme>,
+    );
+
+    await openAdvanced(user);
+    await openSub(user, /^Billing/);
+    expect(screen.queryByText(/Log in to Claude Code/)).not.toBeInTheDocument();
+    unmount();
+
+    // Billing picked while logged out: the quiet login note appears.
+    useAdapterSubscription.mockReturnValue(
+      subscriptionState({ subscriptionOn: true, loggedIn: false }),
+    );
+    render(
+      <Theme>
+        <ReasoningLevelSelector
+          thoughtOption={thoughtOption()}
+          adapter="claude"
+          showBillingMenu
+          workspaceMode="local"
+        />
+      </Theme>,
+    );
+
+    await openAdvanced(user);
+    await openSub(user, /^Billing/);
+    expect(
+      await screen.findByText(
+        "Log in to Claude Code to use Anthropic billing.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Log in" })).toBeInTheDocument();
   }, 20000);
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.test.tsx
@@ -851,10 +851,10 @@ describe("ReasoningLevelSelector", () => {
   }, 20000);
 
   it.each([
-    ["claude", "Your Claude plan", "Your Claude plan"],
-    ["codex", "Your ChatGPT plan", "Your ChatGPT plan"],
+    ["claude", "Anthropic", "Anthropic"],
+    ["codex", "OpenAI", "OpenAI"],
   ] as const)(
-    "disables the %s plan option for cloud tasks and names the reason",
+    "disables the %s billing option for cloud tasks and names the reason",
     async (adapter, planLabel, reasonPrefix) => {
       useAdapterSubscription.mockReturnValue(subscriptionState());
       const user = userEvent.setup({ pointerEventsCheck: 0 });
@@ -877,13 +877,13 @@ describe("ReasoningLevelSelector", () => {
       expect(planItem).toHaveAttribute("aria-disabled", "true");
 
       await expect(
-        screen.findByText(new RegExp(`^${reasonPrefix} only works`)),
+        screen.findByText(new RegExp(`^${reasonPrefix} billing only works`)),
       ).resolves.toBeInTheDocument();
     },
     20000,
   );
 
-  it("keeps the plan option selectable for local tasks", async () => {
+  it("keeps the billing option selectable for local tasks", async () => {
     useAdapterSubscription.mockReturnValue(subscriptionState());
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     render(
@@ -900,7 +900,7 @@ describe("ReasoningLevelSelector", () => {
     await openAdvanced(user);
     await openSub(user, /^Billing/);
     expect(
-      screen.getByRole("menuitemradio", { name: "Your Claude plan" }),
+      screen.getByRole("menuitemradio", { name: "Anthropic" }),
     ).not.toHaveAttribute("aria-disabled", "true");
   }, 20000);
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -150,7 +150,7 @@ export function ReasoningLevelSelector({
     adapter === "claude" && modelAccess === "own-subscription";
   const unavailableReason = (modelId: string): string | undefined =>
     onOwnSubscription && !isAnthropicModelId(modelId)
-      ? "Your Claude plan cannot run this model. Change billing to PostHog credits to use it."
+      ? "Anthropic billing cannot run this model. Change billing to PostHog to use it."
       : undefined;
 
   const handleHarnessSelect = (harness: AgentHarness) => {

--- a/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ReasoningLevelSelector.tsx
@@ -37,6 +37,7 @@ import {
 } from "@posthog/ui/features/sessions/components/HarnessSubmenu";
 import { ModelSelectList } from "@posthog/ui/features/sessions/components/ModelSelectList";
 import { SubscriptionSubmenu } from "@posthog/ui/features/sessions/components/SubscriptionSubmenu";
+import type { WorkspaceModeForAccess } from "@posthog/ui/features/settings/adapterSubscription";
 import type { AgentAdapter } from "@posthog/ui/features/settings/settingsStore";
 import { AnimatedHeight } from "@posthog/ui/primitives/AnimatedHeight";
 import { Spinner } from "@posthog/ui/primitives/Spinner";
@@ -77,6 +78,8 @@ interface ReasoningLevelSelectorProps {
   isLoading?: boolean;
   modelAccess?: ModelAccess;
   showBillingMenu?: boolean;
+  /** Workspace mode of the task being composed; cloud disables plan billing. */
+  workspaceMode?: WorkspaceModeForAccess;
 }
 
 function toDropdownOptions(
@@ -115,6 +118,7 @@ export function ReasoningLevelSelector({
   isLoading,
   modelAccess,
   showBillingMenu,
+  workspaceMode,
 }: ReasoningLevelSelectorProps) {
   const [internalMenuOpen, setInternalMenuOpen] = useState(false);
   const open = menuOpen ?? internalMenuOpen;
@@ -490,7 +494,10 @@ export function ReasoningLevelSelector({
                   />
                 )}
                 {showBillingMenu && adapter && (
-                  <SubscriptionSubmenu adapter={adapter} />
+                  <SubscriptionSubmenu
+                    adapter={adapter}
+                    workspaceMode={workspaceMode}
+                  />
                 )}
                 {hasEffort && (
                   <DropdownMenuSub>

--- a/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
@@ -22,9 +22,15 @@ const PROVIDER_LABEL: Record<Adapter, string> = {
   codex: "OpenAI",
 };
 
-const LOGIN_NOTE: Record<Adapter, string> = {
-  claude: "Log in to Claude Code to use Anthropic billing.",
-  codex: "Connect ChatGPT to use OpenAI billing.",
+const LOGIN_NOTE: Record<Adapter, { link: string; rest: string }> = {
+  claude: {
+    link: "Log in to Claude Code",
+    rest: " to use Anthropic billing.",
+  },
+  codex: {
+    link: "Connect ChatGPT",
+    rest: " to use OpenAI billing.",
+  },
 };
 
 export const SUBSCRIPTION_LOGIN_ACTION: Record<Adapter, string> = {
@@ -133,17 +139,17 @@ export function SubscriptionSubmenu({
             // login, and sessions keep running on PostHog until the login
             // completes. Unknown status counts as not logged in, so the note
             // stays reachable when the status check cannot run or is pending.
-            <div className="flex flex-col gap-1 px-2 py-1.5 text-muted-foreground text-xs">
-              <span>{LOGIN_NOTE[adapter]}</span>
+            <div className="px-2 py-1.5 text-muted-foreground text-xs">
               <button
                 type="button"
-                className="self-start underline underline-offset-2 hover:text-foreground"
+                className="underline underline-offset-2 hover:text-foreground"
                 onClick={() =>
                   openSettings("harness", SUBSCRIPTION_LOGIN_ACTION[adapter])
                 }
               >
-                Log in
+                {LOGIN_NOTE[adapter].link}
               </button>
+              {LOGIN_NOTE[adapter].rest}
             </div>
           )}
       </DropdownMenuSubContent>

--- a/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
@@ -6,11 +6,16 @@ import {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from "@posthog/quill";
 import type { Adapter, ModelAccess } from "@posthog/shared";
 import {
   applyModelAccess,
   useAdapterSubscription,
+  type WorkspaceModeForAccess,
 } from "@posthog/ui/features/settings/adapterSubscription";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 
@@ -29,26 +34,42 @@ export const SUBSCRIPTION_LOGIN_ACTION: Record<Adapter, string> = {
   codex: "codex-login",
 };
 
+const CLOUD_ONLY_REASON: Record<Adapter, string> = {
+  claude:
+    "Your Claude plan only works for local and worktree tasks. Cloud tasks always use PostHog credits.",
+  codex:
+    "Your ChatGPT plan only works for local and worktree tasks. Cloud tasks always use PostHog credits.",
+};
+
+const TOOLTIP_DELAY_MS = 150;
+
 interface SubscriptionSubmenuProps {
   adapter: Adapter;
   closeOnChange?: boolean;
+  /** Workspace mode of the task being composed; cloud forces PostHog credits. */
+  workspaceMode?: WorkspaceModeForAccess;
 }
 
 export function SubscriptionSubmenu({
   adapter,
   closeOnChange = false,
+  workspaceMode,
 }: SubscriptionSubmenuProps): React.JSX.Element | null {
   const subscription = useAdapterSubscription(adapter);
   if (!subscription.flagEnabled) {
     return null;
   }
 
+  // Cloud tasks always bill PostHog credits (see effectiveModelAccess), so the
+  // plan option is disabled there instead of silently overriding the pick.
+  const cloudTask = workspaceMode === "cloud";
   const planLabel = PLAN_LABEL[adapter];
-  const value: ModelAccess = subscription.subscriptionOn
-    ? "own-subscription"
-    : "posthog-gateway";
+  const value: ModelAccess =
+    cloudTask || !subscription.subscriptionOn
+      ? "posthog-gateway"
+      : "own-subscription";
   const valueLabel =
-    subscription.subscriptionOn && subscription.loggedIn
+    subscription.subscriptionOn && subscription.loggedIn && !cloudTask
       ? planLabel
       : "PostHog credits";
 
@@ -79,13 +100,33 @@ export function SubscriptionSubmenu({
           >
             PostHog credits
           </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem
-            value="own-subscription"
-            closeOnClick={closeOnChange}
-            disabled={!subscription.loggedIn}
-          >
-            {planLabel}
-          </DropdownMenuRadioItem>
+          {cloudTask ? (
+            <TooltipProvider delay={TOOLTIP_DELAY_MS}>
+              <Tooltip disableHoverablePopup>
+                <TooltipTrigger render={<span className="flex" />}>
+                  <DropdownMenuRadioItem
+                    value="own-subscription"
+                    closeOnClick={closeOnChange}
+                    disabled
+                    className="opacity-60"
+                  >
+                    {planLabel}
+                  </DropdownMenuRadioItem>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="max-w-60">
+                  {CLOUD_ONLY_REASON[adapter]}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <DropdownMenuRadioItem
+              value="own-subscription"
+              closeOnClick={closeOnChange}
+              disabled={!subscription.loggedIn}
+            >
+              {planLabel}
+            </DropdownMenuRadioItem>
+          )}
         </DropdownMenuRadioGroup>
         {subscription.loggedIn ? null : (
           <DropdownMenuItem

--- a/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
@@ -19,9 +19,9 @@ import {
 } from "@posthog/ui/features/settings/adapterSubscription";
 import { openSettings } from "@posthog/ui/features/settings/hooks/useOpenSettings";
 
-const PLAN_LABEL: Record<Adapter, string> = {
-  claude: "Your Claude plan",
-  codex: "Your ChatGPT plan",
+const PROVIDER_LABEL: Record<Adapter, string> = {
+  claude: "Anthropic",
+  codex: "OpenAI",
 };
 
 const LOGIN_LABEL: Record<Adapter, string> = {
@@ -36,9 +36,9 @@ export const SUBSCRIPTION_LOGIN_ACTION: Record<Adapter, string> = {
 
 const CLOUD_ONLY_REASON: Record<Adapter, string> = {
   claude:
-    "Your Claude plan only works for local and worktree tasks. Cloud tasks always use PostHog credits.",
+    "Anthropic billing only works for local and worktree tasks. Cloud tasks always use PostHog.",
   codex:
-    "Your ChatGPT plan only works for local and worktree tasks. Cloud tasks always use PostHog credits.",
+    "OpenAI billing only works for local and worktree tasks. Cloud tasks always use PostHog.",
 };
 
 const TOOLTIP_DELAY_MS = 150;
@@ -61,17 +61,17 @@ export function SubscriptionSubmenu({
   }
 
   // Cloud tasks always bill PostHog credits (see effectiveModelAccess), so the
-  // plan option is disabled there instead of silently overriding the pick.
+  // provider option is disabled there instead of silently overriding the pick.
   const cloudTask = workspaceMode === "cloud";
-  const planLabel = PLAN_LABEL[adapter];
+  const providerLabel = PROVIDER_LABEL[adapter];
   const value: ModelAccess =
     cloudTask || !subscription.subscriptionOn
       ? "posthog-gateway"
       : "own-subscription";
   const valueLabel =
     subscription.subscriptionOn && subscription.loggedIn && !cloudTask
-      ? planLabel
-      : "PostHog credits";
+      ? providerLabel
+      : "PostHog";
 
   return (
     <DropdownMenuSub>
@@ -98,7 +98,7 @@ export function SubscriptionSubmenu({
             value="posthog-gateway"
             closeOnClick={closeOnChange}
           >
-            PostHog credits
+            PostHog
           </DropdownMenuRadioItem>
           {cloudTask ? (
             <TooltipProvider delay={TOOLTIP_DELAY_MS}>
@@ -110,7 +110,7 @@ export function SubscriptionSubmenu({
                     disabled
                     className="opacity-60"
                   >
-                    {planLabel}
+                    {providerLabel}
                   </DropdownMenuRadioItem>
                 </TooltipTrigger>
                 <TooltipContent side="right" className="max-w-60">
@@ -124,7 +124,7 @@ export function SubscriptionSubmenu({
               closeOnClick={closeOnChange}
               disabled={!subscription.loggedIn}
             >
-              {planLabel}
+              {providerLabel}
             </DropdownMenuRadioItem>
           )}
         </DropdownMenuRadioGroup>

--- a/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
@@ -125,23 +125,27 @@ export function SubscriptionSubmenu({
             </DropdownMenuRadioItem>
           )}
         </DropdownMenuRadioGroup>
-        {subscription.needsConnection && (
-          // A quiet inline note rather than a permanent menu row: it appears
-          // only once the provider option is picked while logged out, and
-          // sessions keep running on PostHog until the login completes.
-          <div className="flex flex-col gap-1 px-2 py-1.5 text-muted-foreground text-xs">
-            <span>{LOGIN_NOTE[adapter]}</span>
-            <button
-              type="button"
-              className="self-start underline underline-offset-2 hover:text-foreground"
-              onClick={() =>
-                openSettings("harness", SUBSCRIPTION_LOGIN_ACTION[adapter])
-              }
-            >
-              Log in
-            </button>
-          </div>
-        )}
+        {!cloudTask &&
+          subscription.subscriptionOn &&
+          !subscription.loggedIn && (
+            // A quiet inline note rather than a permanent menu row: it appears
+            // only once the provider option is picked without a confirmed
+            // login, and sessions keep running on PostHog until the login
+            // completes. Unknown status counts as not logged in, so the note
+            // stays reachable when the status check cannot run or is pending.
+            <div className="flex flex-col gap-1 px-2 py-1.5 text-muted-foreground text-xs">
+              <span>{LOGIN_NOTE[adapter]}</span>
+              <button
+                type="button"
+                className="self-start underline underline-offset-2 hover:text-foreground"
+                onClick={() =>
+                  openSettings("harness", SUBSCRIPTION_LOGIN_ACTION[adapter])
+                }
+              >
+                Log in
+              </button>
+            </div>
+          )}
       </DropdownMenuSubContent>
     </DropdownMenuSub>
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SubscriptionSubmenu.tsx
@@ -1,6 +1,4 @@
-import { SignIn } from "@phosphor-icons/react";
 import {
-  DropdownMenuItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSub,
@@ -24,9 +22,9 @@ const PROVIDER_LABEL: Record<Adapter, string> = {
   codex: "OpenAI",
 };
 
-const LOGIN_LABEL: Record<Adapter, string> = {
-  claude: "Log in to Claude Code",
-  codex: "Log in to ChatGPT",
+const LOGIN_NOTE: Record<Adapter, string> = {
+  claude: "Log in to Claude Code to use Anthropic billing.",
+  codex: "Connect ChatGPT to use OpenAI billing.",
 };
 
 export const SUBSCRIPTION_LOGIN_ACTION: Record<Adapter, string> = {
@@ -122,21 +120,27 @@ export function SubscriptionSubmenu({
             <DropdownMenuRadioItem
               value="own-subscription"
               closeOnClick={closeOnChange}
-              disabled={!subscription.loggedIn}
             >
               {providerLabel}
             </DropdownMenuRadioItem>
           )}
         </DropdownMenuRadioGroup>
-        {subscription.loggedIn ? null : (
-          <DropdownMenuItem
-            onClick={() =>
-              openSettings("harness", SUBSCRIPTION_LOGIN_ACTION[adapter])
-            }
-          >
-            <SignIn size={12} />
-            {LOGIN_LABEL[adapter]}
-          </DropdownMenuItem>
+        {subscription.needsConnection && (
+          // A quiet inline note rather than a permanent menu row: it appears
+          // only once the provider option is picked while logged out, and
+          // sessions keep running on PostHog until the login completes.
+          <div className="flex flex-col gap-1 px-2 py-1.5 text-muted-foreground text-xs">
+            <span>{LOGIN_NOTE[adapter]}</span>
+            <button
+              type="button"
+              className="self-start underline underline-offset-2 hover:text-foreground"
+              onClick={() =>
+                openSettings("harness", SUBSCRIPTION_LOGIN_ACTION[adapter])
+              }
+            >
+              Log in
+            </button>
+          </div>
         )}
       </DropdownMenuSubContent>
     </DropdownMenuSub>

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -1677,6 +1677,7 @@ export function TaskInput({
                         isLoading={isPreviewLoading}
                         modelAccess={composerModelAccess}
                         showBillingMenu
+                        workspaceMode={workspaceMode}
                       />
                     )
                   }


### PR DESCRIPTION
## Problem

When composing a **cloud** task, the Billing submenu in the model selector still offered "Your Claude plan" / "Your ChatGPT plan" as a pickable option, even though cloud tasks always run on PostHog credits — the pick was silently overridden by `effectiveModelAccess`. The long "credits"/"plan" wording read heavier than the menu needed, and the login prompt sat permanently in the Billing submenu even while PostHog was the selected billing.

## Changes

- The own-plan option in the Billing submenu is **disabled for cloud tasks**, with a tooltip: "Anthropic billing only works for local and worktree tasks. Cloud tasks always use PostHog." (OpenAI for Codex). The Billing row shows "PostHog" as the active value in cloud mode.
- Billing copy is now just the provider name: **PostHog** for credits, **Anthropic** for the Claude harness, **OpenAI** for the Codex harness — the menu only ever shows the names relevant to the selected harness. The model-gate reasoning follows the same wording.
- The login prompt no longer sits permanently in the submenu. It appears only once the provider option is picked while logged out, as a quiet inline note ("Log in to Claude Code to use Anthropic billing." + a Log in link). The provider option is selectable while logged out so the note is reachable; sessions keep running on PostHog until the login completes, matching the settings switch behavior.
- The workspace mode of the task being composed is threaded from both composers (task detail input and channel composer) into the billing submenu; local and worktree behavior is unchanged.
- Adds Storybook stories (`LocalBilling`, `CloudBilling`, `LoginPromptBilling`) that open the Advanced view's Billing submenu in both modes and the logged-out login-note state.

**Billing submenu, local task** (PostHog selected, no login prompt while on PostHog):

![billing-local-v2](https://raw.githubusercontent.com/PostHog/pr-assets/9c0a85b3fb2f1f5de48fd9096e608b856d207f5d/2026/09/7dcfe2d7-86cf-4363-b216-69f89e81b225.png)

**Billing submenu, provider picked while logged out** (the login phrase is the link itself, same box for Claude and Codex):

![billing-login-v4](https://raw.githubusercontent.com/PostHog/pr-assets/f5aea1707146ced0349bcb647654b2ce9eb6226c/2026/09/874426e9-24af-4d43-92c8-bacdf74aedea.png)

![billing-codex-login](https://raw.githubusercontent.com/PostHog/pr-assets/25c67aa79013a97c40f7b9fa3c1cca91659b53a4/2026/09/43d2708a-d926-435a-a081-0cdc47ac50e7.png)

**Billing submenu, cloud task** (Anthropic disabled — local/worktree only):

![billing-cloud-v2](https://raw.githubusercontent.com/PostHog/pr-assets/a34ea2260e8f48191f46f5e712be220706c432a7/2026/09/387c0fc5-c275-4bd6-92f1-00d7667cefe8.png)

## How did you test this code?

Cases in `ReasoningLevelSelector.test.tsx`: a parameterized test (claude + codex) asserting the provider item is `aria-disabled` with the reason text for `workspaceMode="cloud"`; one asserting it stays enabled for `workspaceMode="local"`; and one asserting the login note is hidden while PostHog is selected and appears (with the Log in link) when the provider is picked while logged out. The billing submenu had no tests before this PR. Full file run: 31/31 passing. Typecheck and Biome lint pass. The screenshots come from the new Storybook stories rendered in the dev server via a headless browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Authored by an agent (PostHog Desktop cloud task) across three commits on the same branch: (1) disabled own-subscription billing on cloud tasks, (2) shortened the billing copy to bare provider names, (3) made the login prompt conditional on the provider being picked while logged out, and quieter.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*



