### PR TITLE
fix: desktop follow-up recovery and Claude runtime compatibility

### DIFF
--- a/products/desktop/packages/agent/package.json
+++ b/products/desktop/packages/agent/package.json
@@ -178,7 +178,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "1.1.0",
-    "@anthropic-ai/claude-agent-sdk": "0.3.197",
+    "@anthropic-ai/claude-agent-sdk": "0.3.251",
     "@anthropic-ai/sdk": "0.109.0",
     "@earendil-works/pi-agent-core": "catalog:",
     "@earendil-works/pi-ai": "catalog:",

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { toolUpdateFromToolResult } from "./tool-use-to-acp";
+
+describe("toolUpdateFromToolResult", () => {
+  it("does not forward document bytes from Read results", () => {
+    const pdfData = "base64-pdf-data";
+    const result = toolUpdateFromToolResult(
+      {
+        type: "tool_result",
+        tool_use_id: "toolu_1",
+        content: [
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: pdfData,
+            },
+          },
+        ],
+      } as never,
+      { name: "Read", input: {} },
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "content",
+        content: {
+          type: "text",
+          text: "Document content omitted from session updates.",
+        },
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain(pdfData);
+  });
+});

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/tool-use-to-acp.ts
@@ -618,6 +618,12 @@ export function toolUpdateFromToolResult(
                 },
               };
             }
+            if (itemObj.type === "document") {
+              return {
+                type: "content" as const,
+                content: text("Document content omitted from session updates."),
+              };
+            }
             return {
               type: "content" as const,
               content: item as { type: "text"; text: string },

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -538,6 +538,7 @@ describe("buildSessionOptions", () => {
       }).env;
 
       expect(env?.CLAUDE_CODE_ENABLE_ASK_USER_QUESTION_TOOL).toBe("true");
+      expect(env?.CLAUDE_CODE_ENABLE_TODO_TOOLS).toBe("1");
       expect(env?.ENABLE_TOOL_SEARCH).toBe("auto:0");
       expect(env?.CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS).toBe("1");
     });

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -195,6 +195,7 @@ function buildEnvironment(
       ELECTRON_RUN_AS_NODE: "1",
     }),
     CLAUDE_CODE_ENABLE_ASK_USER_QUESTION_TOOL: "true",
