### PR TITLE
feat(batch-exports): require an integration when creating Snowflake exports

### DIFF
--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -921,8 +921,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
             str_fields = ", ".join(f"'{extra_field}'" for extra_field in sorted(extra_fields))
             raise serializers.ValidationError(f"Configuration has unknown field/s: {str_fields}")
 
-        # Some credential/connection fields are optional on the dataclass (integration-backed exports
-        # resolve them at run time), so only fields with no dataclass default are required here.
+        # Destination config fields without a dataclass default must be provided.
         for destination_field in destination_fields:
             is_required = (
                 destination_field.default == dataclasses.MISSING

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -721,10 +721,9 @@ class SnowflakeDestinationRequestSerializer(serializers.Serializer):
 
     type = serializers.ChoiceField(choices=["Snowflake"])
     integration_id = serializers.IntegerField(
-        required=False,
         help_text=(
-            "ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over "
-            "inline credentials. Use the integrations-list MCP tool to find one."
+            "ID of a snowflake-kind Integration providing the account, user and credentials. Required when "
+            "creating a batch export. Use the integrations-list MCP tool to find one."
         ),
     )
     config = SnowflakeDestinationConfigSerializer()
@@ -765,10 +764,9 @@ class BatchExportDestinationRequestField(serializers.JSONField):
 
     Only integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3,
     S3Compatible, Snowflake, Redshift) are exposed in the schema. integration_id is required for
