### PR TITLE
chore(cli): unbreak master's markdown check and format the release changelog

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -261,6 +261,27 @@ jobs:
                   echo "new-version=$new_version" >> "$GITHUB_OUTPUT"
                   echo "Prepared posthog-cli v$new_version"
 
+            # This job commits straight to master, so nothing stands between what Sampo
+            # writes and master's own markdown gates. Sampo indents a multi-paragraph
+            # changeset under its changelog bullet and leaves that indent on the blank
+            # lines between the paragraphs, which the format check rejects.
+            - name: Install pnpm dependencies
+              if: steps.prepare-release.outputs.new-version != ''
+              uses: ./.github/actions/pnpm-install
+              with:
+                  install-command: pnpm install --frozen-lockfile --filter=@posthog/root
+
+            # Same two passes as `hogli format:markdown`, called directly because hogli
+            # needs a Python venv this job does not set up. The last command re-runs the
+            # gate, so an unfixable violation stops the release instead of reddening
+            # master for every open PR.
+            - name: Format the changelog
+              if: steps.prepare-release.outputs.new-version != ''
+              run: |
+                  pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc --fix cli/CHANGELOG.md
+                  pnpm exec oxfmt cli/CHANGELOG.md
+                  pnpm exec markdownlint-cli2 --config .config/.markdownlint-cli2.jsonc cli/CHANGELOG.md
+
             - name: Check release tag
               if: steps.prepare-release.outputs.new-version != ''
               env:

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Minor changes
 
 - [8a28e07ea71](https://github.com/PostHog/posthog/commit/8a28e07ea71c516128bd88889238333950e00aef) Deprecate `--release-mode` on `proguard upload` and `--no-release-bind` on `dsym upload`. Both flags are hidden no-ops now: each command uploads its symbol sets bound to the release it creates, which is what it did before the flags existed. A supplied flag prints a deprecation warning instead of changing the upload, so a released gradle plugin or upload-symbols.sh that still passes one keeps working. `proguard upload` no longer reads `POSTHOG_RELEASE_MODE`; the variable keeps steering `sourcemap inject`, `sourcemap process`, `sourcemap upload`, `hermes inject`, `hermes clone` and `hermes upload`.
-  
+
   Event mode pays off when two releases ship a byte-identical artifact. A proguard map id is a hash of the mapping, and a dSYM symbol set is keyed on the Mach-O `LC_UUID`, so an ordinary release that changes code already gets its own symbol set. The dSYM path also lost release attribution for embedded targets, because one upload covers every target's dSYM but creates one release. — Thanks @ablaszkiewicz!
 
 ## 0.16.2 — 2026-09-01


### PR DESCRIPTION
## Problem

Every PR and every merge-queue batch fails `Frontend formatting` on a file it did not touch.

- `cli/CHANGELOG.md` on master has a blank line with two trailing spaces. `oxfmt --check "**/*.{md,mdx}"` rejects it.
- The glob reads the whole tree, so the failure follows any PR that runs the job.
- A queue batch already failed on it: [run 33631053080](https://github.com/PostHog/posthog/actions/runs/33631053080), step `Check markdown formatting with oxfmt`.
- Sampo wrote that line. It indented the second paragraph of the v0.17.0 changeset under the changelog bullet and kept the indent on the blank line between paragraphs.
- The release job commits straight to master with an app token. No PR run and no queue batch saw the file before master did.

## Changes

- Master and the queue go green again. The trailing whitespace is gone from the v0.17.0 entry.
- The next sampo release cannot repeat this. The release job now formats `cli/CHANGELOG.md` before it commits.
- An unfixable markdown violation stops the release instead of reaching master. The step re-runs the lint gate after formatting.
- The job installs root-only pnpm dependencies to reach the pinned `oxfmt` and `markdownlint-cli2`. Mechanical, same pattern as `ci-backend.yml`.

Nothing user-visible changes, so there is no screenshot.

**Why not `hogli format:markdown`**, which runs the same two passes: `bin/hogli` needs a Python venv, and this job sets up only Rust. Calling the tools directly keeps a Python setup off the release path.

**Why format instead of only checking:** a failed release leaves the changesets on master and needs a human to hand-edit generated output. The formatters are deterministic, and their output still passes `Check release changes`, which already allowlists `cli/CHANGELOG.md`.

## How did you test this code?

- `oxfmt --check` rejects `origin/master`'s copy of the changelog and accepts the fixed one.
- The workflow's three commands, run against the broken file, produce exactly the committed fix.
- `hogli lint:workflows`, `hogli ci:preflight --strict`, and the repo-wide `oxfmt --check "**/*.{md,mdx}"` pass.
- actionlint reports the same 4 shellcheck warnings as master's copy of the workflow. None sit in the new steps.
- Not run: the release workflow itself. It fires only on a push to `cli/.sampo/changesets/*.md` on master.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`, `/simplify`.

The first draft ran only `oxfmt` in the release job. A reuse review found that master gates markdown twice, with `oxfmt --check` and a separate `markdownlint-cli2` step, and that `hogli format:markdown` is the canonical pair. The step now runs both passes and re-checks, so the release fails rather than shipping a violation the formatters cannot fix.

Nothing in this PR comes from outside the repository.

https://claude.ai/code/session_01RTVvvL7Mn3jsd1aEDpatnS
