### PR TITLE
feat(rbac): enforce most-specific access when the org setting is on

### DIFF
--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -536,6 +536,11 @@ class UserAccessControl:
 
         return self._organization.is_feature_available(AvailableFeature.ACCESS_CONTROL)
 
+    @cached_property
+    def _is_most_specific_access_control_enabled(self) -> bool:
+        """True when this organization resolves access most-specific-first (RFC 557)."""
+        return bool(self._organization and self._organization.uses_most_specific_access_resolution)
+
     @property
     def is_organization_admin(self) -> bool:
         """Org owners/admins bypass object- and resource-level access control."""
@@ -918,6 +923,9 @@ class UserAccessControl:
         attached so callers can attribute it.
         """
 
+        if self._is_most_specific_access_control_enabled:
+            return self.resolve_most_specific_resource_access(resource)
+
         # Check if this resource inherits access from a parent resource
         parent_resource = RESOURCE_INHERITANCE_MAP.get(resource)
         if parent_resource:
@@ -1175,6 +1183,16 @@ class UserAccessControl:
         allowed_resource_ids: set[str] = set()
 
         for resource_id, rows in rows_by_object_id.items():
+            if self._is_most_specific_access_control_enabled:
+                # The object has rows, so the resolver decides at the object rung and never
+                # falls back to the resource.
+                access = self._most_specific_object_access_from_rows(resource, rows)
+                if access.access_level == NO_ACCESS_LEVEL:
+                    blocked_resource_ids.add(resource_id)
+                else:
+                    allowed_resource_ids.add(resource_id)
+                continue
+
             row = self._object_rows_decision(resource, rows)
             if row.access_level == NO_ACCESS_LEVEL:
                 blocked_resource_ids.add(resource_id)
@@ -1261,6 +1279,9 @@ class UserAccessControl:
         """
         if self._team is None:
             return True
+        if self._is_most_specific_access_control_enabled:
+            access = self.resolve_most_specific_object_access(self._team)
+            return bool(access and access.access_level != NO_ACCESS_LEVEL)
         level = self.access_level_for_object(self._team, "project")
         return bool(level and level != NO_ACCESS_LEVEL)
 
@@ -1567,6 +1588,12 @@ class UserAccessControl:
         if not resource:
             return None
 
+        if self._is_most_specific_access_control_enabled:
+            resolved_access = self.resolve_most_specific_object_access(obj)
+            if resolved_access is None or (explicit and resolved_access.source == "system_default"):
+                return None
+            return resolved_access.access_level
+
         resolved, access = self._object_access_level_precheck(resource, self._is_creator(obj), explicit=explicit)
         if resolved:
             return access.access_level if access else None
@@ -1623,13 +1650,21 @@ class UserAccessControl:
                 for ac in self._get_access_controls(self._access_controls_filters_for_queryset(resource)):
                     rows_by_object_id[ac.resource_id].append(ac)
 
-            access = self._object_access_level_from_rows(resource, rows_by_object_id.get(object_id, []))
+            object_rows = rows_by_object_id.get(object_id, [])
+            if self._is_most_specific_access_control_enabled:
+                access = self._most_specific_object_access_from_rows(resource, object_rows)
+            else:
+                access = self._object_access_level_from_rows(resource, object_rows)
             results[object_id] = access.access_level if access else None
 
         return results
 
     # ------------------------------------------------------------
-    # Most-specific-wins resolution (RFC 557). Not enforced.
+    # Most-specific-wins resolution (RFC 557).
+    #
+    # Enforced for organizations with `uses_most_specific_access_resolution` on. The enforced
+    # entry points (`get_user_access_level`, `access_level_for_resource`, the queryset filter,
+    # `bulk_object_access_levels`, `has_project_access`) branch to this section for them.
     #
     # The methods in this section come in three tiers:
     # - Entry points (`resolve_most_specific_*_access`): apply the guards for the user, fetch
@@ -1646,12 +1681,12 @@ class UserAccessControl:
     #   `external_data_source`), access resolves as: rules on the object -> its parent ->
     #   the resource -> the parent's resource.
     # The first rule found in this order decides, even when it gives a lower level.
