### PR TITLE
fix(endpoints): revert stale materializations on DAG-scheduled teams

### DIFF
--- a/products/endpoints/backend/logic/execution.py
+++ b/products/endpoints/backend/logic/execution.py
@@ -604,8 +604,6 @@ class EndpointExecutionService(PydanticModelMixin):
             error_label = type(e).__name__
             raise
         finally:
-            # A run that fails is still a use of the endpoint. Stale-materialization
-            # cleanup must not read a heavy version that times out on every call as idle.
             self._track_last_executed(endpoint, version_obj)
             if execution_status is not None:
                 _duration = time.monotonic() - _start_time

--- a/products/endpoints/backend/logic/execution.py
+++ b/products/endpoints/backend/logic/execution.py
@@ -604,6 +604,9 @@ class EndpointExecutionService(PydanticModelMixin):
             error_label = type(e).__name__
             raise
         finally:
+            # A run that fails is still a use of the endpoint. Stale-materialization
+            # cleanup must not read a heavy version that times out on every call as idle.
+            self._track_last_executed(endpoint, version_obj)
             if execution_status is not None:
                 _duration = time.monotonic() - _start_time
                 ENDPOINT_EXECUTION_DURATION_SECONDS.labels(
@@ -641,7 +644,6 @@ class EndpointExecutionService(PydanticModelMixin):
                 version=version_obj.version,
             ),
         )
