### PR TITLE
chore(ci): move five master suites from every push to an hourly cron

### DIFF
--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -278,6 +278,35 @@ Most commits land before a PR is marked ready, and drafts can't merge — so hea
 Add `ready_for_review` to the `pull_request` types, and make aggregator "... Tests Pass" jobs treat `skipped` as success so drafts still report.
 Foot-gun: if the job that selects tests is cancelled mid-flight, its `mode` output is empty — normalize empty-mode **on a draft** to `skip`, or the draft grabs the full matrix and serializes the ready run behind it.
 
+## The hourly master lane
+
+The merge queue's `trunk-merge/**` run tests every commit before it lands, so re-running a heavy suite on the master push tests a commit that CI already covered.
+Those suites skip `push` and take their master coverage — and their Trunk flaky-test baseline — from an hourly `schedule:` instead.
+
+Crons are offset so the runs do not all fire at once, and the offsets live here rather than in the workflows:
+
+| Workflow          | Minute |
+| ----------------- | ------ |
+| `ci-frontend.yml` | 7      |
+| `ci-nodejs.yml`   | 13     |
+| `ci-backend.yml`  | 23     |
+| `ci-dagster.yml`  | 33     |
+| `ci-python.yml`   | 43     |
+| `ci-mcp.yml`      | 53     |
+
+Adding a seventh: pick an unused minute, add the row, and keep the gap at ten minutes.
+
+**The paths filter must be skipped on `schedule`, and every output it feeds must default to `true`.**
+On a cron the action has nothing to diff against: it gets no `base` input, so base resolves to the default branch and equals head, and `before` is set only on push events.
+It falls back to the last commit alone, so one docs-only commit narrows the hourly run to nothing and reports green having tested almost nothing — a silent failure, not a red one.
+Guard the step with `if: github.event_name != 'push' && github.event_name != 'schedule'`, and give each consumed output a `|| 'true'` default.
+
+Any _step_ that reads a filter output needs the same `schedule` arm.
+`ci-dagster.yml`'s `build-matrix` is the cautionary case: without it the matrix is `[]` and the hourly run passes having run no tests.
+
+A lane that stops producing runs is invisible to the master-red alerter: it reads run completions, so a dropped cron reads as unreadable and drops out of evaluation rather than paging.
+Add every converted workflow to `SCHEDULED_GATING_WORKFLOWS` in `ci-alerts-devex.yml` in the same change, or its failures stop paging altogether.
+
 ## Backwards-compat with unrebased PRs
 
 A workflow edit hits every open PR the instant it merges (it runs against PR-merged-with-master), but companion changes — a new dependency, file, or config — only reach a branch when it rebases.

--- a/.agents/skills/authoring-ci-workflows/SKILL.md
+++ b/.agents/skills/authoring-ci-workflows/SKILL.md
@@ -296,6 +296,18 @@ Crons are offset so the runs do not all fire at once, and the offsets live here 
 
 Adding a seventh: pick an unused minute, add the row, and keep the gap at ten minutes.
 
+**Give the cron its own concurrency group.**
+`cancel-in-progress` is false outside pull requests, but GitHub still keeps at most one _pending_ run per group, so a newer run replaces an older pending one.
+An hourly run that shares the ref group with master pushes therefore holds the group for its whole duration while pushes queue behind it, and each new push discards the previous pending one along with whatever per-commit checks it carried.
+
+```yaml
+group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'scheduled' || github.head_ref || github.ref }}
+```
+
+That keeps hourly runs queueing behind each other rather than stacking, and leaves push behavior untouched.
+`ci-backend.yml` reaches the same place from the other side: its push arm is already keyed per SHA, so pushes never share a group with the cron.
+Prefer the `'scheduled'` key when the push lane still runs real per-commit work, because a per-SHA push arm also gives up the deduplication that collapses a burst of master pushes into one run.
+
 **The paths filter must be skipped on `schedule`, and every output it feeds must default to `true`.**
 On a cron the action has nothing to diff against: it gets no `base` input, so base resolves to the default branch and equals head, and `before` is set only on push events.
 It falls back to the last commit alone, so one docs-only commit narrows the hourly run to nothing and reports green having tested almost nothing — a silent failure, not a red one.

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -290,6 +290,11 @@ jobs:
               continue-on-error: true
             - uses: ./.depot/actions/paths-filter
               id: filter
