### PR TITLE
feat(desktop): dive into task UI while the agent connects

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -2374,6 +2374,9 @@ export class SessionService {
           ...readCapabilities(result),
         });
 
+        // Send any prompt the user queued while the agent was connecting.
+        this.flushQueuedMessagesIfIdle(taskId);
+
         // Persist the merged config options
         if (configOptions) {
           this.d.setPersistedConfigOptions(taskRunId, configOptions);
@@ -2513,6 +2516,11 @@ export class SessionService {
     }
     if (existing?.initialPrompt?.length) {
       session.initialPrompt = existing.initialPrompt;
+    }
+    // Keep a prompt the user queued while connecting so a failed connect
+    // leaves it available to the retry / reset flow instead of dropping it.
+    if (existing?.messageQueue?.length) {
+      session.messageQueue = existing.messageQueue;
     }
     this.d.store.setSession(session);
   }
@@ -4196,9 +4204,15 @@ export class SessionService {
         );
       }
       if (session.status === "connecting") {
-        throw new Error(
-          "Session is still connecting. Please wait and try again.",
-        );
+        // Let the user queue one prompt while the agent connects; the
+        // connecting→connected transition drains it. A second submit is a
+        // no-op here (the composer blocks after the first while connecting).
+        if (session.messageQueue.length > 0) {
+          return { stopReason: "queued" };
+        }
+        this.d.store.enqueueMessage(taskId, extractPromptText(prompt));
+        this.d.log.info("Message queued while connecting", { taskId });
+        return { stopReason: "queued" };
       }
       throw new Error(`Session is not ready (status: ${session.status})`);
     }
@@ -4891,6 +4905,11 @@ export class SessionService {
     }
 
     if (session.cloudStatus !== "in_progress") {
+      // One prompt already waiting for the sandbox; the composer blocks after
+      // the first while connecting, so a second submit is a no-op.
+      if (session.messageQueue.length > 0) {
+        return { stopReason: "queued" };
+      }
       this.d.store.enqueueMessage(
         session.taskId,
         transport.promptText,
@@ -4915,6 +4934,11 @@ export class SessionService {
       session.isCloud &&
       session.status !== "connected"
     ) {
+      // One prompt already waiting for the agent to come up; block further
+      // submits until it connects (the composer enforces this in the UI).
+      if (session.messageQueue.length > 0) {
+        return { stopReason: "queued" };
+      }
       this.d.store.enqueueMessage(
         session.taskId,
         transport.promptText,

--- a/products/desktop/packages/core/src/sessions/sessionServiceCompaction.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServiceCompaction.test.ts
@@ -118,6 +118,10 @@ function createHarness() {
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_FLUSH_MS);
     },
     isCompacting: () => sessions[RUN_ID].isCompacting,
+    session: () => sessions[RUN_ID],
+    setStatus: (status: AgentSession["status"]) => {
+      sessions[RUN_ID] = { ...sessions[RUN_ID], status };
+    },
   };
 }
 
@@ -152,5 +156,66 @@ describe("compaction busy state", () => {
     expect(h.isCompacting()).toBe(false);
     await h.service.sendPrompt(TASK_ID, "carry on");
     expect(h.prompt).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sendPrompt while connecting", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("queues the prompt instead of throwing", async () => {
+    const h = createHarness();
+    h.setStatus("connecting");
+
+    const result = await h.service.sendPrompt(TASK_ID, "start on this");
+
+    expect(result.stopReason).toBe("queued");
+    expect(h.session().messageQueue).toHaveLength(1);
+    expect(h.prompt).not.toHaveBeenCalled();
+  });
+
+  it("keeps only the first prompt while connecting", async () => {
+    const h = createHarness();
+    h.setStatus("connecting");
+
+    await h.service.sendPrompt(TASK_ID, "first");
+    await h.service.sendPrompt(TASK_ID, "second");
+
+    expect(h.session().messageQueue).toHaveLength(1);
+  });
+
+  it("still throws when the session is in error", async () => {
+    const h = createHarness();
+    h.setStatus("error");
+
+    await expect(h.service.sendPrompt(TASK_ID, "retry")).rejects.toThrow();
+    expect(h.session().messageQueue).toHaveLength(0);
+  });
+
+  // A failed connect must not silently drop the prompt the user queued while
+  // waiting; it stays available to the retry flow.
+  it("preserves the queued prompt when the connect fails", async () => {
+    const h = createHarness();
+    h.setStatus("connecting");
+    await h.service.sendPrompt(TASK_ID, "hold this");
+    expect(h.session().messageQueue).toHaveLength(1);
+
+    (
+      h.service as unknown as {
+        setErrorSession: (
+          taskId: string,
+          taskRunId: string,
+          taskTitle: string,
+          errorMessage: string,
+        ) => void;
+      }
+    ).setErrorSession(TASK_ID, RUN_ID, "Local Task", "connect failed");
+
+    expect(h.session().status).toBe("error");
+    expect(h.session().messageQueue).toHaveLength(1);
   });
 });

