### PR TITLE
refactor(rbac): derive queryset block/allow sets from the object row decision

### DIFF
--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -1133,7 +1133,7 @@ class UserAccessControl:
         filters = self._access_controls_filters_for_queryset(resource)
         access_controls = self._get_access_controls(filters)
 
-        decision = self._blocked_and_allowed_object_ids(access_controls)
+        decision = self._blocked_and_allowed_object_ids(resource, access_controls)
 
         # Apply filtering logic based on resource-level access
         if not self.has_resource_access(resource):
@@ -1153,48 +1153,33 @@ class UserAccessControl:
 
         return queryset
 
-    def _blocked_and_allowed_object_ids(self, access_controls: list[_AccessControl]) -> ObjectAccessDecision:
-        """Canonical object-level decision over a pool of object access controls (rows with
-        `resource_id` set), returning an ObjectAccessDecision of blocked and allowed ids.
+    def _blocked_and_allowed_object_ids(
+        self, resource: APIScopeObject, access_controls: list[_AccessControl]
+    ) -> ObjectAccessDecision:
+        """Decide the blocked and the allowed object ids from a pool of object rows
+        (rows with `resource_id` set).
 
-        Explicit-wins: if a resource_id has any explicit (role/member) rule, the object is
-        allowed when any explicit rule grants non-"none", otherwise blocked. With no explicit
-        rule, the object is blocked only when every default rule is "none".
+        Each object's rows resolve through `_object_rows_decision`, the same step the
+        object walk uses:
 
