### PR TITLE
fix(warehouse-sources): stamp Delta commit times in the snapshot pin test

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -176,15 +176,12 @@ def test_resolve_raises_when_parent_has_no_synced_table(tmp_path: Path) -> None:
 
 
 def _stamp_commit(uri: str, version: int, committed_at: datetime) -> None:
-    """Set when a Delta commit appears to have landed.
-
-    delta-rs time travel resolves a datetime against the `_delta_log` commit files' modification
-    times, not the `timestamp` inside each commit that `DeltaTable.history()` reports. On Linux
-    the filesystem stamps mtimes from a coarse clock that can lag the commit's own timestamp by a
-    scheduler tick, so two back-to-back writes can both look older than the first commit's
-    `history()` timestamp and the pin lands on the newer version. Stamping the commits keeps the
-    test about the pin, not the clock.
-    """
+    # delta-rs time travel resolves a datetime against the `_delta_log` commit files' modification
+    # times, not the `timestamp` inside each commit that `DeltaTable.history()` reports. On Linux
+    # the filesystem stamps mtimes from a coarse clock that can lag the commit's own timestamp by a
+    # scheduler tick, so two back-to-back writes can both look older than the first commit's
+    # `history()` timestamp and the pin lands on the newer version. Stamping the commits keeps the
+    # test about the pin, not the clock.
     ts = committed_at.timestamp()
     os.utime(Path(uri) / "_delta_log" / f"{version:020d}.json", (ts, ts))
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -1,4 +1,4 @@
-import json
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -175,21 +175,33 @@ def test_resolve_raises_when_parent_has_no_synced_table(tmp_path: Path) -> None:
         _patched_resolve(str(tmp_path / "does_not_exist"))
 
 
+def _stamp_commit(uri: str, version: int, committed_at: datetime) -> None:
+    """Set when a Delta commit appears to have landed.
+
+    delta-rs time travel resolves a datetime against the `_delta_log` commit files' modification
+    times, not the `timestamp` inside each commit that `DeltaTable.history()` reports. On Linux
+    the filesystem stamps mtimes from a coarse clock that can lag the commit's own timestamp by a
+    scheduler tick, so two back-to-back writes can both look older than the first commit's
+    `history()` timestamp and the pin lands on the newer version. Stamping the commits keeps the
+    test about the pin, not the clock.
+    """
+    ts = committed_at.timestamp()
+    os.utime(Path(uri) / "_delta_log" / f"{version:020d}.json", (ts, ts))
+
+
 def test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing(tmp_path: Path) -> None:
     uri = _write_parent_table(tmp_path)
-    v0_table = deltalake.DeltaTable(uri)
-    v0 = v0_table.version()
-    v0_timestamp = datetime.fromtimestamp(v0_table.history()[0]["timestamp"] / 1000, tz=UTC)
+    v0 = deltalake.DeltaTable(uri).version()
 
     # An in-flight full refresh has already committed a partial overwrite on top of v0.
     deltalake.write_deltalake(uri, pa.table({"id": ["partial"], "last_seen": ["x"], "title": ["y"]}), mode="overwrite")
-    partial_refresh_log = Path(uri) / "_delta_log" / "00000000000000000001.json"
-    entries = partial_refresh_log.read_text().splitlines()
-    partial_refresh_commit = json.loads(entries[0])
-    partial_refresh_commit["commitInfo"]["timestamp"] = int(v0_timestamp.timestamp() * 1000) + 1
-    partial_refresh_log.write_text("\n".join([json.dumps(partial_refresh_commit), *entries[1:]]) + "\n")
 
-    pinned = _patched_resolve(uri, snapshot_timestamp=v0_timestamp)
+    v0_committed_at = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+    _stamp_commit(uri, v0, v0_committed_at)
+    _stamp_commit(uri, v0 + 1, v0_committed_at + timedelta(minutes=10))
+
+    # The parent's last completed job finished after v0 landed and before the refresh started writing.
+    pinned = _patched_resolve(uri, snapshot_timestamp=v0_committed_at + timedelta(minutes=1))
 
     assert pinned.version == v0
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -175,15 +175,14 @@ def test_resolve_raises_when_parent_has_no_synced_table(tmp_path: Path) -> None:
         _patched_resolve(str(tmp_path / "does_not_exist"))
 
 
-def _stamp_commit(uri: str, version: int, committed_at: datetime) -> None:
-    # delta-rs time travel resolves a datetime against the `_delta_log` commit files' modification
-    # times, not the `timestamp` inside each commit that `DeltaTable.history()` reports. On Linux
-    # the filesystem stamps mtimes from a coarse clock that can lag the commit's own timestamp by a
-    # scheduler tick, so two back-to-back writes can both look older than the first commit's
-    # `history()` timestamp and the pin lands on the newer version. Stamping the commits keeps the
-    # test about the pin, not the clock.
-    ts = committed_at.timestamp()
-    os.utime(Path(uri) / "_delta_log" / f"{version:020d}.json", (ts, ts))
+def _set_delta_commit_log_mtimes(uri: str, times_by_version: dict[int, datetime]) -> None:
+    # delta-rs resolves a time-travel pin against the `_delta_log` commit files' modification times,
+    # not the `timestamp` inside each commit that `DeltaTable.history()` reports. Those mtimes come
+    # from a coarse filesystem clock that can collapse the gap between two back-to-back writes, so
+    # the test sets them explicitly and stays about the pin rather than about the clock.
+    for version, committed_at in times_by_version.items():
+        ts = committed_at.timestamp()
+        os.utime(Path(uri) / "_delta_log" / f"{version:020d}.json", (ts, ts))
 
 
 def test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing(tmp_path: Path) -> None:
