### PR TITLE
fix(migrations): repair invalid postgres index leftovers

### DIFF
--- a/posthog/management/migration_analysis/operations.py
+++ b/posthog/management/migration_analysis/operations.py
@@ -484,7 +484,7 @@ class RunSQLAnalyzer(OperationAnalyzer):
                         score=1,
                         reason="CREATE INDEX CONCURRENTLY is safe (non-blocking)",
                         details={"sql": sql},
-                        guidance="Also prefix with `SET lock_timeout = 0;` so the deploy lock_timeout can't cancel the build and leave an invalid index that defeats IF NOT EXISTS on retry.",
+                        guidance="Prefer `SafeAddIndexConcurrently` (or the raw-SQL `CreateIndexConcurrently`) from posthog.migration_helpers. IF NOT EXISTS matches by name, not validity, so this raw form skips past an `indisvalid = false` leftover from an interrupted build and never rebuilds it; the helpers detect and rebuild it. If you keep the raw form, also prefix with `SET lock_timeout = 0; SET statement_timeout = 0;` so neither the deploy lock_timeout nor a configured statement_timeout can cancel the build in the first place.",
                     )
                 return OperationRisk(
                     type=self.operation_type,

--- a/posthog/migrations/1334_repair_invalid_index_leftovers.py
+++ b/posthog/migrations/1334_repair_invalid_index_leftovers.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+
+from posthog.migration_helpers import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # CONCURRENTLY can't run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        ("posthog", "1333_uploaded_media_library_index"),
+    ]
+
+    operations = [
+        # Repair the implicit ForeignKey index on posthog_hogfunction.batch_export_id.
+        # Migration 0949 built it with a raw `CREATE INDEX CONCURRENTLY IF NOT EXISTS`,
+        # which matches by name and not by validity, so an interrupted build left it
+        # indisvalid = false and every retry skipped past it. CreateIndexConcurrently
+        # drops and rebuilds an invalid leftover, and leaves a valid index untouched.
+        # No SeparateDatabaseAndState state op: the FK's implicit index is already in state.
+        CreateIndexConcurrently(
+            index_name="posthog_hogfunction_batch_export_id_d64c3403",
+            table_name="posthog_hogfunction",
+            columns="(batch_export_id)",
+        ),
+        # `_ccnew` is the transient name Postgres gives the replacement index during
+        # REINDEX INDEX CONCURRENTLY. An interrupted reindex left this one behind as
+        # indisvalid = false, and no helper can clear it, because they all look an index
+        # up by its declared name, so a leftover under a transient name stays invisible.
+        # One statement per list entry, because Postgres opens an implicit transaction
+        # block around a multi-statement query and refuses DROP INDEX CONCURRENTLY there.
+        migrations.RunSQL(
+            sql=[
+                "SET lock_timeout = 0",
+                "SET statement_timeout = 0",
+                'DROP INDEX CONCURRENTLY IF EXISTS "posthog_mat_team_sl_idx_ccnew"',
+            ],
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        # Rebuild the base index the interrupted reindex was repairing.
+        # No state op: migration 1159 already declares this index in Django state.
+        CreateIndexConcurrently(
+            index_name="posthog_mat_team_sl_idx",
+            table_name="posthog_materializedcolumnslot",
+            columns="(team_id, slot_index)",
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1333_uploaded_media_library_index
+1334_repair_invalid_index_leftovers


### PR DESCRIPTION
## Problem

- Batch export lookups on the hog functions table scan the whole table, because the index that should back them is invalid and the planner ignores it.
- Migration 0949 built `posthog_hogfunction.batch_export_id` with a raw `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. That form matches by name and not by validity, so an interrupted build left the index `indisvalid = false` and every retry skipped past it.
- A second table carries the same kind of leftover. `posthog_materializedcolumnslot` holds `posthog_mat_team_sl_idx_ccnew` as `indisvalid = false`. `_ccnew` is the transient name Postgres gives the replacement index during `REINDEX INDEX CONCURRENTLY`, so an out-of-band reindex was interrupted.
- Nobody reads a slow query from the second one, because the table is pre-launch. The next engineer to rename, rebuild, or drop that index pays for it: an invalid catalog entry stalls the migration, and a stalled migration blocks deploys.
- No repo code can clear the `_ccnew` leftover. The helpers in `posthog/migration_helpers/concurrent_index.py` look an index up by its declared name, so a leftover under a transient name stays invisible to them.

## Changes

- Batch export lookups get an index scan again, once migration 1334 rebuilds the foreign key index.
- Migration 1334 repairs both indexes with `CreateIndexConcurrently`, which drops and rebuilds an `indisvalid = false` leftover and leaves a valid index untouched. A `bin/migrate` retry is a no-op.
- The `_ccnew` drop passes SQL as a list of statements. Postgres opens an implicit transaction block around a multi-statement query and refuses `DROP INDEX CONCURRENTLY` there.
- No `SeparateDatabaseAndState` wrapper. Django state already holds both indexes, one as the foreign key's implicit index and one from migration 1159, so a state operation would drift.
- Mechanical: the migration analyzer guidance for the raw idempotent concurrent-index form now names the invalid-leftover gap and points authors at the helpers.
- Nothing in the UI changes.

> [!NOTE]
> Rolling migration 1334 back drops both indexes, because that is the reverse of `CreateIndexConcurrently`. Re-applying it restores them.

The analyzer change is advisory and does not block. Raw `RunSQL` with `IF NOT EXISTS` stays a documented escape hatch for cases the helpers cannot model, such as partitioned tables and exotic operator classes.

This PR replaces #92376 and #93003, which each repaired one of the two indexes. Close both when this lands. Three sibling repairs stay open and also claim a number above 1333: #92373, #92379 and #92415. Whichever lands first, the rest need `manage.py rebase_migration posthog`.

## How did you test this code?

- `makemigrations --check --dry-run` reports no state drift.
- `sqlmigrate posthog 1334` emits the three expected statements, each prefixed with `SET lock_timeout = 0; SET statement_timeout = 0;`.
- `hogli ci:preflight --strict` passes with 0 failures.
- No test added. The repair acts on catalog state that no fixture reproduces, and `posthog/migration_helpers/test_concurrent_index.py` already covers invalid-leftover recovery in `CreateIndexConcurrently`.
- Not run: the invalid-index recovery path against a live Postgres. 15 tests in `posthog/migration_helpers/test_concurrent_index.py` error at setup on this machine's stale test database, both with and without this migration, so that suite went unverified locally.

<details>
<summary>sqlmigrate posthog 1334</summary>

```sql
-- Concurrently create index posthog_hogfunction_batch_export_id_d64c3403 on posthog_hogfunction
SET lock_timeout = 0;
SET statement_timeout = 0;
CREATE INDEX CONCURRENTLY IF NOT EXISTS "posthog_hogfunction_batch_export_id_d64c3403" ON "posthog_hogfunction" (batch_export_id);
-- Raw SQL operation
SET lock_timeout = 0;
SET statement_timeout = 0;
DROP INDEX CONCURRENTLY IF EXISTS "posthog_mat_team_sl_idx_ccnew";
-- Concurrently create index posthog_mat_team_sl_idx on posthog_materializedcolumnslot
SET lock_timeout = 0;
SET statement_timeout = 0;
CREATE INDEX CONCURRENTLY IF NOT EXISTS "posthog_mat_team_sl_idx" ON "posthog_materializedcolumnslot" (team_id, slot_index);
```

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The handbook already documents the concurrent-index helpers and the weakness of the raw form.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code combined two open agent-authored PRs, #92376 and #93003, into one migration on top of current master. Skills invoked: `/django-migrations`, `/writing-code-comments`, `/writing-pr-descriptions`.
- One migration file instead of two. Both source PRs based on 1333 and each claimed its own number, which meant two numbers to rebase against the three open siblings. Every operation is idempotent, so a partial apply is safe to retry.
- The analyzer guidance change comes from #92376 unaltered. #93003 carried no source change beyond its migration.
- Public artifact: the diff carries nothing from the agent session that is not already in this repository.
