### PR TITLE
chore(ci): let Trunk quarantine warehouse-sources flakes

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -23,8 +23,9 @@
 #   test matrices were skipped has nothing to mirror), Trunk flaky-test quarantine
 #   gate (canonical runs per-shard analytics-uploader steps that post to the
 #   external Trunk service; the upload is best-effort and a local "Fail on test
-#   failure" step owns the pass/fail verdict. Canonical can stage or filter JUnit
-#   before this upload. The shadow strips all of it because a non-blocking timing
+#   failure" step owns the pass/fail verdict. Canonical stages JUnit under per-product
+#   filenames before this upload, and can hold a product back from quarantine by naming
+#   its report as an exclusion. The shadow strips all of it because a non-blocking timing
 #   trial must not post to Trunk, and so it also omits the test
 #   steps' continue-on-error and that verdict step, letting each shard's test
 #   exit code be the verdict directly. Canonical gates each quarantine gate on the

--- a/.github/scripts/prepare-product-junit-for-trunk.sh
+++ b/.github/scripts/prepare-product-junit-for-trunk.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -lt 3 ]; then
-    echo "usage: $0 OUTPUT_DIR MATRIX_FILTERS EXCLUDED_JUNIT_PATH..." >&2
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 OUTPUT_DIR MATRIX_FILTERS [EXCLUDED_JUNIT_PATH...]" >&2
     exit 2
 fi
 

