### PR TITLE
fix(taxonomy): stop relabeling customer properties named source

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/utils.test.ts
+++ b/frontend/src/lib/components/PropertyFilters/utils.test.ts
@@ -136,7 +136,7 @@ describe('formatPropertyLabel() for behavioral filters', () => {
                     { type: PropertyFilterType.Event, key: 'source', operator: PropertyOperator.Exact, value: ['web'] },
                 ],
             },
-            'Did not perform signed_up where Source = web in the last 30\u00a0days',
+            'Did not perform signed_up where source = web in the last 30\u00a0days',
             noActions,
         ],
         [
@@ -147,7 +147,7 @@ describe('formatPropertyLabel() for behavioral filters', () => {
                     { type: PropertyFilterType.Person, key: 'email', operator: PropertyOperator.IsSet, value: null },
                 ],
             },
-            'Performed signed_up where Source = web and Email address ✓ is set in the last 30\u00a0days',
+            'Performed signed_up where source = web and Email address ✓ is set in the last 30\u00a0days',
             noActions,
         ],
     ])('%s', (_name, overrides, expected, actionsById) => {

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -3598,11 +3598,6 @@
             ],
             "label": "Distinct ID"
         },
-        "duration_ms": {
-            "description": "Older unprefixed variant of $mcp_duration_ms. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_duration_ms for new dashboards.",
-            "label": "Duration (ms, unprefixed)",
-            "type": "Numeric"
-        },
         "epik": {
             "description": "Pinterest Click ID",
             "label": "epik"
@@ -3642,10 +3637,6 @@
         "irclid": {
             "description": "Impact Click ID",
             "label": "irclid"
-        },
-        "is_error": {
-            "description": "Older unprefixed variant of $mcp_is_error. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_is_error for new dashboards.",
-            "label": "Is error (unprefixed)"
         },
         "li_fat_id": {
             "description": "LinkedIn First-Party Ad Tracking ID",
@@ -3784,10 +3775,6 @@
             ],
             "label": "Referrer application"
         },
-        "resource_name": {
-            "description": "Older unprefixed variant of $mcp_resource_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_resource_name for new dashboards.",
-            "label": "Resource name (unprefixed)"
-        },
         "revenue": {
             "description": "The revenue associated with the event. By default, this is in USD, but the currency property can be used to specify a different currency.",
             "examples": [
@@ -3799,17 +3786,6 @@
             "description": "Snapchat Click ID",
             "label": "sccid"
         },
-        "source": {
-            "description": "Which PostHog surface the work came from. The surface values are 'web' (the app in a browser), 'posthog_ai' (Max), 'desktop' (the PostHog Desktop app), 'mobile' (the PostHog mobile app), 'slack' (the Slack app), 'mcp' (a third-party agent over MCP), 'cli', and 'api' (a direct API call). On API events, PostHog's own surfaces report themselves, so 'mcp' measures other people's agents. The $mcp_* events are stamped by the MCP server instead, which cannot read the OAuth grant that identifies the Desktop app, so a Desktop request can still show as 'mcp' on those. 'posthog_code' covers the headless coding agents: the cloud agent and the local agent. 'self_driving' is Signals: scouts, report implementations, and scout chat. 'wizard' is the setup agent and 'terraform' is the Terraform provider. Four values are machines rather than surfaces: 'cache_warming', 'alert', 'export', and 'subscription'. Two unrelated properties share this name, so filter to a specific event before breaking down by it. The app also uses 'source' for which control fired an event, with values like 'menu', 'keyboard-shortcut', and 'card_drag_handle'. Some backend paths use it for something else again: 'static' on $http_log, 'blob_v2', 'blob', 'listing' and 'realtime' on the session replay snapshot events, 'mcpcat' on the legacy MCP events, and 'template' or 'custom' on 'mcp_store server installed'. Two surface values also collide with older control names: on 'switched site mode', 'desktop' means the device-mode control rather than the app, and on the AI report events, 'slack' means the delivery channel.",
-            "examples": [
-                "web",
-                "posthog_ai",
-                "mcp",
-                "desktop",
-                "api"
-            ],
-            "label": "Source"
-        },
         "token": {
             "description": "Token used for authentication.",
             "examples": [
@@ -3817,10 +3793,6 @@
             ],
             "ignored_in_assistant": true,
             "label": "Token"
-        },
-        "tool_name": {
-            "description": "Older unprefixed variant of $mcp_tool_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_tool_name for new dashboards.",
-            "label": "Tool name (unprefixed)"
         },
         "ttclid": {
             "description": "TikTok Click ID",
@@ -8620,11 +8592,6 @@
             ],
             "label": "Distinct ID"
         },
