### PR TITLE
feat(tasks): measure agent launcher process gap

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -647,7 +647,11 @@ export class AgentServer {
 
   constructor(config: AgentServerConfig) {
     this.config = config;
-    this.bootTracker = new AgentBootTracker(config.runId);
+    this.bootTracker = new AgentBootTracker(
+      config.runId,
+      undefined,
+      config.launcherToProcessMs,
+    );
     this.posthogExecPermissionRegexSource =
       config.posthogExecPermissionRegex ??
       DEFAULT_POSTHOG_EXEC_PERMISSION_REGEX_SOURCE;
@@ -1715,6 +1719,7 @@ export class AgentServer {
     this.bootTracker = new AgentBootTracker(
       payload.run_id,
       this.httpReadyBootMs,
+      this.config.launcherToProcessMs,
     );
     this.initializationPromise = this._doInitializeSession(
       payload,

--- a/products/desktop/packages/agent/src/server/bin.ts
+++ b/products/desktop/packages/agent/src/server/bin.ts
@@ -6,6 +6,7 @@ import { z } from "zod/v4";
 import { isSupportedReasoningEffort } from "../adapters/reasoning-effort";
 import { DEFAULT_POSTHOG_EXEC_PERMISSION_REGEX_SOURCE } from "../posthog-exec-permission";
 import { AgentServer } from "./agent-server";
+import { launcherToProcessMs } from "./boot-phases";
 import { PiAgentServer } from "./pi-agent-server";
 import {
   claudeCodeConfigSchema,
@@ -38,6 +39,11 @@ const envSchema = z.object({
     .regex(/^\d+$/, "POSTHOG_PROJECT_ID must be a numeric string")
     .transform((val) => parseInt(val, 10)),
   POSTHOG_AGENT_RUNTIME: z.enum(["acp", "pi"]).optional(),
+  POSTHOG_AGENT_LAUNCH_STARTED_AT_MS: z
+    .string()
+    .regex(/^\d+$/)
+    .transform(Number)
+    .optional(),
   POSTHOG_SANDBOX_ID: z.string().min(1).optional(),
   POSTHOG_CODE_RUNTIME_ADAPTER: z.enum(["claude", "codex"]).optional(),
   POSTHOG_CODE_MODEL: z.string().optional(),
@@ -181,6 +187,7 @@ program
     }
 
     const env = envResult.data;
+    delete process.env.POSTHOG_AGENT_LAUNCH_STARTED_AT_MS;
 
     // The telemetry token is only ever consumed here (into the server config);
     // drop it from the process environment so tool subprocesses spawned by the
@@ -263,6 +270,9 @@ program
       taskId: options.taskId,
       runId: options.runId,
       sandboxId: env.POSTHOG_SANDBOX_ID,
+      launcherToProcessMs: launcherToProcessMs(
+        env.POSTHOG_AGENT_LAUNCH_STARTED_AT_MS,
+      ),
       createPr,
       autoPublish,
       mcpServers,

--- a/products/desktop/packages/agent/src/server/boot-phases.test.ts
+++ b/products/desktop/packages/agent/src/server/boot-phases.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { AgentBootTracker } from "./boot-phases";
+import { AgentBootTracker, launcherToProcessMs } from "./boot-phases";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -14,7 +14,7 @@ describe("AgentBootTracker", () => {
       .mockReturnValueOnce(150)
       .mockReturnValueOnce(500);
 
-    const tracker = new AgentBootTracker("run-1", 5);
+    const tracker = new AgentBootTracker("run-1", 5, 7);
     await tracker.measure("context_fetch", async () => "ok");
     tracker.markReady();
 
@@ -24,6 +24,7 @@ describe("AgentBootTracker", () => {
       state: "ready",
       totalMs: 50,
       httpReadyMs: 5,
+      launcherToProcessMs: 7,
       phasesMs: { context_fetch: 25 },
     });
   });
@@ -52,5 +53,13 @@ describe("AgentBootTracker", () => {
       totalMs: 40,
       phasesMs: { acp_initialize: 25 },
     });
+  });
+
+  it("measures the launch wrapper to process boundary", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    vi.spyOn(process, "uptime").mockReturnValue(0.2);
+
+    expect(launcherToProcessMs(700)).toBe(100);
+    expect(launcherToProcessMs()).toBeUndefined();
   });
 });

--- a/products/desktop/packages/agent/src/server/boot-phases.ts
+++ b/products/desktop/packages/agent/src/server/boot-phases.ts
@@ -19,7 +19,16 @@ export interface AgentBootSnapshot {
   failedPhase?: AgentBootPhase;
   totalMs: number;
   httpReadyMs?: number;
+  launcherToProcessMs?: number;
   phasesMs: Partial<Record<AgentBootPhase, number>>;
+}
+
+export function launcherToProcessMs(
+  launcherStartedAtMs?: number,
+): number | undefined {
+  if (launcherStartedAtMs === undefined) return undefined;
+  const processStartedAtMs = Date.now() - process.uptime() * 1000;
+  return Math.max(0, Math.round(processStartedAtMs - launcherStartedAtMs));
 }
 
 export class AgentBootTracker {
@@ -35,6 +44,7 @@ export class AgentBootTracker {
   constructor(
     private readonly bootId: string,
     httpReadyMs?: number,
+    private readonly launcherToProcessMs?: number,
   ) {
     this.httpReadyMs = httpReadyMs;
   }
@@ -84,6 +94,9 @@ export class AgentBootTracker {
       totalMs: this.totalMs ?? this.elapsedMs(),
       ...(this.httpReadyMs !== undefined
         ? { httpReadyMs: this.httpReadyMs }
+        : {}),
+      ...(this.launcherToProcessMs !== undefined
+        ? { launcherToProcessMs: this.launcherToProcessMs }
         : {}),
       phasesMs,
     };

--- a/products/desktop/packages/agent/src/server/pi-agent-server.ts
+++ b/products/desktop/packages/agent/src/server/pi-agent-server.ts
@@ -331,6 +331,10 @@ export class PiAgentServer {
         hasSession: this.session !== null,
         bootMs: this.sessionReadyBootMs,
         sessionInitMs: this.sessionInitMs,
+        boot: {
+          totalMs: this.sessionReadyBootMs,
+          launcherToProcessMs: this.config.launcherToProcessMs,
+        },
       }),
     );
 

--- a/products/desktop/packages/agent/src/server/types.ts
+++ b/products/desktop/packages/agent/src/server/types.ts
@@ -35,6 +35,7 @@ export interface AgentServerConfig {
   taskId: string;
   runId: string;
   sandboxId?: string;
+  launcherToProcessMs?: number;
   createPr?: boolean;
   // User-opted auto-publish: push and open a draft PR on completion even for
   // manual (non-automated-origin) cloud runs. createPr=false still wins.

--- a/products/tasks/backend/logic/services/agent_server_launcher.py
+++ b/products/tasks/backend/logic/services/agent_server_launcher.py
@@ -180,23 +180,31 @@ class AgentServerLaunchMixin(SandboxBase):
             f"{create_pr_flag}{auto_publish_flag}{branch_flag}{mcp_servers_arg}{relay_mcp_servers_arg}"
             f"{domains_flag}{repo_ready_flag}{exec_permission_flag}"
         )
+        launch_started_at = "export POSTHOG_AGENT_LAUNCH_STARTED_AT_MS=$(date +%s%3N)"
 
         if repo_ready_file:
             # Keep the adapter process from inheriting a repository cwd that does not
             # exist yet, even if an overlaid agent-server mishandles its readiness flag.
-            wait_for_repo = f"while [ ! -f {shlex.quote(repo_ready_file)} ]; do sleep 0.1; done; exec {server_cmd}"
+            wait_for_repo = (
+                f"while [ ! -f {shlex.quote(repo_ready_file)} ]; do sleep 0.1; done; "
+                f"{launch_started_at}; exec {server_cmd}"
+            )
             server_cmd = f"bash -c {shlex.quote(wait_for_repo)}"
 
         inner = f"cd /scripts && {server_cmd} > /tmp/agent-server.log 2>&1"
         initialize_env_file = f"bash {shlex.quote(BASH_ENV_SCRIPT)}"
+        launch_started_prefix = "" if repo_ready_file else f"{launch_started_at} && "
 
         if allowed_domains is not None:
             return (
-                f"cd /scripts && {initialize_env_file} && "
+                f"cd /scripts && {launch_started_prefix}{initialize_env_file} && "
                 f"({build_exec_prefix()} {ENV_WRAPPER_SCRIPT} bash -c {shlex.quote(inner)} &)"
             )
         else:
-            return f"cd /scripts && {initialize_env_file} && (nohup {server_cmd} > /tmp/agent-server.log 2>&1 &)"
+            return (
+                f"cd /scripts && {launch_started_prefix}{initialize_env_file} && "
+                f"(nohup {server_cmd} > /tmp/agent-server.log 2>&1 &)"
+            )
 
     def _termination_failure_reason(self) -> str:
         """Provider-specific detail for a sandbox that died before becoming healthy."""

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -641,7 +641,11 @@ class SandboxBase(ABC):
                 if isinstance(raw_phases, dict)
                 else {}
             )
