### PR TITLE
chore(product-analytics): assert the setup screen in the trends spec

### DIFF
--- a/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
+++ b/frontend/src/lib/components/ProductEmptyState/ProductEmptyState.tsx
@@ -139,6 +139,9 @@ export function ProductEmptyState({ config, mode }: ProductEmptyStateProps): JSX
 
     return (
         <div
+            // Frozen selector. Playwright specs use it to detect the setup screen, because a
+            // scene behind this gate does not render until the product has data.
+            data-attr="product-empty-state"
             // Fill the scene: viewport minus the app chrome and the product header above us.
             className="grid w-full flex-1 grid-cols-1 items-stretch gap-10 md:grid-cols-[minmax(0,1fr)_40%] min-h-[calc(100vh-var(--breadcrumbs-height-full,0px)-var(--scene-padding,1rem)-4rem)]"
             style={

--- a/playwright/e2e/product-analytics/insights/trends.spec.ts
+++ b/playwright/e2e/product-analytics/insights/trends.spec.ts
@@ -308,7 +308,9 @@ test.describe('Trends insights', () => {
 
         await test.step('navigate away and verify no orphaned tooltip', async () => {
             await insight.goToList()
-            await expect(page.locator('table')).toBeVisible()
+            // This project saves no insight, so the list opens on the product analytics setup
+            // screen instead of the table. Either surface proves the new scene mounted.
+            await expect(page.locator('table').or(page.getByTestId('product-empty-state')).first()).toBeVisible()
             await expect(insight.trends.tooltip).toHaveCount(0, { timeout: 3000 })
         })
     })

--- a/playwright/e2e/product-analytics/insights/trends.spec.ts
+++ b/playwright/e2e/product-analytics/insights/trends.spec.ts
@@ -309,8 +309,8 @@ test.describe('Trends insights', () => {
         await test.step('navigate away and verify no orphaned tooltip', async () => {
             await insight.goToList()
             // This project saves no insight, so the list opens on the product analytics setup
-            // screen instead of the table. Either surface proves the new scene mounted.
-            await expect(page.locator('table').or(page.getByTestId('product-empty-state')).first()).toBeVisible()
+            // screen rather than the table.
+            await expect(page.getByTestId('product-empty-state')).toBeVisible()
             await expect(insight.trends.tooltip).toHaveCount(0, { timeout: 3000 })
         })
     })


### PR DESCRIPTION
## Problem

Every push to master fails the Playwright E2E check, so every open PR sees a red master. The failing test is `Trends insights > Hover chart to see tooltip with data point values` ([failing job](https://github.com/PostHog/posthog/actions/runs/33621354993/job/100219582257)).

- The test navigates to the insights list to prove no chart tooltip survives the navigation, then asserts the list table is visible.
- Its workspace saves no insight, so the list opens on the product analytics setup screen instead of the table. #91049 added that gate.
- Trunk quarantined the failure on #91049 and on master until this morning, so the regression landed and stayed green for 12 hours ([the PR's own job](https://github.com/PostHog/posthog/actions/runs/33551701891/job/100003169645)).

## Changes

- The tooltip step asserts the setup screen, which is the only surface the list can render for a project with no saved insights.
- `ProductEmptyState` renders `data-attr="product-empty-state"` as the hook for that assertion.
- Nothing looks different in the app. The `data-attr` is the only production change.

The step keeps asserting one specific page, so it still fails if the navigation does not land. A locator matching the table or the setup screen would pass on both pages and prove neither.

## How did you test this code?

- Not run locally. The local dev database is behind on migrations, so the Playwright setup endpoint refuses to create a workspace. The E2E check on this PR is the verification.
- No new test. This restores an existing test that depended on data its workspace never creates.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code investigated a reported master-red E2E failure, confirmed the failing spec and its cause, and wrote this fix. Skills invoked: `/writing-tests`, `/writing-ui-components`, `/writing-code-comments`, `/writing-pr-descriptions`.

The first hypothesis was a race between the setup-status query and the scene render. The gate holds a spinner while the status loads, so the failure is deterministic instead: master reported `139 passed` before #91049 and `138 passed, 1 failed` after, on every run. Seeding an insight into the spec's workspace was the other option, and it was rejected because the tooltip test does not need saved insights to prove its point.