-        "duration_ms": {
-            "description": "Older unprefixed variant of $mcp_duration_ms. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_duration_ms for new dashboards.",
-            "label": "Duration (ms, unprefixed)",
-            "type": "Numeric"
-        },
         "email": {
             "description": "The email address of the user.",
             "examples": [
@@ -8674,10 +8641,6 @@
         "irclid": {
             "description": "Impact Click ID Data from the last time this user was seen.",
             "label": "Latest irclid"
-        },
-        "is_error": {
-            "description": "Older unprefixed variant of $mcp_is_error. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_is_error for new dashboards.",
-            "label": "Is error (unprefixed)"
         },
         "li_fat_id": {
             "description": "LinkedIn First-Party Ad Tracking ID Data from the last time this user was seen.",
@@ -8816,10 +8779,6 @@
             ],
             "label": "Referrer application"
         },
-        "resource_name": {
-            "description": "Older unprefixed variant of $mcp_resource_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_resource_name for new dashboards.",
-            "label": "Resource name (unprefixed)"
-        },
         "revenue": {
             "description": "The revenue associated with the event. By default, this is in USD, but the currency property can be used to specify a different currency.",
             "examples": [
@@ -8831,17 +8790,6 @@
             "description": "Snapchat Click ID Data from the last time this user was seen.",
             "label": "Latest sccid"
         },
-        "source": {
-            "description": "Which PostHog surface the work came from. The surface values are 'web' (the app in a browser), 'posthog_ai' (Max), 'desktop' (the PostHog Desktop app), 'mobile' (the PostHog mobile app), 'slack' (the Slack app), 'mcp' (a third-party agent over MCP), 'cli', and 'api' (a direct API call). On API events, PostHog's own surfaces report themselves, so 'mcp' measures other people's agents. The $mcp_* events are stamped by the MCP server instead, which cannot read the OAuth grant that identifies the Desktop app, so a Desktop request can still show as 'mcp' on those. 'posthog_code' covers the headless coding agents: the cloud agent and the local agent. 'self_driving' is Signals: scouts, report implementations, and scout chat. 'wizard' is the setup agent and 'terraform' is the Terraform provider. Four values are machines rather than surfaces: 'cache_warming', 'alert', 'export', and 'subscription'. Two unrelated properties share this name, so filter to a specific event before breaking down by it. The app also uses 'source' for which control fired an event, with values like 'menu', 'keyboard-shortcut', and 'card_drag_handle'. Some backend paths use it for something else again: 'static' on $http_log, 'blob_v2', 'blob', 'listing' and 'realtime' on the session replay snapshot events, 'mcpcat' on the legacy MCP events, and 'template' or 'custom' on 'mcp_store server installed'. Two surface values also collide with older control names: on 'switched site mode', 'desktop' means the device-mode control rather than the app, and on the AI report events, 'slack' means the delivery channel.",
-            "examples": [
-                "web",
-                "posthog_ai",
-                "mcp",
-                "desktop",
-                "api"
-            ],
-            "label": "Source"
-        },
         "token": {
             "description": "Token used for authentication.",
             "examples": [
@@ -8849,10 +8797,6 @@
             ],
             "ignored_in_assistant": true,
             "label": "Token"
-        },
-        "tool_name": {
-            "description": "Older unprefixed variant of $mcp_tool_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_tool_name for new dashboards.",
-            "label": "Tool name (unprefixed)"
         },
         "ttclid": {
             "description": "TikTok Click ID Data from the last time this user was seen.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -33,13 +33,15 @@ def visible_definitions(group: str) -> Iterator[tuple[str, CoreFilterDefinition]
             yield name, definition
 
 
-# Generic property names that PostHog's own internal events use, kept out of the core taxonomy.
-# The taxonomy is global, so a core entry relabels every property of that name in every project:
-# it wins the label, the PostHog logo and the example values, even where the team has written its
-# own description. These names are common enough in customer schemas that the cost of describing
-# PostHog's internal meaning outweighs the benefit. Document such a property under a $-prefixed
-# name instead.
-RESERVED_UNPREFIXED_INTERNAL_PROPERTIES: frozenset[str] = frozenset(
+# Property names that only PostHog's own internal analytics sets. No PostHog SDK writes them into
+# a customer's project, so this taxonomy has nothing true to say about a property of that name.
+# The taxonomy is global and has no per-team scoping, so an entry wins the label, the PostHog logo
+# and the example values on every property of that name in every project, even where the team
+# wrote its own description. These names are common in customer schemas, so an entry relabels the
+# team's own property with PostHog's internal meaning.
+# The test is whether a PostHog SDK can put the property in customer data, not whether the name
+# carries a $ prefix: utm_source, gclid, revenue and version are unprefixed and belong here.
+POSTHOG_INTERNAL_ONLY_PROPERTIES: frozenset[str] = frozenset(
     {"source", "tool_name", "resource_name", "duration_ms", "is_error"}
 )
 
@@ -2994,11 +2996,9 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         # in-tree trackEvent path). They overlap with the $mcp_*-prefixed core properties above
         # and will be retired once @posthog/mcp reaches general availability — they are not yet
         # deprecated, because @posthog/mcp is still in internal testing.
-        # Only names inside the "mcp_" namespace belong here. A core entry wins the label, the
-        # PostHog logo and the example values on every property of that name in every project, so
-        # a generic name relabels a customer's own property with PostHog's internal meaning. The
-        # $mcp_*-prefixed entries above document these events for the people who query them; see
-        # RESERVED_UNPREFIXED_INTERNAL_PROPERTIES for the names kept out on purpose.
+        # Only names inside the "mcp_" namespace belong here. A name a customer could plausibly
+        # use for their own data does not, however internal its meaning is to us — see
+        # POSTHOG_INTERNAL_ONLY_PROPERTIES for the names kept out on purpose.
         "mcp_client_name": {
             "label": "MCP client name (unprefixed)",
             "description": "Older unprefixed variant of $mcp_client_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_name for new dashboards.",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -33,6 +33,17 @@ def visible_definitions(group: str) -> Iterator[tuple[str, CoreFilterDefinition]
             yield name, definition
 
 
+# Generic property names that PostHog's own internal events use, kept out of the core taxonomy.
+# The taxonomy is global, so a core entry relabels every property of that name in every project:
+# it wins the label, the PostHog logo and the example values, even where the team has written its
+# own description. These names are common enough in customer schemas that the cost of describing
+# PostHog's internal meaning outweighs the benefit. Document such a property under a $-prefixed
+# name instead.
+RESERVED_UNPREFIXED_INTERNAL_PROPERTIES: frozenset[str] = frozenset(
+    {"source", "tool_name", "resource_name", "duration_ms", "is_error"}
+)
+
+
 """
 Same as https://github.com/PostHog/posthog-js/blob/master/src/utils/event-utils.ts
 Ideally this would be imported from one place.
@@ -2983,6 +2994,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         # in-tree trackEvent path). They overlap with the $mcp_*-prefixed core properties above
         # and will be retired once @posthog/mcp reaches general availability — they are not yet
         # deprecated, because @posthog/mcp is still in internal testing.
+        # Only names inside the "mcp_" namespace belong here. A core entry wins the label, the
+        # PostHog logo and the example values on every property of that name in every project, so
+        # a generic name relabels a customer's own property with PostHog's internal meaning. The
+        # $mcp_*-prefixed entries above document these events for the people who query them; see
+        # RESERVED_UNPREFIXED_INTERNAL_PROPERTIES for the names kept out on purpose.
         "mcp_client_name": {
             "label": "MCP client name (unprefixed)",
             "description": "Older unprefixed variant of $mcp_client_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_client_name for new dashboards.",
@@ -3024,50 +3040,6 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "MCP server version (unprefixed, internal)",
             "description": "Older unprefixed variant of $mcp_version. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_version for new dashboards.",
             "type": "Numeric",
-        },
-        "tool_name": {
-            "label": "Tool name (unprefixed)",
-            "description": "Older unprefixed variant of $mcp_tool_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_tool_name for new dashboards.",
-        },
-        "resource_name": {
-            "label": "Resource name (unprefixed)",
-            "description": "Older unprefixed variant of $mcp_resource_name. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_resource_name for new dashboards.",
-        },
-        "duration_ms": {
-            "label": "Duration (ms, unprefixed)",
-            "description": "Older unprefixed variant of $mcp_duration_ms. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_duration_ms for new dashboards.",
-            "type": "Numeric",
-        },
-        "is_error": {
-            "label": "Is error (unprefixed)",
-            "description": "Older unprefixed variant of $mcp_is_error. Emitted on events from the pre-@posthog/mcp code paths; prefer $mcp_is_error for new dashboards.",
-        },
-        "source": {
-            "label": "Source",
-            "description": (
-                "Which PostHog surface the work came from. The surface values are 'web' (the app in a "
-                "browser), 'posthog_ai' (Max), 'desktop' (the PostHog Desktop app), 'mobile' (the PostHog "
-                "mobile app), 'slack' (the Slack app), 'mcp' (a third-party agent over MCP), 'cli', and "
-                "'api' (a direct API call). On API events, PostHog's own surfaces report themselves, so "
-                "'mcp' measures other people's agents. The $mcp_* events are stamped by the MCP server "
-                "instead, which cannot read the OAuth grant that identifies the Desktop app, so a Desktop "
-                "request can still show as 'mcp' on those. "
-                "'posthog_code' covers the headless coding agents: the cloud agent and the local agent. "
-                "'self_driving' is Signals: scouts, report implementations, and scout chat. "
-                "'wizard' is the setup agent and 'terraform' is the Terraform provider. "
-                "Four values are machines rather than surfaces: 'cache_warming', 'alert', 'export', and "
-                "'subscription'. "
-                "Two unrelated properties share this name, so filter to a specific event before breaking "
-                "down by it. The app also uses 'source' for which control fired an event, with values "
-                "like 'menu', 'keyboard-shortcut', and 'card_drag_handle'. Some backend paths use it for "
-                "something else again: 'static' on $http_log, 'blob_v2', 'blob', 'listing' and 'realtime' "
-                "on the session replay snapshot events, 'mcpcat' on the legacy MCP events, and 'template' "
-                "or 'custom' on 'mcp_store server installed'. Two "
-                "surface values also collide with older control names: on 'switched site mode', "
-                "'desktop' means the device-mode control rather than the app, and on the AI report "
-                "events, 'slack' means the delivery channel."
-            ),
-            "examples": ["web", "posthog_ai", "mcp", "desktop", "api"],
         },
         "mcp_runtime": {
             "label": "MCP runtime",

--- a/posthog/taxonomy/test/test_event_properties_taxonomy.py
+++ b/posthog/taxonomy/test/test_event_properties_taxonomy.py
@@ -1,7 +1,7 @@
 from posthog.taxonomy.taxonomy import (
     CAMPAIGN_PROPERTIES,
     CORE_FILTER_DEFINITIONS_BY_GROUP,
-    RESERVED_UNPREFIXED_INTERNAL_PROPERTIES,
+    POSTHOG_INTERNAL_ONLY_PROPERTIES,
     SESSION_INITIAL_PROPERTIES_ADAPTED_FROM_EVENTS,
 )
 
@@ -30,12 +30,12 @@ def test_should_have_every_property_in_session_adopted_from_person() -> None:
         assert f"$entry_{prop.replace('$', '')}" in session_props
 
 
-def test_reserved_unprefixed_names_stay_out_of_the_core_taxonomy() -> None:
+def test_posthog_internal_only_properties_stay_out_of_the_core_taxonomy() -> None:
     # A core entry wins the label, the PostHog logo and the example values on every property of
-    # that name in every project, so a generic name relabels a customer's own property.
+    # that name in every project, so it relabels a customer's own property of the same name.
     for group, definitions in CORE_FILTER_DEFINITIONS_BY_GROUP.items():
-        collisions = RESERVED_UNPREFIXED_INTERNAL_PROPERTIES & set(definitions)
-        assert not collisions, f"{group} must not define {sorted(collisions)} — use a $-prefixed name"
+        collisions = POSTHOG_INTERNAL_ONLY_PROPERTIES & set(definitions)
+        assert not collisions, f"{group} must not define {sorted(collisions)} — no SDK sets these in customer data"
 
 
 def test_mcp_properties_mirrors_every_mcp_event_property() -> None:

--- a/posthog/taxonomy/test/test_event_properties_taxonomy.py
+++ b/posthog/taxonomy/test/test_event_properties_taxonomy.py
@@ -1,6 +1,7 @@
 from posthog.taxonomy.taxonomy import (
     CAMPAIGN_PROPERTIES,
     CORE_FILTER_DEFINITIONS_BY_GROUP,
+    RESERVED_UNPREFIXED_INTERNAL_PROPERTIES,
     SESSION_INITIAL_PROPERTIES_ADAPTED_FROM_EVENTS,
 )
 
@@ -27,6 +28,14 @@ def test_should_have_every_property_in_session_adopted_from_person() -> None:
     session_props = CORE_FILTER_DEFINITIONS_BY_GROUP["session_properties"].keys()
     for prop in SESSION_INITIAL_PROPERTIES_ADAPTED_FROM_EVENTS:
         assert f"$entry_{prop.replace('$', '')}" in session_props
+
+
+def test_reserved_unprefixed_names_stay_out_of_the_core_taxonomy() -> None:
+    # A core entry wins the label, the PostHog logo and the example values on every property of
+    # that name in every project, so a generic name relabels a customer's own property.
+    for group, definitions in CORE_FILTER_DEFINITIONS_BY_GROUP.items():
+        collisions = RESERVED_UNPREFIXED_INTERNAL_PROPERTIES & set(definitions)
+        assert not collisions, f"{group} must not define {sorted(collisions)} — use a $-prefixed name"
 
 
 def test_mcp_properties_mirrors_every_mcp_event_property() -> None:


### PR DESCRIPTION
## Problem

A team with its own event property called `source` sees it presented as a PostHog property: the hedgehog logo, the label "Source", and the example values `web, posthog_ai, mcp, desktop, api`, which describe PostHog's own product surfaces. The team's own description still shows, and filtering still works, so the data is fine and only the framing is wrong.

The core taxonomy is global. An entry in it wins the label, the logo and the examples on every property of that name, in every project, whether or not the team defined that property itself. Five generic names reached it through PostHog's internal MCP instrumentation: `source`, `tool_name`, `resource_name`, `duration_ms` and `is_error`. All five are common in customer schemas.

There is no way for a team to suppress a core entry today, so the fix has to be to stop shipping the entry.

## Changes

- A property named `source`, `tool_name`, `resource_name`, `duration_ms` or `is_error` now renders as the team's own property again, with no logo, no PostHog label and no PostHog examples.
- The same five names now appear in `property_definitions` responses that pass `exclude_core_properties=true`, because they are no longer core.
- `POSTHOG_INTERNAL_ONLY_PROPERTIES` records the names and the reason, so the next internal property does not land in the shared taxonomy by the same route.
- The `$mcp_`-namespaced entries stay, along with the `mcp_`-prefixed unprefixed variants. Those names are namespaced enough that a customer will not have picked them.
- This does not rename anything to `$source`. There is no `$source`, and PostHog's own `source` property is unchanged — it keeps being captured, it just carries no taxonomy entry. The prefix is a convention for what PostHog SDKs write into customer projects; the test applied here is whether a name can reach customer data at all.
- Mechanical: `core-filter-definitions-by-group.json` regenerated from `taxonomy.py`. No other entry changed.

Deleting the five entries beats hiding them behind a flag or letting a team definition override a core one. The `system` flag only hides a property from the properties table, and an override would need a per-project resolution path through every surface that renders a property key.

## How did you test this code?

- `test_posthog_internal_only_properties_stay_out_of_the_core_taxonomy` fails if any of the five names returns to any taxonomy group. No existing test covered a name entering the shared taxonomy.
- `frontend/src/lib/components/PropertyFilters/utils.test.ts` formats a filter on `source` and now expects `source = web` rather than `Source = web`. It doubles as a canary on the rendered label.
- Ran locally: `posthog/taxonomy/test/`, and the Jest suites under `frontend/src/lib/components/TaxonomicFilter/`, plus `PropertyFilters/utils.test.ts`, `PropertyKeyInfo`, `lib/utils/events.test.ts` and `taxonomy/coreFilterDefinitions.test.ts`.
- Not run: the database-backed API suites and repo-wide mypy. `hogli ci:preflight --fix` reported no failures.
- Not checked manually in a browser. The change is data only, and the rendering path is covered by the tests above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus) from a customer question relayed in Slack. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

The first attempt moved all 22 unprefixed legacy MCP entries into the existing `mcp_properties` group rather than deleting any. That broke the group's contract, which is the `$mcp_`-prefixed schema and nothing else, so it was reverted in favor of dropping only the five names that collide with ordinary customer schemas.

Public artifact check: the diff, the commit message and this description carry no material from the session. The customer, their schema and the thread contents are not named anywhere.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BALLBBKAB/p1788353415014929)*

