### PR TITLE
perf(hogql): cache the session lookback bound for an hour

### DIFF
--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -24,7 +24,10 @@ from posthog.uuidt import UUIDT
 
 SESSION_BUFFER_DAYS = 3
 DEFAULT_SESSION_LOOKBACK_DAYS = 30
-DEFAULT_SESSION_LOOKBACK_CACHE_TTL_SECONDS = 60
+# Ingestion floors last_seen_at to the hour, and the bound it feeds is a days-scale
+# lookback window, so a long TTL loses no precision. The uncached read is expensive:
+# last_seen_at is unindexed, so Postgres sorts the team's whole definition set.
+DEFAULT_SESSION_LOOKBACK_CACHE_TTL_SECONDS = 3600
 # beyond this, duplicating the id list into the join subquery risks query-size limits;
 # covers the largest observed production batch (~1.2k ids) at ~13% of max_query_size
 SESSION_ID_LITERAL_PUSHDOWN_MAX_IDS = 2000


### PR DESCRIPTION
## Problem

- Loading an unfiltered session query can wait seconds on a Postgres read: on a cache miss, the session lookback bound fetches the newest `last_seen_at` from the team's event definitions.
- `last_seen_at` is unindexed, so Postgres reads and sorts the team's whole definition set. Large teams pay the most.
- The cached result expires every 60 seconds per team, so the query re-runs constantly.
- #93010 proposed an index on `(team_id, last_seen_at DESC)` instead. Ingestion updates `last_seen_at` continuously, and indexing the column stops those updates being HOT - benchmarked at ~3x slower per update, with every update then writing all seven of the table's indexes.

## Changes

- The lookback bound cache now holds for an hour instead of a minute, so the expensive read runs ~60x less often. Nothing user-visible changes.
- An hour of staleness is below the value's own resolution: ingestion floors `last_seen_at` to the hour, and the bound subtracts a 30-day window from it.
- Mechanical: one constant and a comment.

## How did you test this code?

- No new test. The change is a cache timeout; the bound's construction is unchanged and already covered.
- The write-path benchmark and query plans behind choosing this over the index are in the #93010 review thread.
- Not run: the full hogql suite locally; CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code while evaluating the pganalyze-driven index PRs with Sam. Skills invoked: /writing-pr-descriptions.
- The session measured the lookback read on production replicas via the internal Metabase, then benchmarked the `last_seen_at` write path locally with and without the proposed index (74% HOT without, 0% with, ~3x per-update cost). That trade is why this replaces #93010's index.
- Nothing in this PR draws on non-public material.