### PR TITLE
chore(ingestion): test that group upserts do not depend on event order

### DIFF
--- a/nodejs/src/common/groups/group-type-manager.ordering.test.ts
+++ b/nodejs/src/common/groups/group-type-manager.ordering.test.ts
@@ -1,0 +1,90 @@
+import { DateTime } from 'luxon'
+
+import { TeamManager } from '~/common/utils/team-manager'
+import { GroupTypeIndex, ProjectId, TeamId } from '~/types'
+
+import { GroupTypeManager, MAX_GROUP_TYPES_PER_TEAM } from './group-type-manager'
+import { GroupRepository } from './repositories/group-repository.interface'
+
+jest.mock('~/common/utils/posthog', () => ({
+    captureTeamEvent: jest.fn(),
+}))
+
+/**
+ * In-memory posthog_grouptypemapping with the same allocation semantics as
+ * PostgresGroupRepository.insertGroupType: unique on (project, type) and on (project, index),
+ * an existing type returns its index, a taken index moves on to the next one, and nothing
+ * beyond MAX_GROUP_TYPES_PER_TEAM is ever allocated.
+ */
+class InMemoryGroupTypeMappings {
+    private rows: { group_type: string; group_type_index: GroupTypeIndex }[] = []
+
+    asRepository(): GroupRepository {
+        return {
+            fetchGroupTypesByProjectIds: (projectIds: ProjectId[]) =>
+                Promise.resolve(Object.fromEntries(projectIds.map((id) => [String(id), [...this.rows]]))),
+            insertGroupType: (
+                _teamId: TeamId,
+                projectId: ProjectId,
+                groupType: string,
+                index: number,
+                createdAt: DateTime
+            ): Promise<[GroupTypeIndex | null, boolean]> => {
+                if (index < 0 || index >= MAX_GROUP_TYPES_PER_TEAM) {
+                    return Promise.resolve([null, false])
+                }
+                const existing = this.rows.find((row) => row.group_type === groupType)
+                if (existing) {
+                    return Promise.resolve([existing.group_type_index, false])
+                }
+                if (this.rows.some((row) => row.group_type_index === index)) {
+                    return this.asRepository().insertGroupType(_teamId, projectId, groupType, index + 1, createdAt)
+                }
+                this.rows.push({ group_type: groupType, group_type_index: index as GroupTypeIndex })
+                return Promise.resolve([index as GroupTypeIndex, true])
+            },
+        } as unknown as GroupRepository
+    }
+}
+
+describe('GroupTypeManager ordering', () => {
+    const teamId: TeamId = 1
+    const projectId = 1 as ProjectId
+    const timestamp = DateTime.fromISO('2026-01-01T10:00:00.000Z', { zone: 'utc' })
+    const teamManager = { getTeam: () => Promise.resolve(null) } as unknown as TeamManager
+
+    async function allocateInOrder(groupTypes: string[]): Promise<Record<string, GroupTypeIndex | null>> {
+        const manager = new GroupTypeManager(new InMemoryGroupTypeMappings().asRepository(), teamManager)
+        const allocated: Record<string, GroupTypeIndex | null> = {}
+        for (const groupType of groupTypes) {
+            allocated[groupType] = await manager.fetchGroupTypeIndex(teamId, projectId, groupType, timestamp)
+        }
+        return allocated
+    }
+
+    // Group type slots are handed out in arrival order. Two distinct_ids introducing different
+    // types are not ordered relative to each other today, so which type lands in which $group_N
+    // column, and which type is dropped once the five slots are full, is already decided by
+    // arrival rather than by anything the customer controls.
+    it('assigns $group_N columns in arrival order, so the same types get different columns in a different order', async () => {
+        const types = ['company', 'project', 'organization', 'workspace', 'account']
+
+        const forward = await allocateInOrder(types)
+        const reversed = await allocateInOrder([...types].reverse())
+
+        expect(forward).toEqual({ company: 0, project: 1, organization: 2, workspace: 3, account: 4 })
+        expect(reversed).toEqual({ account: 0, workspace: 1, organization: 2, project: 3, company: 4 })
+    })
+
+    it('drops whichever type arrives sixth, so the set of surviving types depends on order', async () => {
+        const types = ['company', 'project', 'organization', 'workspace', 'account', 'channel']
+
+        const forward = await allocateInOrder(types)
+        const reversed = await allocateInOrder([...types].reverse())
+
+        expect(forward.channel).toBeNull()
+        expect(forward.company).not.toBeNull()
+        expect(reversed.company).toBeNull()
+        expect(reversed.channel).not.toBeNull()
+    })
+})

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.ordering.test.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.ordering.test.ts
@@ -5,24 +5,25 @@ import { Properties } from '~/plugin-scaffold'
 import { Group, GroupTypeIndex, ProjectId, TeamId } from '~/types'
 import { RaceConditionError } from '~/common/utils/utils'
 
-import { BatchWritingGroupStore } from './batch-writing-group-store'
+import { BatchWritingGroupStore, BatchWritingGroupStoreOptions } from './batch-writing-group-store'
 import { ClickhouseGroupRepository } from '~/common/groups/repositories/clickhouse-group-repository'
