### PR TITLE
feat(projects): let TaggedItem point at a project

### DIFF
--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -1596,6 +1596,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -2282,6 +2283,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -3744,6 +3746,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -6408,6 +6411,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -7087,6 +7091,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -11752,6 +11757,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -15188,6 +15194,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"

--- a/posthog/migrations/1335_taggeditem_project.py
+++ b/posthog/migrations/1335_taggeditem_project.py
@@ -1,0 +1,299 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1334_remove_cimd_blocklist_entry"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveConstraint(
+                    model_name="taggeditem",
+                    name="exactly_one_related_object",
+                ),
+                migrations.AlterUniqueTogether(
+                    name="taggeditem",
+                    unique_together=set(),
+                ),
+                migrations.AddField(
+                    model_name="taggeditem",
+                    name="project",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_constraint=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="tagged_items",
+                        to="posthog.project",
+                    ),
+                ),
+                migrations.AlterUniqueTogether(
+                    name="taggeditem",
+                    unique_together={
+                        (
+                            "tag",
+                            "dashboard",
+                            "insight",
+                            "event_definition",
+                            "property_definition",
+                            "action",
+                            "feature_flag",
+                            "experiment_saved_metric",
+                            "ticket",
+                            "account",
+                            "endpoint",
+                            "replay_scanner",
+                            "project",
+                        )
+                    },
+                ),
+                migrations.AddConstraint(
+                    model_name="taggeditem",
+                    constraint=models.UniqueConstraint(
+                        condition=models.Q(("project__isnull", False)),
+                        fields=("tag", "project"),
+                        name="unique_project_tagged_item",
+                    ),
+                ),
+                migrations.AddConstraint(
+                    model_name="taggeditem",
+                    constraint=models.CheckConstraint(
+                        condition=models.Q(
+                            models.Q(
+                                ("dashboard__isnull", False),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", False),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", False),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", False),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", False),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", False),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", False),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", False),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", False),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", False),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", False),
+                                ("project__isnull", True),
+                            ),
+                            models.Q(
+                                ("dashboard__isnull", True),
+                                ("insight__isnull", True),
+                                ("event_definition__isnull", True),
+                                ("property_definition__isnull", True),
+                                ("action__isnull", True),
+                                ("feature_flag__isnull", True),
+                                ("experiment_saved_metric__isnull", True),
+                                ("ticket__isnull", True),
+                                ("account__isnull", True),
+                                ("endpoint__isnull", True),
+                                ("replay_scanner__isnull", True),
+                                ("project__isnull", False),
+                            ),
+                            _connector="OR",
+                        ),
+                        name="exactly_one_related_object",
+                    ),
+                ),
+            ],
+            database_operations=[
+                # posthog_project is read on nearly every request, so the column lands without
+                # an inline FK constraint. 1338 adds the constraint NOT VALID and 1339 validates
+                # it, which keeps the lock on the parent to a brief metadata-only ALTER.
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_taggeditem" ADD COLUMN "project_id" bigint NULL;
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE "posthog_taggeditem" DROP COLUMN IF EXISTS "project_id";
+                    """,
+                ),
+                migrations.RunSQL(
+                    sql="""
+                                ALTER TABLE "posthog_taggeditem" DROP CONSTRAINT IF EXISTS "exactly_one_related_object";
+                                ALTER TABLE "posthog_taggeditem" ADD CONSTRAINT "exactly_one_related_object" CHECK ( /* -- existing-table-constraint-ignore */
+                                    (
+                                    (dashboard_id IS NOT NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NOT NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NOT NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NOT NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NOT NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NOT NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NOT NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NOT NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NOT NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NOT NULL AND replay_scanner_id IS NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NOT NULL AND project_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL AND project_id IS NOT NULL) /* -- not-null-ignore */
+                                    )
+                                ) NOT VALID;
+                    """,
+                    reverse_sql="""
+                                ALTER TABLE "posthog_taggeditem" DROP CONSTRAINT IF EXISTS "exactly_one_related_object";
+                                ALTER TABLE "posthog_taggeditem" ADD CONSTRAINT "exactly_one_related_object" CHECK ( /* -- existing-table-constraint-ignore */
+                                    (
+                                    (dashboard_id IS NOT NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NOT NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NOT NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NOT NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NOT NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NOT NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NOT NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NOT NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NOT NULL AND endpoint_id IS NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NOT NULL AND replay_scanner_id IS NULL) OR /* -- not-null-ignore */
+                                    (dashboard_id IS NULL AND insight_id IS NULL AND event_definition_id IS NULL AND property_definition_id IS NULL AND action_id IS NULL AND feature_flag_id IS NULL AND experiment_saved_metric_id IS NULL AND ticket_id IS NULL AND account_id IS NULL AND endpoint_id IS NULL AND replay_scanner_id IS NOT NULL) /* -- not-null-ignore */
+                                    )
+                                ) NOT VALID;
+                    """,
+                ),
+                # 1337 re-adds this as a constraint over the index 1336 builds concurrently.
+                migrations.RunSQL(
+                    sql="""
+                        ALTER TABLE "posthog_taggeditem" DROP CONSTRAINT IF EXISTS "posthog_taggeditem_tag_id_dashboard_id_insi_replay_scan_uniq";
+                    """,
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+    ]

--- a/posthog/migrations/1336_taggeditem_project_indexes.py
+++ b/posthog/migrations/1336_taggeditem_project_indexes.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+from posthog.migration_helpers import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # CONCURRENTLY can't run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1335_taggeditem_project"),
+    ]
+
+    # `CreateIndexConcurrently` drops any invalid leftover from an interrupted build before
+    # retrying, so a transient cancellation can't wedge 1337's ADD CONSTRAINT USING INDEX.
+    # Django state for these indexes and constraints was added in 1335.
+    operations = [
+        CreateIndexConcurrently(
+            index_name="posthog_taggeditem_project_id_0a61d235",
+            table_name="posthog_taggeditem",
+            columns='("project_id")',
+        ),
+        CreateIndexConcurrently(
+            index_name="unique_project_tagged_item",
+            table_name="posthog_taggeditem",
+            columns='("tag_id", "project_id")',
+            unique=True,
+            where='WHERE "project_id" IS NOT NULL',
+        ),
+        CreateIndexConcurrently(
+            index_name="posthog_taggeditem_tag_id_dashboard_id_insi_4ec15a8f_uniq",
+            table_name="posthog_taggeditem",
+            columns=(
+                '("tag_id", "dashboard_id", "insight_id", "event_definition_id", "property_definition_id", '
+                '"action_id", "feature_flag_id", "experiment_saved_metric_id", "ticket_id", "account_id", '
+                '"endpoint_id", "replay_scanner_id", "project_id")'
+            ),
+            unique=True,
+        ),
+    ]

--- a/posthog/migrations/1337_taggeditem_project_unique_constraint.py
+++ b/posthog/migrations/1337_taggeditem_project_unique_constraint.py
@@ -1,0 +1,39 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1336_taggeditem_project_indexes"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE "posthog_taggeditem" ADD CONSTRAINT "posthog_taggeditem_tag_id_dashboard_id_insi_4ec15a8f_uniq"
+                UNIQUE USING INDEX "posthog_taggeditem_tag_id_dashboard_id_insi_4ec15a8f_uniq"; -- existing-table-constraint-ignore
+            """,
+            # The reverse restores the replay-scanner-wide constraint that 1335 dropped with a noop
+            # reverse. It must build the index itself: this migration unapplies before 1336, so
+            # nothing else has.
+            reverse_sql="""
+                ALTER TABLE "posthog_taggeditem" DROP CONSTRAINT IF EXISTS "posthog_taggeditem_tag_id_dashboard_id_insi_4ec15a8f_uniq";
+                CREATE UNIQUE INDEX IF NOT EXISTS "posthog_taggeditem_tag_id_dashboard_id_insi_replay_scan_uniq"
+                ON "posthog_taggeditem" (
+                    "tag_id",
+                    "dashboard_id",
+                    "insight_id",
+                    "event_definition_id",
+                    "property_definition_id",
+                    "action_id",
+                    "feature_flag_id",
+                    "experiment_saved_metric_id",
+                    "ticket_id",
+                    "account_id",
+                    "endpoint_id",
+                    "replay_scanner_id"
+                );
+                ALTER TABLE "posthog_taggeditem" ADD CONSTRAINT "posthog_taggeditem_tag_id_dashboard_id_insi_replay_scan_uniq"
+                UNIQUE USING INDEX "posthog_taggeditem_tag_id_dashboard_id_insi_replay_scan_uniq"; -- existing-table-constraint-ignore
+            """,
+        ),
+    ]