+              # No `!= 'schedule'` arm, unlike canonical: this shadow has no `schedule`
+              # trigger (depot-exempt, see the header), so there is no cron run whose
+              # filter could narrow to a single commit. Canonical's reason for the extra
+              # arm is "The hourly master lane" in
+              # .agents/skills/authoring-ci-workflows/SKILL.md.
               if: github.event_name != 'push' # Run all tests on master push
               with:
                   list-files: 'escape'

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -63,7 +63,10 @@ env:
     # evaluated on its own, so a green master-push run can't mask a red scheduled run. Backend CI is
     # split this way: master push runs only the per-commit checks (migrations, OpenAPI types, repo
     # checks), and the test matrices run hourly.
-    SCHEDULED_GATING_WORKFLOWS: 'ci-backend.yml'
+    # Frontend CI is split the same way — jest runs hourly, while typecheck, format and bundle size
+    # stay on every push. Node.js, Dagster, Python and MCP moved their whole suite to the cron, so
+    # their push lane now only proves the run dispatched; the scheduled lane carries the coverage.
+    SCHEDULED_GATING_WORKFLOWS: 'ci-backend.yml,ci-frontend.yml,ci-nodejs.yml,ci-dagster.yml,ci-python.yml,ci-mcp.yml'
     # A scheduled lane produces one run an hour, so it needs its own arms: the push streak of 5
     # would take 5 hours to trip, while the push wall-clock arm of 60 minutes pages on a single
     # flaky run held for one tick. Two red ticks in a row, or red across two ticks, is the honest

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -63,9 +63,9 @@ env:
     # evaluated on its own, so a green master-push run can't mask a red scheduled run. Backend CI is
     # split this way: master push runs only the per-commit checks (migrations, OpenAPI types, repo
     # checks), and the test matrices run hourly.
-    # Frontend CI is split the same way — jest runs hourly, while typecheck, format and bundle size
-    # stay on every push. Node.js, Dagster, Python and MCP moved their whole suite to the cron, so
-    # their push lane now only proves the run dispatched; the scheduled lane carries the coverage.
+    # Frontend CI is split the same way: jest runs hourly, while typecheck, format and bundle size
+    # run on every push. For Node.js, Dagster, Python and MCP the whole suite is on the cron, so
+    # their push lane only proves the run dispatched and the scheduled lane carries the coverage.
     SCHEDULED_GATING_WORKFLOWS: 'ci-backend.yml,ci-frontend.yml,ci-nodejs.yml,ci-dagster.yml,ci-python.yml,ci-mcp.yml'
     # A scheduled lane produces one run an hour, so it needs its own arms: the push streak of 5
     # would take 5 hours to trip, while the push wall-clock arm of 60 minutes pages on a single

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -156,8 +156,9 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               # Skipped on master push and on the hourly schedule: every output then
-              # defaults to true. On schedule the action would otherwise diff only the
-              # last commit and could turn the full-matrix run into a no-op.
+              # defaults to true. See "The hourly master lane" in
+              # .agents/skills/authoring-ci-workflows/SKILL.md for why a cron cannot
+              # diff, and what breaks if this guard is dropped.
               if: github.event_name != 'push' && github.event_name != 'schedule'
               id: filter
               with:

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -5,6 +5,12 @@ on:
         branches:
             - master
     pull_request:
+    schedule:
+        # Hourly run against the newest master state. Master pushes no longer run the
+        # dagster suite per commit — the merge queue's trunk-merge/** run already gated
+        # every commit before it landed — so this is where master's coverage comes from.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '33 * * * *'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -106,7 +112,11 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: every output then
+              # defaults to true. See "The hourly master lane" in
+              # .agents/skills/authoring-ci-workflows/SKILL.md for why a cron cannot
+              # diff, and what breaks if this guard is dropped.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
@@ -233,7 +243,9 @@ jobs:
 
             - name: Read ClickHouse versions from JSON
               id: read-versions
-              if: github.event_name == 'push' || steps.filter.outputs.dagster == 'true'
+              # `schedule` has to be listed explicitly for the same reason as build-matrix
+              # below, which consumes this step's oldest_supported output.
+              if: github.event_name == 'schedule' || steps.filter.outputs.dagster == 'true'
               run: |
                   oldest_supported=$(jq -r '.oldest_supported' .github/clickhouse-versions.json)
                   if [ -z "$oldest_supported" ] || [ "$oldest_supported" = "null" ]; then
@@ -244,7 +256,10 @@ jobs:
 
             - name: Build sharded test matrix
               id: build-matrix
