### PR TITLE
feat(desktop): add Simplified Technical English toggle

### DIFF
--- a/products/desktop/packages/agent/src/adapters/ste100-guidance.ts
+++ b/products/desktop/packages/agent/src/adapters/ste100-guidance.ts
@@ -1,0 +1,20 @@
+import { SIMPLIFIED_TECHNICAL_ENGLISH_INSTRUCTION } from "@posthog/shared/product-engineer-prompt";
+import { isBenjaminEnabled } from "./benjamin-guidance";
+
+export { SIMPLIFIED_TECHNICAL_ENGLISH_INSTRUCTION };
+
+type SystemPrompt = string | { append: string };
+
+export function appendSte100Guidance(
+  prompt: SystemPrompt,
+  env: NodeJS.ProcessEnv = process.env,
+): SystemPrompt {
+  if (!isBenjaminEnabled(env)) return prompt;
+
+  const instructions = typeof prompt === "string" ? prompt : prompt.append;
+  const combined = [instructions, SIMPLIFIED_TECHNICAL_ENGLISH_INSTRUCTION]
+    .filter(Boolean)
+    .join("\n\n");
+
+  return typeof prompt === "string" ? combined : { append: combined };
+}

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -28,6 +28,7 @@ import {
 } from "vitest";
 import { POSTHOG_NOTIFICATIONS } from "../acp-extensions";
 import { getSessionJsonlPath } from "../adapters/claude/session/jsonl-hydration";
+import { SIMPLIFIED_TECHNICAL_ENGLISH_INSTRUCTION as STE100_INSTRUCTION } from "../adapters/ste100-guidance";
 import type { PermissionMode } from "../execution-mode";
 import type { PostHogAPIClient } from "../posthog-api";
 import type { ResumeState } from "../resume";
