### PR TITLE
feat(usage): roll up hourly usage records in temporal

### DIFF
--- a/posthog/management/commands/start_temporal_worker.py
+++ b/posthog/management/commands/start_temporal_worker.py
@@ -41,6 +41,10 @@ from posthog.temporal.backfill_materialized_property import (
     ACTIVITIES as BACKFILL_MATERIALIZED_PROPERTY_ACTIVITIES,
     BackfillMaterializedPropertiesBatchWorkflow,
 )
+from posthog.temporal.billing_usage_rollup import (
+    ACTIVITIES as BILLING_USAGE_ROLLUP_ACTIVITIES,
+    WORKFLOWS as BILLING_USAGE_ROLLUP_WORKFLOWS,
+)
 from posthog.temporal.cleanup_property_definitions import (
     ACTIVITIES as CLEANUP_PROPDEFS_ACTIVITIES,
     WORKFLOWS as CLEANUP_PROPDEFS_WORKFLOWS,
@@ -413,12 +417,18 @@ _task_queue_specs = [
     ),
     (
         settings.ANALYTICS_PLATFORM_TASK_QUEUE,
-        EXPORT_WORKFLOWS + SUBSCRIPTION_WORKFLOWS + ALERT_WORKFLOWS + PULSE_WORKFLOWS + SYNC_EVENTS_RETENTION_WORKFLOWS,
+        EXPORT_WORKFLOWS
+        + SUBSCRIPTION_WORKFLOWS
+        + ALERT_WORKFLOWS
+        + PULSE_WORKFLOWS
+        + SYNC_EVENTS_RETENTION_WORKFLOWS
+        + BILLING_USAGE_ROLLUP_WORKFLOWS,
         EXPORT_ACTIVITIES
         + SUBSCRIPTION_ACTIVITIES
         + ALERT_ACTIVITIES
         + PULSE_ACTIVITIES
-        + SYNC_EVENTS_RETENTION_ACTIVITIES,
+        + SYNC_EVENTS_RETENTION_ACTIVITIES
+        + BILLING_USAGE_ROLLUP_ACTIVITIES,
     ),
     (
         settings.TASKS_TASK_QUEUE,

--- a/posthog/models/usage_ingestion/billing_usage_records.py
+++ b/posthog/models/usage_ingestion/billing_usage_records.py
@@ -129,6 +129,17 @@ ENGINE = {
 """.strip()
 
 
+def BILLING_USAGE_RECORDS_HOURLY_EXISTING_ROWS_SQL(
+    table_name: str = BILLING_USAGE_RECORDS_HOURLY_TABLE,
+) -> str:
+    return f"""
+SELECT count()
+FROM {table_name} FINAL
+WHERE hour >= %(day_start)s
+  AND hour < %(day_end)s
+"""
+
+
 def BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL(
     source_table: str = BILLING_USAGE_RECORDS_TABLE,
     target_table: str = BILLING_USAGE_RECORDS_HOURLY_TABLE,

--- a/posthog/temporal/billing_usage_rollup/__init__.py
+++ b/posthog/temporal/billing_usage_rollup/__init__.py
@@ -1,0 +1,5 @@
+from posthog.temporal.billing_usage_rollup.activities import rollup_billing_usage_records
+from posthog.temporal.billing_usage_rollup.workflow import RollupBillingUsageRecordsWorkflow
+
+WORKFLOWS = [RollupBillingUsageRecordsWorkflow]
+ACTIVITIES = [rollup_billing_usage_records]

--- a/posthog/temporal/billing_usage_rollup/activities.py
+++ b/posthog/temporal/billing_usage_rollup/activities.py
@@ -1,0 +1,40 @@
+import asyncio
+from datetime import UTC, date, datetime, time, timedelta
+
+import structlog
+from temporalio import activity
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.client.connection import Workload
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.models.usage_ingestion.billing_usage_records import BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL
+from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+from posthog.temporal.common.heartbeat import Heartbeater
+
+logger = structlog.get_logger(__name__)
+
+BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS = 28
+
+
+def rollup_billing_usage_records_day(day: date) -> None:
+    day_start = datetime.combine(day, time.min, UTC)
+    day_end = day_start + timedelta(days=1)
+
+    with tags_context(product=Product.BILLING, feature=Feature.BILLING_ETL, workload=Workload.OFFLINE.value):
+        sync_execute(
+            BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL(),
+            {"day_start": day_start, "day_end": day_end, "rolled_up_at": datetime.now(UTC)},
+            workload=Workload.OFFLINE,
+        )
+
+
+@activity.defn(name="rollup-billing-usage-records")
+async def rollup_billing_usage_records(input: BillingUsageRecordsRollupInput) -> None:
+    day = (
+        date.fromisoformat(input.day)
+        if input.day is not None
+        else (datetime.now(UTC) - timedelta(days=BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS)).date()
+    )
+    async with Heartbeater():
+        await asyncio.to_thread(rollup_billing_usage_records_day, day)
+    logger.info("rolled_up_billing_usage_records", day=day.isoformat())

--- a/posthog/temporal/billing_usage_rollup/activities.py
+++ b/posthog/temporal/billing_usage_rollup/activities.py
@@ -7,34 +7,37 @@ from temporalio import activity
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
-from posthog.models.usage_ingestion.billing_usage_records import BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL
+from posthog.models.usage_ingestion.billing_usage_records import (
+    BILLING_USAGE_RECORDS_HOURLY_EXISTING_ROWS_SQL,
+    BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL,
+)
 from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
 from posthog.temporal.common.heartbeat import Heartbeater
 
 logger = structlog.get_logger(__name__)
 
-BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS = 28
-
 
 def rollup_billing_usage_records_day(day: date) -> None:
     day_start = datetime.combine(day, time.min, UTC)
     day_end = day_start + timedelta(days=1)
+    parameters = {"day_start": day_start, "day_end": day_end}
 
     with tags_context(product=Product.BILLING, feature=Feature.BILLING_ETL, workload=Workload.OFFLINE.value):
+        existing_rows = sync_execute(BILLING_USAGE_RECORDS_HOURLY_EXISTING_ROWS_SQL(), parameters)[0][0]
+        if existing_rows:
+            logger.warning(
+                "reconciling_existing_billing_usage_rollup", day=day.isoformat(), existing_rows=existing_rows
+            )
         sync_execute(
             BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL(),
-            {"day_start": day_start, "day_end": day_end, "rolled_up_at": datetime.now(UTC)},
+            {**parameters, "rolled_up_at": datetime.now(UTC)},
             workload=Workload.OFFLINE,
         )
 
 
 @activity.defn(name="rollup-billing-usage-records")
 async def rollup_billing_usage_records(input: BillingUsageRecordsRollupInput) -> None:
-    day = (
-        date.fromisoformat(input.day)
-        if input.day is not None
-        else (datetime.now(UTC) - timedelta(days=BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS)).date()
-    )
+    day = date.fromisoformat(input.day)
     async with Heartbeater():
         await asyncio.to_thread(rollup_billing_usage_records_day, day)
     logger.info("rolled_up_billing_usage_records", day=day.isoformat())

--- a/posthog/temporal/billing_usage_rollup/activities.py
+++ b/posthog/temporal/billing_usage_rollup/activities.py
@@ -7,7 +7,7 @@ from temporalio import activity
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
-from posthog.models.usage_ingestion.billing_usage_records import BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL
+from posthog.models.usage_ingestion.billing_usage_records import BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL
 from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
 from posthog.temporal.common.heartbeat import Heartbeater
 
@@ -22,7 +22,7 @@ def rollup_billing_usage_records_day(day: date) -> None:
 
     with tags_context(product=Product.BILLING, feature=Feature.BILLING_ETL, workload=Workload.OFFLINE.value):
         sync_execute(
-            BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL(),
+            BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL(),
             {"day_start": day_start, "day_end": day_end, "rolled_up_at": datetime.now(UTC)},
             workload=Workload.OFFLINE,
         )

--- a/posthog/temporal/billing_usage_rollup/schedule.py
+++ b/posthog/temporal/billing_usage_rollup/schedule.py
@@ -1,0 +1,52 @@
+from datetime import timedelta
+
+from django.conf import settings
+
+from temporalio import common
+from temporalio.client import (
+    Client,
+    Schedule,
+    ScheduleActionStartWorkflow,
+    ScheduleCalendarSpec,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
+    ScheduleRange,
+    ScheduleSpec,
+)
+
+from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
+
+SCHEDULE_ID = "rollup-billing-usage-records-schedule"
+WORKFLOW_NAME = "rollup-billing-usage-records"
+
+
+def build_schedule() -> Schedule:
+    return Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_NAME,
+            BillingUsageRecordsRollupInput(),
+            id=SCHEDULE_ID,
+            task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
+            execution_timeout=timedelta(hours=2),
+            retry_policy=common.RetryPolicy(maximum_attempts=1),
+        ),
+        spec=ScheduleSpec(
+            calendars=[
+                ScheduleCalendarSpec(
+                    comment="Daily at 05:00 UTC",
+                    hour=[ScheduleRange(start=5, end=5)],
+                    minute=[ScheduleRange(start=0, end=0)],
+                )
+            ]
+        ),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP, catchup_window=timedelta(days=1)),
+    )
+
+
+async def create_billing_usage_rollup_schedule(client: Client) -> None:
+    schedule = build_schedule()
+    if await a_schedule_exists(client, SCHEDULE_ID):
+        await a_update_schedule(client, SCHEDULE_ID, schedule)
+    else:
+        await a_create_schedule(client, SCHEDULE_ID, schedule, trigger_immediately=False)

--- a/posthog/temporal/billing_usage_rollup/schedule.py
+++ b/posthog/temporal/billing_usage_rollup/schedule.py
@@ -14,7 +14,10 @@ from temporalio.client import (
     ScheduleSpec,
 )
 
-from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+from posthog.temporal.billing_usage_rollup.types import (
+    BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS,
+    BillingUsageRecordsRollupWorkflowInput,
+)
 from posthog.temporal.common.schedule import a_create_schedule, a_schedule_exists, a_update_schedule
 
 SCHEDULE_ID = "rollup-billing-usage-records-schedule"
@@ -25,10 +28,9 @@ def build_schedule() -> Schedule:
     return Schedule(
         action=ScheduleActionStartWorkflow(
             WORKFLOW_NAME,
-            BillingUsageRecordsRollupInput(),
+            BillingUsageRecordsRollupWorkflowInput(),
             id=SCHEDULE_ID,
             task_queue=settings.ANALYTICS_PLATFORM_TASK_QUEUE,
-            execution_timeout=timedelta(hours=2),
             retry_policy=common.RetryPolicy(maximum_attempts=1),
         ),
         spec=ScheduleSpec(
@@ -40,7 +42,10 @@ def build_schedule() -> Schedule:
                 )
             ]
         ),
-        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP, catchup_window=timedelta(days=1)),
+        policy=SchedulePolicy(
+            overlap=ScheduleOverlapPolicy.SKIP,
+            catchup_window=timedelta(days=BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS + 1),
+        ),
     )
 
 

--- a/posthog/temporal/billing_usage_rollup/types.py
+++ b/posthog/temporal/billing_usage_rollup/types.py
@@ -1,0 +1,12 @@
+from datetime import date
+
+from posthog.dataclasses import frozen
+
+
+@frozen
+class BillingUsageRecordsRollupInput:
+    day: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.day is not None:
+            date.fromisoformat(self.day)

--- a/posthog/temporal/billing_usage_rollup/types.py
+++ b/posthog/temporal/billing_usage_rollup/types.py
@@ -2,11 +2,21 @@ from datetime import date
 
 from posthog.dataclasses import frozen
 
+BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS = 28
+
 
 @frozen
 class BillingUsageRecordsRollupInput:
-    day: str | None = None
+    day: str
 
     def __post_init__(self) -> None:
-        if self.day is not None:
-            date.fromisoformat(self.day)
+        date.fromisoformat(self.day)
+
+
+@frozen
+class BillingUsageRecordsRollupWorkflowInput:
+    last_completed_day: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.last_completed_day is not None:
+            date.fromisoformat(self.last_completed_day)

--- a/posthog/temporal/billing_usage_rollup/workflow.py
+++ b/posthog/temporal/billing_usage_rollup/workflow.py
@@ -1,0 +1,25 @@
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+from posthog.temporal.common.base import PostHogWorkflow
+
+with workflow.unsafe.imports_passed_through():
+    from posthog.temporal.billing_usage_rollup.activities import rollup_billing_usage_records
+
+
+@workflow.defn(name="rollup-billing-usage-records")
+class RollupBillingUsageRecordsWorkflow(PostHogWorkflow):
+    inputs_cls = BillingUsageRecordsRollupInput
+
+    @workflow.run
+    async def run(self, input: BillingUsageRecordsRollupInput) -> None:
+        await workflow.execute_activity(
+            rollup_billing_usage_records,
+            input,
+            start_to_close_timeout=timedelta(hours=2),
+            heartbeat_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3, initial_interval=timedelta(minutes=5)),
+        )

--- a/posthog/temporal/billing_usage_rollup/workflow.py
+++ b/posthog/temporal/billing_usage_rollup/workflow.py
@@ -1,25 +1,73 @@
-from datetime import timedelta
+from datetime import UTC, date, datetime, time, timedelta
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
+from temporalio.exceptions import ActivityError
 
-from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+from posthog.temporal.billing_usage_rollup.types import (
+    BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS,
+    BillingUsageRecordsRollupInput,
+    BillingUsageRecordsRollupWorkflowInput,
+)
 from posthog.temporal.common.base import PostHogWorkflow
+from posthog.temporal.common.utils import get_scheduled_start_time
 
 with workflow.unsafe.imports_passed_through():
     from posthog.temporal.billing_usage_rollup.activities import rollup_billing_usage_records
 
 
+ROLLUP_HOUR_UTC = 5
+
+
+def latest_safe_rollup_day(now: datetime) -> date:
+    return (now - timedelta(days=BILLING_USAGE_RECORDS_ROLLUP_DELAY_DAYS + 1)).date()
+
+
+def next_rollup_day(last_completed_day: date, now: datetime) -> date | None:
+    candidate = last_completed_day + timedelta(days=1)
+    return candidate if candidate <= latest_safe_rollup_day(now) else None
+
+
+def time_until_next_rollup(now: datetime) -> timedelta:
+    next_rollup = datetime.combine(now.date(), time(ROLLUP_HOUR_UTC), UTC)
+    if now >= next_rollup:
+        next_rollup += timedelta(days=1)
+    return next_rollup - now
+
+
 @workflow.defn(name="rollup-billing-usage-records")
 class RollupBillingUsageRecordsWorkflow(PostHogWorkflow):
-    inputs_cls = BillingUsageRecordsRollupInput
+    inputs_cls = BillingUsageRecordsRollupWorkflowInput
 
     @workflow.run
-    async def run(self, input: BillingUsageRecordsRollupInput) -> None:
-        await workflow.execute_activity(
-            rollup_billing_usage_records,
-            input,
-            start_to_close_timeout=timedelta(hours=2),
-            heartbeat_timeout=timedelta(minutes=5),
-            retry_policy=RetryPolicy(maximum_attempts=3, initial_interval=timedelta(minutes=5)),
+    async def run(self, input: BillingUsageRecordsRollupWorkflowInput) -> None:
+        last_completed_day = (
+            date.fromisoformat(input.last_completed_day)
+            if input.last_completed_day is not None
+            else latest_safe_rollup_day(get_scheduled_start_time()) - timedelta(days=1)
         )
+        day = next_rollup_day(last_completed_day, workflow.now())
+
+        if day is None:
+            await workflow.sleep(time_until_next_rollup(workflow.now()))
+            workflow.continue_as_new(
+                BillingUsageRecordsRollupWorkflowInput(last_completed_day=last_completed_day.isoformat())
+            )
+
+        assert day is not None
+
+        try:
+            await workflow.execute_activity(
+                rollup_billing_usage_records,
+                BillingUsageRecordsRollupInput(day=day.isoformat()),
+                start_to_close_timeout=timedelta(hours=2),
+                heartbeat_timeout=timedelta(minutes=5),
+                retry_policy=RetryPolicy(maximum_attempts=3, initial_interval=timedelta(minutes=5)),
+            )
+        except ActivityError:
+            await workflow.sleep(timedelta(hours=1))
+            workflow.continue_as_new(
+                BillingUsageRecordsRollupWorkflowInput(last_completed_day=last_completed_day.isoformat())
+            )
+
+        workflow.continue_as_new(BillingUsageRecordsRollupWorkflowInput(last_completed_day=day.isoformat()))

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -49,6 +49,7 @@ from posthog.temporal.alerts.schedule import (
     create_run_investigation_safety_net_schedule,
     create_schedule_due_alert_checks_schedule,
 )
+from posthog.temporal.billing_usage_rollup.schedule import create_billing_usage_rollup_schedule
 from posthog.temporal.common.client import async_connect
 from posthog.temporal.common.schedule import a_create_schedule, a_delete_schedule, a_schedule_exists, a_update_schedule
 from posthog.temporal.experiments.schedule import (
@@ -896,6 +897,7 @@ schedules = [
     create_error_tracking_recommendations_refresh_schedule,
     create_enforce_max_replay_retention_schedule,
     create_sync_events_retention_schedule,
+    create_billing_usage_rollup_schedule,
     create_replay_count_metrics_schedule,
     create_weekly_digest_schedule,
     create_intent_clustering_coordinator_schedule,

--- a/posthog/temporal/tests/billing_usage_rollup/test_activities.py
+++ b/posthog/temporal/tests/billing_usage_rollup/test_activities.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+import pytest
+from unittest.mock import patch
+
+from temporalio.testing import ActivityEnvironment
+
+from posthog.temporal.billing_usage_rollup.activities import rollup_billing_usage_records
+from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+
+
+@pytest.mark.asyncio
+async def test_rollup_activity_uses_the_requested_day() -> None:
+    with patch("posthog.temporal.billing_usage_rollup.activities.rollup_billing_usage_records_day") as rollup:
+        await ActivityEnvironment().run(rollup_billing_usage_records, BillingUsageRecordsRollupInput(day="2026-05-05"))
+
+    rollup.assert_called_once_with(date(2026, 5, 5))

--- a/posthog/temporal/tests/billing_usage_rollup/test_activities.py
+++ b/posthog/temporal/tests/billing_usage_rollup/test_activities.py
@@ -13,6 +13,7 @@ from posthog.clickhouse.client import sync_execute
 from posthog.models.usage_ingestion.billing_usage_records import (
     BASE_BILLING_USAGE_RECORDS_COLUMNS,
     BILLING_USAGE_RECORDS_HOURLY_DATA_TABLE_SQL,
+    BILLING_USAGE_RECORDS_HOURLY_EXISTING_ROWS_SQL,
     BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL,
 )
 from posthog.temporal.billing_usage_rollup.activities import rollup_billing_usage_records
@@ -78,15 +79,28 @@ class TestRollupActivityStorage(ClickhouseTestMixin, SimpleTestCase):
             """
         )
 
-        with patch(
-            "posthog.temporal.billing_usage_rollup.activities.BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL",
-            return_value=BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL(SOURCE_TABLE, TARGET_TABLE),
+        with (
+            patch(
+                "posthog.temporal.billing_usage_rollup.activities.BILLING_USAGE_RECORDS_HOURLY_EXISTING_ROWS_SQL",
+                return_value=BILLING_USAGE_RECORDS_HOURLY_EXISTING_ROWS_SQL(TARGET_TABLE),
+            ),
+            patch(
+                "posthog.temporal.billing_usage_rollup.activities.BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL",
+                return_value=BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL(SOURCE_TABLE, TARGET_TABLE),
+            ),
         ):
-            asyncio.run(
-                ActivityEnvironment().run(
-                    rollup_billing_usage_records, BillingUsageRecordsRollupInput(day=DAY.isoformat())
+            for _ in range(2):
+                asyncio.run(
+                    ActivityEnvironment().run(
+                        rollup_billing_usage_records, BillingUsageRecordsRollupInput(day=DAY.isoformat())
+                    )
                 )
-            )
+
+        target_final_rows, target_final_quantity = sync_execute(
+            f"SELECT count(), sum(quantity) FROM {TARGET_TABLE} FINAL"
+        )[0]
+        self.assertEqual(target_final_rows, 100 * 4 * 4 * 24)
+        self.assertEqual(target_final_quantity, ROW_COUNT)
 
         sync_execute(f"OPTIMIZE TABLE {SOURCE_TABLE} FINAL")
         sync_execute(f"OPTIMIZE TABLE {TARGET_TABLE} FINAL")

--- a/posthog/temporal/tests/billing_usage_rollup/test_activities.py
+++ b/posthog/temporal/tests/billing_usage_rollup/test_activities.py
@@ -12,8 +12,8 @@ from temporalio.testing import ActivityEnvironment
 from posthog.clickhouse.client import sync_execute
 from posthog.models.usage_ingestion.billing_usage_records import (
     BASE_BILLING_USAGE_RECORDS_COLUMNS,
-    BILLING_USAGE_RECORDS_DAILY_DATA_TABLE_SQL,
-    BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL,
+    BILLING_USAGE_RECORDS_HOURLY_DATA_TABLE_SQL,
+    BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL,
 )
 from posthog.temporal.billing_usage_rollup.activities import rollup_billing_usage_records
 from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
@@ -44,7 +44,7 @@ class TestRollupActivityStorage(ClickhouseTestMixin, SimpleTestCase):
             ORDER BY (team_id, toDate(timestamp), producer_id, usage_key, record_id)
             """
         )
-        sync_execute(BILLING_USAGE_RECORDS_DAILY_DATA_TABLE_SQL(TARGET_TABLE))
+        sync_execute(BILLING_USAGE_RECORDS_HOURLY_DATA_TABLE_SQL(TARGET_TABLE))
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -79,8 +79,8 @@ class TestRollupActivityStorage(ClickhouseTestMixin, SimpleTestCase):
         )
 
         with patch(
-            "posthog.temporal.billing_usage_rollup.activities.BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL",
-            return_value=BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL(SOURCE_TABLE, TARGET_TABLE),
+            "posthog.temporal.billing_usage_rollup.activities.BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL",
+            return_value=BILLING_USAGE_RECORDS_HOURLY_ROLLUP_SQL(SOURCE_TABLE, TARGET_TABLE),
         ):
             asyncio.run(
                 ActivityEnvironment().run(
@@ -95,7 +95,7 @@ class TestRollupActivityStorage(ClickhouseTestMixin, SimpleTestCase):
 
         self.assertEqual(source_rows, ROW_COUNT)
         self.assertEqual(source_quantity, target_quantity)
-        self.assertEqual(target_rows, 100 * 4 * 4)
+        self.assertEqual(target_rows, 100 * 4 * 4 * 24)
         self.assertLess(target_rows, source_rows)
         self.assertLess(target_bytes, source_bytes)
 

--- a/posthog/temporal/tests/billing_usage_rollup/test_activities.py
+++ b/posthog/temporal/tests/billing_usage_rollup/test_activities.py
@@ -1,12 +1,27 @@
+import asyncio
 from datetime import date
 
 import pytest
+from posthog.test.base import ClickhouseTestMixin
 from unittest.mock import patch
+
+from django.test import SimpleTestCase
 
 from temporalio.testing import ActivityEnvironment
 
+from posthog.clickhouse.client import sync_execute
+from posthog.models.usage_ingestion.billing_usage_records import (
+    BASE_BILLING_USAGE_RECORDS_COLUMNS,
+    BILLING_USAGE_RECORDS_DAILY_DATA_TABLE_SQL,
+    BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL,
+)
 from posthog.temporal.billing_usage_rollup.activities import rollup_billing_usage_records
 from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+
+SOURCE_TABLE = "test_billing_usage_records_rollup_activity_source"
+TARGET_TABLE = "test_billing_usage_records_rollup_activity_target"
+DAY = date(2026, 5, 5)
+ROW_COUNT = 1_000_000
 
 
 @pytest.mark.asyncio
@@ -15,3 +30,82 @@ async def test_rollup_activity_uses_the_requested_day() -> None:
         await ActivityEnvironment().run(rollup_billing_usage_records, BillingUsageRecordsRollupInput(day="2026-05-05"))
 
     rollup.assert_called_once_with(date(2026, 5, 5))
+
+
+class TestRollupActivityStorage(ClickhouseTestMixin, SimpleTestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        sync_execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {SOURCE_TABLE}
+            ({BASE_BILLING_USAGE_RECORDS_COLUMNS})
+            ENGINE = ReplacingMergeTree(inserted_at)
+            ORDER BY (team_id, toDate(timestamp), producer_id, usage_key, record_id)
+            """
+        )
+        sync_execute(BILLING_USAGE_RECORDS_DAILY_DATA_TABLE_SQL(TARGET_TABLE))
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        try:
+            sync_execute(f"DROP TABLE IF EXISTS {SOURCE_TABLE}")
+            sync_execute(f"DROP TABLE IF EXISTS {TARGET_TABLE} SYNC")
+        finally:
+            super().tearDownClass()
+
+    def setUp(self) -> None:
+        super().setUp()
+        sync_execute(f"TRUNCATE TABLE {SOURCE_TABLE}")
+        sync_execute(f"TRUNCATE TABLE {TARGET_TABLE}")
+
+    def test_activity_rolls_up_a_large_source_table(self) -> None:
+        sync_execute(
+            f"""
+            INSERT INTO {SOURCE_TABLE}
+            SELECT
+                1,
+                concat('load-test-', toString(number)),
+                concat('producer-', toString(intDiv(number, 100) % 4)),
+                1 + (number % 100),
+                toUUID(concat('00000000-0000-0000-0000-', leftPad(toString(1 + (number % 100)), 12, '0'))),
+                concat('usage-', toString(intDiv(number, 400) % 4)),
+                'units',
+                1,
+                toDateTime64('2026-05-05 00:00:00', 6, 'UTC') + toIntervalSecond(number % 86400),
+                toDateTime64('2026-05-05 00:00:00', 6, 'UTC') + toIntervalDay(1)
+            FROM numbers({ROW_COUNT})
+            """
+        )
+
+        with patch(
+            "posthog.temporal.billing_usage_rollup.activities.BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL",
+            return_value=BILLING_USAGE_RECORDS_DAILY_ROLLUP_SQL(SOURCE_TABLE, TARGET_TABLE),
+        ):
+            asyncio.run(
+                ActivityEnvironment().run(
+                    rollup_billing_usage_records, BillingUsageRecordsRollupInput(day=DAY.isoformat())
+                )
+            )
+
+        sync_execute(f"OPTIMIZE TABLE {SOURCE_TABLE} FINAL")
+        sync_execute(f"OPTIMIZE TABLE {TARGET_TABLE} FINAL")
+        source_rows, source_quantity, source_bytes = self._table_stats(SOURCE_TABLE)
+        target_rows, target_quantity, target_bytes = self._table_stats(TARGET_TABLE)
+
+        self.assertEqual(source_rows, ROW_COUNT)
+        self.assertEqual(source_quantity, target_quantity)
+        self.assertEqual(target_rows, 100 * 4 * 4)
+        self.assertLess(target_rows, source_rows)
+        self.assertLess(target_bytes, source_bytes)
+
+    @staticmethod
+    def _table_stats(table: str) -> tuple[int, int, int]:
+        result = sync_execute(
+            f"""
+            SELECT count(), sum(quantity),
+                (SELECT sum(bytes_on_disk) FROM system.parts WHERE active AND database = currentDatabase() AND table = '{table}')
+            FROM {table}
+            """
+        )
+        return result[0]

--- a/posthog/temporal/tests/billing_usage_rollup/test_schedule.py
+++ b/posthog/temporal/tests/billing_usage_rollup/test_schedule.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+
+from temporalio.client import ScheduleActionStartWorkflow, ScheduleOverlapPolicy
+
+from posthog.temporal.billing_usage_rollup.schedule import SCHEDULE_ID, WORKFLOW_NAME, build_schedule
+from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+
+
+def test_billing_usage_rollup_schedule() -> None:
+    schedule = build_schedule()
+    assert isinstance(schedule.action, ScheduleActionStartWorkflow)
+    assert schedule.action.workflow == WORKFLOW_NAME
+    assert list(schedule.action.args) == [BillingUsageRecordsRollupInput()]
+    assert schedule.action.id == SCHEDULE_ID
+    assert schedule.action.task_queue == settings.ANALYTICS_PLATFORM_TASK_QUEUE
+    assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP
+
+
+def test_billing_usage_rollup_schedule_is_registered() -> None:
+    from posthog.temporal.billing_usage_rollup.schedule import (  # noqa: PLC0415 — heavy registry import, kept off module load
+        create_billing_usage_rollup_schedule,
+    )
+    from posthog.temporal.schedule import schedules  # noqa: PLC0415 — heavy registry import, kept off module load
+
+    assert create_billing_usage_rollup_schedule in schedules

--- a/posthog/temporal/tests/billing_usage_rollup/test_schedule.py
+++ b/posthog/temporal/tests/billing_usage_rollup/test_schedule.py
@@ -3,14 +3,14 @@ from django.conf import settings
 from temporalio.client import ScheduleActionStartWorkflow, ScheduleOverlapPolicy
 
 from posthog.temporal.billing_usage_rollup.schedule import SCHEDULE_ID, WORKFLOW_NAME, build_schedule
-from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupInput
+from posthog.temporal.billing_usage_rollup.types import BillingUsageRecordsRollupWorkflowInput
 
 
 def test_billing_usage_rollup_schedule() -> None:
     schedule = build_schedule()
     assert isinstance(schedule.action, ScheduleActionStartWorkflow)
     assert schedule.action.workflow == WORKFLOW_NAME
-    assert list(schedule.action.args) == [BillingUsageRecordsRollupInput()]
+    assert list(schedule.action.args) == [BillingUsageRecordsRollupWorkflowInput()]
     assert schedule.action.id == SCHEDULE_ID
     assert schedule.action.task_queue == settings.ANALYTICS_PLATFORM_TASK_QUEUE
     assert schedule.policy.overlap == ScheduleOverlapPolicy.SKIP

--- a/posthog/temporal/tests/billing_usage_rollup/test_workflow.py
+++ b/posthog/temporal/tests/billing_usage_rollup/test_workflow.py
@@ -1,0 +1,26 @@
+from datetime import UTC, date, datetime
+
+from parameterized import parameterized
+
+from posthog.temporal.billing_usage_rollup.workflow import next_rollup_day
+
+
+@parameterized.expand(
+    [
+        (
+            "rollup waits for a full correction window",
+            datetime(2026, 6, 2, 5, tzinfo=UTC),
+            date(2026, 5, 3),
+            date(2026, 5, 4),
+        ),
+        (
+            "rollup catches up from its oldest missing day",
+            datetime(2026, 6, 2, 5, tzinfo=UTC),
+            date(2026, 5, 1),
+            date(2026, 5, 2),
+        ),
+        ("rollup does not repeat a completed day", datetime(2026, 6, 2, 5, tzinfo=UTC), date(2026, 5, 4), None),
+    ]
+)
+def test_next_rollup_day(_case: str, now: datetime, last_completed_day: date, expected: date | None) -> None:
+    assert next_rollup_day(last_completed_day, now) == expected


### PR DESCRIPTION
## Problem

Long-range usage reporting needs hourly snapshots that recover after worker pauses without missing or duplicating a day.

## Changes

- Temporal stores the last completed day in workflow state and catches up missed safe days.
- The coordinator waits until every record in a UTC day exceeds the 28-day correction window.
- Existing hourly rows trigger a warning and a replacement snapshot, so retries remain self-healing.
- This internal change has no user-visible interface.

### Before

```mermaid
flowchart LR
    S{{Daily schedule}} --> A[Choose day at activity start]
    A --> C[(ClickHouse hourly table)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class S phYellow;
    class A phBlue;
    class C phGray;
```

### After

```mermaid
flowchart LR
    S{{Daily schedule}} --> W[Temporal coordinator with checkpoint]
    W --> A[Roll one safe UTC day]
    A --> Q[Check existing hourly range]
    Q --> C[(ClickHouse replaceable snapshots)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class S phYellow;
    class W,A,Q phBlue;
    class C phGray;
```

## How did you test this code?

- Ran `hogli test posthog/temporal/tests/billing_usage_rollup`.
- Ran `hogli test posthog/models/usage_ingestion/test/test_billing_usage_records_hourly.py`.
- The standard storage test inserts one million rows and reruns the same hourly rollup.
- Not run: repository-wide type checks.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This internal workflow adds no documented interface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented a user-directed recovery design.
- Skills used: `/clickhouse-migrations`, `/stacking-prs`, `/writing-tests`, `/writing-dataclasses`, and `/writing-pr-descriptions`.
- The public diff contains no session-derived data.