### PR TITLE
fix(desktop): ignore expected Pi shutdown errors

### DIFF
--- a/products/desktop/packages/core/src/pi-runtime/piExtensionController.test.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piExtensionController.test.ts
@@ -191,6 +191,20 @@ describe("PiExtensionController", () => {
     expect(controller.store.getState().tasks["task-1"]).toBeUndefined();
   });
 
+  it("ignores a missing Pi session when the extension subscription ends", async () => {
+    const handlers: ExtensionSubscriptionHandlers[] = [];
+    const session = createSession(handlers);
+    const controller = createController(session);
+    await controller.connect("task-1");
+
+    handlers[0].error(new Error("Pi session not found for task task-1"));
+
+    expect(controller.store.getState().tasks["task-1"].notifications).toEqual(
+      [],
+    );
+    controller.disconnect("task-1");
+  });
+
   it("preserves pending state on reconnect and ignores stale callbacks", async () => {
     vi.useFakeTimers();
     try {

--- a/products/desktop/packages/core/src/pi-runtime/piExtensionController.ts
+++ b/products/desktop/packages/core/src/pi-runtime/piExtensionController.ts
@@ -258,7 +258,10 @@ export class PiExtensionController {
       return;
     }
 
-    if (error !== undefined) {
+    if (
+      error !== undefined &&
+      !String(error).includes("Pi session not found for task")
+    ) {
       this.dispatch(taskId, {
         type: "notification",
         notification: {


### PR DESCRIPTION
## Problem

Desktop users see Pi extension error notifications while the app is closing.

## Changes

- Suppress this error

## How did you test this code?

- `pnpm --filter @posthog/core test` guards the missing-session notification regression.
- `pnpm typecheck`
- `pnpm lint`
- `./bin/hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This change only suppresses an expected shutdown error.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used image inspection, read, edit, and bash tools. This local agent session has no public URL.

Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, `/running-ci-preflight`, and `/writing-pr-descriptions`.

The final implementation replaced a cross-process shutdown protocol with a targeted guard for expected missing-session errors.
