### PR TITLE
feat(conversations): redesign the ticket session recording panel

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2825,6 +2825,9 @@ importers:
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
 
   products/core_events: {}
 

--- a/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.stories.tsx
+++ b/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.stories.tsx
@@ -1,0 +1,174 @@
+import type { Decorator, Meta, StoryObj } from '@storybook/react'
+import { HttpResponse } from 'msw'
+import { useEffect, useRef } from 'react'
+
+import { recordingMetaJson } from 'scenes/session-recordings/__mocks__/recording_meta'
+import { snapshotsAsJSONLines } from 'scenes/session-recordings/__mocks__/recording_snapshots'
+import { SessionPlayerModal } from 'scenes/session-recordings/player/modal/SessionPlayerModal'
+
+import { mswDecorator } from '~/mocks/browser'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
+
+import type { ReplayObservationApi } from 'products/replay_vision/frontend/generated/api.schemas'
+
+import { SessionRecordingPanel } from './SessionRecordingPanel'
+
+// The ticket scene gives this panel the sidebar column next to the chat: about 300px when the
+// chat panel is wide, up to about 600px on a large window. Both widths get a story.
+
+const RECORDING_ID = recordingMetaJson.id
+const DISTINCT_ID = recordingMetaJson.distinct_id
+
+const SUMMARY: ReplayObservationApi = {
+    id: '019f9582-93e7-77c1-8912-4f541d70cb13',
+    scanner_id: 'inline-summary',
+    scanner_origin: 'inline',
+    session_id: RECORDING_ID,
+    status: 'succeeded',
+    error_reason: '',
+    workflow_id: '',
+    scanner_snapshot: { name: 'Quick summary', scanner_type: 'summarizer' },
+    scanner_result: {
+        model_output: {
+            title: 'Checkout failed after a coupon code was applied',
+            summary:
+                'The user added two items to the cart and opened checkout. They entered a coupon code, which was accepted, then pressed Pay. The page showed a validation error on the card field twice before they gave up and opened the support widget.',
+        },
+        signals_count: 0,
+    },
+    triggered_by: 'on_demand',
+    triggered_by_user: null,
+    backfill_id: null,
+} as ReplayObservationApi
+
+// Summarizing needs scanner editor access, which the storybook app context does not grant by default.
+const grantScannerAccess: Decorator = function GrantScannerAccess(Story): JSX.Element {
+    const appContext = (window as any).POSTHOG_APP_CONTEXT
+    const original = useRef<{ value: unknown }>()
+    if (appContext && !original.current) {
+        original.current = { value: appContext.resource_access_control }
+        appContext.resource_access_control = {
+            ...appContext.resource_access_control,
+            [AccessControlResourceType.ReplayScanner]: AccessControlLevel.Editor,
+            [AccessControlResourceType.SessionRecording]: AccessControlLevel.Editor,
+        }
+    }
+    useEffect(
+        () => () => {
+            if (appContext && original.current) {
+                appContext.resource_access_control = original.current.value
+            }
+        },
+        [appContext]
+    )
+    return <Story />
+}
+
+function visionMocks(observations: ReplayObservationApi[]): Decorator {
+    return mswDecorator({
+        get: {
+            '/api/environments/:team_id/session_recordings/:id': recordingMetaJson,
+            '/api/environments/:team_id/session_recordings/:id/snapshots': ({ request }) => {
+                if (new URL(request.url).searchParams.get('source') === 'blob_v2') {
+                    return new HttpResponse(snapshotsAsJSONLines())
+                }
+                return [
+                    200,
+                    {
+                        sources: [
+                            {
+                                source: 'blob_v2',
+                                start_timestamp: '2023-08-11T12:03:36.097000Z',
+                                end_timestamp: '2023-08-11T12:04:52.268000Z',
+                                blob_key: '0',
+                            },
+                        ],
+                    },
+                ]
+            },
+            'api/projects/:team/notebooks': { count: 0, next: null, previous: null, results: [] },
+            '/api/projects/:team_id/vision/observations/': { count: observations.length, results: observations },
+            '/api/projects/:team_id/vision/scanners/': { count: 0, next: null, previous: null, results: [] },
+            '/api/projects/:team_id/vision/quota/': {
+                credit_limit: null,
+                credits_used: 0,
+                remaining: null,
+                exhausted: false,
+                period_start: '2023-08-01T00:00:00Z',
+                period_end: '2023-09-01T00:00:00Z',
+                projected_monthly_credits: 0,
+                scanners_monthly_credits: 0,
+                backfills_committed_credits: 0,
+                free_monthly_credits: 0,
+            },
+        },
+        post: {
+            '/api/environments/:team_id/query/:kind': () => [200, { results: [] }],
+        },
+    })
+}
+
+const meta: Meta<typeof SessionRecordingPanel> = {
+    title: 'Scenes-App/Support/SessionRecordingPanel',
+    component: SessionRecordingPanel,
+    parameters: {
+        layout: 'padded',
+        viewMode: 'story',
+        mockDate: '2023-08-11',
+        testOptions: { waitForLoadersToDisappear: false },
+    },
+    decorators: [
+        grantScannerAccess,
+        // The app shell mounts this modal globally; "Expand" opens the recording in it
+        (Story) => (
+            <>
+                <Story />
+                <SessionPlayerModal />
+            </>
+        ),
+        visionMocks([]),
+    ],
+}
+export default meta
+
+type Story = StoryObj<typeof SessionRecordingPanel>
+
+function Sidebar({ width, children }: { width: number; children: React.ReactNode }): JSX.Element {
+    // eslint-disable-next-line react/forbid-dom-props
+    return <div style={{ width }}>{children}</div>
+}
+
+const withRecording = { sessionContext: { session_replay_url: `/replay/${RECORDING_ID}` }, distinctId: DISTINCT_ID }
+
+export const NarrowSidebar: Story = {
+    render: () => (
+        <Sidebar width={320}>
+            <SessionRecordingPanel {...withRecording} />
+        </Sidebar>
+    ),
+}
+
+export const WideSidebar: Story = {
+    render: () => (
+        <Sidebar width={560}>
+            <SessionRecordingPanel {...withRecording} />
+        </Sidebar>
+    ),
+}
+
+export const Summarized: Story = {
+    decorators: [visionMocks([SUMMARY])],
+    render: () => (
+        <Sidebar width={320}>
+            <SessionRecordingPanel {...withRecording} />
+        </Sidebar>
+    ),
+}
+
+export const NoRecording: Story = {
+    render: () => (
+        <Sidebar width={320}>
+            <SessionRecordingPanel sessionContext={{}} distinctId={DISTINCT_ID} />
+        </Sidebar>
+    ),
+}

