### PR TITLE
feat(mcp-store): show auth type and URL on the gateway server detail

### DIFF
--- a/products/mcp_store/frontend/gateway/GatewayServerScene.tsx
+++ b/products/mcp_store/frontend/gateway/GatewayServerScene.tsx
@@ -22,7 +22,7 @@ import { userLogic } from 'scenes/userLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 
-import { MCPToolApprovalStateEnumApi, ResolvedToolPolicyApi } from '../generated/api.schemas'
+import { MCPAuthTypeEnumApi, MCPToolApprovalStateEnumApi, ResolvedToolPolicyApi } from '../generated/api.schemas'
 import { ServerIcon } from '../scene/icons'
 import { isPolicyStateAllowedByCeiling } from './gatewayPolicyUtils'
 import { GatewayRouteGuard } from './GatewayRouteGuard'
@@ -32,6 +32,11 @@ import { getGatewayServerRemovalAction } from './gatewayServerRemoval'
 import { GatewayServersLoadError } from './GatewayServersHome'
 import { POLICY_OPTIONS, PolicySummary } from './gatewayUtils'
 import { mcpGatewayLogic } from './mcpGatewayLogic'
+
+const AUTH_TYPE_LABELS: Record<MCPAuthTypeEnumApi, string> = {
+    api_key: 'API key',
+    oauth: 'OAuth',
+}
 
 export const scene: SceneExport<(typeof gatewayServerLogic)['props']> = {
     component: GatewayServerRouteScene,
@@ -130,9 +135,16 @@ export function GatewayServerScene({
                     </div>
                     {server.description && <div className="text-secondary mt-1">{server.description}</div>}
                     <div className="flex items-center gap-3 mt-2 text-xs text-secondary">
-                        {server.created_by && (
-                            <span>Added by {server.created_by.first_name || server.created_by.email}</span>
-                        )}
+                        <span className="min-w-0 truncate">
+                            {[
+                                server.created_by &&
+                                    `Added by ${server.created_by.first_name || server.created_by.email}`,
+                                server.template_auth_type && AUTH_TYPE_LABELS[server.template_auth_type],
+                                server.url,
+                            ]
+                                .filter(Boolean)
+                                .join(' · ')}
+                        </span>
                         {server.docs_url && (
                             <LemonButton
                                 size="xsmall"


### PR DESCRIPTION
## Problem

A member who opens an MCP server in the gateway cannot see the server's URL or how it authenticates without leaving the page. The header only says who added it.

## Changes

- The line under the server name now reads like `Added by Chris · OAuth · https://mcp.example.com/mcp`, in the same small secondary text as before.
- Dividers only appear between items that exist, so a server with no recorded creator shows `OAuth · https://...`.
- The auth type labels reuse the words from the add-server form: "API key" and "OAuth".
- The line truncates in a narrow scene, so a long URL does not push the header out of view.

> [!NOTE]
> The auth type only shows for catalog servers. The server payload carries `template_auth_type`, which is null for custom servers because each member picks their own auth type per connection. Custom servers show the creator and the URL only. Exposing the caller's own auth type on `your_connection` is a possible follow-up.

No screenshot: the local dev stack was not healthy during this session and the scene has no Storybook story.

## How did you test this code?

- Oxfmt and oxlint pass on the changed file. The frontend typecheck reports no errors in it.
- Not run: any rendering of the scene. No automated test covers this header line.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5.1), session: https://claude.ai/code/session_01LdjJtKRYuH9QYKXW3sS1Qc
- Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions
- The change first landed on an unrelated branch and was moved to this branch from a worktree cut from master at the reviewer's request.

https://claude.ai/code/session_01LdjJtKRYuH9QYKXW3sS1Qc
