### PR TITLE
fix(conversations): explain why a personal email address can't be connected

### DIFF
--- a/posthog/models/integration/email.py
+++ b/posthog/models/integration/email.py
@@ -42,7 +42,10 @@ class EmailIntegration:
         provider: str = config.get("provider", "ses")
 
         if domain in free_email_domains_list or domain in disposable_email_domains_list:
-            raise ValidationError(f"Email domain {domain} is not supported. Please use a custom domain.")
+            raise ValidationError(
+                f"We can't send email from {domain}. Sending needs DNS records on a domain you own, "
+                "so use an address like hello@yourcompany.com."
+            )
 
         # Check if any other integration already exists in a different team with the same domain,
         # if so, ensure this team is part of the same organization. If not, we block creation.

--- a/posthog/models/test/integration/test_email.py
+++ b/posthog/models/test/integration/test_email.py
@@ -78,7 +78,7 @@ class TestEmailIntegrationDomainValidation(BaseTest):
             EmailIntegration.create_native_integration(
                 config, team_id=self.team.id, organization_id=str(self.organization.id), created_by=self.user
             )
-        assert "not supported" in str(exc.value)
+        assert "gmail.com" in str(exc.value)
 
         # Test with a disposable email domain
         disposable_domain = next(iter(disposable_email_domains_list))
@@ -89,7 +89,6 @@ class TestEmailIntegrationDomainValidation(BaseTest):
                 config, team_id=self.team.id, organization_id=str(self.organization.id), created_by=self.user
             )
         assert disposable_domain in str(exc.value)
-        assert "not supported" in str(exc.value)
 
     @patch("products.workflows.backend.providers.SESProvider.create_email_domain")
     def test_cross_org_guard_blocks_mixed_case_domain(self, mock_create_email_domain):
@@ -141,7 +140,7 @@ class TestEmailIntegrationDomainValidation(BaseTest):
                 organization_id=str(self.organization.id),
                 created_by=self.user,
             )
-        assert "not supported" in str(exc.value)
+        assert email.split("@")[1].lower() in str(exc.value)
 
 
 class TestEmailIntegrationCrossTenantStaleVerification(BaseTest):

--- a/products/conversations/backend/api/email_settings.py
+++ b/products/conversations/backend/api/email_settings.py
@@ -11,7 +11,9 @@ from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 import structlog
+from disposable_email_domains import blocklist as disposable_email_domains_list
 from drf_spectacular.utils import OpenApiResponse, extend_schema
+from free_email_domains import whitelist as free_email_domains_list
 from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -57,6 +59,11 @@ from products.conversations.backend.services.email_channel_setup import (
 )
 
 logger = structlog.get_logger(__name__)
+
+SHARED_EMAIL_DOMAIN_ERROR = (
+    "We can't send support email from {domain}. Sending needs DNS records on a domain you own, "
+    "so use an address like support@yourcompany.com."
+)
 
 FORWARDING_CHALLENGE_BASE_COOLDOWN_SECONDS = 30
 FORWARDING_CHALLENGE_MAX_COOLDOWN_SECONDS = 60 * 60
@@ -499,6 +506,11 @@ class EmailConnectView(APIView):
         sibling: EmailChannel | None = None
         dns_records: dict = {}
         if kind == EmailChannelKind.SUPPORT:
+            # A shared provider domain can never pass DNS verification, so Mailgun would reject it
+            # later with a message about the domain being claimed by someone else.
+            if domain in free_email_domains_list or domain in disposable_email_domains_list:
+                return Response({"error": SHARED_EMAIL_DOMAIN_ERROR.format(domain=domain)}, status=400)
+
             if (
                 EmailChannel.objects.filter(domain=domain, kind=EmailChannelKind.SUPPORT)
                 .exclude(team__organization_id=team.organization_id)

--- a/products/conversations/backend/api/tests/test_email_endpoints.py
+++ b/products/conversations/backend/api/tests/test_email_endpoints.py
@@ -764,6 +764,23 @@ class TestEmailMultiConfig(BaseTest):
         "products.conversations.backend.api.email_settings.get_instance_setting",
         return_value="mg.posthog.com",
     )
