### PR TITLE
fix(signals): remove inbox report menu edge shadow

### DIFF
--- a/products/signals/frontend/inbox/components/cards/ReportContextMenu.tsx
+++ b/products/signals/frontend/inbox/components/cards/ReportContextMenu.tsx
@@ -199,7 +199,9 @@ function ReportContextMenuItems({
     // behavior), so the link actions a person expects there come back as menu items.
     const browserLinkItems = (
         <>
-            <ContextMenuSeparator />
+            {/* This separator sits outside a padded menu group. Its default negative margin sets
+                horizontal overflow on ScrollableShadows and adds a shadow to the menu's right edge. */}
+            <ContextMenuSeparator className="mx-0" />
             <ContextMenuGroup>
                 <ContextMenuItem asChild>
                     <ButtonPrimitive


### PR DESCRIPTION
## Problem

People who open a report's context menu see an unintended shadow along its right edge.

## Changes

- Report context menus no longer show the inner right-edge shadow.
- The link-section divider now stays inside the menu's scroll width.

| Before | After |
| --- | --- |
| ![Report context menu before the fix](https://raw.githubusercontent.com/PostHog/pr-assets/d9760fa22f89b74cf4b0732c09e1cabb0b0ada34/2026/09/ea87ccbe-0cf9-4e26-a49e-3ab1e0d71df7.png) | ![Report context menu after the fix](https://raw.githubusercontent.com/PostHog/pr-assets/1fff798630963a03f6f3fee21749ed261ec940b3/2026/09/4c954efb-aeb9-4f14-a41c-b40a2307ea13.png) |

## How did you test this code?

- The focused menu test covers existing action and status behavior.
- The full frontend TypeScript check reports no errors.
- Storybook confirms that the menu loses horizontal overflow after a right-click.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This change only removes a visual artifact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and visually verified this small UI fix in an isolated worktree.

Skills: `/run-posthog`, `/writing-code-comments`, `/writing-pr-descriptions`, and Browser control.