### PR TITLE
chore: move conversations alerts away from the main channel

### DIFF
--- a/owners.yaml
+++ b/owners.yaml
@@ -16,6 +16,7 @@ teams:
         slack: '#team-clickhouse'
     conversations:
         slack: '#team-conversations'
+        notifications: '#support-conversations'
     mcp-analytics:
         slack: '#team-mcp-analytics'
     platform-ux:


### PR DESCRIPTION
move it from #team-conversations to #support-conversations