### PR TITLE
fix(insights): stop the trends tooltip test reading the previous query

### DIFF
--- a/playwright/e2e/product-analytics/insights/trends.spec.ts
+++ b/playwright/e2e/product-analytics/insights/trends.spec.ts
@@ -299,7 +299,11 @@ test.describe('Trends insights', () => {
             await insight.trends.addBreakdown('Browser')
             await insight.trends.waitForChart()
             await insight.trends.selectEvent(0, customEventsWithBreakdown.eventName)
-            await insight.trends.waitForChart()
+            // Read the breakdown rows before hovering. waitForChart only waits for the
+            // loader to detach, which is already true while the previous query's chart
+            // is still mounted, so the hover below would sample the old series.
+            await insight.trends.expectRowTotal('Chrome', customEventsWithBreakdown.expected.chromeCount)
+            await insight.trends.expectRowTotal('Firefox', customEventsWithBreakdown.expected.firefoxCount)
             await insight.trends.hoverChartAt(0.5, 0.5)
             const multiText = await insight.trends.tooltip.textContent()
             expect(multiText).toContain('Chrome')
@@ -308,7 +312,9 @@ test.describe('Trends insights', () => {
 
         await test.step('navigate away and verify no orphaned tooltip', async () => {
             await insight.goToList()
-            await expect(page.locator('table')).toBeVisible()
+            // The scene heading renders whether or not the list has rows. A table only
+            // appears once something is saved, which depends on what ran before this.
+            await expect(page.getByRole('heading', { name: 'Product analytics', level: 1 })).toBeVisible()
             await expect(insight.trends.tooltip).toHaveCount(0, { timeout: 3000 })
         })
     })


### PR DESCRIPTION
## Problem

Every PR in the repo is red on one Playwright test, and it is not their fault.

`Trends insights › Hover chart to see tooltip with data point values` has been failing on master. Trunk reclassified it from flaky to broken, and Trunk only quarantines flaky tests, so the quarantine gate stopped absorbing the failure. Three consecutive master runs went red, and the run before them was reported green only because the same test failed and was still quarantined.

Nothing about the product is broken. Both defects are waits in the test.

## Changes

**The hover read the previous query's chart.** After the test switches the series, `waitForChart` only waits for the loading indicator to detach, which is already true while the old chart is still mounted, so it returned against stale content and the tooltip described the wrong series.

- The test now reads the two breakdown rows before hovering, which pins the new result on screen.
- `expectRowTotal` polls, so it cannot pass while the old rows are up. The page object already carries a comment describing this exact transition, which is what the helper was built for.

The run artifact shows the stale state directly. The insight is named `custom_test_event count by event's Browser`, while the results row reads `Chrome … 38 0 10 8 6 5 7 0 2` — that total and daily shape are the `$pageview` fixture, not the custom event.

**The last step asserted a `table` on the insights list.** A table only renders once something is saved, so that step passed only when an earlier test in the same worker had saved an insight, and failed whenever this test ran alone. It now asserts the scene heading, which renders in both the empty and populated states. This is the cross-test ordering dependency the testing conventions rule out.

The fixture needs no change, which is worth stating because it looks like it should. Chrome and Firefox sit on different days, but trends returns dense arrays, and quill's `buildTooltipContext` keeps any finite value and skips only null and NaN gaps, so Firefox still renders a zero row on Chrome's day. The assertion was always satisfiable.

## How did you test this code?

No new tests. This changes what an existing test waits for, and adds no coverage.

Run against the local E2E stack on `http://localhost:8010`:

- The target test failed in isolation before this change and passes after it.
- The whole spec goes 10 passed. The one remaining failure is the CSV export step, which fails the same way on unmodified master locally, because this stack runs no exports worker. It passes in CI.
- The target test then ran 10/10 under `--repeat-each 10 --workers 3`.

<details>
<summary>Flakiness run</summary>

```text
Running 10 tests using 3 workers
  10 passed (1.3m)
```

</details>

Not checked: the stale-chart race never reproduced locally, because local timing favours the query finishing first. The fix is argued from the artifact and from the polling helper rather than from a local red-to-green on that specific step. The CI run on this PR is what confirms it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Opus 5 in Claude Code. Skills invoked: `/playwright-test`, `/writing-tests`, `/writing-pr-descriptions`.

Found while investigating why an unrelated CI stack ([#93229](https://github.com/PostHog/posthog/pull/93229) and [#91749](https://github.com/PostHog/posthog/pull/91749)) could not go green. Those PRs change only workflow YAML, so the failure was traced to master rather than to them, and this fix is deliberately separate from that stack so it can land on its own.

Two dead ends worth recording. The first read blamed the fixture's day split for making `toContain('Firefox')` unsatisfiable; reading quill's tooltip context builder and its gap test ruled that out. The second was reproducing with `-g`, which produced a different failure at the final step and turned out to be the second, independent defect rather than noise.