--- a/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.test.ts
+++ b/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.test.ts
@@ -1,0 +1,22 @@
+import { recordingIdFromReplayUrl } from './SessionRecordingPanel'
+
+describe('recordingIdFromReplayUrl', () => {
+    it.each([
+        ['/replay/abc123', 'abc123'],
+        ['/replay/abc123?t=42', 'abc123'],
+        ['https://us.posthog.com/replay/abc123?source=widget', 'abc123'],
+        [undefined, null],
+        ['', null],
+    ])('parses %p to %p', (input, expected) => {
+        expect(recordingIdFromReplayUrl(input)).toBe(expected)
+    })
+
+    // session_context comes from the public widget endpoint, which stores non-string scalars verbatim.
+    // A non-string value must resolve to no recording instead of crashing the ticket scene.
+    it.each([42, true, { url: '/replay/abc123' }, ['/replay/abc123'], null])(
+        'returns null for the non-string value %p',
+        (input) => {
+            expect(recordingIdFromReplayUrl(input)).toBeNull()
+        }
+    )
+})

--- a/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.tsx
+++ b/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.tsx
@@ -1,9 +1,19 @@
+import { useActions } from 'kea'
+
+import { IconExpand45, IconExternal } from '@posthog/icons'
 import { LemonButton, LemonCollapse } from '@posthog/lemon-ui'
 
+import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { SessionRecordingPlayer } from 'scenes/session-recordings/player/SessionRecordingPlayer'
+import {
+    SessionRecordingPlayerMode,
+    sessionRecordingPlayerLogic,
+} from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { urls } from 'scenes/urls'
 
 import { PersonsTabType } from '~/types'
