### PR TITLE
fix(messaging): rate-limit push subscription 401s from invalid tokens

### DIFF
--- a/products/messaging/backend/api/push_subscriptions.py
+++ b/products/messaging/backend/api/push_subscriptions.py
@@ -84,6 +84,14 @@ MAX_BODY_BYTES = 16 * 1024
 _encrypted_fields = EncryptedFieldMixin()
 
 
+# A misconfigured app ships its invalid token inside every install, and the SDK re-posts it on
+# every app open, so one bad build is a fleet-sized 401 storm that only self-resolves when the
+# burst drains. Allow a trickle of real 401s per token (visible while integrating, and enough to
+# attribute the burst) and answer the excess with a 429, which matches what the traffic actually
+# is: not an auth problem, one app sending too many requests.
+_INVALID_TOKEN_401_WINDOW_SECONDS = 60
+_INVALID_TOKEN_401_LIMIT = 10
+
 # Verification-mode precedence. An app_id can match more than one integration — config identifiers
 # (project_id / bundle_id) aren't covered by a uniqueness constraint — so mode resolution must fail
 # closed: take the strictest mode across every match so a lax duplicate can't downgrade a sibling's
@@ -192,6 +200,7 @@ def _rejection_response(
     detail: str | None = None,
     api_key_fingerprint: str | None = None,
     exc_info: bool = False,
+    log: bool = True,
 ) -> HttpResponse:
     # request.method is an arbitrary attacker-controlled token on the method_not_allowed path (any
     # HTTP verb reaches this view), so bound the counter label to the supported verbs to keep
