### PR TITLE
fix(hogql): make trino diagnostics opt in

### DIFF
--- a/docs/internal/hogql-trino-compiler.md
+++ b/docs/internal/hogql-trino-compiler.md
@@ -39,6 +39,8 @@ For managed DuckLake data, call `compile_hogql_to_trino_sql(...)` through the ma
 - materialized saved queries to their `posthog_data_modeling_team_<team_id>` DuckLake copies;
 - copied warehouse sources to their provisioned data-import schema and table names.
 
+The compiler returns Trino SQL and parameter values by default. Pass `include_hogql=True` to include a normalized HogQL diagnostic; this optional rendering reuses the compilation database.
+
 The control-plane read accepts both `trino_catalog_name` and the earlier `catalog` field during a rolling deployment. A disabled or non-ready Trino target, an organization mismatch, a missing team row, or an unmapped relation fails compilation before SQL submission. The helper only compiles; deploying it does not change query routing or execute Trino SQL.
 
 Trino compilation currently requires `personsOnEventsMode=person_id_override_properties_on_events`. The compiler rejects unset, disabled, V1, and joined modes before semantic lowering so it cannot silently apply V2 person attribution to a query that requested different behavior.

--- a/products/managed_warehouse/backend/facade/client.py
+++ b/products/managed_warehouse/backend/facade/client.py
@@ -58,6 +58,7 @@ def compile_hogql_to_trino_sql(
     team: Team | None = None,
     user: User | None = None,
     bypass_warehouse_access_control: bool = False,
+    include_hogql: bool = False,
 ) -> TrinoCompiledQuery:
     from products.managed_warehouse.backend.trino_compiler import (  # noqa: PLC0415 -- keep the optional compiler off startup paths
         compile_hogql_to_trino_sql as _compile_hogql_to_trino_sql,
@@ -69,6 +70,7 @@ def compile_hogql_to_trino_sql(
         team=team,
         user=user,
         bypass_warehouse_access_control=bypass_warehouse_access_control,
+        include_hogql=include_hogql,
     )
 
 

--- a/products/managed_warehouse/backend/facade/contracts.py
+++ b/products/managed_warehouse/backend/facade/contracts.py
@@ -290,7 +290,7 @@ class TrinoCompiledQuery:
 
     sql: str
     values: dict[str, Any]
-    hogql: str
+    hogql: str | None = None
 
 
 @dataclass

--- a/products/managed_warehouse/backend/tests/test_trino_compiler.py
+++ b/products/managed_warehouse/backend/tests/test_trino_compiler.py
@@ -82,7 +82,13 @@ class TestReadyTrinoCatalogName:
 
 
 class TestCompileHogQLToTrinoSQL:
-    def test_populates_core_table_locators_from_control_plane_state(self) -> None:
+    @pytest.mark.parametrize(
+        ("include_hogql", "expected_hogql", "expected_print_calls"),
+        [(False, None, 1), (True, "SELECT event FROM events", 2)],
+    )
+    def test_populates_core_table_locators_from_control_plane_state(
+        self, include_hogql: bool, expected_hogql: str | None, expected_print_calls: int
+    ) -> None:
         team = _team()
         membership = _membership(team_id=team.pk, organization_id=str(team.organization_id))
         database = mock.MagicMock()
@@ -116,10 +122,12 @@ class TestCompileHogQLToTrinoSQL:
                 team.pk,
                 HogQLQuery(query="SELECT event FROM events LIMIT 1"),
                 team=team,
+                include_hogql=include_hogql,
             )
 
         assert compiled.sql == "SELECT event FROM target"
         assert compiled.values == {}
+        assert compiled.hogql == expected_hogql
         build_locators.assert_called_once_with(
             database,
             team.pk,
@@ -130,6 +138,11 @@ class TestCompileHogQLToTrinoSQL:
         assert trino_context.trino_table_locators == locators
         assert trino_context.modifiers is modifiers
         assert prepare_and_print.call_args_list[0].kwargs["dialect"] == "trino"
+        assert prepare_and_print.call_count == expected_print_calls
+        if include_hogql:
+            hogql_context = prepare_and_print.call_args_list[1].args[1]
+            assert hogql_context.database is database
+            assert prepare_and_print.call_args_list[1].kwargs["dialect"] == "hogql"
 
     def test_fails_closed_without_a_ready_catalog(self) -> None:
         team = _team()

--- a/products/managed_warehouse/backend/trino_compiler.py
+++ b/products/managed_warehouse/backend/trino_compiler.py
@@ -54,11 +54,13 @@ def compile_hogql_to_trino_sql(
     team: Team | None = None,
     user: User | None = None,
     bypass_warehouse_access_control: bool = False,
+    include_hogql: bool = False,
 ) -> TrinoCompiledQuery:
     """Compile HogQL for the ready Trino catalog that serves the team's DuckLake data.
 
     Set ``bypass_warehouse_access_control`` only for trusted internal callers that compile
     without a user. This entry point does not execute the returned SQL or alter query routing.
+    Set ``include_hogql`` to render normalized HogQL for diagnostics.
     """
     from posthog.hogql import ast  # noqa: PLC0415
     from posthog.hogql.context import HogQLContext  # noqa: PLC0415
@@ -132,18 +134,20 @@ def compile_hogql_to_trino_sql(
         database=database,
         trino_table_locators=trino_table_locators,
     )
-    hogql_ast = clone_expr(parsed)
+    hogql_ast = clone_expr(parsed) if include_hogql else None
     trino_sql, _ = prepare_and_print_ast(parsed, trino_context, dialect="trino")
 
-    hogql_context = HogQLContext(
-        team_id=team_id,
-        team=team,
-        user=user,
-        enable_select_queries=True,
-        modifiers=query_modifiers,
-        # The diagnostic HogQL rendering must use the same caller-authorized access posture.
-        bypass_warehouse_access_control=bypass_warehouse_access_control,
-    )
-    hogql_pretty, _ = prepare_and_print_ast(hogql_ast, hogql_context, dialect="hogql")
+    hogql_pretty: str | None = None
+    if hogql_ast is not None:
+        hogql_context = HogQLContext(
+            team_id=team_id,
+            team=team,
+            user=user,
+            enable_select_queries=True,
+            modifiers=query_modifiers,
+            bypass_warehouse_access_control=bypass_warehouse_access_control,
+            database=database,
+        )
+        hogql_pretty, _ = prepare_and_print_ast(hogql_ast, hogql_context, dialect="hogql")
 
     return TrinoCompiledQuery(sql=trino_sql, values=dict(trino_context.values), hogql=hogql_pretty)


### PR DESCRIPTION
## Problem

Developers compiling HogQL for Trino wait for a normalized HogQL diagnostic that execution callers do not consume.

The diagnostic runs a second semantic preparation pass for every successful compilation.

## Changes

- Trino compilation now skips normalized HogQL rendering unless callers pass include_hogql=True.
- Opt-in rendering reuses the compilation database instead of reconstructing team metadata.
- The result returns None for diagnostics by default.
- This change has no user-facing visual effect.

## How did you test this code?

- Extended the compiler test to guard the default single-pass path and explicit diagnostic rendering.
- Ran the focused managed warehouse compiler test.
- Ran repository-wide mypy and the CI preflight.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the internal HogQL to Trino compiler guide with the opt-in diagnostic behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored the change with repository shell and patch tools. Skills invoked: /writing-dataclasses, /writing-tests, /writing-code-comments, and /writing-pr-descriptions.

The committed code and tests contain no production or external data.