@@ -193,12 +192,11 @@ def test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing(tmp_pat
     # An in-flight full refresh has already committed a partial overwrite on top of v0.
     deltalake.write_deltalake(uri, pa.table({"id": ["partial"], "last_seen": ["x"], "title": ["y"]}), mode="overwrite")
 
-    v0_committed_at = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
-    _stamp_commit(uri, v0, v0_committed_at)
-    _stamp_commit(uri, v0 + 1, v0_committed_at + timedelta(minutes=10))
+    snapshot_committed_at = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+    _set_delta_commit_log_mtimes(uri, {v0: snapshot_committed_at, v0 + 1: snapshot_committed_at + timedelta(minutes=2)})
 
     # The parent's last completed job finished after v0 landed and before the refresh started writing.
-    pinned = _patched_resolve(uri, snapshot_timestamp=v0_committed_at + timedelta(minutes=1))
+    pinned = _patched_resolve(uri, snapshot_timestamp=snapshot_committed_at + timedelta(minutes=1))
 
     assert pinned.version == v0
 


### PR DESCRIPTION
## Problem

Anyone whose PR shares a Trunk merge-queue batch with a warehouse-sources shard can get thrown out of the queue by `test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing` failing with `assert 1 == 0`. It failed 3/3 attempts in both the batch run and the bisection run for #92922 (a cohorts-only PR), while master's own CI on the identical base commit (7e12bc8) passed.

The test writes a Delta table (v0), takes v0's commit timestamp from `DeltaTable.history()`, immediately overwrites (v1), then pins at that timestamp and expects v0. But delta-rs time travel does not compare against `history()` timestamps: `get_version_timestamp` / `version_timestamp` in delta-rs 1.6.1 return the `_delta_log` commit files' `last_modified`. On Linux, file mtimes come from the kernel's coarse clock and can lag the in-process clock by a scheduler tick, so on a fast runner both commit files can look older than v0's own timestamp. The binary search then lands on v1. Reruns don't help because the outcome tracks the runner's speed, not luck, and it never reproduces on macOS, where mtimes are fine-grained.

## Changes

- Replaces the in-branch change that #84280 carried to master for this same test (commit "fix(warehouse-sources): stabilize parent snapshot test"). That change rewrote the v1 commit's `commitInfo.timestamp` to v0's plus one millisecond. Delta-rs never reads that field for time travel, so the rewrite only worked because writing the file refreshed its mtime, and a probe confirmed it: with the file's mtime set back to the lagging value the pin still lands on v1. It also left the test without a comment saying why it does what it does.
- The test stamps the two commit files with explicit, well-separated mtimes and pins between them, so the assertion is about the pin and not about which clock ticked first. This is also the production shape: `finished_at` sits strictly between the completed job's last commit and the next run's first one. The commits sit 2 minutes apart and the pin 1 minute after the first — the helper name and those offsets come from #93192, which fixed the same test independently and is closed in favor of this PR.
- A small `_set_delta_commit_log_mtimes` helper carries a comment on why delta-rs needs this, so the next person doesn't rediscover it. The `json` import #84280 added goes away with the rewrite it served.

No production code changes.

## How did you test this code?

- Rebased onto master after #84280 landed; the test passes locally under flox on the rebased branch, ruff is clean; the `APIBaseTest`-based classes in the file error locally only because no Postgres is running, which is unrelated to this change.
- Reproduced the CI failure mechanism in a standalone script against deltalake 1.6.1: with the two commit files' mtimes forced to lag v0's `history()` timestamp by 1ms, `load_as_version(v0_timestamp)` loads version 1; with the explicit stamps used here, it loads version 0.
- Evidence: bisection run [33608387907](https://github.com/PostHog/posthog/actions/runs/33608387907/job/100178205594) and batch run [33604779252](https://github.com/PostHog/posthog/actions/runs/33604779252/job/100166846019), both failing this test 3/3; master on the same base commit: [33607068880](https://github.com/PostHog/posthog/actions/runs/33607068880/job/100178869836) green.
- Not checked: I did not run this on a Linux runner myself; the fix removes the dependency on mtime granularity rather than tuning around it.

Note for a follow-up, not changed here: the `resolve_parent_table_ref` docstring describes the rollback as comparing `finished_at` against "Delta commit timestamps stamped by worker clocks". Against S3 it actually compares against S3's `LastModified`, which is S3's clock at second granularity.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1). Diagnosis started from the failed merge-queue job link: read the shard logs, compared the queue branch's base SHA against master's check runs, read the pinned delta-rs source for `load_with_datetime`, and reproduced the mtime-lag mechanism in a scratch script before touching the test. No repo skills were invoked. Skill updates capturing the lesson (writing-tests, fixing-flaky-tests, triaging-merge-queue-failures) are in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