--- a/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.test.ts
@@ -1,7 +1,10 @@
 import type { AgentSession } from "@posthog/shared";
 import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
-import { deriveSessionViewState } from "./sessionViewState";
+import {
+  deriveSessionLifecycleState,
+  deriveSessionViewState,
+} from "./sessionViewState";
 
 function makeTask(runStatus: TaskRunStatus, runId = "run-1"): Task {
   return {
@@ -46,7 +49,7 @@ function makeSession(
 }
 
 describe("deriveSessionViewState", () => {
-  it("keeps the loading view through optimistic prompts and setup events", () => {
+  it("opens the live cloud chat while setup events stream in", () => {
     const session = makeSession("in_progress");
     session.optimisticItems = [
       {
@@ -72,7 +75,7 @@ describe("deriveSessionViewState", () => {
     expect(
       deriveSessionViewState(session, makeTask("in_progress"), null, true)
         .isInitializing,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("opens the live cloud chat after the active run sends its prompt", () => {
@@ -204,7 +207,7 @@ describe("deriveSessionViewState", () => {
     ).toBe(true);
   });
 
-  it("keeps a local session loading until its first prompt", () => {
+  it("opens a connecting local session, but not an older run's", () => {
     const task = makeTask("in_progress");
     if (task.latest_run) {
       task.latest_run.environment = "local";
@@ -215,20 +218,14 @@ describe("deriveSessionViewState", () => {
 
     expect(
       deriveSessionViewState(session, task, null, false).isInitializing,
-    ).toBe(true);
-
-    session.status = "connected";
-    session.initialPrompt = [
-      { type: "text", text: "Inspect the example task" },
-    ];
-    expect(
-      deriveSessionViewState(session, task, null, false).isInitializing,
-    ).toBe(true);
-
-    session.firstPromptForRunId = session.taskRunId;
-    expect(
-      deriveSessionViewState(session, task, null, false).isInitializing,
     ).toBe(false);
+
+    const olderSession = makeSession("in_progress", "old-run");
+    olderSession.isCloud = false;
+    olderSession.status = "connecting";
+    expect(
+      deriveSessionViewState(olderSession, task, null, false).isInitializing,
+    ).toBe(true);
   });
 
   it("opens a connected local task when no initial prompt remains to send", () => {
@@ -257,5 +254,138 @@ describe("deriveSessionViewState", () => {
     expect(state.isCloudRunNotTerminal).toBe(true);
     expect(state.isCloudRunTerminal).toBe(false);
     expect(state.isInitializing).toBe(true);
+  });
+
+  const oneEvent = [{} as AgentSession["events"][number]];
+
+  it.each([
+    {
+      name: "local connecting shows the composer, not a full-panel spinner",
+      isCloud: false,
+      status: "connecting" as const,
+      events: [] as AgentSession["events"],
+      runStatus: "in_progress" as TaskRunStatus,
+      isConnecting: true,
+      isInitializing: false,
+      isRunning: false,
+    },
+    {
+      name: "local connecting with a painted tail is not initializing",
+      isCloud: false,
+      status: "connecting" as const,
+      events: oneEvent,
+      runStatus: "in_progress" as TaskRunStatus,
+      isConnecting: true,
+      isInitializing: false,
+      isRunning: false,
+    },
+    {
+      name: "local connected is neither connecting nor initializing",
+      isCloud: false,
+      status: "connected" as const,
+      events: oneEvent,
+      runStatus: "in_progress" as TaskRunStatus,
+      isConnecting: false,
+      isInitializing: false,
+      isRunning: true,
+    },
+    {
+      name: "cloud provisioning shows the composer while the sandbox spins up",
+      isCloud: true,
+      status: "connecting" as const,
+      events: [] as AgentSession["events"],
+      runStatus: "in_progress" as TaskRunStatus,
+      isConnecting: true,
+      isInitializing: false,
+      isRunning: true,
+    },
+    {
+      name: "cloud connected is not connecting",
+      isCloud: true,
+      status: "connected" as const,
+      events: oneEvent,
+      runStatus: "in_progress" as TaskRunStatus,
+      isConnecting: false,
+      isInitializing: false,
+      isRunning: true,
+    },
+    {
+      name: "a terminal cloud run is done, not connecting",
+      isCloud: true,
+      status: "connecting" as const,
+      events: oneEvent,
+      runStatus: "completed" as TaskRunStatus,
+      isConnecting: false,
+      isInitializing: false,
+      isRunning: true,
+    },
+  ])(
+    "$name",
+    ({
+      isCloud,
+      status,
+      events,
+      runStatus,
+      isConnecting,
+      isInitializing,
+      isRunning,
+    }) => {
+      const session = makeSession(runStatus);
+      session.isCloud = isCloud;
+      session.status = status;
+      session.events = events;
+
+      const state = deriveSessionViewState(
+        session,
+        makeTask(runStatus),
+        null,
+        isCloud,
+      );
+
+      expect(state.isConnecting).toBe(isConnecting);
+      expect(state.isInitializing).toBe(isInitializing);
+      expect(state.isRunning).toBe(isRunning);
+    },
+  );
+
+  it("is not connecting before a session exists", () => {
+    const state = deriveSessionViewState(
+      undefined,
+      makeTask("not_started"),
+      null,
+      true,
+    );
+
+    expect(state.isConnecting).toBe(false);
+    expect(state.isInitializing).toBe(true);
+  });
+});
+
+describe("deriveSessionLifecycleState", () => {
+  it("keeps a local session starting until its first prompt", () => {
+    const task = makeTask("in_progress");
+    if (task.latest_run) {
+      task.latest_run.environment = "local";
+    }
+    const session = makeSession("in_progress");
+    session.isCloud = false;
+    session.status = "connecting";
+
+    expect(
+      deriveSessionLifecycleState(session, task, false).isInitializing,
+    ).toBe(true);
+
+    session.status = "connected";
+    session.initialPrompt = [
+      { type: "text", text: "Inspect the example task" },
+    ];
+    expect(
+      deriveSessionLifecycleState(session, task, false).isInitializing,
+    ).toBe(true);
+
+    session.firstPromptForRunId = session.taskRunId;
+    expect(
+      deriveSessionLifecycleState(session, task, false).isInitializing,
+    ).toBe(false);
   });
 });

--- a/products/desktop/packages/core/src/sessions/sessionViewState.ts
+++ b/products/desktop/packages/core/src/sessions/sessionViewState.ts
@@ -12,6 +12,7 @@ export interface SessionViewState {
   isCloudRunTerminal: boolean;
   cloudStatus: TaskRunStatus | null;
   isRunning: boolean;
+  isConnecting: boolean;
   hasError: boolean;
   events: AcpMessage[];
   isPromptPending: boolean;
@@ -25,6 +26,7 @@ export interface SessionViewState {
 
 export interface SessionLifecycleState {
   isCloud: boolean;
+  sessionMatchesActiveRun: boolean;
   isCloudRunNotTerminal: boolean;
   isCloudRunTerminal: boolean;
   cloudStatus: TaskRunStatus | null;
@@ -74,6 +76,7 @@ export function deriveSessionLifecycleState(
 
   return {
     isCloud: effectiveIsCloud,
+    sessionMatchesActiveRun,
     isCloudRunNotTerminal: effectiveIsCloud && !isCloudRunTerminal,
     isCloudRunTerminal,
     cloudStatus,
@@ -99,11 +102,11 @@ export function deriveSessionViewState(
   );
   const {
     isCloud: effectiveIsCloud,
+    sessionMatchesActiveRun,
     isCloudRunNotTerminal,
     isCloudRunTerminal,
     cloudStatus,
     hasError,
-    isInitializing,
   } = lifecycle;
   const isRunning = effectiveIsCloud
     ? !hasError
@@ -112,6 +115,31 @@ export function deriveSessionViewState(
   const events = session?.events ?? [];
   const isPromptPending = session?.isPromptPending ?? false;
   const promptStartedAt = session?.promptStartedAt;
+
+  const isHydratingEmptyTranscript =
+    effectiveIsCloud &&
+    events.length === 0 &&
+    !isCloudRunTerminal &&
+    (session?.isHydratingTranscript ?? false);
+  // Once the active run has a session we dive straight into the thread +
+  // composer, even while the agent is still connecting, so a full-panel
+  // spinner only shows when there is nothing to render yet: no session for
+  // this run, a transcript still loading, or a dead session a restart is
+  // replacing. A task row keeps the wider startup window of the lifecycle
+  // state, because it reports "starting" until the first prompt lands.
+  const isInitializing = hasError
+    ? isTaskStarting
+    : !sessionMatchesActiveRun || isHydratingEmptyTranscript;
+
+  // The window between a session existing and the agent handshake landing.
+  // Cloud runs sit in "connecting" while the sandbox provisions; both hosts
+  // flip to "connected" once the agent accepts messages. Terminal cloud runs
+  // are done, not connecting.
+  const isConnecting =
+    !hasError &&
+    !!session &&
+    session.status !== "connected" &&
+    !isCloudRunTerminal;
 
   const cloudBranch = effectiveIsCloud
     ? (workspace?.baseBranch ?? task.latest_run?.branch ?? null)
@@ -123,6 +151,7 @@ export function deriveSessionViewState(
     isCloudRunTerminal,
     cloudStatus,
     isRunning: !!isRunning,
+    isConnecting,
     hasError,
     events,
     isPromptPending,

--- a/products/desktop/packages/ui/src/features/permissions/PlanContent.test.tsx
+++ b/products/desktop/packages/ui/src/features/permissions/PlanContent.test.tsx
@@ -39,6 +39,7 @@ vi.mock("../sessions/sessionStore", () => ({
   useModeConfigOptionForTask: () => undefined,
   useModelConfigOptionForTask: () => undefined,
   usePendingPermissionsForTask: () => new Map(),
+  useQueuedMessagesForTask: () => [],
   useSessionSelector: () => false,
   useSessionStore: () => undefined,
   useThoughtLevelConfigOptionForTask: () => undefined,

--- a/products/desktop/packages/ui/src/features/sessions/components/ConnectingIndicator.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConnectingIndicator.tsx
@@ -1,0 +1,49 @@
+import { Text } from "@posthog/quill";
+import type { TaskRunStatus } from "@posthog/shared/domain-types";
+import { Spinner } from "@posthog/ui/primitives/Spinner";
+
+interface ConnectingIndicatorProps {
+  isCloud?: boolean;
+  cloudStatus?: TaskRunStatus | null;
+  queued?: boolean;
+}
+
+function label(
+  isCloud: boolean,
+  cloudStatus: TaskRunStatus | null | undefined,
+): string {
+  if (!isCloud) {
+    return "Connecting to agent";
+  }
+  switch (cloudStatus) {
+    case "queued":
+      return "Waiting in the queue";
+    case "in_progress":
+      return "Starting the sandbox";
+    default:
+      return "Connecting to agent";
+  }
+}
+
+export function ConnectingIndicator({
+  isCloud = false,
+  cloudStatus,
+  queued = false,
+}: ConnectingIndicatorProps) {
+  const text = queued
+    ? "Your message will send once the agent connects"
+    : label(isCloud, cloudStatus);
+
+  return (
+    <div className="flex select-none items-center gap-2 px-1 py-1">
+      <Spinner
+        size="sm"
+        aria-hidden="true"
+        className="shrink-0 text-(--gray-9)"
+      />
+      <Text render={<span />} className="truncate text-(--gray-11) text-[13px]">
+        {text}
+      </Text>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/EmbeddedSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/EmbeddedSessionView.tsx
@@ -32,11 +32,13 @@ export function EmbeddedSessionView({
     repoPath,
     isCloud,
     isRunning,
+    isConnecting,
     hasError,
     events,
     isPromptPending,
     promptStartedAt,
     isInitializing,
+    cloudStatus,
     cloudBranch,
     errorTitle,
     errorMessage,
@@ -64,6 +66,7 @@ export function EmbeddedSessionView({
         taskId={taskId}
         task={task}
         isRunning={isRunning}
+        isConnecting={isConnecting}
         isPromptPending={isPromptPending}
         promptStartedAt={promptStartedAt}
         onSendPrompt={handleSendPrompt}
@@ -79,6 +82,7 @@ export function EmbeddedSessionView({
         onNewSession={isCloud ? undefined : handleNewSession}
         isInitializing={isInitializing}
         isCloud={isCloud}
+        cloudStatus={cloudStatus}
         compact
         isActiveSession={isActiveSession}
         threadActions={threadActions?.({

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -12,7 +12,7 @@ import {
 } from "@posthog/core/task-detail/previewConfig";
 import { useService } from "@posthog/di/react";
 import { type AcpMessage, FAST_MODE_FLAG } from "@posthog/shared";
-import type { Task } from "@posthog/shared/domain-types";
+import type { Task, TaskRunStatus } from "@posthog/shared/domain-types";
 import {
   spendStopMessage,
   useSpendStop,
@@ -31,6 +31,7 @@ import { resolveAndAttachDroppedFiles } from "@posthog/ui/features/message-edito
 import { PermissionSelector } from "@posthog/ui/features/permissions/PermissionSelector";
 import { CloudStreamDisconnectedBanner } from "@posthog/ui/features/sessions/components/CloudSessionLifecycle";
 import { ComposerWidth } from "@posthog/ui/features/sessions/components/ComposerWidth";
+import { ConnectingIndicator } from "@posthog/ui/features/sessions/components/ConnectingIndicator";
 import { ContextUsageIndicator } from "@posthog/ui/features/sessions/components/ContextUsageIndicator";
 import type { PromptRecallHandler } from "@posthog/ui/features/sessions/components/chat-thread/composerPromptRecall";
 import {
@@ -66,6 +67,7 @@ import {
   useModeConfigOptionForTask,
   useModelConfigOptionForTask,
   usePendingPermissionsForTask,
+  useQueuedMessagesForTask,
   useSessionSelector,
   useThoughtLevelConfigOptionForTask,
 } from "@posthog/ui/features/sessions/sessionStore";
@@ -102,6 +104,8 @@ interface SessionViewProps {
   taskId?: string;
   task?: Task;
   isRunning: boolean;
+  /** Session exists but the agent has not finished connecting yet. */
+  isConnecting?: boolean;
   isPromptPending?: boolean | null;
   promptStartedAt?: number | null;
   onBeforeSubmit?: (text: string, clearEditor: () => void) => boolean;
@@ -121,6 +125,7 @@ interface SessionViewProps {
   onNewSession?: () => void;
   isInitializing?: boolean;
   isCloud?: boolean;
+  cloudStatus?: TaskRunStatus | null;
   slackThreadUrl?: string;
   compact?: boolean;
   isActiveSession?: boolean;
@@ -138,6 +143,7 @@ export function SessionView({
   taskId,
   task,
   isRunning,
+  isConnecting = false,
   isPromptPending = false,
   promptStartedAt,
   onBeforeSubmit,
@@ -157,6 +163,7 @@ export function SessionView({
   onNewSession,
   isInitializing = false,
   isCloud = false,
+  cloudStatus = null,
   slackThreadUrl,
   compact = false,
   isActiveSession = true,
@@ -279,12 +286,19 @@ export function SessionView({
   const setContext = useDraftStore((s) => s.actions.setContext);
   const requestFocus = useDraftStore((s) => s.actions.requestFocus);
 
+  const queuedCount = useQueuedMessagesForTask(taskId).length;
+  // Let the user type while the agent connects, and enqueue one prompt that
+  // sends on connect. After one is queued, block the composer until connected.
+  const queuedWhileConnecting = isConnecting && queuedCount > 0;
+  const composerDisabled =
+    (!isRunning && !isConnecting) || queuedWhileConnecting;
+
   useEffect(() => {
     setContext(sessionId, {
       taskId,
       repoPath,
       cloudBranch,
-      disabled: !isRunning,
+      disabled: composerDisabled,
       isLoading: !!isPromptPending,
     });
   }, [
@@ -293,7 +307,7 @@ export function SessionView({
     taskId,
     repoPath,
     cloudBranch,
-    isRunning,
+    composerDisabled,
     isPromptPending,
   ]);
 
@@ -760,6 +774,13 @@ export function SessionView({
                 ) : (
                   <Box className="shrink-0">
                     <ComposerWidth compact={compact}>
+                      {isConnecting && (
+                        <ConnectingIndicator
+                          isCloud={isCloud}
+                          cloudStatus={cloudStatus}
+                          queued={queuedWhileConnecting}
+                        />
+                      )}
                       {taskId && (
                         <SessionSummaryPanel
                           taskId={taskId}
@@ -777,11 +798,11 @@ export function SessionView({
                         ref={editorRef}
                         sessionId={sessionId}
                         placeholder={
-                          isRunning
-                            ? "Type a message... ! for bash mode, / for skills"
-                            : "Waiting for the agent..."
+                          composerDisabled
+                            ? "Waiting for the agent..."
+                            : "Type a message... ! for bash mode, / for skills"
                         }
-                        disabled={!isRunning}
+                        disabled={composerDisabled}
                         submitDisabledExternal={
                           !isOnline ||
                           attachmentsUploading ||

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -7080,14 +7080,18 @@ describe("SessionService", () => {
       );
     });
 
-    it("throws when session is connecting", async () => {
+    it("queues one message while the session is connecting", async () => {
       const service = getSessionService();
       mockSessionStoreSetters.getSessionByTaskId.mockReturnValue(
         createMockSession({ status: "connecting" }),
       );
 
-      await expect(service.sendPrompt("task-123", "Hello")).rejects.toThrow(
-        "Session is still connecting",
+      const result = await service.sendPrompt("task-123", "Hello");
+
+      expect(result.stopReason).toBe("queued");
+      expect(mockSessionStoreSetters.enqueueMessage).toHaveBeenCalledWith(
+        "task-123",
+        "Hello",
       );
     });
 

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskLogsPanel.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskLogsPanel.tsx
@@ -56,6 +56,8 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
     repoPath,
     isCloud,
     isRunning,
+    isConnecting,
+    cloudStatus,
     hasError,
     events,
     isPromptPending,
@@ -161,6 +163,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
               taskId={taskId}
               task={task}
               isRunning={isRunning}
+              isConnecting={isConnecting}
               isSuspended={isSuspended}
               onRestoreWorktree={
                 isSuspended ? handleRestoreWorktree : undefined
@@ -183,6 +186,7 @@ export function TaskLogsPanel({ taskId, task, hideInput }: TaskLogsPanelProps) {
               onNewSession={isCloud ? undefined : handleNewSession}
               isInitializing={isInitializing}
               isCloud={isCloud}
+              cloudStatus={cloudStatus}
               slackThreadUrl={slackThreadUrl}
             />
           </ErrorBoundary>


### PR DESCRIPTION
## Problem

Opening a task that is still connecting shows a full-panel "Connecting to agent" spinner, so you cannot read the thread or start typing until the agent is ready. Cloud tasks show the same kind of full-panel wait while the sandbox provisions.

- The composer is hidden behind the spinner, so a prompt you already know you want to send has to wait for the connection.
- The spinner takes up the whole panel for a state that is often brief.

## Changes

- Switching to a task shows the thread and composer immediately, with a small inline "Connecting to agent" line above the composer instead of the full-panel spinner. Cloud provisioning shows the sandbox status ("Waiting in the queue", "Starting the sandbox") in the same inline spot.
- You can type and submit one prompt while the agent connects. It queues, shows in the existing queued-messages dock, and sends automatically once the agent is ready.
- After one prompt is queued, the composer is disabled until the agent connects, so only a single prompt waits.
- A failed connect keeps the queued prompt instead of dropping it, so it stays available to the retry flow.
- `deriveSessionViewState` gains an `isConnecting` flag and narrows `isInitializing` to only the "no session yet" (and cloud transcript-hydrating) cases; `SessionView` uses these to gate the composer and the indicator. Mechanical: the touched composer markup moved from Radix `Box` to `div`, and the new indicator uses `@posthog/quill`.

No screenshot: the app could not be launched in this environment (a native dependency build and registry access both failed), so no before/after image was captured.

## How did you test this code?

Automated tests added and run locally from the `packages/core` and `packages/ui` workspaces:

- `sessionViewState.test.ts` — cases for `isConnecting` and the narrowed `isInitializing` across local connecting (with and without a painted tail), cloud provisioning, connected, terminal, and no-session. Catches a regression that re-shows the full-panel spinner while a session exists.
- `sessionServiceCompaction.test.ts` — `sendPrompt` while connecting queues instead of throwing; a second submit keeps the queue at one; an errored session still throws; a failed connect preserves the queued prompt. Catches loss of the queue-while-connecting behavior, the single-prompt guard, and prompt loss on connect failure.
- `sessionServiceHost.test.ts` — updated the existing "throws when connecting" case to assert the new queue behavior.

Not verified: the connecting-to-connected drain path end to end (needs the running app), and any manual UI check. CI reports suite pass counts.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @frankh.

Authored with Claude (PostHog Desktop). Skills invoked: `/writing-tests` (test value gate) and `/writing-pr-descriptions` (this body). Component choice and Radix rules for the desktop package were followed from `products/desktop/AGENTS.md`.

Design decisions across the session: the drain-on-connect hook attaches to the single local `connecting → connected` transition and reuses the existing `flushQueuedMessagesIfIdle` helper rather than adding a new drain path; cloud reuses its existing queue-and-drain triggers and only gained a single-prompt guard. The full reconnect-path drain was left to manual verification rather than a heavy, brittle unit test.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