+    CLAUDE_CODE_ENABLE_TODO_TOOLS: "1",
     // Offload all MCP tools by default
     ENABLE_TOOL_SEARCH: "auto:0",
     // Enable idle state as end-of-turn signal (required for SDK 0.2.114+)

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -1310,6 +1310,22 @@ describe("AgentServer HTTP Mode", () => {
       expect(testServer.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
     });
 
+    it("quietly ends an interactive follow-up that ended without a response", async () => {
+      const testServer = createFailureTestServer();
+
+      const result = await testServer.handleTurnFailure(
+        interactivePayload,
+        "followup",
+        new Error(
+          "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+        ),
+      );
+
+      expect(result).toEqual({ recoverable: false });
+      expect(testServer.eventStreamSender.enqueue).not.toHaveBeenCalled();
+      expect(testServer.posthogAPI.updateTaskRun).not.toHaveBeenCalled();
+    });
+
     function createRetryTestServer(prompt: ReturnType<typeof vi.fn>) {
       const testServer = createFailureTestServer();
       testServer.session = {
@@ -2832,6 +2848,50 @@ describe("AgentServer HTTP Mode", () => {
       expect(anonymousSecond.result?.stopReason).toBe("end_turn");
       expect(prompt).toHaveBeenCalledTimes(4);
     }, 20000);
+
+    it("allows a no-response follow-up to be retried with the same messageId", async () => {
+      const s = createServer();
+      await s.start();
+      const prompt = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new Error(
+            "Internal error: [ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+          ),
+        )
+        .mockResolvedValueOnce({ stopReason: "end_turn" });
+      const serverInternals = s as unknown as {
+        session: { clientConnection: { prompt: typeof prompt } };
+      };
+      serverInternals.session.clientConnection.prompt = prompt;
+
+      const send = async () => {
+        const response = await fetch(`http://localhost:${port}/command`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${createToken()}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: "no-response",
+            method: "user_message",
+            params: { content: "continue", messageId: "message-1" },
+          }),
+        });
+        return (await response.json()) as {
+          error?: { message?: string };
+          result?: { stopReason?: string };
+        };
+      };
+
+      const first = await send();
+      expect(first.error?.message).toContain("[ede_diagnostic]");
+
+      const second = await send();
+      expect(second.result?.stopReason).toBe("end_turn");
+      expect(prompt).toHaveBeenCalledTimes(2);
+    }, 30000);
 
     it("steers an active turn without emitting a separate turn completion", async () => {
       const s = createServer();

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -2387,6 +2387,12 @@ export class AgentServer {
     const { classification, message } = this.extractErrorClassification(error);
     const isUpstreamFailure =
       upstreamProviderFailureClassifications.has(classification);
+    const isTurnWithoutResponse =
+      classification === "turn_ended_without_response";
+    const retryableFollowup =
+      isTurnWithoutResponse &&
+      phase === "followup" &&
+      this.getEffectiveMode(payload) === "interactive";
     const displayMessage = isUpstreamFailure
       ? UPSTREAM_PROVIDER_FAILURE_MESSAGE
       : message || "Agent error";
@@ -2394,8 +2400,9 @@ export class AgentServer {
       isUpstreamFailure &&
       phase === "followup" &&
       this.getEffectiveMode(payload) === "interactive";
-    const expectedIdleTransportClosure =
-      recoverable && /^ACP connection closed$/i.test(message.trim());
+    const suppressClientError =
+      retryableFollowup ||
+      (recoverable && /^ACP connection closed$/i.test(message.trim()));
 
     this.logger.error(`send_${phase}_task_message_failed`, {
       classification,
@@ -2403,13 +2410,17 @@ export class AgentServer {
       recoverable,
     });
 
-    if (!expectedIdleTransportClosure) {
+    if (!suppressClientError) {
       this.broadcastTurnFailure(classification, displayMessage);
     }
 
     if (recoverable) {
       this.broadcastTurnComplete("error_recoverable");
       return { recoverable: true };
+    }
+
+    if (retryableFollowup) {
+      return { recoverable: false };
     }
 
     await this.signalTaskComplete(payload, "error", displayMessage);

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -38,6 +38,7 @@ import {
   isPersistedOptionSupported,
   isRateLimitError,
   isTransientUpstreamError,
+  isTurnEndedWithoutResponseError,
   leadingSlashCommand,
   type ModelAccess,
   mergeConfigOptions,
@@ -4520,6 +4521,18 @@ export class SessionService {
           isCompacting: false,
           promptStartedAt: null,
         });
+      }
+
+      if (isTurnEndedWithoutResponseError(errorMessage, errorDetails)) {
+        this.d.log.warn("Turn ended without an assistant response", {
+          taskRunId: session.taskRunId,
+          errorMessage,
+          errorDetails,
+        });
+        throw new Error(
+          "The model ended this turn without a response. Your session is unaffected — please send the message again.",
+          { cause: error },
+        );
       }
 
       // A provider request that timed out or dropped leaves the session

--- a/products/desktop/packages/core/src/sessions/sessionServicePromptRecovery.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionServicePromptRecovery.test.ts
@@ -95,6 +95,24 @@ describe("SessionService prompt recovery on fatal session errors", () => {
     expect(promptMutate).toHaveBeenCalledTimes(2);
   });
 
+  it("uses an accurate message for a turn that ended without a response", async () => {
+    const { service, promptMutate, recoverSpy, store } = createHarness();
+    promptMutate.mockRejectedValue(
+      new Error(
+        "Internal error: [ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+      ),
+    );
+
+    await expect(service.sendPrompt(TASK_ID, "hello again")).rejects.toThrow(
+      /ended this turn without a response/,
+    );
+    expect(recoverSpy).not.toHaveBeenCalled();
+    expect(store.updateSession).toHaveBeenCalledWith(
+      TASK_RUN_ID,
+      expect.objectContaining({ isPromptPending: false }),
+    );
+  });
+
   it.each([
     {
       case: "recovery fails",

--- a/products/desktop/packages/shared/src/errors.test.ts
+++ b/products/desktop/packages/shared/src/errors.test.ts
@@ -8,6 +8,7 @@ import {
   isNotAuthenticatedError,
   isRateLimitError,
   isTransientUpstreamError,
+  isTurnEndedWithoutResponseError,
   NotAuthenticatedError,
   serializeError,
 } from "./errors";
@@ -154,6 +155,12 @@ describe("classifyPromptFailure", () => {
     ["Cloud usage limit reached", undefined, "usage_limit", false],
     ["API Error: 529 overloaded", undefined, "transient", true],
     ["boom", "upstream_timeout", "transient", true],
+    [
+      "[ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+      "turn_ended_without_response",
+      "transient",
+      true,
+    ],
     ["Authentication required", undefined, "authentication", true],
     ["process exited", undefined, "fatal_session", true],
     ["invalid model", undefined, "unknown", false],
@@ -204,6 +211,14 @@ describe("isFatalSessionError", () => {
     ).toBe(false);
   });
 
+  it("does not treat a no-response diagnostic as fatal", () => {
+    expect(
+      isFatalSessionError(
+        "Internal error: [ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null",
+      ),
+    ).toBe(false);
+  });
+
   it("does not treat a free-tier model-gate 403 as fatal despite the Internal error wrapper", () => {
     // Shim-less body (no "(rate_limit)" suffix), so this exercises the
     // model-gate exclusion rather than the rate-limit one.
@@ -237,6 +252,13 @@ describe("isTransientUpstreamError", () => {
         "API Error: the operation timed out",
       ),
     ).toBe(true);
+  });
+
+  it("recognises a no-response diagnostic separately", () => {
+    const message =
+      "Internal error: [ede_diagnostic] result_type=user last_content_type=n/a stop_reason=null";
+    expect(isTransientUpstreamError(message)).toBe(false);
+    expect(isTurnEndedWithoutResponseError(message)).toBe(true);
   });
 
   it.each([

--- a/products/desktop/packages/shared/src/errors.ts
+++ b/products/desktop/packages/shared/src/errors.ts
@@ -118,6 +118,9 @@ const UPSTREAM_TRANSIENT_ERROR_REGEXES = [
   /API Error:\s*(?:429|5\d\d)\b/i,
 ] as const;
 
+const TURN_ENDED_WITHOUT_RESPONSE_REGEX =
+  /\[ede_diagnostic\]\s+result_type=user\b/i;
+
 function includesAny(
   value: string | undefined,
   patterns: readonly string[],
@@ -158,6 +161,16 @@ export function isTransientUpstreamError(
   );
 }
 
+export function isTurnEndedWithoutResponseError(
+  errorMessage: string,
+  errorDetails?: string,
+): boolean {
+  return (
+    TURN_ENDED_WITHOUT_RESPONSE_REGEX.test(errorMessage) ||
+    (!!errorDetails && TURN_ENDED_WITHOUT_RESPONSE_REGEX.test(errorDetails))
+  );
+}
+
 export type PromptFailureKind =
   | "usage_limit"
   | "transient"
@@ -185,6 +198,17 @@ export function classifyPromptFailure(
       message,
       retryable: false,
       limitCause,
+    };
+  }
+  if (
+    errorType === "turn_ended_without_response" ||
+    isTurnEndedWithoutResponseError(message, errorDetails)
+  ) {
+    return {
+      kind: "transient",
+      message,
+      retryable: true,
+      limitCause: null,
     };
   }
   if (
@@ -227,6 +251,7 @@ export function isFatalSessionError(
   errorDetails?: string,
 ): boolean {
   if (isRateLimitError(errorMessage, errorDetails)) return false;
+  if (isTurnEndedWithoutResponseError(errorMessage, errorDetails)) return false;
   if (isTransientUpstreamError(errorMessage, errorDetails)) return false;
   if (classifyGatewayLimitError(errorMessage, errorDetails) === "model_gate") {
     return false;

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -142,6 +142,7 @@ export {
   isNotAuthenticatedError,
   isRateLimitError,
   isTransientUpstreamError,
+  isTurnEndedWithoutResponseError,
   NotAuthenticatedError,
   type PromptFailure,
   type PromptFailureKind,

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -739,8 +739,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.197
-        version: 0.3.197(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        specifier: 0.3.251
+        version: 0.3.251(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: 0.109.0
         version: 0.109.0(zod@4.4.3)
@@ -1790,8 +1790,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197':
-    resolution: {integrity: sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.251':
+    resolution: {integrity: sha512-C23h+Dbddcc4gai95+lhm4/94am2IOq+bf3IdEDDS7EPqDQqajo2s5q1/ZSwq9rOc0RJLT7Ws72ZCzYJh67KSg==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1800,8 +1800,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197':
-    resolution: {integrity: sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.251':
+    resolution: {integrity: sha512-HrLnb3ggk+vMbymUvbosgPmxWp4W6Ot+0mNVjoBYDn5OZrTV3C3LRtbWf7jwcGyKMcg0xJf0AqiudQ2BRrlr8A==}
     cpu: [x64]
     os: [darwin]
 
@@ -1811,8 +1811,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197':
-    resolution: {integrity: sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.251':
+    resolution: {integrity: sha512-RTUf7TPBUkQ6oV3pDkEdcD47I0uH0ZpvmZlXHnrLGznFqyLr+7XHupOxUMJD0Jwm9v5qeqpNiPAYB0dL4RYiHg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -1823,8 +1823,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197':
-    resolution: {integrity: sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.251':
+    resolution: {integrity: sha512-3E27F5j82EWOyEniRW7crmo0jWYYQmPDdP52jWq6Y6aytiyYIdUFMEGZZ6chVHNlZiU7GsjTa3teKk2xlQ68lQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1835,8 +1835,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197':
-    resolution: {integrity: sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.251':
+    resolution: {integrity: sha512-SzXrdy7jjrjJIuTG+VMRAY0YZ3G/8w21WuhAozwnvnEUAPo6NDv6lgFinu7NO8J6CPE+MK2sGze6JeCF+ljgUg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1847,8 +1847,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197':
-    resolution: {integrity: sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.251':
+    resolution: {integrity: sha512-qCD87XPjcNM1u4ukqmcgpHDl3Y6l+cW8j7kPzH91Y5yLBYJ5xYZA2KtJ7AYNEPOteVyOGJw/efmva0S8CRr0fg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1858,8 +1858,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197':
-    resolution: {integrity: sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.251':
+    resolution: {integrity: sha512-FH1ZLcyc97ie3h7CSlIxA1ppXILgf0V8sFQrWnHyKBrthJXQkMHXhsTq9OZV/2KhXslNf2hTe0gHpZ1nCL1Gmg==}
     cpu: [arm64]
     os: [win32]
 
@@ -1868,8 +1868,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197':
-    resolution: {integrity: sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.251':
+    resolution: {integrity: sha512-/jmtFIvfF0UFMxSZ8WV2Aus8aGA3+8Ft6AHvWuBJkY5jM2ubfqi6GnBjKCAL831TTllp2rKZlViANtWWRBvpvg==}
     cpu: [x64]
     os: [win32]
 
@@ -1881,8 +1881,8 @@ packages:
       '@modelcontextprotocol/sdk': ^1.29.0
       zod: 4.4.3
 
-  '@anthropic-ai/claude-agent-sdk@0.3.197':
-    resolution: {integrity: sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==}
+  '@anthropic-ai/claude-agent-sdk@0.3.251':
+    resolution: {integrity: sha512-DqSi8mH2tQYRlVV0G+lJnQ/WbjJZ/a+8cJ3vPuYoqh8esIIvXHm1ZOXV1UPGsFYRnbBytEoiSGitguEXd+sQ+Q==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -16328,49 +16328,49 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.251':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.251':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.251':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.251':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.251':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.251':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.251':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.156':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.251':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk@0.3.156(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
@@ -16388,20 +16388,20 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.156
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.156
 
-  '@anthropic-ai/claude-agent-sdk@0.3.197(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.251(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.109.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.251
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.251
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.251
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.251
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.251
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.251
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.251
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.251
 
   '@anthropic-ai/sdk@0.109.0(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Why

A transient follow-up race was surfaced as a fatal internal error, and the selected Claude model can start with an incompatible bundled runtime.

## Changes

- Treat no-response follow-ups as recoverable without surfacing a misleading client error.
- Recognize the diagnostic as transient in the shared client classifier.
- Upgrade the Claude Agent SDK to the compatible runtime release.

