### PR TITLE
feat(experiments): queue a rerun for edits made during a recalculation

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
@@ -103,11 +103,13 @@ export const ExperimentReloadAction = ({
     lastRefresh,
     onClick,
     progress,
+    queuedHint,
 }: {
     isRefreshing: boolean
     lastRefresh: string | null
     onClick: () => void
     progress?: { completed: number; total: number }
+    queuedHint?: string
 }): JSX.Element => {
     const { autoRefresh, experiment } = useValues(experimentLogic)
     const { setAutoRefresh, setPageVisibility, stopAutoRefreshInterval } = useActions(experimentLogic)
@@ -158,7 +160,7 @@ export const ExperimentReloadAction = ({
                     size="xsmall"
                     icon={isRefreshing ? <Spinner textColored /> : <IconRefresh />}
                     data-attr="refresh-experiment"
-                    disabledReason={isRefreshing ? 'Loading...' : null}
+                    disabledReason={isRefreshing ? (queuedHint ?? 'Loading...') : null}
                     sideAction={
                         ended
                             ? undefined

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadActionContainer.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadActionContainer.tsx
@@ -37,7 +37,7 @@ export function ExperimentReloadActionContainer({
 
 function RecalculationReloadAction({ experiment }: { experiment: Experiment }): JSX.Element {
     const metricsLogic = experimentMetricsLogic({ experiment })
-    const { isRecalculating, recalculationProgress, lastRefresh } = useValues(metricsLogic)
+    const { isRecalculating, recalculationProgress, lastRefresh, queuedRerun } = useValues(metricsLogic)
     const { triggerRecalculation } = useActions(metricsLogic)
     const { autoRefresh, currentRefresh } = useValues(experimentLogic)
     const { refreshExperimentResults, reportExperimentMetricsRefreshed } = useActions(experimentLogic)
@@ -47,6 +47,7 @@ function RecalculationReloadAction({ experiment }: { experiment: Experiment }): 
             isRefreshing={isRecalculating}
             lastRefresh={lastRefresh}
             progress={recalculationProgress}
+            queuedHint={queuedRerun ? 'Changes will apply after the current recalculation finishes' : undefined}
             onClick={() => {
                 reportExperimentMetricsRefreshed(experiment, true, {
                     triggered_by: 'manual',

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -853,6 +853,55 @@ describe('experimentMetricsLogic', () => {
             expect(logic.values.currentRecalculation).toEqual(expect.objectContaining({ status: 'in_progress' }))
             expect(logic.values.primaryMetricsResults[0]).toEqual(primaryResult)
         })
+
+        it('fires the queued rerun when the current run reaches terminal', async () => {
+            const createMock = jest.fn(() => [201, pendingRecalculation])
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [404, {}],
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/': () => [
+                        200,
+                        inProgressRecalculation,
+                    ],
+                },
+                post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+            })
+            jest.useFakeTimers()
+            mountLogic()
+
+            // Flush the afterMount → 404 → cold-run trigger → poll(create) chain before queuing.
+            await jest.advanceTimersByTimeAsync(0)
+
+            // A config change arrives while the cold run is active: it queues instead of posting.
+            logic.actions.triggerRecalculation('metric_config_change')
+            expect(logic.values.queuedRerun).toBe('metric_config_change')
+
+            // Now let the active run reach terminal; the retrieve mock always answers 'in_progress', so
+            // repoint it to 'completed' for the tick that follows.
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [404, {}],
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/': () => [
+                        200,
+                        completedRecalculation2,
+                    ],
+                },
+                post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+            })
+
+            await expectLogic(logic, async () => {
+                await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+            }).toDispatchActions([
+                (a) => a.type === logic.actionTypes.setQueuedRerun && a.payload.trigger === null,
+                (a) =>
+                    a.type === logic.actionTypes.triggerRecalculation && a.payload.trigger === 'metric_config_change',
+            ])
+
+            expect(logic.values.queuedRerun).toBeNull()
+            // The rerun fired as a fresh run (not re-queued), since the prior run was terminal by then.
+            await jest.advanceTimersByTimeAsync(0)
+            expect(createMock).toHaveBeenCalledTimes(2)
+        })
     })
 
     describe('liveRowsProgress', () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -13,7 +13,7 @@ import { Experiment } from '~/types'
 
 import type { ExperimentMetricsRecalculationApi } from 'products/experiments/frontend/generated/api.schemas'
 
-import { experimentMetricsLogic } from './experimentMetricsLogic'
+import { experimentMetricsLogic, strongerRerunTrigger } from './experimentMetricsLogic'
 
 jest.mock('@posthog/lemon-ui', () => ({
     ...jest.requireActual('@posthog/lemon-ui'),
@@ -947,6 +947,43 @@ describe('experimentMetricsLogic', () => {
                 logic.actions.triggerRecalculation()
             }).toNotHaveDispatchedActions(['pollRecalculation', 'setCurrentRecalculation'])
             expect(createMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('strongerRerunTrigger', () => {
+        it('ranks experiment_config_change above metric_config_change', () => {
+            expect(strongerRerunTrigger('metric_config_change', 'experiment_config_change')).toBe(
+                'experiment_config_change'
+            )
+            expect(strongerRerunTrigger('experiment_config_change', 'metric_config_change')).toBe(
+                'experiment_config_change'
+            )
+        })
+        it('keeps metric_config_change when both are metric-scoped', () => {
+            expect(strongerRerunTrigger('metric_config_change', 'metric_config_change')).toBe('metric_config_change')
+        })
+        it('treats manual and cold_run as full-advance (>= experiment scope)', () => {
+            expect(strongerRerunTrigger('metric_config_change', 'manual')).toBe('manual')
+            expect(strongerRerunTrigger('metric_config_change', 'cold_run')).toBe('cold_run')
+        })
+    })
+
+    describe('queuedRerun reducer', () => {
+        beforeEach(() => {
+            mountLogic()
+        })
+        it('coalesces to the stronger scope', () => {
+            logic.actions.setQueuedRerun('metric_config_change')
+            expect(logic.values.queuedRerun).toBe('metric_config_change')
+            logic.actions.setQueuedRerun('experiment_config_change')
+            expect(logic.values.queuedRerun).toBe('experiment_config_change')
+            logic.actions.setQueuedRerun('metric_config_change')
+            expect(logic.values.queuedRerun).toBe('experiment_config_change')
+        })
+        it('clears on null', () => {
+            logic.actions.setQueuedRerun('metric_config_change')
+            logic.actions.setQueuedRerun(null)
+            expect(logic.values.queuedRerun).toBeNull()
         })
     })
 })

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -599,6 +599,54 @@ describe('experimentMetricsLogic', () => {
             }).toDispatchActions(['setCurrentRecalculation'])
             expect(createMock).toHaveBeenCalled()
         })
+
+        describe('queuing', () => {
+            it('queues instead of posting when a run is active', async () => {
+                const createMock = jest.fn(() => [201, pendingRecalculation])
+                useMocks({
+                    get: {
+                        '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
+                            200,
+                            inProgressRecalculation,
+                        ],
+                    },
+                    post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+                })
+                mountLogic()
+                await expectLogic(logic).toDispatchActions(['setCurrentRecalculation'])
+                expect(logic.values.isRecalculating).toBe(true)
+
+                await expectLogic(logic, () => {
+                    logic.actions.triggerRecalculation('metric_config_change')
+                }).toDispatchActions(['setQueuedRerun'])
+
+                expect(logic.values.queuedRerun).toBe('metric_config_change')
+                expect(createMock).not.toHaveBeenCalled()
+            })
+
+            it('does not queue a cold_run (cold_run always starts fresh)', async () => {
+                const createMock = jest.fn(() => [201, pendingRecalculation])
+                useMocks({
+                    get: {
+                        '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
+                            200,
+                            inProgressRecalculation,
+                        ],
+                    },
+                    post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+                })
+                mountLogic()
+                await expectLogic(logic).toDispatchActions(['setCurrentRecalculation'])
+                expect(logic.values.isRecalculating).toBe(true)
+
+                await expectLogic(logic, () => {
+                    logic.actions.triggerRecalculation('cold_run')
+                }).toDispatchActions(['setCurrentRecalculation'])
+
+                expect(logic.values.queuedRerun).toBeNull()
+                expect(createMock).toHaveBeenCalled()
+            })
+        })
     })
 
     describe('loading + progress selectors', () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -13,7 +13,7 @@ import { Experiment } from '~/types'
 
 import type { ExperimentMetricsRecalculationApi } from 'products/experiments/frontend/generated/api.schemas'
 
-import { experimentMetricsLogic, strongerRerunTrigger } from './experimentMetricsLogic'
+import { experimentMetricsLogic } from './experimentMetricsLogic'
 
 jest.mock('@posthog/lemon-ui', () => ({
     ...jest.requireActual('@posthog/lemon-ui'),
@@ -1100,24 +1100,6 @@ describe('experimentMetricsLogic', () => {
                 logic.actions.triggerRecalculation()
             }).toNotHaveDispatchedActions(['pollRecalculation', 'setCurrentRecalculation'])
             expect(createMock).not.toHaveBeenCalled()
-        })
-    })
-
-    describe('strongerRerunTrigger', () => {
-        it('ranks experiment_config_change above metric_config_change', () => {
-            expect(strongerRerunTrigger('metric_config_change', 'experiment_config_change')).toBe(
-                'experiment_config_change'
-            )
-            expect(strongerRerunTrigger('experiment_config_change', 'metric_config_change')).toBe(
-                'experiment_config_change'
-            )
-        })
-        it('keeps metric_config_change when both are metric-scoped', () => {
-            expect(strongerRerunTrigger('metric_config_change', 'metric_config_change')).toBe('metric_config_change')
-        })
-        it('treats manual and cold_run as full-advance (>= experiment scope)', () => {
-            expect(strongerRerunTrigger('metric_config_change', 'manual')).toBe('manual')
-            expect(strongerRerunTrigger('metric_config_change', 'cold_run')).toBe('cold_run')
         })
     })
 

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -791,6 +791,8 @@ describe('experimentMetricsLogic', () => {
 
             // Flush afterMount → 404 → trigger → poll(create), then drive enough ticks to exhaust retries.
             await jest.advanceTimersByTimeAsync(0)
+            // A config change queued a rerun while the run was in flight.
+            logic.actions.setQueuedRerun('metric_config_change')
             for (let i = 0; i < MAX_POLL_RETRIES + 2; i++) {
                 await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
             }
@@ -800,6 +802,9 @@ describe('experimentMetricsLogic', () => {
             expect(lemonToast.error).toHaveBeenCalledWith(
                 'Failed to load recalculation results. Please reload to try again.'
             )
+            // The bail clears the queued rerun so it can't strand: the terminal branch (its only consumer)
+            // never runs on a give-up path.
+            expect(logic.values.queuedRerun).toBeNull()
         })
 
         it('on a cold_run, applies partial results mid-flight before the run is terminal', async () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -902,6 +902,62 @@ describe('experimentMetricsLogic', () => {
             await jest.advanceTimersByTimeAsync(0)
             expect(createMock).toHaveBeenCalledTimes(2)
         })
+
+        it('coalesces multiple queued config changes into a single rerun at the stronger scope', async () => {
+            const createMock = jest.fn(() => [201, pendingRecalculation])
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [404, {}],
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/': () => [
+                        200,
+                        inProgressRecalculation,
+                    ],
+                },
+                post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+            })
+            jest.useFakeTimers()
+            mountLogic()
+
+            // Flush the afterMount → 404 → cold-run trigger → poll(create) chain before queuing.
+            await jest.advanceTimersByTimeAsync(0)
+
+            // Two config changes arrive while the cold run is still active: they coalesce to the
+            // stronger scope instead of posting twice, so exactly one rerun fires later.
+            logic.actions.triggerRecalculation('metric_config_change')
+            expect(logic.values.queuedRerun).toBe('metric_config_change')
+            logic.actions.triggerRecalculation('experiment_config_change')
+            expect(logic.values.queuedRerun).toBe('experiment_config_change')
+
+            // Still one active run: neither queued change posted a create.
+            expect(createMock).toHaveBeenCalledTimes(1)
+
+            // Now let the active run reach terminal; the retrieve mock always answers 'in_progress', so
+            // repoint it to 'completed' for the tick that follows.
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [404, {}],
+                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/:recalc_id/': () => [
+                        200,
+                        completedRecalculation2,
+                    ],
+                },
+                post: { '/api/projects/:team_id/experiments/:id/metrics_recalculation/': createMock },
+            })
+
+            await expectLogic(logic, async () => {
+                await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+            }).toDispatchActions([
+                (a) => a.type === logic.actionTypes.setQueuedRerun && a.payload.trigger === null,
+                (a) =>
+                    a.type === logic.actionTypes.triggerRecalculation &&
+                    a.payload.trigger === 'experiment_config_change',
+            ])
+
+            expect(logic.values.queuedRerun).toBeNull()
+            // Exactly one fresh rerun fired, coalesced to the stronger scope.
+            await jest.advanceTimersByTimeAsync(0)
+            expect(createMock).toHaveBeenCalledTimes(2)
+        })
     })
 
     describe('liveRowsProgress', () => {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -56,25 +56,6 @@ export const RECALCULATION_STATUSES = {
 
 export type RecalculationStatuses = (typeof RECALCULATION_STATUSES)[keyof typeof RECALCULATION_STATUSES]
 
-// Higher rank = stronger recalculation scope. A metric-scoped rerun reuses the window (cache-hits
-// unchanged metrics); everything else advances the window and recomputes all metrics, so it wins a
-// coalesce. Unknown triggers default to the strong end so a rerun never silently under-recomputes.
-const RERUN_TRIGGER_RANK: Partial<Record<ExperimentMetricsRecalculationTriggerEnumApi, number>> = {
-    metric_config_change: 0,
-    experiment_config_change: 1,
-    manual: 1,
-    cold_run: 1,
-    auto_refresh: 1,
-}
-
-export const rerunTriggerRank = (trigger: ExperimentMetricsRecalculationTriggerEnumApi): number =>
-    RERUN_TRIGGER_RANK[trigger] ?? 1
-
-export const strongerRerunTrigger = (
-    a: ExperimentMetricsRecalculationTriggerEnumApi,
-    b: ExperimentMetricsRecalculationTriggerEnumApi
-): ExperimentMetricsRecalculationTriggerEnumApi => (rerunTriggerRank(b) > rerunTriggerRank(a) ? b : a)
-
 /** Transient per-metric retry state written by the calc activity between failed attempts. */
 export interface MetricRetryInfo {
     attempt: number
@@ -358,13 +339,14 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 setCurrentRecalculation: () => false,
             },
         ],
-        // The single pending rerun requested while a run was active. Coalesces to the stronger scope;
-        // in-memory and per-tab (v1). Fired and cleared by the poll-terminal branch.
         queuedRerun: [
             null as ExperimentMetricsRecalculationTriggerEnumApi | null,
             {
+                /**
+                 * If the state is `experiment_config_change`, it sticks.
+                 */
                 setQueuedRerun: (state, { trigger }) =>
-                    trigger === null || state === null ? trigger : strongerRerunTrigger(state, trigger),
+                    trigger === null ? null : state === 'experiment_config_change' ? state : trigger,
             },
         ],
         primaryMetricsResults: [
@@ -732,12 +714,13 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     return
                 }
                 /**
-                 * A run is already active: don't create a second one (the backend enforces one active
-                 * run per experiment). Remember the change, coalesced to the stronger scope, and fire it
-                 * from the poll-terminal branch when the current run ends. cold_run is the initial fill and
-                 * never queues.
+                 * If we have a recalculation in flight, and the user has changed the experiment or the metrics configuration,
+                 * we schedule a new recalculation with the corresponding trigger.
                  */
-                if (trigger !== 'cold_run' && values.isRecalculating) {
+                if (
+                    (trigger === 'experiment_config_change' || trigger === 'metric_config_change') &&
+                    values.isRecalculating
+                ) {
                     actions.setQueuedRerun(trigger)
                     return
                 }
@@ -937,10 +920,13 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     )
                 }
 
+                /**
+                 * The user has changed the experiment or the metrics configuration while a recalculation was in flight.
+                 * We clear the flag an trigger a new recalculation to reflect the changes. Cache resolution is handled by the
+                 * durable execution backend, so we'll try to reuse the cached results.
+                 */
                 const queued = values.queuedRerun
                 if (queued) {
-                    // A config change arrived during this run. Clear the queue first so the fresh run's
-                    // own queuing (if the user keeps editing) starts clean, then fire the coalesced rerun.
                     actions.setQueuedRerun(null)
                     actions.triggerRecalculation(queued)
                 }

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -933,6 +933,14 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                         `${recalculation.failed_metrics} of ${recalculation.total_metrics} metrics failed to load`
                     )
                 }