-        self._track_last_executed(endpoint, version_obj)
 
         self._maybe_shadow_ducklake(
             endpoint,

--- a/products/endpoints/backend/tasks/tasks.py
+++ b/products/endpoints/backend/tasks/tasks.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import Any
 
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 
 from celery import shared_task
@@ -9,6 +10,7 @@ from structlog import get_logger
 from posthog.celery_queues import CeleryQueue
 from posthog.scoping_audit import skip_team_scope_audit
 
+from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
 from products.endpoints.backend.logic.ducklake_shadow import run_ducklake_shadow_comparison
 from products.endpoints.backend.metrics import ENDPOINT_MATERIALIZATION_EVENT_TOTAL
 from products.endpoints.backend.models import EndpointVersion
@@ -58,9 +60,9 @@ def deactivate_stale_materializations() -> None:
 
     This task finds endpoint versions where:
     1. The version has an active materialization (saved_query.is_materialized = True)
-    2. The materialization has run in the past 24h (saved_query.last_run_at within 24h)
+    2. The materialization has run in the past 24h (a completed job, or saved_query.last_run_at)
     3. The materialization was enabled at least 30 days ago (saved_query.created_at)
-    4. The endpoint was last executed over 30 days ago (via API key)
+    4. The version was last executed over 30 days ago (via API key)
 
     For matching versions, the materialization is reverted to save resources.
     """
@@ -68,13 +70,29 @@ def deactivate_stale_materializations() -> None:
     twenty_four_hours_ago = now - timedelta(hours=24)
     stale_threshold = now - timedelta(days=STALE_THRESHOLD_DAYS)
 
+    # DAG-scheduled materializations record each run on DataModelingJob and never
+    # write saved_query.last_run_at, so "ran recently" has to accept either source.
+    recent_job = DataModelingJob.objects.filter(
+        saved_query_id=OuterRef("saved_query_id"),
+        status=DataModelingJobStatus.COMPLETED,
+        last_run_at__gte=twenty_four_hours_ago,
+    )
+    ran_recently = Q(saved_query__last_run_at__gte=twenty_four_hours_ago) | Q(Exists(recent_job))
+
+    # A superseded version keeps its own last_executed_at, so an active endpoint
+    # does not shield its old versions. Versions that predate the field fall back
+    # to the endpoint's timestamp.
+    version_stale = Q(last_executed_at__lt=stale_threshold) | Q(
+        last_executed_at__isnull=True, endpoint__last_executed_at__lt=stale_threshold
+    )
+
     stale_versions = EndpointVersion.objects.filter(
+        ran_recently,
+        version_stale,
         saved_query__isnull=False,
         saved_query__is_materialized=True,
-        saved_query__last_run_at__gte=twenty_four_hours_ago,
         saved_query__deleted=False,
         saved_query__created_at__lte=stale_threshold,
-        endpoint__last_executed_at__lt=stale_threshold,
         endpoint__deleted=False,
     ).select_related("saved_query", "endpoint")
 

--- a/products/endpoints/backend/tasks/tasks.py
+++ b/products/endpoints/backend/tasks/tasks.py
@@ -70,8 +70,6 @@ def deactivate_stale_materializations() -> None:
     twenty_four_hours_ago = now - timedelta(hours=24)
     stale_threshold = now - timedelta(days=STALE_THRESHOLD_DAYS)
 
-    # DAG-scheduled materializations record each run on DataModelingJob and never
-    # write saved_query.last_run_at, so "ran recently" has to accept either source.
     recent_job = DataModelingJob.objects.filter(
         saved_query_id=OuterRef("saved_query_id"),
         status=DataModelingJobStatus.COMPLETED,
@@ -79,9 +77,6 @@ def deactivate_stale_materializations() -> None:
     )
     ran_recently = Q(saved_query__last_run_at__gte=twenty_four_hours_ago) | Q(Exists(recent_job))
 
-    # A superseded version keeps its own last_executed_at, so an active endpoint
-    # does not shield its old versions. Versions that predate the field fall back
-    # to the endpoint's timestamp.
     version_stale = Q(last_executed_at__lt=stale_threshold) | Q(
         last_executed_at__isnull=True, endpoint__last_executed_at__lt=stale_threshold
     )

--- a/products/endpoints/backend/tests/test_deactivate_stale_materializations.py
+++ b/products/endpoints/backend/tests/test_deactivate_stale_materializations.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from django.utils import timezone
 
-from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
 from products.endpoints.backend.models import Endpoint, EndpointVersion
 from products.endpoints.backend.tasks.tasks import (
     STALE_THRESHOLD_DAYS,
@@ -227,6 +227,69 @@ class TestDeactivateStaleMaterializationsTask(BaseTest):
         # Should be deactivated because it's at or past the threshold
         version.refresh_from_db()
         assert version.saved_query is None
+
+    @mock.patch("products.endpoints.backend.tasks.tasks._deactivate_version_materialization")
+    def test_selects_stale_version_whose_saved_query_last_run_at_is_never_written(self, mock_deactivate):
+        now = timezone.now()
+        _, version = self._create_materialized_endpoint(
+            name="v2_scheduled",
+            last_run_at=now - timedelta(days=40),
+            last_executed_at=now - timedelta(days=45),
+            materialization_created_at=now - timedelta(days=45),
+        )
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=version.saved_query,
+            status=DataModelingJob.Status.COMPLETED,
+            last_run_at=now - timedelta(hours=1),
+        )
+
+        deactivate_stale_materializations()
+
+        mock_deactivate.assert_called_once()
+        assert mock_deactivate.call_args[0][0].id == version.id
+
+    @mock.patch("products.endpoints.backend.tasks.tasks._deactivate_version_materialization")
+    def test_deactivates_superseded_version_of_an_active_endpoint(self, mock_deactivate):
+        now = timezone.now()
+        endpoint, old_version = self._create_materialized_endpoint(
+            name="active_endpoint",
+            last_executed_at=now - timedelta(days=5),
+            materialization_created_at=now - timedelta(days=45),
+        )
+        EndpointVersion.objects.filter(id=old_version.id).update(last_executed_at=now - timedelta(days=45))
+
+        current_saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="active_endpoint_v2",
+            query=self.sample_hogql_query,
+            is_materialized=True,
+            last_run_at=now,
+            origin=DataWarehouseSavedQuery.Origin.ENDPOINT,
+            table=DataWarehouseTable.objects.create(
+                team=self.team,
+                name="active_endpoint_v2_table",
+                format=DataWarehouseTable.TableFormat.Parquet,
+                url_pattern="s3://test-bucket/active_endpoint_v2_table",
+            ),
+        )
+        DataWarehouseSavedQuery.objects.filter(id=current_saved_query.id).update(created_at=now - timedelta(days=40))
+        current_version = EndpointVersion.objects.create(
+            endpoint=endpoint,
+            version=2,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            saved_query=current_saved_query,
+            last_executed_at=now - timedelta(days=5),
+        )
+        endpoint.current_version = 2
+        endpoint.save(update_fields=["current_version"])
+
+        deactivate_stale_materializations()
+
+        deactivated_ids = {call.args[0].id for call in mock_deactivate.call_args_list}
+        assert deactivated_ids == {old_version.id}
+        assert current_version.id not in deactivated_ids
 
 
 class TestDeactivateEndpointMaterialization(BaseTest):

--- a/products/endpoints/backend/tests/test_endpoint.py
+++ b/products/endpoints/backend/tests/test_endpoint.py
@@ -14,6 +14,7 @@ from rest_framework import status
 
 from posthog.schema import EndpointLastExecutionTimesRequest
 
+from posthog.exceptions import ClickHouseQueryTimeOut
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team import Team
@@ -853,6 +854,30 @@ class TestEndpoint(ClickhouseTestMixin, APIBaseTest):
         )
 
         endpoint = Endpoint.objects.get(name="test_query_1", team=self.team)
+        version = EndpointVersion.objects.get(endpoint=endpoint, version=1)
+        self.assertIsNotNone(endpoint.last_executed_at)
+        self.assertIsNotNone(version.last_executed_at)
+
+    def test_api_key_run_that_times_out_still_stamps_last_executed_at(self):
+        create_endpoint_with_version(
+            name="slow_query",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "SELECT 1"},
+            created_by=self.user,
+            is_active=True,
+        )
+
+        with mock.patch(
+            "products.endpoints.backend.logic.execution.process_query_model",
+            side_effect=ClickHouseQueryTimeOut(),
+        ):
+            response = self.client.get(
+                f"/api/environments/{self.team.id}/endpoints/slow_query/run/",
+                headers={"authorization": f"Bearer {self.api_key}"},
+            )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+
+        endpoint = Endpoint.objects.get(name="slow_query", team=self.team)
         version = EndpointVersion.objects.get(endpoint=endpoint, version=1)
         self.assertIsNotNone(endpoint.last_executed_at)
         self.assertIsNotNone(version.last_executed_at)


### PR DESCRIPTION
## Problem

A materialized endpoint version that nobody calls any more keeps re-materializing every day, forever, on any team that materializes through the data modeling DAG.

`deactivate_stale_materializations` is meant to revert those. It never selects a row on DAG-scheduled teams, and it never selects a superseded version of an endpoint that is still in use:

- The "ran in the last 24h" filter reads `saved_query.last_run_at`. DAG runs record on `DataModelingJob` and never write that field, so the filter is always false there.
- The "idle for 30 days" filter reads `endpoint.last_executed_at`. Every version of an active endpoint shares it, so the old versions can never be idle.
- `last_executed_at` is stamped only after a successful run. A version whose query times out on every call looks like it is never used.

Together this means a team that iterates on an endpoint pays for every version it ever shipped. On one team the superseded versions consume most of the endpoint materialization compute, and read from none of it.

In production the task's own fingerprint confirms this: endpoint saved queries soft-deleted at exactly 05:00 UTC, its schedule. It fired most days until early August, and it has selected nothing in either region since the day that region moved endpoint materialization onto the DAG.

## Changes

- Stale cleanup now reverts superseded versions on DAG-scheduled teams. "Ran recently" accepts a completed `DataModelingJob` in the last 24h as well as `saved_query.last_run_at`.
- Stale cleanup now reverts an old version while the endpoint's current version stays in use. Idleness is judged on the version's own `last_executed_at`, falling back to the endpoint's only where the version field was never written.
- A run that fails still counts as a use of the endpoint. `last_executed_at` is stamped in the `finally` block, so a version that times out on every call is not reverted as idle.
- Mechanical: the query is expressed with `Q` and `Exists` instead of flat keyword filters.

## How did you test this code?

Three red-first tests, each failing on `master` and passing here:

- `test_selects_stale_version_whose_saved_query_last_run_at_is_never_written`: a version with a recent completed job but no `saved_query.last_run_at` is reverted.
- `test_deactivates_superseded_version_of_an_active_endpoint`: the old version is reverted while the current version, executed five days ago, is kept.
- `test_api_key_run_that_times_out_still_stamps_last_executed_at`: a run raising `ClickHouseQueryTimeOut` still stamps endpoint and version.

Full endpoints backend suite: 369 passed. Ruff clean. Repo-wide mypy was still running at draft time; result to follow in a comment.

## 🤖 Agent context

- Session type: interactive, from a support thread about an EU customer whose endpoints were timing out.
- Model used: Claude Fable 5.1.
- Skills used: investigating-data-modeling-and-endpoints-prod, writing-tests, writing-pr-descriptions.
- Repo instructions followed: CLAUDE.md test and commit rules, red-first tests per the user's global bug-fix rule.
- Scope kept: the serving-gate defect that caused the customer's timeouts was already fixed in #84276. This PR is only the cleanup task and the timestamp stamping.