@@ -4336,6 +4337,35 @@ describe("AgentServer HTTP Mode", () => {
       expect(
         (s as unknown as TestableServer).buildCodexInstructions(sessionPrompt),
       ).toContain("BENJAMIN-PLUS MODE ACTIVE");
+    });
+
+    it("injects STE100 guidance into Slack prompts when POSTHOG_BENJAMIN is set", () => {
+      vi.stubEnv("POSTHOG_BENJAMIN", "1");
+      vi.stubEnv("POSTHOG_CODE_INTERACTION_ORIGIN", "slack");
+      const s = createServer();
+      const sessionPrompt = (
+        s as unknown as TestableServer
+      ).buildSessionSystemPrompt();
+
+      expect(
+        typeof sessionPrompt === "string"
+          ? sessionPrompt
+          : sessionPrompt.append,
+      ).toContain(STE100_INSTRUCTION);
+    });
+
+    it("does not inject STE100 guidance into user-created prompts", () => {
+      vi.stubEnv("POSTHOG_BENJAMIN", "1");
+      const s = createServer();
+      const sessionPrompt = (
+        s as unknown as TestableServer
+      ).buildSessionSystemPrompt();
+      const prompt =
+        typeof sessionPrompt === "string"
+          ? sessionPrompt
+          : sessionPrompt.append;
+
+      expect(prompt).not.toContain(STE100_INSTRUCTION);
     });
 
     it("omits benjamin from codex instructions when POSTHOG_BENJAMIN is unset", () => {

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -79,6 +79,7 @@ import {
   SIGNED_MERGE_QUALIFIED_TOOL_NAME,
   SIGNED_REWRITE_QUALIFIED_TOOL_NAME,
 } from "../adapters/signed-commit-shared";
+import { appendSte100Guidance } from "../adapters/ste100-guidance";
 import type { PermissionMode } from "../execution-mode";
 import { DEFAULT_CODEX_MODEL, fetchGatewayModels } from "../gateway-models";
 import { OtelRunTelemetry } from "../otel-telemetry";
@@ -3848,7 +3849,13 @@ export class AgentServer {
     );
     const userPrompt = this.config.claudeCode?.systemPrompt;
 
-    return buildCloudSessionSystemPrompt(cloudAppend, userPrompt);
+    const sessionPrompt = buildCloudSessionSystemPrompt(
+      cloudAppend,
+      userPrompt,
+    );
+    return this.getCloudInteractionOrigin() === "slack"
+      ? appendSte100Guidance(sessionPrompt)
+      : sessionPrompt;
   }
 
   private buildCodexInstructions(

--- a/products/desktop/packages/core/src/billing/costChecklist.test.ts
+++ b/products/desktop/packages/core/src/billing/costChecklist.test.ts
@@ -43,6 +43,15 @@ describe("buildCostChecklist", () => {
     ).toEqual([]);
   });
 
+  it("reflects the Simplified Technical English setting", () => {
+    expect(
+      buildCostChecklist({ ...base, ste100Enabled: false }),
+    ).toContainEqual({ kind: "ste100", done: false });
+    expect(buildCostChecklist({ ...base, ste100Enabled: true })).toContainEqual(
+      { kind: "ste100", done: true },
+    );
+  });
+
   it("keeps a completed item as a checked record and sinks it below active work", () => {
     const items = buildCostChecklist({
       ...base,

--- a/products/desktop/packages/core/src/billing/costChecklist.ts
+++ b/products/desktop/packages/core/src/billing/costChecklist.ts
@@ -14,6 +14,7 @@ import { modelCostMultiplier } from "./modelPricing";
 export type CostChecklistItemKind =
   | "model-notch"
   | "custom-image"
+  | "ste100"
   | "install-skill";
 
 export type CostChecklistItem =
@@ -25,6 +26,7 @@ export type CostChecklistItem =
     }
   | { kind: "model-notch"; done: true; modelId: string }
   | { kind: "custom-image"; done: boolean }
+  | { kind: "ste100"; done: boolean }
   | { kind: "install-skill"; done: boolean; skillId: string; name: string };
 
 /**
@@ -84,6 +86,7 @@ export interface CostChecklistInput {
    * cannot start.
    */
   hasCustomImage: boolean | null;
+  ste100Enabled?: boolean;
   /**
    * Every skill worth a row, in ranked order, each already resolved to
    * whether it is present locally.
@@ -100,6 +103,7 @@ export interface CostChecklistInput {
 export function buildCostChecklist({
   defaultModelId,
   hasCustomImage,
+  ste100Enabled,
   skills,
   completed,
 }: CostChecklistInput): CostChecklistItem[] {
@@ -132,6 +136,14 @@ export function buildCostChecklist({
     finished.push({ kind: "custom-image", done: true });
   } else if (hasCustomImage === false) {
     active.push({ kind: "custom-image", done: false });
+  }
+
+  if (ste100Enabled !== undefined) {
+    if (ste100Enabled) {
+      finished.push({ kind: "ste100", done: true });
+    } else {
+      active.push({ kind: "ste100", done: false });
+    }
   }
 
   // Installing is its own record, so these rows follow the skill list rather

--- a/products/desktop/packages/shared/src/product-engineer-prompt.ts
+++ b/products/desktop/packages/shared/src/product-engineer-prompt.ts
@@ -1,3 +1,6 @@
+export const SIMPLIFIED_TECHNICAL_ENGLISH_INSTRUCTION =
+  "Talk and write only in Simplified Technical English (ASD-STE100).";
+
 export const PRODUCT_ENGINEER_PROMPT = `Operate as an expert product engineer. Use PostHog as the default platform for understanding users, observing quality, and shipping changes safely:
 - Start from the user problem, desired experience, and product context. Understand why the work matters before deciding what to build.
 - Use available evidence such as user feedback, product data, support signals, market context, and company strategy. Ask for missing context when it would change the decision.

--- a/products/desktop/packages/ui/src/features/cost-management/CostChecklistPanel.stories.tsx
+++ b/products/desktop/packages/ui/src/features/cost-management/CostChecklistPanel.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta<typeof CostChecklistPanel> = {
   args: {
     onSwitchModel: () => {},
     onCreateImage: () => {},
+    onSte100Toggle: () => {},
     onInstallSkill: () => {},
     onUninstallSkill: () => {},
     onOpenSkill: () => {},
@@ -32,15 +33,17 @@ const modelNotch: CostChecklistItem = {
 };
 
 const customImage: CostChecklistItem = { kind: "custom-image", done: false };
+const ste100: CostChecklistItem = { kind: "ste100", done: false };
 
 export const BothActive: StoryObj<typeof CostChecklistPanel> = {
-  args: { items: [modelNotch, customImage] },
+  args: { items: [modelNotch, customImage, ste100] },
 };
 
 export const OneDone: StoryObj<typeof CostChecklistPanel> = {
   args: {
     items: [
       customImage,
+      ste100,
       { kind: "model-notch", done: true, modelId: "claude-sonnet-5" },
     ],
   },
@@ -77,6 +80,7 @@ export const EverySuggestion: StoryObj<typeof CostChecklistPanel> = {
     items: [
       modelNotch,
       customImage,
+      ste100,
       {
         kind: "install-skill",
         done: false,

--- a/products/desktop/packages/ui/src/features/cost-management/CostChecklistPanel.tsx
+++ b/products/desktop/packages/ui/src/features/cost-management/CostChecklistPanel.tsx
@@ -11,6 +11,7 @@ interface CostChecklistPanelProps {
   items: CostChecklistItem[];
   onSwitchModel: (toModelId: string) => void;
   onCreateImage: () => void;
+  onSte100Toggle: (enabled: boolean) => void;
   onInstallSkill: (skillId: string) => void;
   onUninstallSkill: (skillId: string) => void;
   /** Opens one skill's details, with its links. */
@@ -28,6 +29,7 @@ export function CostChecklistPanel({
   items,
   onSwitchModel,
   onCreateImage,
+  onSte100Toggle,
   onInstallSkill,
   onUninstallSkill,
   onOpenSkill,
@@ -60,6 +62,7 @@ export function CostChecklistPanel({
             {...rowContent(item, {
               onSwitchModel,
               onCreateImage,
+              onSte100Toggle,
               onInstallSkill,
               onUninstallSkill,
               onOpenSkill,
@@ -80,6 +83,7 @@ export function CostChecklistPanel({
 interface RowHandlers {
   onSwitchModel: (toModelId: string) => void;
   onCreateImage: () => void;
+  onSte100Toggle: (enabled: boolean) => void;
   onInstallSkill: (skillId: string) => void;
   onUninstallSkill: (skillId: string) => void;
   onOpenSkill: (skillId: string) => void;
@@ -160,6 +164,32 @@ function rowContent(item: CostChecklistItem, h: RowHandlers): RowContent {
               </Button>
             ),
           };
+
+    case "ste100":
+      return {
+        title: "Simplified Technical English (ASD-STE100)",
+        detail:
+          "Uses clear and consistent technical language in agent sessions.",
+        action: item.done ? (
+          <Button
+            variant="link-muted"
+            size="sm"
+            data-attr="cost-management-disable-ste100"
+            onClick={() => h.onSte100Toggle(false)}
+          >
+            Disable
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            data-attr="cost-management-inject-ste100"
+            onClick={() => h.onSte100Toggle(true)}
+          >
+            Inject
+          </Button>
+        ),
+      };
 
     case "install-skill": {
       const skill = leanSkillById(item.skillId);

--- a/products/desktop/packages/ui/src/features/cost-management/CostManagementSettings.tsx
+++ b/products/desktop/packages/ui/src/features/cost-management/CostManagementSettings.tsx
@@ -7,7 +7,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@posthog/quill";
-import { formatModelId } from "@posthog/shared";
+import { ANALYTICS_EVENTS, formatModelId } from "@posthog/shared";
 import { CostManagementView } from "@posthog/ui/features/cost-management/CostManagementView";
 import { CustomImageBuildDialog } from "@posthog/ui/features/cost-management/CustomImageBuildDialog";
 import { LeanSkillDialog } from "@posthog/ui/features/cost-management/LeanSkillDialog";
@@ -22,11 +22,13 @@ import { useInstallMarketplaceSkill } from "@posthog/ui/features/skills/useMarke
 import { useDeleteSkill } from "@posthog/ui/features/skills/useSkillMutations";
 import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnalysisEnabled";
 import { toast } from "@posthog/ui/primitives/toast";
+import { track } from "@posthog/ui/shell/analytics";
 import { useState } from "react";
 
 export function CostManagementSettings() {
   const spendAnalysisEnabled = useSpendAnalysisEnabled();
   const setLastUsedModel = useSettingsStore((state) => state.setLastUsedModel);
+  const setSte100Enabled = useSettingsStore((state) => state.setSte100Enabled);
   const markDone = useSettingsStore((state) => state.markCostChecklistDone);
   const items = useCostChecklist();
   const cloudRepository = useSettingsStore(
@@ -84,6 +86,14 @@ export function CostManagementSettings() {
     });
   };
 
+  const toggleSte100 = (enabled: boolean) => {
+    setSte100Enabled(enabled);
+    track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+      setting_name: "simplified_technical_english",
+      new_value: enabled,
+    });
+  };
+
   const installById = async (skillId: string) => {
     const skill = leanSkillById(skillId);
     if (!skill) return;
@@ -132,6 +142,7 @@ export function CostManagementSettings() {
         items={items}
         onSwitchModel={switchDefaultModel}
         onCreateImage={() => setBuildingImage(true)}
+        onSte100Toggle={toggleSte100}
         onInstallSkill={(skillId) => void installById(skillId)}
         onUninstallSkill={(skillId) => void uninstallById(skillId)}
         onOpenSkill={setOpenSkillId}

--- a/products/desktop/packages/ui/src/features/cost-management/CostManagementView.tsx
+++ b/products/desktop/packages/ui/src/features/cost-management/CostManagementView.tsx
@@ -8,6 +8,7 @@ interface CostManagementViewProps {
   items: CostChecklistItem[];
   onSwitchModel: (toModelId: string) => void;
   onCreateImage: () => void;
+  onSte100Toggle: (enabled: boolean) => void;
   onInstallSkill: (skillId: string) => void;
   onUninstallSkill: (skillId: string) => void;
   onOpenSkill: (skillId: string) => void;
@@ -18,6 +19,7 @@ export function CostManagementView({
   items,
   onSwitchModel,
   onCreateImage,
+  onSte100Toggle,
   onInstallSkill,
   onUninstallSkill,
   onOpenSkill,
@@ -35,6 +37,7 @@ export function CostManagementView({
           items={items}
           onSwitchModel={onSwitchModel}
           onCreateImage={onCreateImage}
+          onSte100Toggle={onSte100Toggle}
           onInstallSkill={onInstallSkill}
           onUninstallSkill={onUninstallSkill}
           onOpenSkill={onOpenSkill}

--- a/products/desktop/packages/ui/src/features/cost-management/useCostChecklist.ts
+++ b/products/desktop/packages/ui/src/features/cost-management/useCostChecklist.ts
@@ -16,6 +16,7 @@ import { useMemo } from "react";
 export function useCostChecklist(): CostChecklistItem[] {
   const defaultModelId = useSettingsStore((state) => state.lastUsedModel);
   const completed = useSettingsStore((state) => state.costChecklistDone);
+  const ste100Enabled = useSettingsStore((state) => state.ste100Enabled);
   const { images, customImagesEnabled, customImagesDisabled } =
     useSandboxCustomImages();
   const skills = useSkills();
@@ -39,6 +40,7 @@ export function useCostChecklist(): CostChecklistItem[] {
   return buildCostChecklist({
     defaultModelId,
     hasCustomImage,
+    ste100Enabled,
     skills: skillsLoaded
       ? LEAN_SKILLS.map((skill) => ({
           skillId: skill.skillId,

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -271,6 +271,7 @@ const mockFeatureFlags = vi.hoisted(() => ({
 
 const mockSettingsState = vi.hoisted(() => ({
   customInstructions: "",
+  ste100Enabled: true,
   codexModelAccess: "posthog-gateway" as "posthog-gateway" | "own-subscription",
   claudeModelAccess: "posthog-gateway" as
     | "posthog-gateway"
@@ -488,6 +489,7 @@ describe("SessionService", () => {
     mockHasSessionPromptEventForTaskRun.mockReturnValue(false);
     resetSessionService();
     mockSettingsState.customInstructions = "";
+    mockSettingsState.ste100Enabled = true;
     mockSettingsState.codexModelAccess = "posthog-gateway";
     mockSettingsState.claudeModelAccess = "posthog-gateway";
     mockSettingsState.spokenNotifications = false;
@@ -871,7 +873,10 @@ describe("SessionService", () => {
       });
 
       expect(mockTrpcAgent.start.mutate).toHaveBeenCalledWith(
-        expect.objectContaining({ customInstructions: "synced from file" }),
+        expect.objectContaining({
+          customInstructions:
+            "synced from file\n\nTalk and write only in Simplified Technical English (ASD-STE100).",
+        }),
       );
     });
 

--- a/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.stories.tsx
@@ -29,6 +29,8 @@ const meta: Meta<typeof PersonalizationSettingsView> = {
     syncFromFile: false,
     onSyncToggle: () => {},
     synced: null,
+    ste100Enabled: true,
+    onSte100Toggle: () => {},
   },
   // Match the settings dialog's content column so rows size realistically.
   decorators: [

--- a/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PersonalizationSettings.tsx
@@ -24,6 +24,8 @@ export interface PersonalizationSettingsViewProps {
   syncFromFile: boolean;
   onSyncToggle: (checked: boolean) => void;
   synced: SyncedCustomInstructions | null;
+  ste100Enabled: boolean;
+  onSte100Toggle: (checked: boolean) => void;
 }
 
 // Pure render of the instructions block. The container below owns the store
@@ -35,6 +37,8 @@ export function PersonalizationSettingsView({
   syncFromFile,
   onSyncToggle,
   synced,
+  ste100Enabled,
+  onSte100Toggle,
 }: PersonalizationSettingsViewProps) {
   return (
     <SettingsSection
@@ -42,6 +46,17 @@ export function PersonalizationSettingsView({
       description="Included in every agent session"
     >
       <SettingsCard>
+        <SettingsCardRow
+          label="Use Simplified Technical English (ASD-STE100)"
+          description="Ask the agent to use clear and consistent technical language"
+        >
+          <Switch
+            size="sm"
+            aria-label="Use Simplified Technical English (ASD-STE100)"
+            checked={ste100Enabled}
+            onCheckedChange={onSte100Toggle}
+          />
+        </SettingsCardRow>
         <SettingsCardRow
           label="Sync from AGENTS.md / CLAUDE.md"
           description="Use your user-level AGENTS.md (or CLAUDE.md) instead of the instructions below, so they live in one place"
@@ -110,6 +125,8 @@ export function PersonalizationSettings() {
     (s) => s.setSyncCustomInstructionsFromFile,
   );
   const synced = useSettingsStore((s) => s.syncedCustomInstructions);
+  const ste100Enabled = useSettingsStore((s) => s.ste100Enabled);
+  const setSte100Enabled = useSettingsStore((s) => s.setSte100Enabled);
 
   // The draft renders over the store value only while edits are pending
   // (null = none), instead of copying the store into state and mirroring it
@@ -155,6 +172,17 @@ export function PersonalizationSettings() {
     [setSyncFromFile],
   );
 
+  const handleSte100Toggle = useCallback(
+    (checked: boolean) => {
+      setSte100Enabled(checked);
+      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+        setting_name: "simplified_technical_english",
+        new_value: checked,
+      });
+    },
+    [setSte100Enabled],
+  );
+
   return (
     <div className="flex flex-col gap-7">
       <PersonalizationSettingsView
@@ -164,6 +192,8 @@ export function PersonalizationSettings() {
         syncFromFile={syncFromFile}
         onSyncToggle={handleSyncToggle}
         synced={synced}
+        ste100Enabled={ste100Enabled}
+        onSte100Toggle={handleSte100Toggle}
       />
       <FunSection />
     </div>

--- a/products/desktop/packages/ui/src/features/settings/settingsSearch.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsSearch.test.ts
@@ -13,6 +13,11 @@ describe("searchSettings", () => {
       "Spoken narration",
     ],
     ["ranks a label prefix above keyword hits", "dock badge", "Dock badge"],
+    [
+      "finds Simplified Technical English by its standard name",
+      "STE100",
+      "Simplified Technical English (ASD-STE100)",
+    ],
   ])("%s", (_name, query, expectedFirstLabel) => {
     const results = searchSettings(query, NO_HIDDEN);
     expect(results[0]?.label).toBe(expectedFirstLabel);

--- a/products/desktop/packages/ui/src/features/settings/settingsSearch.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsSearch.ts
@@ -128,6 +128,11 @@ const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   },
   {
     category: "personalization",
+    label: "Simplified Technical English (ASD-STE100)",
+    keywords: ["ste100", "clear language", "writing style"],
+  },
+  {
+    category: "personalization",
     label: "Hedgehog mode",
     keywords: ["hedgehog", "buddy", "fun"],
   },

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.test.ts
@@ -507,34 +507,66 @@ describe("getEffectiveCustomInstructions", () => {
       label: "typed instructions when sync is off",
       sync: false,
       syncedValue: synced,
+      ste100Enabled: false,
       expected: "typed",
     },
     {
       label: "file content when sync is on and a file was found",
       sync: true,
       syncedValue: synced,
+      ste100Enabled: false,
       expected: "from file",
     },
     {
       label: "nothing when sync is on but no file was found",
       sync: true,
       syncedValue: null,
+      ste100Enabled: false,
       expected: "",
     },
     {
       label: "nothing when the synced file is whitespace",
       sync: true,
       syncedValue: { ...synced, content: " \n" },
+      ste100Enabled: false,
       expected: "",
     },
-  ])("returns $label", ({ sync, syncedValue, expected }) => {
+    {
+      label: "adds the language instruction when enabled",
+      sync: false,
+      syncedValue: null,
+      ste100Enabled: true,
+      expected:
+        "typed\n\nTalk and write only in Simplified Technical English (ASD-STE100).",
+    },
+  ])("returns $label", ({ sync, syncedValue, ste100Enabled, expected }) => {
     expect(
       getEffectiveCustomInstructions({
         customInstructions: "typed",
         syncCustomInstructionsFromFile: sync,
         syncedCustomInstructions: syncedValue,
+        ste100Enabled,
       }),
     ).toBe(expected);
+  });
+
+  it("keeps synced instructions within the session limit when enabled", () => {
+    const result = getEffectiveCustomInstructions({
+      customInstructions: "",
+      syncCustomInstructionsFromFile: true,
+      syncedCustomInstructions: {
+        ...synced,
+        content: "x".repeat(20_000),
+      },
+      ste100Enabled: true,
+    });
+
+    expect(result).toHaveLength(20_000);
+    expect(
+      result.endsWith(
+        "Talk and write only in Simplified Technical English (ASD-STE100).",
+      ),
+    ).toBe(true);
   });
 });
 
@@ -544,6 +576,7 @@ describe("feature settingsStore custom instructions sync persistence", () => {
 
     useSettingsStore.setState({
       syncCustomInstructionsFromFile: false,
+      ste100Enabled: true,
       syncedCustomInstructions: null,
     });
   });
@@ -570,6 +603,7 @@ describe("feature settingsStore custom instructions sync persistence", () => {
     const persisted = JSON.parse(lastCall[1]);
 
     expect(persisted.state.syncCustomInstructionsFromFile).toBe(true);
+    expect(persisted.state.ste100Enabled).toBe(true);
     expect(persisted.state).not.toHaveProperty("syncedCustomInstructions");
   });
 });

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.ts
@@ -15,6 +15,7 @@ import type {
   WorkspaceMode,
 } from "@posthog/shared";
 import type { EffortLevel } from "@posthog/shared/domain-types";
+import { SIMPLIFIED_TECHNICAL_ENGLISH_INSTRUCTION } from "@posthog/shared/product-engineer-prompt";
 import {
   TIP_SHOWINGS,
   type TipKey,
@@ -22,6 +23,8 @@ import {
 import { electronStorage } from "@posthog/ui/shell/rendererStorage";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+
+const MAX_EFFECTIVE_CUSTOM_INSTRUCTIONS_LENGTH = 20_000;
 
 // ---------- Types ----------
 
@@ -232,6 +235,7 @@ export interface SettingsStore {
   autoConvertLongText: AutoConvertLongText;
   sendMessagesWith: SendMessagesWith;
   customInstructions: string;
+  ste100Enabled: boolean;
   // When on, personalization mirrors the user-level AGENTS.md (or CLAUDE.md)
   // instead of the hand-typed customInstructions above.
   syncCustomInstructionsFromFile: boolean;
@@ -239,6 +243,7 @@ export interface SettingsStore {
   setAutoConvertLongText: (value: AutoConvertLongText) => void;
   setSendMessagesWith: (mode: SendMessagesWith) => void;
   setCustomInstructions: (instructions: string) => void;
+  setSte100Enabled: (enabled: boolean) => void;
   setSyncCustomInstructionsFromFile: (enabled: boolean) => void;
   setSyncedCustomInstructions: (
     synced: SyncedCustomInstructions | null,
@@ -495,12 +500,14 @@ export const useSettingsStore = create<SettingsStore>()(
       autoConvertLongText: "2500",
       sendMessagesWith: "enter",
       customInstructions: "",
+      ste100Enabled: true,
       syncCustomInstructionsFromFile: false,
       syncedCustomInstructions: null,
       setAutoConvertLongText: (value) => set({ autoConvertLongText: value }),
       setSendMessagesWith: (mode) => set({ sendMessagesWith: mode }),
       setCustomInstructions: (instructions) =>
         set({ customInstructions: instructions }),
+      setSte100Enabled: (enabled) => set({ ste100Enabled: enabled }),
       setSyncCustomInstructionsFromFile: (enabled) =>
         set({ syncCustomInstructionsFromFile: enabled }),
       setSyncedCustomInstructions: (synced) =>
@@ -694,6 +701,7 @@ export const useSettingsStore = create<SettingsStore>()(
         autoConvertLongText: state.autoConvertLongText,
         sendMessagesWith: state.sendMessagesWith,
         customInstructions: state.customInstructions,
+        ste100Enabled: state.ste100Enabled,
         syncCustomInstructionsFromFile: state.syncCustomInstructionsFromFile,
 
         // Diff viewer
@@ -826,15 +834,27 @@ export function getEffectiveCustomInstructions(
   state: Pick<
     SettingsStore,
     | "customInstructions"
+    | "ste100Enabled"
     | "syncCustomInstructionsFromFile"
     | "syncedCustomInstructions"
   >,
 ): string {
-  if (state.syncCustomInstructionsFromFile) {
-    const content = state.syncedCustomInstructions?.content ?? "";
-    return content.trim() ? content : "";
+  const content = state.syncCustomInstructionsFromFile
+    ? (state.syncedCustomInstructions?.content ?? "")
+    : state.customInstructions;
+  if (!state.ste100Enabled) {
+    return state.syncCustomInstructionsFromFile
+      ? content.trim()
+        ? content
+        : ""
+      : content;
   }
-  return state.customInstructions;
+  const instruction = SIMPLIFIED_TECHNICAL_ENGLISH_INSTRUCTION;
+  const availableContentLength =
+    MAX_EFFECTIVE_CUSTOM_INSTRUCTIONS_LENGTH - instruction.length - 2;
+  return [content.trim().slice(0, availableContentLength), instruction]
+    .filter(Boolean)
+    .join("\n\n");
 }
 
 /**


### PR DESCRIPTION
## Problem

Desktop users could not control whether custom instructions included Simplified Technical English.

## Changes

- Add a persisted toggle in Desktop Personalization.
- Apply the instruction to Desktop sessions when enabled.