+
+import { RecordingSummary } from 'products/replay_vision/frontend/components/RecordingSummary'
 
 interface SessionRecordingPanelProps {
     sessionContext?: {
@@ -13,12 +23,42 @@ interface SessionRecordingPanelProps {
     distinctId?: string
 }
 
+// The widget stores the replay link as a path like /replay/:recordingId, sometimes with a query string.
+function recordingIdFromReplayUrl(replayUrl: string | undefined): string | null {
+    if (!replayUrl) {
+        return null
+    }
+    return replayUrl.split('?')[0].split('/').filter(Boolean).pop() ?? null
+}
+
 export function SessionRecordingPanel({ sessionContext, distinctId }: SessionRecordingPanelProps): JSX.Element {
-    // Extract recording ID from session_replay_url
-    // URL format: /replay/:recordingId or similar
-    const recordingId = sessionContext?.session_replay_url
-        ? sessionContext.session_replay_url.split('?')[0].split('/').filter(Boolean).pop()
-        : null
+    const recordingId = recordingIdFromReplayUrl(sessionContext?.session_replay_url)
+    const playerKey = `ticket-recording-${recordingId}`
+    const { openSessionPlayer } = useActions(sessionPlayerModalLogic)
+
+    const inlinePlayer = (): ReturnType<typeof sessionRecordingPlayerLogic.findMounted> =>
+        recordingId ? sessionRecordingPlayerLogic.findMounted({ sessionRecordingId: recordingId, playerKey }) : null
+
+    const expandRecording = (): void => {
+        if (!recordingId) {
+            return
+        }
+        // The modal is a second player for the same recording, so this one must not keep playing behind it
+        inlinePlayer()?.actions.setPause()
+        openSessionPlayer({ id: recordingId })
+    }
+
+    const seeAllRecordings = distinctId ? (
+        <LemonButton
+            type="tertiary"
+            size="xsmall"
+            className="ml-auto"
+            to={`${urls.personByDistinctId(distinctId)}#activeTab=${PersonsTabType.SESSION_RECORDINGS}`}
+            data-attr="ticket-recording-see-all"
+        >
+            See all recordings →
+        </LemonButton>
+    ) : null
 
     return (
         <LemonCollapse
@@ -27,29 +67,58 @@ export function SessionRecordingPanel({ sessionContext, distinctId }: SessionRec
                 {
                     key: 'session-recording',
                     header: 'Session recording',
-                    content: (
-                        <div>
-                            {!recordingId ? (
-                                <div className="text-muted-alt text-xs">No session recording available</div>
-                            ) : (
-                                <div className="max-h-[500px] h-[500px] flex justify-center items-center">
-                                    <SessionRecordingPlayer
-                                        sessionRecordingId={recordingId}
-                                        playerKey={`ticket-recording-${recordingId}`}
-                                        autoPlay={false}
-                                    />
-                                </div>
-                            )}
-                            {distinctId && (
-                                <div className="mt-2 pt-2 border-t flex justify-end">
+                    content: recordingId ? (
+                        <div className="flex flex-col">
+                            {/* Cancels the collapse body padding so the player gets the full column width. Height follows that width, so a narrow column does not get a tall box around a tiny frame. */}
+                            <div className="flex -mx-4 -mt-4 border-b aspect-[16/11] min-h-60 max-h-[26rem]">
+                                <SessionRecordingPlayer
+                                    sessionRecordingId={recordingId}
+                                    playerKey={playerKey}
+                                    mode={SessionRecordingPlayerMode.Standard}
+                                    autoPlay={false}
+                                    noMeta
+                                    noBorder
+                                    noDock
+                                    withSidebar={false}
+                                />
+                            </div>
+                            <div className="py-3 border-b">
+                                <RecordingSummary
+                                    sessionId={recordingId}
+                                    onSeek={(timestampMs) => inlinePlayer()?.actions.seekToTime(timestampMs)}
+                                />
+                            </div>
+                            <div className="flex flex-wrap items-center justify-between gap-2 pt-3">
+                                <div className="flex flex-wrap gap-1">
                                     <LemonButton
-                                        type="tertiary"
+                                        type="secondary"
                                         size="xsmall"
-                                        to={`${urls.personByDistinctId(distinctId)}#activeTab=${PersonsTabType.SESSION_RECORDINGS}`}
+                                        icon={<IconExpand45 />}
+                                        onClick={expandRecording}
+                                        tooltip="Watch in a larger view with the activity panel"
+                                        data-attr="ticket-recording-expand"
                                     >
-                                        See all recordings →
+                                        Expand
+                                    </LemonButton>
+                                    <LemonButton
+                                        type="secondary"
+                                        size="xsmall"
+                                        icon={<IconExternal />}
+                                        to={urls.replaySingle(recordingId)}
+                                        targetBlank
+                                        data-attr="ticket-recording-open-replay"
+                                    >
+                                        Open in replay
                                     </LemonButton>
                                 </div>
+                                {seeAllRecordings}
+                            </div>
+                        </div>
+                    ) : (
+                        <div>
+                            <div className="text-muted-alt text-xs">No recording was captured for this session.</div>
+                            {seeAllRecordings && (
+                                <div className="mt-2 pt-2 border-t flex justify-end">{seeAllRecordings}</div>
                             )}
                         </div>
                     ),

--- a/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.tsx
+++ b/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.tsx
@@ -24,8 +24,10 @@ interface SessionRecordingPanelProps {
 }
 
 // The widget stores the replay link as a path like /replay/:recordingId, sometimes with a query string.
-function recordingIdFromReplayUrl(replayUrl: string | undefined): string | null {
-    if (!replayUrl) {
+// The public widget endpoint keeps non-string scalars in session_context, so guard the type here: a
+// numeric value would otherwise crash .split() and take the whole ticket scene down.
+export function recordingIdFromReplayUrl(replayUrl: unknown): string | null {
+    if (typeof replayUrl !== 'string') {
         return null
     }
     return replayUrl.split('?')[0].split('/').filter(Boolean).pop() ?? null

--- a/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.tsx
+++ b/products/conversations/frontend/scenes/ticket/SessionRecordingPanel.tsx
@@ -3,6 +3,7 @@ import { useActions } from 'kea'
 import { IconExpand45, IconExternal } from '@posthog/icons'
 import { LemonButton, LemonCollapse } from '@posthog/lemon-ui'
 
+import { newInternalTab } from 'lib/utils/newInternalTab'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { SessionRecordingPlayer } from 'scenes/session-recordings/player/SessionRecordingPlayer'
 import {
@@ -45,9 +46,23 @@ export function SessionRecordingPanel({ sessionContext, distinctId }: SessionRec
         if (!recordingId) {
             return
         }
+        const player = inlinePlayer()
         // The modal is a second player for the same recording, so this one must not keep playing behind it
-        inlinePlayer()?.actions.setPause()
-        openSessionPlayer({ id: recordingId })
+        player?.actions.setPause()
+        // Open the larger view at the moment the responder scrubbed to, so it does not restart from 0:00.
+        // currentTimestamp is an absolute unix ms and reaches the modal player through ?timestamp=.
+        openSessionPlayer({ id: recordingId }, player?.values.currentTimestamp ?? null)
+    }
+
+    const openInReplay = (): void => {
+        if (!recordingId) {
+            return
+        }
+        // A new browser tab, computed on click so it carries the scrubbed position, like ViewRecordingButton.
+        const currentTimestamp = inlinePlayer()?.values.currentTimestamp
+        newInternalTab(
+            urls.replaySingle(recordingId, currentTimestamp ? { unixTimestampMillis: currentTimestamp } : undefined)
+        )
     }
 
     const seeAllRecordings = distinctId ? (
@@ -106,8 +121,7 @@ export function SessionRecordingPanel({ sessionContext, distinctId }: SessionRec
                                         type="secondary"
                                         size="xsmall"
                                         icon={<IconExternal />}
-                                        to={urls.replaySingle(recordingId)}
-                                        targetBlank
+                                        onClick={openInReplay}
                                         data-attr="ticket-recording-open-replay"
                                     >
                                         Open in replay

--- a/products/conversations/package.json
+++ b/products/conversations/package.json
@@ -16,7 +16,8 @@
         "@testing-library/react": "^14.3.1",
         "@testing-library/user-event": "^14.6.1",
         "jest": "^29.7.0",
-        "kea-test-utils": "catalog:"
+        "kea-test-utils": "catalog:",
+        "msw": "^2.14.6"
     },
     "peerDependencies": {
         "@posthog/brand": "catalog:",

--- a/products/replay_vision/frontend/components/ObservationsDock.tsx
+++ b/products/replay_vision/frontend/components/ObservationsDock.tsx
@@ -1,26 +1,19 @@
 import { useActions, useValues } from 'kea'
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 
-import { IconChevronDown, IconInfo, IconLogomark, IconNotebook } from '@posthog/icons'
-import { LemonButton, Spinner, Tooltip } from '@posthog/lemon-ui'
+import { IconChevronDown } from '@posthog/icons'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
-import { LemonMenuItem, LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
 import { sessionRecordingPlayerLogic } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
-import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
-import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
 
-import { AccessControlLevel } from '~/types'
-
-import type { ReplayScannerApi } from '../generated/api.schemas'
 import { observationsDockLogic } from '../logics/observationsDockLogic'
-import { visionQuotaLogic } from '../logics/visionQuotaLogic'
-import { getReplayVisionEditDisabledReason } from '../utils/accessControl'
-import { BUILT_IN_SUMMARY_LABEL, dockObservations, isUnsuccessfulScan } from '../utils/observation'
-import { quotaUx } from '../utils/quotaProjection'
-import { VisionDocsLink, visionDocsUrl } from './DocsLink'
+import { dockObservations, isUnsuccessfulScan } from '../utils/observation'
+import { VisionDocsLink } from './DocsLink'
 import { ObservationDockCard } from './ObservationCard'
+import { SummarizeButton } from './SummarizeButton'
+import { SummarizeExplainer } from './SummarizeExplainer'
 
 const COLLAPSED_HEIGHT = 44
 const DEFAULT_EXPANDED_HEIGHT = 480
@@ -34,142 +27,6 @@ export function ObservationsDock(): JSX.Element | null {
         return null
     }
     return <ObservationsDockContent sessionId={sessionRecordingId} />
-}
-
-/** Runs whichever summarizer `resolveSummarizer` settles on, and lets the user pick another. */
-function SummarizeButton({ sessionId }: { sessionId: string }): JSX.Element {
-    const logic = observationsDockLogic({ sessionId })
-    const { summarizing, defaultSummarizer, summarizerScanners } = useValues(logic)
-    const { summarize, summarizeWith } = useActions(logic)
-    const { quota } = useValues(visionQuotaLogic)
-    const { dataProcessingAccepted } = useValues(aiConsentLogic)
-    const [consentRequested, setConsentRequested] = useState(false)
-    const { disabledReason: quotaDisabledReason, tooltip: quotaTooltip } = quotaUx(quota)
-    // `loading` only disables the button itself. The caret and the menu rows are their own buttons, so
-    // without this a second summarizer is one click away mid-run, and it spends the quota again.
-    const inFlightDisabledReason = summarizing ? 'A summary is already running' : null
-    // Both paths are scanner writes: an inline scan mints a scanner, and `observe` is a write action on
-    // the scanner it runs. Each also exposes recording contents, so both need recording read as well.
-    const builtInDisabledReason = inFlightDisabledReason ?? getReplayVisionEditDisabledReason() ?? quotaDisabledReason
-    // Object-level, so a scanner this user cannot edit is disabled rather than answering with a 403.
-    const scannerDisabledReason = (scanner: ReplayScannerApi): string | null | undefined =>
-        inFlightDisabledReason ??
-        getReplayVisionEditDisabledReason(scanner.user_access_level as AccessControlLevel | null) ??
-        quotaDisabledReason
-    // Nobody could tell which summarizer the button used, so it says so.
-    const label = defaultSummarizer ? `Summarize with ${defaultSummarizer.name}` : 'Summarize this recording'
-    const summarizerTooltip = defaultSummarizer
-        ? `Runs your "${defaultSummarizer.name}" scanner on this recording.`
-        : 'Writes a summary using a built-in prompt.'
-
-    const menuItems: LemonMenuItem[] = [
-        ...summarizerScanners.map((scanner) => ({
-            key: scanner.id,
-            label: scanner.name,
-            active: scanner.id === defaultSummarizer?.id,
-            disabledReason: scannerDisabledReason(scanner),
-            onClick: () => summarizeWith(scanner.id),
-            'data-attr': 'vision-summarize-pick-scanner',
-        })),
-        {
-            key: 'built-in',
-            // Every other row is a scanner the team owns and can open. This one is PostHog's, so it
-            // carries the logomark and says so, rather than reading as a scanner they cannot find.
-            label: (
-                <span className="flex items-center justify-between gap-2 w-full">
-                    <span className="truncate">{BUILT_IN_SUMMARY_LABEL}</span>
-                    <span className="flex items-center gap-1.5 text-xs shrink-0">
-                        <IconLogomark className="text-base text-primary" />
-                        <span className="text-muted">Built in</span>
-                    </span>
-                </span>
-            ),
-            tooltip: 'Uses a built-in prompt. Nothing is saved to your scanners, so there is nothing to open or edit.',
-            active: !defaultSummarizer,
-            disabledReason: builtInDisabledReason,
-            onClick: () => summarizeWith(null),
-            'data-attr': 'vision-summarize-pick-built-in',
-        },
-    ]
-
-    const button = (
-        <LemonButton
-            size="small"
-            type="secondary"
-            icon={<IconNotebook />}
-            loading={summarizing}
-            // The endpoint refuses without org AI approval, so ask for it here rather than toasting a 400.
-            onClick={() => (dataProcessingAccepted ? summarize() : setConsentRequested(true))}
-            disabledReason={defaultSummarizer ? scannerDisabledReason(defaultSummarizer) : builtInDisabledReason}
-            tooltip={quotaTooltip ?? summarizerTooltip}
-            data-attr="vision-summarize-recording"
-            data-ph-capture-attribute-summarizer={defaultSummarizer ? 'configured' : 'built-in'}
-            // The dropdown is the only way to reach a second summarizer, so it appears once one exists.
-            sideAction={
-                summarizerScanners.length > 0 && dataProcessingAccepted
-                    ? {
-                          icon: <IconChevronDown />,
-                          dropdown: { placement: 'bottom-end', overlay: <LemonMenuOverlay items={menuItems} /> },
-                          divider: false,
-                          disabledReason: inFlightDisabledReason,
-                          'aria-label': 'Choose a summarizer',
-                          'data-attr': 'vision-summarize-choose',
-                      }
-                    : null
-            }
-        >
-            <span className="truncate">{dataProcessingAccepted ? label : 'Allow AI analysis and summarize'}</span>
-        </LemonButton>
-    )
-
-    if (dataProcessingAccepted) {
-        return button
-    }
-
-    return (
-        <AIConsentPopoverWrapper
-            placement="bottom-end"
-            showArrow
-            ignoreDismissal
-            hideTrainingDisclaimer
-            hidden={!consentRequested}
-            onApprove={() => {
-                setConsentRequested(false)
-                summarize()
-            }}
-            onDismiss={() => setConsentRequested(false)}
-        >
-            {button}
-        </AIConsentPopoverWrapper>
-    )
-}
-
-/**
- * The dock sits on every standard replay player, so it reaches people who have never heard of Replay
- * vision and meet the summarize button with no idea what it is or what it will spend.
- */
-function SummarizeExplainer(): JSX.Element {
-    return (
-        <Tooltip
-            placement="bottom"
-            // Base UI opens tooltips on hover only, which leaves this unreachable on a touch device.
-            openOnClick
-            title={
-                <>
-                    <p className="mb-1">Replay vision uses AI to watch recordings for you.</p>
-                    <p className="mb-0">
-                        Summarizing writes up what the user did in this session, so you can read it instead of watching
-                        it.
-                    </p>
-                </>
-            }
-            docLink={`${visionDocsUrl()}?utm_medium=in-product&utm_campaign=summarize-explainer`}
-        >
-            <span className="inline-flex items-center text-muted" data-attr="vision-summarize-info">
-                <IconInfo />
-            </span>
-        </Tooltip>
-    )
 }
 
 function ObservationsDockContent({ sessionId }: { sessionId: string }): JSX.Element {

--- a/products/replay_vision/frontend/components/RecordingSummary.tsx
+++ b/products/replay_vision/frontend/components/RecordingSummary.tsx
@@ -1,0 +1,52 @@
+import { useActions, useValues } from 'kea'
+
+import { Spinner } from '@posthog/lemon-ui'
+
+import { observationsDockLogic } from '../logics/observationsDockLogic'
+import { dockObservations } from '../utils/observation'
+import { ObservationDockCard } from './ObservationCard'
+import { SummarizeButton } from './SummarizeButton'
+import { SummarizeExplainer } from './SummarizeExplainer'
+
+/**
+ * The summarize control and its results for a host that embeds the player without its chrome, where the
+ * player's own dock is not shown. Results lay out in the host's flow instead of a resizable dock, so a
+ * narrow column can show them without squeezing the video.
+ */
+export function RecordingSummary({
+    sessionId,
+    onSeek,
+}: {
+    sessionId: string
+    onSeek?: (timestampMs: number) => void
+}): JSX.Element {
+    const logic = observationsDockLogic({ sessionId })
+    const { observations, observationsLoading, retryingObservationIds } = useValues(logic)
+    const { retryObservation } = useActions(logic)
+
+    const shown = dockObservations(observations)
+
+    return (
+        <div className="flex flex-col gap-2" data-attr="vision-recording-summary">
+            <div className="flex flex-wrap items-center gap-2">
+                <SummarizeButton sessionId={sessionId} />
+                <SummarizeExplainer />
+            </div>
+            {observationsLoading && shown.length === 0 ? (
+                <div className="flex items-center gap-2 text-muted text-sm">
+                    <Spinner /> Loading summaries…
+                </div>
+            ) : (
+                shown.map((observation) => (
+                    <ObservationDockCard
+                        key={observation.id}
+                        observation={observation}
+                        onSeek={onSeek}
+                        onRetry={() => retryObservation(observation.id)}
+                        retrying={retryingObservationIds.includes(observation.id)}
+                    />
+                ))
+            )}
+        </div>
+    )
+}

--- a/products/replay_vision/frontend/components/SummarizeButton.tsx
+++ b/products/replay_vision/frontend/components/SummarizeButton.tsx
@@ -1,0 +1,126 @@
+import { useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { IconChevronDown, IconLogomark, IconNotebook } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { LemonMenuItem, LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
+import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
+import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
+
+import { AccessControlLevel } from '~/types'
+
+import type { ReplayScannerApi } from '../generated/api.schemas'
+import { observationsDockLogic } from '../logics/observationsDockLogic'
+import { visionQuotaLogic } from '../logics/visionQuotaLogic'
+import { getReplayVisionEditDisabledReason } from '../utils/accessControl'
+import { BUILT_IN_SUMMARY_LABEL } from '../utils/observation'
+import { quotaUx } from '../utils/quotaProjection'
+
+/** Runs whichever summarizer `resolveSummarizer` settles on, and lets the user pick another. */
+export function SummarizeButton({ sessionId }: { sessionId: string }): JSX.Element {
+    const logic = observationsDockLogic({ sessionId })
+    const { summarizing, defaultSummarizer, summarizerScanners } = useValues(logic)
+    const { summarize, summarizeWith } = useActions(logic)
+    const { quota } = useValues(visionQuotaLogic)
+    const { dataProcessingAccepted } = useValues(aiConsentLogic)
+    const [consentRequested, setConsentRequested] = useState(false)
+    const { disabledReason: quotaDisabledReason, tooltip: quotaTooltip } = quotaUx(quota)
+    // `loading` only disables the button itself. The caret and the menu rows are their own buttons, so
+    // without this a second summarizer is one click away mid-run, and it spends the quota again.
+    const inFlightDisabledReason = summarizing ? 'A summary is already running' : null
+    // Both paths are scanner writes: an inline scan mints a scanner, and `observe` is a write action on
+    // the scanner it runs. Each also exposes recording contents, so both need recording read as well.
+    const builtInDisabledReason = inFlightDisabledReason ?? getReplayVisionEditDisabledReason() ?? quotaDisabledReason
+    // Object-level, so a scanner this user cannot edit is disabled rather than answering with a 403.
+    const scannerDisabledReason = (scanner: ReplayScannerApi): string | null | undefined =>
+        inFlightDisabledReason ??
+        getReplayVisionEditDisabledReason(scanner.user_access_level as AccessControlLevel | null) ??
+        quotaDisabledReason
+    // Nobody could tell which summarizer the button used, so it says so.
+    const label = defaultSummarizer ? `Summarize with ${defaultSummarizer.name}` : 'Summarize this recording'
+    const summarizerTooltip = defaultSummarizer
+        ? `Runs your "${defaultSummarizer.name}" scanner on this recording.`
+        : 'Writes a summary using a built-in prompt.'
+
+    const menuItems: LemonMenuItem[] = [
+        ...summarizerScanners.map((scanner) => ({
+            key: scanner.id,
+            label: scanner.name,
+            active: scanner.id === defaultSummarizer?.id,
+            disabledReason: scannerDisabledReason(scanner),
+            onClick: () => summarizeWith(scanner.id),
+            'data-attr': 'vision-summarize-pick-scanner',
+        })),
+        {
+            key: 'built-in',
+            // Every other row is a scanner the team owns and can open. This one is PostHog's, so it
+            // carries the logomark and says so, rather than reading as a scanner they cannot find.
+            label: (
+                <span className="flex items-center justify-between gap-2 w-full">
+                    <span className="truncate">{BUILT_IN_SUMMARY_LABEL}</span>
+                    <span className="flex items-center gap-1.5 text-xs shrink-0">
+                        <IconLogomark className="text-base text-primary" />
+                        <span className="text-muted">Built in</span>
+                    </span>
+                </span>
+            ),
+            tooltip: 'Uses a built-in prompt. Nothing is saved to your scanners, so there is nothing to open or edit.',
+            active: !defaultSummarizer,
+            disabledReason: builtInDisabledReason,
+            onClick: () => summarizeWith(null),
+            'data-attr': 'vision-summarize-pick-built-in',
+        },
+    ]
+
+    const button = (
+        <LemonButton
+            size="small"
+            type="secondary"
+            icon={<IconNotebook />}
+            loading={summarizing}
+            // The endpoint refuses without org AI approval, so ask for it here rather than toasting a 400.
+            onClick={() => (dataProcessingAccepted ? summarize() : setConsentRequested(true))}
+            disabledReason={defaultSummarizer ? scannerDisabledReason(defaultSummarizer) : builtInDisabledReason}
+            tooltip={quotaTooltip ?? summarizerTooltip}
+            data-attr="vision-summarize-recording"
+            data-ph-capture-attribute-summarizer={defaultSummarizer ? 'configured' : 'built-in'}
+            // The dropdown is the only way to reach a second summarizer, so it appears once one exists.
+            sideAction={
+                summarizerScanners.length > 0 && dataProcessingAccepted
+                    ? {
+                          icon: <IconChevronDown />,
+                          dropdown: { placement: 'bottom-end', overlay: <LemonMenuOverlay items={menuItems} /> },
+                          divider: false,
+                          disabledReason: inFlightDisabledReason,
+                          'aria-label': 'Choose a summarizer',
+                          'data-attr': 'vision-summarize-choose',
+                      }
+                    : null
+            }
+        >
+            <span className="truncate">{dataProcessingAccepted ? label : 'Allow AI analysis and summarize'}</span>
+        </LemonButton>
+    )
+
+    if (dataProcessingAccepted) {
+        return button
+    }
+
+    return (
+        <AIConsentPopoverWrapper
+            placement="bottom-end"
+            showArrow
+            ignoreDismissal
+            hideTrainingDisclaimer
+            hidden={!consentRequested}
+            onApprove={() => {
+                setConsentRequested(false)
+                summarize()
+            }}
+            onDismiss={() => setConsentRequested(false)}
+        >
+            {button}
+        </AIConsentPopoverWrapper>
+    )
+}

--- a/products/replay_vision/frontend/components/SummarizeExplainer.tsx
+++ b/products/replay_vision/frontend/components/SummarizeExplainer.tsx
@@ -1,0 +1,32 @@
+import { IconInfo } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { visionDocsUrl } from './DocsLink'
+
+/**
+ * The dock sits on every standard replay player, so it reaches people who have never heard of Replay
+ * vision and meet the summarize button with no idea what it is or what it will spend.
+ */
+export function SummarizeExplainer(): JSX.Element {
+    return (
+        <Tooltip
+            placement="bottom"
+            // Base UI opens tooltips on hover only, which leaves this unreachable on a touch device.
+            openOnClick
+            title={
+                <>
+                    <p className="mb-1">Replay vision uses AI to watch recordings for you.</p>
+                    <p className="mb-0">
+                        Summarizing writes up what the user did in this session, so you can read it instead of watching
+                        it.
+                    </p>
+                </>
+            }
+            docLink={`${visionDocsUrl()}?utm_medium=in-product&utm_campaign=summarize-explainer`}
+        >
+            <span className="inline-flex items-center text-muted" data-attr="vision-summarize-info">
+                <IconInfo />
+            </span>
+        </Tooltip>
+    )
+}

--- a/products/replay_vision/frontend/logics/observationsDockLogic.test.ts
+++ b/products/replay_vision/frontend/logics/observationsDockLogic.test.ts
@@ -199,6 +199,22 @@ describe('observationsDockLogic', () => {
         nextRecording.unmount()
     })
 
+    it('opens the dock after a summary starts without persisting the auto-expand preference', async () => {
+        // The shared summarize button also runs on the ticket panel, which renders no dock. Opening the
+        // dock after a scan starts must not rewrite the collapsed preference the user saved on the replay
+        // page, or summarizing one recording silently re-expands the dock for every later one.
+        preferences.actions.setSummaryDockAutoExpand(false)
+        await expectLogic(logic).toDispatchActions(['loadObservationsSuccess'])
+
+        logic.actions.summarize()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        releaseInlineScan()
+
+        await expectLogic(logic).toDispatchActions(['summarizeSuccess'])
+        await expectLogic(logic).toMatchValues({ dockOpen: true })
+        await expectLogic(preferences).toMatchValues({ summaryDockAutoExpand: false })
+    })
+
     const loadScanners = async (scanners: ReplayScannerApi[]): Promise<void> => {
         scannerResults = scanners
         // The mock holds the scanner fetch open, and its release hook only exists once the handler runs.

--- a/products/replay_vision/frontend/logics/observationsDockLogic.ts
+++ b/products/replay_vision/frontend/logics/observationsDockLogic.ts
@@ -74,6 +74,9 @@ export interface observationsDockLogicActions {
     observeSuccess: () => {
         value: true
     }
+    openDock: () => {
+        value: true
+    }
     retryObservation: (observationId: string) => {
         observationId: string
     }
@@ -82,9 +85,6 @@ export interface observationsDockLogicActions {
     }
     retryObservationSuccess: (observationId: string) => {
         observationId: string
-    }
-    openDock: () => {
-        value: true
     }
     setDockOpen: (open: boolean) => {
         open: boolean

--- a/products/replay_vision/frontend/logics/observationsDockLogic.ts
+++ b/products/replay_vision/frontend/logics/observationsDockLogic.ts
@@ -83,6 +83,9 @@ export interface observationsDockLogicActions {
     retryObservationSuccess: (observationId: string) => {
         observationId: string
     }
+    openDock: () => {
+        value: true
+    }
     setDockOpen: (open: boolean) => {
         open: boolean
     }
@@ -154,6 +157,10 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
         retryObservation: (observationId: string) => ({ observationId }),
         retryObservationSuccess: (observationId: string) => ({ observationId }),
         retryObservationFailure: (observationId: string) => ({ observationId }),
+        // Opens the dock for this recording only. setDockOpen persists the cross-recording preference
+        // through its listener, so programmatic opens after a summary must use this instead, or they
+        // overwrite a collapse the user made, including from a host that has no dock at all.
+        openDock: true,
         setDockOpen: (open: boolean) => ({ open }),
         setScannerPickerOpen: (open: boolean) => ({ open }),
         setScannerSearch: (search: string) => ({ search }),
@@ -203,6 +210,7 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
             false,
             {
                 setDockOpen: (_, { open }) => open,
+                openDock: () => true,
             },
         ],
         scannerPickerOpen: [
@@ -288,7 +296,7 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
                 return
             }
             if (values.observations.some((o) => isSummaryObservation(o) && o.status === 'succeeded')) {
-                actions.setDockOpen(true)
+                actions.openDock()
             }
         }
         // Show the row that is coming, and re-read the quota the scan spent. Only call this when a scan
@@ -333,7 +341,7 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
                     // the row may not be readable here, and the reload can also fail. Confirm the row
                     // is in hand before naming it, and leave a way to re-read when it stays hidden.
                     actions.summarizeFailure()
-                    actions.setDockOpen(true)
+                    actions.openDock()
                     // Both retries re-read the same rows, but they follow different failures: a row the
                     // reload could not see, and a reload that did not complete. Keep them apart.
                     const tryAgain = (dataAttr: string): ToastButton => ({
@@ -372,7 +380,7 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
                     // A scan is in flight either way — ours, or one this project already had running
                     // against the shared inline scanner — so the poll window has a row to wait for.
                     actions.summarizeSuccess()
-                    actions.setDockOpen(true)
+                    actions.openDock()
                     afterScanStarted()
                 } else {
                     // Nothing started and nothing to read, so the poll window would watch for a row
@@ -417,7 +425,8 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
             },
             loadObservationsFailure: reschedulePoll,
 
-            // Every open and close runs through here, so the preference tracks the last one the user made.
+            // The user's explicit dock toggle is the only caller of setDockOpen, so persisting here keeps
+            // the cross-recording preference tracking their last choice. Programmatic opens use openDock.
             setDockOpen: ({ open }) => actions.setSummaryDockAutoExpand(open),
 
             observe: async ({ scannerId }) => {
@@ -436,7 +445,7 @@ export const observationsDockLogic = kea<observationsDockLogicType>([
                 if (values.observations.some((o) => o.scanner_id === scannerId)) {
                     lemonToast.info('This scanner has already been run on this recording.')
                     actions.observeFailure()
-                    actions.setDockOpen(true)
+                    actions.openDock()
                     return
                 }
                 cache.observeInFlight = true


### PR DESCRIPTION
## Problem

Support teammates reading a ticket get the session recording in a 300 to 600px sidebar column. The panel embedded the full replay player there, including its meta bar and inspector sidebar, so opening the activity panel squeezed the video to a sliver and clipped the inspector. A summary of the recording was not visible in the ticket at all.

## Changes

- The panel shows the video and its controls only, fills the column width, and sizes its height from that width.
- Expand opens the recording in the player modal, where the activity panel has room. Open in replay links to the replay page.
- Summarize this recording sits under the player, and an existing summary shows there as a card with seekable timestamps.
- Mechanical: the summarize button and its explainer move out of the replay vision dock into their own files, so the dock and the panel share them.

| Before, activity panel open | After, with a summary |
| --- | --- |
| ![ticket-recording-before](https://raw.githubusercontent.com/PostHog/pr-assets/5c3733624c987e8e5358e3786c546b8dea71b5ff/2026/09/f8607822-a5b2-4be6-a895-85fcf9cabb33.png) | ![ticket-recording-after](https://raw.githubusercontent.com/PostHog/pr-assets/8193d8e74bf1fc99bd3a483ce1ef30892ea5628e/2026/09/11c7f376-deb3-41c2-b89f-48d9f1b86ffe.png) |


<img width="1035" height="1213" alt="image" src="https://github.com/user-attachments/assets/8365d8db-964a-4299-a29d-8e3ff8819c27" />

expanded view 
<img width="2556" height="1291" alt="image" src="https://github.com/user-attachments/assets/5fce95a2-547f-47d5-982a-728446d9621e" />


## How did you test this code?

- New Storybook stories render the panel at 320px and 560px, with and without a summary, and with no recording. They catch the narrow-column layout regressing.
- Rendered each story headlessly and clicked through hover controls and Expand.
- Not run: Jest, since no logic changed. The full frontend TypeScript check passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5.1) with Storybook and Playwright for rendering. Skills invoked: /writing-ui-components, /writing-user-facing-copy, /writing-pr-descriptions. The first pass dropped the inspector from the panel and added Expand; the summary section came in a second pass at the driver's request. The story fixture is invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
