### PR TITLE
fix(ingestion): keep queued person properties across a batch read

### DIFF
--- a/nodejs/src/common/persons/person-update-batch.ts
+++ b/nodejs/src/common/persons/person-update-batch.ts
@@ -20,6 +20,9 @@ export interface PersonUpdate {
     // Fine-grained property tracking
     properties_to_set: Properties // Properties to set/update
     properties_to_unset: string[] // Property keys to unset
+    // Keys queued since the last flush. properties_to_set also holds folded-in snapshots and
+    // flushed writes, so it cannot tell a queued key from a stale one.
+    pending_keys: Set<string>
     original_is_identified: boolean
     original_created_at: DateTime
     original_last_seen_at: DateTime | null
@@ -51,6 +54,7 @@ export function fromInternalPerson(person: InternalPerson, distinctId: string): 
         needs_write: false,
         properties_to_set: {},
         properties_to_unset: [],
+        pending_keys: new Set(),
         original_is_identified: person.is_identified,
         original_created_at: person.created_at,
         original_last_seen_at: person.last_seen_at,

--- a/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.test.ts
@@ -255,6 +255,7 @@ describe('PostgresPersonRepository', () => {
                 original_is_identified: false,
                 original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 original_last_seen_at: null,
+                pending_keys: new Set<string>(),
             }
         }
 
@@ -1751,6 +1752,7 @@ describe('PostgresPersonRepository', () => {
                 original_is_identified: false,
                 original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 original_last_seen_at: null,
+                pending_keys: new Set<string>(),
             }
 
             // First update should succeed
@@ -1788,6 +1790,7 @@ describe('PostgresPersonRepository', () => {
                 original_is_identified: false,
                 original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 original_last_seen_at: null,
+                pending_keys: new Set<string>(),
             }
 
             // Update should fail due to version mismatch
@@ -1823,6 +1826,7 @@ describe('PostgresPersonRepository', () => {
                 original_is_identified: false,
                 original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 original_last_seen_at: null,
+                pending_keys: new Set<string>(),
             }
 
             // Update should fail because person doesn't exist
@@ -1854,6 +1858,7 @@ describe('PostgresPersonRepository', () => {
                 original_is_identified: false,
                 original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 original_last_seen_at: null,
+                pending_keys: new Set<string>(),
             }
 
             const [actualVersion, messages] = await repository.updatePersonAssertVersion(personUpdate)
@@ -1894,6 +1899,7 @@ describe('PostgresPersonRepository', () => {
                 original_is_identified: false,
                 original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 original_last_seen_at: null,
+                pending_keys: new Set<string>(),
             }
 
             const [actualVersion, messages] = await repository.updatePersonAssertVersion(personUpdate)
@@ -1932,6 +1938,7 @@ describe('PostgresPersonRepository', () => {
                 original_is_identified: false,
                 original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 original_last_seen_at: null,
+                pending_keys: new Set<string>(),
             }
 
             const [actualVersion, messages] = await repository.updatePersonAssertVersion(personUpdate)
@@ -2560,6 +2567,7 @@ describe('PostgresPersonRepository', () => {
                     original_is_identified: false,
                     original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                     original_last_seen_at: null,
+                    pending_keys: new Set<string>(),
                 }
 
                 await expect(oversizedRepository.updatePersonAssertVersion(personUpdate)).rejects.toThrow(
@@ -2810,6 +2818,7 @@ describe('PostgresPersonRepository', () => {
                 original_is_identified: false,
                 original_created_at: DateTime.fromISO('2020-01-01T00:00:00.000Z'),
                 original_last_seen_at: null,
+                pending_keys: new Set<string>(),
             })
 
             const personUpdate1 = createPersonUpdate(person1, 'test-assert-1')

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
@@ -1140,18 +1140,14 @@ describe('BatchWritingPersonStore', () => {
     })
 
     it('should let pending property writes win over a same-batch re-read, and a fresh read win once flushed', async () => {
-        // Mirrors $identify($set) followed by $create_alias in one batch: the alias distinct ID is
-        // not in the batch cache, so it reads the person from Postgres. That read lands on the same
-        // cache entry. It must not revert the property the $identify queued, and it must still pick
-        // up a key this batch never touched.
+        // $identify($set) then $create_alias in one batch: the alias ID misses the cache and re-reads
+        // the same person from Postgres.
         const identifiedDistinctId = 'user-email@example.com'
         const aliasDistinctId = 'user-device-abc123'
         const laterDistinctId = 'user-device-xyz789'
-        const cacheKey = `${teamId}:${person.id}`
 
         const mockRepo = createMockRepository()
         let storedProperties: Properties = { queued_prop: 'db_value', untouched_prop: 'db_value' }
-        // Every distinct ID resolves to the same stored person, as it does after an earlier merge.
         mockRepo.fetchPerson = jest
             .fn()
             .mockImplementation(() => Promise.resolve({ ...person, properties: { ...storedProperties } }))
@@ -1168,14 +1164,10 @@ describe('BatchWritingPersonStore', () => {
             true
         )
 
-        // Another writer changes the key this batch never queued, then the alias ID reads the person.
+        // Another writer changes the untouched key before the alias re-read.
         storedProperties = { queued_prop: 'db_value', untouched_prop: 'other_writer_value' }
         await personStore.fetchForUpdate(teamId, aliasDistinctId, 0)
 
-        expect(personStore.getUpdateCache().get(cacheKey)?.properties_to_set).toEqual({
-            queued_prop: 'queued_value',
-            untouched_prop: 'other_writer_value',
-        })
         const afterReRead = await personStore.fetchForUpdate(teamId, identifiedDistinctId, 0)
         expect(afterReRead?.properties).toEqual({
             queued_prop: 'queued_value',
@@ -1193,13 +1185,78 @@ describe('BatchWritingPersonStore', () => {
             ])
         )
 
-        // The flush cleared needs_write but left properties_to_set populated. From here the entry
-        // holds no pending write, so a newer database value has to win over it.
+        // After the flush, another writer changes the flushed key and this store re-dirties the entry.
         storedProperties = { queued_prop: 'newer_db_value', untouched_prop: 'other_writer_value' }
+        await personStore.updatePersonWithPropertiesDiffForUpdate(
+            person,
+            { later_prop: 'later_value' },
+            [],
+            {},
+            identifiedDistinctId,
+            0,
+            true
+        )
         await personStore.fetchForUpdate(teamId, laterDistinctId, 0)
 
         const afterFlushedReRead = await personStore.fetchForUpdate(teamId, identifiedDistinctId, 0)
-        expect(afterFlushedReRead?.properties.queued_prop).toBe('newer_db_value')
+        expect(afterFlushedReRead?.properties).toEqual({
+            queued_prop: 'newer_db_value',
+            untouched_prop: 'other_writer_value',
+            later_prop: 'later_value',
+        })
+
+        await personStore.flush()
+
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(2)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenLastCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    properties_to_set: {
+                        queued_prop: 'newer_db_value',
+                        untouched_prop: 'other_writer_value',
+                        later_prop: 'later_value',
+                    },
+                }),
+            ])
+        )
+    })
+
+    it('should keep a queued set that restores the stored value across a same-batch re-read', async () => {
+        // The queued value equals the baseline but is still a pending write.
+        const identifiedDistinctId = 'user-email@example.com'
+        const aliasDistinctId = 'user-device-abc123'
+
+        const mockRepo = createMockRepository()
+        let storedProperties: Properties = { plan: 'free' }
+        mockRepo.fetchPerson = jest
+            .fn()
+            .mockImplementation(() => Promise.resolve({ ...person, properties: { ...storedProperties } }))
+        const personStore = new BatchWritingPersonsStore(mockRepo, mockIngestionWarningsOutputs)
+
+        await personStore.fetchForUpdate(teamId, identifiedDistinctId, 0)
+        for (const plan of ['pro', 'free']) {
+            await personStore.updatePersonWithPropertiesDiffForUpdate(
+                person,
+                { plan },
+                [],
+                {},
+                identifiedDistinctId,
+                0,
+                true
+            )
+        }
+
+        storedProperties = { plan: 'enterprise' }
+        await personStore.fetchForUpdate(teamId, aliasDistinctId, 0)
+
+        const afterReRead = await personStore.fetchForUpdate(teamId, identifiedDistinctId, 0)
+        expect(afterReRead?.properties).toEqual({ plan: 'free' })
+
+        await personStore.flush()
+
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([expect.objectContaining({ properties_to_set: { plan: 'free' } })])
+        )
     })
 
     it('should handle set/unset conflicts when merging updates for same person via different distinct IDs', async () => {
@@ -3197,6 +3254,7 @@ describe('BatchWritingPersonStore', () => {
                 properties: person.properties,
                 properties_to_set: { new_prop: 'value' },
                 properties_to_unset: [],
+                pending_keys: new Set<string>(),
                 version: person.version,
                 created_at: person.created_at,
                 is_identified: false,

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.test.ts
@@ -11,6 +11,7 @@ import { fromInternalPerson } from '~/common/persons/person-update-batch'
 import { DependencyUnavailableError, MessageSizeTooLarge } from '~/common/utils/db/error'
 import { PostgresRouter } from '~/common/utils/db/postgres'
 import { emitIngestionWarning } from '~/ingestion/common/ingestion-warnings'
+import { Properties } from '~/plugin-scaffold'
 import { createMockIngestionOutputs } from '~/tests/helpers/mock-ingestion-outputs'
 import { InternalPerson, TeamId } from '~/types'
 
@@ -1136,6 +1137,69 @@ describe('BatchWritingPersonStore', () => {
                 }),
             ])
         )
+    })
+
+    it('should let pending property writes win over a same-batch re-read, and a fresh read win once flushed', async () => {
+        // Mirrors $identify($set) followed by $create_alias in one batch: the alias distinct ID is
+        // not in the batch cache, so it reads the person from Postgres. That read lands on the same
+        // cache entry. It must not revert the property the $identify queued, and it must still pick
+        // up a key this batch never touched.
+        const identifiedDistinctId = 'user-email@example.com'
+        const aliasDistinctId = 'user-device-abc123'
+        const laterDistinctId = 'user-device-xyz789'
+        const cacheKey = `${teamId}:${person.id}`
+
+        const mockRepo = createMockRepository()
+        let storedProperties: Properties = { queued_prop: 'db_value', untouched_prop: 'db_value' }
+        // Every distinct ID resolves to the same stored person, as it does after an earlier merge.
+        mockRepo.fetchPerson = jest
+            .fn()
+            .mockImplementation(() => Promise.resolve({ ...person, properties: { ...storedProperties } }))
+        const personStore = new BatchWritingPersonsStore(mockRepo, mockIngestionWarningsOutputs)
+
+        await personStore.fetchForUpdate(teamId, identifiedDistinctId, 0)
+        await personStore.updatePersonWithPropertiesDiffForUpdate(
+            person,
+            { queued_prop: 'queued_value' },
+            [],
+            {},
+            identifiedDistinctId,
+            0,
+            true
+        )
+
+        // Another writer changes the key this batch never queued, then the alias ID reads the person.
+        storedProperties = { queued_prop: 'db_value', untouched_prop: 'other_writer_value' }
+        await personStore.fetchForUpdate(teamId, aliasDistinctId, 0)
+
+        expect(personStore.getUpdateCache().get(cacheKey)?.properties_to_set).toEqual({
+            queued_prop: 'queued_value',
+            untouched_prop: 'other_writer_value',
+        })
+        const afterReRead = await personStore.fetchForUpdate(teamId, identifiedDistinctId, 0)
+        expect(afterReRead?.properties).toEqual({
+            queued_prop: 'queued_value',
+            untouched_prop: 'other_writer_value',
+        })
+
+        await personStore.flush()
+
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledTimes(1)
+        expect(mockRepo.updatePersonsBatch).toHaveBeenCalledWith(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    properties_to_set: { queued_prop: 'queued_value', untouched_prop: 'other_writer_value' },
+                }),
+            ])
+        )
+
+        // The flush cleared needs_write but left properties_to_set populated. From here the entry
+        // holds no pending write, so a newer database value has to win over it.
+        storedProperties = { queued_prop: 'newer_db_value', untouched_prop: 'other_writer_value' }
+        await personStore.fetchForUpdate(teamId, laterDistinctId, 0)
+
+        const afterFlushedReRead = await personStore.fetchForUpdate(teamId, identifiedDistinctId, 0)
+        expect(afterFlushedReRead?.properties.queued_prop).toBe('newer_db_value')
     })
 
     it('should handle set/unset conflicts when merging updates for same person via different distinct IDs', async () => {

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -446,9 +446,23 @@ class BatchWritingPersonsCache {
             is_identified: existingPersonUpdate.is_identified || person.is_identified,
         }
 
+        // A read for another distinct id of this person brings a fresh database snapshot. Writes
+        // this batch queued since its last flush have to survive it. `properties_to_set` also
+        // holds keys folded in from an earlier snapshot, so re-apply only the keys that differ
+        // from this entry's own baseline. The rest stay free to take the newer value.
+        const pendingSets: Properties = {}
+        if (existingPersonUpdate.needs_write) {
+            for (const [key, value] of Object.entries(existingPersonUpdate.properties_to_set)) {
+                if (existingPersonUpdate.properties[key] !== value) {
+                    pendingSets[key] = value
+                }
+            }
+        }
+
         mergedPersonUpdate.properties_to_set = {
             ...existingPersonUpdate.properties_to_set,
             ...person.properties,
+            ...pendingSets,
             ...person.properties_to_set,
         }
         for (const key of person.properties_to_unset) {

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -258,6 +258,7 @@ class BatchWritingPersonsCache {
                 properties: { ...result.properties },
                 properties_to_set: { ...result.properties_to_set },
                 properties_to_unset: [...result.properties_to_unset],
+                pending_keys: new Set(result.pending_keys),
             }
         }
 
@@ -446,16 +447,11 @@ class BatchWritingPersonsCache {
             is_identified: existingPersonUpdate.is_identified || person.is_identified,
         }
 
-        // A read for another distinct id of this person brings a fresh database snapshot. Writes
-        // this batch queued since its last flush have to survive it. `properties_to_set` also
-        // holds keys folded in from an earlier snapshot, so re-apply only the keys that differ
-        // from this entry's own baseline. The rest stay free to take the newer value.
+        // Queued sets must survive a fresh database snapshot; every other key takes the newer value.
         const pendingSets: Properties = {}
-        if (existingPersonUpdate.needs_write) {
-            for (const [key, value] of Object.entries(existingPersonUpdate.properties_to_set)) {
-                if (existingPersonUpdate.properties[key] !== value) {
-                    pendingSets[key] = value
-                }
+        for (const key of existingPersonUpdate.pending_keys) {
+            if (Object.hasOwn(existingPersonUpdate.properties_to_set, key)) {
+                pendingSets[key] = existingPersonUpdate.properties_to_set[key]
             }
         }
 
@@ -465,8 +461,10 @@ class BatchWritingPersonsCache {
             ...pendingSets,
             ...person.properties_to_set,
         }
+        mergedPersonUpdate.pending_keys = new Set([...existingPersonUpdate.pending_keys, ...person.pending_keys])
         for (const key of person.properties_to_unset) {
             delete mergedPersonUpdate.properties_to_set[key]
+            mergedPersonUpdate.pending_keys.delete(key)
         }
 
         mergedPersonUpdate.properties_to_unset = [
@@ -700,6 +698,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             // after this point will re-set needs_write=true and the next
             // flush will pick those changes up.
             update.needs_write = false
+            update.pending_keys.clear()
         }
         // END synchronous linearization point.
 
@@ -1913,6 +1912,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             // Add all properties from the update to properties_to_set
             Object.entries(update.properties).forEach(([key, value]) => {
                 personUpdate.properties_to_set[key] = value
+                personUpdate.pending_keys.add(key)
                 // Remove from unset list if it was there
                 const unsetIndex = personUpdate.properties_to_unset.indexOf(key)
                 if (unsetIndex !== -1) {
@@ -1977,6 +1977,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
         // Add properties to set (merge with existing properties_to_set)
         Object.entries(propertiesToSet).forEach(([key, value]) => {
             personUpdate.properties_to_set[key] = value
+            personUpdate.pending_keys.add(key)
             // Remove from unset list if it was there
             const unsetIndex = personUpdate.properties_to_unset.indexOf(key)
             if (unsetIndex !== -1) {
@@ -1991,6 +1992,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             }
             // Remove from set list if it was there
             delete personUpdate.properties_to_set[key]
+            personUpdate.pending_keys.delete(key)
         })
 
         // Handle is_identified specially with || operator
@@ -2268,6 +2270,7 @@ export class BatchWritingPersonsStore implements PersonsStore, BatchWritingStore
             needs_write: personUpdate.needs_write,
             properties_to_set: personUpdate.properties_to_set,
             properties_to_unset: personUpdate.properties_to_unset,
+            pending_keys: personUpdate.pending_keys,
             original_is_identified: personUpdate.original_is_identified,
             original_created_at: personUpdate.original_created_at,
             original_last_seen_at: personUpdate.original_last_seen_at,


### PR DESCRIPTION
## Problem

An `$identify` that sets a person property, followed by `$create_alias` in the same batch, leaves the profile on the old value. Every `$identify` sends the new value and none of them stick.

The batch person store keys its cache by person id. When an event reads a distinct id that is not cached but belongs to a cached person, the store reads Postgres and merges that snapshot into the entry.

The merge spread the snapshot over the writes the batch had queued, so the queued value was gone before the flush.

## Changes

* A property set earlier in the batch now survives a later read of the same person from Postgres.
* A key the batch never set still takes the newer database value, so a write from another pod is not reverted.
* A key the store already flushed also takes the newer database value, even after a later event dirties the same entry again.
* Each cache entry now tracks the keys queued since its last flush in a `pending_keys` set. The merge re-applies exactly those keys over the snapshot.
* The flush clears `pending_keys` at the same point it clears `needs_write`.

Why a set and not a value comparison: `properties_to_set` also holds keys folded in from earlier snapshots and from flushed writes, and the entry's baseline `properties` never advances after a flush.
Comparing values against that baseline treats every flushed key as still queued once another event dirties the entry, which reverts newer values from other pods.
The set has no such ambiguity, and it also covers a queued set whose value happens to equal the baseline.

The rest of the diff is mechanical: the new field on `PersonUpdate`, its clone in the cache read, and test fixtures that build a `PersonUpdate` literal.

## How did you test this code?

Two tests in `batch-writing-person-store.test.ts`.

* The first covers the alias re-read. It fails on the unfixed code with the queued value lost. Its tail dirties the entry after a flush and re-reads, and fails on a version that infers queued keys from values, because the flushed key then reverts to its old value.
* The second queues a set whose value equals the stored baseline and re-reads. It fails on a version that infers queued keys from values, because that version sees no queued write.

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code implemented a plan written earlier in the same session.
Skills invoked: `/implement-plan`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `code-review` in a review subagent.

Public artifact: the work started from a customer report.
The property names and values in the test are invented.
