### PR TITLE
feat(mcp): stamp the vendor header as $mcp_vendor_client

### DIFF
--- a/services/mcp/src/hono/analytics.ts
+++ b/services/mcp/src/hono/analytics.ts
@@ -78,7 +78,7 @@ function buildBaseProperties(
               }
             : {}),
         mcp_runtime: 'hono',
-        mcp_vendor_client: clientIdentity.mcpVendorClient,
+        $mcp_vendor_client: clientIdentity.mcpVendorClient,
         ...buildMCPSessionAnalyticsProperties(state.sessionContext),
     }
     return { properties, groups }
@@ -450,7 +450,7 @@ export function trackAuthFailure(props: RequestProperties, failure: McpAuthFailu
                 $mcp_region: props.region,
                 $mcp_auth_method: classifyAuthMethod(props.apiToken),
                 mcp_runtime: 'hono',
-                mcp_vendor_client: props.mcpVendorClient,
+                $mcp_vendor_client: props.mcpVendorClient,
                 $mcp_auth_failure_reason: failure.reason,
                 ...(failure.status ? { $mcp_auth_status: failure.status } : {}),
                 ...(failure.missingScope ? { $mcp_missing_scope: failure.missingScope } : {}),

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -231,7 +231,7 @@ export class RequestContext {
             $mcp_mode: requestContext.mode,
             $mcp_region: requestContext.region,
             mcp_runtime: 'hono',
-            mcp_vendor_client: requestContext.mcpVendorClient,
+            $mcp_vendor_client: requestContext.mcpVendorClient,
             ...buildMCPSessionAnalyticsProperties(sessionContext),
         }
     }

--- a/services/mcp/tests/hono/analytics.test.ts
+++ b/services/mcp/tests/hono/analytics.test.ts
@@ -104,7 +104,7 @@ describe('Hono MCP analytics contexts', () => {
             $mcp_mode: 'cli',
             $mcp_region: 'us',
             $mcp_auth_method: 'personal_api_key',
-            mcp_vendor_client: 'ClaudeAI',
+            $mcp_vendor_client: 'ClaudeAI',
             mcp_session_client_name: 'claude-code',
             mcp_session_client_version: '1.0',
             mcp_session_protocol_version: '2025-03-26',
@@ -165,7 +165,7 @@ describe('Hono MCP analytics contexts', () => {
             ['$mcp_client_version', 'mcpClientVersion'],
             ['$mcp_protocol_version', 'mcpProtocolVersion'],
             ['$mcp_consumer', 'mcpConsumer'],
-            ['mcp_vendor_client', 'mcpVendorClient'],
+            ['$mcp_vendor_client', 'mcpVendorClient'],
         ] as const)(
             '%s: live value wins when both live and session values are present',
             async (eventProp, contextField) => {
@@ -184,7 +184,7 @@ describe('Hono MCP analytics contexts', () => {
             ['$mcp_client_version', 'mcpClientVersion'],
             ['$mcp_protocol_version', 'mcpProtocolVersion'],
             ['$mcp_consumer', 'mcpConsumer'],
-            ['mcp_vendor_client', 'mcpVendorClient'],
+            ['$mcp_vendor_client', 'mcpVendorClient'],
         ] as const)(
             '%s: falls back to the session-pinned value when the live request has none (the tools/call case)',
             async (eventProp, contextField) => {
@@ -203,7 +203,7 @@ describe('Hono MCP analytics contexts', () => {
             ['$mcp_client_version', 'mcpClientVersion'],
             ['$mcp_protocol_version', 'mcpProtocolVersion'],
             ['$mcp_consumer', 'mcpConsumer'],
-            ['mcp_vendor_client', 'mcpVendorClient'],
+            ['$mcp_vendor_client', 'mcpVendorClient'],
         ] as const)(
             '%s: stays undefined (never an empty string) when both live and session values are absent',
             async (eventProp, contextField) => {
@@ -225,7 +225,7 @@ describe('Hono MCP analytics contexts', () => {
                 $mcp_client_version: '2.0',
                 $mcp_protocol_version: '2025-03-26',
                 $mcp_consumer: 'request-consumer',
-                mcp_vendor_client: 'ClaudeAI',
+                $mcp_vendor_client: 'ClaudeAI',
             })
         })
 

--- a/services/mcp/tests/hono/auth-instrumentation.test.ts
+++ b/services/mcp/tests/hono/auth-instrumentation.test.ts
@@ -92,7 +92,7 @@ describe('MCP auth instrumentation', () => {
             $mcp_auth_status: 401,
             $mcp_auth_method: 'oauth',
             $mcp_client_name: 'claude-ai',
-            mcp_vendor_client: 'ClaudeAI',
+            $mcp_vendor_client: 'ClaudeAI',
         })
         expect(call.properties.$mcp_missing_scope).toBeUndefined()
     })

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -276,7 +276,7 @@ describe('RequestContext', () => {
                 $mcp_client_name: 'Claude Desktop',
                 $mcp_client_version: '2.0',
                 $mcp_consumer: 'request-consumer',
-                mcp_vendor_client: 'ClaudeAI',
+                $mcp_vendor_client: 'ClaudeAI',
                 mcp_session_client_name: 'claude-code',
                 mcp_session_client_version: '1.0',
                 mcp_session_consumer: 'session-consumer',


### PR DESCRIPTION
## Problem

PostHog's own MCP server stamps the `x-anthropic-client` vendor header as a raw non-`$` `mcp_vendor_client` property — a wire key neither SDK emits. Customer servers instrumented with `@posthog/mcp` / `posthog.mcp` emit **`$mcp_vendor_client`**, so dogfood and customer traffic spoke two different schemas for the same signal.

Follow-up to [#93189](https://github.com/PostHog/posthog/pull/93189), which made harness resolution read `$mcp_vendor_client` first (with the old key coalesced for historical rows).

## Change (minimal)

A wire-key rename at the three places the property is stamped — no return-shape changes, no new plumbing, no dependency bump:

- `analytics.ts` — `buildBaseProperties` (rides on `$mcp_initialize`, `$mcp_tool_call`, `$mcp_tools_list`, `$ai_generation`, `$ai_span`) and the `$mcp_auth_failed` capture
- `request-context.ts` — `buildClientProperties` (project/org-switch events)

The value is unchanged: it already passes `sanitizeHeaderValue` (control-char strip, trim, 1000-char cap), which is stricter than the SDK's own header normalization.

**Deliberately not done here:** routing the header through the SDK's `vendorClient` capture argument. That argument only exists from `@posthog/mcp` 0.11.0 and the `@posthog/mcp-analytics` alias pins 0.10.2, so adopting it means a 0.10.2 → 0.11.7 bump — worth doing (long-standing dogfood lag), but a separate change with its own blast radius. The property this PR emits is byte-identical either way.

## Testing

`pnpm vitest run` in `services/mcp` — 2940 tests passed. Test assertions updated with the same key rename.

## Merge order

After [#93189](https://github.com/PostHog/posthog/pull/93189), so the harness SQL already understands the new key when the emitter switches.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*