### PR TITLE
fix(inbox): apply triage reviewer removal optimistically to the queue

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -3,6 +3,7 @@ import {
   type InboxScope,
   inboxReviewerScopeValue,
   inboxScopeTriggerLabel,
+  matchesInboxScope,
 } from "@posthog/core/inbox/reportMembership";
 import { parsePrUrl } from "@posthog/core/inbox/reportPresentation";
 import { Button } from "@posthog/quill";
@@ -25,9 +26,10 @@ import {
   useReportTasks,
 } from "@posthog/ui/features/inbox/hooks/useReportTasks";
 import { useReportChatPanelStore } from "@posthog/ui/features/inbox/stores/reportChatPanelStore";
+import { toast } from "@posthog/ui/primitives/toast";
 import { navigateToInboxReportDetail } from "@posthog/ui/router/navigationBridge";
 import { track } from "@posthog/ui/shell/analytics";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -128,8 +130,25 @@ export function ReportTriageFocus({
 
   // The queue shrinks under us when a report is archived; clamping (rather
   // than resetting) is what makes archive-and-advance work.
-  const clamped = Math.min(index, Math.max(0, reports.length - 1));
-  const report = reports[clamped];
+  //
+  // Removing yourself as reviewer shrinks the queue too (only in a scope where
+  // membership depends on being a reviewer), so the removal is applied
+  // optimistically: the report leaves the rendered queue on the keypress, not
+  // when the server catches up. Without this, navigating while the request is
+  // in flight double-advances - the index moves, then the shrink moves the
+  // reports under it, and the next report is silently skipped.
+  const [optimisticRemovedId, setOptimisticRemovedId] = useState<string | null>(
+    null,
+  );
+  const queue = useMemo(
+    () =>
+      optimisticRemovedId === null
+        ? reports
+        : reports.filter((r) => r.id !== optimisticRemovedId),
+    [reports, optimisticRemovedId],
+  );
+  const clamped = Math.min(index, Math.max(0, queue.length - 1));
+  const report = queue[clamped];
   const reportId = report?.id;
   const { data: reportTasks, isLoading: reportTasksLoading } = useReportTasks(
     reportId ?? "",
@@ -152,8 +171,8 @@ export function ReportTriageFocus({
     !!existingPrUrl &&
     parsePrUrl(existingPrUrl) !== null;
   const prShortcut = canOpenPr ? "open" : canCreatePr ? "create" : null;
-  const previousReport = clamped > 0 ? reports[clamped - 1] : null;
-  const nextReport = clamped < reports.length - 1 ? reports[clamped + 1] : null;
+  const previousReport = clamped > 0 ? queue[clamped - 1] : null;
+  const nextReport = clamped < queue.length - 1 ? queue[clamped + 1] : null;
   const { prefetch } = useInboxReportDetailPrefetch(
     report
       ? {
@@ -194,10 +213,52 @@ export function ReportTriageFocus({
   const canRemoveSelfFromReviewers =
     bulkActions.removeReviewerDisabledReason === null &&
     report?.is_suggested_reviewer === true;
+
   const handleRemoveReviewer = useCallback(() => {
-    if (bulkActions.isRemovingReviewer) return;
-    void bulkActions.removeReviewerSelected();
-  }, [bulkActions]);
+    if (bulkActions.isRemovingReviewer || !report) return;
+    const removed = report;
+    const removedIndex = clamped;
+    // Only scopes that filter on reviewer status drop the report from the
+    // queue; elsewhere it stays and only the hint disappears.
+    const leavesQueue =
+      matchesInboxScope(removed, scope) &&
+      !matchesInboxScope({ ...removed, is_suggested_reviewer: false }, scope);
+    if (leavesQueue) {
+      setOptimisticRemovedId(removed.id);
+    }
+    void (async () => {
+      const result = await bulkActions
+        .removeReviewerSelected({ suppressFailureToast: true })
+        .catch(() => null);
+      if (result?.succeededIds.includes(removed.id)) {
+        // The filter stays until the refetch drops the report, so the
+        // handoff is invisible; the cleanup effect below releases it.
+        return;
+      }
+      if (leavesQueue) {
+        setOptimisticRemovedId(null);
+      }
+      toast.warning("Couldn't remove you as reviewer", {
+        description: `${removed.title} is still in your queue.`,
+        action: {
+          label: "Back to report",
+          onClick: () => setIndex(removedIndex),
+        },
+      });
+    })();
+  }, [bulkActions, report, clamped, scope]);
+
+  // Release the optimistic removal once the server state catches up: after a
+  // successful removal the refetched queue no longer holds the report, so the
+  // filter becomes a no-op.
+  useEffect(() => {
+    if (
+      optimisticRemovedId !== null &&
+      !reports.some((r) => r.id === optimisticRemovedId)
+    ) {
+      setOptimisticRemovedId(null);
+    }
+  }, [reports, optimisticRemovedId]);
 
   const handleDismissConfirm = useCallback(
     async (result: DismissReportDialogResult) => {
@@ -210,8 +271,8 @@ export function ReportTriageFocus({
   );
 
   const goNext = useCallback(
-    () => setIndex((i) => Math.min(i + 1, reports.length - 1)),
-    [reports.length],
+    () => setIndex((i) => Math.min(i + 1, queue.length - 1)),
+    [queue.length],
   );
   const goPrev = useCallback(() => setIndex((i) => Math.max(i - 1, 0)), []);
   const handleExit = useCallback(() => {
@@ -308,7 +369,7 @@ export function ReportTriageFocus({
         <ReportTriageFocusView
           report={report}
           position={clamped + 1}
-          total={reports.length}
+          total={queue.length}
           scopeLabel={inboxScopeTriggerLabel(scope)}
           hasActiveFilters={hasActiveFilters}
           previousReport={previousReport}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -188,7 +188,12 @@ export function ReportTriageFocus({
   );
   const dismissPending = bulkActions.isSuppressing || bulkActions.isSnoozing;
 
-  const canRemoveSelfFromReviewers = report?.is_suggested_reviewer === true;
+  // Gate on the hook's disabled reason, not just is_suggested_reviewer, so the
+  // hint stays hidden until the current-user query has resolved (a press with
+  // no meUuid silently no-ops).
+  const canRemoveSelfFromReviewers =
+    bulkActions.removeReviewerDisabledReason === null &&
+    report?.is_suggested_reviewer === true;
   const handleRemoveReviewer = useCallback(() => {
     if (bulkActions.isRemovingReviewer) return;
     void bulkActions.removeReviewerSelected();

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocus.tsx
@@ -188,6 +188,12 @@ export function ReportTriageFocus({
   );
   const dismissPending = bulkActions.isSuppressing || bulkActions.isSnoozing;
 
+  const canRemoveSelfFromReviewers = report?.is_suggested_reviewer === true;
+  const handleRemoveReviewer = useCallback(() => {
+    if (bulkActions.isRemovingReviewer) return;
+    void bulkActions.removeReviewerSelected();
+  }, [bulkActions]);
+
   const handleDismissConfirm = useCallback(
     async (result: DismissReportDialogResult) => {
       const ok = isDismissalReasonSnooze(result.reason)
@@ -251,6 +257,10 @@ export function ReportTriageFocus({
           event.preventDefault();
           handleOpenReport();
           break;
+        case "r":
+          event.preventDefault();
+          if (canRemoveSelfFromReviewers) handleRemoveReviewer();
+          break;
         case "Escape":
           event.preventDefault();
           handleExit();
@@ -259,7 +269,16 @@ export function ReportTriageFocus({
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [dismissOpen, report, goNext, goPrev, handleExit, handleOpenReport]);
+  }, [
+    dismissOpen,
+    report,
+    goNext,
+    goPrev,
+    handleExit,
+    handleOpenReport,
+    canRemoveSelfFromReviewers,
+    handleRemoveReviewer,
+  ]);
 
   if (!report) {
     // The queue ran dry mid-session — every decision is made.
@@ -291,6 +310,7 @@ export function ReportTriageFocus({
           nextReport={nextReport}
           expanded={expanded}
           prShortcut={prShortcut}
+          canRemoveSelfFromReviewers={canRemoveSelfFromReviewers}
           actions={
             <ReportVerdictBanner
               report={report}

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusQueue.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusQueue.test.tsx
@@ -1,0 +1,212 @@
+import type { InboxScope } from "@posthog/core/inbox/reportMembership";
+import type { SignalReport } from "@posthog/shared/types";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  bulkActions: {
+    removeReviewerDisabledReason: null as string | null,
+    isRemovingReviewer: false,
+    removeReviewerSelected: vi.fn(
+      (): Promise<{ succeededIds: string[] } | null> =>
+        Promise.resolve({ succeededIds: [] }),
+    ),
+    isSuppressing: false,
+    isSnoozing: false,
+    snoozeDisabledReason: null as string | null,
+    suppressSelected: vi.fn(() => Promise.resolve(true)),
+    snoozeSelected: vi.fn(() => Promise.resolve(true)),
+  },
+  viewProps: null as Record<string, unknown> | null,
+  toastWarning: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useInboxBulkActions", () => ({
+  useInboxBulkActions: () => mocks.bulkActions,
+}));
+
+vi.mock("@posthog/ui/features/inbox/hooks/useReportTasks", () => ({
+  useReportTasks: () => ({ data: [], isLoading: false }),
+  findContinuableImplementationTask: () => null,
+  getTaskPrUrl: () => null,
+}));
+
+vi.mock(
+  "@posthog/ui/features/inbox/hooks/useInboxReportDetailPrefetch",
+  () => ({
+    useInboxReportDetailPrefetch: () => ({ prefetch: vi.fn() }),
+  }),
+);
+
+vi.mock("@posthog/ui/router/navigationBridge", () => ({
+  navigateToInboxReportDetail: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/shell/analytics", () => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@posthog/ui/primitives/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: mocks.toastWarning,
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@posthog/ui/features/inbox/components/ReportTriageFocusView", () => ({
+  ReportTriageFocusView: (props: Record<string, unknown>) => {
+    mocks.viewProps = props;
+    return null;
+  },
+}));
+
+vi.mock("@posthog/ui/features/inbox/components/ReportVerdictBanner", () => ({
+  ReportVerdictBanner: () => null,
+}));
+
+vi.mock(
+  "@posthog/ui/features/inbox/components/SuggestedReviewerAvatarStack",
+  () => ({ SuggestedReviewerAvatarStack: () => null }),
+);
+
+vi.mock("@posthog/ui/features/inbox/components/ReportChatSidebar", () => ({
+  ReportChatSidebar: () => null,
+}));
+
+vi.mock("@posthog/ui/features/inbox/components/DismissReportDialog", () => ({
+  DismissReportDialog: () => null,
+}));
+
+import { ReportTriageFocus } from "./ReportTriageFocus";
+
+function report(id: string): SignalReport {
+  return {
+    id,
+    title: `Report ${id}`,
+    summary: null,
+    status: "ready",
+    total_weight: 1,
+    signal_count: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    artefact_count: 0,
+    implementation_pr_url: null,
+    actionability: "immediately_actionable",
+    is_suggested_reviewer: true,
+  };
+}
+
+function renderTriage(
+  reports: SignalReport[],
+  scope: InboxScope = "for-you",
+): { onExit: ReturnType<typeof vi.fn> } {
+  const onExit = vi.fn();
+  render(
+    <ReportTriageFocus
+      reports={reports}
+      allReports={reports}
+      scope={scope}
+      hasActiveFilters={false}
+      onExit={onExit}
+    />,
+  );
+  return { onExit };
+}
+
+async function pressR(): Promise<void> {
+  await userEvent.keyboard("r");
+}
+
+async function pressArrowDown(): Promise<void> {
+  await userEvent.keyboard("{ArrowDown}");
+}
+
+describe("ReportTriageFocus queue behavior on remove-reviewer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.viewProps = null;
+    mocks.bulkActions.isRemovingReviewer = false;
+    mocks.bulkActions.removeReviewerSelected.mockReset();
+  });
+
+  it("shows the report after the removed one (queue-shrink advance)", async () => {
+    const reports = [report("a"), report("b"), report("c")];
+    mocks.bulkActions.removeReviewerSelected.mockResolvedValue({
+      succeededIds: ["a"],
+    });
+    renderTriage(reports);
+
+    await pressR();
+
+    await waitFor(() =>
+      expect((mocks.viewProps?.report as SignalReport).id).toBe("b"),
+    );
+  });
+
+  it("never skips the next report when the user navigates while removal is pending", async () => {
+    const reports = [report("a"), report("b"), report("c")];
+    let settle: (result: { succeededIds: string[] }) => void = () => {};
+    mocks.bulkActions.removeReviewerSelected.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve;
+        }),
+    );
+    renderTriage(reports);
+
+    await pressR();
+    await pressArrowDown();
+    expect((mocks.viewProps?.report as SignalReport).id).toBe("c");
+
+    settle({ succeededIds: ["a"] });
+    await waitFor(() =>
+      expect((mocks.viewProps?.report as SignalReport).id).toBe("c"),
+    );
+  });
+
+  it("offers a jump back to the report when the removal fails", async () => {
+    const reports = [report("a"), report("b"), report("c")];
+    let settle: (result: { succeededIds: string[] }) => void = () => {};
+    mocks.bulkActions.removeReviewerSelected.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          settle = resolve;
+        }),
+    );
+    renderTriage(reports);
+
+    await pressR();
+    await pressArrowDown();
+    settle({ succeededIds: [] });
+
+    await waitFor(() => expect(mocks.toastWarning).toHaveBeenCalledOnce());
+    const [, options] = mocks.toastWarning.mock.calls[0] as [
+      string,
+      { action: { label: string; onClick: () => void } },
+    ];
+    expect(options.action.label).toBe("Back to report");
+
+    options.action.onClick();
+    await waitFor(() =>
+      expect((mocks.viewProps?.report as SignalReport).id).toBe("a"),
+    );
+  });
+
+  it("keeps the report in the queue in entire-project scope", async () => {
+    const reports = [report("a"), report("b"), report("c")];
+    mocks.bulkActions.removeReviewerSelected.mockResolvedValue({
+      succeededIds: ["a"],
+    });
+    renderTriage(reports, "entire-project");
+
+    await pressR();
+
+    await waitFor(() => expect(mocks.viewProps?.total).toBe(3));
+    expect((mocks.viewProps?.report as SignalReport).id).toBe("a");
+  });
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusView.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusView.stories.tsx
@@ -88,6 +88,7 @@ const meta: Meta<typeof ReportTriageFocusView> = {
     nextReport,
     expanded: false,
     prShortcut: "create",
+    canRemoveSelfFromReviewers: true,
     actions: createPrActions(),
     reviewers: (
       <span className="rounded bg-(--gray-3) px-1.5 py-0.5 text-[12px] text-gray-11">
@@ -119,6 +120,10 @@ export const ExistingPr: Story = {
 
 export const ExpandedSummary: Story = {
   args: { expanded: true },
+};
+
+export const NotAReviewer: Story = {
+  args: { canRemoveSelfFromReviewers: false },
 };
 
 export const LongTitle: Story = {

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusView.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportTriageFocusView.tsx
@@ -35,6 +35,8 @@ export interface ReportTriageFocusViewProps {
   nextReport?: SignalReport | null;
   expanded: boolean;
   prShortcut: "open" | "create" | null;
+  /** Shows the R hint: pressing it removes the current user from reviewers. */
+  canRemoveSelfFromReviewers: boolean;
   actions: ReactNode;
   reviewers?: ReactNode;
   onExit: () => void;
@@ -54,6 +56,7 @@ export function ReportTriageFocusView({
   nextReport,
   expanded,
   prShortcut,
+  canRemoveSelfFromReviewers,
   actions,
   reviewers,
   onExit,
@@ -269,6 +272,12 @@ export function ReportTriageFocusView({
           <KeyHint>O</KeyHint>
           open
         </span>
+        {canRemoveSelfFromReviewers && (
+          <span className="flex items-center gap-1">
+            <KeyHint>R</KeyHint>
+            remove me as reviewer
+          </span>
+        )}
         <span className="flex items-center gap-1">
           <KeyHint>Enter</KeyHint>
           summary

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBulkActions.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxBulkActions.ts
@@ -47,7 +47,7 @@ function toReviewerWriteContent(
     .filter((entry): entry is SuggestedReviewerWriteEntry => entry !== null);
 }
 
-interface BulkActionResult {
+export interface BulkActionResult {
   successCount: number;
   failureCount: number;
   succeededIds: string[];
@@ -424,7 +424,16 @@ export function useInboxBulkActions(
    * `is_suggested_reviewer`).
    */
   const removeReviewerMutation = useAuthenticatedMutation(
-    async (client, input: { reportIds: string[]; meUuid: string }) =>
+    async (
+      client,
+      input: {
+        reportIds: string[];
+        meUuid: string;
+        // Lets a caller that renders its own failure UX (triage's jump-back
+        // toast) suppress the hook's failure toasts; success is unchanged.
+        suppressFailureToast?: boolean;
+      },
+    ) =>
       runBulkAction(input.reportIds, async (reportId) => {
         const artefacts = await client.getSignalReportArtefacts(reportId);
         const artefact = artefacts.results.find(
@@ -451,20 +460,24 @@ export function useInboxBulkActions(
         );
       }),
     {
-      onSuccess: async (result) => {
+      onSuccess: async (result, variables) => {
         trackBulkAction("remove_suggested_reviewer", result);
         await invalidateInboxQueries();
         applyBulkResultToSelection(result);
 
         if (result.failureCount > 0) {
-          toast.error(formatBulkActionSummary("removeReviewer", result));
+          if (!variables.suppressFailureToast) {
+            toast.error(formatBulkActionSummary("removeReviewer", result));
+          }
           return;
         }
 
         toast.success(formatBulkActionSummary("removeReviewer", result));
       },
-      onError: (error) => {
-        toast.error(error.message || "Failed to remove yourself as reviewer");
+      onError: (error, variables) => {
+        if (!variables.suppressFailureToast) {
+          toast.error(error.message || "Failed to remove yourself as reviewer");
+        }
       },
     },
   );
@@ -527,26 +540,34 @@ export function useInboxBulkActions(
     reingestMutation,
   ]);
 
-  const removeReviewerSelected = useCallback(async () => {
-    if (eligibility.removeReviewerDisabledReason !== null || !meUuid) {
-      return false;
-    }
+  const removeReviewerSelected = useCallback(
+    async (options?: {
+      suppressFailureToast?: boolean;
+    }): Promise<BulkActionResult | null> => {
+      if (eligibility.removeReviewerDisabledReason !== null || !meUuid) {
+        return null;
+      }
 
-    const reportIds = eligibility.selectedReports
-      .filter((report) => report.is_suggested_reviewer)
-      .map((report) => report.id);
-    if (reportIds.length === 0) {
-      return false;
-    }
+      const reportIds = eligibility.selectedReports
+        .filter((report) => report.is_suggested_reviewer)
+        .map((report) => report.id);
+      if (reportIds.length === 0) {
+        return null;
+      }
 
-    await removeReviewerMutation.mutateAsync({ reportIds, meUuid });
-    return true;
-  }, [
-    eligibility.removeReviewerDisabledReason,
-    eligibility.selectedReports,
-    meUuid,
-    removeReviewerMutation,
-  ]);
+      return removeReviewerMutation.mutateAsync({
+        reportIds,
+        meUuid,
+        suppressFailureToast: options?.suppressFailureToast,
+      });
+    },
+    [
+      eligibility.removeReviewerDisabledReason,
+      eligibility.selectedReports,
+      meUuid,
+      removeReviewerMutation,
+    ],
+  );
 
   return {
     selectedReports: eligibility.selectedReports,


### PR DESCRIPTION
## Problem

Stacked on [#92877](https://github.com/PostHog/posthog/pull/92877) (the triage "r" shortcut). In triage mode's "For you" scope, pressing "r" on report A and then moving to the next report before the removal request finishes makes the queue skip a report: the index advances to B, the refetch then removes A from the queue, and the view lands on C. B is never shown.

The review thread on the base PR called this out. The chosen direction: keep moving forwards assuming the removal succeeds, and when it fails, show a toast that jumps back to the report so the failure can be dealt with.

## Changes

- Pressing "r" in triage mode now removes the report from the rendered queue on the keypress (only in scopes where queue membership depends on being a reviewer, e.g. "For you"), so the existing clamp-and-advance behavior applies synchronously and no report is skipped.
- When the removal fails, the report reappears in the queue and a warning toast ("Couldn't remove you as reviewer") offers a "Back to report" action that returns to it.
- In scopes like "Entire project" where the report is not queue-filtered by reviewer status, nothing changes: the report stays in the queue.
- `useInboxBulkActions.removeReviewerSelected` now returns the per-report result and accepts `suppressFailureToast` so the triage view can own the failure UX. The bulk selection bar's behavior is unchanged (mechanical).

## How did you test this code?

TDD: new `ReportTriageFocusQueue.test.tsx` written red first (3 of 4 cases failing), then the implementation turned them green. The four cases lock in:

- advance shows the report after the removed one (no skip)
- navigating while the removal is in flight never skips the next report (the reported bug)
- on failure, a toast offers "Back to report" and clicking it returns to the report
- in "Entire project" scope the report stays in the queue

`pnpm --filter @posthog/ui typecheck` passes, Biome clean, `vitest run src/features/inbox` passes (163 tests). Did not run the app manually; the new cases cover the state transitions the bug lived in.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - the desktop app's triage shortcuts are not covered in `docs/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Desktop (cloud coding agent). The direction (optimistic forward motion + failure toast with jump back, rather than blocking navigation) was chosen by the user when asking for this stacked fix. Skills invoked: /writing-tests (TDD, component-level regression tests), /writing-ui-components, /writing-user-facing-copy (toast text), /writing-code-comments, /writing-pr-descriptions. Design: a local optimistic filter in `ReportTriageFocus` rather than optimistic React Query cache updates, so the shared report-list caches stay server-driven and rollback is a single state reset. Public-artifact gate: no session material beyond the feature direction itself.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*