-    # The enforced methods resolve differently: they take the highest level across the
+    # The legacy methods resolve differently: they take the highest level across the
     # member and role overrides, and rules on the resource win over the object's own default.
     #
-    # DO NOT CALL THESE METHODS FOR ENFORCEMENT YET.
-    # Call `get_user_access_level`, `check_access_level_for_object`, or
-    # `access_level_for_resource` instead.
+    # Do not call these methods directly for enforcement. Call `get_user_access_level`,
+    # `check_access_level_for_object`, or `access_level_for_resource`, which apply the
+    # organization's resolution mode.
     # ------------------------------------------------------------
 
     def resolve_most_specific_object_access(self, obj: Model) -> Optional[ResolvedAccess]:

--- a/products/access_control/backend/facade/user_access_control.py
+++ b/products/access_control/backend/facade/user_access_control.py
@@ -762,6 +762,18 @@ class UserAccessControl:
         if not resource or not org_membership:
             return None
 
+        if self._is_most_specific_access_control_enabled:
+            resolved = self.resolve_most_specific_object_access(obj)
+            if resolved is None:
+                return None
+            if specific_only:
+                # Only a member or role row on the object itself is a specific rule.
+                decided_by_object_row = resolved.source == "object" and resolved.source_subject != "default"
+                return resolved.access_level if decided_by_object_row else None
+            if explicit and resolved.source == "system_default":
+                return None
+            return resolved.access_level
+
         # Creators always have highest access
         if self._is_creator(obj):
             return highest_access_level(resource)

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -638,11 +638,21 @@ class TestUserAccessControlSerializer(BaseUserAccessControlTest):
         assert serializer.get_user_access_level(self.dashboard) == "viewer"
 
     def test_resource_level_takes_priority(self):
-        # Both resource-level and object-level; resource-level should take priority
+        # Legacy resolution: resource-level rules beat the object's own default rule
         self._create_access_control(resource="dashboard", resource_id=None, access_level="editor")
         self._create_access_control(resource="dashboard", resource_id=str(self.dashboard.id), access_level="viewer")
         serializer = self.Serializer(self.dashboard, context={"user_access_control": self.user_access_control})
         assert serializer.get_user_access_level(self.dashboard) == "editor"
+
+    def test_object_rule_takes_priority_in_most_specific_mode(self):
+        # Most-specific resolution: the object's own rule beats the resource level
+        self.organization.uses_most_specific_access_resolution = True
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
+        self._create_access_control(resource="dashboard", resource_id=None, access_level="editor")
+        self._create_access_control(resource="dashboard", resource_id=str(self.dashboard.id), access_level="viewer")
+        serializer = self.Serializer(self.dashboard, context={"user_access_control": self.user_access_control})
+        assert serializer.get_user_access_level(self.dashboard) == "viewer"
 
     def test_falls_back_to_object_level(self):
         # Only object-level present
@@ -917,7 +927,27 @@ class TestUserAccessControlGetUserAccessLevel(BaseUserAccessControlTest):
         )
 
         access_level = self.user_access_control.get_user_access_level(self.other_dashboard)
-        assert access_level == "editor"  # Higher level wins
+        assert access_level == "editor"  # Legacy resolution: higher level wins across member and role rows
+
+    def test_member_row_beats_role_row_in_most_specific_mode(self):
+        self.organization.uses_most_specific_access_resolution = True
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(self.other_dashboard.id),
+            access_level="viewer",
+            organization_member=self.organization_membership,
+        )
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(self.other_dashboard.id),
+            access_level="editor",
+            role=self.role_a,
+        )
+
+        access_level = self.user_access_control.get_user_access_level(self.other_dashboard)
+        assert access_level == "viewer"  # The member's own row decides, not the highest row
 
     def test_project_level_access_for_team_objects(self):
         """Test project-level access for team objects"""

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -949,6 +949,56 @@ class TestUserAccessControlGetUserAccessLevel(BaseUserAccessControlTest):
         access_level = self.user_access_control.get_user_access_level(self.other_dashboard)
         assert access_level == "viewer"  # The member's own row decides, not the highest row
 
