### PR TITLE
fix(billing): keep real-time usage reads inside the memory limit

### DIFF
--- a/docs/internal/usage-record-producers.md
+++ b/docs/internal/usage-record-producers.md
@@ -22,9 +22,15 @@ The cost is that deduplication is scoped to a UTC day, so a reprocess that cross
 `inserted_at` is the engine's version column but is deliberately absent from the HogQL schema.
 `timestamp` is monotonic per resend, so `argMax(quantity, timestamp)` reads what a merge would keep, and one time column cannot be confused for the other.
 
-Read with `argMax(quantity, timestamp)` grouped by the sort key. HogQL rejects `FINAL` outright, so this is the only correct shape there.
+A read that must be exact uses `argMax(quantity, timestamp)` grouped by the sort key. HogQL rejects `FINAL` outright, so this is the only exact shape there.
 The collapse happens on merge, so a plain `sum(quantity)` counts every un-merged duplicate.
 Measured locally: two identical batches landing in separate parts read as 6 rows summing 18 without `FINAL`, and 3 rows summing 9 with it.
+
+That shape does not scale, so do not reach for it by default.
+`record_id` is unique per row, so grouping by the sort key holds one aggregation state per row, and the query exceeds ClickHouse's per-query memory limit.
+A plain `sum(quantity)` stays inside the limit and overstates a total by a fraction of a percent, because a resend is rare.
+So a monitoring or in-product read sums raw rows and says it is not the billed number.
+Reserve the exact shape for a read that is scoped tightly enough to afford it.
 
 | producer_id         | usage_key                                                         | unit           | record_id                                                                                       | deployment                         |
 | ------------------- | ----------------------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------- |