+
+                const queued = values.queuedRerun
+                if (queued) {
+                    // A config change arrived during this run. Clear the queue first so the fresh run's
+                    // own queuing (if the user keeps editing) starts clean, then fire the coalesced rerun.
+                    actions.setQueuedRerun(null)
+                    actions.triggerRecalculation(queued)
+                }
             },
         }
     }),

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -836,8 +836,14 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 }
                 cache.activeRecalculationId = recalculationId
 
+                /**
+                 * if for any reason the recalculation workflow never reaches terminal state, we need to
+                 * stop polling, and clear recalculation state. This includes any queued rerun, that will never
+                 * be fired.
+                 */
                 if (Date.now() - (cache.recalcStartMs ?? Date.now()) > MAX_POLL_DURATION_MS) {
                     actions.setRecalculatingMetricUuids([])
+                    actions.setQueuedRerun(null)
                     lemonToast.error('Recalculation appears stuck. Please reload to try again.')
                     return
                 }
@@ -856,9 +862,11 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     /**
                      * Retry on transient errors, but give up after MAX_POLL_RETRIES consecutive failures so a
                      * persistently failing endpoint can't poll forever.
+                     * If we reach the retry cap, we also need to clear queued reruns that never fire.
                      */
                     cache.pollRetryCount = (cache.pollRetryCount ?? 0) + 1
                     if (cache.pollRetryCount >= MAX_POLL_RETRIES) {
+                        actions.setQueuedRerun(null)
                         lemonToast.error('Failed to load recalculation results. Please reload to try again.')
                         return
                     }

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -729,6 +729,16 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     return
                 }
                 /**
+                 * A run is already active: don't create a second one (the backend enforces one active
+                 * run per experiment). Remember the change, coalesced to the stronger scope, and fire it
+                 * from the poll-terminal branch when the current run ends. cold_run is the initial fill and
+                 * never queues.
+                 */
+                if (trigger !== 'cold_run' && values.isRecalculating) {
+                    actions.setQueuedRerun(trigger)
+                    return
+                }
+                /**
                  * Dim the metrics that already show something (a value or an error) so they read as
                  * "refreshing" until the new result streams in. Cold runs have nothing prior, so nothing to dim.
                  */

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -56,6 +56,22 @@ export const RECALCULATION_STATUSES = {
 
 export type RecalculationStatuses = (typeof RECALCULATION_STATUSES)[keyof typeof RECALCULATION_STATUSES]
 
+// Higher rank = stronger recalculation scope. A metric-scoped rerun reuses the window (cache-hits
+// unchanged metrics); everything else advances the window and recomputes all metrics, so it wins a
+// coalesce. Unknown triggers default to the strong end so a rerun never silently under-recomputes.
+const RERUN_TRIGGER_RANK: Partial<Record<TriggerEnumApi, number>> = {
+    metric_config_change: 0,
+    experiment_config_change: 1,
+    manual: 1,
+    cold_run: 1,
+    auto_refresh: 1,
+}
+
+export const rerunTriggerRank = (trigger: TriggerEnumApi): number => RERUN_TRIGGER_RANK[trigger] ?? 1
+
+export const strongerRerunTrigger = (a: TriggerEnumApi, b: TriggerEnumApi): TriggerEnumApi =>
+    rerunTriggerRank(b) > rerunTriggerRank(a) ? b : a
+
 /** Transient per-metric retry state written by the calc activity between failed attempts. */
 export interface MetricRetryInfo {
     attempt: number
@@ -169,6 +185,7 @@ export interface experimentMetricsLogicValues {
     nextRetryAt: string | null
     primaryMetricsResults: CachedNewExperimentQueryResponse[]
     primaryMetricsResultsErrors: (unknown | null)[]
+    queuedRerun: TriggerEnumApi | null
     recalculatingMetricUuids: string[]
     recalculationDisplayState: 'cold' | 'initial' | 'partial' | 'refreshing' | 'resting'
     recalculationLoading: boolean
@@ -248,6 +265,9 @@ export interface experimentMetricsLogicActions {
     setPrimaryMetricsResultsErrors: (errors: (unknown | null)[]) => {
         errors: unknown[]
     }
+    setQueuedRerun: (trigger: TriggerEnumApi | null) => {
+        trigger: TriggerEnumApi | null
+    }
     setRecalculatingMetricUuids: (uuids: string[]) => {
         uuids: string[]
     }
@@ -318,6 +338,7 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
         setRecalculationLoading: (loading: boolean) => ({ loading }),
         // The metrics still showing a stale value while a non-cold recalc refreshes them in place.
         setRecalculatingMetricUuids: (uuids: string[]) => ({ uuids }),
+        setQueuedRerun: (trigger: TriggerEnumApi | null) => ({ trigger }),
     }),
     reducers({
         currentRecalculation: [
@@ -332,6 +353,15 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 setRecalculationLoading: (_, { loading }) => loading,
                 loadLatestRecalculation: () => true,
                 setCurrentRecalculation: () => false,
+            },
+        ],
+        // The single pending rerun requested while a run was active. Coalesces to the stronger scope;
+        // in-memory and per-tab (v1). Fired and cleared by the poll-terminal branch.
+        queuedRerun: [
+            null as TriggerEnumApi | null,
+            {
+                setQueuedRerun: (state, { trigger }) =>
+                    trigger === null || state === null ? trigger : strongerRerunTrigger(state, trigger),
             },
         ],
         primaryMetricsResults: [

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -59,7 +59,7 @@ export type RecalculationStatuses = (typeof RECALCULATION_STATUSES)[keyof typeof
 // Higher rank = stronger recalculation scope. A metric-scoped rerun reuses the window (cache-hits
 // unchanged metrics); everything else advances the window and recomputes all metrics, so it wins a
 // coalesce. Unknown triggers default to the strong end so a rerun never silently under-recomputes.
-const RERUN_TRIGGER_RANK: Partial<Record<TriggerEnumApi, number>> = {
+const RERUN_TRIGGER_RANK: Partial<Record<ExperimentMetricsRecalculationTriggerEnumApi, number>> = {
     metric_config_change: 0,
     experiment_config_change: 1,
     manual: 1,
@@ -67,10 +67,13 @@ const RERUN_TRIGGER_RANK: Partial<Record<TriggerEnumApi, number>> = {
     auto_refresh: 1,
 }
 
-export const rerunTriggerRank = (trigger: TriggerEnumApi): number => RERUN_TRIGGER_RANK[trigger] ?? 1
+export const rerunTriggerRank = (trigger: ExperimentMetricsRecalculationTriggerEnumApi): number =>
+    RERUN_TRIGGER_RANK[trigger] ?? 1
 
-export const strongerRerunTrigger = (a: TriggerEnumApi, b: TriggerEnumApi): TriggerEnumApi =>
-    rerunTriggerRank(b) > rerunTriggerRank(a) ? b : a
+export const strongerRerunTrigger = (
+    a: ExperimentMetricsRecalculationTriggerEnumApi,
+    b: ExperimentMetricsRecalculationTriggerEnumApi
+): ExperimentMetricsRecalculationTriggerEnumApi => (rerunTriggerRank(b) > rerunTriggerRank(a) ? b : a)
 
 /** Transient per-metric retry state written by the calc activity between failed attempts. */
 export interface MetricRetryInfo {
@@ -185,7 +188,7 @@ export interface experimentMetricsLogicValues {
     nextRetryAt: string | null
     primaryMetricsResults: CachedNewExperimentQueryResponse[]
     primaryMetricsResultsErrors: (unknown | null)[]
-    queuedRerun: TriggerEnumApi | null
+    queuedRerun: ExperimentMetricsRecalculationTriggerEnumApi | null
     recalculatingMetricUuids: string[]
     recalculationDisplayState: 'cold' | 'initial' | 'partial' | 'refreshing' | 'resting'
     recalculationLoading: boolean
@@ -265,8 +268,8 @@ export interface experimentMetricsLogicActions {
     setPrimaryMetricsResultsErrors: (errors: (unknown | null)[]) => {
         errors: unknown[]
     }
-    setQueuedRerun: (trigger: TriggerEnumApi | null) => {
-        trigger: TriggerEnumApi | null
+    setQueuedRerun: (trigger: ExperimentMetricsRecalculationTriggerEnumApi | null) => {
+        trigger: ExperimentMetricsRecalculationTriggerEnumApi | null
     }
     setRecalculatingMetricUuids: (uuids: string[]) => {
         uuids: string[]
@@ -338,7 +341,7 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
         setRecalculationLoading: (loading: boolean) => ({ loading }),
         // The metrics still showing a stale value while a non-cold recalc refreshes them in place.
         setRecalculatingMetricUuids: (uuids: string[]) => ({ uuids }),
-        setQueuedRerun: (trigger: TriggerEnumApi | null) => ({ trigger }),
+        setQueuedRerun: (trigger: ExperimentMetricsRecalculationTriggerEnumApi | null) => ({ trigger }),
     }),
     reducers({
         currentRecalculation: [
@@ -358,7 +361,7 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
         // The single pending rerun requested while a run was active. Coalesces to the stronger scope;
         // in-memory and per-tab (v1). Fired and cleared by the poll-terminal branch.
         queuedRerun: [
-            null as TriggerEnumApi | null,
+            null as ExperimentMetricsRecalculationTriggerEnumApi | null,
             {
                 setQueuedRerun: (state, { trigger }) =>
                     trigger === null || state === null ? trigger : strongerRerunTrigger(state, trigger),


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

When a user changes experiment or metric configuration while a metrics recalculation is running, the edit is lost. The backend enforces one active recalculation per experiment, so a mid-run change neither starts a fresh run nor is remembered for later. The user has to notice the run finished and reload by hand to apply the change.

## Changes

<!-- For each change a person can notice, say what they will now see or do differently, not only the code path that does it. Mark the rest as mechanical so a reviewer knows nothing user-visible is hiding in it. -->

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR makes a config change made during a running recalculation start a follow-up run automatically once the current run finishes, without ever creating a second active run. It is frontend only; the backend "one active run per experiment" rule is untouched.

### Queue the rerun in the metrics logic

`experimentMetricsLogic` gains a single in-memory `queuedRerun` item. When `triggerRecalculation` fires with a config-change trigger while a run is active (`isRecalculating`), it records that trigger instead of posting a create. Only the two config-change triggers reach the queue; a `cold_run` and any other trigger start their run normally. More changes during the same run coalesce onto that one item, keeping the stronger scope: once the queued item is `experiment_config_change` (advance the window, recompute all) it stays there, and a `metric_config_change` (reuse the window, cache-hit unchanged metrics) never downgrades it.

When the current run reaches a terminal status, the poll clears the queued item and fires it as a fresh recalculation. By that point the run is terminal, so the fresh run starts rather than re-queuing.

The queue is per tab and in memory, so a reload during a run drops it. Durable, server-side scheduling is a planned follow-up, out of scope here.

- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`

### Reload control hint

While a rerun is queued, the reload control shows "Changes will apply after the current recalculation finishes", so the mid-run edit does not read as ignored. The button is already disabled during a run, so there is no double-submission.

- `frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx`
- `frontend/src/scenes/experiments/ExperimentView/ExperimentReloadActionContainer.tsx`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

```bash
pnpm --filter=@posthog/frontend jest experimentMetricsLogic.test.ts
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

New logic tests cover the regressions a reviewer would worry about: a change during a run queues instead of posting a second run; a `cold_run` still starts fresh; multiple different-scope changes during one run coalesce to a single stronger-scope rerun that fires exactly once on terminal; and the fired rerun starts a fresh run rather than re-queuing.

The reload-control hint is not yet verified in the running app; screenshot to follow.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

None.

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8

Manually refactored: **yes**

Skills used:

- /brainstorming (superpowers)
- /writing-plans (superpowers)
- /subagent-driven-development (superpowers)
- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Frontend-only v1 by design: the queue is a single in-memory item in `experimentMetricsLogic`, so the backend "one active run per experiment" invariant and its DB constraint stay untouched. Durable server-side scheduling (a `QUEUED` status) is a deliberate future stack.
- Coalescing is a sticky reducer over the two config-change triggers: the queue guard admits only `experiment_config_change` and `metric_config_change`, so the reducer keeps `experiment_config_change` once set and otherwise takes the incoming trigger. This replaced an earlier ranked-trigger helper, since only those two values ever reach the queue.
- The rerun fires from the poll-terminal branch after `setCurrentRecalculation` flips the run terminal, so `isRecalculating` is false and the rerun starts a fresh run instead of re-queuing.