+    def test_specific_access_level_uses_member_row_in_most_specific_mode(self):
+        self.organization.uses_most_specific_access_resolution = True
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(self.other_dashboard.id),
+            access_level="none",
+            organization_member=self.organization_membership,
+        )
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(self.other_dashboard.id),
+            access_level="editor",
+            role=self.role_a,
+        )
+
+        assert self.user_access_control.specific_access_level_for_object(self.other_dashboard) == "none"
+
+    def test_specific_access_level_ignores_default_rows_in_most_specific_mode(self):
+        self.organization.uses_most_specific_access_resolution = True
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(self.other_dashboard.id),
+            access_level="none",
+        )
+
+        assert self.user_access_control.specific_access_level_for_object(self.other_dashboard) is None
+
+    def test_access_level_for_team_uses_member_row_in_most_specific_mode(self):
+        self.organization.uses_most_specific_access_resolution = True
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
+        self._create_access_control(
+            resource="project",
+            resource_id=str(self.team.id),
+            access_level="none",
+            organization_member=self.organization_membership,
+        )
+        self._create_access_control(
+            resource="project",
+            resource_id=str(self.team.id),
+            access_level="admin",
+            role=self.role_a,
+        )
+
+        assert self.user_access_control.access_level_for_object(self.team) == "none"
+
     def test_project_level_access_for_team_objects(self):
         """Test project-level access for team objects"""
         # Create project-level access control

--- a/products/feature_flags/backend/api/test/__snapshots__/test_organization_feature_flag.ambr
+++ b/products/feature_flags/backend/api/test/__snapshots__/test_organization_feature_flag.ambr
@@ -1292,53 +1292,6 @@
 # ---
 # name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.8
   '''
-  SELECT "posthog_user"."id",
-         "posthog_user"."password",
-         "posthog_user"."last_login",
-         "posthog_user"."first_name",
-         "posthog_user"."last_name",
-         "posthog_user"."is_staff",
-         "posthog_user"."date_joined",
-         "posthog_user"."uuid",
-         "posthog_user"."current_organization_id",
-         "posthog_user"."current_team_id",
-         "posthog_user"."email",
-         "posthog_user"."pending_email",
-         "posthog_user"."distinct_id",
-         "posthog_user"."is_email_verified",
-         "posthog_user"."credentials_reviewed_at",
-         "posthog_user"."requested_password_reset_at",
-         "posthog_user"."requested_2fa_reset_at",
-         "posthog_user"."has_seen_product_intro_for",
-         "posthog_user"."strapi_id",
-         "posthog_user"."is_active",
-         "posthog_user"."role_at_organization",
-         "posthog_user"."theme_mode",
-         "posthog_user"."partial_notification_settings",
-         "posthog_user"."anonymize_data",
-         "posthog_user"."allow_impersonation",
-         "posthog_user"."toolbar_mode",
-         "posthog_user"."hedgehog_config",
-         "posthog_user"."allow_sidebar_suggestions",
-         "posthog_user"."shortcut_position",
-         "posthog_user"."passkeys_enabled_for_2fa",
-         "posthog_user"."hide_mcp_hints",
-         "posthog_user"."ui_configuration",
-         "posthog_user"."onboarding_skipped_at",
-         "posthog_user"."onboarding_skipped_reason",
-         "posthog_user"."onboarding_skipped_organization_id",
-         "posthog_user"."onboarding_delegated_to_invite_id",
-         "posthog_user"."onboarding_delegated_to_organization_id",
-         "posthog_user"."onboarding_delegation_accepted_at",
-         "posthog_user"."events_column_config",
-         "posthog_user"."email_opt_in"
-  FROM "posthog_user"
-  WHERE "posthog_user"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.9
-  '''
   SELECT "posthog_organizationmembership"."id",
          "posthog_organizationmembership"."organization_id",
          "posthog_organizationmembership"."user_id",
