### PR TITLE
feat(ingestion-consumer): prototype group-granularity completion

### DIFF
--- a/rust/common/kafka-consumer/src/partition_offset_ledger.rs
+++ b/rust/common/kafka-consumer/src/partition_offset_ledger.rs
@@ -72,6 +72,7 @@ impl std::error::Error for LedgerError {}
 /// covers, and how many of its offsets Kafka never delivered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TakenFrontier {
+    pub first: Offset,
     pub offset: Offset,
     pub charge: Charge,
     pub gap_offset_count: usize,
@@ -230,6 +231,7 @@ impl PartitionOffsetLedger {
 
     pub fn take_frontier(&mut self) -> Option<TakenFrontier> {
         let frontier_offset = self.frontier()?;
+        let window_base = self.base_offset.expect("a frontier implies a window base");
         let mut charge = Charge::ZERO;
         let mut gap_offset_count = 0;
         for slot in self.slots.drain(..self.completed_prefix_len) {
@@ -242,6 +244,7 @@ impl PartitionOffsetLedger {
         self.base_offset = Some(frontier_offset);
         self.completed_prefix_len = 0;
         Some(TakenFrontier {
+            first: window_base,
             offset: frontier_offset,
             charge,
             gap_offset_count,
@@ -447,10 +450,16 @@ mod tests {
         let mut ledger = PartitionOffsetLedger::new(1);
         ledger.charge([charge(0), charge(1)]).unwrap();
         ledger.complete([Offset(0), Offset(1)]).unwrap();
-        ledger.take_frontier().unwrap();
+        let first_take = ledger.take_frontier().unwrap();
+        assert_eq!(first_take.first, Offset(0));
         ledger.charge([charge(2)]).unwrap();
         ledger.complete([Offset(2)]).unwrap();
         assert_eq!(ledger.frontier(), Some(Offset(3)));
-        assert_eq!(ledger.take_frontier().unwrap().charge.events, 1);
+        let second_take = ledger.take_frontier().unwrap();
+        assert_eq!(second_take.charge.events, 1);
+        assert_eq!(
+            second_take.first, first_take.offset,
+            "each take starts where the last one ended"
+        );
     }
 }

--- a/rust/common/kafka-consumer/src/topic_offset_ledger.rs
+++ b/rust/common/kafka-consumer/src/topic_offset_ledger.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use metrics::{counter, gauge};
 
 use crate::charge::Charge;
-use crate::partition_offset_ledger::{Held, LedgerError, PartitionOffsetLedger};
+use crate::partition_offset_ledger::{Held, LedgerError, PartitionOffsetLedger, TakenFrontier};
 use crate::types::Offset;
 
 /// Offsets a partition holds uncommitted.
@@ -194,11 +194,12 @@ impl TopicOffsetLedger {
         result
     }
 
-    /// Drain the completed prefix and return the frontier it reached; `None`
-    /// when the partition has no ledger or nothing has completed at the front
-    /// of its window. The drained offsets leave the window, so the gauges
-    /// follow them down.
-    pub fn take_frontier(&self, topic_partition: &TopicPartition) -> Option<Offset> {
+    /// Drain the completed prefix and return the span it covers: the window
+    /// base it started from and the frontier it reached. `None` when the
+    /// partition has no ledger or nothing has completed at the front of its
+    /// window. The drained offsets leave the window, so the gauges follow
+    /// them down.
+    pub fn take_frontier(&self, topic_partition: &TopicPartition) -> Option<TakenFrontier> {
         let (taken, held) = {
             let mut partitions = self.partitions.lock().unwrap();
             let ledger = partitions.get_mut(topic_partition)?;
@@ -207,7 +208,7 @@ impl TopicOffsetLedger {
         };
         publish_held(topic_partition, held);
         count_gap_offsets(topic_partition, taken.gap_offset_count);
-        Some(taken.offset)
+        Some(taken)
     }
 
     /// What the partition's window still holds; nothing without a ledger.
@@ -336,7 +337,10 @@ mod tests {
             .expect("live ledger settles");
         assert_eq!(frontier, Some(Offset(12)));
 
-        assert_eq!(ledger.take_frontier(&p0), Some(Offset(12)));
+        assert_eq!(
+            ledger.take_frontier(&p0).map(|taken| taken.offset),
+            Some(Offset(12))
+        );
         assert_eq!(ledger.held(&p0).offsets, 0);
     }
 
@@ -389,7 +393,7 @@ mod tests {
             .settle(&p0, 0, [Offset(11)])
             .expect("live ledger settles");
         assert_eq!(frontier, None);
-        assert_eq!(ledger.take_frontier(&p0), None);
+        assert!(ledger.take_frontier(&p0).is_none());
         assert_eq!(ledger.held(&p0).offsets, 2);
 
         // The late completion arrives with the next batch and the held
@@ -398,7 +402,10 @@ mod tests {
             .settle(&p0, 0, [Offset(10)])
             .expect("live ledger settles");
         assert_eq!(frontier, Some(Offset(12)));
-        assert_eq!(ledger.take_frontier(&p0), Some(Offset(12)));
+        assert_eq!(
+            ledger.take_frontier(&p0).map(|taken| taken.offset),
+            Some(Offset(12))
+        );
         assert_eq!(ledger.held(&p0).offsets, 0);
     }
 
@@ -692,6 +699,6 @@ mod tests {
         );
         assert_eq!(ledger.held(&p0).offsets, 0);
         assert_eq!(ledger.generation(&p0), 1);
-        assert_eq!(ledger.take_frontier(&p0), None);
+        assert!(ledger.take_frontier(&p0).is_none());
     }
 }

--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use common_continuous_profiling::ContinuousProfilingConfig;
 use envconfig::Envconfig;
 use rdkafka::ClientConfig;
@@ -6,6 +8,31 @@ use tracing::info;
 use crate::discovery::DiscoveryMode;
 use crate::routing::RoutingStrategy;
 use common_kafka_consumer::config::ConsumerConfigBuilder;
+
+/// The unit that completes and commits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum CompletionGranularity {
+    /// A poll completes as a whole, oldest first.
+    #[default]
+    Poll,
+    /// Each send's groups complete on their own, in any order, and the ledger
+    /// frontier gates each partition's commit.
+    Group,
+}
+
+impl FromStr for CompletionGranularity {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_lowercase().as_str() {
+            "poll" => Ok(Self::Poll),
+            "group" => Ok(Self::Group),
+            other => Err(format!(
+                "unknown consumer completion granularity '{other}' (expected 'poll' or 'group')"
+            )),
+        }
+    }
+}
 
 /// Configuration for the ingestion consumer.
 ///
@@ -167,6 +194,12 @@ pub struct Config {
     /// CONSUMER_MAX_BACKGROUND_TASKS setting used by the Kafka consumer wrapper.
     #[envconfig(from = "CONSUMER_MAX_BACKGROUND_TASKS", default = "1")]
     pub consumer_max_background_tasks: usize,
+
+    /// The unit that completes and commits. `poll` completes a whole poll at a
+    /// time, oldest first. `group` completes each send's groups on their own,
+    /// so a stalled key holds only its own partition.
+    #[envconfig(from = "CONSUMER_COMPLETION_GRANULARITY", default = "poll")]
+    pub consumer_completion_granularity: CompletionGranularity,
 
     // ---- Debug API ----
     /// Serve the real-time debug API (`/debug/load`, `/debug/state`,
@@ -462,5 +495,24 @@ impl Config {
         builder = builder.strip_classic_protocol_keys_if_consumer();
 
         builder.build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CompletionGranularity;
+    use std::str::FromStr;
+
+    #[test]
+    fn completion_granularity_parses_known_values() {
+        assert_eq!(
+            CompletionGranularity::from_str(" POLL "),
+            Ok(CompletionGranularity::Poll)
+        );
+        assert_eq!(
+            CompletionGranularity::from_str("group"),
+            Ok(CompletionGranularity::Group)
+        );
+        assert!(CompletionGranularity::from_str("batch").is_err());
     }
 }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -146,13 +146,30 @@ impl InFlightPoll {
         self.covered >= self.message_count
     }
 
-    fn contains(&self, partition: Partition, offset: i64) -> bool {
-        self.partitions.iter().any(|(topic_partition, deliveries)| {
-            topic_partition.partition == partition.0
-                && deliveries.span.first <= offset
-                && offset <= deliveries.span.last
-        })
+    /// The poll's entry for the partition whose offset span holds `offset`.
+    /// A [`GroupCompletion`] carries no topic, so the poll supplies it,
+    /// together with the ledger stamp the offsets were charged under.
+    fn holding(
+        &self,
+        partition: Partition,
+        offset: i64,
+    ) -> Option<(&TopicPartition, &PartitionDeliveries)> {
+        self.partitions
+            .iter()
+            .find(|(topic_partition, deliveries)| {
+                topic_partition.partition == partition.0
+                    && deliveries.span.first <= offset
+                    && offset <= deliveries.span.last
+            })
     }
+}
+
+/// One completion the ledger may mark: the partition it belongs to, the
+/// stamp its offsets were charged under, and the offsets themselves.
+struct MatchedCompletion {
+    topic_partition: TopicPartition,
+    stamp: u64,
+    offsets: Vec<Offset>,
 }
 
 /// Credit a completion to the poll it belongs to: the one collected under the
@@ -161,14 +178,29 @@ impl InFlightPoll {
 /// poll matches. A completion that matches no in-flight poll (its partition
 /// was revoked and reassigned while the group was out, or its poll is gone)
 /// is discarded and counted.
-fn apply_completion(in_flight: &mut VecDeque<InFlightPoll>, completion: GroupCompletion) {
-    let Some(first) = completion.offsets.first().map(|offset| offset.0) else {
-        return;
-    };
-    let Some(poll) = in_flight.iter_mut().find(|poll| {
-        poll.assignment_epoch == completion.assignment_epoch
-            && poll.contains(completion.partition, first)
-    }) else {
+///
+/// With `for_ledger`, returns what the ledger needs for a completion the
+/// workers accepted whole; a short one is credited to the poll, which then
+/// fails its accepted check, and is never marked complete. Without it the
+/// caller settles nothing per completion, so the poll is credited and nothing
+/// is built.
+fn apply_completion(
+    in_flight: &mut VecDeque<InFlightPoll>,
+    completion: GroupCompletion,
+    for_ledger: bool,
+) -> Option<MatchedCompletion> {
+    let first = completion.offsets.first().map(|offset| offset.0)?;
+    let matched = in_flight.iter_mut().find_map(|poll| {
+        if poll.assignment_epoch != completion.assignment_epoch {
+            return None;
+        }
+        let (topic_partition, deliveries) = poll.holding(completion.partition, first)?;
+        // The ledger settles with the stamp the slice was charged under, not
+        // the epoch the batcher stamps at submit.
+        let charged = for_ledger.then(|| (topic_partition.clone(), deliveries.generation));
+        Some((poll, charged))
+    });
+    let Some((poll, charged)) = matched else {
         counter!("ingestion_consumer_stale_group_completions_total").increment(1);
         warn!(
             partition = %completion.partition,
@@ -176,10 +208,21 @@ fn apply_completion(in_flight: &mut VecDeque<InFlightPoll>, completion: GroupCom
             epoch = completion.assignment_epoch,
             "Discarding group completion that matches no in-flight poll"
         );
-        return;
+        return None;
     };
     poll.covered += completion.offsets.len() as u32;
     poll.accepted += completion.accepted;
+
+    // Absent when the caller does not settle per completion.
+    let (topic_partition, stamp) = charged?;
+    if completion.accepted as usize != completion.offsets.len() {
+        return None;
+    }
+    Some(MatchedCompletion {
+        topic_partition,
+        stamp,
+        offsets: completion.offsets,
+    })
 }
 
 /// Options for constructing an [`IngestionConsumer`] from pre-built parts.
@@ -505,7 +548,9 @@ impl IngestionConsumer {
         {
             tokio::select! {
                 completion = completions.recv() => match completion {
-                    Some(completion) => apply_completion(in_flight_polls, completion),
+                    Some(completion) => {
+                        self.apply_completions(in_flight_polls, completions, completion)?
+                    }
                     None => anyhow::bail!("batcher completion channel closed"),
                 },
                 failure = errors.recv() => match failure {
@@ -525,7 +570,10 @@ impl IngestionConsumer {
             );
         }
 
-        self.commit_offsets(&poll.partitions)?;
+        // At group granularity the completions already committed the frontier.
+        if self.completion_granularity == CompletionGranularity::Poll {
+            self.commit_offsets(&poll.partitions)?;
+        }
         emit_latest_processed_timestamp_metrics(&poll.partitions, &self.group_id);
         record_if(&self.debug_recorder, || DebugEventKind::BatchCommitted {
             batch_id: poll.poll_id.clone(),
@@ -539,6 +587,65 @@ impl IngestionConsumer {
         self.handle.report_healthy();
 
         Ok(())
+    }
+
+    /// Credit one wake's completions to their polls, and at group granularity
+    /// commit the partitions they advanced. Both paths drain what is already
+    /// queued, so one commit carries every partition that advanced while the
+    /// loop was busy; only the group path keeps what it drained.
+    ///
+    /// The drain stops as soon as the oldest poll is covered. The caller pops
+    /// that poll before the next completion is matched, and a later poll may
+    /// hold the same offsets again: a partition regained inside a batch is
+    /// redelivered from its committed offset, and a completion for those
+    /// offsets must credit the poll that carried the redelivery, not the one
+    /// already covered ahead of it.
+    fn apply_completions(
+        &self,
+        in_flight_polls: &mut VecDeque<InFlightPoll>,
+        completions: &mut mpsc::UnboundedReceiver<GroupCompletion>,
+        first: GroupCompletion,
+    ) -> anyhow::Result<()> {
+        let front_is_complete =
+            |polls: &VecDeque<InFlightPoll>| polls.front().is_some_and(InFlightPoll::is_complete);
+
+        if self.completion_granularity != CompletionGranularity::Group {
+            let _ = apply_completion(in_flight_polls, first, false);
+            while !front_is_complete(in_flight_polls) {
+                let Ok(completion) = completions.try_recv() else {
+                    break;
+                };
+                let _ = apply_completion(in_flight_polls, completion, false);
+            }
+            return Ok(());
+        }
+
+        let mut matched: Vec<MatchedCompletion> = apply_completion(in_flight_polls, first, true)
+            .into_iter()
+            .collect();
+        while !front_is_complete(in_flight_polls) {
+            let Ok(completion) = completions.try_recv() else {
+                break;
+            };
+            matched.extend(apply_completion(in_flight_polls, completion, true));
+        }
+        self.commit_group_frontiers(matched)
+    }
+
+    /// Commit the ledger frontier of every partition a wake's completions
+    /// advanced. This runs in the wait for the oldest poll because the batcher
+    /// owns the flush: the loop keeps applying completions while that poll is
+    /// out, so commit latency is bounded by one `collect_batch`.
+    fn commit_group_frontiers(&self, matched: Vec<MatchedCompletion>) -> anyhow::Result<()> {
+        let spans = settle_group_completions(&self.topic_offset_ledger, matched);
+        if spans.is_empty() {
+            return Ok(());
+        }
+        self.submit_commit(
+            spans
+                .iter()
+                .map(|(topic_partition, span)| (topic_partition, span)),
+        )
     }
 
     fn fail_batch_processing(&self, err: anyhow::Error) {
@@ -834,6 +941,49 @@ fn frontier_span(span: &OffsetSpan, frontier: Option<Offset>) -> Option<OffsetSp
     })
 }
 
+/// Mark a wake's completions on their partition ledgers and return the span
+/// each partition is now ready to commit. A partition whose window base is
+/// still incomplete gets no span and stays on its last commit; a completion
+/// the ledger rejects as stale settles nothing.
+fn settle_group_completions(
+    ledger: &TopicOffsetLedger,
+    matched: Vec<MatchedCompletion>,
+) -> Vec<(TopicPartition, OffsetSpan)> {
+    // A wake covers few partitions, and each is drained once, after every
+    // completion in the wake has landed.
+    let mut advanced: Vec<TopicPartition> = Vec::new();
+    for completion in matched {
+        let MatchedCompletion {
+            topic_partition,
+            stamp,
+            offsets,
+        } = completion;
+        // The ledger counts a rejection itself, so a rejected slice just
+        // settles nothing here.
+        let Ok(frontier) = ledger.settle(&topic_partition, stamp, offsets) else {
+            continue;
+        };
+        if frontier.is_some() && !advanced.contains(&topic_partition) {
+            advanced.push(topic_partition);
+        }
+    }
+
+    advanced
+        .into_iter()
+        .filter_map(|topic_partition| {
+            let taken = ledger.take_frontier(&topic_partition)?;
+            // The frontier is next-to-read and the span is last-processed, so
+            // the commit adds the 1 back. `first` is the window base, where
+            // the commit sentinel requires the span to start.
+            let span = OffsetSpan {
+                first: taken.first.0,
+                last: taken.offset.0 - 1,
+            };
+            Some((topic_partition, span))
+        })
+        .collect()
+}
+
 /// Emit the per-poll parity metrics (received counts, batch sizes,
 /// utilization, and lag) right after collection, before the poll is
 /// submitted.
@@ -1073,14 +1223,17 @@ mod tests {
     fn apply_completion_credits_the_poll_holding_the_offsets() {
         let mut in_flight = VecDeque::from([poll(1, 0, 0, 3, 4), poll(1, 0, 4, 7, 4)]);
 
-        apply_completion(&mut in_flight, completion(1, 0, &[4, 6], 2));
+        let matched = apply_completion(&mut in_flight, completion(1, 0, &[4, 6], 2), true)
+            .expect("an accepted completion reaches the ledger");
+        assert_eq!(matched.topic_partition, TopicPartition::new("test", 0));
+        assert_eq!(matched.offsets, vec![Offset(4), Offset(6)]);
 
         assert_eq!(in_flight[0].covered, 0);
         assert_eq!(in_flight[1].covered, 2);
         assert_eq!(in_flight[1].accepted, 2);
         assert!(!in_flight[1].is_complete());
 
-        apply_completion(&mut in_flight, completion(1, 0, &[5, 7], 2));
+        apply_completion(&mut in_flight, completion(1, 0, &[5, 7], 2), true);
         assert!(in_flight[1].is_complete());
     }
 
@@ -1091,7 +1244,7 @@ mod tests {
         // completions in its own poll.
         let mut in_flight = VecDeque::from([poll(1, 0, 0, 3, 4), poll(2, 0, 0, 3, 4)]);
 
-        apply_completion(&mut in_flight, completion(2, 0, &[0, 1, 2, 3], 4));
+        apply_completion(&mut in_flight, completion(2, 0, &[0, 1, 2, 3], 4), true);
 
         assert_eq!(in_flight[0].covered, 0);
         assert_eq!(in_flight[1].covered, 4);
@@ -1102,11 +1255,55 @@ mod tests {
         let mut in_flight = VecDeque::from([poll(1, 0, 0, 3, 4)]);
 
         // Wrong partition, then wrong epoch: neither may be credited.
-        apply_completion(&mut in_flight, completion(1, 2, &[1], 1));
-        apply_completion(&mut in_flight, completion(9, 0, &[1], 1));
+        assert!(apply_completion(&mut in_flight, completion(1, 2, &[1], 1), true).is_none());
+        assert!(apply_completion(&mut in_flight, completion(9, 0, &[1], 1), true).is_none());
 
         assert_eq!(in_flight[0].covered, 0);
         assert_eq!(in_flight[0].accepted, 0);
+    }
+
+    #[test]
+    fn a_short_accepted_completion_never_reaches_the_ledger() {
+        let mut in_flight = VecDeque::from([poll(1, 0, 0, 3, 4)]);
+
+        // The worker under-reports: the poll must still see the coverage and
+        // fail its accepted check, but the ledger must not commit past the
+        // messages the worker dropped.
+        let matched = apply_completion(&mut in_flight, completion(1, 0, &[0, 1], 1), true);
+
+        assert!(matched.is_none());
+        assert_eq!(in_flight[0].covered, 2);
+        assert_eq!(in_flight[0].accepted, 1);
+    }
+
+    #[test]
+    fn a_completion_outside_the_ledger_path_only_credits_the_poll() {
+        let mut in_flight = VecDeque::from([poll(1, 0, 0, 3, 4)]);
+
+        // Poll granularity settles nothing per completion, so it must not pay
+        // for the partition key the ledger path needs.
+        let matched = apply_completion(&mut in_flight, completion(1, 0, &[0, 1, 2, 3], 4), false);
+
+        assert!(matched.is_none());
+        assert_eq!(in_flight[0].covered, 4);
+        assert_eq!(in_flight[0].accepted, 4);
+    }
+
+    #[test]
+    fn apply_completion_reports_the_stamp_the_offsets_were_charged_under() {
+        // The batcher stamps the completion with the assignment epoch; the
+        // ledger settles with the generation the slice was charged under.
+        let mut in_flight = VecDeque::from([poll(3, 0, 0, 3, 4)]);
+        in_flight[0]
+            .partitions
+            .get_mut(&TopicPartition::new("test", 0))
+            .expect("the poll charged the partition")
+            .generation = 2;
+
+        let matched = apply_completion(&mut in_flight, completion(3, 0, &[0, 1, 2, 3], 4), true)
+            .expect("an accepted completion reaches the ledger");
+
+        assert_eq!(matched.stamp, 2);
     }
 
     #[test]
@@ -1139,5 +1336,123 @@ mod tests {
             last: 21,
         };
         assert_eq!(frontier_span(&span, None), None);
+    }
+
+    fn ledger() -> Arc<TopicOffsetLedger> {
+        Arc::new(TopicOffsetLedger::new())
+    }
+
+    fn charge_offsets(
+        ledger: &TopicOffsetLedger,
+        topic_partition: &TopicPartition,
+        stamp: u64,
+        offsets: &[i64],
+    ) {
+        ledger
+            .charge(
+                topic_partition,
+                stamp,
+                offsets.iter().map(|&o| (Offset(o), Charge::ZERO)),
+            )
+            .expect("the test ledger accepts the charge");
+    }
+
+    fn matched(topic_partition: &TopicPartition, stamp: u64, offsets: &[i64]) -> MatchedCompletion {
+        MatchedCompletion {
+            topic_partition: topic_partition.clone(),
+            stamp,
+            offsets: offsets.iter().map(|&o| Offset(o)).collect(),
+        }
+    }
+
+    #[test]
+    fn a_partition_commits_only_once_its_completed_prefix_is_contiguous() {
+        let ledger = ledger();
+        let p0 = TopicPartition::new("events", 0);
+        charge_offsets(&ledger, &p0, 0, &[10, 11, 12]);
+
+        let spans = settle_group_completions(&ledger, vec![matched(&p0, 0, &[12])]);
+        assert!(spans.is_empty(), "the window base is still incomplete");
+
+        let spans = settle_group_completions(&ledger, vec![matched(&p0, 0, &[10, 11])]);
+        assert_eq!(
+            spans,
+            vec![(
+                p0,
+                OffsetSpan {
+                    first: 10,
+                    last: 12
+                }
+            )],
+            "the late completion releases the whole prefix"
+        );
+    }
+
+    #[test]
+    fn a_partition_with_a_held_prefix_does_not_hold_back_another() {
+        let ledger = ledger();
+        let p0 = TopicPartition::new("events", 0);
+        let p1 = TopicPartition::new("events", 1);
+        charge_offsets(&ledger, &p0, 0, &[10, 11]);
+        charge_offsets(&ledger, &p1, 0, &[20, 21]);
+
+        let spans = settle_group_completions(
+            &ledger,
+            vec![matched(&p0, 0, &[10, 11]), matched(&p1, 0, &[21])],
+        );
+
+        assert_eq!(
+            spans,
+            vec![(
+                p0,
+                OffsetSpan {
+                    first: 10,
+                    last: 11
+                }
+            )],
+            "partition 1 waits for offset 20"
+        );
+    }
+
+    #[test]
+    fn a_stale_stamp_completion_commits_nothing() {
+        let ledger = ledger();
+        let p0 = TopicPartition::new("events", 0);
+        charge_offsets(&ledger, &p0, 0, &[10]);
+
+        // The partition is revoked and reassigned while the group is out, so
+        // Kafka redelivers the offset under a new ledger generation.
+        ledger.forget_partitions([("events", 0)]);
+        charge_offsets(&ledger, &p0, 1, &[10]);
+
+        let spans = settle_group_completions(&ledger, vec![matched(&p0, 0, &[10])]);
+
+        assert!(spans.is_empty());
+        assert_eq!(
+            ledger.held(&p0).offsets,
+            1,
+            "the redelivered offset stays uncompleted"
+        );
+    }
+
+    #[test]
+    fn a_later_span_starts_where_the_last_one_ended() {
+        let ledger = ledger();
+        let p0 = TopicPartition::new("events", 0);
+        charge_offsets(&ledger, &p0, 0, &[10, 11]);
+
+        let first = settle_group_completions(&ledger, vec![matched(&p0, 0, &[10])]);
+        let second = settle_group_completions(&ledger, vec![matched(&p0, 0, &[11])]);
+
+        // The commit sentinel rejects a span that does not continue the last
+        // committed one.
+        assert_eq!(second[0].1.first, first[0].1.last + 1);
+        assert_eq!(
+            second[0].1,
+            OffsetSpan {
+                first: 11,
+                last: 11
+            }
+        );
     }
 }

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -16,7 +16,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use crate::batcher::{make_batch_id, Batcher, BatcherOutputs};
-use crate::config::Config;
+use crate::config::{CompletionGranularity, Config};
 use crate::debug_recorder::{record_if, DebugEventKind, DebugRecorder, PartitionOffset};
 use crate::discovery::DiscoveryMode;
 use crate::dispatcher::Dispatcher;
@@ -200,6 +200,8 @@ pub struct IngestionConsumerOptions {
     pub deferred_flush_timeout: Duration,
     /// Debug event recorder; `None` unless `DEBUG_API_ENABLED`.
     pub debug_recorder: Option<Arc<DebugRecorder>>,
+    /// The unit that completes and commits.
+    pub completion_granularity: CompletionGranularity,
 }
 
 /// The main consumer loop: reads from Kafka, demuxes each poll into groups,
@@ -227,6 +229,8 @@ pub struct IngestionConsumer {
     /// from. Shared with the consumer's [`SentinelContext`], which forgets
     /// partitions on rebalance.
     topic_offset_ledger: Arc<TopicOffsetLedger>,
+    /// Selects the unit that completes and commits.
+    completion_granularity: CompletionGranularity,
 }
 
 impl IngestionConsumer {
@@ -256,6 +260,7 @@ impl IngestionConsumer {
             commit_sentinel,
             debug_recorder: options.debug_recorder,
             topic_offset_ledger,
+            completion_granularity: options.completion_granularity,
             consumer: Arc::new(consumer),
             batcher,
             outputs: Some(outputs),
@@ -326,6 +331,7 @@ impl IngestionConsumer {
             commit_sentinel,
             debug_recorder,
             topic_offset_ledger,
+            completion_granularity: config.consumer_completion_granularity,
             batcher,
             outputs: Some(outputs),
             transport,
@@ -360,7 +366,10 @@ impl IngestionConsumer {
             return;
         }
 
-        info!("Consumer loop starting");
+        info!(
+            completion_granularity = ?self.completion_granularity,
+            "Consumer loop starting"
+        );
         record_if(&self.debug_recorder, || DebugEventKind::ConsumerStarted {
             group_id: self.group_id.clone(),
             workers: self.worker_urls.clone(),

--- a/rust/ingestion-consumer/tests/e2e_integration_test.rs
+++ b/rust/ingestion-consumer/tests/e2e_integration_test.rs
@@ -579,6 +579,29 @@ impl Harness {
         .await
     }
 
+    /// Group granularity: each send completes on its own and commits its
+    /// partitions' frontiers, so a stalled send holds only the partitions it
+    /// sits on.
+    async fn start_group_granularity(
+        topic: &str,
+        partitions: i32,
+        worker_count: usize,
+        max_in_flight: usize,
+    ) -> Self {
+        Self::start_inner(
+            topic,
+            partitions,
+            worker_count,
+            max_in_flight,
+            Duration::from_secs(60),
+            fast_registry_config(),
+            0,
+            ComponentOptions::new(),
+            CompletionGranularity::Group,
+        )
+        .await
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn start_inner(
         topic: &str,
@@ -1997,21 +2020,12 @@ async fn consumer_crash_before_commit_redelivers_without_loss() {
     harness.stop().await;
 }
 
-/// The broker-committed offset is the ledger frontier — one past everything
-/// the workers accepted — and a restart resumes from it with no loss and no
-/// redelivery.
-#[tokio::test]
-async fn the_committed_offset_is_the_ledger_frontier() {
-    let topic = format!("e2e-ledger-commit-{}", Uuid::new_v4());
-    let mut harness = Harness::start(
-        &topic,
-        1,
-        1,
-        1,
-        Duration::from_secs(60),
-        fast_registry_config(),
-    )
-    .await;
+/// The broker-committed offset is the ledger frontier — one past everything the
+/// workers accepted — and a restart resumes from it with no loss and no
+/// redelivery. Shared by both granularities: which unit completes must not
+/// change where the frontier lands.
+async fn assert_commits_track_the_ledger_frontier(mut harness: Harness) {
+    let topic = harness.topic.clone();
     let producer = make_producer();
 
     for seq in 0..10usize {
@@ -2045,6 +2059,172 @@ async fn the_committed_offset_is_the_ledger_frontier() {
         total, 15,
         "a committed frontier behind the accepted work would redeliver here"
     );
+
+    harness.stop().await;
+}
+
+#[tokio::test]
+async fn the_committed_offset_is_the_ledger_frontier() {
+    let topic = format!("e2e-ledger-commit-{}", Uuid::new_v4());
+    assert_commits_track_the_ledger_frontier(
+        Harness::start(
+            &topic,
+            1,
+            1,
+            1,
+            Duration::from_secs(60),
+            fast_registry_config(),
+        )
+        .await,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn group_granularity_commits_the_ledger_frontier() {
+    let topic = format!("e2e-group-commit-{}", Uuid::new_v4());
+    assert_commits_track_the_ledger_frontier(
+        Harness::start_group_granularity(&topic, 1, 1, 1).await,
+    )
+    .await;
+}
+
+/// The two keys of the stalled-partition scenario, one per partition.
+const STALL_KEYS: [(i32, &str); 2] = [(0, "user-a"), (1, "user-b")];
+
+/// Land one poll that carries two partitions and splits across two blocked
+/// workers: 5 messages keyed `user-a` on partition 0 and 5 keyed `user-b` on
+/// partition 1. Placement is deterministic — the dispatcher's default bin-pack
+/// routing puts each key on the least-loaded worker, and the first key's five
+/// messages already count as in-flight load on the worker that took them, so
+/// the second key goes to the other one. Returns the per-worker gate guards;
+/// dropping one releases that worker's send.
+async fn stall_two_partitions_on_two_workers(
+    harness: &Harness,
+    topic: &str,
+) -> Vec<Option<tokio::sync::OwnedMutexGuard<()>>> {
+    let mut guards = Vec::new();
+    for worker in &harness.workers {
+        guards.push(Some(worker.block().await));
+    }
+
+    let producer = make_producer();
+    let mut sends = Vec::new();
+    for seq in 0..5usize {
+        for (partition, key) in STALL_KEYS {
+            sends.push(produce(&producer, topic, partition, "tok", key, seq));
+        }
+    }
+    // Produce concurrently so all ten messages fall inside one collection window.
+    futures::future::join_all(sends).await;
+
+    wait_until(
+        Duration::from_secs(10),
+        "both workers to hold a sub-batch",
+        || harness.workers.iter().all(|w| w.arrived_count() > 0),
+    )
+    .await;
+
+    guards
+}
+
+/// The partition whose key worker `idx` accepted, once its send resolved.
+/// Asserts the split: one worker holds exactly one key's five messages.
+fn accepted_partition(harness: &Harness, idx: usize) -> i32 {
+    let worker = &harness.workers[idx];
+    assert_eq!(
+        worker.count(),
+        5,
+        "each worker must hold exactly one key's messages"
+    );
+    STALL_KEYS
+        .iter()
+        .find(|(_, key)| !worker.seqs_for(key).is_empty())
+        .map(|(partition, _)| *partition)
+        .expect("the released worker accepted neither key")
+}
+
+/// Group granularity: a stalled send holds only its own partition. Both keys
+/// ride one poll on separate workers; releasing one worker commits that key's
+/// partition while the other worker still holds its send.
+#[tokio::test]
+async fn group_granularity_commits_a_partition_while_another_stalls() {
+    let topic = format!("e2e-group-stall-{}", Uuid::new_v4());
+    let harness = Harness::start_group_granularity(&topic, 2, 2, 2).await;
+    let mut guards = stall_two_partitions_on_two_workers(&harness, &topic).await;
+
+    guards[0] = None;
+    wait_until(
+        Duration::from_secs(10),
+        "the released worker to accept its key",
+        || harness.workers[0].count() == 5,
+    )
+    .await;
+    let released = accepted_partition(&harness, 0);
+    let stalled = 1 - released;
+
+    wait_until(
+        Duration::from_secs(10),
+        "the released partition to commit",
+        || harness.committed_offset(released) == Some(5),
+    )
+    .await;
+    assert_eq!(
+        harness.committed_offset(stalled),
+        None,
+        "the stalled send must hold its own partition back"
+    );
+
+    guards[1] = None;
+    wait_until(
+        Duration::from_secs(10),
+        "the stalled partition to commit once released",
+        || harness.committed_offset(stalled) == Some(5),
+    )
+    .await;
+
+    harness.stop().await;
+}
+
+/// Poll granularity holds both partitions while one send stalls: the poll
+/// commits as a whole, so the released partition waits for the stalled one.
+/// This is what group granularity replaces.
+#[tokio::test]
+async fn poll_granularity_holds_both_partitions_while_one_stalls() {
+    let topic = format!("e2e-poll-stall-{}", Uuid::new_v4());
+    let harness = Harness::start(
+        &topic,
+        2,
+        2,
+        2,
+        Duration::from_secs(60),
+        fast_registry_config(),
+    )
+    .await;
+    let mut guards = stall_two_partitions_on_two_workers(&harness, &topic).await;
+
+    guards[0] = None;
+    wait_until(
+        Duration::from_secs(10),
+        "the released worker to accept its key",
+        || harness.workers[0].count() == 5,
+    )
+    .await;
+    let released = accepted_partition(&harness, 0);
+
+    assert_eq!(
+        harness.committed_offset(released),
+        None,
+        "an accepted send commits nothing until its whole poll completes"
+    );
+
+    guards[1] = None;
+    wait_until(
+        Duration::from_secs(10),
+        "both partitions to commit once the poll completes",
+        || harness.committed_offset(0) == Some(5) && harness.committed_offset(1) == Some(5),
+    )
+    .await;
 
     harness.stop().await;
 }

--- a/rust/ingestion-consumer/tests/e2e_integration_test.rs
+++ b/rust/ingestion-consumer/tests/e2e_integration_test.rs
@@ -25,6 +25,7 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use common_kafka_consumer::{TopicOffsetLedger, TopicPartition};
+use ingestion_consumer::config::CompletionGranularity;
 use ingestion_consumer::consumer::{IngestionConsumer, IngestionConsumerOptions};
 use ingestion_consumer::discovery::reconcile_membership;
 use ingestion_consumer::dispatcher::Dispatcher;
@@ -435,6 +436,7 @@ struct Harness {
     pub ledger: Arc<TopicOffsetLedger>,
     max_in_flight: usize,
     deferred_flush_timeout: Duration,
+    completion_granularity: CompletionGranularity,
 }
 
 /// Build a Kafka consumer subscribed to `topic` in `group_id`, configured like
@@ -531,6 +533,7 @@ impl Harness {
             registry_config,
             0,
             ComponentOptions::new(),
+            CompletionGranularity::Poll,
         )
         .await
     }
@@ -553,6 +556,7 @@ impl Harness {
             ComponentOptions::new()
                 .with_liveness_deadline(liveness_deadline)
                 .with_stall_threshold(stall_threshold),
+            CompletionGranularity::Poll,
         )
         .await
     }
@@ -570,6 +574,7 @@ impl Harness {
             fast_registry_config(),
             batch_size_bytes,
             ComponentOptions::new(),
+            CompletionGranularity::Poll,
         )
         .await
     }
@@ -584,6 +589,7 @@ impl Harness {
         registry_config: WorkerRegistryConfig,
         batch_size_bytes: usize,
         component_options: ComponentOptions,
+        completion_granularity: CompletionGranularity,
     ) -> Self {
         create_topic(topic, partitions).await;
 
@@ -635,6 +641,7 @@ impl Harness {
                 group_id: "e2e-test".to_string(),
                 deferred_flush_timeout,
                 debug_recorder: None,
+                completion_granularity,
             },
             handle,
         );
@@ -657,6 +664,7 @@ impl Harness {
             ledger,
             max_in_flight,
             deferred_flush_timeout,
+            completion_granularity,
         }
     }
 
@@ -709,6 +717,7 @@ impl Harness {
                 group_id: "e2e-test".to_string(),
                 deferred_flush_timeout: self.deferred_flush_timeout,
                 debug_recorder: None,
+                completion_granularity: self.completion_granularity,
             },
             handle,
         );
@@ -2560,6 +2569,7 @@ async fn second_consumer_joining_the_group_preserves_all_messages() {
             group_id: "e2e-test".to_string(),
             deferred_flush_timeout: Duration::from_secs(60),
             debug_recorder: None,
+            completion_granularity: CompletionGranularity::Poll,
         },
         handle2,
     );
@@ -2667,6 +2677,7 @@ async fn partition_lost_and_regained_keeps_the_consumer_alive() {
             group_id: "e2e-test".to_string(),
             deferred_flush_timeout: Duration::from_secs(60),
             debug_recorder: None,
+            completion_granularity: CompletionGranularity::Poll,
         },
         handle2,
     );
@@ -2780,6 +2791,7 @@ async fn fenced_static_member_exits_on_fatal_error() {
             group_id: "e2e-test".to_string(),
             deferred_flush_timeout: Duration::from_secs(60),
             debug_recorder: None,
+            completion_granularity: CompletionGranularity::Poll,
         },
         handle,
     );


### PR DESCRIPTION
## Problem

A key that stalls on one worker holds back the commits of every partition in the same poll, and of every later poll behind it, because a poll commits as a whole and oldest first.
[Cycle 8 of the driver-model plan](https://github.com/PostHog/posthog/blob/master/rust/ingestion-consumer/docs/driver-model-plan.md#cycle-8-a-stalled-key-stalls-only-its-partition) makes commits advance per partition as groups complete.
Its change 21 needs the ledger frontier commits (#91766), the shadow ledger (#91764), and the batcher boundary with its `GroupCompletion` channel (#93162), all merged now, plus the cycle 2 cleanup (#94950) that makes the frontier the only commit source.

This PR implements change 21, stacked on #94950.

## Changes

- Operators can set `CONSUMER_COMPLETION_GRANULARITY=group` to let each partition commit as soon as its own sends resolve. The default `poll` keeps today's behavior byte for byte.
- At `group` granularity, a stalled key delays only the partitions it sits on. Other partitions commit through the stall. The admission cap still frees a slot only when a whole poll is covered, so replay exposure does not grow.

Mechanism:

- `apply_completion` now returns the matched poll's topic-partition and the ledger generation its slice was charged under. The ledger is marked with that stamp, not the completion's assignment epoch, so it settles exactly what the poll path settles, and the ledger's own staleness rule drops a completion from a revoked and regained partition.
- `CommitLedger` gains `take_frontier`, a drain that returns the span it covered. The consumer still never touches the ledger directly.
- The completion arm of `complete_oldest_poll` drains what is queued, marks the ledger, takes each advanced frontier, and issues one sentinel-checked commit for all of them. It is a `select!` arm and not a task because the batcher took the deferred flush out of the poll loop, so the loop keeps applying completions while the oldest poll is out.
- The drain stops as soon as the oldest poll is covered, so the caller pops it before the next completion is matched. Two in-flight polls can hold the same offsets when a partition is regained inside a batch and redelivered, and `apply_completion` credits the first poll that holds the offset; popping the covered one first is what keeps the redelivery's completion on the poll that carried it. The e2e harness builds consumers with a detached sentinel context and no assignment epoch, so it exercises exactly this case (`partition_lost_and_regained_keeps_the_consumer_alive` wedged about four runs in five with an unbounded drain).
- `TakenFrontier` gains `first`, the window base before the take, so the commit sentinel's "each span continues the last" check holds for per-partition commits.
- A completion whose accepted count is short of its offsets marks nothing. The poll then fails its accepted check and the process exits, as today, and the committed frontier covers only accepted work.
- Mechanical: the e2e harness threads the granularity next to the ledger mode.

> [!NOTE]
> Commit latency at `group` granularity is bounded by one `collect_batch`: completions are only read inside `complete_oldest_poll`, because a completion arm beside `collect_batch` would cancel a collect in progress and drop the messages it already took from librdkafka.

## How did you test this code?

New tests, each named for the regression it catches:

- `group_granularity_commits_a_partition_while_another_stalls` (e2e): one poll split across two workers, one worker blocked. The released partition commits while the stalled one stays uncommitted, then commits once released. At `poll` granularity this fails.
- `poll_granularity_holds_both_partitions_while_one_stalls` (e2e): the same scenario at the default, pinning today's behavior so the switch is the only thing that changes it.
- `group_granularity_commits_the_ledger_frontier` (e2e): the group twin of `commit_mode_commits_the_ledger_frontier`. A crash and restart resume from the committed frontier with no loss and no redelivery.
- `apply_completion` unit tests: a short-accepted completion credits the poll but never reaches the ledger; the ledger gets the generation the slice was charged under, not the assignment epoch; the poll path returns nothing for the ledger.
- `settle_group_completions` unit tests: a partition commits only once its prefix is contiguous; one partition's held prefix does not hold another back; a stale-stamp completion after a reassign settles nothing; a later span starts where the last one ended, which is what the commit sentinel requires.
- `TakenFrontier.first`: the first take starts at the first delivery, and each later take starts where the previous one ended.

Run locally inside flox against a local Kafka: both crates' unit suites, clippy with `-D warnings`, and the whole `e2e_integration_test` file (39 tests; the 36 existing ones unchanged). On the final rebase one full run had `forced_reap_at_drain_timeout_reroutes_deferred_work` fail on a worker-placement assertion in a path this PR does not touch; it passes alone on repeated runs, so it is a load flake of the local broker.

> [!NOTE]
> The e2e harness never wires the assignment epoch into the consumer's sentinel context, so in tests every poll carries the same epoch across a rebalance. #93162's completion-to-poll correlation by epoch is therefore untested end to end; it holds in tests only by the pop-before-next-match ordering described above.

Not run: the full Rust workspace, and anything outside `common-kafka-consumer` and `ingestion-consumer`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The plan document already describes change 21; this PR does not edit it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: https://claude.ai/code/session_01FRH82uuAio1ojr33MWsgyc. A planning session assembled the base, wrote a commit-by-commit plan, and Opus subagents implemented the commits.
- Skills invoked: `/writing-pr-descriptions`.
- Decisions across the session: a first version built a temporary completion interface and a committer task on top of #91766 alone; a second re-based it on the real boundary from #93162 with stand-in commits for the then-open PRs; this version sits directly on master now that all three have merged.