-    every one of those except Snowflake, where inline credentials remain supported for the time
-    being. Existing Postgres, Snowflake and Redshift exports created before integrations keep their
-    inline credentials. Runtime validation remains
-    `BatchExportDestinationSerializer.validate_destination`.
+    every one of them. Existing Postgres, Snowflake and Redshift exports created before
+    integrations keep their inline credentials and stay valid when edited. Runtime validation
+    remains `BatchExportDestinationSerializer.validate_destination`.
     """
 
     pass
@@ -885,8 +883,7 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text=(
             "ID of a team-scoped Integration providing credentials, for destinations that authenticate "
-            "through one. Required for all of those except Snowflake, which still supports inline "
-            "credentials."
+            "through one. Required for all of them."
         ),
     )
 
@@ -925,21 +922,12 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(f"Configuration has unknown field/s: {str_fields}")
 
         # Some credential/connection fields are optional on the dataclass (integration-backed exports
-        # resolve them at run time), so they must be required here only when no Integration is linked.
-        # Only Snowflake needs this. Every other destination requires an Integration, so
-        # `validate_destination` reports a missing one. Listing them here would report a missing
-        # credential field instead, because this check runs first.
-        # TODO: remove this code once integrations are enforced for Snowflake
-        conditionally_required: set[str] = set()
-        if attrs.get("integration") is None:
-            if export_type == BatchExportDestination.Destination.SNOWFLAKE:
-                conditionally_required = {"account", "user"}
-
+        # resolve them at run time), so only fields with no dataclass default are required here.
         for destination_field in destination_fields:
             is_required = (
                 destination_field.default == dataclasses.MISSING
                 and destination_field.default_factory == dataclasses.MISSING
-            ) or destination_field.name in conditionally_required
+            )
             if destination_field.name not in config:
                 if is_required and not is_patch:
                     # When patching we expect a partial configuration. So, we don't
@@ -1446,12 +1434,18 @@ class BatchExportSerializer(serializers.ModelSerializer):
             integration: Integration | None = destination_attrs.get("integration")
 
             # Sticky integration: an export that uses one cannot drop back to inline credentials.
-            # TODO: remove this guard once integrations are mandatory for Snowflake and inline credentials are gone.
+            # TODO: remove this guard once inline credentials are gone.
             if instance is not None and instance.destination.integration is not None and integration is None:
                 raise serializers.ValidationError(
                     "Cannot remove the integration from a Snowflake batch export that uses one. "
                     "Re-send its `integration` to keep it (or a different one to swap)."
                 )
+
+            # New Snowflake exports must use an Integration for credentials. Exports created before
+            # integrations existed keep their inline credentials, so only require it on create
+            # (`instance is None`); existing inline-credential exports stay valid when edited.
+            if integration is None and instance is None:
+                raise serializers.ValidationError("Integration is required for Snowflake batch exports")
 
             if integration is not None:
                 # (Team ownership is already enforced by the team-scoped `integration` field.)
@@ -1890,9 +1884,9 @@ def recursive_dict_merge(
 @extend_schema(tags=["batch_exports"])
 @extend_schema_view(
     # Request bodies use a polymorphic destination schema so that integration-backed types
-    # (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake) advertise
-    # integration_id up front — required for Databricks, AzureBlob and BigQuery, optional for Postgres,
-    # the S3 family and Snowflake.
+    # (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible, Snowflake, Redshift) advertise
+    # integration_id up front. It is required for every one of them; Postgres, Snowflake and Redshift
+    # exports created before integrations keep their inline credentials on update.
     # Responses continue to use BatchExportSerializer.
     create=extend_schema(request=BatchExportRequestSerializer),
     update=extend_schema(request=BatchExportRequestSerializer),

--- a/products/batch_exports/backend/tests/api/fixtures.py
+++ b/products/batch_exports/backend/tests/api/fixtures.py
@@ -10,7 +10,6 @@ from products.batch_exports.backend.models.batch_export import (
     BatchExportDestination,
     BatchExportRun,
 )
-from products.batch_exports.backend.service import sync_batch_export
 from products.batch_exports.backend.tests.api.operations import create_batch_export_ok
 
 
@@ -95,36 +94,6 @@ def create_integration_backed_snowflake_export(client: TestClient, team: Team, u
     client.force_login(user)
     batch_export = create_batch_export_ok(client, team.pk, export_data)
     return integration, batch_export
-
-
-def create_legacy_inline_snowflake_export(team: Team, user: User) -> BatchExport:
-    """Seed a Snowflake batch export with inline credentials, bypassing API validation.
-
-    The API requires an integration on create; exports like this exist from before integrations,
-    and editing them must keep working. Mirrors a legacy password-auth export. The Temporal
-    schedule is created too so that patching the export (which syncs it) works.
-    """
-    destination = BatchExportDestination.objects.create(
-        type=BatchExportDestination.Destination.SNOWFLAKE,
-        config={
-            "account": "my-account",
-            "user": "user",
-            "password": "password123",
-            "database": "my-db",
-            "warehouse": "COMPUTE_WH",
-            "schema": "public",
-            "table_name": "my_events",
-            "authentication_type": "password",
-        },
-    )
-    batch_export = BatchExport.objects.create(
-        team=team,
-        name="my-snowflake-destination",
-        destination=destination,
-        interval="hour",
-    )
-    sync_batch_export(batch_export, created=True)
-    return batch_export
 
 
 def create_backfill(team, batch_export, start_at, end_at, status, finished_at) -> BatchExportBackfill:

--- a/products/batch_exports/backend/tests/api/fixtures.py
+++ b/products/batch_exports/backend/tests/api/fixtures.py
@@ -10,6 +10,7 @@ from products.batch_exports.backend.models.batch_export import (
     BatchExportDestination,
     BatchExportRun,
 )
+from products.batch_exports.backend.service import sync_batch_export
 from products.batch_exports.backend.tests.api.operations import create_batch_export_ok
 
 
@@ -94,6 +95,36 @@ def create_integration_backed_snowflake_export(client: TestClient, team: Team, u
     client.force_login(user)
     batch_export = create_batch_export_ok(client, team.pk, export_data)
     return integration, batch_export
+
+
+def create_legacy_inline_snowflake_export(team: Team, user: User) -> BatchExport:
+    """Seed a Snowflake batch export with inline credentials, bypassing API validation.
+
+    The API requires an integration on create; exports like this exist from before integrations,
+    and editing them must keep working. Mirrors a legacy password-auth export. The Temporal
+    schedule is created too so that patching the export (which syncs it) works.
+    """
+    destination = BatchExportDestination.objects.create(
+        type=BatchExportDestination.Destination.SNOWFLAKE,
+        config={
+            "account": "my-account",
+            "user": "user",
+            "password": "password123",
+            "database": "my-db",
+            "warehouse": "COMPUTE_WH",
+            "schema": "public",
+            "table_name": "my_events",
+            "authentication_type": "password",
+        },
+    )
+    batch_export = BatchExport.objects.create(
+        team=team,
+        name="my-snowflake-destination",
+        destination=destination,
+        interval="hour",
+    )
+    sync_batch_export(batch_export, created=True)
+    return batch_export
 
 
 def create_backfill(team, batch_export, start_at, end_at, status, finished_at) -> BatchExportBackfill:

--- a/products/batch_exports/backend/tests/api/test_create_snowflake.py
+++ b/products/batch_exports/backend/tests/api/test_create_snowflake.py
@@ -18,72 +18,40 @@ pytestmark = [
 
 
 @pytest.mark.parametrize(
-    "auth_type,credentials,expected_status",
+    "auth_type,credentials",
     [
-        # Password auth type tests
-        (
-            "password",
-            {"password": "abc123"},
-            status.HTTP_201_CREATED,
-        ),
-        (
-            "password",
-            {},
-            status.HTTP_400_BAD_REQUEST,
-        ),
-        # Key pair auth type tests
-        (
-            "keypair",
-            {"private_key": "SECRET_KEY"},
-            status.HTTP_201_CREATED,
-        ),
-        (
-            "keypair",
-            {},
-            status.HTTP_400_BAD_REQUEST,
-        ),
+        ("password", {"password": "abc123"}),
+        ("keypair", {"private_key": "SECRET_KEY"}),
     ],
 )
-def test_create_snowflake_batch_export_validates_credentials(
-    client: HttpClient, auth_type, credentials, expected_status, temporal, organization, team, user
+def test_create_snowflake_batch_export_with_inline_credentials_is_rejected(
+    client: HttpClient, auth_type, credentials, temporal, organization, team, user
 ):
-    """Test creating a BatchExport with Snowflake destination validates credentials based on auth type."""
-
-    destination_data = {
-        "type": "Snowflake",
-        "config": {
-            "account": "my-account",
-            "user": "user",
-            "database": "my-db",
-            "warehouse": "COMPUTE_WH",
-            "schema": "public",
-            "table_name": "my_events",
-            "authentication_type": auth_type,
-            **credentials,
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-production-snowflake-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
+    """Inline credentials are no longer enough to create a Snowflake export: an Integration is required."""
     client.force_login(user)
-
     response = create_batch_export(
         client,
         team.pk,
-        batch_export_data,
+        {
+            "name": "my-export",
+            "interval": "hour",
+            "destination": {
+                "type": "Snowflake",
+                "config": {
+                    "account": "my-account",
+                    "user": "user",
+                    "database": "my-db",
+                    "warehouse": "COMPUTE_WH",
+                    "schema": "public",
+                    "table_name": "my_events",
+                    "authentication_type": auth_type,
+                    **credentials,
+                },
+            },
+        },
     )
-
-    assert response.status_code == expected_status
-
-    if expected_status == status.HTTP_400_BAD_REQUEST:
-        if auth_type == "password":
-            assert "Password is required if authentication type is password" in response.json()["detail"]
-        else:
-            assert "Private key is required if authentication type is key pair" in response.json()["detail"]
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json()["detail"] == "Integration is required for Snowflake batch exports"
 
 
 def test_create_snowflake_batch_export_using_integration(client: HttpClient, temporal, organization, team, user):

--- a/products/batch_exports/backend/tests/api/test_create_snowflake.py
+++ b/products/batch_exports/backend/tests/api/test_create_snowflake.py
@@ -27,7 +27,6 @@ pytestmark = [
 def test_create_snowflake_batch_export_with_inline_credentials_is_rejected(
     client: HttpClient, auth_type, credentials, temporal, organization, team, user
 ):
-    """Inline credentials are no longer enough to create a Snowflake export: an Integration is required."""
     client.force_login(user)
     response = create_batch_export(
         client,

--- a/products/batch_exports/backend/tests/api/test_test.py
+++ b/products/batch_exports/backend/tests/api/test_test.py
@@ -19,9 +19,7 @@ from products.batch_exports.backend.api.destination_tests.databricks import (
     DatabricksDestinationTest,
     DatabricksEstablishConnectionTestStep,
 )
-from products.batch_exports.backend.api.destination_tests.snowflake import SnowflakeEstablishConnectionTestStep
 from products.batch_exports.backend.models.batch_export import BatchExportDestination
-from products.batch_exports.backend.tests.api.fixtures import create_integration_backed_snowflake_export
 from products.batch_exports.backend.tests.api.operations import create_batch_export_ok
 
 pytestmark = [
@@ -233,41 +231,6 @@ def test_run_test_step_rejects_destination_type_change(
     assert "Cannot change destination type" in response.json()["detail"]
     # Validation must fail before any destination test (and therefore any outbound request) runs.
     mock_get_destination_test.assert_not_called()
-
-
-def test_can_run_snowflake_test_step_for_partial_config(client: HttpClient, temporal, organization, team, user):
-    """A test step can run against a partial Snowflake config, merged with the stored config and integration."""
-    integration, batch_export = create_integration_backed_snowflake_export(client, team, user)
-
-    batch_export_data = {
-        "name": "my-production-snowflake-destination",
-        "destination": {
-            "type": "Snowflake",
-            "config": {"schema": "other_schema"},
-            "integration": integration.id,
-        },
-        "interval": "hour",
-    }
-
-    with unittest.mock.patch(
-        "products.batch_exports.backend.api.destination_tests.base.DestinationTest.run_step"
-    ) as run_step_mocked:
-        fake_test_step = SnowflakeEstablishConnectionTestStep()
-        fake_test_step.result = DestinationTestStepResult(status=Status.PASSED, message=None)
-        run_step_mocked.return_value = fake_test_step
-
-        response = client.post(
-            f"/api/projects/{team.pk}/batch_exports/{batch_export['id']}/run_test_step",
-            {**{"step": 0}, **batch_export_data},
-            content_type="application/json",
-        )
-
-    assert response.status_code == status.HTTP_200_OK, response.json()
-
-    destination_test = response.json()
-
-    assert destination_test["result"]["status"] == "Passed", destination_test
-    assert destination_test["result"]["message"] is None
 
 
 def test_can_run_s3_test_step_with_additional_fields(

--- a/products/batch_exports/backend/tests/api/test_test.py
+++ b/products/batch_exports/backend/tests/api/test_test.py
@@ -21,7 +21,7 @@ from products.batch_exports.backend.api.destination_tests.databricks import (
     DatabricksEstablishConnectionTestStep,
 )
 from products.batch_exports.backend.api.destination_tests.snowflake import SnowflakeEstablishConnectionTestStep
-from products.batch_exports.backend.models.batch_export import BatchExportDestination
+from products.batch_exports.backend.models.batch_export import BatchExport, BatchExportDestination
 from products.batch_exports.backend.tests.api.operations import create_batch_export_ok
 
 pytestmark = [
@@ -295,24 +295,16 @@ def test_can_run_snowflake_test_step_for_partial_config(
         config["private_key_passphrase"] = snowflake_config["private_key_passphrase"]
     elif snowflake_config["authentication_type"] == "password":
         config["password"] = snowflake_config["password"]
+    config["authentication_type"] = snowflake_config["authentication_type"]
 
-    destination_data = {
-        "type": "Snowflake",
-        "config": config,
-    }
-
-    batch_export_data = {
-        "name": "my-production-snowflake-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
-    client.force_login(user)
-
-    batch_export = create_batch_export_ok(
-        client,
-        team.pk,
-        batch_export_data,
+    # Inline-credential Snowflake exports can no longer be created over the API, but ones created
+    # before integrations still exist: seed one directly to exercise their test-step flow.
+    destination = BatchExportDestination.objects.create(type="Snowflake", config=config)
+    batch_export = BatchExport.objects.create(
+        team=team,
+        name="my-production-snowflake-destination",
+        destination=destination,
+        interval="hour",
     )
 
     batch_export_data = {
@@ -324,6 +316,8 @@ def test_can_run_snowflake_test_step_for_partial_config(
         "interval": "hour",
     }
 
+    client.force_login(user)
+
     with unittest.mock.patch(
         "products.batch_exports.backend.api.destination_tests.base.DestinationTest.run_step"
     ) as run_step_mocked:
@@ -332,7 +326,7 @@ def test_can_run_snowflake_test_step_for_partial_config(
         run_step_mocked.return_value = fake_test_step
 
         response = client.post(
-            f"/api/projects/{team.pk}/batch_exports/{batch_export['id']}/run_test_step",
+            f"/api/projects/{team.pk}/batch_exports/{batch_export.id}/run_test_step",
             {**{"step": 0}, **batch_export_data},
             content_type="application/json",
         )

--- a/products/batch_exports/backend/tests/api/test_test.py
+++ b/products/batch_exports/backend/tests/api/test_test.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 import functools
 
@@ -21,7 +20,8 @@ from products.batch_exports.backend.api.destination_tests.databricks import (
     DatabricksEstablishConnectionTestStep,
 )
 from products.batch_exports.backend.api.destination_tests.snowflake import SnowflakeEstablishConnectionTestStep
-from products.batch_exports.backend.models.batch_export import BatchExport, BatchExportDestination
+from products.batch_exports.backend.models.batch_export import BatchExportDestination
+from products.batch_exports.backend.tests.api.fixtures import create_integration_backed_snowflake_export
 from products.batch_exports.backend.tests.api.operations import create_batch_export_ok
 
 pytestmark = [
@@ -235,88 +235,19 @@ def test_run_test_step_rejects_destination_type_change(
     mock_get_destination_test.assert_not_called()
 
 
-@pytest.fixture
-def database():
-    """Generate a unique database name for tests."""
-    return f"test_batch_exports_{uuid.uuid4()}"
-
-
-@pytest.fixture
-def schema():
-    """Generate a unique schema name for tests."""
-    return f"test_batch_exports_{uuid.uuid4()}"
-
-
-@pytest.fixture
-def snowflake_config(database, schema) -> dict[str, str | None]:
-    """Return a Snowflake configuration dictionary to use in tests."""
-    warehouse = os.getenv("SNOWFLAKE_WAREHOUSE", "warehouse")
-    account = os.getenv("SNOWFLAKE_ACCOUNT", "account")
-    role = os.getenv("SNOWFLAKE_ROLE", None)
-    username = os.getenv("SNOWFLAKE_USERNAME", "username")
-    password = os.getenv("SNOWFLAKE_PASSWORD", "password")
-    private_key = os.getenv("SNOWFLAKE_PRIVATE_KEY")
-    private_key_passphrase = os.getenv("SNOWFLAKE_PRIVATE_KEY_PASSPHRASE")
-
-    config = {
-        "user": username,
-        "warehouse": warehouse,
-        "account": account,
-        "database": database,
-        "schema": schema,
-        "role": role,
-    }
-    if private_key:
-        config["private_key"] = private_key
-        config["private_key_passphrase"] = private_key_passphrase
-        config["authentication_type"] = "keypair"
-    elif password:
-        config["password"] = password
-        config["authentication_type"] = "password"
-    else:
-        raise ValueError("Either password or private key must be set")
-    return config
-
-
-def test_can_run_snowflake_test_step_for_partial_config(
-    client: HttpClient, snowflake_config, temporal, organization, team, user
-):
-    config = {
-        "role": snowflake_config["role"],
-        "schema": snowflake_config["schema"],
-        "account": snowflake_config["account"],
-        "database": snowflake_config["database"],
-        "warehouse": snowflake_config["warehouse"],
-        "table_name": "events",
-        "user": snowflake_config["user"],
-    }
-    if snowflake_config["authentication_type"] == "keypair":
-        config["private_key"] = snowflake_config["private_key"]
-        config["private_key_passphrase"] = snowflake_config["private_key_passphrase"]
-    elif snowflake_config["authentication_type"] == "password":
-        config["password"] = snowflake_config["password"]
-    config["authentication_type"] = snowflake_config["authentication_type"]
-
-    # Inline-credential Snowflake exports can no longer be created over the API, but ones created
-    # before integrations still exist: seed one directly to exercise their test-step flow.
-    destination = BatchExportDestination.objects.create(type="Snowflake", config=config)
-    batch_export = BatchExport.objects.create(
-        team=team,
-        name="my-production-snowflake-destination",
-        destination=destination,
-        interval="hour",
-    )
+def test_can_run_snowflake_test_step_for_partial_config(client: HttpClient, temporal, organization, team, user):
+    """A test step can run against a partial Snowflake config, merged with the stored config and integration."""
+    integration, batch_export = create_integration_backed_snowflake_export(client, team, user)
 
     batch_export_data = {
         "name": "my-production-snowflake-destination",
         "destination": {
             "type": "Snowflake",
-            "config": {"account": "Something", "authentication_type": "password"},
+            "config": {"schema": "other_schema"},
+            "integration": integration.id,
         },
         "interval": "hour",
     }
-
-    client.force_login(user)
 
     with unittest.mock.patch(
         "products.batch_exports.backend.api.destination_tests.base.DestinationTest.run_step"
@@ -326,7 +257,7 @@ def test_can_run_snowflake_test_step_for_partial_config(
         run_step_mocked.return_value = fake_test_step
 
         response = client.post(
-            f"/api/projects/{team.pk}/batch_exports/{batch_export.id}/run_test_step",
+            f"/api/projects/{team.pk}/batch_exports/{batch_export['id']}/run_test_step",
             {**{"step": 0}, **batch_export_data},
             content_type="application/json",
         )

--- a/products/batch_exports/backend/tests/api/test_update_snowflake.py
+++ b/products/batch_exports/backend/tests/api/test_update_snowflake.py
@@ -4,12 +4,11 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
-from products.batch_exports.backend.tests.api.fixtures import create_integration_backed_snowflake_export
-from products.batch_exports.backend.tests.api.operations import (
-    create_batch_export_ok,
-    get_batch_export_ok,
-    patch_batch_export,
+from products.batch_exports.backend.tests.api.fixtures import (
+    create_integration_backed_snowflake_export,
+    create_legacy_inline_snowflake_export,
 )
+from products.batch_exports.backend.tests.api.operations import get_batch_export_ok, patch_batch_export
 
 pytestmark = [
     pytest.mark.django_db,
@@ -19,33 +18,7 @@ pytestmark = [
 
 def test_can_patch_snowflake_batch_export_credentials(client: HttpClient, temporal, organization, team, user):
     """Test we can switch Snowflake authentication types while preserving credentials."""
-    destination_data = {
-        "type": "Snowflake",
-        "config": {
-            "account": "my-account",
-            "user": "user",
-            "password": "password123",
-            "database": "my-db",
-            "warehouse": "COMPUTE_WH",
-            "schema": "public",
-            "table_name": "my_events",
-            "authentication_type": "password",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-snowflake-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
-    client.force_login(user)
-
-    batch_export = create_batch_export_ok(
-        client,
-        team.pk,
-        batch_export_data,
-    )
+    batch_export = create_legacy_inline_snowflake_export(team, user)
 
     # Test switching to key pair auth type
     new_destination_data = {
@@ -60,15 +33,17 @@ def test_can_patch_snowflake_batch_export_credentials(client: HttpClient, tempor
         "destination": new_destination_data,
     }
 
-    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    client.force_login(user)
+
+    response = patch_batch_export(client, team.pk, str(batch_export.id), new_batch_export_data)
     assert response.status_code == status.HTTP_200_OK, response.json()
 
     # Verify the auth type switch worked and other fields were preserved
-    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-    assert batch_export["destination"]["type"] == "Snowflake"
-    assert batch_export["destination"]["config"]["account"] == "my-account"
-    assert batch_export["destination"]["config"]["authentication_type"] == "keypair"
-    assert "private_key" not in batch_export["destination"]["config"]  # Private key should be hidden in response
+    batch_export_json = get_batch_export_ok(client, team.pk, str(batch_export.id))
+    assert batch_export_json["destination"]["type"] == "Snowflake"
+    assert batch_export_json["destination"]["config"]["account"] == "my-account"
+    assert batch_export_json["destination"]["config"]["authentication_type"] == "keypair"
+    assert "private_key" not in batch_export_json["destination"]["config"]  # Private key should be hidden in response
 
     # Test switching back to password auth type without providing password (should keep original)
     new_destination_data = {
@@ -82,48 +57,22 @@ def test_can_patch_snowflake_batch_export_credentials(client: HttpClient, tempor
         "destination": new_destination_data,
     }
 
-    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    response = patch_batch_export(client, team.pk, str(batch_export.id), new_batch_export_data)
     assert response.status_code == status.HTTP_200_OK, response.json()
 
     # Verify switched back to password auth and kept original password
-    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-    assert batch_export["destination"]["type"] == "Snowflake"
-    assert batch_export["destination"]["config"]["account"] == "my-account"
-    assert batch_export["destination"]["config"]["authentication_type"] == "password"
-    assert "password" not in batch_export["destination"]["config"]  # Password should be hidden in response
+    batch_export_json = get_batch_export_ok(client, team.pk, str(batch_export.id))
+    assert batch_export_json["destination"]["type"] == "Snowflake"
+    assert batch_export_json["destination"]["config"]["account"] == "my-account"
+    assert batch_export_json["destination"]["config"]["authentication_type"] == "password"
+    assert "password" not in batch_export_json["destination"]["config"]  # Password should be hidden in response
 
 
 def test_switching_snowflake_auth_type_to_keypair_requires_private_key(
     client: HttpClient, temporal, organization, team, user
 ):
     """Test that switching to keypair authentication requires a private key to be provided."""
-    destination_data = {
-        "type": "Snowflake",
-        "config": {
-            "account": "my-account",
-            "user": "user",
-            "password": "password123",
-            "database": "my-db",
-            "warehouse": "COMPUTE_WH",
-            "schema": "public",
-            "table_name": "my_events",
-            "authentication_type": "password",
-        },
-    }
-
-    batch_export_data = {
-        "name": "my-snowflake-destination",
-        "destination": destination_data,
-        "interval": "hour",
-    }
-
-    client.force_login(user)
-
-    batch_export = create_batch_export_ok(
-        client,
-        team.pk,
-        batch_export_data,
-    )
+    batch_export = create_legacy_inline_snowflake_export(team, user)
 
     # Test switching to keypair auth type without providing a private key
     new_destination_data = {
@@ -137,14 +86,36 @@ def test_switching_snowflake_auth_type_to_keypair_requires_private_key(
         "destination": new_destination_data,
     }
 
-    response = patch_batch_export(client, team.pk, batch_export["id"], new_batch_export_data)
+    client.force_login(user)
+
+    response = patch_batch_export(client, team.pk, str(batch_export.id), new_batch_export_data)
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "Private key is required if authentication type is key pair" in response.json()["detail"]
 
     # Verify the auth type was not changed
-    batch_export = get_batch_export_ok(client, team.pk, batch_export["id"])
-    assert batch_export["destination"]["type"] == "Snowflake"
-    assert batch_export["destination"]["config"]["authentication_type"] == "password"
+    batch_export_json = get_batch_export_ok(client, team.pk, str(batch_export.id))
+    assert batch_export_json["destination"]["type"] == "Snowflake"
+    assert batch_export_json["destination"]["config"]["authentication_type"] == "password"
+
+
+def test_updating_legacy_snowflake_export_without_integration_is_permitted(
+    client: HttpClient, temporal, organization, team, user
+):
+    """Exports created before integrations (inline credentials, no integration) stay editable: patching
+    them without sending an integration still works, for now."""
+    batch_export = create_legacy_inline_snowflake_export(team, user)
+
+    client.force_login(user)
+
+    response = patch_batch_export(
+        client,
+        team.pk,
+        str(batch_export.id),
+        {"destination": {"type": "Snowflake", "config": {"schema": "new_schema"}}},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json()["destination"]["config"]["schema"] == "new_schema"
+    assert response.json()["destination"]["integration"] is None
 
 
 @pytest.mark.parametrize("integration_value", [None, "omitted"])

--- a/products/batch_exports/backend/tests/api/test_update_snowflake.py
+++ b/products/batch_exports/backend/tests/api/test_update_snowflake.py
@@ -4,118 +4,13 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
-from products.batch_exports.backend.tests.api.fixtures import (
-    create_integration_backed_snowflake_export,
-    create_legacy_inline_snowflake_export,
-)
-from products.batch_exports.backend.tests.api.operations import get_batch_export_ok, patch_batch_export
+from products.batch_exports.backend.tests.api.fixtures import create_integration_backed_snowflake_export
+from products.batch_exports.backend.tests.api.operations import patch_batch_export
 
 pytestmark = [
     pytest.mark.django_db,
     pytest.mark.usefixtures("temporal_worker", "cleanup"),
 ]
-
-
-def test_can_patch_snowflake_batch_export_credentials(client: HttpClient, temporal, organization, team, user):
-    """Test we can switch Snowflake authentication types while preserving credentials."""
-    batch_export = create_legacy_inline_snowflake_export(team, user)
-
-    # Test switching to key pair auth type
-    new_destination_data = {
-        "type": "Snowflake",
-        "config": {
-            "authentication_type": "keypair",
-            "private_key": "SECRET_KEY",
-        },
-    }
-
-    new_batch_export_data = {
-        "destination": new_destination_data,
-    }
-
-    client.force_login(user)
-
-    response = patch_batch_export(client, team.pk, str(batch_export.id), new_batch_export_data)
-    assert response.status_code == status.HTTP_200_OK, response.json()
-
-    # Verify the auth type switch worked and other fields were preserved
-    batch_export_json = get_batch_export_ok(client, team.pk, str(batch_export.id))
-    assert batch_export_json["destination"]["type"] == "Snowflake"
-    assert batch_export_json["destination"]["config"]["account"] == "my-account"
-    assert batch_export_json["destination"]["config"]["authentication_type"] == "keypair"
-    assert "private_key" not in batch_export_json["destination"]["config"]  # Private key should be hidden in response
-
-    # Test switching back to password auth type without providing password (should keep original)
-    new_destination_data = {
-        "type": "Snowflake",
-        "config": {
-            "authentication_type": "password",
-        },
-    }
-
-    new_batch_export_data = {
-        "destination": new_destination_data,
-    }
-
-    response = patch_batch_export(client, team.pk, str(batch_export.id), new_batch_export_data)
-    assert response.status_code == status.HTTP_200_OK, response.json()
-
-    # Verify switched back to password auth and kept original password
-    batch_export_json = get_batch_export_ok(client, team.pk, str(batch_export.id))
-    assert batch_export_json["destination"]["type"] == "Snowflake"
-    assert batch_export_json["destination"]["config"]["account"] == "my-account"
-    assert batch_export_json["destination"]["config"]["authentication_type"] == "password"
-    assert "password" not in batch_export_json["destination"]["config"]  # Password should be hidden in response
-
-
-def test_switching_snowflake_auth_type_to_keypair_requires_private_key(
-    client: HttpClient, temporal, organization, team, user
-):
-    """Test that switching to keypair authentication requires a private key to be provided."""
-    batch_export = create_legacy_inline_snowflake_export(team, user)
-
-    # Test switching to keypair auth type without providing a private key
-    new_destination_data = {
-        "type": "Snowflake",
-        "config": {
-            "authentication_type": "keypair",
-        },
-    }
-
-    new_batch_export_data = {
-        "destination": new_destination_data,
-    }
-
-    client.force_login(user)
-
-    response = patch_batch_export(client, team.pk, str(batch_export.id), new_batch_export_data)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert "Private key is required if authentication type is key pair" in response.json()["detail"]
-
-    # Verify the auth type was not changed
-    batch_export_json = get_batch_export_ok(client, team.pk, str(batch_export.id))
-    assert batch_export_json["destination"]["type"] == "Snowflake"
-    assert batch_export_json["destination"]["config"]["authentication_type"] == "password"
-
-
-def test_updating_legacy_snowflake_export_without_integration_is_permitted(
-    client: HttpClient, temporal, organization, team, user
-):
-    """Exports created before integrations (inline credentials, no integration) stay editable: patching
-    them without sending an integration still works, for now."""
-    batch_export = create_legacy_inline_snowflake_export(team, user)
-
-    client.force_login(user)
-
-    response = patch_batch_export(
-        client,
-        team.pk,
-        str(batch_export.id),
-        {"destination": {"type": "Snowflake", "config": {"schema": "new_schema"}}},
-    )
-    assert response.status_code == status.HTTP_200_OK, response.json()
-    assert response.json()["destination"]["config"]["schema"] == "new_schema"
-    assert response.json()["destination"]["integration"] is None
 
 
 @pytest.mark.parametrize("integration_value", [None, "omitted"])

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -477,7 +477,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.
+     * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of them.
      * @nullable
      */
     integration_id?: number | null
@@ -1408,8 +1408,8 @@ export const SnowflakeDestinationRequestApiType = {
  */
 export interface SnowflakeDestinationRequestApi {
     type: SnowflakeDestinationRequestApiType
-    /** ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
-    integration_id?: number
+    /** ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+    integration_id: number
     config: SnowflakeDestinationConfigApi
 }
 

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -299,9 +299,8 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         type: zod.enum(['Snowflake']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -996,9 +995,8 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                         type: zod.enum(['Snowflake']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -1448,9 +1446,8 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         type: zod.enum(['Snowflake']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -1984,7 +1981,7 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of them.'
                     ),
             })
             .describe(
@@ -2429,7 +2426,7 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of them.'
                     ),
             })
             .describe(
@@ -2863,7 +2860,7 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of them.'
                     ),
             })
             .describe(
@@ -3318,7 +3315,7 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.'
+                        'ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of them.'
                     ),
             })
             .describe(

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12118,7 +12118,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of those except Snowflake, which still supports inline credentials.
+         * ID of a team-scoped Integration providing credentials, for destinations that authenticate through one. Required for all of them.
          * @nullable
          */
       integration_id?: number | null;
@@ -13099,8 +13099,8 @@ export namespace Schemas {
      */
     export interface SnowflakeDestinationRequest {
       type: SnowflakeDestinationRequestType;
-      /** ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
-      integration_id?: number;
+      /** ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+      integration_id: number;
       config: SnowflakeDestinationConfig;
     }
 

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -313,9 +313,8 @@ export const BatchExportsCreateBody = () => zod
                         type: zod.enum(['Snowflake']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -765,9 +764,8 @@ export const BatchExportsPartialUpdateBody = () => zod
                         type: zod.enum(['Snowflake']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
@@ -384,7 +384,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {
@@ -392,7 +392,7 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type", "config"],
+                    "required": ["type", "integration_id", "config"],
                     "type": "object"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
@@ -383,7 +383,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of a snowflake-kind Integration providing the account, user and credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of a snowflake-kind Integration providing the account, user and credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {
@@ -391,7 +391,7 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type", "config"],
+                    "required": ["type", "integration_id", "config"],
                     "type": "object"
                 },
                 {


### PR DESCRIPTION
## Problem

It is still possible to create Snowflake batch exports with inline credentials, even though integrations are the preferred way.

We now want to enforce them for all new Snowflake batch exports.

Snowflake exports created before integrations existed keep their inline credentials: patching them without an integration stays valid, for now.

## Changes

- Creating a Snowflake batch export without an integration now returns 400, matching the other destinations.
- The OpenAPI schema marks `integration_id` required for Snowflake, so generated frontend and MCP clients enforce it up front.


## How did you test this code?

- The Snowflake API tests assert inline-credential creation is rejected for both auth types, and that removal of an integration from an existing export is rejected while swapping or re-sending one works.
- Credential validation by auth type is covered at the integration layer (`posthog/models/test/integration/test_snowflake.py`), and integration swapping destination-agnostically in `test_update.py`.
- Ran the full `products/batch_exports/backend/tests/api/` suite locally


## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: PostHog Desktop cloud task (pi harness), directed by the assignee through several review rounds.
- Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-pr-descriptions`, `/writing-code-comments`.


---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*