-              if: github.event_name == 'push' || steps.filter.outputs.dagster == 'true'
+              # `schedule` has to be listed explicitly: the paths filter is skipped there,
+              # so steps.filter.outputs.dagster is empty. Without this the matrix would be
+              # [] and the hourly run would report green having run no tests at all.
+              if: github.event_name == 'schedule' || steps.filter.outputs.dagster == 'true'
               env:
                   OLDEST_SUPPORTED: ${{ steps.read-versions.outputs.oldest_supported }}
               run: |
@@ -450,12 +465,15 @@ jobs:
             fail-fast: false
             matrix:
                 include: ${{ fromJson(needs.select-tests.outputs.matrix_include || needs.changes.outputs.matrix_include || '[]') }}
-        # !cancelled() lets this run when select-tests is skipped (master,
+        # !cancelled() lets this run when select-tests is skipped (schedule,
         # merge queue) or failed (fall back to the full matrix); mode 'none'
         # means the diff cannot affect any dagster test, so nothing runs and
         # the merge-queue full suite remains the gate.
+        # Skipped on master push: the merge queue already ran the suite for every
+        # landed commit, and the hourly scheduled run keeps master coverage.
         if: >-
             ${{ !cancelled()
+            && github.event_name != 'push'
             && needs.select-tests.outputs.mode != 'none'
             && (needs.changes.outputs.dagster_direct == 'true'
                 || (needs.changes.outputs.merge_queue == 'true'

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -6,14 +6,19 @@ on:
             - master
     pull_request:
     schedule:
-        # Hourly run against the newest master state. Master pushes no longer run the
-        # dagster suite per commit — the merge queue's trunk-merge/** run already gated
-        # every commit before it landed — so this is where master's coverage comes from.
+        # Where master's coverage for the dagster suite comes from. The merge queue's
+        # trunk-merge/** run gates every commit before it lands, so the push lane does
+        # not repeat it.
         # Offset from the other hourly CI crons so the runs do not all fire at once.
         - cron: '33 * * * *'
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    # The hourly lane gets its own group, so it queues behind itself rather than
+    # behind master pushes. Sharing the ref group would let a slow hourly run hold
+    # the group while pushes pile up pending, and GitHub keeps only the newest
+    # pending run per group — so the older push, and its per-commit checks, would
+    # be dropped.
+    group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'scheduled' || github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -15,18 +15,20 @@ on:
         branches:
             - master
     schedule:
-        # Hourly jest run against the newest master state. Master pushes no longer run
-        # jest per commit — the merge queue's trunk-merge/** run already gated every
-        # commit before it landed — so this is where master's jest coverage and its
-        # Trunk flaky-test baseline come from. Typecheck, format and bundle size stay
-        # on every push, because they are cheap and per-commit meaningful.
+        # Where master's jest coverage and its Trunk flaky-test baseline come from.
+        # The merge queue's trunk-merge/** run gates every commit before it lands, so
+        # the push lane does not repeat the suite. Typecheck, format and bundle size
+        # run on every push instead, being cheap and per-commit meaningful.
         # Offset from the other hourly CI crons so the runs do not all fire at once.
         - cron: '7 * * * *'
 
 concurrency:
-    # Scheduled runs share the ref group with master pushes and do not cancel, so a
-    # slow hourly run queues the next one instead of stacking runs.
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    # The hourly lane gets its own group, so it queues behind itself rather than
+    # behind master pushes. Sharing the ref group would let a slow hourly run hold
+    # the group while pushes pile up pending, and GitHub keeps only the newest
+    # pending run per group — so the older push, and its per-commit checks, would
+    # be dropped.
+    group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'scheduled' || github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -14,8 +14,18 @@ on:
     push:
         branches:
             - master
+    schedule:
+        # Hourly jest run against the newest master state. Master pushes no longer run
+        # jest per commit — the merge queue's trunk-merge/** run already gated every
+        # commit before it landed — so this is where master's jest coverage and its
+        # Trunk flaky-test baseline come from. Typecheck, format and bundle size stay
+        # on every push, because they are cheap and per-commit meaningful.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '7 * * * *'
 
 concurrency:
+    # Scheduled runs share the ref group with master pushes and do not cancel, so a
+    # slow hourly run queues the next one instead of stacking runs.
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -81,7 +91,11 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: every output then
+              # defaults to true. See "The hourly master lane" in
+              # .agents/skills/authoring-ci-workflows/SKILL.md for why a cron cannot
+              # diff, and what breaks if this guard is dropped.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   list-files: 'escape'
@@ -194,11 +208,11 @@ jobs:
             # above is inline YAML — paths-filter takes one or the other. The exclude-only
             # filter is true only when some changed file lives OUTSIDE every excluded dir.
             - name: Derive Node-only product workspace exclusions
-              if: github.event_name != 'push'
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               run: bin/frontend-exclude-filter > "$RUNNER_TEMP/frontend-exclude.yml"
             - uses: ./.github/actions/paths-filter
               id: exclude
-              if: github.event_name != 'push'
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: ${{ runner.temp }}/frontend-exclude.yml
@@ -342,7 +356,9 @@ jobs:
     frontend-format:
         name: Frontend formatting
         needs: changes
-        if: needs.changes.outputs.frontend == 'true'
+        # Not on the hourly cron: that lane exists for jest only, and formatting
+        # already ran on the push that landed each commit.
+        if: needs.changes.outputs.frontend == 'true' && github.event_name != 'schedule'
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -424,7 +440,9 @@ jobs:
     frontend-bundle-size:
         name: Frontend bundle size
         needs: [changes]
-        if: needs.changes.outputs.frontend_code == 'true'
+        # Not on the hourly cron: the vs-base comparison build is pull_request-only,
+        # so a cron run measures an absolute size with nothing to compare it against.
+        if: needs.changes.outputs.frontend_code == 'true' && github.event_name != 'schedule'
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -672,7 +690,9 @@ jobs:
     frontend-typescript-checks:
         name: Frontend typechecking
         needs: [changes]
-        if: needs.changes.outputs.frontend_code == 'true'
+        # Not on the hourly cron: that lane exists for jest only, and typechecking
+        # already ran on the push that landed each commit.
+        if: needs.changes.outputs.frontend_code == 'true' && github.event_name != 'schedule'
         # tsgo peaks ~12 GB type-checking the whole frontend, which OOM-kills it on a 16 GB
         # runner (ubuntu-latest and depot-ubuntu-24.04-4 alike). Peak tracks the type graph,
         # not parallelism or lib checking: skipLibCheck is already on, GOMAXPROCS and
@@ -769,9 +789,13 @@ jobs:
         # A status function is required because select-jest-tests is skipped on ready
         # PRs and master pushes, and a skipped need would otherwise cascade a skip here.
         # !cancelled() rather than always() so a superseded run's shards stop promptly.
+        # Skipped on master push: the merge queue already ran the full matrix for every
+        # landed commit, and the hourly scheduled run keeps master's jest coverage and
+        # its Trunk flaky baseline.
         if: |
             !cancelled() && needs.changes.outputs.frontend_code == 'true'
             && needs.select-jest-tests.outputs.should_run != 'false'
+            && github.event_name != 'push'
         name: Jest test (${{ matrix.segment }} - ${{ matrix.chunk }})
         strategy:
             # If one test fails, still run the others
@@ -779,8 +803,9 @@ jobs:
             # On draft PRs, select-jest-tests may narrow this to two jobs
             # running only the tests reachable from changed frontend source files,
             # or skip jest entirely (should_run=false) when selection can't be
-            # trusted. On ready PRs and master pushes it's skipped, so
-            # we fall back to the full four-chunk fanout (the merge gate).
+            # trusted. On ready PRs and the hourly scheduled run it's skipped, so
+            # we fall back to the full four-chunk fanout. Master pushes do not
+            # reach here at all (see the `if` above).
             # `segment` is a single fixed value: it survives only as the naming
             # token for job, JUnit file and artifact, which the timings reporter
             # parses as `junit-results-frontend-<segment>-<chunk>`. There used to

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -12,15 +12,19 @@ on:
         # No labeled/unlabeled triggers here, so it takes effect from the next push.
         types: [opened, synchronize, reopened, ready_for_review]
     schedule:
-        # Hourly run against the newest master state. Master pushes no longer run the
-        # build, unit or integration tests per commit — the merge queue's trunk-merge/**
-        # run already gated every commit before it landed — so this is where master's
-        # coverage comes from.
+        # Where master's coverage for the build, unit and integration tests comes from.
+        # The merge queue's trunk-merge/** run gates every commit before it lands, so
+        # the push lane does not repeat them.
         # Offset from the other hourly CI crons so the runs do not all fire at once.
         - cron: '53 * * * *'
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    # The hourly lane gets its own group, so it queues behind itself rather than
+    # behind master pushes. Sharing the ref group would let a slow hourly run hold
+    # the group while pushes pile up pending, and GitHub keeps only the newest
+    # pending run per group — so the older push, and its per-commit checks, would
+    # be dropped.
+    group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'scheduled' || github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -6,10 +6,18 @@ on:
     pull_request:
         # Draft PRs run build + unit tests only; the integration tests (which boot
         # the full PostHog backend and trigger on any non-pytest Python change) run
-        # when the PR is marked ready for review; that full run is the merge gate.
+        # when the PR is marked ready for review. The merge queue's trunk-merge/**
+        # run is the gate.
         # The `no-ci` label silences this workflow on a draft entirely (prototypes).
         # No labeled/unlabeled triggers here, so it takes effect from the next push.
         types: [opened, synchronize, reopened, ready_for_review]
+    schedule:
+        # Hourly run against the newest master state. Master pushes no longer run the
+        # build, unit or integration tests per commit — the merge queue's trunk-merge/**
+        # run already gated every commit before it landed — so this is where master's
+        # coverage comes from.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '53 * * * *'
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -30,7 +38,8 @@ jobs:
         timeout-minutes: 5
         # A draft PR labeled `no-ci` skips this workflow entirely (prototypes):
         # every other job needs this one, and the gates treat skipped as success.
-        # ready_for_review re-runs everything, so the merge gate is unaffected.
+        # The merge queue's trunk-merge/** run is the gate, so skipping a draft
+        # never weakens what protects master.
         if: >-
             github.event_name != 'pull_request'
             || github.event.pull_request.draft != true
@@ -56,7 +65,11 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: every output then
+              # defaults to true. See "The hourly master lane" in
+              # .agents/skills/authoring-ci-workflows/SKILL.md for why a cron cannot
+              # diff, and what breaks if this guard is dropped.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
@@ -142,7 +155,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         needs: changes
-        if: needs.changes.outputs.mcp == 'true'
+        # Not on master push — master coverage comes from the hourly run (see `schedule`).
+        if: needs.changes.outputs.mcp == 'true' && github.event_name != 'push'
 
         steps:
             - name: Checkout code
@@ -223,7 +237,8 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         needs: changes
-        if: needs.changes.outputs.mcp == 'true'
+        # Not on master push — master coverage comes from the hourly run (see `schedule`).
+        if: needs.changes.outputs.mcp == 'true' && github.event_name != 'push'
         steps:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -306,8 +321,11 @@ jobs:
         # Skipped on drafts: these boot the full PostHog backend and trigger on any
         # non-pytest Python change, so they're the expensive half of this workflow.
         # Build and unit tests still run on drafts; the `MCP Tests Pass` aggregator
-        # treats skipped as success, and the ready-for-review run is the merge gate.
-        if: needs.changes.outputs.mcp == 'true' && (github.event.pull_request.draft != true || startsWith(github.head_ref, 'trunk-merge/'))
+        # treats skipped as success, and the merge queue's trunk-merge/** run is the gate.
+        # Not on master push either — see the hourly `schedule` trigger.
+        if: >-
+            needs.changes.outputs.mcp == 'true' && github.event_name != 'push'
+            && (github.event.pull_request.draft != true || startsWith(github.head_ref, 'trunk-merge/'))
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -4,6 +4,12 @@ on:
     push:
         branches:
             - master
+    schedule:
+        # Hourly run against the newest master state. Master pushes no longer run the
+        # Node.js checks per commit — the merge queue's trunk-merge/** run already gated
+        # every commit before it landed — so this is where master's coverage comes from.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '13 * * * *'
 
 env:
     OBJECT_STORAGE_ENABLED: true
@@ -49,7 +55,11 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY }}
             - uses: ./.github/actions/paths-filter
               id: filter
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: the decision step below
+              # treats both as "run everything". See "The hourly master lane" in
+              # .agents/skills/authoring-ci-workflows/SKILL.md for why a cron cannot
+              # diff, and what breaks if this guard is dropped.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   filters: |
@@ -95,14 +105,18 @@ jobs:
                         - '.github/actions/rust-compute-affected/**'
 
             - name: Install rust for affected-crate detection
-              if: github.event_name != 'push' && steps.filter.outputs.rust == 'true'
+              # Not needed on schedule either: the decision step below already returns
+              # nodejs=true there without consulting the affected-crate set.
+              if: github.event_name != 'push' && github.event_name != 'schedule' && steps.filter.outputs.rust == 'true'
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
 
             - name: Compute affected Rust crates
               id: rust-affected
-              if: github.event_name != 'push' && steps.filter.outputs.rust == 'true'
+              # Not needed on schedule either: the decision step below already returns
+              # nodejs=true there without consulting the affected-crate set.
+              if: github.event_name != 'push' && github.event_name != 'schedule' && steps.filter.outputs.rust == 'true'
               uses: ./.github/actions/rust-compute-affected
               with:
                   event-name: ${{ github.event_name }}
@@ -118,7 +132,10 @@ jobs:
                   RUST_AFFECTED_CRATES: ${{ steps.rust-affected.outputs.crates }}
                   RUST_NODE_E2E_CRATES: '["ingestion-consumer"]'
               run: |
-                  if [ "${{ github.event_name }}" = "push" ]; then
+                  # `schedule` alongside `push`: the paths filter is skipped on both, so
+                  # NODEJS_CHANGED is empty there. Without this the hourly run would decide
+                  # nodejs=false and report green having run no tests at all.
+                  if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "schedule" ]; then
                     echo "nodejs=true" >> "$GITHUB_OUTPUT"
                     exit 0
                   fi
@@ -143,7 +160,8 @@ jobs:
                   echo "nodejs=false" >> "$GITHUB_OUTPUT"
 
     lint:
-        if: needs.changes.outputs.nodejs == 'true'
+        # Not on master push — master coverage comes from the hourly run (see `schedule`).
+        if: needs.changes.outputs.nodejs == 'true' && github.event_name != 'push'
         name: Node.js Code quality (depot-ubuntu-24.04)
         needs: changes
         runs-on: depot-ubuntu-24.04
@@ -208,7 +226,8 @@ jobs:
                         fi
 
     build:
-        if: needs.changes.outputs.nodejs == 'true'
+        # Not on master push — master coverage comes from the hourly run (see `schedule`).
+        if: needs.changes.outputs.nodejs == 'true' && github.event_name != 'push'
         name: Node.js Build (depot-ubuntu-24.04)
         needs: changes
         runs-on: depot-ubuntu-24.04
@@ -270,7 +289,8 @@ jobs:
                   fi
 
     tests:
-        if: needs.changes.outputs.nodejs == 'true'
+        # Not on master push — master coverage comes from the hourly run (see `schedule`).
+        if: needs.changes.outputs.nodejs == 'true' && github.event_name != 'push'
         name: Node.js ${{ matrix.lane }} Tests ${{ matrix.shard }}/${{ matrix.shard_count }} (depot-ubuntu-24.04-4)
         needs: changes
         runs-on: depot-ubuntu-24.04-4
@@ -592,7 +612,8 @@ jobs:
                   docker compose -f docker-compose.dev.yml exec clickhouse cat /var/log/clickhouse-server/clickhouse-server.err.log
 
     rust_ingestion_e2e:
-        if: needs.changes.outputs.nodejs == 'true'
+        # Not on master push — master coverage comes from the hourly run (see `schedule`).
+        if: needs.changes.outputs.nodejs == 'true' && github.event_name != 'push'
         name: Rust ingestion consumer Node API e2e (depot-ubuntu-24.04-4)
         needs: changes
         runs-on: depot-ubuntu-24.04-4

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -5,9 +5,9 @@ on:
         branches:
             - master
     schedule:
-        # Hourly run against the newest master state. Master pushes no longer run the
-        # Node.js checks per commit — the merge queue's trunk-merge/** run already gated
-        # every commit before it landed — so this is where master's coverage comes from.
+        # Where master's coverage for the Node.js checks comes from. The merge queue's
+        # trunk-merge/** run gates every commit before it lands, so the push lane does
+        # not repeat them.
         # Offset from the other hourly CI crons so the runs do not all fire at once.
         - cron: '13 * * * *'
 
@@ -23,7 +23,12 @@ env:
     RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    # The hourly lane gets its own group, so it queues behind itself rather than
+    # behind master pushes. Sharing the ref group would let a slow hourly run hold
+    # the group while pushes pile up pending, and GitHub keeps only the newest
+    # pending run per group — so the older push, and its per-commit checks, would
+    # be dropped.
+    group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'scheduled' || github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -6,9 +6,9 @@ on:
             - master
     pull_request:
     schedule:
-        # Hourly run against the newest master state. Master pushes no longer run the
-        # checks per commit — the merge queue's trunk-merge/** run already gated every
-        # commit before it landed — so this is where master's coverage comes from.
+        # Where master's coverage for these checks comes from. The merge queue's
+        # trunk-merge/** run gates every commit before it lands, so the push lane does
+        # not repeat them.
         # Offset from the other hourly CI crons so the runs do not all fire at once.
         - cron: '43 * * * *'
 
@@ -17,7 +17,12 @@ permissions:
     pull-requests: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    # The hourly lane gets its own group, so it queues behind itself rather than
+    # behind master pushes. Sharing the ref group would let a slow hourly run hold
+    # the group while pushes pile up pending, and GitHub keeps only the newest
+    # pending run per group — so the older push, and its per-commit checks, would
+    # be dropped.
+    group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && 'scheduled' || github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -5,6 +5,12 @@ on:
         branches:
             - master
     pull_request:
+    schedule:
+        # Hourly run against the newest master state. Master pushes no longer run the
+        # checks per commit — the merge queue's trunk-merge/** run already gated every
+        # commit before it landed — so this is where master's coverage comes from.
+        # Offset from the other hourly CI crons so the runs do not all fire at once.
+        - cron: '43 * * * *'
 
 permissions:
     contents: read
@@ -45,7 +51,11 @@ jobs:
                   # This workflow opts in for the whole repository. It runs on every pull
                   # request, so one wiring covers every shape the comparison needs to see.
                   PATHS_FILTER_SHADOW_POSTHOG_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
-              if: github.event_name != 'push' # Run all tests on master push
+              # Skipped on master push and on the hourly schedule: every output then
+              # defaults to true. See "The hourly master lane" in
+              # .agents/skills/authoring-ci-workflows/SKILL.md for why a cron cannot
+              # diff, and what breaks if this guard is dropped.
+              if: github.event_name != 'push' && github.event_name != 'schedule'
               with:
                   token: ${{ steps.app-token.outputs.token || github.token }}
                   list-files: 'escape'
@@ -95,7 +105,9 @@ jobs:
 
     code-quality:
         needs: changes
-        if: needs.changes.outputs.python == 'true'
+        # Skipped on master push: the merge queue already ran this for every landed
+        # commit, and the hourly scheduled run keeps master coverage.
+        if: needs.changes.outputs.python == 'true' && github.event_name != 'push'
         timeout-minutes: 30
 
         name: Python code quality (depot-ubuntu-24.04)


### PR DESCRIPTION
## Problem

Nobody sees a difference, but the DevEx budget does: five CI workflows re-test every commit on master after the merge queue already tested it.

The queue's `trunk-merge/**` run is the merge gate, and it runs everything against the same tree before the commit lands. The master push then runs the whole suite again. Backend CI stopped paying for that in [#90195](https://github.com/PostHog/posthog/pull/90195); jest, Node.js, Dagster, Python and MCP still do.

## Changes

**Master coverage for five workflows moves from every push to an hourly cron.**

- Jest, Node.js, Dagster, Python and MCP now run hourly and skip the master push.
- Frontend keeps typecheck, format and bundle size on every push. They are cheap and per-commit meaningful, so only jest moves.
- All five join `SCHEDULED_GATING_WORKFLOWS` in `ci-alerts-devex.yml`, in this same PR. That lane is what pages on a red scheduled run.
- Crons are staggered so six hourly runs do not fan out into one dispatch window: frontend `:07`, Node.js `:13`, backend `:23`, Dagster `:33`, Python `:43`, MCP `:53`.
- The cron gets its own concurrency group, so it never holds the group that master pushes queue in. Without this a slow hourly run makes each new push discard the previous pending one, and on Frontend CI that pending run carries typecheck, format and bundle size.
- The `authoring-ci-workflows` skill gains a section on the lane, so a seventh workflow picks its minute without re-deriving the spacing. Documentation only.

Nothing a PostHog user sees changes. No PR-side behavior changes either: this PR only removes work from the master push and adds the cron.

Before:

```mermaid
flowchart LR
    PR[Pull request] --> Queue[Merge queue<br/>trunk-merge/**]
    Queue --> Landed[Commit on master]
    Landed --> Push[Master push run]
    Push --> Suite[Full suite, again]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class PR phYellow;
    class Queue,Push phBlue;
    class Landed,Suite phGray;
```

After:

```mermaid
flowchart LR
    PR[Pull request] --> Queue[Merge queue<br/>trunk-merge/**]
    Queue --> Landed[Commit on master]
    Landed --> Push[Master push run]
    Push --> Cheap[Per-commit checks only]
    Cron[Hourly cron] --> Hourly[Full suite against<br/>newest master]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class PR,Cron phYellow;
    class Queue,Push phBlue;
    class Landed,Cheap,Hourly phGray;
```

### Size the saving off the executed rate, not the push rate

Master push runs share one concurrency group per workflow, and GitHub keeps at most one pending run per group, so a burst collapses to the newest. Sampling ci-frontend over 2.7 hours: 50 master-push runs, **12 executed, 38 cancelled while pending**. That is roughly 4.4 executed runs an hour.

Measured job-minutes per *executed* master-push run, which is what each cron replaces:

| Workflow          | Job-min | Jobs |
| ----------------- | ------- | ---- |
| Frontend (jest)   | 59      | 16   |
| Dagster           | 82      | 6    |
| MCP               | 41      | 5    |
| Node.js           | 35      | 10   |
| Python            | 7       | 3    |

> [!WARNING]
> Four silent failure modes came up. None would have failed loudly; each produces a green run that tested less than it looks.
> **Dagster** builds its shard matrix in a step gated on `push` or the paths filter, and reads ClickHouse versions the same way. On `schedule` both would skip, leaving an empty matrix.
> **Node.js** decides `nodejs=true` from the same kind of push-only branch, and would have answered false on the cron.
> **The shared concurrency group** let the cron and master pushes contend. `cancel-in-progress` is false outside pull requests, but GitHub keeps at most one pending run per group, so the newest push replaces the older pending one and takes its per-commit checks with it. Caught in review by Greptile.
> **The paths filter** is skipped on `schedule` in all five, so its outputs fall back to `true`. Left as-is the action has nothing to diff against on a cron: no `base` input, so base resolves to the default branch and equals head, and `before` is push-only. It falls back to the last commit alone, so a docs-only commit at the head of master would narrow the hourly run to nothing.

### What is deliberately not changed

- **Storybook** — its master push sets `VR_PURPOSE: observe`, recording Visual Review baseline drift per commit. An hourly run would attribute drift to a batch of commits.
- **Playwright E2E on master** — same baseline role, already excluded from #90195 for it.
- **Rust** — master builds are incremental and already deduplicated. An hourly rebuild-all would be a wash.
- **Hog** — `release-hogvm` publishes a new HogVM TypeScript version from the master push, keyed off `hog-tests` outputs. Gating that off push would stop those releases.
- **Security** — nine per-language filters plus `semgrep --baseline-commit`, so it only reports on changed lines.

## How did you test this code?

No new automated tests. The change is workflow triggers and job conditions, which this repo covers with linters rather than unit tests.

- `bin/hogli lint:workflows` passes, 8 checks across 131 workflows.
- `actionlint` reports no new findings on the seven touched workflows.
- `bin/hogli ci:preflight --strict` passes, including the `.depot` shadow-drift check.

Not checked, and worth knowing before merge:

- No cron has fired. The first hourly run after merge is the real test, and the scheduled alert lanes have no baseline until then.
- The alerter reads run completions, so a lane whose cron stops firing goes unreadable and drops out of evaluation rather than paging. Cron reliability was measured at about five of six due hours on 31 Aug, with one two-hour gap, against the lane's six-hour staleness bound. That margin is not instrumented, and a "lane produced no runs in six hours" arm would close it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The `authoring-ci-workflows` skill is updated in this PR. No user-facing docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code. Skills invoked: `/authoring-ci-workflows`, `/stacking-prs`, `/writing-pr-descriptions`.

This is the bottom layer of a two-PR stack split out of [#91749](https://github.com/PostHog/posthog/pull/91749), which combined this cadence change with a set of PR-side test selectors. The split follows the risk seam rather than the file seam: this half has a precedent already running on master since 28 Aug, and one hard coupling that punishes splitting further, because `ci-alerts-devex.yml` must land with the crons or a workflow's failures stop paging. Splitting it per workflow would put five diffs on the same `SCHEDULED_GATING_WORKFLOWS` line.

Candidates came from measuring per-workflow cost through the GitHub Actions API rather than reading the YAML. That produced the concurrency-dedup finding, which cut the estimated saving by about 4x and is why it is stated up front. Storybook looked identical to jest in a summary table until `VR_PURPOSE` turned up, and Hog came off the list after finding `release-hogvm`.
