### PR TITLE
fix(warehouse-sources): pin the parent snapshot test to a stable clock

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -1,4 +1,4 @@
-import json
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -64,6 +64,12 @@ def _write_multi_fragment_table(tmp_path: Path, fragments: int = 3, rows_per_fra
         table = pa.table({"id": ids, "last_seen": ["2026-03-01"] * rows_per_fragment})
         deltalake.write_deltalake(uri, table, mode="overwrite" if fragment == 0 else "append")
     return uri
+
+
+def _set_delta_commit_log_mtimes(uri: str, times_by_version: dict[int, datetime]) -> None:
+    for version, committed_at in times_by_version.items():
+        log = Path(uri) / "_delta_log" / f"{version:020d}.json"
+        os.utime(log, (committed_at.timestamp(), committed_at.timestamp()))
 
 
 def _patched_resolve(uri: str, snapshot_timestamp=None, row_filter=None):
@@ -177,19 +183,15 @@ def test_resolve_raises_when_parent_has_no_synced_table(tmp_path: Path) -> None:
 
 def test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing(tmp_path: Path) -> None:
     uri = _write_parent_table(tmp_path)
-    v0_table = deltalake.DeltaTable(uri)
-    v0 = v0_table.version()
-    v0_timestamp = datetime.fromtimestamp(v0_table.history()[0]["timestamp"] / 1000, tz=UTC)
+    v0 = deltalake.DeltaTable(uri).version()
 
     # An in-flight full refresh has already committed a partial overwrite on top of v0.
     deltalake.write_deltalake(uri, pa.table({"id": ["partial"], "last_seen": ["x"], "title": ["y"]}), mode="overwrite")
-    partial_refresh_log = Path(uri) / "_delta_log" / "00000000000000000001.json"
-    entries = partial_refresh_log.read_text().splitlines()
-    partial_refresh_commit = json.loads(entries[0])
-    partial_refresh_commit["commitInfo"]["timestamp"] = int(v0_timestamp.timestamp() * 1000) + 1
-    partial_refresh_log.write_text("\n".join([json.dumps(partial_refresh_commit), *entries[1:]]) + "\n")
 
-    pinned = _patched_resolve(uri, snapshot_timestamp=v0_timestamp)
+    snapshot_committed_at = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+    _set_delta_commit_log_mtimes(uri, {v0: snapshot_committed_at, v0 + 1: snapshot_committed_at + timedelta(minutes=2)})
+
+    pinned = _patched_resolve(uri, snapshot_timestamp=snapshot_committed_at + timedelta(minutes=1))
 
     assert pinned.version == v0
 


### PR DESCRIPTION
## Problem

Anyone opening a PR that runs the warehouse-sources shard hits a red check that has nothing to do with their change. `test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing` has failed 103 times across 72 branches since 2026-09-01, 7 of them on master. It also reds the hourly [Backend CI schedule on master](https://github.com/PostHog/posthog/actions/runs/33614647172) most hours.

Delta time travel picks a version by each commit log's file modification time, not by the timestamp recorded inside the log. The fixture pinned by the recorded timestamp, so the two clocks never had to agree.

The fixture writes two commits back to back. They land 1 to 3 milliseconds apart. Any coarsening of the mtime clock collapses that gap, and the pin then resolves to the in-flight overwrite instead of the completed snapshot.

## Changes

- The test stamps both commit logs and pins between them, so the pin no longer depends on how finely the filesystem records modification times.
- The two commits sit 2 minutes apart and the pin sits 1 minute after the first. That is also closer to production than the old fixture: `_snapshot_pin_as_of` returns the parent's last completed `finished_at`, which falls between the two commits rather than on the first one.
- `_set_delta_commit_log_mtimes` replaces the rewrite of `commitInfo.timestamp` added in #84280. Delta ignores that field when it resolves a version, so the rewrite could not close the race.
- No production code changes. Nothing user-visible changes.

## How did you test this code?

The assertion is unchanged, so this guards the same regression as before: a child fan-out must read the parent's last completed snapshot, never a torn overwrite from an in-flight full refresh.

Reproducing the failure needs a coarsened mtime clock, which no test can impose on its own filesystem. A local probe did it directly against `deltalake`, flooring both log mtimes before resolving.

<details>
<summary>Probe results, 20 to 30 iterations per row</summary>

| Fixture | Native mtime | Floored to 10 ms | Floored to 1 s |
| --- | --- | --- | --- |
| Before #84280 | passes | not measured | fails 20/20 |
| On master today, `commitInfo` rewrite | passes | fails 13/20 | fails 20/20 |
| This PR | passes | passes | passes |

The new fixture also passes with mtimes floored to 60 seconds.

</details>

- `test_warehouse_parent.py` passes locally. The changed test passed 30 consecutive runs.
- Not run: the 12 `APIBaseTest` classes in the same file. The local test database is in a broken state (`relation "django_content_type" already exists`), unrelated to this change. CI runs them.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- [x] skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) after a request to explain why Backend CI was red on master.

Skills invoked: `/debugging-ci-failures`, `/writing-tests`, `/writing-pr-descriptions`.

The session found the flake through `hogli ci:insights`, then established by probe that delta-rs resolves a time-travel pin against log file mtimes rather than `commitInfo.timestamp`. That ruled out the fix already on master and pointed at stamping the mtimes instead.

Public artifact: nothing here comes from outside this repository. The probe scripts ran against synthetic Delta tables and are not committed.
