### PR TITLE
feat(desktop): richer show_actions buttons with kind icons and compose cards

### DIFF
--- a/products/desktop/packages/agent/src/adapters/local-tools/tools/show-actions.ts
+++ b/products/desktop/packages/agent/src/adapters/local-tools/tools/show-actions.ts
@@ -20,6 +20,10 @@ const SHOW_ACTIONS_TOOL_DESCRIPTION =
   "`compose` opens the new-task composer prefilled with `prompt` (and `repo` " +
   "when given). The user reads, edits and sends it themselves, so it does NOT " +
   "start a task and does NOT send anything on click. " +
+  "A `compose` action also takes an optional `description`, which no other " +
+  "kind accepts. Giving one draws that button as a larger card instead of a " +
+  "pill, so use it for the offers that matter most. Write one short sentence " +
+  "on what the prefilled task will do, never a restatement of the label. " +
   "`open_space` opens a channel's feed. `open_canvas` opens a canvas inside a " +
   "channel, and needs both `channel_id` and `canvas_id`. " +
   "`open_inbox` opens Self-driving, where PostHog files the reports it writes " +

--- a/products/desktop/packages/core/src/sessions/showActions.test.ts
+++ b/products/desktop/packages/core/src/sessions/showActions.test.ts
@@ -29,10 +29,17 @@ describe("isShowActionsCall", () => {
 });
 
 describe("readShowActions", () => {
+  // The description is presentation, like the label, so it has to stay out of
+  // the action the host turns into a link.
   it("drops an action the host would refuse to open", () => {
     const buttons = readShowActions({
       actions: [
-        { kind: "compose", label: "Add PostHog", prompt: "/instrument" },
+        {
+          kind: "compose",
+          label: "Add PostHog",
+          description: "Instruments the app so events start arriving",
+          prompt: "/instrument",
+        },
         { kind: "open_space", label: "Open the space", channel_id: "  " },
         { kind: "open_website", label: "Go", url: "https://evil.example" },
       ],
@@ -41,6 +48,7 @@ describe("readShowActions", () => {
     expect(buttons).toEqual([
       {
         label: "Add PostHog",
+        description: "Instruments the app so events start arriving",
         action: { kind: "compose", prompt: "/instrument" },
       },
     ]);

--- a/products/desktop/packages/shared/src/agent-actions.ts
+++ b/products/desktop/packages/shared/src/agent-actions.ts
@@ -68,12 +68,27 @@ const labelSchema = z
     "Button text. Short and in sentence case, naming what the button does.",
   );
 
+const descriptionSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(140)
+  .describe(
+    "Optional. One short sentence saying what the prefilled task will do. " +
+      "Never a restatement of the label.",
+  );
+
 /**
- * One button as the agent offers it: an action plus the text on it. `label`
- * never reaches a link, which is why {@link agentActionSchema} leaves it out.
+ * One button as the agent offers it: an action plus the text on it. `label` and
+ * `description` never reach a link, which is why {@link agentActionSchema}
+ * leaves them out.
  */
 export const showActionSchema = z.discriminatedUnion("kind", [
-  z.object({ ...composeFields, label: labelSchema }),
+  z.object({
+    ...composeFields,
+    label: labelSchema,
+    description: descriptionSchema.optional(),
+  }),
   z.object({ ...openSpaceFields, label: labelSchema }),
   z.object({ ...openCanvasFields, label: labelSchema }),
   z.object({ ...openInboxFields, label: labelSchema }),
@@ -86,11 +101,18 @@ export const openAgentActionInput = z.object({ action: agentActionSchema });
 /** One button as the renderer draws it: its text, and the verb behind it. */
 export interface ShowActionButton {
   label: string;
+  description?: string;
   action: AgentAction;
 }
 
 /** Split a button back into the text on it and the verb behind it. */
 export function splitShowAction(button: ShowAction): ShowActionButton {
+  // Only compose carries a description, so the two branches keep the rest of
+  // the object typed as an action the host will accept.
+  if (button.kind === "compose") {
+    const { label, description, ...action } = button;
+    return { label, description, action };
+  }
   const { label, ...action } = button;
   return { label, action };
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.stories.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.stories.tsx
@@ -1,0 +1,82 @@
+import { ShowActionsRow } from "@posthog/ui/features/sessions/components/session-update/ShowActionsRow";
+import type { ToolCall } from "@posthog/ui/features/sessions/types";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+function showActionsCall(actions: unknown[]): ToolCall {
+  return {
+    toolCallId: "story-show-actions",
+    rawInput: { actions },
+    status: "completed",
+  } as ToolCall;
+}
+
+const meta: Meta<typeof ShowActionsRow> = {
+  title: "Features/Sessions/ShowActionsRow",
+  component: ShowActionsRow,
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ShowActionsRow>;
+
+export const Pills: Story = {
+  args: {
+    toolCall: showActionsCall([
+      {
+        kind: "compose",
+        label: "Fix the login bug",
+        prompt: "Fix the login redirect loop on session expiry",
+      },
+      { kind: "open_space", label: "Open #growth", channel_id: "chan-1" },
+      {
+        kind: "open_canvas",
+        label: "Explore PostHog Desktop",
+        channel_id: "chan-1",
+        canvas_id: "canvas-1",
+      },
+      { kind: "open_inbox", label: "Review findings" },
+    ]),
+    turnComplete: true,
+  },
+};
+
+// A compose action with a description renders as a card; the rest stay pills.
+export const CardsAndPills: Story = {
+  args: {
+    toolCall: showActionsCall([
+      {
+        kind: "compose",
+        label: "Add PostHog to your app",
+        description:
+          "Opens a task that instruments your codebase and files a PR to review",
+        prompt: "Add PostHog analytics to my app and open a pull request",
+      },
+      {
+        kind: "compose",
+        label: "Set up error tracking",
+        description: "Wires exception capture into your existing SDK setup",
+        prompt: "Enable PostHog error tracking in my app",
+      },
+      { kind: "open_inbox", label: "Review findings" },
+      { kind: "open_space", label: "Open #growth", channel_id: "chan-1" },
+    ]),
+    turnComplete: true,
+  },
+};
+
+export const SingleCard: Story = {
+  args: {
+    toolCall: showActionsCall([
+      {
+        kind: "compose",
+        label: "Add PostHog to your app",
+        description:
+          "Opens a task that instruments your codebase and files a PR to review",
+        prompt: "Add PostHog analytics to my app and open a pull request",
+      },
+    ]),
+    turnComplete: true,
+  },
+};

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.test.tsx
@@ -56,6 +56,26 @@ describe("ShowActionsRow", () => {
     expect(screen.queryByText("Open the canvas")).toBeNull();
   });
 
+  it("keeps the order the agent supplied, even with a pill before a card", () => {
+    renderCard([
+      { kind: "open_space", label: "Open the space", channel_id: "chan" },
+      {
+        kind: "compose",
+        label: "Add PostHog",
+        description: "Instruments the app and opens a task to review it",
+        prompt: "/instrument",
+      },
+      { kind: "open_inbox", label: "Review findings" },
+    ]);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      "Open the space",
+      "Add PostHogInstruments the app and opens a task to review it",
+      "Review findings",
+    ]);
+  });
+
   it("hands the host a typed action, never a url", async () => {
     renderCard([
       { kind: "open_space", label: "Open the space", channel_id: "chan" },

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.test.tsx
@@ -2,7 +2,7 @@ import type { ToolCall } from "@posthog/ui/features/sessions/types";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const openAgentAction = vi.hoisted(() => vi.fn());
 
@@ -28,16 +28,30 @@ function renderCard(actions: unknown[]) {
 }
 
 describe("ShowActionsRow", () => {
+  beforeEach(() => {
+    openAgentAction.mockClear();
+  });
+
   it("draws a button per usable action and drops one that cannot open anything", () => {
     renderCard([
       { kind: "compose", label: "Fix the bug", prompt: "Fix the login bug" },
+      {
+        kind: "compose",
+        label: "Add PostHog",
+        description: "Instruments the app and opens a task to review it",
+        prompt: "/instrument",
+      },
       { kind: "open_space", label: "Open the space", channel_id: "chan" },
       // No canvas id, so this one could only ever build a broken link.
       { kind: "open_canvas", label: "Open the canvas", channel_id: "chan" },
     ]);
 
-    expect(screen.getAllByRole("button")).toHaveLength(2);
+    expect(screen.getAllByRole("button")).toHaveLength(3);
     expect(screen.getByText("Fix the bug")).toBeTruthy();
+    expect(screen.getByText("Add PostHog")).toBeTruthy();
+    expect(
+      screen.getByText("Instruments the app and opens a task to review it"),
+    ).toBeTruthy();
     expect(screen.getByText("Open the space")).toBeTruthy();
     expect(screen.queryByText("Open the canvas")).toBeNull();
   });
@@ -52,6 +66,31 @@ describe("ShowActionsRow", () => {
     await waitFor(() => expect(openAgentAction).toHaveBeenCalled());
     expect(openAgentAction.mock.calls[0]?.[0]).toEqual({
       action: { kind: "open_space", channel_id: "chan" },
+    });
+  });
+
+  // A description is presentation, like the label, so the host must never be
+  // handed one: it would ride into the url the host builds.
+  it("keeps the description off the action it sends the host", async () => {
+    renderCard([
+      {
+        kind: "compose",
+        label: "Fix the bug",
+        description: "Opens a task that patches the login redirect",
+        prompt: "Fix the login bug",
+      },
+    ]);
+
+    expect(screen.getByText("Fix the bug")).toBeTruthy();
+    expect(
+      screen.getByText("Opens a task that patches the login redirect"),
+    ).toBeTruthy();
+
+    await userEvent.click(screen.getByText("Fix the bug"));
+
+    await waitFor(() => expect(openAgentAction).toHaveBeenCalled());
+    expect(openAgentAction.mock.calls[0]?.[0]).toEqual({
+      action: { kind: "compose", prompt: "Fix the login bug" },
     });
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
@@ -1,9 +1,29 @@
+import {
+  Hash,
+  type Icon,
+  Layout,
+  PencilSimple,
+  Tray,
+} from "@phosphor-icons/react";
 import { readShowActions } from "@posthog/core/sessions/showActions";
 import { useHostTRPC } from "@posthog/host-router/react";
-import { Button } from "@posthog/quill";
+import { Button, Text } from "@posthog/quill";
+import type { ShowActionButton } from "@posthog/shared";
 import type { ToolViewProps } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
 import { toast } from "@posthog/ui/primitives/toast";
 import { useMutation } from "@tanstack/react-query";
+
+// The UI picks the icon and accent from the verb, so the agent never gets to
+// choose either and every button of a kind looks the same everywhere.
+const ACTION_LOOKS: Record<
+  ShowActionButton["action"]["kind"],
+  { icon: Icon; color: string }
+> = {
+  compose: { icon: PencilSimple, color: "blue" },
+  open_canvas: { icon: Layout, color: "purple" },
+  open_inbox: { icon: Tray, color: "orange" },
+  open_space: { icon: Hash, color: "green" },
+};
 
 /**
  * The buttons a `show_actions` call offered, drawn where the agent offered them.
@@ -26,21 +46,85 @@ export function ShowActionsRow({ toolCall }: ToolViewProps) {
 
   if (buttons.length === 0) return null;
 
+  const cards = buttons.filter((button) => button.description);
+  const pills = buttons.filter((button) => !button.description);
+
   // No surrounding card: the buttons sit in the conversation, which already
   // frames them. A box around them would draw a second frame around nothing.
   return (
-    <div className="flex flex-wrap gap-2">
-      {buttons.map(({ label, action }, index) => (
-        <Button
-          key={`${index}-${label}`}
-          variant="outline"
-          size="sm"
-          disabled={openAction.isPending}
-          onClick={() => openAction.mutate({ action })}
-        >
-          {label}
-        </Button>
-      ))}
+    <div className="flex flex-col gap-2">
+      {cards.length > 0 && (
+        <div className="flex max-w-sm flex-col gap-2">
+          {cards.map(({ label, description, action }, index) => {
+            const { icon: ActionIcon, color } = ACTION_LOOKS[action.kind];
+            return (
+              <button
+                key={`${index}-${label}`}
+                type="button"
+                disabled={openAction.isPending}
+                onClick={() => openAction.mutate({ action })}
+                style={
+                  {
+                    "--card-hover-border": `var(--${color}-6)`,
+                  } as React.CSSProperties
+                }
+                className="flex w-full cursor-pointer items-start gap-2.5 rounded-xl border border-(--gray-a3) bg-(--color-panel-solid) px-2.5 py-2 text-left shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)] transition-[border-color,box-shadow] hover:border-(--card-hover-border) hover:shadow-[0_2px_8px_rgba(0,0,0,0.06),0_1px_3px_rgba(0,0,0,0.04)] disabled:cursor-default disabled:opacity-60"
+              >
+                <div
+                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
+                  style={{ backgroundColor: `var(--${color}-3)` }}
+                >
+                  <ActionIcon
+                    size={14}
+                    weight="duotone"
+                    color={`var(--${color}-9)`}
+                    aria-hidden
+                  />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <Text
+                    size="xs"
+                    weight="medium"
+                    className="min-w-0 truncate text-(--gray-12)"
+                  >
+                    {label}
+                  </Text>
+                  <Text
+                    size="xs"
+                    className="line-clamp-1 text-(--gray-11) leading-normal"
+                  >
+                    {description}
+                  </Text>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+      {pills.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {pills.map(({ label, action }, index) => {
+            const { icon: ActionIcon, color } = ACTION_LOOKS[action.kind];
+            return (
+              <Button
+                key={`${index}-${label}`}
+                variant="outline"
+                size="sm"
+                disabled={openAction.isPending}
+                onClick={() => openAction.mutate({ action })}
+              >
+                <ActionIcon
+                  size={14}
+                  weight="duotone"
+                  color={`var(--${color}-9)`}
+                  aria-hidden
+                />
+                {label}
+              </Button>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ShowActionsRow.tsx
@@ -46,33 +46,88 @@ export function ShowActionsRow({ toolCall }: ToolViewProps) {
 
   if (buttons.length === 0) return null;
 
-  const cards = buttons.filter((button) => button.description);
-  const pills = buttons.filter((button) => !button.description);
+  // Consecutive same-shape buttons form one run, so the agent's order
+  // survives: a pill before a card still renders before that card.
+  const runs: ShowActionButton[][] = [];
+  for (const button of buttons) {
+    const isCard = Boolean(button.description);
+    const lastRun = runs.at(-1);
+    if (lastRun && Boolean(lastRun[0].description) === isCard) {
+      lastRun.push(button);
+    } else {
+      runs.push([button]);
+    }
+  }
 
   // No surrounding card: the buttons sit in the conversation, which already
   // frames them. A box around them would draw a second frame around nothing.
   return (
     <div className="flex flex-col gap-2">
-      {cards.length > 0 && (
-        <div className="flex max-w-sm flex-col gap-2">
-          {cards.map(({ label, description, action }, index) => {
-            const { icon: ActionIcon, color } = ACTION_LOOKS[action.kind];
-            return (
-              <button
-                key={`${index}-${label}`}
-                type="button"
-                disabled={openAction.isPending}
-                onClick={() => openAction.mutate({ action })}
-                style={
-                  {
-                    "--card-hover-border": `var(--${color}-6)`,
-                  } as React.CSSProperties
-                }
-                className="flex w-full cursor-pointer items-start gap-2.5 rounded-xl border border-(--gray-a3) bg-(--color-panel-solid) px-2.5 py-2 text-left shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)] transition-[border-color,box-shadow] hover:border-(--card-hover-border) hover:shadow-[0_2px_8px_rgba(0,0,0,0.06),0_1px_3px_rgba(0,0,0,0.04)] disabled:cursor-default disabled:opacity-60"
-              >
-                <div
-                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
-                  style={{ backgroundColor: `var(--${color}-3)` }}
+      {runs.map((run) =>
+        run[0].description ? (
+          <div
+            key={`${run[0].label}-${run[0].action.kind}`}
+            className="flex max-w-sm flex-col gap-2"
+          >
+            {run.map(({ label, description, action }) => {
+              const { icon: ActionIcon, color } = ACTION_LOOKS[action.kind];
+              return (
+                <button
+                  key={`${label}-${action.kind}`}
+                  type="button"
+                  disabled={openAction.isPending}
+                  onClick={() => openAction.mutate({ action })}
+                  style={
+                    {
+                      "--card-hover-border": `var(--${color}-6)`,
+                    } as React.CSSProperties
+                  }
+                  className="flex w-full cursor-pointer items-start gap-2.5 rounded-xl border border-(--gray-a3) bg-(--color-panel-solid) px-2.5 py-2 text-left shadow-[0_1px_3px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.02)] transition-[border-color,box-shadow] hover:border-(--card-hover-border) hover:shadow-[0_2px_8px_rgba(0,0,0,0.06),0_1px_3px_rgba(0,0,0,0.04)] disabled:cursor-default disabled:opacity-60"
+                >
+                  <div
+                    className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
+                    style={{ backgroundColor: `var(--${color}-3)` }}
+                  >
+                    <ActionIcon
+                      size={14}
+                      weight="duotone"
+                      color={`var(--${color}-9)`}
+                      aria-hidden
+                    />
+                  </div>
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <Text
+                      size="xs"
+                      weight="medium"
+                      className="min-w-0 truncate text-(--gray-12)"
+                    >
+                      {label}
+                    </Text>
+                    <Text
+                      size="xs"
+                      className="line-clamp-1 text-(--gray-11) leading-normal"
+                    >
+                      {description}
+                    </Text>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div
+            key={`${run[0].label}-${run[0].action.kind}`}
+            className="flex flex-wrap gap-2"
+          >
+            {run.map(({ label, action }) => {
+              const { icon: ActionIcon, color } = ACTION_LOOKS[action.kind];
+              return (
+                <Button
+                  key={`${label}-${action.kind}`}
+                  variant="outline"
+                  size="sm"
+                  disabled={openAction.isPending}
+                  onClick={() => openAction.mutate({ action })}
                 >
                   <ActionIcon
                     size={14}
@@ -80,50 +135,12 @@ export function ShowActionsRow({ toolCall }: ToolViewProps) {
                     color={`var(--${color}-9)`}
                     aria-hidden
                   />
-                </div>
-                <div className="flex min-w-0 flex-1 flex-col gap-1">
-                  <Text
-                    size="xs"
-                    weight="medium"
-                    className="min-w-0 truncate text-(--gray-12)"
-                  >
-                    {label}
-                  </Text>
-                  <Text
-                    size="xs"
-                    className="line-clamp-1 text-(--gray-11) leading-normal"
-                  >
-                    {description}
-                  </Text>
-                </div>
-              </button>
-            );
-          })}
-        </div>
-      )}
-      {pills.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {pills.map(({ label, action }, index) => {
-            const { icon: ActionIcon, color } = ACTION_LOOKS[action.kind];
-            return (
-              <Button
-                key={`${index}-${label}`}
-                variant="outline"
-                size="sm"
-                disabled={openAction.isPending}
-                onClick={() => openAction.mutate({ action })}
-              >
-                <ActionIcon
-                  size={14}
-                  weight="duotone"
-                  color={`var(--${color}-9)`}
-                  aria-hidden
-                />
-                {label}
-              </Button>
-            );
-          })}
-        </div>
+                  {label}
+                </Button>
+              );
+            })}
+          </div>
+        ),
       )}
     </div>
   );


### PR DESCRIPTION
## Problem

the buttons the agent can show (via `show_actions` tool) are too plain

we want to leverage these more during onboarding

let's make them look nicer first 

## Changes

- each type of button now has an icon and a color
- compose buttons can have a description which makes the card bigger and prettier
- buttons render in the order the agent supplied, even when pills and cards mix

<img width="1218" height="102" alt="Screenshot 2026-09-02 at 9 20 04 AM" src="https://github.com/user-attachments/assets/7de5f057-6873-461b-a386-ce32241ebcf7" />
<img width="824" height="354" alt="Screenshot 2026-09-02 at 9 20 09 AM" src="https://github.com/user-attachments/assets/7156a873-f675-498a-9179-ec1ffd2e55ca" />


---- ai gen below ----

## How did you test this code?

- `ShowActionsRow` tests: a described compose renders as a card with its description, undescribed actions stay pills, and a card click sends the typed action without `label` or `description` (a leaked description would ride into the URL the host builds).
- An order test catches the regression where the renderer partitioned actions into cards-then-pills and reordered a pill that preceded a card.
- `readShowActions` test now asserts `description` lands on the button, not inside the action.
- Typecheck across shared/core/ui/agent and Biome pass locally.
- Not run: the app itself; the card rendering was not eyeballed in a live session.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code (Fable 5 orchestrating an Opus implementation agent); skills invoked: `/posthog-desktop`, `/writing-ui-components`, `/writing-tests`, `/writing-pr-descriptions`.
- Design decision made in-session: icon and color come from a fixed per-kind map in the renderer rather than schema fields, so buttons stay consistent across sessions and invalid icon names cannot occur.