-        Reads the `role_id` / `organization_member_id` columns rather than the `.role` /
-        `.organization_member` FK accessors — equivalent result (id is None iff the relation is
-        None) without firing a query per row.
+        - decides "none": blocked, hidden from lists.
+        - explicit (member or role) grant: allowed, listed even without resource access.
+        - default grant: ignored here, because legacy precedence puts resource rules
+          above an object's default rules.
         """
-        resource_id_access_levels: dict[str, list[str]] = {}
+        rows_by_object_id: dict[str, list[_AccessControl]] = defaultdict(list)
         for access_control in access_controls:
-            resource_id_access_levels.setdefault(access_control.resource_id, []).append(access_control.access_level)
+            rows_by_object_id[access_control.resource_id].append(access_control)
 
         blocked_resource_ids: set[str] = set()
         allowed_resource_ids: set[str] = set()
 
-        for resource_id, access_levels in resource_id_access_levels.items():
-            # Get the access controls for this specific resource_id to check role/member
-            resource_access_controls = [ac for ac in access_controls if ac.resource_id == resource_id]
-
-            # Only consider access controls that have explicit role or member (not defaults)
-            explicit_access_controls = [
-                ac for ac in resource_access_controls if ac.role_id is not None or ac.organization_member_id is not None
-            ]
-
-            if not explicit_access_controls:
-                if all(access_level == NO_ACCESS_LEVEL for access_level in access_levels):
-                    blocked_resource_ids.add(resource_id)
-                # No explicit controls for this object - don't block it
-                continue
-
-            # Check if user has any non-"none" access to this specific object
-            has_specific_access = any(ac.access_level != NO_ACCESS_LEVEL for ac in explicit_access_controls)
-
-            if has_specific_access:
-                allowed_resource_ids.add(resource_id)
-            else:
-                # All explicit access levels are "none" - block this object
+        for resource_id, rows in rows_by_object_id.items():
+            row = self._object_rows_decision(resource, rows)
+            if row.access_level == NO_ACCESS_LEVEL:
                 blocked_resource_ids.add(resource_id)
+            elif self._row_subject(row) != "default":
+                allowed_resource_ids.add(resource_id)
 
         return ObjectAccessDecision(
             blocked_ids=frozenset(blocked_resource_ids), allowed_ids=frozenset(allowed_resource_ids)
@@ -1223,7 +1208,7 @@ class UserAccessControl:
 
         result: dict[APIScopeObject, frozenset[str]] = {}
         for resource, acs in object_rows_by_resource.items():
-            blocked = self._blocked_and_allowed_object_ids(acs).blocked_ids
+            blocked = self._blocked_and_allowed_object_ids(resource, acs).blocked_ids
             if blocked:
                 result[resource] = blocked
         return result
@@ -1255,7 +1240,7 @@ class UserAccessControl:
 
         result: dict[APIScopeObject, frozenset[str]] = {}
         for resource, acs in object_rows_by_resource.items():
-            allowed = self._blocked_and_allowed_object_ids(acs).allowed_ids
+            allowed = self._blocked_and_allowed_object_ids(resource, acs).allowed_ids
             if allowed and not self.has_resource_access(resource):
                 result[resource] = allowed
         return result
@@ -1488,6 +1473,20 @@ class UserAccessControl:
             return "role"
         return "default"
 
+    @staticmethod
+    def _object_rows_decision(resource: APIScopeObject, rows: list[_AccessControl]) -> _AccessControl:
+        """Select the deciding row from one object's own rows, before any resource-level fallback.
+
+        Explicit-wins: when the object has any explicit (member or role) row, the highest
+        explicit row decides. Otherwise the highest default row decides. `rows` must be
+        non-empty.
+
+        Shared by the object walk and `_blocked_and_allowed_object_ids` so the per-object
+        checks and the queryset filters cannot drift.
+        """
+        explicit_rows = [ac for ac in rows if ac.role_id is not None or ac.organization_member_id is not None]
+        return UserAccessControl._highest_access_from_rows(resource, explicit_rows or rows)
+
     def _object_access_level_from_rows(
         self,
         resource: APIScopeObject,
@@ -1506,7 +1505,7 @@ class UserAccessControl:
             ac for ac in object_access_controls if ac.role_id is not None or ac.organization_member_id is not None
         ]
         if explicit_rows:
-            row = self._highest_access_from_rows(resource, explicit_rows)
+            row = self._object_rows_decision(resource, object_access_controls)
             return ResolvedAccess(
                 access_level=row.access_level,
                 source="object",


### PR DESCRIPTION
## Problem

The legacy queryset filter decides which objects lists hide or show with its own inlined heuristic, separate from the per-object walk. Two private copies of "which row decides for an object" can drift, and the mode switch in #93251 needs the list path to branch on one function. 

## Changes

- Extracts the legacy object row decision into `_object_rows_decision`: explicit (member or role) rows decide at the highest level, default rows only when no explicit row exists.
- `_blocked_and_allowed_object_ids` and the explicit branch of `_object_access_level_from_rows` now share it, so per-object checks and queryset filters cannot drift.
- Behavior-preserving: blocked and allowed id sets come out identical for every input the old heuristic handled.


### Legacy resolution, before this PR

Entry points in yellow, resolvers over rows in blue, decision primitives in gray.

```mermaid
flowchart TD
    GUAL["get_user_<br/>access_level"] --> OALFR["_object_access_<br/>level_from_rows"]
    BULK["bulk_object_<br/>access_levels"] --> OALFR
    OALFR -->|"explicit rows,<br/>default rows"| HAFR["_highest_access_<br/>from_rows"]
    OALFR -->|resource rung| ALFR["access_level_<br/>for_resource"]
    ALFR --> HAFR
    FQ["filter_queryset_<br/>by_access_level"] --> BAO["_blocked_and_<br/>allowed_object_ids"]
    BAO -->|"inline explicit-wins<br/>heuristic"| BAO

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class GUAL,BULK,ALFR,FQ phYellow;
    class OALFR,BAO phBlue;
    class HAFR phGray;
```

### Legacy resolution, after this PR

The object walk and the queryset filter share `_object_rows_decision`. The inline heuristic is gone.

```mermaid
flowchart TD
    GUAL["get_user_<br/>access_level"] --> OALFR["_object_access_<br/>level_from_rows"]
    BULK["bulk_object_<br/>access_levels"] --> OALFR
    OALFR -->|explicit rows| ORD["_object_rows_<br/>decision"]
    OALFR -->|default rows| HAFR["_highest_access_<br/>from_rows"]
    OALFR -->|resource rung| ALFR["access_level_<br/>for_resource"]
    ALFR --> HAFR
    FQ["filter_queryset_<br/>by_access_level"] --> BAO["_blocked_and_<br/>allowed_object_ids"]
    BAO -->|per object| ORD
    ORD --> HAFR

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class GUAL,BULK,ALFR,FQ phYellow;
    class OALFR,BAO phBlue;
    class ORD,HAFR phGray;
```

`_object_rows_decision` is the legacy twin of `_most_specific_rows_decision` from #93248. 
#93251 branches between the two per organization.

## How did you test this code?

- `test_user_access_control.py`, `test_user_access_control_pbt.py` (the legacy-resolution oracle suite), and `test_access_control.py` pass locally.
- No new tests: the PBT oracles already pin the block/allow semantics this refactor must preserve.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.