-            for source, target in (("totalMs", "server_total"), ("httpReadyMs", "http_ready")):
+            for source, target in (
+                ("totalMs", "server_total"),
+                ("httpReadyMs", "http_ready"),
+                ("launcherToProcessMs", "launcher_to_process"),
+            ):
                 duration = boot.get(source) if isinstance(boot, dict) else None
                 if isinstance(duration, int | float) and not isinstance(duration, bool):
                     phases[target] = max(0, int(duration))

--- a/products/tasks/backend/logic/services/tests/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_docker_sandbox.py
@@ -58,14 +58,14 @@ def test_docker_sandbox_does_not_combine_agent_server_start_and_health(sandbox: 
 
 def test_read_agent_server_boot_metrics_includes_process_milestones(sandbox: DockerSandbox):
     response = ExecutionResult(
-        stdout='{"sessionInitMs":90,"boot":{"totalMs":140,"httpReadyMs":12,"phasesMs":{"context_fetch":40,"secret":1}}}',
+        stdout='{"sessionInitMs":90,"boot":{"totalMs":140,"httpReadyMs":12,"launcherToProcessMs":8,"phasesMs":{"context_fetch":40,"secret":1}}}',
         stderr="",
         exit_code=0,
     )
     with patch.object(sandbox, "execute", return_value=response):
         assert sandbox.read_agent_server_boot_metrics() == (
             90,
-            {"context_fetch": 40, "server_total": 140, "http_ready": 12},
+            {"context_fetch": 40, "server_total": 140, "http_ready": 12, "launcher_to_process": 8},
         )
 
 

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -516,6 +516,7 @@ class TestModalSandboxAgentServer:
         assert "--createPr true" in command
         assert "agentsh exec" not in command
         assert "nohup" in command
+        assert "export POSTHOG_AGENT_LAUNCH_STARTED_AT_MS=$(date +%s%3N)" in command
 
     def test_start_agent_server_waits_for_repository_before_launch(self, mock_sandbox: Any):
         mock_sandbox.execute = MagicMock(
@@ -532,7 +533,10 @@ class TestModalSandboxAgentServer:
         )
 
         command = _agent_server_launch_command(mock_sandbox.execute)
-        assert "while [ ! -f /tmp/workspace/.repo-ready ]; do sleep 0.1; done; exec env" in command
+        barrier = command.index("while [ ! -f /tmp/workspace/.repo-ready ]; do sleep 0.1; done")
+        marker = command.index("export POSTHOG_AGENT_LAUNCH_STARTED_AT_MS=$(date +%s%3N)")
+        process = command.index("exec env", marker)
+        assert barrier < marker < process
         assert "--repoReadyFile /tmp/workspace/.repo-ready" in command
 
     def test_start_agent_server_wraps_with_agentsh_when_domains_provided(self, mock_sandbox: Any):
@@ -559,6 +563,7 @@ class TestModalSandboxAgentServer:
         assert "bash /tmp/agentsh-bash-env.sh" in command
         assert "/tmp/agentsh-env-wrapper.sh" in command
         assert "./node_modules/.bin/agent-server" in command
+        assert "export POSTHOG_AGENT_LAUNCH_STARTED_AT_MS=$(date +%s%3N)" in command
 
     def test_start_agent_server_wraps_with_agentsh_when_domains_empty(self, mock_sandbox: Any):
         mock_sandbox.execute = MagicMock(

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -1273,7 +1273,7 @@ async def test_sandbox_started_carries_run_attribution(origin_product, team_id, 
                 health_poll_ms=None,
                 ready_wait_ms=None,
                 session_init_ms=None,
-                boot_phases_ms={},
+                boot_phases_ms={"launcher_to_process": 7},
                 shadow_launched=False,
             )
         ),
@@ -1291,6 +1291,7 @@ async def test_sandbox_started_carries_run_attribution(origin_product, team_id, 
     assert sandbox_started["origin_product"] == origin_product
     assert sandbox_started["team_id"] == team_id
     assert sandbox_started["task_run_id"] == "run-id"
+    assert sandbox_started["agent_launcher_to_process_ms"] == 7
 
 
 @pytest.mark.django_db

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1761,6 +1761,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 "agent_session_init_ms": agent_server_output.session_init_ms,
                 "agent_server_total_ms": agent_server_output.boot_phases_ms.get("server_total"),
                 "agent_server_http_ready_ms": agent_server_output.boot_phases_ms.get("http_ready"),
+                "agent_launcher_to_process_ms": agent_server_output.boot_phases_ms.get("launcher_to_process"),
                 "agent_context_fetch_ms": agent_server_output.boot_phases_ms.get("context_fetch"),
                 "agent_acp_initialize_ms": agent_server_output.boot_phases_ms.get("acp_initialize"),
                 "agent_repository_ready_ms": agent_server_output.boot_phases_ms.get("repository_ready"),

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -162,6 +162,7 @@ Tracked after sandbox and agent server are provisioned.
 | `agent_session_init_ms`         | `int`  | Agent session initialization time                         |
 | `agent_server_total_ms`         | `int`  | Agent server initialization time                          |
 | `agent_server_http_ready_ms`    | `int`  | Time from agent process start to HTTP listen              |
+| `agent_launcher_to_process_ms`  | `int`  | Time from sandbox launch command to agent process start   |
 | `agent_context_fetch_ms`        | `int`  | Task and run context fetch time inside agent-server       |
 | `agent_acp_initialize_ms`       | `int`  | ACP process handshake time                                |
 | `agent_repository_ready_ms`     | `int`  | Time waiting on the repository-ready barrier              |


### PR DESCRIPTION
## Problem

Boot telemetry cannot separate sandbox launcher overhead from agent-server process startup. This leaves the next optimization target hidden inside the existing invocation measurement.

## Changes

- Records launch-wrapper entry and derives the delay to Node process start.
- Exposes the optional timing for ACP and Pi runs as `agent_launcher_to_process_ms`.
- Keeps older sandbox images compatible when the new timing is absent.