@@ -202,20 +211,21 @@ def _rejection_response(
     # exc_info attaches the active exception's traceback for paths that swallow one (capture_failed),
     # so a 500 is diagnosable from this single labeled event rather than just the counter.
     sdk = _parse_user_agent_sdk(request)
-    logger.warning(
-        "push_subscription_rejected",
-        code=code,
-        status_code=status_code,
-        method=request.method,
-        team_id=team_id,
-        # app_id is client-supplied, so bound it to keep a hostile value from bloating the log line.
-        app_id=app_id[:128] if isinstance(app_id, str) else app_id,
-        detail=detail,
-        sdk_name=sdk.name,
-        sdk_version=sdk.version,
-        api_key_fingerprint=api_key_fingerprint,
-        exc_info=exc_info,
-    )
+    if log:
+        logger.warning(
+            "push_subscription_rejected",
+            code=code,
+            status_code=status_code,
+            method=request.method,
+            team_id=team_id,
+            # app_id is client-supplied, so bound it to keep a hostile value from bloating the log line.
+            app_id=app_id[:128] if isinstance(app_id, str) else app_id,
+            detail=detail,
+            sdk_name=sdk.name,
+            sdk_version=sdk.version,
+            api_key_fingerprint=api_key_fingerprint,
+            exc_info=exc_info,
+        )
     return cors_response(
         request,
         generate_exception_response(
@@ -226,6 +236,21 @@ def _rejection_response(
             status_code=status_code,
         ),
     )
+
+
+def _invalid_token_401_allowed(fingerprint: str) -> bool:
+    """Fixed-window budget for invalid-token 401s, keyed on the fingerprint. Key expiry bounds
+    the keyspace: keys only ever exist inside the window that created them. Fails closed: if
+    the cache is down every invalid token reads as over budget, which quiets the storm the
+    limit exists to prevent and changes nothing for a client that was already failing."""
+    window = int(time.time()) // _INVALID_TOKEN_401_WINDOW_SECONDS
+    key = f"push_subscriptions:invalid_token_401:{fingerprint}:{window}"
+    try:
+        if cache.add(key, 1, 2 * _INVALID_TOKEN_401_WINDOW_SECONDS):
+            return True
+        return cache.incr(key) <= _INVALID_TOKEN_401_LIMIT
+    except Exception:
+        return False
 
 
 @csrf_exempt
@@ -288,15 +313,26 @@ def push_subscriptions(request: Request):
 
     team = Team.objects.get_team_from_cache_or_token(api_key)
     if not team:
-        # Fingerprint the rejected token so a cohort of these can be traced to one bad app
-        # configuration, which is the usual cause of a burst of invalid-token rejections.
+        fingerprint = _api_key_fingerprint(api_key)
+        if _invalid_token_401_allowed(fingerprint):
+            # Fingerprint the rejected token so a cohort of these can be traced to one bad app
+            # configuration, which is the usual cause of a burst of invalid-token rejections.
+            return _rejection_response(
+                request,
+                "Invalid project token.",
+                error_type="authentication_error",
+                code="invalid_api_key",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                api_key_fingerprint=fingerprint,
+            )
         return _rejection_response(
             request,
-            "Invalid project token.",
-            error_type="authentication_error",
-            code="invalid_api_key",
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            api_key_fingerprint=_api_key_fingerprint(api_key),
+            "Too many requests.",
+            error_type="throttled",
+            code="rate_limited",
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            api_key_fingerprint=fingerprint,
+            log=False,
         )
 
     distinct_id = data.get("distinct_id")

--- a/products/messaging/backend/api/test/test_push_subscriptions.py
+++ b/products/messaging/backend/api/test/test_push_subscriptions.py
@@ -20,6 +20,7 @@ from posthog.models.team.team_caching import set_team_in_cache
 
 from products.messaging.backend.api.push_identity_tokens import sign_push_identity_token, sign_push_identity_token_es256
 from products.messaging.backend.api.push_subscriptions import (
+    _INVALID_TOKEN_401_LIMIT,
     PUSH_SUBSCRIPTION_DISCARD_COUNTER,
     PUSH_SUBSCRIPTION_REJECTION_COUNTER,
     _api_key_fingerprint,
@@ -254,13 +255,33 @@ class TestPushSubscriptionsAPI(BaseTest):
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_invalid_token_returns_401(self):
-        response = self._post(
-            {"distinct_id": "user-1", "device_token": "t", "platform": "android", "app_id": "proj"},
-            api_key="phc_invalid_token",
-        )
+    @parameterized.expand([("post",), ("delete",)])
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_invalid_token_401s_are_rate_limited(self, method: str, mock_capture: MagicMock):
+        request = self._post if method == "post" else self._delete
+        payload = {"distinct_id": "user-1", "device_token": "t", "platform": "android", "app_id": "proj"}
 
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        for _ in range(_INVALID_TOKEN_401_LIMIT):
+            response = request(payload, api_key="phc_invalid_token")
+            assert response.status_code == status.HTTP_401_UNAUTHORIZED
+            assert response.json()["code"] == "invalid_api_key"
+
+        response = request(payload, api_key="phc_invalid_token")
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert response.json()["code"] == "rate_limited"
+        mock_capture.assert_not_called()
+
+    @patch("products.messaging.backend.api.push_subscriptions.capture_internal")
+    def test_invalid_token_rate_limit_fails_closed_when_cache_unavailable(self, mock_capture: MagicMock):
+        with patch("products.messaging.backend.api.push_subscriptions.cache") as mock_cache:
+            mock_cache.add.side_effect = Exception("redis down")
+            response = self._post(
+                {"distinct_id": "user-1", "device_token": "t", "platform": "android", "app_id": "proj"},
+                api_key="phc_invalid_token",
+            )
+
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        mock_capture.assert_not_called()
 
     def test_missing_required_fields(self):
         response = self._post({"distinct_id": "user-1"})
@@ -615,6 +636,20 @@ class TestPushSubscriptionsAPI(BaseTest):
         assert entry["api_key_fingerprint"] and entry["api_key_fingerprint"] != bad_token
         # The raw token is a credential, so it must never reach the log, in any field.
         assert bad_token not in json.dumps(entry)
+
+    def test_rate_limited_rejection_increments_the_counter_without_logging(self):
+        counter = PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code="rate_limited", method="POST")
+        before = counter._value.get()
+        payload = {"distinct_id": "user-1", "device_token": "t", "platform": "android", "app_id": "proj"}
+        for _ in range(_INVALID_TOKEN_401_LIMIT):
+            self._post(payload, api_key="phc_invalid_token")
+
+        with capture_logs() as logs:
+            for _ in range(3):
+                assert self._post(payload, api_key="phc_invalid_token").status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+        assert counter._value.get() == before + 3
+        assert [entry for entry in logs if entry["event"] == "push_subscription_rejected"] == []
 
     def test_unsupported_method_collapses_counter_label(self):
         counter = PUSH_SUBSCRIPTION_REJECTION_COUNTER.labels(code="method_not_allowed", method="other")


### PR DESCRIPTION
🤖 This PR was opened by a bot on behalf of the task author.

## Why

The Django 401-ratio alert pages on-call most mornings. The 401s are not a real auth problem. They come from `POST /api/push_subscriptions`: one app build shipped with an invalid project token, and the PostHog Android SDK in every install re-posts that token on every app open. The burst drains after ~30 minutes, then comes back the next day. It is a misconfigured app, not a credential attack.

## What changed

Invalid-token requests to `/api/push_subscriptions` now get:

- **Under a small budget (10 per token per minute):** the same real 401 `invalid_api_key` as before, with the same counter and log line. A developer integrating still sees the true error, and a burst stays attributable to one token fingerprint.
- **Over budget:** `429 rate_limited`. The 429 path increments the `push_subscription_rejection` counter but does not log per request, since the under-limit requests already carry the detail.

The limiter is a fixed window in Redis keyed on the token fingerprint. Keys expire with their window, so the keyspace stays bounded. It fails closed: if Redis is down, invalid tokens get 429s (they were failing anyway), instead of the storm returning.

Nothing else changes: valid tokens, missing tokens, identity-verification failures, and all other rejection codes behave exactly as before.

## Testing

- Parameterized POST/DELETE test: first 10 invalid-token requests get 401, the 11th gets 429 with `code=rate_limited`.
- Counter test: 429s increment the counter with no per-request log line.
- Cache-outage test: fails closed to 429.
- Existing SDK-attribution and raw-token-redaction test still passes (real 401 path is unchanged).
- Full file: 43 passed.

## Notes for reviewers

- Effect on the alert: one misconfigured app can now produce at most 10 401s/minute instead of ~1,500/minute at peak, so the 10% ratio threshold stops being reachable from this cause.
- An alternative/complement is excluding this endpoint class in the alerting rule itself (envoy metrics have no path label, so that needs a different signal). Happy to take either route.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*