### PR TITLE
feat(desktop): mobile pick the model first and auto-select its harness

### DIFF
--- a/products/desktop/apps/mobile/src/app/task/index.tsx
+++ b/products/desktop/apps/mobile/src/app/task/index.tsx
@@ -11,7 +11,6 @@ import {
   type ExecutionMode,
   getReasoningEffortOptions,
   isSupportedReasoningEffort,
-  KIMI_MODEL_FLAG,
   type SupportedReasoningEffort,
   serializeCloudPrompt,
   supports1MContext,
@@ -27,8 +26,7 @@ import {
   PaperclipIcon,
   StopIcon,
 } from "phosphor-react-native";
-import { useFeatureFlag } from "posthog-react-native";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -59,7 +57,6 @@ import { DotBackground } from "@/features/tasks/composer/DotBackground";
 import {
   type ContextWindow,
   DEFAULT_CONTEXT_WINDOW,
-  filterKimiModelConfigOptions,
   getMobileExecutionModes,
   getModelConfigOption,
 } from "@/features/tasks/composer/options";
@@ -111,16 +108,9 @@ export default function NewTaskScreen() {
   const keyboard = useReanimatedKeyboardAnimation();
   const restingBottom = bottom("compact");
   const [adapter, setAdapter] = useState<Adapter>("claude");
-  const {
-    configOptions: liveConfigOptions,
-    hasLiveConfig,
-    isConfigReady,
-  } = useCloudTaskConfigOptions(adapter);
-  const kimiEnabled = !!useFeatureFlag(KIMI_MODEL_FLAG);
-  const configOptions = useMemo(
-    () => filterKimiModelConfigOptions(liveConfigOptions, kimiEnabled),
-    [liveConfigOptions, kimiEnabled],
-  );
+  const [model, setModel] = useState<string>(DEFAULT_GATEWAY_MODEL);
+  const { configOptions, modelGroups, hasLiveConfig, isConfigReady } =
+    useCloudTaskConfigOptions(adapter, model);
   const modelConfigOption = getModelConfigOption(configOptions);
   const {
     error,
@@ -192,7 +182,6 @@ export default function NewTaskScreen() {
     }
     return DEFAULT_CLAUDE_EXECUTION_MODE;
   });
-  const [model, setModel] = useState<string>(DEFAULT_GATEWAY_MODEL);
   const [reasoning, setReasoning] = useState<SupportedReasoningEffort>(() => {
     const prefs = usePreferencesStore.getState();
     const desired =
@@ -622,6 +611,7 @@ export default function NewTaskScreen() {
                         contextWindow={contextWindow}
                         fastMode={fastMode}
                         configOptions={configOptions}
+                        modelGroups={modelGroups}
                         onAdapterChange={(next) => {
                           setAdapter(next.adapter);
                           setMode(next.mode);

--- a/products/desktop/apps/mobile/src/features/tasks/composer/AgentConfigControls.test.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/AgentConfigControls.test.tsx
@@ -1,4 +1,7 @@
-import type { CloudTaskConfigOption } from "@posthog/shared";
+import type {
+  CloudTaskConfigOption,
+  CloudTaskConfigSelectGroup,
+} from "@posthog/shared";
 import { createElement, type ReactNode } from "react";
 import { act, create } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
@@ -46,6 +49,8 @@ vi.mock("@/lib/theme", () => ({
   }),
 }));
 
+const HARNESS_META = "posthog.code/modelHarness";
+
 const ladderModelOption: CloudTaskConfigOption = {
   id: "model",
   name: "Model",
@@ -62,6 +67,41 @@ const ladderModelOption: CloudTaskConfigOption = {
 
 const configOptions: CloudTaskConfigOption[] = [ladderModelOption];
 
+const modelGroups: CloudTaskConfigSelectGroup[] = [
+  {
+    group: "anthropic",
+    name: "Anthropic",
+    options: [
+      {
+        value: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        _meta: { [HARNESS_META]: "claude" },
+      },
+      {
+        value: "claude-opus-5",
+        name: "Claude Opus 5",
+        _meta: { [HARNESS_META]: "claude" },
+      },
+      {
+        value: "claude-fable-5",
+        name: "Claude Fable 5",
+        _meta: { [HARNESS_META]: "claude" },
+      },
+    ],
+  },
+  {
+    group: "openai",
+    name: "OpenAI",
+    options: [
+      {
+        value: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        _meta: { [HARNESS_META]: "codex" },
+      },
+    ],
+  },
+];
+
 function baseProps() {
   return {
     adapter: "claude" as const,
@@ -71,6 +111,7 @@ function baseProps() {
     contextWindow: "1m" as const,
     fastMode: false,
     configOptions,
+    modelGroups,
     onAdapterChange: vi.fn(),
     onModeChange: vi.fn(),
     onModelChange: vi.fn(),
@@ -128,7 +169,7 @@ describe("AgentConfigControls", () => {
     expect(props.onReasoningChange).toHaveBeenCalledWith("xhigh");
   });
 
-  it("resets to the other harness's middle preset when switching harness", () => {
+  it("switches harness when picking a model from the other harness", () => {
     const props = baseProps();
     const renderer = render(props);
 
@@ -139,17 +180,35 @@ describe("AgentConfigControls", () => {
       ).props.onPress(),
     );
     act(() => findPressableWithText(renderer, "Advanced").props.onPress());
-    act(() => findPressableWithText(renderer, "Codex").props.onPress());
+    act(() => findPressableWithText(renderer, "GPT-5.6 Sol").props.onPress());
 
     expect(props.onAdapterChange).toHaveBeenCalledWith({
       adapter: "codex",
       mode: "auto",
       model: "gpt-5.6-sol",
-      reasoning: "medium",
+      reasoning: "high",
     });
+    expect(props.onModelChange).not.toHaveBeenCalled();
   });
 
-  it("hides adapter switching while the active run locks the adapter", () => {
+  it("keeps a same-harness pick on the current adapter", () => {
+    const props = baseProps();
+    const renderer = render(props);
+
+    act(() =>
+      findPressableWithText(
+        renderer,
+        "Claude Sonnet 5 · Medium",
+      ).props.onPress(),
+    );
+    act(() => findPressableWithText(renderer, "Advanced").props.onPress());
+    act(() => findPressableWithText(renderer, "Claude Opus 5").props.onPress());
+
+    expect(props.onModelChange).toHaveBeenCalledWith("claude-opus-5");
+    expect(props.onAdapterChange).not.toHaveBeenCalled();
+  });
+
+  it("hides the other harness's models when the run locks the adapter", () => {
     const props = { ...baseProps(), canChangeAdapter: false };
     const renderer = render(props);
 
@@ -161,7 +220,10 @@ describe("AgentConfigControls", () => {
     );
     act(() => findPressableWithText(renderer, "Advanced").props.onPress());
 
-    expect(() => findPressableWithText(renderer, "Codex")).toThrow();
+    expect(() => findPressableWithText(renderer, "GPT-5.6 Sol")).toThrow();
+    expect(() =>
+      findPressableWithText(renderer, "Claude Opus 5"),
+    ).not.toThrow();
   });
 
   it("only surfaces the fast mode toggle when the flag is on and the model supports it", () => {

--- a/products/desktop/apps/mobile/src/features/tasks/composer/AgentConfigControls.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/AgentConfigControls.tsx
@@ -3,6 +3,7 @@ import type { CloudComposerSelection } from "@posthog/core/task-detail/composerM
 import {
   type Adapter,
   type CloudTaskConfigOption,
+  type CloudTaskConfigSelectGroup,
   type ExecutionMode,
   FAST_MODE_FLAG,
   getReasoningEffortOptions,
@@ -20,20 +21,21 @@ import {
   Sparkle,
 } from "phosphor-react-native";
 import { useFeatureFlag } from "posthog-react-native";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { useThemeColors } from "@/lib/theme";
 import { AgentConfigSheet } from "./AgentConfigSheet";
 import {
   type AgentPreset,
   type ContextWindow,
   DEFAULT_CONTEXT_WINDOW,
+  findModelOptionInGroups,
   getAgentPresets,
-  getComposerModelOptions,
-  getConfigOptionLabel,
   getMiddlePreset,
   getMobileExecutionModes,
   getModelConfigOption,
-  resolveHarnessSwitchSelection,
+  harnessForModel,
+  resolveCrossHarnessModelSelection,
+  toMobileModelGroups,
 } from "./options";
 import { Pill } from "./Pill";
 import { SelectSheet } from "./SelectSheet";
@@ -46,6 +48,11 @@ interface AgentConfigControlsProps {
   contextWindow: ContextWindow;
   fastMode: boolean;
   configOptions: readonly CloudTaskConfigOption[];
+  modelGroups: readonly CloudTaskConfigSelectGroup[];
+  /**
+   * Called for both cross-harness picks and manual harness switches. Same
+   * shape as the desktop `resolveCloudComposerAdapterChange` result.
+   */
   onAdapterChange: (selection: CloudComposerSelection) => void;
   onModeChange: (mode: ExecutionMode) => void;
   onModelChange: (model: string) => void;
@@ -81,6 +88,7 @@ export function AgentConfigControls({
   contextWindow,
   fastMode,
   configOptions,
+  modelGroups,
   onAdapterChange,
   onModeChange,
   onModelChange,
@@ -98,12 +106,29 @@ export function AgentConfigControls({
     getAvailableModesForAdapter(adapter),
   );
   const modelConfigOption = getModelConfigOption(configOptions);
-  const modelOptions = getComposerModelOptions(modelConfigOption);
+  // A running session locks the adapter, so hide the other harness's models —
+  // picking one on a live session would push an invalid model to the run.
+  const mobileModelGroups = useMemo(() => {
+    const filtered = canChangeAdapter
+      ? modelGroups
+      : modelGroups
+          .map((group) => ({
+            ...group,
+            options: group.options.filter(
+              (option) =>
+                harnessForModel(modelGroups, option.value) === adapter,
+            ),
+          }))
+          .filter((group) => group.options.length > 0);
+    return toMobileModelGroups(filtered);
+  }, [modelGroups, canChangeAdapter, adapter]);
   const reasoningOptions = getReasoningEffortOptions(adapter, model) ?? [];
-  const presets = getAgentPresets(adapter, modelConfigOption);
+  const presets = useMemo(
+    () => getAgentPresets(adapter, modelConfigOption),
+    [adapter, modelConfigOption],
+  );
 
-  const modelLabel =
-    getConfigOptionLabel(modelConfigOption.options, model) ?? model;
+  const modelLabel = findModelOptionInGroups(modelGroups, model)?.name ?? model;
   const effortLabel =
     reasoningOptions.find((option) => option.value === reasoning)?.name ??
     reasoning;
@@ -118,6 +143,15 @@ export function AgentConfigControls({
   const applyPreset = (preset: AgentPreset) => {
     if (preset.model !== model) onModelChange(preset.model);
     if (preset.effort !== reasoning) onReasoningChange(preset.effort);
+  };
+
+  const handleModelChange = (next: string) => {
+    const pickedHarness = harnessForModel(modelGroups, next);
+    if (pickedHarness !== adapter) {
+      onAdapterChange(resolveCrossHarnessModelSelection(pickedHarness, next));
+      return;
+    }
+    onModelChange(next);
   };
 
   const handleReset = () => {
@@ -184,25 +218,18 @@ export function AgentConfigControls({
       <AgentConfigSheet
         open={configSheetOpen}
         onClose={() => setConfigSheetOpen(false)}
-        adapter={adapter}
         model={model}
         reasoning={reasoning}
         contextWindow={contextWindow}
         fastMode={fastActive}
         presets={presets}
         reasoningOptions={reasoningOptions}
-        modelOptions={modelOptions}
+        modelGroups={mobileModelGroups}
         fastModeAvailable={fastModeAvailable}
         contextWindowAvailable={contextWindowAvailable}
-        canChangeAdapter={canChangeAdapter}
         onSelectPreset={applyPreset}
-        onModelChange={onModelChange}
+        onModelChange={handleModelChange}
         onReasoningChange={onReasoningChange}
-        onAdapterSelect={(next) => {
-          if (next !== adapter) {
-            onAdapterChange(resolveHarnessSwitchSelection(adapter));
-          }
-        }}
         onFastModeChange={onFastModeChange}
         onContextWindowChange={onContextWindowChange}
         onReset={handleReset}

--- a/products/desktop/apps/mobile/src/features/tasks/composer/AgentConfigSheet.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/AgentConfigSheet.tsx
@@ -1,40 +1,32 @@
 import { Text } from "@components/text";
-import type { Adapter, SupportedReasoningEffort } from "@posthog/shared";
+import type { SupportedReasoningEffort } from "@posthog/shared";
 import {
   ArrowCounterClockwise,
   CaretDown,
   Check,
   Lightning,
 } from "phosphor-react-native";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { Pressable, ScrollView, Switch, View } from "react-native";
 import { SheetContainer } from "@/components/SheetContainer";
 import { useThemeColors } from "@/lib/theme";
-import type { AgentPreset, ContextWindow, MobileModelOption } from "./options";
-
-const ADAPTER_LABELS: Record<Adapter, string> = {
-  claude: "Claude Code",
-  codex: "Codex",
-};
+import type { AgentPreset, ContextWindow, MobileModelGroup } from "./options";
 
 interface AgentConfigSheetProps {
   open: boolean;
   onClose: () => void;
-  adapter: Adapter;
   model: string;
   reasoning: SupportedReasoningEffort;
   contextWindow: ContextWindow;
   fastMode: boolean;
   presets: AgentPreset[];
   reasoningOptions: ReadonlyArray<{ value: string; name: string }>;
-  modelOptions: MobileModelOption[];
+  modelGroups: MobileModelGroup[];
   fastModeAvailable: boolean;
   contextWindowAvailable: boolean;
-  canChangeAdapter: boolean;
   onSelectPreset: (preset: AgentPreset) => void;
   onModelChange: (model: string) => void;
   onReasoningChange: (value: SupportedReasoningEffort) => void;
-  onAdapterSelect: (adapter: Adapter) => void;
   onFastModeChange: (enabled: boolean) => void;
   onContextWindowChange: (value: ContextWindow) => void;
   onReset: () => void;
@@ -43,6 +35,14 @@ interface AgentConfigSheetProps {
 function SectionLabel({ children }: { children: string }) {
   return (
     <Text className="px-4 pt-4 pb-1 font-medium text-[12px] text-gray-10 uppercase tracking-wide">
+      {children}
+    </Text>
+  );
+}
+
+function GroupHeader({ children }: { children: string }) {
+  return (
+    <Text className="px-4 pt-3 pb-1 font-medium text-[11px] text-gray-10 uppercase tracking-wide">
       {children}
     </Text>
   );
@@ -116,27 +116,25 @@ function Segmented<T extends string>({
 export function AgentConfigSheet({
   open,
   onClose,
-  adapter,
   model,
   reasoning,
   contextWindow,
   fastMode,
   presets,
   reasoningOptions,
-  modelOptions,
+  modelGroups,
   fastModeAvailable,
   contextWindowAvailable,
-  canChangeAdapter,
   onSelectPreset,
   onModelChange,
   onReasoningChange,
-  onAdapterSelect,
   onFastModeChange,
   onContextWindowChange,
   onReset,
 }: AgentConfigSheetProps) {
   const themeColors = useThemeColors();
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const showGroupHeaders = modelGroups.length > 1;
 
   return (
     <SheetContainer open={open} onClose={onClose}>
@@ -211,33 +209,26 @@ export function AgentConfigSheet({
 
         {advancedOpen ? (
           <>
-            {canChangeAdapter ? (
-              <>
-                <SectionLabel>Harness</SectionLabel>
-                <Segmented
-                  value={adapter}
-                  onChange={onAdapterSelect}
-                  options={[
-                    { value: "claude", label: ADAPTER_LABELS.claude },
-                    { value: "codex", label: ADAPTER_LABELS.codex },
-                  ]}
-                />
-              </>
-            ) : null}
-
             <SectionLabel>Model</SectionLabel>
-            {modelOptions.map((option) => (
-              <Row
-                key={option.value}
-                label={option.label}
-                description={
-                  option.disabled ? "Upgrade required" : option.description
-                }
-                selected={option.value === model}
-                onPress={() => {
-                  if (!option.disabled) onModelChange(option.value);
-                }}
-              />
+            {modelGroups.map((group) => (
+              <Fragment key={group.key}>
+                {showGroupHeaders ? (
+                  <GroupHeader>{group.name}</GroupHeader>
+                ) : null}
+                {group.options.map((option) => (
+                  <Row
+                    key={option.value}
+                    label={option.label}
+                    description={
+                      option.disabled ? "Upgrade required" : option.description
+                    }
+                    selected={option.value === model}
+                    onPress={() => {
+                      if (!option.disabled) onModelChange(option.value);
+                    }}
+                  />
+                ))}
+              </Fragment>
             ))}
 
             {reasoningOptions.length > 0 ? (

--- a/products/desktop/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/TaskChatComposer.tsx
@@ -7,7 +7,6 @@ import {
   DEFAULT_GATEWAY_MODEL,
   DEFAULT_REASONING_EFFORT,
   type ExecutionMode,
-  KIMI_MODEL_FLAG,
   type SupportedReasoningEffort,
 } from "@posthog/shared";
 import * as Haptics from "expo-haptics";
@@ -20,9 +19,8 @@ import {
   Stack,
   Stop,
 } from "phosphor-react-native";
-import { useFeatureFlag } from "posthog-react-native";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -52,7 +50,6 @@ import {
 import type { PendingAttachment } from "./attachments/types";
 import {
   type ContextWindow,
-  filterKimiModelConfigOptions,
   getModelConfigOption,
   resolveComposerPrimaryAction,
 } from "./options";
@@ -130,13 +127,8 @@ export function TaskChatComposer({
   artifactsSlot,
 }: TaskChatComposerProps) {
   const themeColors = useThemeColors();
-  const { configOptions: liveConfigOptions, hasLiveConfig } =
-    useCloudTaskConfigOptions(adapter);
-  const kimiEnabled = !!useFeatureFlag(KIMI_MODEL_FLAG);
-  const configOptions = useMemo(
-    () => filterKimiModelConfigOptions(liveConfigOptions, kimiEnabled),
-    [liveConfigOptions, kimiEnabled],
-  );
+  const { configOptions, modelGroups, hasLiveConfig } =
+    useCloudTaskConfigOptions(adapter, model);
   const modelConfigOption = getModelConfigOption(configOptions);
   const [message, setMessage] = useState(() => initialMessage ?? "");
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
@@ -423,6 +415,7 @@ export function TaskChatComposer({
                   contextWindow={contextWindow}
                   fastMode={fastMode}
                   configOptions={configOptions}
+                  modelGroups={modelGroups}
                   onAdapterChange={onAdapterChange}
                   onModeChange={onModeChange}
                   onModelChange={onModelChange}

--- a/products/desktop/apps/mobile/src/features/tasks/composer/options.test.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/options.test.ts
@@ -1,51 +1,20 @@
 import {
   type CloudTaskConfigOption,
-  DEFAULT_GATEWAY_MODEL,
+  type CloudTaskConfigSelectGroup,
   restrictedModelMeta,
 } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 import {
-  filterKimiModelConfigOptions,
-  filterKimiModelOption,
   getAgentPresets,
-  getComposerModelOptions,
   getMiddlePreset,
   getMobileExecutionModes,
+  harnessForModel,
   resolveComposerPrimaryAction,
-  resolveHarnessSwitchSelection,
+  resolveCrossHarnessModelSelection,
+  toMobileModelGroups,
 } from "./options";
 
-const KIMI = "moonshotai/kimi-k3";
-
-const kimiModelOption: CloudTaskConfigOption = {
-  id: "model",
-  name: "Model",
-  type: "select",
-  currentValue: DEFAULT_GATEWAY_MODEL,
-  options: [
-    { value: DEFAULT_GATEWAY_MODEL, name: "Claude Opus 4.8" },
-    { value: KIMI, name: "Kimi K3" },
-  ],
-  category: "model",
-  description: "Choose a model",
-};
-
-const modelOption: CloudTaskConfigOption = {
-  id: "model",
-  name: "Model",
-  type: "select",
-  currentValue: DEFAULT_GATEWAY_MODEL,
-  options: [
-    { value: DEFAULT_GATEWAY_MODEL, name: "Claude Opus 4.8" },
-    {
-      value: "claude-fable-5",
-      name: "Claude Fable 5",
-      _meta: restrictedModelMeta(),
-    },
-  ],
-  category: "model",
-  description: "Choose a model",
-};
+const HARNESS_META = "posthog.code/modelHarness";
 
 describe("mobile composer options", () => {
   it("hides unrestricted execution modes", () => {
@@ -66,81 +35,6 @@ describe("mobile composer options", () => {
     ).toEqual(["plan"]);
   });
 
-  it("adapts live model options for the mobile picker", () => {
-    expect(getComposerModelOptions(modelOption)).toEqual([
-      {
-        value: DEFAULT_GATEWAY_MODEL,
-        label: "Claude Opus 4.8",
-        description: undefined,
-        disabled: false,
-      },
-      {
-        value: "claude-fable-5",
-        label: "Claude Fable 5",
-        description: undefined,
-        disabled: true,
-      },
-    ]);
-  });
-
-  describe("filterKimiModelOption", () => {
-    it("keeps Kimi K3 when the flag is on", () => {
-      const filtered = filterKimiModelOption(kimiModelOption, true);
-      expect(filtered.options.map((o) => o.value)).toContain(KIMI);
-    });
-
-    it("drops Kimi K3 when the flag is off", () => {
-      const filtered = filterKimiModelOption(kimiModelOption, false);
-      expect(filtered.options.map((o) => o.value)).not.toContain(KIMI);
-      expect(filtered.options.map((o) => o.value)).toEqual([
-        DEFAULT_GATEWAY_MODEL,
-      ]);
-    });
-
-    it("rewrites a persisted Kimi selection to a visible model when the flag is off", () => {
-      const filtered = filterKimiModelOption(
-        { ...kimiModelOption, currentValue: KIMI },
-        false,
-      );
-      expect(filtered.currentValue).toBe(DEFAULT_GATEWAY_MODEL);
-    });
-
-    it("leaves an already-visible selection untouched when the flag is off", () => {
-      const filtered = filterKimiModelOption(kimiModelOption, false);
-      expect(filtered.currentValue).toBe(DEFAULT_GATEWAY_MODEL);
-    });
-  });
-
-  describe("filterKimiModelConfigOptions", () => {
-    const modeOption: CloudTaskConfigOption = {
-      id: "mode",
-      name: "Mode",
-      type: "select",
-      currentValue: "plan",
-      options: [{ value: "plan", name: "Plan" }],
-      category: "mode",
-      description: "Execution mode",
-    };
-
-    it("returns the config set untouched when the flag is on", () => {
-      const input = [modeOption, kimiModelOption];
-      expect(filterKimiModelConfigOptions(input, true)).toBe(input);
-    });
-
-    it("strips Kimi from only the model option when the flag is off", () => {
-      const filtered = filterKimiModelConfigOptions(
-        [modeOption, kimiModelOption],
-        false,
-      );
-      const model = filtered.find((option) => option.category === "model");
-      const mode = filtered.find((option) => option.category === "mode");
-      expect(model?.options.map((o) => o.value)).toEqual([
-        DEFAULT_GATEWAY_MODEL,
-      ]);
-      expect(mode).toBe(modeOption);
-    });
-  });
-
   describe("agent presets", () => {
     const ladderConfig: CloudTaskConfigOption = {
       id: "model",
@@ -150,7 +44,6 @@ describe("mobile composer options", () => {
       options: [
         { value: "claude-sonnet-5", name: "Claude Sonnet 5" },
         { value: "claude-opus-5", name: "Claude Opus 5" },
-        // Restricted models drop out of the scale entirely.
         {
           value: "claude-fable-5",
           name: "Claude Fable 5",
@@ -202,22 +95,85 @@ describe("mobile composer options", () => {
     });
   });
 
-  describe("resolveHarnessSwitchSelection", () => {
-    it("switches to the codex middle notch", () => {
-      expect(resolveHarnessSwitchSelection("claude")).toMatchObject({
-        adapter: "codex",
-        model: "gpt-5.6-sol",
-        reasoning: "medium",
-      });
+  describe("harnessForModel", () => {
+    const groups: CloudTaskConfigSelectGroup[] = [
+      {
+        group: "anthropic",
+        name: "Anthropic",
+        options: [
+          {
+            value: "claude-opus-5",
+            name: "Claude Opus 5",
+            _meta: { [HARNESS_META]: "claude" },
+          },
+        ],
+      },
+      {
+        group: "openai",
+        name: "OpenAI",
+        options: [
+          {
+            value: "gpt-5.6-sol",
+            name: "GPT-5.6 Sol",
+            _meta: { [HARNESS_META]: "codex" },
+          },
+        ],
+      },
+    ];
+
+    it("reads the harness stamp from the picked option", () => {
+      expect(harnessForModel(groups, "gpt-5.6-sol")).toBe("codex");
     });
 
-    it("switches to the claude middle notch", () => {
-      expect(resolveHarnessSwitchSelection("codex")).toMatchObject({
-        adapter: "claude",
-        model: "claude-opus-5",
-        reasoning: "medium",
-      });
+    it("falls back to the model id shape when the pick is not in the catalog", () => {
+      // A gateway blip may have dropped the model; the composer must still let
+      // the currently-running model stay picked, so the harness has to resolve.
+      expect(harnessForModel(groups, "gpt-5.9-nova")).toBe("codex");
+      expect(harnessForModel(groups, "claude-opus-4-99")).toBe("claude");
     });
+  });
+
+  describe("resolveCrossHarnessModelSelection", () => {
+    it("lands on the target harness's default mode and reasoning", () => {
+      expect(resolveCrossHarnessModelSelection("codex", "gpt-5.6-sol")).toEqual(
+        {
+          adapter: "codex",
+          mode: "auto",
+          model: "gpt-5.6-sol",
+          reasoning: "high",
+        },
+      );
+    });
+  });
+
+  it("keys mobile groups on their vendor and adapts each option", () => {
+    const groups: CloudTaskConfigSelectGroup[] = [
+      {
+        group: "anthropic",
+        name: "Anthropic",
+        options: [
+          {
+            value: "claude-opus-5",
+            name: "Claude Opus 5",
+            _meta: restrictedModelMeta(),
+          },
+        ],
+      },
+    ];
+    expect(toMobileModelGroups(groups)).toEqual([
+      {
+        key: "anthropic",
+        name: "Anthropic",
+        options: [
+          {
+            value: "claude-opus-5",
+            label: "Claude Opus 5",
+            description: undefined,
+            disabled: true,
+          },
+        ],
+      },
+    ]);
   });
 
   it.each([

--- a/products/desktop/apps/mobile/src/features/tasks/composer/options.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/composer/options.ts
@@ -1,16 +1,19 @@
-import type { ModeInfo } from "@posthog/core/sessions/executionModes";
 import {
-  type CloudComposerSelection,
-  resolveCloudComposerAdapterChange,
-} from "@posthog/core/task-detail/composerModelPolicy";
+  getDefaultExecutionModeForAdapter,
+  type ModeInfo,
+} from "@posthog/core/sessions/executionModes";
+import type { CloudComposerSelection } from "@posthog/core/task-detail/composerModelPolicy";
 import {
   type Adapter,
+  adapterForModelId,
   type CloudTaskConfigOption,
+  type CloudTaskConfigSelectGroup,
+  DEFAULT_REASONING_EFFORT,
   getCapabilityLadder,
   getReasoningEffortOptions,
-  isModalModelId,
   isRestrictedModelOption,
   type SupportedReasoningEffort,
+  selectOptionHarness,
 } from "@posthog/shared";
 
 export type ContextWindow = "200k" | "1m";
@@ -30,6 +33,12 @@ export interface MobileModelOption {
   disabled: boolean;
 }
 
+export interface MobileModelGroup {
+  key: string;
+  name: string;
+  options: MobileModelOption[];
+}
+
 export function getMobileExecutionModes(
   modes: readonly ModeInfo[],
 ): ModeInfo[] {
@@ -46,61 +55,66 @@ export function getModelConfigOption(
   return option;
 }
 
-/**
- * Drops the Kimi K3 model from the live model config when the feature flag is
- * off, and rewrites a persisted or server-default Kimi selection to the first
- * remaining option so it never leaks into the picker. Mirrors the desktop
- * `stripKimiModelOption` filter, but over the mobile `CloudTaskConfigOption`.
- */
-export function filterKimiModelOption(
-  modelOption: CloudTaskConfigOption,
-  kimiEnabled: boolean,
-): CloudTaskConfigOption {
-  if (kimiEnabled) return modelOption;
-  const options = modelOption.options.filter(
-    (option) => !isModalModelId(option.value),
-  );
+function toMobileModelOption(option: {
+  value: string;
+  name: string;
+  description?: string;
+  _meta?: Record<string, unknown>;
+}): MobileModelOption {
   return {
-    ...modelOption,
-    options,
-    currentValue: isModalModelId(modelOption.currentValue)
-      ? (options[0]?.value ?? modelOption.currentValue)
-      : modelOption.currentValue,
-  };
-}
-
-/**
- * Applies {@link filterKimiModelOption} to the model option within a live
- * config set, leaving the other categories untouched. Callers filter once at
- * the source so the model auto-resolve effect and the picker share Kimi-free
- * options.
- */
-export function filterKimiModelConfigOptions(
-  configOptions: readonly CloudTaskConfigOption[],
-  kimiEnabled: boolean,
-): readonly CloudTaskConfigOption[] {
-  if (kimiEnabled) return configOptions;
-  return configOptions.map((option) =>
-    option.category === "model" ? filterKimiModelOption(option, false) : option,
-  );
-}
-
-export function getComposerModelOptions(
-  modelOption: CloudTaskConfigOption,
-): MobileModelOption[] {
-  return modelOption.options.map((option) => ({
     value: option.value,
     label: option.name,
     description: option.description,
     disabled: isRestrictedModelOption(option._meta),
+  };
+}
+
+export function toMobileModelGroups(
+  groups: readonly CloudTaskConfigSelectGroup[],
+): MobileModelGroup[] {
+  return groups.map((group) => ({
+    key: group.group,
+    name: group.name,
+    options: group.options.map(toMobileModelOption),
   }));
 }
 
-export function getConfigOptionLabel(
-  options: ReadonlyArray<{ value: string; name: string }>,
-  value: string | undefined,
-): string | undefined {
-  return options.find((option) => option.value === value)?.name ?? value;
+export function findModelOptionInGroups(
+  groups: readonly CloudTaskConfigSelectGroup[],
+  value: string,
+):
+  | { value: string; name: string; _meta?: Record<string, unknown> }
+  | undefined {
+  for (const group of groups) {
+    const entry = group.options.find((option) => option.value === value);
+    if (entry) return entry;
+  }
+  return undefined;
+}
+
+export function harnessForModel(
+  groups: readonly CloudTaskConfigSelectGroup[],
+  value: string,
+): Adapter {
+  const entry = findModelOptionInGroups(groups, value);
+  return selectOptionHarness(entry?._meta) ?? adapterForModelId(value);
+}
+
+/**
+ * The composer selection for a cross-harness model pick: switches to the
+ * picked model's harness, lands on that harness's default mode and reasoning
+ * effort, and carries the picked model along.
+ */
+export function resolveCrossHarnessModelSelection(
+  adapter: Adapter,
+  model: string,
+): CloudComposerSelection {
+  return {
+    adapter,
+    mode: getDefaultExecutionModeForAdapter(adapter),
+    model,
+    reasoning: DEFAULT_REASONING_EFFORT,
+  };
 }
 
 /**
@@ -131,32 +145,15 @@ export function getAgentPresets(
   });
 }
 
-/** Index of the balanced middle notch on a Faster→Smarter ordered scale. */
 function middleIndex(length: number): number {
   return Math.floor((length - 1) / 2);
 }
 
-/** The balanced middle notch used as the reset target and harness default. */
 export function getMiddlePreset(
   presets: readonly AgentPreset[],
 ): AgentPreset | undefined {
   if (presets.length === 0) return undefined;
   return presets[middleIndex(presets.length)];
-}
-
-/**
- * Switches to the other harness, landing on that harness's middle-notch model
- * and effort rather than a bare default. The composer re-resolves the model
- * against the live config once it loads if this pairing isn't offered yet.
- */
-export function resolveHarnessSwitchSelection(
-  currentAdapter: Adapter,
-): CloudComposerSelection {
-  const base = resolveCloudComposerAdapterChange(currentAdapter);
-  const ladder = getCapabilityLadder(base.adapter);
-  const middle = ladder[middleIndex(ladder.length)];
-  if (!middle) return base;
-  return { ...base, model: middle.model, reasoning: middle.effort };
 }
 
 export type ComposerPrimaryAction =

--- a/products/desktop/apps/mobile/src/features/tasks/hooks/useCloudTaskConfigOptions.test.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/hooks/useCloudTaskConfigOptions.test.ts
@@ -1,17 +1,18 @@
 import {
-  type CloudTaskConfigOption,
   DEFAULT_GATEWAY_MODEL,
+  type GatewayModel,
   GLM53_FLASH_MODEL_FLAG,
   GLM53_MODEL_FLAG,
+  KIMI_MODEL_FLAG,
 } from "@posthog/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type PropsWithChildren } from "react";
 import { act, create } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetCloudTaskConfigOptions, mockUseAuthStore, mockUseFeatureFlag } =
+const { mockGetCloudTaskGatewayModels, mockUseAuthStore, mockUseFeatureFlag } =
   vi.hoisted(() => ({
-    mockGetCloudTaskConfigOptions: vi.fn(),
+    mockGetCloudTaskGatewayModels: vi.fn(),
     mockUseAuthStore: vi.fn(),
     mockUseFeatureFlag: vi.fn(),
   }));
@@ -26,7 +27,7 @@ vi.mock("@/features/auth", () => ({
 
 vi.mock("@/lib/posthogApiClient", () => ({
   getPostHogApiClient: () => ({
-    getCloudTaskConfigOptions: mockGetCloudTaskConfigOptions,
+    getCloudTaskGatewayModels: mockGetCloudTaskGatewayModels,
   }),
 }));
 
@@ -43,14 +44,17 @@ function createWrapper(queryClient: QueryClient) {
   };
 }
 
-async function renderHook() {
+async function renderHook(
+  adapter: "claude" | "codex" = "claude",
+  currentValue?: string,
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   let currentResult: ReturnType<typeof useCloudTaskConfigOptions>;
 
   function HookProbe() {
-    currentResult = useCloudTaskConfigOptions("claude");
+    currentResult = useCloudTaskConfigOptions(adapter, currentValue);
     return null;
   }
 
@@ -80,9 +84,33 @@ async function waitForAssertion(assertion: () => void): Promise<void> {
   }
 }
 
+function inferOwnedBy(id: string): string {
+  if (id.startsWith("claude-") || id.startsWith("anthropic/"))
+    return "anthropic";
+  if (id.startsWith("gpt-") || id.startsWith("openai/")) return "openai";
+  if (id.startsWith("@cf/")) return "cloudflare";
+  if (id.startsWith("zai-org/") || id.includes("deepseek")) return "baseten";
+  return id.split("/")[0] ?? "anthropic";
+}
+
+function gatewayModel(
+  id: string,
+  extra: Partial<GatewayModel> = {},
+): GatewayModel {
+  return {
+    id,
+    owned_by: inferOwnedBy(id),
+    context_window: 200_000,
+    supports_streaming: true,
+    supports_vision: false,
+    allowed: true,
+    ...extra,
+  };
+}
+
 describe("useCloudTaskConfigOptions", () => {
   beforeEach(() => {
-    mockGetCloudTaskConfigOptions.mockReset();
+    mockGetCloudTaskGatewayModels.mockReset();
     mockUseFeatureFlag.mockReset();
     mockUseFeatureFlag.mockReturnValue(false);
     mockUseAuthStore.mockImplementation((selector) =>
@@ -90,51 +118,57 @@ describe("useCloudTaskConfigOptions", () => {
     );
   });
 
-  it("uses the authenticated live Claude catalog", async () => {
-    const liveOptions: CloudTaskConfigOption[] = [
-      {
-        id: "model",
-        name: "Model",
-        type: "select",
-        currentValue: "claude-sonnet-5",
-        options: [{ value: "claude-sonnet-5", name: "Claude Sonnet 5" }],
-        category: "model",
-        description: "Choose a model",
-      },
-    ];
-    mockGetCloudTaskConfigOptions.mockResolvedValue(liveOptions);
+  it("builds per-adapter config options from the gateway models", async () => {
+    mockGetCloudTaskGatewayModels.mockResolvedValue([
+      gatewayModel("claude-sonnet-5"),
+      gatewayModel("gpt-5.6-sol"),
+    ]);
 
-    const result = await renderHook();
+    const result = await renderHook("claude");
     await waitForAssertion(() => {
-      expect(result.current.configOptions).toEqual(liveOptions);
+      const modelOption = getModelConfigOption(result.current.configOptions);
+      expect(modelOption.options.map((o) => o.value)).toEqual([
+        "claude-sonnet-5",
+      ]);
       expect(result.current.hasLiveConfig).toBe(true);
     });
-    expect(mockGetCloudTaskConfigOptions).toHaveBeenCalledWith("claude");
+  });
+
+  it("groups both harnesses' models by vendor for the cross-harness picker", async () => {
+    mockGetCloudTaskGatewayModels.mockResolvedValue([
+      gatewayModel("claude-sonnet-5"),
+      gatewayModel("gpt-5.6-sol"),
+    ]);
+
+    const result = await renderHook("claude");
+    await waitForAssertion(() => {
+      const groups = result.current.modelGroups.map((g) => ({
+        group: g.group,
+        options: g.options.map((o) => o.value),
+      }));
+      expect(groups).toEqual([
+        { group: "anthropic", options: ["claude-sonnet-5"] },
+        { group: "openai", options: ["gpt-5.6-sol"] },
+      ]);
+    });
   });
 
   it("replaces a hidden GLM current model with a visible model", async () => {
-    mockGetCloudTaskConfigOptions.mockResolvedValue([
-      {
-        id: "model",
-        name: "Model",
-        type: "select",
-        currentValue: "@cf/zai-org/glm-5.2",
-        options: [
-          { value: "@cf/zai-org/glm-5.2", name: "GLM-5.2" },
-          { value: "claude-sonnet-5", name: "Claude Sonnet 5" },
-        ],
-        category: "model",
-        description: "Choose a model",
-      },
-    ] satisfies CloudTaskConfigOption[]);
+    mockGetCloudTaskGatewayModels.mockResolvedValue([
+      gatewayModel("zai-org/glm-5.3"),
+      gatewayModel("claude-sonnet-5"),
+    ]);
 
-    const result = await renderHook();
+    const result = await renderHook("claude");
     await waitForAssertion(() => {
       const modelOption = getModelConfigOption(result.current.configOptions);
-      expect(modelOption.currentValue).toBe("claude-sonnet-5");
       expect(modelOption.options.map((option) => option.value)).toEqual([
         "claude-sonnet-5",
       ]);
+      // Cross-harness groups drop the empty Z.ai group along with its heading.
+      expect(result.current.modelGroups.map((g) => g.group)).not.toContain(
+        "zai-org",
+      );
     });
   });
 
@@ -145,26 +179,14 @@ describe("useCloudTaskConfigOptions", () => {
     mockUseFeatureFlag.mockImplementation(
       (flag: string) => flag === enabledFlag,
     );
-    mockGetCloudTaskConfigOptions.mockResolvedValue([
-      {
-        id: "model",
-        name: "Model",
-        type: "select",
-        currentValue: model,
-        options: [
-          { value: "@cf/zai-org/glm-5.2", name: "GLM-5.2" },
-          { value: "zai-org/glm-5.3", name: "GLM-5.3" },
-          { value: "zai-org/glm-5.3-flash", name: "GLM-5.3 Flash" },
-        ],
-        category: "model",
-        description: "Choose a model",
-      },
-    ] satisfies CloudTaskConfigOption[]);
+    mockGetCloudTaskGatewayModels.mockResolvedValue([
+      gatewayModel("zai-org/glm-5.3"),
+      gatewayModel("zai-org/glm-5.3-flash"),
+    ]);
 
-    const result = await renderHook();
+    const result = await renderHook("claude");
     await waitForAssertion(() => {
       const modelOption = getModelConfigOption(result.current.configOptions);
-      expect(modelOption.currentValue).toBe(model);
       expect(modelOption.options.map((option) => option.value)).toEqual([
         model,
       ]);
@@ -176,19 +198,67 @@ describe("useCloudTaskConfigOptions", () => {
       selector({ oauthAccessToken: null }),
     );
 
-    const result = await renderHook();
+    const result = await renderHook("claude");
 
     expect(
       getModelConfigOption(result.current.configOptions).currentValue,
     ).toBe(DEFAULT_GATEWAY_MODEL);
-    expect(mockGetCloudTaskConfigOptions).not.toHaveBeenCalled();
+    expect(mockGetCloudTaskGatewayModels).not.toHaveBeenCalled();
     expect(result.current.isConfigReady).toBe(true);
   });
 
-  it("makes the shared fallback usable after the live catalog fails", async () => {
-    mockGetCloudTaskConfigOptions.mockRejectedValue(new Error("offline"));
+  it("keeps a model missing from the catalog selectable via a synthetic entry", async () => {
+    mockGetCloudTaskGatewayModels.mockResolvedValue([
+      gatewayModel("claude-sonnet-5"),
+    ]);
 
-    const result = await renderHook();
+    // A gateway blip drops the running model; the picker must still list it so
+    // the user can see what's selected instead of an empty highlight.
+    const result = await renderHook("claude", "claude-fable-legacy");
+    await waitForAssertion(() => {
+      expect(
+        result.current.modelGroups.some((group) =>
+          group.options.some(
+            (option) => option.value === "claude-fable-legacy",
+          ),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("hides Kimi K3 when its flag is off and keeps it when on", async () => {
+    mockGetCloudTaskGatewayModels.mockResolvedValue([
+      gatewayModel("moonshotai/kimi-k3", { owned_by: "modal" }),
+      gatewayModel("claude-sonnet-5"),
+    ]);
+
+    let flagOn = false;
+    mockUseFeatureFlag.mockImplementation(
+      (flag: string) => flag === KIMI_MODEL_FLAG && flagOn,
+    );
+
+    const off = await renderHook("claude");
+    await waitForAssertion(() => {
+      const values = getModelConfigOption(
+        off.current.configOptions,
+      ).options.map((option) => option.value);
+      expect(values).not.toContain("moonshotai/kimi-k3");
+    });
+
+    flagOn = true;
+    const on = await renderHook("claude");
+    await waitForAssertion(() => {
+      const values = getModelConfigOption(on.current.configOptions).options.map(
+        (option) => option.value,
+      );
+      expect(values).toContain("moonshotai/kimi-k3");
+    });
+  });
+
+  it("makes the shared fallback usable after the live catalog fails", async () => {
+    mockGetCloudTaskGatewayModels.mockRejectedValue(new Error("offline"));
+
+    const result = await renderHook("claude");
     await waitForAssertion(() => {
       expect(result.current.isConfigReady).toBe(true);
     });

--- a/products/desktop/apps/mobile/src/features/tasks/hooks/useCloudTaskConfigOptions.ts
+++ b/products/desktop/apps/mobile/src/features/tasks/hooks/useCloudTaskConfigOptions.ts
@@ -1,8 +1,11 @@
 import {
   type Adapter,
   buildCloudTaskConfigOptions,
+  buildProviderModelGroups,
   type CloudTaskConfigOption,
+  type CloudTaskConfigSelectGroup,
   DEEPSEEK_MODEL_FLAG,
+  type GatewayModel,
   GLM_MODEL_FLAG,
   GLM53_FLASH_MODEL_FLAG,
   GLM53_MODEL_FLAG,
@@ -10,72 +13,106 @@ import {
   isGlm53FlashModelId,
   isGlm53ModelId,
   isGlmModelId,
+  isModalModelId,
   isRestrictedModelOption,
+  KIMI_MODEL_FLAG,
 } from "@posthog/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useFeatureFlag } from "posthog-react-native";
+import { useMemo } from "react";
 import { useAuthStore } from "@/features/auth";
 import { getPostHogApiClient } from "@/lib/posthogApiClient";
 
 export const cloudTaskConfigOptionKeys = {
   all: ["cloud-task-config-options"] as const,
-  adapter: (adapter: Adapter) =>
-    [...cloudTaskConfigOptionKeys.all, adapter] as const,
+  models: () => [...cloudTaskConfigOptionKeys.all, "models"] as const,
 };
 
-const fallbackOptionsByAdapter: Record<Adapter, CloudTaskConfigOption[]> = {
-  claude: buildCloudTaskConfigOptions([], "claude"),
-  codex: buildCloudTaskConfigOptions([], "codex"),
-};
+const emptyModels: GatewayModel[] = [];
 
-export function useCloudTaskConfigOptions(adapter: Adapter = "claude") {
+export function useCloudTaskConfigOptions(
+  adapter: Adapter = "claude",
+  currentValue?: string,
+) {
   const oauthAccessToken = useAuthStore((state) => state.oauthAccessToken);
   const glmEnabled = useFeatureFlag(GLM_MODEL_FLAG);
   const glm53Enabled = useFeatureFlag(GLM53_MODEL_FLAG);
   const glm53FlashEnabled = useFeatureFlag(GLM53_FLASH_MODEL_FLAG);
   const deepseekEnabled = useFeatureFlag(DEEPSEEK_MODEL_FLAG);
+  const kimiEnabled = useFeatureFlag(KIMI_MODEL_FLAG);
   const query = useQuery({
-    queryKey: cloudTaskConfigOptionKeys.adapter(adapter),
-    queryFn: () => getPostHogApiClient().getCloudTaskConfigOptions(adapter),
+    queryKey: cloudTaskConfigOptionKeys.models(),
+    queryFn: () => getPostHogApiClient().getCloudTaskGatewayModels(),
     enabled: !!oauthAccessToken,
     staleTime: 5 * 60 * 1000,
   });
-  const configOptions = query.data ?? fallbackOptionsByAdapter[adapter];
-  const isHiddenModel = (value: string) =>
-    (!glm53Enabled && isGlm53ModelId(value)) ||
-    (!glm53FlashEnabled && isGlm53FlashModelId(value)) ||
-    (!glmEnabled &&
-      isGlmModelId(value) &&
-      !isGlm53ModelId(value) &&
-      !isGlm53FlashModelId(value)) ||
-    (!deepseekEnabled && isDeepseekModelId(value));
-  const visibleConfigOptions =
-    glmEnabled && glm53Enabled && glm53FlashEnabled && deepseekEnabled
-      ? configOptions
-      : configOptions.map((option) =>
-          option.category === "model"
-            ? (() => {
-                const options = option.options.filter(
-                  (model) => !isHiddenModel(model.value),
-                );
-                const currentValue = options.some(
-                  (model) =>
-                    model.value === option.currentValue &&
-                    !isRestrictedModelOption(model._meta),
-                )
-                  ? option.currentValue
-                  : (options.find(
-                      (model) => !isRestrictedModelOption(model._meta),
-                    )?.value ?? option.currentValue);
-                return { ...option, currentValue, options };
-              })()
-            : option,
-        );
+  const models = query.data ?? emptyModels;
+  const hasLiveConfig = query.data !== undefined;
+
+  const visibleModels = useMemo(
+    () =>
+      models.filter(
+        (model) =>
+          !(!glm53Enabled && isGlm53ModelId(model.id)) &&
+          !(!glm53FlashEnabled && isGlm53FlashModelId(model.id)) &&
+          !(
+            !glmEnabled &&
+            isGlmModelId(model.id) &&
+            !isGlm53ModelId(model.id) &&
+            !isGlm53FlashModelId(model.id)
+          ) &&
+          !(!deepseekEnabled && isDeepseekModelId(model.id)) &&
+          !(!kimiEnabled && isModalModelId(model.id)),
+      ),
+    [
+      models,
+      glmEnabled,
+      glm53Enabled,
+      glm53FlashEnabled,
+      deepseekEnabled,
+      kimiEnabled,
+    ],
+  );
+
+  const configOptions = useMemo(
+    () =>
+      buildCloudTaskConfigOptions(visibleModels, adapter).map((option) => {
+        if (option.category !== "model") return option;
+        const nextCurrent = option.options.some(
+          (model) =>
+            model.value === option.currentValue &&
+            !isRestrictedModelOption(model._meta),
+        )
+          ? option.currentValue
+          : (option.options.find(
+              (model) => !isRestrictedModelOption(model._meta),
+            )?.value ?? option.currentValue);
+        return { ...option, currentValue: nextCurrent };
+      }),
+    [visibleModels, adapter],
+  );
+
+  const baseModelGroups = useMemo(
+    () => buildProviderModelGroups(visibleModels, adapter),
+    [visibleModels, adapter],
+  );
+
+  // Only rebuild with the synthetic current-value entry when the pick is
+  // absent from the catalog. A same-catalog model change reuses baseModelGroups.
+  const modelGroups = useMemo(() => {
+    if (!currentValue) return baseModelGroups;
+    const present = baseModelGroups.some((group) =>
+      group.options.some((option) => option.value === currentValue),
+    );
+    if (present) return baseModelGroups;
+    return buildProviderModelGroups(visibleModels, adapter, currentValue);
+  }, [baseModelGroups, visibleModels, adapter, currentValue]);
 
   return {
     ...query,
-    configOptions: visibleConfigOptions,
-    hasLiveConfig: query.data !== undefined,
+    configOptions: configOptions as readonly CloudTaskConfigOption[],
+    modelGroups: modelGroups as readonly CloudTaskConfigSelectGroup[],
+    hasLiveConfig,
     isConfigReady:
       !oauthAccessToken || query.data !== undefined || query.isError,
   };

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -16,6 +16,7 @@ import {
   type CloudTaskConfigOption,
   DISMISSAL_REASON_OPTIONS,
   type DismissalReasonOptionValue,
+  type GatewayModel,
   getCloudTaskGatewayUrl,
   isSupportedReasoningEffort,
   normalizeGatewayModelsResponse,
@@ -1762,9 +1763,7 @@ export class PostHogAPIClient {
     return data;
   }
 
-  async getCloudTaskConfigOptions(
-    adapter: Adapter = "claude",
-  ): Promise<CloudTaskConfigOption[]> {
+  async getCloudTaskGatewayModels(): Promise<GatewayModel[]> {
     const teamId = await this.getTeamId();
     const url = new URL(`${getCloudTaskGatewayUrl(this.apiHost)}/v1/models`);
     const response = await this.api.fetcher.fetch({
@@ -1775,8 +1774,14 @@ export class PostHogAPIClient {
         header: buildPosthogProjectHeaderRecord(teamId),
       },
     });
+    return normalizeGatewayModelsResponse(await response.json());
+  }
+
+  async getCloudTaskConfigOptions(
+    adapter: Adapter = "claude",
+  ): Promise<CloudTaskConfigOption[]> {
     return buildCloudTaskConfigOptions(
-      normalizeGatewayModelsResponse(await response.json()),
+      await this.getCloudTaskGatewayModels(),
       adapter,
     );
   }


### PR DESCRIPTION
## Problem

Mobile task creators picked a harness (Claude Code or Codex) before seeing any models, so a Codex-shaped user landed on Claude by default and had to remember to switch first.
Port of #91948, which flipped desktop to model-first: one grouped catalog of every model, and the harness follows the pick.

## Changes

- The advanced model list in the composer sheet now shows every model from both harnesses, grouped by vendor with section headers (Anthropic, OpenAI, then the rest).
- Picking a model from the other harness switches the harness and lands on that harness's default mode and reasoning effort in one step.
- The Harness segmented control is dropped from the sheet — the sheet reads better small, and the harness now follows the model anyway.
- On a live task run (adapter locked) the picker hides the other harness's models, so a same-run pick can't send an invalid model to the session.
- The Faster → Smarter preset scale stays per-harness, driven by the current adapter's `modelConfigOption`; a preset pick keeps the current harness.
- Kimi rollout filtering moves out of both composer call sites and into `useCloudTaskConfigOptions` next to GLM, GLM 5.3, GLM 5.3 Flash, and DeepSeek, so callers just consume the hook's output.
- Mechanical: `useCloudTaskConfigOptions` fetches raw gateway models once (adapter-agnostic) and derives both the per-adapter `configOptions` (mode/effort, presets) and the cross-harness `modelGroups` (picker catalog) via `useMemo`; `getCloudTaskConfigOptions` on the api-client is refactored around a new `getCloudTaskGatewayModels`.
- Mechanical: shared helpers `adapterForModelId`, `buildProviderModelGroups`, `selectOptionHarness` from `@posthog/shared` are reused, not re-implemented.

## How did you test this code?

- `pnpm --filter @posthog/mobile typecheck` — no new type errors.
- `pnpm --filter @posthog/mobile lint` — clean.
- `pnpm --filter @posthog/mobile test` — 612 tests pass.
- `pnpm --filter @posthog/api-client test` — 232 tests pass.
- New / extended tests: cross-harness model pick that swaps adapter, same-harness pick that doesn't, locked-adapter hiding the other harness, a model missing from the catalog staying selectable via the synthetic entry, Kimi flag on/off.
- Not run: interactive on-device verification of the sheet (no simulator in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs cover this composer path.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Ported the desktop change to mobile per the task brief. Skills invoked: `/simplify` on the diff before opening.

Design decisions:
- Dropped the manual Harness segmented control on mobile. The desktop version keeps a Harness row because there's room; the mobile sheet is small and reads better without it once model drives the harness.
- Kept presets per-harness — the Faster → Smarter scale still uses the current adapter's flat `modelConfigOption`, so preset picks never cross the harness boundary.
- Fetched raw gateway models in `useCloudTaskConfigOptions` and derived both views instead of double-fetching per adapter, so a cross-harness pick doesn't wait on a second network round-trip.
- Kept `getCloudTaskConfigOptions` on the api-client as a thin wrapper for backward compatibility.

Not covered:
- No changes to `products/desktop/apps/code`.
- The `packages/api-client` change is minimal: one new method (`getCloudTaskGatewayModels`) and a refactor of the existing method to reuse it.
- Considered folding `resolveCrossHarnessModelSelection` into the shared `resolveCloudComposerAdapterChange`, but that would touch desktop callers; kept the mobile helper local.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*