--- a/.github/scripts/prepare-product-junit-for-trunk.test.sh
+++ b/.github/scripts/prepare-product-junit-for-trunk.test.sh
@@ -16,7 +16,7 @@ create_product() {
 
 run_case() {
     local name="$1" filters="$2" expected_status="$3" warehouse_report="$4" other_report="$5"
-    local excluded_paths="${6:-products/warehouse_sources/junit-product.xml}"
+    local excluded_paths="${6-products/warehouse_sources/junit-product.xml}"
     local root="$workdir/$name" output status excluded_path product
     read -r -a exclusions <<<"$excluded_paths"
     mkdir -p "$root"
@@ -25,7 +25,7 @@ run_case() {
     create_product "$root" other @posthog/products-other "$other_report"
 
     set +e
-    output=$(cd "$root" && bash "$script" trunk-junit "$filters" "${exclusions[@]}" 2>&1)
+    output=$(cd "$root" && bash "$script" trunk-junit "$filters" ${exclusions[@]+"${exclusions[@]}"} 2>&1)
     status=$?
     set -e
 
@@ -34,13 +34,17 @@ run_case() {
         printf '%s\n' "$output"
         exit 1
     fi
-    for excluded_path in "${exclusions[@]}"; do
+    for excluded_path in ${exclusions[@]+"${exclusions[@]}"}; do
         product="$(basename "$(dirname "$excluded_path")")"
         if [ -e "$root/trunk-junit/junit-product-$product.xml" ]; then
             echo "FAIL: $name staged excluded report $excluded_path"
             exit 1
         fi
     done
+    if [ "${#exclusions[@]}" -eq 0 ] && [ ! -e "$root/trunk-junit/junit-product-warehouse_sources.xml" ]; then
+        echo "FAIL: $name did not stage a report that nothing excludes"
+        exit 1
+    fi
     if [ ! -e "$root/trunk-junit/junit-product-warehouse_sources_queue.xml" ]; then
         echo "FAIL: $name did not stage an included report"
         exit 1
@@ -53,5 +57,6 @@ run_case selected-report-missing '--filter=@posthog/products-warehouse-sources' 
 run_case selected-report-passes '--filter=@posthog/products-warehouse-sources' 0 '<testsuite tests="1" failures="0" />' '<testsuite tests="1" failures="0" />'
 run_case selected-report-fails '--filter=@posthog/products-warehouse-sources' 1 '<testsuite tests="1" failures="1"><testcase><failure /></testcase></testsuite>' '<testsuite tests="1" failures="0" />'
 run_case multiple-exclusions '--filter=@posthog/products-other' 0 '<testsuite tests="1" failures="0" />' '<testsuite tests="1" failures="0" />' 'products/warehouse_sources/junit-product.xml products/other/junit-product.xml'
+run_case no-exclusions-stages-a-failed-report '--filter=@posthog/products-warehouse-sources' 0 '<testsuite tests="1" failures="1"><testcase><failure /></testcase></testsuite>' '<testsuite tests="1" failures="0" />' ''
 
 echo "Product JUnit preparation regression cases passed."

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1064,7 +1064,8 @@ jobs:
                   set -e
                   exit $overall
 
-            # Excluded reports bypass Trunk quarantine, so this step owns their verdict.
+            # Stages every product's report under a per-product filename. Pass a report path to
+            # exclude a product from Trunk quarantine; this step then owns that product's verdict.
             - name: Prepare product JUnit for Trunk
               id: prepare_product_junit
               if: always()
@@ -1074,8 +1075,7 @@ jobs:
               run: |
                   bash .github/scripts/prepare-product-junit-for-trunk.sh \
                       trunk-junit \
-                      "$PRODUCT_FILTERS" \
-                      products/warehouse_sources/junit-product.xml
+                      "$PRODUCT_FILTERS"
 
             # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
             # the verdict, so a Trunk outage can't red a passing shard. Internal PRs only (needs the


### PR DESCRIPTION
## Problem

A flaky test in warehouse-sources reds the shard for everyone, where the same flake in any other product would be quarantined and pass. Trunk cannot quarantine what it never receives, and warehouse-sources JUnit is withheld from the upload.

Both quarantine variables are on org-wide (`TRUNK_UPLOAD_ENABLED` and `TRUNK_QUARANTINE_ENABLED` are `true`), and warehouse-sources is the only product excluded. #89769 added that exclusion on 2026-08-27 and recorded no reason for it.

The current cost is one test: `test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing` has failed 103 times across 72 branches since 2026-09-01. In [this run](https://github.com/PostHog/posthog/actions/runs/33614647172/job/100198108673) the quarantine gate passed and the preparation step reds the shard on its own.

```mermaid
flowchart LR
    A[warehouse-sources JUnit] --> B{Excluded?}
    B -->|yes| C[Not staged, not uploaded]
    C --> D[Any failure reds the shard]
    E[Every other product] --> F[Uploaded to Trunk]
    F --> G[Known flake quarantined]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,E phYellow;
    class B,C,F phBlue;
    class D phRed;
    class G phGray;
```

## Changes

- Warehouse-sources JUnit now reaches Trunk, so a known flake there is masked like any other product's and stops failing unrelated PRs.
- A real warehouse-sources failure still reds the shard. The Trunk uploader exits non-zero on a failure it could not quarantine, and the "Fail on test failure" step reads that.
- `prepare-product-junit-for-trunk.sh` accepts an empty exclusion list. The mechanism stays, so excluding a product again is one argument.
- The `.depot` shadow keeps its documented exemption. It strips the whole Trunk path, so there is nothing to mirror.

```mermaid
flowchart LR
    A[Every product's JUnit] --> B[Staged per product]
    B --> C[Uploaded to Trunk]
    C --> D{Quarantined?}
    D -->|yes| E[Shard passes]
    D -->|no| F[Shard reds]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C,D phBlue;
    class F phRed;
    class E phGray;
```

> [!NOTE]
> This changes what a red shard means for warehouse-sources: a failure Trunk already knows as flaky no longer fails the job. That is the point, and it is also how every other product already behaves.

Nothing user-visible changes. No product code changes.

## How did you test this code?

`prepare-product-junit-for-trunk.test.sh` gains one case, `no-exclusions-stages-a-failed-report`. It catches the regression this PR creates the risk of: with no exclusions, a failing report must be staged for Trunk rather than failing the script. It also guards the empty-array expansion under `set -u`, which would otherwise red every product shard at once.

- The shell suite passes locally, 6 cases.
- `shellcheck` passes on both scripts. `hogli lint:workflows` passes. `actionlint` reports the same 46 findings on `ci-backend.yml` as master, so this adds none.
- Not run: Backend CI itself. The behavior change only appears when Trunk holds a quarantine record for a failing test, which no local run can produce.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- [x] skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5) after a request to explain why Backend CI was red on master.

Skills invoked: `/debugging-ci-failures`, `/authoring-ci-workflows`, `/writing-tests`, `/writing-pr-descriptions`.

Two shapes were considered. Reverting #89769 outright would delete the script, its tests, and the shellcheck job that runs them. Removing only the exclusion argument keeps the mechanism for the next product that needs it, at the cost of leaving the `prepare_product_junit` verdict branch unreachable until one does. The second was chosen as the smaller and more reversible change.

#93192 fixes the flaky test itself. The two are independent: this one decides how a warehouse-sources flake is handled, that one removes the current instance.

Open question for the reviewer: #89769 records no reason for the exclusion, so its author should confirm that nothing depended on it.

Public artifact: nothing here comes from outside this repository.