@@ -1390,6 +1343,53 @@
   INNER JOIN "posthog_organization" ON ("posthog_organizationmembership"."organization_id" = "posthog_organization"."id")
   WHERE ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
          AND "posthog_organizationmembership"."user_id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestOrganizationFeatureFlagCopy.test_copy_feature_flag_create_new.9
+  '''
+  SELECT "posthog_user"."id",
+         "posthog_user"."password",
+         "posthog_user"."last_login",
+         "posthog_user"."first_name",
+         "posthog_user"."last_name",
+         "posthog_user"."is_staff",
+         "posthog_user"."date_joined",
+         "posthog_user"."uuid",
+         "posthog_user"."current_organization_id",
+         "posthog_user"."current_team_id",
+         "posthog_user"."email",
+         "posthog_user"."pending_email",
+         "posthog_user"."distinct_id",
+         "posthog_user"."is_email_verified",
+         "posthog_user"."credentials_reviewed_at",
+         "posthog_user"."requested_password_reset_at",
+         "posthog_user"."requested_2fa_reset_at",
+         "posthog_user"."has_seen_product_intro_for",
+         "posthog_user"."strapi_id",
+         "posthog_user"."is_active",
+         "posthog_user"."role_at_organization",
+         "posthog_user"."theme_mode",
+         "posthog_user"."partial_notification_settings",
+         "posthog_user"."anonymize_data",
+         "posthog_user"."allow_impersonation",
+         "posthog_user"."toolbar_mode",
+         "posthog_user"."hedgehog_config",
+         "posthog_user"."allow_sidebar_suggestions",
+         "posthog_user"."shortcut_position",
+         "posthog_user"."passkeys_enabled_for_2fa",
+         "posthog_user"."hide_mcp_hints",
+         "posthog_user"."ui_configuration",
+         "posthog_user"."onboarding_skipped_at",
+         "posthog_user"."onboarding_skipped_reason",
+         "posthog_user"."onboarding_skipped_organization_id",
+         "posthog_user"."onboarding_delegated_to_invite_id",
+         "posthog_user"."onboarding_delegated_to_organization_id",
+         "posthog_user"."onboarding_delegation_accepted_at",
+         "posthog_user"."events_column_config",
+         "posthog_user"."email_opt_in"
+  FROM "posthog_user"
+  WHERE "posthog_user"."id" = 99999
   LIMIT 21
   '''
 # ---


### PR DESCRIPTION
## Problem

This PR finally makes access control resolution switch between the legacy and the most-specific resolution, based on the `uses_most_specific_access_resolution` organization setting.

The switch applies to all access control callers. A switch on one path only would recreate the mismatch between lists and detail views that the new resolution removes.

## Changes

For an organization with the setting on, members get access resolved by the most specific rule everywhere. Organizations with the setting off, which is every existing organization, are unchanged.

- `get_user_access_level` and `access_level_for_resource` branch to the most-specific entry points.
- The queryset filter branches per object to `_most_specific_object_access_from_rows`, so lists and detail views ask the same resolver. A member "none" row hides an object also when a role row grants more. Any deciding grant on the object shows it, without resource-level access.
- `bulk_object_access_levels` branches between the two rows-based resolvers, legacy and most-specific.
- `has_project_access` resolves the team through the object entry point instead of the pooled-highest legacy path.
- The divergence reporter runs only on the legacy branch. In the new mode there is nothing to compare.
- The section comment for RFC 557 no longer says "not enforced".

> [!NOTE]
Every organization stays on the legacy precedence unless the setting is enabled via django admin. 
#93752 opts in new orgs + there'll be another PR to opt in unaffected orgs.

## How did you test this code?

- Two new tests opt one organization into the new mode and pin the two precedence changes: a member row beats a higher role row, and an object rule beats the resource level. No existing test covered either.
- Not run locally for the final revision. CI is the check for `test_user_access_control.py`, `test_user_access_control_pbt.py`, `test_resolution_preview.py`, and `test_access_control.py`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None yet.