### PR TITLE
feat(experiments): show activation event in metric form exposure banner

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -41,7 +41,7 @@ import {
     ExperimentRatioMetricOutlierHandling,
 } from './ExperimentMetricOutlierHandling'
 import { ExperimentMetricThreshold, isThresholdAvailableForMath } from './ExperimentMetricThreshold'
-import { EXPOSURE_DEFAULT_EVENT, isDefaultExposureConfig } from './exposureContract'
+import { EXPOSURE_DEFAULT_EVENT, getActivationConfig, isDefaultExposureConfig } from './exposureContract'
 import { filterToMetricConfig, filterToMetricSource } from './metricQueryUtils'
 import { createFilterForSource, getFilter } from './metricQueryUtils'
 import { commonActionFilterProps } from './Metrics/Selectors'
@@ -281,6 +281,8 @@ export function ExperimentMetricForm({
 
     const hideDeleteBtn = (_: any, index: number): boolean => index === 0
 
+    const activationConfig = getActivationConfig(exposureCriteria)
+
     return (
         <SceneContent>
             <SceneSection title={isSharedMetric ? 'Shared metric type' : 'Metric type'} className="max-w-prose">
@@ -313,6 +315,12 @@ export function ExperimentMetricForm({
                             <>
                                 Counts only after exposure event{' '}
                                 <LemonTag>{getExposureCriteriaLabel(exposureCriteria, resolvedExposureEvent)}</LemonTag>
+                                {activationConfig && (
+                                    <>
+                                        and activation event{' '}
+                                        <LemonTag>{getExposureConfigDisplayName(activationConfig)}</LemonTag>
+                                    </>
+                                )}
                             </>
                         ) : (
                             <>


### PR DESCRIPTION
## Problem

The metric form banner says a metric counts only after the exposure event, even when an activation event also gates it.
Users on the activation event feature (behind the `experiment-activation-event` flag) see metric setup that ignores half of their exposure criteria.

## Changes

- The banner now reads "Counts only after exposure event `<event>` and activation event `<event>`" when an activation event is set.
- `getActivationConfig` decides visibility, so a custom exposure event (which disables activation) keeps the old text. This matches the exposures card and needs no flag check.
- No screenshot: the form was not rendered in a running app. The change adds the words "and activation event" plus one tag to the existing banner.

<img width="560" height="122" alt="Screenshot 2026-09-02 at 13 47 37" src="https://github.com/user-attachments/assets/cb798450-6ecf-4541-ae30-a1b28c78cc21" />

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` and `fix` pass locally.
- Not run: manual rendering. The gating logic itself is covered by the existing `exposureContract.test.ts`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, the feature is still behind a flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code ([session](https://claude.ai/code/session_012feia3V7DmWYrUccDABGtx)). Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions. The banner reuses `getActivationConfig` and `getExposureConfigDisplayName` instead of adding a `useFeatureFlag` check, so an existing activation config stays visible for teams unflagged later, consistent with `Exposures.tsx`.
