### PR TITLE
chore(owners): route the activity scene to web analytics

### DIFF
--- a/frontend/src/scenes/owners.yaml
+++ b/frontend/src/scenes/owners.yaml
@@ -6,7 +6,7 @@ rules:
     - match: '/actions/'
       owners: team-product-analytics
     - match: '/activity/'
-      owners: team-platform-features
+      owners: team-web-analytics
     - match: '/agentic/'
       owners: team-growth
     - match: '/alerts/'


### PR DESCRIPTION
## Problem

Platform Features gets review requests for every change under `frontend/src/scenes/activity/`, a folder it does not maintain. The folder holds the Activity section of the app: the events explorer, the sessions explorer, and the live events feed. It has no activity log or audit log code, and web analytics engineers wrote nearly all of its recent commits.

The rule dates from the initial owners.yaml rollout (#68872), where "activity" was read as activity logs.

## Changes

- Pull requests that touch `frontend/src/scenes/activity/` now request a review from Team Web Analytics instead of Team Platform Features.
- Mechanical: one owner value changed in `frontend/src/scenes/owners.yaml`.

## How did you test this code?

Not run: no automated test covers this file. The owners resolver check in CI validates the file.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

Started from a question about why Platform Features was requested on #92840, traced the request to this rule, and checked the folder's contents and commit authors to pick the new owner.