--- a/posthog/migrations/1338_taggeditem_project_fk.py
+++ b/posthog/migrations/1338_taggeditem_project_fk.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+from posthog.migration_helpers import AddForeignKeyNotValid
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1337_taggeditem_project_unique_constraint"),
+    ]
+
+    # NOT VALID skips the child-row scan, so the lock this takes on posthog_project is a brief
+    # metadata-only ALTER rather than one held across a full scan. 1339 validates it lock-free.
+    operations = [
+        AddForeignKeyNotValid(
+            model_name="taggeditem",
+            name="posthog_taggeditem_project_id_fk",
+            column="project_id",
+            to_table="posthog_project",
+            to_column="id",
+        ),
+    ]

--- a/posthog/migrations/1339_validate_taggeditem_project_fk.py
+++ b/posthog/migrations/1339_validate_taggeditem_project_fk.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+from posthog.migration_helpers import ValidateForeignKey
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1338_taggeditem_project_fk"),
+    ]
+
+    # VALIDATE scans under SHARE UPDATE EXCLUSIVE, so it does not block reads or writes.
+    operations = [
+        ValidateForeignKey(
+            model_name="taggeditem",
+            name="posthog_taggeditem_project_id_fk",
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1334_remove_cimd_blocklist_entry
+1339_validate_taggeditem_project_fk

--- a/posthog/models/project.py
+++ b/posthog/models/project.py
@@ -100,6 +100,15 @@ class Project(UpdatedMetaFields):
 
     __repr__ = sane_repr("id", "name")
 
+    @property
+    def team_id(self) -> int:
+        """The id of this project's passthrough team, which a project shares.
+
+        Tag rows are team-scoped, so the shared tagging helpers reach the right namespace
+        through this attribute without loading the team.
+        """
+        return self.pk
+
     @cached_property
     def passthrough_team(self) -> "Team":
         return self.teams.get(pk=self.pk)

--- a/posthog/models/tagged_item.py
+++ b/posthog/models/tagged_item.py
@@ -16,6 +16,7 @@ RELATED_OBJECTS = (
     "account",
     "endpoint",
     "replay_scanner",
+    "project",
 )
 
 
@@ -114,6 +115,17 @@ class TaggedItem(ModelActivityMixin, UUIDTModel):
         null=True,
         blank=True,
         related_name="tagged_items",
+    )
+    project = models.ForeignKey(
+        "posthog.Project",
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="tagged_items",
+        # posthog_project is read on nearly every request, so creating this FK's database
+        # constraint inline would lock it. A later migration adds the constraint NOT VALID
+        # and validates it separately.
+        db_constraint=False,
     )
 
     class Meta:

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -296,7 +296,8 @@
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
-         "posthog_taggeditem"."replay_scanner_id"
+         "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
@@ -315,7 +316,8 @@
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
-         "posthog_taggeditem"."replay_scanner_id"
+         "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
@@ -1213,7 +1215,8 @@
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
-         "posthog_taggeditem"."replay_scanner_id"
+         "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
@@ -1232,7 +1235,8 @@
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
-         "posthog_taggeditem"."replay_scanner_id"
+         "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''

--- a/products/actions/backend/api/test/__snapshots__/test_action.ambr
+++ b/products/actions/backend/api/test/__snapshots__/test_action.ambr
@@ -476,6 +476,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"
@@ -1107,6 +1108,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"

--- a/products/feature_flags/backend/api/test/__snapshots__/test_feature_flag.ambr
+++ b/products/feature_flags/backend/api/test/__snapshots__/test_feature_flag.ambr
@@ -798,6 +798,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -1514,7 +1514,8 @@
          "posthog_taggeditem"."ticket_id",
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
-         "posthog_taggeditem"."replay_scanner_id"
+         "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id"
   FROM "posthog_taggeditem"
   WHERE "posthog_taggeditem"."insight_id" IN (1,
                                               2,
@@ -1593,6 +1594,7 @@
          "posthog_taggeditem"."account_id",
          "posthog_taggeditem"."endpoint_id",
          "posthog_taggeditem"."replay_scanner_id",
+         "posthog_taggeditem"."project_id",
          "posthog_tag"."id",
          "posthog_tag"."name",
          "posthog_tag"."team_id"


### PR DESCRIPTION
## Problem

Projects are the only major PostHog resource that cannot be tagged. This adds the column that makes it possible. It is the schema half of #92307, split out so the migrations land on their own.

## Changes

- Add a `project` column to `posthog_taggeditem`, so a tag relationship can point at a project.
- Nothing writes the column yet. The API and UI that use it are in #92307, stacked on this.
- Five migrations, because three rules each force their own: `CREATE INDEX CONCURRENTLY` cannot run in a transaction, `ADD CONSTRAINT ... USING INDEX` needs a finished index, and a foreign key to a hot table must be added `NOT VALID` and validated separately.
- `posthog_project` is a hot table, so the foreign key carries no database constraint at creation and takes no lock on the parent.
- Mechanical: five query snapshots now list the new column, because it widens the `SELECT` the tag prefetch emits.

> [!NOTE]
> `replay_scanner` added a column to this same table in 1301/1302/1303 and needed three migrations. This needs two more only because its foreign key points at `posthog_project` rather than a product table, so the constraint cannot be attached inline.

## How did you test this code?

- `makemigrations --check` reports no drift and `showmigrations` shows a linear 1334-1338 chain.
- 92 existing tests covering the five updated query snapshots pass.
- Migration risk analysis reports 0 blocked.
- Not run: the full backend suite. CI covers it.

Agent-authored; only the automated checks above were run.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Skills invoked: `/django-migrations`, `/stacking-prs`, `/writing-tests`, `/creating-pull-requests`, `/writing-pr-descriptions`.

Split out of #92307 after that PR hit a migration renumber: master took 1332 and 1333 mid-review, and the whole chain had to move to 1334-1338 by hand because `rebase_migration` only renumbers a single migration. `posthog/migrations` takes about 1.8 new migrations a day, so a five-migration chain is exposed to that every rebase. Landing the schema on its own closes that window and leaves the feature PR with no migrations at all.