--- a/frontend/src/scenes/real-time-usage/realTimeUsageLogic.test.ts
+++ b/frontend/src/scenes/real-time-usage/realTimeUsageLogic.test.ts
@@ -37,13 +37,11 @@ describe('real-time usage logic', () => {
             [
                 {
                     project: { id: 1, name: 'First project' },
-                    rows: response([['ingestion', 'events', 'events', 2]]),
-                    timeSeries: response([[bucket, 'ingestion: events (events)', 2]]),
+                    usage: response([[bucket, 'ingestion', 'events', 'events', 2]]),
                 },
                 {
                     project: { id: 2, name: 'Second project' },
-                    rows: response([['ingestion', 'events', 'events', 3]]),
-                    timeSeries: response([[bucket, 'ingestion: events (events)', 3]]),
+                    usage: response([[bucket, 'ingestion', 'events', 'events', 3]]),
                 },
             ],
             '1d',

--- a/frontend/src/scenes/real-time-usage/realTimeUsageLogic.ts
+++ b/frontend/src/scenes/real-time-usage/realTimeUsageLogic.ts
@@ -30,8 +30,7 @@ type RealTimeUsageData = {
 
 type ProjectUsageData = {
     project: { id: number; name: string }
-    rows: HogQLQueryResponse
-    timeSeries: HogQLQueryResponse
+    usage: HogQLQueryResponse
 }
 
 const RANGE_INTERVALS: Record<UsageRange, string> = {
@@ -46,7 +45,7 @@ const RANGE_SECONDS: Record<UsageRange, number> = {
     '30d': 30 * 24 * 60 * 60,
 }
 
-const PROJECT_QUERY_CONCURRENCY = 5
+const PROJECT_QUERY_CONCURRENCY = 10
 
 // Buckets are cut by integer arithmetic on the Unix timestamp rather than by dateTrunc, so a bucket
 // is the same absolute instant for every project and for the browser. dateTrunc cuts on the team's
@@ -100,18 +99,16 @@ function bucketStarts(range: UsageRange, granularity: UsageGranularity): number[
     return Array.from({ length: count }, (_, index) => end - (count - 1 - index) * step)
 }
 
-function usageQuery(range: UsageRange, granularity: UsageGranularity, timeSeries: boolean): string {
+// Collapsing an un-merged resend needs a group by record_id, which is unique per row, so the
+// aggregation holds one state per row and exceeds ClickHouse's per-query memory limit. This page
+// reports usage as it arrives rather than the billed number, so a plain sum is close enough.
+// One query serves both the chart and the table, because the table is this result summed over its
+// buckets.
+function usageQuery(range: UsageRange, granularity: UsageGranularity): string {
     const interval = RANGE_INTERVALS[range]
     const step = GRANULARITY_SECONDS[granularity]
-    const bucket = `intDiv(toUnixTimestamp(recorded_at), ${step}) * ${step}`
-    // Grouped by the table's sorting key so un-merged duplicates of one record collapse instead
-    // of summing. HogQL rejects FINAL, and timestamp is monotonic per resend, so argMax on it
-    // picks the same row a merge would keep.
-    const canonicalRecords = `SELECT producer_id, usage_key, unit, record_id, argMax(quantity, timestamp) AS quantity, max(timestamp) AS recorded_at FROM posthog.billing_usage_records WHERE timestamp >= now() - INTERVAL ${interval} GROUP BY toDate(timestamp), producer_id, usage_key, unit, record_id`
 
-    return timeSeries
-        ? `SELECT ${bucket} AS bucket, concat(producer_id, ': ', usage_key, ' (', unit, ')') AS series, sum(quantity) AS quantity FROM (${canonicalRecords}) GROUP BY bucket, series ORDER BY bucket, series`
-        : `SELECT producer_id, usage_key, unit, sum(quantity) AS quantity FROM (${canonicalRecords}) GROUP BY producer_id, usage_key, unit ORDER BY quantity DESC, producer_id, usage_key`
+    return `SELECT intDiv(toUnixTimestamp(timestamp), ${step}) * ${step} AS bucket, producer_id, usage_key, unit, sum(quantity) AS quantity FROM posthog.billing_usage_records WHERE timestamp >= now() - INTERVAL ${interval} GROUP BY bucket, producer_id, usage_key, unit`
 }
 
 async function queryUsage(teamId: number, query: string): Promise<HogQLQueryResponse> {
@@ -137,26 +134,25 @@ export function parseUsageData(
     const series = new Map<string, Map<number, number>>()
 
     for (const response of responses) {
-        for (const [producerId, usageKey, unit, quantity] of response.rows.results ?? []) {
-            const key = `${breakdownByProject ? `${response.project.id}:` : ''}${producerId}:${usageKey}:${unit}`
-            const current = rows.get(key)
-            rows.set(key, {
+        for (const [bucket, producerId, usageKey, unit, quantity] of response.usage.results ?? []) {
+            const meter = `${producerId}: ${usageKey} (${unit})`
+            const amount = Number(quantity)
+
+            const rowKey = `${breakdownByProject ? `${response.project.id}:` : ''}${producerId}:${usageKey}:${unit}`
+            const current = rows.get(rowKey)
+            rows.set(rowKey, {
                 projectName: breakdownByProject ? response.project.name : undefined,
                 producerId: String(producerId),
                 usageKey: String(usageKey),
                 unit: String(unit),
-                quantity: (current?.quantity ?? 0) + Number(quantity),
+                quantity: (current?.quantity ?? 0) + amount,
             })
-        }
 
-        for (const [bucket, seriesName, quantity] of response.timeSeries.results ?? []) {
+            const seriesKey = breakdownByProject ? `${response.project.id}:${response.project.name}: ${meter}` : meter
+            const values = series.get(seriesKey) ?? new Map<number, number>()
             const bucketStart = Number(bucket)
-            const key = breakdownByProject
-                ? `${response.project.id}:${response.project.name}: ${seriesName}`
-                : String(seriesName)
-            const values = series.get(key) ?? new Map<number, number>()
-            values.set(bucketStart, (values.get(bucketStart) ?? 0) + Number(quantity))
-            series.set(key, values)
+            values.set(bucketStart, (values.get(bucketStart) ?? 0) + amount)
+            series.set(seriesKey, values)
         }
     }
 
@@ -228,8 +224,7 @@ export const realTimeUsageLogic = kea<realTimeUsageLogicType>([
             null as RealTimeUsageData | null,
             {
                 loadUsageData: async (): Promise<RealTimeUsageData> => {
-                    const rowsQuery = usageQuery(values.usageRange, values.usageGranularity, false)
-                    const timeSeriesQuery = usageQuery(values.usageRange, values.usageGranularity, true)
+                    const query = usageQuery(values.usageRange, values.usageGranularity)
                     const teams = values.currentOrganization?.teams ?? []
                     const selectedTeams = values.selectedProjectIds.length
                         ? teams.filter((team) => values.selectedProjectIds.includes(team.id))
@@ -243,8 +238,7 @@ export const realTimeUsageLogic = kea<realTimeUsageLogicType>([
                             projectQueryConcurrency.run({
                                 fn: async () => ({
                                     project: { id: team.id, name: team.name },
-                                    rows: await queryUsage(team.id, rowsQuery),
-                                    timeSeries: await queryUsage(team.id, timeSeriesQuery),
+                                    usage: await queryUsage(team.id, query),
                                 }),
                             })
                         )

--- a/posthog/hogql/database/schema/billing_usage_records.py
+++ b/posthog/hogql/database/schema/billing_usage_records.py
@@ -20,9 +20,12 @@ class BillingUsageRecordsTable(Table):
     visible only in the project that produced them.
 
     Rows deduplicate on ``(team_id, toDate(timestamp), producer_id, usage_key, record_id)``, and
-    the collapse only happens on merge. Read with ``argMax(quantity, timestamp)`` grouped by that
-    key; a plain ``sum(quantity)`` counts duplicates that have not merged yet, and HogQL rejects
-    ``FINAL``.
+    the collapse only happens on merge. ``argMax(quantity, timestamp)`` grouped by that key is the
+    exact read, because HogQL rejects ``FINAL``, but ``record_id`` is unique per row, so that
+    grouping holds one aggregation state per row and exceeds the per-query memory limit over any
+    real range. A plain ``sum(quantity)`` counts un-merged duplicates instead, which overstates a
+    total by a fraction of a percent. Prefer the plain sum unless the read is both scoped to a
+    small range and required to be exact.
     """
 
     description: str = "Durable product-usage records emitted by event ingestion, CDP, and feature flags."


### PR DESCRIPTION
## Problem

The real-time usage page under organization billing fails to load a project's usage: the query behind it dies with ClickHouse error 241, exceeding the per-query memory limit.

- Each per-project read wrapped the table in a subquery grouped by `record_id`, to collapse resends that a merge has not collapsed yet.
- `record_id` is unique per row, so that grouping holds one aggregation state per row.
- Reproduced against prod-US: the old shape for one project over one day hits the limit, and one such failure is already in `system.query_log`.
- Every recorded run of this page so far was PostHog's own organization, so it breaks on the smallest tenant it has.

## Changes

- The page loads instead of failing, and each project costs one query rather than two.
- The read sums raw rows, with no `record_id` subquery, so memory scales with the number of series rather than the number of rows.
- One bucketed query now serves both the chart and the table, because the table is that result summed over its buckets. This replaces two scans of the same partition.
- Project queries run 10 at a time instead of 5.
- `docs/internal/usage-record-producers.md` and the `BillingUsageRecordsTable` docstring both told readers to group by the sort key and called it the only correct shape. Both now carry the memory cost and name the plain sum as the default, because that guidance is why the page was written this way.

> [!NOTE]
> Totals read a fraction of a percent higher, because a resend counts twice until a merge collapses it. The page reports usage as it arrives and is not the billed number. No in-app notice, since the surface is staff-allowlisted and the shift sits far below what a reader would act on.

The chart legend, the project breakdown prefix and the table columns are unchanged, so nothing looks different beyond the page now returning data. Series names move from a `concat` in SQL to the same template string in TypeScript.

## How did you test this code?

- Ran the scene's Jest suite, and adapted its existing fixture to the single-response shape. No new test: the change alters the query and the parse input, and the existing project-breakdown case already covers the merge across projects.
- Ran both query shapes against prod-US ClickHouse through the Grafana datasource for one project over 24 hours. The old shape returned error 241; the new one returned in about a second.
- Compared the two totals over one project and one hour to size the accuracy cost.
- Not checked: the page in a browser, because this workspace has no dev stack running. The repo-wide `typescript:check` fails only on pre-existing `@posthog/quill` module resolution errors from the unbuilt nested workspace, and reports nothing in this scene.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/internal/usage-record-producers.md` is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`, `/query-clickhouse-via-metabase` for the production query paths.

The investigation started from the same failure on the "Realtime billing usage ingestion" Grafana dashboard, whose ClickHouse panels used this identical `argMax` shape and hit the same limit. Those panels were fixed directly in Grafana and are not part of this diff. Tracing the shape back found this page and the two documents that prescribe it, which is why the docs change rides along.

Considered and rejected: keeping the exact read and bounding the range. That helps a stat panel, but this page offers a 30 day range, so the shape would fail again at the range a reader most wants.

Two known limits left alone. The page still fans out one query per project, since HogQL scopes this table by `team_id` and an organization-wide read needs a different path. `refresh: 'force_blocking'` still bypasses the query cache on every filter change.

Nothing in this diff or description carries material from the agent session that is not already public. Measured row counts and memory figures are kept out on purpose; they cover PostHog's own project and internal cluster limits.