-import { GroupRepository } from '~/common/groups/repositories/group-repository.interface'
-
-jest.mock('~/ingestion/common/ingestion-warnings', () => ({
-    emitIngestionWarning: jest.fn().mockResolvedValue(undefined),
-}))
-
-import { GroupsOutput, IngestionWarningsOutput } from '~/common/outputs'
+import {
+    GroupCreate,
+    GroupCreateResult,
+    GroupPropertiesToSetUpdate,
+    GroupRepository,
+} from '~/common/groups/repositories/group-repository.interface'
+import { GroupsOutput } from '~/common/outputs'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 
 /**
- * In-memory stand-in for the posthog_group table with the same concurrency semantics as
+ * In-memory stand-in for the posthog_group table with the same write semantics as
  * PostgresGroupRepository: insertGroup throws RaceConditionError on a duplicate row,
- * updateGroup bumps version unconditionally, updateGroupOptimistically is a compare-and-swap
- * on version. Each method body has no await, so every operation is atomic — the same
- * guarantee a single SQL statement gives. One table can be shared between several stores
- * to model several ingestion workers writing the same rows.
+ * updateGroupOptimistically is a compare-and-swap on version, and the batch statements
+ * merge properties and take the earliest created_at server-side. Each method body has no
+ * await, so every operation is atomic — the same guarantee a single SQL statement gives.
+ * One table can be shared between several stores to model several ingestion workers
+ * writing the same rows.
  */
 class InMemoryGroupTable {
     private rows = new Map<string, Group>()
@@ -32,13 +33,46 @@ class InMemoryGroupTable {
         return `${teamId}:${groupTypeIndex}:${groupKey}`
     }
 
+    private clone(row: Group): Group {
+        return { ...row, group_properties: { ...row.group_properties } }
+    }
+
     get(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): Group | undefined {
         const row = this.rows.get(this.key(teamId, groupTypeIndex, groupKey))
-        return row ? { ...row, group_properties: { ...row.group_properties } } : undefined
+        return row ? this.clone(row) : undefined
     }
 
     seed(group: Group): void {
         this.rows.set(this.key(group.team_id, group.group_type_index, group.group_key), group)
+    }
+
+    private insert(
+        teamId: TeamId,
+        groupTypeIndex: GroupTypeIndex,
+        groupKey: string,
+        groupProperties: Properties,
+        createdAt: DateTime
+    ): Group {
+        const row: Group = {
+            id: this.rows.size + 1,
+            team_id: teamId,
+            group_type_index: groupTypeIndex,
+            group_key: groupKey,
+            group_properties: { ...groupProperties },
+            created_at: createdAt,
+            version: 1,
+            properties_last_updated_at: {},
+            properties_last_operation: {},
+        }
+        this.rows.set(this.key(teamId, groupTypeIndex, groupKey), row)
+        return row
+    }
+
+    private merge(row: Group, propertiesToSet: Properties, createdAt: DateTime): Group {
+        row.group_properties = { ...row.group_properties, ...propertiesToSet }
+        row.created_at = DateTime.min(row.created_at, createdAt)
+        row.version += 1
+        return row
     }
 
     asRepository(): GroupRepository {
@@ -53,23 +87,33 @@ class InMemoryGroupTable {
                 groupProperties: Properties,
                 createdAt: DateTime
             ) => {
-                const key = this.key(teamId, groupTypeIndex, groupKey)
-                if (this.rows.has(key)) {
+                if (this.rows.has(this.key(teamId, groupTypeIndex, groupKey))) {
                     return Promise.reject(new RaceConditionError('Parallel posthog_group inserts, retry'))
                 }
-                this.rows.set(key, {
-                    id: this.rows.size + 1,
-                    team_id: teamId,
-                    group_type_index: groupTypeIndex,
-                    group_key: groupKey,
-                    group_properties: { ...groupProperties },
-                    created_at: createdAt,
-                    version: 1,
-                    properties_last_updated_at: {},
-                    properties_last_operation: {},
-                })
-                return Promise.resolve(1)
+                return Promise.resolve(
+                    this.insert(teamId, groupTypeIndex, groupKey, groupProperties, createdAt).version
+                )
             },
+            insertGroupsBatch: (creates: GroupCreate[]) =>
+                Promise.resolve(
+                    creates.map((create): GroupCreateResult => {
+                        const existing = this.rows.get(this.key(create.teamId, create.groupTypeIndex, create.groupKey))
+                        if (existing) {
+                            return {
+                                ...this.clone(this.merge(existing, create.groupProperties, create.createdAt)),
+                                inserted: false,
+                            }
+                        }
+                        const row = this.insert(
+                            create.teamId,
+                            create.groupTypeIndex,
+                            create.groupKey,
+                            create.groupProperties,
+                            create.createdAt
+                        )
+                        return { ...this.clone(row), inserted: true }
+                    })
+                ),
             updateGroup: (
                 teamId: TeamId,
                 groupTypeIndex: GroupTypeIndex,
@@ -81,11 +125,18 @@ class InMemoryGroupTable {
                 if (!row) {
                     return Promise.resolve(undefined)
                 }
-                row.version += 1
                 row.group_properties = { ...groupProperties }
                 row.created_at = createdAt
+                row.version += 1
                 return Promise.resolve(row.version)
             },
+            updateGroupsBatch: (updates: GroupPropertiesToSetUpdate[]) =>
+                Promise.resolve(
+                    updates.flatMap((update) => {
+                        const row = this.rows.get(this.key(update.teamId, update.groupTypeIndex, update.groupKey))
+                        return row ? [this.clone(this.merge(row, update.propertiesToSet, update.createdAt))] : []
+                    })
+                ),
             updateGroupOptimistically: (
                 teamId: TeamId,
                 groupTypeIndex: GroupTypeIndex,
@@ -99,9 +150,9 @@ class InMemoryGroupTable {
                     this.optimisticConflicts += 1
                     return Promise.resolve(undefined)
                 }
-                row.version += 1
                 row.group_properties = { ...groupProperties }
                 row.created_at = createdAt
+                row.version += 1
                 return Promise.resolve(row.version)
             },
             fetchGroupTypesByProjectIds: () => Promise.resolve({}),
@@ -123,26 +174,30 @@ describe('BatchWritingGroupStore ordering', () => {
     const t2 = DateTime.fromISO('2026-01-01T11:00:00.000Z', { zone: 'utc' })
     const t3 = DateTime.fromISO('2026-01-01T12:00:00.000Z', { zone: 'utc' })
 
-    type GroupIdentify = { distinctId: string; properties: Properties; timestamp: DateTime }
+    type GroupIdentify = { properties: Properties; timestamp: DateTime }
 
-    // Three users identify the same company from three distinct_ids. Because the pipeline only
-    // serializes per token:distinct_id, these can be processed in any order and in parallel.
+    // Three users identify the same company from three distinct_ids. The pipeline only
+    // serializes per token:distinct_id, so these can be processed in any order and in parallel.
     const events: GroupIdentify[] = [
-        { distinctId: 'alice', properties: { plan: 'enterprise' }, timestamp: t2 },
-        { distinctId: 'bob', properties: { seats: 40 }, timestamp: t1 },
-        { distinctId: 'carol', properties: { name: 'Acme' }, timestamp: t3 },
+        { properties: { plan: 'enterprise' }, timestamp: t2 },
+        { properties: { seats: 40 }, timestamp: t1 },
+        { properties: { name: 'Acme' }, timestamp: t3 },
     ]
+    const mergedProperties = { plan: 'enterprise', seats: 40, name: 'Acme' }
 
     const stores: BatchWritingGroupStore[] = []
 
-    function newStore(table: InMemoryGroupTable): BatchWritingGroupStore {
-        const clickhouse = {
-            upsertGroup: jest.fn().mockResolvedValue(undefined),
-        } as unknown as ClickhouseGroupRepository
-        const outputs = {} as unknown as IngestionOutputs<GroupsOutput | IngestionWarningsOutput>
-        const store = new BatchWritingGroupStore(outputs, table.asRepository(), clickhouse, {
+    function newStore(
+        table: InMemoryGroupTable,
+        options: Partial<BatchWritingGroupStoreOptions>
+    ): BatchWritingGroupStore {
+        const clickhouse = new ClickhouseGroupRepository({
+            queueMessages: jest.fn().mockResolvedValue(undefined),
+        } as unknown as IngestionOutputs<GroupsOutput>)
+        const store = new BatchWritingGroupStore(table.asRepository(), clickhouse, {
             optimisticUpdateRetryInterval: 1,
             metricEmissionIntervalMs: 0,
+            ...options,
         })
         stores.push(store)
         return store
@@ -157,10 +212,11 @@ describe('BatchWritingGroupStore ordering', () => {
 
     async function processInOrder(
         ordered: GroupIdentify[],
+        options: Partial<BatchWritingGroupStoreOptions>,
         flushAfterEach: boolean
-    ): Promise<{ row: Group | undefined; table: InMemoryGroupTable }> {
+    ): Promise<Group | undefined> {
         const table = new InMemoryGroupTable()
-        const store = newStore(table)
+        const store = newStore(table, options)
         for (const [batchId, event] of ordered.entries()) {
             await store.upsertGroup(
                 teamId,
@@ -176,83 +232,92 @@ describe('BatchWritingGroupStore ordering', () => {
             }
         }
         await store.flush()
-        return { row: table.get(teamId, groupTypeIndex, groupKey), table }
+        return table.get(teamId, groupTypeIndex, groupKey)
     }
 
-    describe.each([
-        ['all in one batch', false],
-        ['one batch per event', true],
-    ])('%s', (_label, flushAfterEach) => {
-        it('reaches the same group properties whichever order the events are processed in', async () => {
-            const forward = await processInOrder(events, flushAfterEach)
-            const reversed = await processInOrder([...events].reverse(), flushAfterEach)
-            const rotated = await processInOrder([events[1], events[2], events[0]], flushAfterEach)
+    // Every write path the store can take: server-side merge (default), per-row version CAS,
+    // and deferred batched creates.
+    describe.each<[string, Partial<BatchWritingGroupStoreOptions>]>([
+        ['batched merge updates', { useBatchUpdates: true }],
+        ['individual CAS updates', { useBatchUpdates: false }],
+        ['batched creates', { useBatchCreates: true }],
+    ])('%s', (_label, options) => {
+        it.each([
+            ['all in one batch', false],
+            ['one batch per event', true],
+        ])(
+            'reaches the same group properties whichever order the events are processed in, %s',
+            async (_l, flushAfterEach) => {
+                const forward = await processInOrder(events, options, flushAfterEach)
+                const reversed = await processInOrder([...events].reverse(), options, flushAfterEach)
+                const rotated = await processInOrder([events[1], events[2], events[0]], options, flushAfterEach)
 
-            const expected = { plan: 'enterprise', seats: 40, name: 'Acme' }
-            expect(forward.row?.group_properties).toEqual(expected)
-            expect(reversed.row?.group_properties).toEqual(expected)
-            expect(rotated.row?.group_properties).toEqual(expected)
-            expect(reversed.row?.version).toEqual(forward.row?.version)
-        })
+                expect(forward?.group_properties).toEqual(mergedProperties)
+                expect(reversed?.group_properties).toEqual(mergedProperties)
+                expect(rotated?.group_properties).toEqual(mergedProperties)
+                expect(reversed?.version).toEqual(forward?.version)
+            }
+        )
 
-        // The store computes created_at = min(existing, event timestamp) when it creates a row
-        // or takes the transactional path, but the batched merge path keeps the cached created_at
-        // and never looks at the incoming timestamp (addToBatch), and the CAS-conflict refetch
-        // does not min either. So created_at depends on which event happened to arrive first.
-        // Marked failing to document the gap; passing it needs DateTime.min in both places.
+        // Only row creation takes min(now, event timestamp). When the group is already cached,
+        // addToBatch keeps the cached created_at and never looks at the incoming timestamp, so
+        // the LEAST() in the batch statements never sees an earlier event. The row ends up with
+        // whichever event happened to create it. Marked failing to document the gap.
         it.failing(
             'keeps created_at as the earliest event timestamp whichever order the events arrive in',
             async () => {
-                const forward = await processInOrder(events, flushAfterEach)
-                const reversed = await processInOrder([...events].reverse(), flushAfterEach)
+                const forward = await processInOrder(events, options, false)
+                const reversed = await processInOrder([...events].reverse(), options, false)
 
-                expect(forward.row?.created_at.toISO()).toBe(t1.toISO())
-                expect(reversed.row?.created_at.toISO()).toBe(t1.toISO())
+                expect(forward?.created_at.toISO()).toBe(t1.toISO())
+                expect(reversed?.created_at.toISO()).toBe(t1.toISO())
             }
         )
-    })
 
-    it('two workers flushing the same group at once converge with no lost update', async () => {
-        const table = new InMemoryGroupTable()
-        table.seed({
-            id: 1,
-            team_id: teamId,
-            group_type_index: groupTypeIndex,
-            group_key: groupKey,
-            group_properties: { name: 'Acme' },
-            created_at: t1,
-            version: 1,
-            properties_last_updated_at: {},
-            properties_last_operation: {},
+        it('two workers flushing the same group at once converge with no lost update', async () => {
+            const table = new InMemoryGroupTable()
+            table.seed({
+                id: 1,
+                team_id: teamId,
+                group_type_index: groupTypeIndex,
+                group_key: groupKey,
+                group_properties: { name: 'Acme' },
+                created_at: t1,
+                version: 1,
+                properties_last_updated_at: {},
+                properties_last_operation: {},
+            })
+            const workerA = newStore(table, options)
+            const workerB = newStore(table, options)
+
+            // Both workers read version 1 into their caches before either writes.
+            await workerA.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { plan: 'enterprise' }, t2)
+            await workerB.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { seats: 40 }, t2)
+
+            await Promise.all([workerA.flush(), workerB.flush()])
+
+            const row = table.get(teamId, groupTypeIndex, groupKey)
+            expect(row?.group_properties).toEqual(mergedProperties)
+            expect(row?.version).toBe(3)
+            if (options.useBatchUpdates === false) {
+                // On this path the version compare-and-swap, not arrival order, resolved the interleaving.
+                expect(table.optimisticConflicts).toBeGreaterThan(0)
+            }
         })
-        const workerA = newStore(table)
-        const workerB = newStore(table)
 
-        // Both workers read version 1 into their caches before either writes.
-        await workerA.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { plan: 'enterprise' }, t2)
-        await workerB.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { seats: 40 }, t2)
+        it('two workers racing to create the same group both end up in the row', async () => {
+            const table = new InMemoryGroupTable()
+            const workerA = newStore(table, options)
+            const workerB = newStore(table, options)
 
-        await Promise.all([workerA.flush(), workerB.flush()])
+            await Promise.all([
+                workerA.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { plan: 'enterprise' }, t2),
+                workerB.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { seats: 40 }, t1),
+            ])
+            await Promise.all([workerA.flush(), workerB.flush()])
 
-        const row = table.get(teamId, groupTypeIndex, groupKey)
-        expect(row?.group_properties).toEqual({ name: 'Acme', plan: 'enterprise', seats: 40 })
-        expect(row?.version).toBe(3)
-        // The version compare-and-swap, not arrival order, is what resolved the interleaving.
-        expect(table.optimisticConflicts).toBeGreaterThan(0)
-    })
-
-    it('two workers racing to create the same group both end up in the row', async () => {
-        const table = new InMemoryGroupTable()
-        const workerA = newStore(table)
-        const workerB = newStore(table)
-
-        await Promise.all([
-            workerA.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { plan: 'enterprise' }, t2),
-            workerB.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { seats: 40 }, t1),
-        ])
-        await Promise.all([workerA.flush(), workerB.flush()])
-
-        const row = table.get(teamId, groupTypeIndex, groupKey)
-        expect(row?.group_properties).toEqual({ plan: 'enterprise', seats: 40 })
+            const row = table.get(teamId, groupTypeIndex, groupKey)
+            expect(row?.group_properties).toEqual({ plan: 'enterprise', seats: 40 })
+        })
     })
 })

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.ordering.test.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.ordering.test.ts
@@ -1,0 +1,258 @@
+// sort-imports-ignore
+import { DateTime } from 'luxon'
+
+import { Properties } from '~/plugin-scaffold'
+import { Group, GroupTypeIndex, ProjectId, TeamId } from '~/types'
+import { RaceConditionError } from '~/common/utils/utils'
+
+import { BatchWritingGroupStore } from './batch-writing-group-store'
+import { ClickhouseGroupRepository } from '~/common/groups/repositories/clickhouse-group-repository'
+import { GroupRepository } from '~/common/groups/repositories/group-repository.interface'
+
+jest.mock('~/ingestion/common/ingestion-warnings', () => ({
+    emitIngestionWarning: jest.fn().mockResolvedValue(undefined),
+}))
+
+import { GroupsOutput, IngestionWarningsOutput } from '~/common/outputs'
+import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
+
+/**
+ * In-memory stand-in for the posthog_group table with the same concurrency semantics as
+ * PostgresGroupRepository: insertGroup throws RaceConditionError on a duplicate row,
+ * updateGroup bumps version unconditionally, updateGroupOptimistically is a compare-and-swap
+ * on version. Each method body has no await, so every operation is atomic — the same
+ * guarantee a single SQL statement gives. One table can be shared between several stores
+ * to model several ingestion workers writing the same rows.
+ */
+class InMemoryGroupTable {
+    private rows = new Map<string, Group>()
+    optimisticConflicts = 0
+
+    private key(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): string {
+        return `${teamId}:${groupTypeIndex}:${groupKey}`
+    }
+
+    get(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): Group | undefined {
+        const row = this.rows.get(this.key(teamId, groupTypeIndex, groupKey))
+        return row ? { ...row, group_properties: { ...row.group_properties } } : undefined
+    }
+
+    seed(group: Group): void {
+        this.rows.set(this.key(group.team_id, group.group_type_index, group.group_key), group)
+    }
+
+    asRepository(): GroupRepository {
+        const repository = {
+            fetchGroup: (teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string) =>
+                Promise.resolve(this.get(teamId, groupTypeIndex, groupKey)),
+            fetchGroupsByKeys: () => Promise.resolve([]),
+            insertGroup: (
+                teamId: TeamId,
+                groupTypeIndex: GroupTypeIndex,
+                groupKey: string,
+                groupProperties: Properties,
+                createdAt: DateTime
+            ) => {
+                const key = this.key(teamId, groupTypeIndex, groupKey)
+                if (this.rows.has(key)) {
+                    return Promise.reject(new RaceConditionError('Parallel posthog_group inserts, retry'))
+                }
+                this.rows.set(key, {
+                    id: this.rows.size + 1,
+                    team_id: teamId,
+                    group_type_index: groupTypeIndex,
+                    group_key: groupKey,
+                    group_properties: { ...groupProperties },
+                    created_at: createdAt,
+                    version: 1,
+                    properties_last_updated_at: {},
+                    properties_last_operation: {},
+                })
+                return Promise.resolve(1)
+            },
+            updateGroup: (
+                teamId: TeamId,
+                groupTypeIndex: GroupTypeIndex,
+                groupKey: string,
+                groupProperties: Properties,
+                createdAt: DateTime
+            ) => {
+                const row = this.rows.get(this.key(teamId, groupTypeIndex, groupKey))
+                if (!row) {
+                    return Promise.resolve(undefined)
+                }
+                row.version += 1
+                row.group_properties = { ...groupProperties }
+                row.created_at = createdAt
+                return Promise.resolve(row.version)
+            },
+            updateGroupOptimistically: (
+                teamId: TeamId,
+                groupTypeIndex: GroupTypeIndex,
+                groupKey: string,
+                expectedVersion: number,
+                groupProperties: Properties,
+                createdAt: DateTime
+            ) => {
+                const row = this.rows.get(this.key(teamId, groupTypeIndex, groupKey))
+                if (!row || row.version !== expectedVersion) {
+                    this.optimisticConflicts += 1
+                    return Promise.resolve(undefined)
+                }
+                row.version += 1
+                row.group_properties = { ...groupProperties }
+                row.created_at = createdAt
+                return Promise.resolve(row.version)
+            },
+            fetchGroupTypesByProjectIds: () => Promise.resolve({}),
+            fetchGroupTypesByTeamIds: () => Promise.resolve({}),
+            insertGroupType: () => Promise.resolve([null, false]),
+            inTransaction: (_description: string, transaction: (tx: any) => Promise<any>) => transaction(repository),
+        }
+        return repository as unknown as GroupRepository
+    }
+}
+
+describe('BatchWritingGroupStore ordering', () => {
+    const teamId: TeamId = 1
+    const projectId = 1 as ProjectId
+    const groupTypeIndex: GroupTypeIndex = 0
+    const groupKey = 'acme'
+
+    const t1 = DateTime.fromISO('2026-01-01T10:00:00.000Z', { zone: 'utc' })
+    const t2 = DateTime.fromISO('2026-01-01T11:00:00.000Z', { zone: 'utc' })
+    const t3 = DateTime.fromISO('2026-01-01T12:00:00.000Z', { zone: 'utc' })
+
+    type GroupIdentify = { distinctId: string; properties: Properties; timestamp: DateTime }
+
+    // Three users identify the same company from three distinct_ids. Because the pipeline only
+    // serializes per token:distinct_id, these can be processed in any order and in parallel.
+    const events: GroupIdentify[] = [
+        { distinctId: 'alice', properties: { plan: 'enterprise' }, timestamp: t2 },
+        { distinctId: 'bob', properties: { seats: 40 }, timestamp: t1 },
+        { distinctId: 'carol', properties: { name: 'Acme' }, timestamp: t3 },
+    ]
+
+    const stores: BatchWritingGroupStore[] = []
+
+    function newStore(table: InMemoryGroupTable): BatchWritingGroupStore {
+        const clickhouse = {
+            upsertGroup: jest.fn().mockResolvedValue(undefined),
+        } as unknown as ClickhouseGroupRepository
+        const outputs = {} as unknown as IngestionOutputs<GroupsOutput | IngestionWarningsOutput>
+        const store = new BatchWritingGroupStore(outputs, table.asRepository(), clickhouse, {
+            optimisticUpdateRetryInterval: 1,
+            metricEmissionIntervalMs: 0,
+        })
+        stores.push(store)
+        return store
+    }
+
+    afterEach(async () => {
+        for (const store of stores.splice(0)) {
+            await store.flush()
+            await store.shutdown()
+        }
+    })
+
+    async function processInOrder(
+        ordered: GroupIdentify[],
+        flushAfterEach: boolean
+    ): Promise<{ row: Group | undefined; table: InMemoryGroupTable }> {
+        const table = new InMemoryGroupTable()
+        const store = newStore(table)
+        for (const [batchId, event] of ordered.entries()) {
+            await store.upsertGroup(
+                teamId,
+                projectId,
+                groupTypeIndex,
+                groupKey,
+                event.properties,
+                event.timestamp,
+                flushAfterEach ? batchId : 0
+            )
+            if (flushAfterEach) {
+                await store.flush()
+            }
+        }
+        await store.flush()
+        return { row: table.get(teamId, groupTypeIndex, groupKey), table }
+    }
+
+    describe.each([
+        ['all in one batch', false],
+        ['one batch per event', true],
+    ])('%s', (_label, flushAfterEach) => {
+        it('reaches the same group properties whichever order the events are processed in', async () => {
+            const forward = await processInOrder(events, flushAfterEach)
+            const reversed = await processInOrder([...events].reverse(), flushAfterEach)
+            const rotated = await processInOrder([events[1], events[2], events[0]], flushAfterEach)
+
+            const expected = { plan: 'enterprise', seats: 40, name: 'Acme' }
+            expect(forward.row?.group_properties).toEqual(expected)
+            expect(reversed.row?.group_properties).toEqual(expected)
+            expect(rotated.row?.group_properties).toEqual(expected)
+            expect(reversed.row?.version).toEqual(forward.row?.version)
+        })
+
+        // The store computes created_at = min(existing, event timestamp) when it creates a row
+        // or takes the transactional path, but the batched merge path keeps the cached created_at
+        // and never looks at the incoming timestamp (addToBatch), and the CAS-conflict refetch
+        // does not min either. So created_at depends on which event happened to arrive first.
+        // Marked failing to document the gap; passing it needs DateTime.min in both places.
+        it.failing(
+            'keeps created_at as the earliest event timestamp whichever order the events arrive in',
+            async () => {
+                const forward = await processInOrder(events, flushAfterEach)
+                const reversed = await processInOrder([...events].reverse(), flushAfterEach)
+
+                expect(forward.row?.created_at.toISO()).toBe(t1.toISO())
+                expect(reversed.row?.created_at.toISO()).toBe(t1.toISO())
+            }
+        )
+    })
+
+    it('two workers flushing the same group at once converge with no lost update', async () => {
+        const table = new InMemoryGroupTable()
+        table.seed({
+            id: 1,
+            team_id: teamId,
+            group_type_index: groupTypeIndex,
+            group_key: groupKey,
+            group_properties: { name: 'Acme' },
+            created_at: t1,
+            version: 1,
+            properties_last_updated_at: {},
+            properties_last_operation: {},
+        })
+        const workerA = newStore(table)
+        const workerB = newStore(table)
+
+        // Both workers read version 1 into their caches before either writes.
+        await workerA.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { plan: 'enterprise' }, t2)
+        await workerB.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { seats: 40 }, t2)
+
+        await Promise.all([workerA.flush(), workerB.flush()])
+
+        const row = table.get(teamId, groupTypeIndex, groupKey)
+        expect(row?.group_properties).toEqual({ name: 'Acme', plan: 'enterprise', seats: 40 })
+        expect(row?.version).toBe(3)
+        // The version compare-and-swap, not arrival order, is what resolved the interleaving.
+        expect(table.optimisticConflicts).toBeGreaterThan(0)
+    })
+
+    it('two workers racing to create the same group both end up in the row', async () => {
+        const table = new InMemoryGroupTable()
+        const workerA = newStore(table)
+        const workerB = newStore(table)
+
+        await Promise.all([
+            workerA.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { plan: 'enterprise' }, t2),
+            workerB.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { seats: 40 }, t1),
+        ])
+        await Promise.all([workerA.flush(), workerB.flush()])
+
+        const row = table.get(teamId, groupTypeIndex, groupKey)
+        expect(row?.group_properties).toEqual({ plan: 'enterprise', seats: 40 })
+    })
+})

--- a/nodejs/src/ingestion/common/groups/batch-writing-group-store.ordering.test.ts
+++ b/nodejs/src/ingestion/common/groups/batch-writing-group-store.ordering.test.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 
 import { Properties } from '~/plugin-scaffold'
 import { Group, GroupTypeIndex, ProjectId, TeamId } from '~/types'
+import { parseJSON } from '~/common/utils/json-parse'
 import { RaceConditionError } from '~/common/utils/utils'
 
 import { BatchWritingGroupStore, BatchWritingGroupStoreOptions } from './batch-writing-group-store'
@@ -16,18 +17,96 @@ import {
 import { GroupsOutput } from '~/common/outputs'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 
+type PendingOperation = { label: string; run: () => void }
+
+/**
+ * Decides when each database call the store makes is allowed to complete. In immediate mode
+ * every call completes as soon as it is made. In driven mode calls queue up and `drive` releases
+ * them one at a time, in an order chosen by `pick`, so a test can force a specific interleaving
+ * between workers or fuzz over many. Every call body is synchronous, so a call is atomic — the
+ * same guarantee a single SQL statement gives.
+ */
+class Scheduler {
+    private pending: PendingOperation[] = []
+    private driving = false
+
+    constructor(private pick: (labels: string[]) => number = () => 0) {}
+
+    gate<T>(label: string, operation: () => T): Promise<T> {
+        if (!this.driving) {
+            try {
+                return Promise.resolve(operation())
+            } catch (error) {
+                return Promise.reject(error)
+            }
+        }
+        return new Promise<T>((resolve, reject) => {
+            this.pending.push({
+                label,
+                run: () => {
+                    try {
+                        resolve(operation())
+                    } catch (error) {
+                        reject(error)
+                    }
+                },
+            })
+        })
+    }
+
+    async drive<T>(work: () => Promise<T>): Promise<T> {
+        this.driving = true
+        let settled = false
+        const result = work().finally(() => {
+            settled = true
+        })
+        result.catch(() => undefined)
+        try {
+            while (!settled) {
+                await new Promise((resolve) => setImmediate(resolve))
+                if (this.pending.length === 0) {
+                    continue
+                }
+                const index = this.pick(this.pending.map((op) => op.label)) % this.pending.length
+                const [operation] = this.pending.splice(index, 1)
+                operation.run()
+            }
+        } finally {
+            this.driving = false
+        }
+        return result
+    }
+}
+
+function seededRandom(seed: number): () => number {
+    let state = seed >>> 0
+    return () => {
+        state = (state + 0x6d2b79f5) >>> 0
+        let t = state
+        t = Math.imul(t ^ (t >>> 15), t | 1)
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+}
+
 /**
  * In-memory stand-in for the posthog_group table with the same write semantics as
  * PostgresGroupRepository: insertGroup throws RaceConditionError on a duplicate row,
- * updateGroupOptimistically is a compare-and-swap on version, and the batch statements
- * merge properties and take the earliest created_at server-side. Each method body has no
- * await, so every operation is atomic — the same guarantee a single SQL statement gives.
- * One table can be shared between several stores to model several ingestion workers
- * writing the same rows.
+ * updateGroupOptimistically is a compare-and-swap on version, and the batch statements merge
+ * properties and take the earliest created_at server-side. One table is shared between several
+ * stores to model several ingestion workers writing the same rows; `asRepository(worker)` labels
+ * that worker's calls for the scheduler.
  */
 class InMemoryGroupTable {
     private rows = new Map<string, Group>()
     optimisticConflicts = 0
+    createRaces = 0
+
+    constructor(private scheduler: Scheduler = new Scheduler()) {}
+
+    get contentionEvents(): number {
+        return this.optimisticConflicts + this.createRaces
+    }
 
     private key(teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string): string {
         return `${teamId}:${groupTypeIndex}:${groupKey}`
@@ -75,10 +154,13 @@ class InMemoryGroupTable {
         return row
     }
 
-    asRepository(): GroupRepository {
+    asRepository(worker: string = 'db'): GroupRepository {
+        const gate = <T>(operation: string, body: () => T): Promise<T> =>
+            this.scheduler.gate(`${worker}:${operation}`, body)
+
         const repository = {
             fetchGroup: (teamId: TeamId, groupTypeIndex: GroupTypeIndex, groupKey: string) =>
-                Promise.resolve(this.get(teamId, groupTypeIndex, groupKey)),
+                gate('fetchGroup', () => this.get(teamId, groupTypeIndex, groupKey)),
             fetchGroupsByKeys: () => Promise.resolve([]),
             insertGroup: (
                 teamId: TeamId,
@@ -86,19 +168,20 @@ class InMemoryGroupTable {
                 groupKey: string,
                 groupProperties: Properties,
                 createdAt: DateTime
-            ) => {
-                if (this.rows.has(this.key(teamId, groupTypeIndex, groupKey))) {
-                    return Promise.reject(new RaceConditionError('Parallel posthog_group inserts, retry'))
-                }
-                return Promise.resolve(
-                    this.insert(teamId, groupTypeIndex, groupKey, groupProperties, createdAt).version
-                )
-            },
+            ) =>
+                gate('insertGroup', () => {
+                    if (this.rows.has(this.key(teamId, groupTypeIndex, groupKey))) {
+                        this.createRaces += 1
+                        throw new RaceConditionError('Parallel posthog_group inserts, retry')
+                    }
+                    return this.insert(teamId, groupTypeIndex, groupKey, groupProperties, createdAt).version
+                }),
             insertGroupsBatch: (creates: GroupCreate[]) =>
-                Promise.resolve(
+                gate('insertGroupsBatch', () =>
                     creates.map((create): GroupCreateResult => {
                         const existing = this.rows.get(this.key(create.teamId, create.groupTypeIndex, create.groupKey))
                         if (existing) {
+                            this.createRaces += 1
                             return {
                                 ...this.clone(this.merge(existing, create.groupProperties, create.createdAt)),
                                 inserted: false,
@@ -120,18 +203,19 @@ class InMemoryGroupTable {
                 groupKey: string,
                 groupProperties: Properties,
                 createdAt: DateTime
-            ) => {
-                const row = this.rows.get(this.key(teamId, groupTypeIndex, groupKey))
-                if (!row) {
-                    return Promise.resolve(undefined)
-                }
-                row.group_properties = { ...groupProperties }
-                row.created_at = createdAt
-                row.version += 1
-                return Promise.resolve(row.version)
-            },
+            ) =>
+                gate('updateGroup', () => {
+                    const row = this.rows.get(this.key(teamId, groupTypeIndex, groupKey))
+                    if (!row) {
+                        return undefined
+                    }
+                    row.group_properties = { ...groupProperties }
+                    row.created_at = createdAt
+                    row.version += 1
+                    return row.version
+                }),
             updateGroupsBatch: (updates: GroupPropertiesToSetUpdate[]) =>
-                Promise.resolve(
+                gate('updateGroupsBatch', () =>
                     updates.flatMap((update) => {
                         const row = this.rows.get(this.key(update.teamId, update.groupTypeIndex, update.groupKey))
                         return row ? [this.clone(this.merge(row, update.propertiesToSet, update.createdAt))] : []
@@ -144,17 +228,18 @@ class InMemoryGroupTable {
                 expectedVersion: number,
                 groupProperties: Properties,
                 createdAt: DateTime
-            ) => {
-                const row = this.rows.get(this.key(teamId, groupTypeIndex, groupKey))
-                if (!row || row.version !== expectedVersion) {
-                    this.optimisticConflicts += 1
-                    return Promise.resolve(undefined)
-                }
-                row.group_properties = { ...groupProperties }
-                row.created_at = createdAt
-                row.version += 1
-                return Promise.resolve(row.version)
-            },
+            ) =>
+                gate('updateGroupOptimistically', () => {
+                    const row = this.rows.get(this.key(teamId, groupTypeIndex, groupKey))
+                    if (!row || row.version !== expectedVersion) {
+                        this.optimisticConflicts += 1
+                        return undefined
+                    }
+                    row.group_properties = { ...groupProperties }
+                    row.created_at = createdAt
+                    row.version += 1
+                    return row.version
+                }),
             fetchGroupTypesByProjectIds: () => Promise.resolve({}),
             fetchGroupTypesByTeamIds: () => Promise.resolve({}),
             insertGroupType: () => Promise.resolve([null, false]),
@@ -162,6 +247,17 @@ class InMemoryGroupTable {
         }
         return repository as unknown as GroupRepository
     }
+}
+
+type EmittedGroupRow = { version: number; group_properties: Properties }
+
+function emittedRows(flushResults: Awaited<ReturnType<BatchWritingGroupStore['flush']>>): EmittedGroupRow[] {
+    return flushResults.flatMap((result) =>
+        result.messages.map((message) => {
+            const parsed = parseJSON(message.value.toString())
+            return { version: parsed.version, group_properties: parseJSON(parsed.group_properties) }
+        })
+    )
 }
 
 describe('BatchWritingGroupStore ordering', () => {
@@ -189,12 +285,13 @@ describe('BatchWritingGroupStore ordering', () => {
 
     function newStore(
         table: InMemoryGroupTable,
-        options: Partial<BatchWritingGroupStoreOptions>
+        options: Partial<BatchWritingGroupStoreOptions>,
+        worker: string = 'db'
     ): BatchWritingGroupStore {
         const clickhouse = new ClickhouseGroupRepository({
             queueMessages: jest.fn().mockResolvedValue(undefined),
         } as unknown as IngestionOutputs<GroupsOutput>)
-        const store = new BatchWritingGroupStore(table.asRepository(), clickhouse, {
+        const store = new BatchWritingGroupStore(table.asRepository(worker), clickhouse, {
             optimisticUpdateRetryInterval: 1,
             metricEmissionIntervalMs: 0,
             ...options,
@@ -209,6 +306,20 @@ describe('BatchWritingGroupStore ordering', () => {
             await store.shutdown()
         }
     })
+
+    function seededRow(properties: Properties): Group {
+        return {
+            id: 1,
+            team_id: teamId,
+            group_type_index: groupTypeIndex,
+            group_key: groupKey,
+            group_properties: properties,
+            created_at: t1,
+            version: 1,
+            properties_last_updated_at: {},
+            properties_last_operation: {},
+        }
+    }
 
     async function processInOrder(
         ordered: GroupIdentify[],
@@ -276,17 +387,7 @@ describe('BatchWritingGroupStore ordering', () => {
 
         it('two workers flushing the same group at once converge with no lost update', async () => {
             const table = new InMemoryGroupTable()
-            table.seed({
-                id: 1,
-                team_id: teamId,
-                group_type_index: groupTypeIndex,
-                group_key: groupKey,
-                group_properties: { name: 'Acme' },
-                created_at: t1,
-                version: 1,
-                properties_last_updated_at: {},
-                properties_last_operation: {},
-            })
+            table.seed(seededRow({ name: 'Acme' }))
             const workerA = newStore(table, options)
             const workerB = newStore(table, options)
 
@@ -319,5 +420,113 @@ describe('BatchWritingGroupStore ordering', () => {
             const row = table.get(teamId, groupTypeIndex, groupKey)
             expect(row?.group_properties).toEqual({ plan: 'enterprise', seats: 40 })
         })
+
+        // Adversarial schedules. Three workers each process three $groupidentify events for the
+        // same group, spread across two batches, flushing at random points, while the scheduler
+        // releases their database calls in a seeded random order. Whatever the interleaving, the
+        // row must end with every key, no worker may be left holding an unflushed delta, and the
+        // highest-version row emitted for ClickHouse must be the final Postgres state.
+        it('converges to the union of all writes under 150 fuzzed interleavings of three workers', async () => {
+            const workers = ['A', 'B', 'C']
+            const eventsPerWorker = 3
+            const expected: Properties = {}
+            for (const worker of workers) {
+                for (let i = 0; i < eventsPerWorker; i++) {
+                    expected[`${worker}${i}`] = `${worker}-${i}`
+                }
+            }
+
+            let contendedRuns = 0
+            for (let seed = 1; seed <= 150; seed++) {
+                const random = seededRandom(seed)
+                const scheduler = new Scheduler((labels) => Math.floor(random() * labels.length))
+                const table = new InMemoryGroupTable(scheduler)
+                const workerStores = workers.map((worker) => newStore(table, options, worker))
+                const flushResults: Awaited<ReturnType<BatchWritingGroupStore['flush']>> = []
+
+                try {
+                    await scheduler.drive(() =>
+                        Promise.all(
+                            workerStores.map(async (store, w) => {
+                                for (let i = 0; i < eventsPerWorker; i++) {
+                                    const worker = workers[w]
+                                    await store.upsertGroup(
+                                        teamId,
+                                        projectId,
+                                        groupTypeIndex,
+                                        groupKey,
+                                        { [`${worker}${i}`]: `${worker}-${i}` },
+                                        t2,
+                                        random() < 0.5 ? 0 : 1
+                                    )
+                                    if (random() < 0.3) {
+                                        flushResults.push(...(await store.flush()))
+                                    }
+                                }
+                                flushResults.push(...(await store.flush()))
+                                flushResults.push(...(await store.flush()))
+                            })
+                        )
+                    )
+
+                    const row = table.get(teamId, groupTypeIndex, groupKey)
+                    expect(row?.group_properties).toEqual(expected)
+
+                    const newest = emittedRows(flushResults).reduce((best, candidate) =>
+                        candidate.version > best.version ? candidate : best
+                    )
+                    expect(newest.version).toBe(row?.version)
+                    expect(newest.group_properties).toEqual(expected)
+
+                    for (const store of workerStores) {
+                        // Throws if a delta is still dirty, which would mean a flush lost a write.
+                        await store.shutdown()
+                    }
+                    stores.splice(0)
+                    if (table.contentionEvents > 0) {
+                        contendedRuns += 1
+                    }
+                } catch (error) {
+                    throw new Error(`seed ${seed}: ${error instanceof Error ? error.message : String(error)}`)
+                }
+            }
+            // Convergence on uncontended schedules proves nothing. Most seeds must have made
+            // workers collide on a create or a version check.
+            expect(contendedRuns).toBeGreaterThan(75)
+        })
+
+        // The one thing order does decide: two writers setting the same key to different
+        // values. The winner is whichever database call the scheduler releases last, and both
+        // outcomes are reachable. Today these two writers are two distinct_ids on two workers,
+        // so the per-distinct_id lane does not order them either.
+        it.each([
+            ['A', 'pro'],
+            ['B', 'free'],
+        ])(
+            'lets the last writer win on a shared key: releasing worker %s first leaves plan=%s',
+            async (first, winner) => {
+                const scheduler = new Scheduler((labels) => {
+                    const preferred = labels.findIndex((label) => label.startsWith(`${first}:`))
+                    return preferred === -1 ? 0 : preferred
+                })
+                const table = new InMemoryGroupTable(scheduler)
+                table.seed(seededRow({ name: 'Acme' }))
+                const workerA = newStore(table, options, 'A')
+                const workerB = newStore(table, options, 'B')
+
+                await scheduler.drive(async () => {
+                    await Promise.all([
+                        workerA.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { plan: 'free' }, t2),
+                        workerB.upsertGroup(teamId, projectId, groupTypeIndex, groupKey, { plan: 'pro' }, t2),
+                    ])
+                    await Promise.all([workerA.flush(), workerB.flush()])
+                })
+
+                expect(table.get(teamId, groupTypeIndex, groupKey)?.group_properties).toEqual({
+                    name: 'Acme',
+                    plan: winner,
+                })
+            }
+        )
     })
 })

--- a/nodejs/src/ingestion/common/groups/group-update.test.ts
+++ b/nodejs/src/ingestion/common/groups/group-update.test.ts
@@ -1,0 +1,56 @@
+import { Properties } from '~/plugin-scaffold'
+
+import { calculateUpdate } from './group-update'
+
+function permutations<T>(items: T[]): T[][] {
+    if (items.length <= 1) {
+        return [items]
+    }
+    return items.flatMap((item, i) =>
+        permutations([...items.slice(0, i), ...items.slice(i + 1)]).map((rest) => [item, ...rest])
+    )
+}
+
+function applyInOrder(updates: Properties[]): Properties {
+    return updates.reduce<Properties>((current, update) => calculateUpdate(current, update).properties, {})
+}
+
+describe('calculateUpdate', () => {
+    // Group property merging is the only piece of group ingestion that can observe event order.
+    // These tests pin down exactly how much order matters: none for distinct keys, last-write-wins
+    // for the same key. Nothing here depends on timestamps — see the comment in calculateUpdate.
+    describe('ordering', () => {
+        it('produces the same properties in every order when updates touch different keys', () => {
+            const updates: Properties[] = [{ name: 'Acme' }, { plan: 'enterprise' }, { seats: 40 }]
+
+            const results = permutations(updates).map(applyInOrder)
+
+            expect(results).toHaveLength(6)
+            for (const result of results) {
+                expect(result).toEqual({ name: 'Acme', plan: 'enterprise', seats: 40 })
+            }
+        })
+
+        it('is last-write-wins for the same key, and this is the only order-dependent behaviour', () => {
+            expect(applyInOrder([{ plan: 'free' }, { plan: 'enterprise' }])).toEqual({ plan: 'enterprise' })
+            expect(applyInOrder([{ plan: 'enterprise' }, { plan: 'free' }])).toEqual({ plan: 'free' })
+        })
+
+        it('never removes a key, so a partial update cannot undo an earlier one', () => {
+            expect(applyInOrder([{ name: 'Acme', plan: 'free' }, { plan: 'enterprise' }])).toEqual({
+                name: 'Acme',
+                plan: 'enterprise',
+            })
+            expect(applyInOrder([{ name: 'Acme', plan: 'free' }, {}])).toEqual({ name: 'Acme', plan: 'free' })
+        })
+
+        it('is idempotent: replaying an update reports no change', () => {
+            const first = calculateUpdate({}, { name: 'Acme' })
+            const replay = calculateUpdate(first.properties, { name: 'Acme' })
+
+            expect(first.updated).toBe(true)
+            expect(replay.updated).toBe(false)
+            expect(replay.properties).toEqual(first.properties)
+        })
+    })
+})

--- a/nodejs/src/ingestion/common/groups/group-update.test.ts
+++ b/nodejs/src/ingestion/common/groups/group-update.test.ts
@@ -16,9 +16,8 @@ function applyInOrder(updates: Properties[]): Properties {
 }
 
 describe('calculateUpdate', () => {
-    // Group property merging is the only piece of group ingestion that can observe event order.
-    // These tests pin down exactly how much order matters: none for distinct keys, last-write-wins
-    // for the same key. Nothing here depends on timestamps — see the comment in calculateUpdate.
+    // Property merging is the only piece of group ingestion that can observe event order.
+    // These pin down how much: none for distinct keys, last-write-wins for the same key.
     describe('ordering', () => {
         it('produces the same properties in every order when updates touch different keys', () => {
             const updates: Properties[] = [{ name: 'Acme' }, { plan: 'enterprise' }, { seats: 40 }]
@@ -31,26 +30,9 @@ describe('calculateUpdate', () => {
             }
         })
 
-        it('is last-write-wins for the same key, and this is the only order-dependent behaviour', () => {
+        it('is last-write-wins for the same key, and this is the only order-dependent behavior', () => {
             expect(applyInOrder([{ plan: 'free' }, { plan: 'enterprise' }])).toEqual({ plan: 'enterprise' })
             expect(applyInOrder([{ plan: 'enterprise' }, { plan: 'free' }])).toEqual({ plan: 'free' })
-        })
-
-        it('never removes a key, so a partial update cannot undo an earlier one', () => {
-            expect(applyInOrder([{ name: 'Acme', plan: 'free' }, { plan: 'enterprise' }])).toEqual({
-                name: 'Acme',
-                plan: 'enterprise',
-            })
-            expect(applyInOrder([{ name: 'Acme', plan: 'free' }, {}])).toEqual({ name: 'Acme', plan: 'free' })
-        })
-
-        it('is idempotent: replaying an update reports no change', () => {
-            const first = calculateUpdate({}, { name: 'Acme' })
-            const replay = calculateUpdate(first.properties, { name: 'Acme' })
-
-            expect(first.updated).toBe(true)
-            expect(replay.updated).toBe(false)
-            expect(replay.properties).toEqual(first.properties)
         })
     })
 })


### PR DESCRIPTION
## Problem

Group analytics is gated on person processing, and the stated reason is often that groups need the per-distinct_id ordering the identified path gives them. Nobody could point at a test that says whether that is true. This PR adds the tests so we can argue from them instead of from memory, and it tries hard to make them fail.

The ordering question matters because the pipeline only serializes per `token:distinct_id`. Three users identifying the same company from three devices already arrive in arbitrary order and on different workers today.

## Changes

- `calculateUpdate` is shown to be commutative for distinct keys and last-write-wins for the same key, with no timestamp comparison. That is the whole extent of order sensitivity in the merge.
- `BatchWritingGroupStore` reaches the same row whichever order the `$groupidentify` events for a group are processed in, in one batch or one batch per event.
- Every database call the store makes is gated behind a scheduler, so a test decides when each call completes. Three workers process three events each for the same group across two batches with random flush points, under 150 seeded schedules per write path. Each run must end with every key in the row, no worker holding an unflushed delta, and the highest-version row emitted for ClickHouse equal to the final Postgres state. A run only counts if the schedule actually collided (a create race or a version conflict), and more than half must.
- Two deterministic schedules show the one thing order does decide: two writers setting the same key to different values, where releasing either worker first makes the other win. Today those two writers are two distinct_ids on two workers, so the per-distinct_id lane does not order them either.
- `GroupTypeManager` allocation is arrival-ordered. The same five types get different `$group_N` columns in a different order, and when a sixth type arrives, which one is dropped depends on order. Documented as existing behavior, not changed.
- All store cases run across the three write paths: batched server-side merge (default), individual optimistic CAS, and batched creates.
- The store tests use an in-memory `posthog_group` table with the repository's write semantics (duplicate insert raises `RaceConditionError`, CAS on `version`, `||` merge and `LEAST(created_at)` in the batch statements). The existing store tests use fixed-return mocks, which cannot express interleavings.

> [!NOTE]
> Three cases are marked `it.failing` on purpose. `created_at` is only taken as `min(now, event timestamp)` when a row is created. When the group is already cached, `addToBatch` keeps the cached `created_at` and ignores the incoming timestamp, so the `LEAST()` in the batch statements never sees an earlier event. The row keeps whichever event happened to create it. This is the one place group *row* state depends on arrival order. I left it documented rather than fixed so reviewers can decide whether it is worth a production change. There is no `it.failing` precedent in `nodejs/`, so shout if you would rather see this as a plain comment or a separate issue.

> [!NOTE]
> Not tested here, but worth knowing when reading the results: the ClickHouse `groups` table collapses on Kafka `_timestamp`, the produce to `clickhouse_groups` is unkeyed, and the `version` in the message is dropped by the materialized view. The fuzz test shows the highest-version emitted row is always right, which is what a version-keyed collapse would need. The current timestamp-keyed collapse is order-dependent on the Kafka side regardless of which ingestion lane events take.

## How did you test this code?

Ran the three new files with Jest locally. 28 cases, 25 pass, 3 fail as declared by `it.failing`. The fuzz cases run 150 schedules each and finish in well under a second per write path.

Not run: the Postgres-backed integration suites. The in-memory table mirrors the SQL in `postgres-group-repository.ts` by reading it, not by executing it, so a divergence between the two would not show up here. A follow-up could run the same schedules against `PostgresGroupRepository` in the integration file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) wrote the tests while I directed an architecture review of group analytics ingestion. The review found that group writes are designed to tolerate any interleaving (version CAS, server-side merge, unkeyed ClickHouse produce) and that the only order-sensitive behavior is last-write-wins on a property value. I then asked for the tests to be red-teamed rather than to pass on the happy schedule, which is where the scheduler, the seeded fuzzing, the contention threshold, and the group type allocation cases came from.

Decisions along the way. The tests were first written against a June checkout and reworked for master's batched merge and batched create paths, which is why they run across a `describe.each` of write paths. Two `calculateUpdate` cases (idempotence, keys never removed) were dropped as already covered. The `created_at` gap was found by writing the test, not by reading the code, and is left as `it.failing` rather than fixed. The ClickHouse collapse concern is stated in the description rather than tested because the store hands messages back to its caller and the hazard lives in the produce and the table engine.

Skills consulted from the repo: `writing-tests`, `writing-pr-descriptions`, `writing-code-comments`.