+    def test_connect_rejects_shared_provider_domain(self, _mock_setting: MagicMock, mock_mailgun: MagicMock):
+        response = self.client.post(
+            "/api/conversations/v1/email/connect",
+            {"from_email": "support@gmail.com", "from_name": "Support"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert "gmail.com" in response.json()["error"]
+        mock_mailgun.assert_not_called()
+        assert not EmailChannel.objects.filter(team=self.team).exists()
+
+    @patch("products.conversations.backend.api.email_settings.mailgun_add_domain", return_value={})
+    @patch(
+        "products.conversations.backend.api.email_settings.get_instance_setting",
+        return_value="mg.posthog.com",
+    )
     def test_same_domain_skips_mailgun_add(self, _mock_setting: MagicMock, mock_mailgun: MagicMock):
         self.client.post(
             "/api/conversations/v1/email/connect",

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -19,6 +19,12 @@ const BASE_AI_CHANNELS: TicketChannel[] = ['widget', 'email', 'slack']
 /** Kept in sync with SUPPORT_SLACK_FILE_SCOPES in products/conversations/backend/support_slack.py. */
 const SLACK_FILE_SCOPES = ['files:read', 'files:write']
 
+/** The email endpoints explain why a request failed, so show that instead of a generic message. */
+function emailErrorMessage(error: unknown, fallback: string): string {
+    const failure = error as { data?: { error?: string }; detail?: string } | null
+    return failure?.data?.error || failure?.detail || fallback
+}
+
 export function aiAllChannelsForFeatureFlags(featureFlags: Record<string, boolean | string>): TicketChannel[] {
     const channels: TicketChannel[] = [...BASE_AI_CHANNELS]
     if (featureFlags[FEATURE_FLAGS.PRODUCT_SUPPORT_TEAMS_ENABLED]) {
@@ -1396,8 +1402,8 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                     },
                 })
                 lemonToast.success('Email address connected')
-            } catch {
-                lemonToast.error('Failed to connect email')
+            } catch (error) {
+                lemonToast.error(emailErrorMessage(error, 'Failed to connect email. Please try again.'))
                 actions.connectEmailDone(null)
             }
         },
@@ -1445,8 +1451,8 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 } else {
                     lemonToast.warning('Domain not yet verified. Please check your DNS records and try again.')
                 }
-            } catch {
-                lemonToast.error('Failed to verify domain')
+            } catch (error) {
+                lemonToast.error(emailErrorMessage(error, 'Failed to verify domain. Please try again.'))
                 actions.verifyEmailDomainDone(configId, false, null)
             }
         },
@@ -1458,8 +1464,8 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 })
                 actions.sendTestEmailDone(configId)
                 lemonToast.success(`Test email sent to ${response.sent_to}`)
-            } catch {
-                lemonToast.error('Failed to send test email. Check SMTP settings.')
+            } catch (error) {
+                lemonToast.error(emailErrorMessage(error, 'Failed to send test email. Check SMTP settings.'))
                 actions.sendTestEmailDone(configId)
             }
         },


### PR DESCRIPTION
## Problem

Someone connecting a support inbox on a personal address (`support@gmail.com`) sees only "Failed to connect email" and has no way to know that a domain they own is required.

- The settings page catches every failure and toasts a fixed string, so the server's explanation never reaches the screen.
- The server does not check the domain either. It asks Mailgun to register `gmail.com`, and reports that the domain "may already be claimed by another account", which points at the wrong problem.
- A shared provider domain can never pass DNS verification, so the request was always going to fail.

## Changes

- Connecting a support address on a free or disposable provider domain now fails with "We can't send support email from gmail.com. Sending needs DNS records on a domain you own, so use an address like support@yourcompany.com."
- The connect, verify domain, and send test toasts now show the server's message, so limits, permission errors, and Mailgun failures each read differently.
- The messaging email sender rejection now names the domain and the next step, replacing "not supported. Please use a custom domain."
- Personal addresses still work for customer communication channels, which use forwarding rather than domain verification. Only support channels are gated.
- Mechanical: three test assertions moved off the old wording onto the rejected domain.

No screenshots: the change is toast text and an error string, and no layout changed.

## How did you test this code?

Automated, run in the sandbox:

- New endpoint test for a personal-provider support address: asserts 400, that the message names the domain, that Mailgun is never called, and that no channel row is created. Nothing covered this path before, so the endpoint used to reach Mailgun and return the misleading conflict message.
- Existing `TestEmailMultiConfig` and the email integration model tests pass, including the case that keeps personal addresses working for customer communication channels.

Not checked: the frontend toasts by hand. The dev stack was not booted, so the toast copy is covered by the logic path only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.
- Public artifact: nothing here carries material from the session. The example domains are `gmail.com` and `yourcompany.com`, and no customer, account, or address from the originating thread appears in the diff or this description.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1788303703937119?thread_ts=1788303703.937119&cid=C08S2L0S5MZ)*
