### PR TITLE
feat(desktop): make pi the remote-configured default harness

### DIFF
--- a/products/desktop/packages/core/src/task-detail/configOptions.test.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.test.ts
@@ -5,6 +5,7 @@ import {
   flattenConfigValues,
   harnessForModelValue,
   modelOptionForHarness,
+  resolveAgentRuntime,
   syntheticPiModelSelection,
 } from "./configOptions";
 
@@ -99,6 +100,47 @@ describe("syntheticPiModelSelection", () => {
       thinkingLevels: [],
     });
   });
+});
+
+describe("resolveAgentRuntime", () => {
+  it.each([
+    {
+      label: "uses the saved choice over the default when Pi is enabled",
+      savedRuntime: "acp" as const,
+      defaultHarness: "pi" as const,
+      piHarnessEnabled: true,
+      expected: "acp",
+    },
+    {
+      label: "falls back to the fleet default without a saved choice",
+      savedRuntime: null,
+      defaultHarness: "pi" as const,
+      piHarnessEnabled: true,
+      expected: "pi",
+    },
+    {
+      label: "follows a rolled-back default of acp without a saved choice",
+      savedRuntime: null,
+      defaultHarness: "acp" as const,
+      piHarnessEnabled: true,
+      expected: "acp",
+    },
+    {
+      label:
+        "falls back to acp when the Pi kill switch is off, even with a saved pi choice",
+      savedRuntime: "pi" as const,
+      defaultHarness: "pi" as const,
+      piHarnessEnabled: false,
+      expected: "acp",
+    },
+  ])(
+    "$label",
+    ({ savedRuntime, defaultHarness, piHarnessEnabled, expected }) => {
+      expect(
+        resolveAgentRuntime(savedRuntime, defaultHarness, piHarnessEnabled),
+      ).toBe(expected);
+    },
+  );
 });
 
 describe("modelOptionForHarness", () => {

--- a/products/desktop/packages/core/src/task-detail/configOptions.ts
+++ b/products/desktop/packages/core/src/task-detail/configOptions.ts
@@ -1,6 +1,7 @@
 import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import {
   type Adapter,
+  type AgentRuntime,
   adapterForModelId,
   flattenSelectOptions,
   formatModelId,
@@ -19,6 +20,21 @@ export function flattenConfigValues(option: SessionConfigOption): string[] {
   return (option.options as RawOptionItem[]).flatMap((o) =>
     o.options ? o.options.map((g) => g.value) : o.value ? [o.value] : [],
   );
+}
+
+/**
+ * Which harness a composer resolves to. An explicit saved choice always
+ * wins; otherwise the fleet default applies. The Pi kill switch overrides
+ * both, so disabling it never leaves a user stuck on an unavailable
+ * harness.
+ */
+export function resolveAgentRuntime(
+  savedRuntime: AgentRuntime | null,
+  defaultHarness: AgentRuntime,
+  piHarnessEnabled: boolean,
+): AgentRuntime {
+  if (!piHarnessEnabled) return "acp";
+  return savedRuntime ?? defaultHarness;
 }
 
 export function isValidConfigValue(

--- a/products/desktop/packages/shared/src/agent-runtime.ts
+++ b/products/desktop/packages/shared/src/agent-runtime.ts
@@ -1,3 +1,10 @@
 export const AGENT_RUNTIMES = ["acp", "pi"] as const;
 
 export type AgentRuntime = (typeof AGENT_RUNTIMES)[number];
+
+/** Fleet-wide harness when a user has no explicit choice saved. Remote-configured via DEFAULT_HARNESS_FLAG. */
+export const DEFAULT_AGENT_RUNTIME: AgentRuntime = "pi";
+
+export function isAgentRuntime(value: unknown): value is AgentRuntime {
+  return (AGENT_RUNTIMES as readonly string[]).includes(value as string);
+}

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -104,3 +104,15 @@ export const BEDROCK_GATEWAY_VARIANTS = ["test", "control"] as const;
 export type BedrockGatewayVariant = (typeof BEDROCK_GATEWAY_VARIANTS)[number];
 /** Gates the organization context wiki: the Context explorer in the nav rails. */
 export const CONTEXT_LAYER_FLAG = "context-layer";
+
+/** Kill switch for the Pi runtime harness (client and cloud). */
+export const PI_HARNESS_FLAG = "pi-harness";
+
+/**
+ * Remote-configured fleet default for which harness (Pi or ACP) a composer
+ * resolves to when the user has no saved runtime choice. Payload is an
+ * AgentRuntime string ("pi" | "acp"); missing or invalid payload falls back
+ * to DEFAULT_AGENT_RUNTIME. Lets the default roll back to ACP without a
+ * release, independent of the PI_HARNESS_FLAG kill switch.
+ */
+export const DEFAULT_HARNESS_FLAG = "posthog-code-default-harness";

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -4,9 +4,14 @@ import type {
 } from "@posthog/core/pi-runtime/piSessionController";
 import {
   isValidConfigValue,
+  resolveAgentRuntime,
   syntheticPiModelSelection,
 } from "@posthog/core/task-detail/configOptions";
-import { type AgentRuntime, adapterForModelId } from "@posthog/shared";
+import {
+  type AgentRuntime,
+  adapterForModelId,
+  PI_HARNESS_FLAG,
+} from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
   subscriptionModelAccess,
@@ -25,6 +30,7 @@ import { toast } from "../../../primitives/toast";
 import { spendStopMessage, useSpendStop } from "../../billing/useSpendStop";
 import { useChannelWikiContext } from "../../context-wiki/hooks/useContextWiki";
 import { useContextLayerFlag } from "../../feature-flags/useContextLayerFlag";
+import { useDefaultAgentHarness } from "../../feature-flags/useDefaultAgentHarness";
 import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
 import { useFeatureFlagsLoaded } from "../../feature-flags/useFeatureFlagsLoaded";
 import { useUserRepositoryIntegration } from "../../integrations/useIntegrations";
@@ -134,7 +140,8 @@ export const ChannelHomeComposer = forwardRef<
   );
   const [selectedPiThinkingLevel, setSelectedPiThinkingLevel] =
     useState<PiThinkingLevel | null>(null);
-  const piHarnessEnabled = useFeatureFlag("pi-harness", import.meta.env.DEV);
+  const piHarnessEnabled = useFeatureFlag(PI_HARNESS_FLAG, import.meta.env.DEV);
+  const defaultHarness = useDefaultAgentHarness();
   const flagsLoaded = useFeatureFlagsLoaded();
   const { data: piModelCatalog = [], isPending: isPiConfigLoading } =
     usePiModelCatalog(runtime === "pi");
@@ -151,9 +158,13 @@ export const ChannelHomeComposer = forwardRef<
 
     didResolveRuntimeRef.current = true;
     setRuntime(
-      piHarnessEnabled && lastUsedAgentRuntime === "pi" ? "pi" : "acp",
+      resolveAgentRuntime(
+        lastUsedAgentRuntime,
+        defaultHarness,
+        piHarnessEnabled,
+      ),
     );
-  }, [flagsLoaded, lastUsedAgentRuntime, piHarnessEnabled]);
+  }, [flagsLoaded, lastUsedAgentRuntime, piHarnessEnabled, defaultHarness]);
 
   const { hasGithubIntegration, isLoadingIntegrations } =
     useUserRepositoryIntegration();

--- a/products/desktop/packages/ui/src/features/feature-flags/useDefaultAgentHarness.test.ts
+++ b/products/desktop/packages/ui/src/features/feature-flags/useDefaultAgentHarness.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useDefaultAgentHarness } from "./useDefaultAgentHarness";
+
+const useFeatureFlagPayload = vi.hoisted(() => vi.fn());
+
+vi.mock("./useFeatureFlagPayload", () => ({ useFeatureFlagPayload }));
+
+describe("useDefaultAgentHarness", () => {
+  it.each([
+    { label: "matches an acp payload", payload: "acp", expected: "acp" },
+    { label: "matches a pi payload", payload: "pi", expected: "pi" },
+    {
+      label: "falls back to pi when the payload is missing",
+      payload: undefined,
+      expected: "pi",
+    },
+    {
+      label: "falls back to pi for a payload outside the runtime enum",
+      payload: "claude",
+      expected: "pi",
+    },
+  ])("$label", ({ payload, expected }) => {
+    useFeatureFlagPayload.mockReturnValue(payload);
+
+    const { result } = renderHook(() => useDefaultAgentHarness());
+
+    expect(result.current).toBe(expected);
+  });
+});

--- a/products/desktop/packages/ui/src/features/feature-flags/useDefaultAgentHarness.ts
+++ b/products/desktop/packages/ui/src/features/feature-flags/useDefaultAgentHarness.ts
@@ -1,0 +1,18 @@
+import {
+  type AgentRuntime,
+  DEFAULT_AGENT_RUNTIME,
+  DEFAULT_HARNESS_FLAG,
+  isAgentRuntime,
+} from "@posthog/shared";
+import { useFeatureFlagPayload } from "@posthog/ui/features/feature-flags/useFeatureFlagPayload";
+
+/**
+ * The fleet-wide default harness for a user with no saved runtime choice.
+ * Remote-configured via DEFAULT_HARNESS_FLAG's payload so the default can
+ * roll back to ACP without a release. An unmatched flag or an invalid
+ * payload keeps the app on DEFAULT_AGENT_RUNTIME.
+ */
+export function useDefaultAgentHarness(): AgentRuntime {
+  const payload = useFeatureFlagPayload(DEFAULT_HARNESS_FLAG);
+  return isAgentRuntime(payload) ? payload : DEFAULT_AGENT_RUNTIME;
+}

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.test.ts
@@ -52,6 +52,10 @@ describe("feature settingsStore defaults", () => {
       "local",
     );
   });
+
+  it("has no saved agent runtime override for a fresh profile, so the fleet default applies", () => {
+    expect(useSettingsStore.getState().lastUsedAgentRuntime).toBeNull();
+  });
 });
 
 describe("feature settingsStore cloud selections", () => {
@@ -86,6 +90,20 @@ describe("feature settingsStore cloud selections", () => {
     await useSettingsStore.persist.rehydrate();
 
     expect(useSettingsStore.getState().lastUsedAgentRuntime).toBe("pi");
+  });
+
+  it("clears a pre-v2 saved acp runtime on migration, so the fleet default applies instead", async () => {
+    getItem.mockResolvedValue(
+      JSON.stringify({
+        state: { lastUsedAgentRuntime: "acp" },
+        version: 1,
+      }),
+    );
+    useSettingsStore.setState({ lastUsedAgentRuntime: "pi" });
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().lastUsedAgentRuntime).toBeNull();
   });
 
   it("persists Pi and ACP model selections independently", async () => {

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.ts
@@ -142,7 +142,12 @@ export interface SettingsStore {
   lastUsedRunMode: "local" | "cloud";
   lastUsedLocalWorkspaceMode: LocalWorkspaceMode;
   lastUsedWorkspaceMode: WorkspaceMode;
-  lastUsedAgentRuntime: AgentRuntime;
+  /**
+   * The user's explicit harness choice, or null when they haven't overridden
+   * the fleet default (see useDefaultAgentHarness). Set only by an explicit
+   * harness switch, never by resolving what a composer actually runs.
+   */
+  lastUsedAgentRuntime: AgentRuntime | null;
   lastUsedAdapter: AgentAdapter;
   lastUsedModel: string | null;
   lastUsedPiModel: string | null;
@@ -170,6 +175,7 @@ export interface SettingsStore {
   setLastUsedRunMode: (mode: "local" | "cloud") => void;
   setLastUsedLocalWorkspaceMode: (mode: LocalWorkspaceMode) => void;
   setLastUsedWorkspaceMode: (mode: WorkspaceMode) => void;
+  /** Records an explicit harness switch, overriding the fleet default until called again. */
   setLastUsedAgentRuntime: (runtime: AgentRuntime) => void;
   setLastUsedAdapter: (adapter: AgentAdapter) => void;
   setLastUsedModel: (model: string) => void;
@@ -374,7 +380,7 @@ export const useSettingsStore = create<SettingsStore>()(
       lastUsedRunMode: "local",
       lastUsedLocalWorkspaceMode: "local",
       lastUsedWorkspaceMode: DEFAULT_WORKSPACE_MODE,
-      lastUsedAgentRuntime: "acp",
+      lastUsedAgentRuntime: null,
       lastUsedAdapter: "claude",
       lastUsedModel: null,
       lastUsedPiModel: null,
@@ -643,9 +649,15 @@ export const useSettingsStore = create<SettingsStore>()(
     {
       name: "settings-storage",
       storage: electronStorage,
-      version: 1,
+      version: 2,
       // v1 ships the merged model/reasoning control: bust everyone's saved
       // selection state once so all users start on the new defaults.
+      // v2 makes the fleet default (useDefaultAgentHarness) apply to everyone
+      // who never explicitly chose a harness. Pre-v2, "acp" was both the
+      // implicit initial value and the only other option, so a stored "acp"
+      // cannot be told apart from "never touched" — it is cleared so the fleet
+      // default takes over. A stored "pi" only ever came from an explicit
+      // switch (the old default was always "acp"), so it survives untouched.
       migrate: (persisted, version) => {
         const state = (persisted ?? {}) as Record<string, unknown>;
         if (version < 1) {
@@ -653,6 +665,9 @@ export const useSettingsStore = create<SettingsStore>()(
           state.lastUsedReasoningEffort = null;
           state.lastUsedContextWindow = null;
           state.lastUsedFastMode = null;
+        }
+        if (version < 2 && state.lastUsedAgentRuntime !== "pi") {
+          state.lastUsedAgentRuntime = null;
         }
         return state;
       },

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -13,6 +13,7 @@ import {
   harnessForModelValue,
   isValidConfigValue,
   modelOptionForHarness,
+  resolveAgentRuntime,
   syntheticPiModelSelection,
 } from "@posthog/core/task-detail/configOptions";
 import { useServiceOptional } from "@posthog/di/react";
@@ -22,6 +23,7 @@ import {
   type AgentRuntime,
   ANALYTICS_EVENTS,
   adapterForModelId,
+  PI_HARNESS_FLAG,
 } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
 import {
@@ -38,6 +40,7 @@ import {
   useTaskRepositoryDraftStore,
 } from "@posthog/ui/features/canvas/stores/taskRepositoryDraftStore";
 import { useChannelReportsEnabled } from "@posthog/ui/features/feature-flags/useChannelReportsEnabled";
+import { useDefaultAgentHarness } from "@posthog/ui/features/feature-flags/useDefaultAgentHarness";
 import { useOpenInboxReport } from "@posthog/ui/features/inbox/hooks/useOpenInboxReport";
 import {
   subscriptionModelAccess,
@@ -484,7 +487,8 @@ export function TaskInput({
     hasGithubIntegration,
   } = useUserRepositoryIntegration();
 
-  const piHarnessEnabled = useFeatureFlag("pi-harness", import.meta.env.DEV);
+  const piHarnessEnabled = useFeatureFlag(PI_HARNESS_FLAG, import.meta.env.DEV);
+  const defaultHarness = useDefaultAgentHarness();
   const flagsLoaded = useFeatureFlagsLoaded();
   const reposReady = areReposReady({
     isLoadingRepos,
@@ -498,9 +502,19 @@ export function TaskInput({
     }
     didResolveRuntimeRef.current = true;
     setRuntime(
-      piHarnessEnabled && lastUsedAgentRuntime === "pi" ? "pi" : "acp",
+      resolveAgentRuntime(
+        lastUsedAgentRuntime,
+        defaultHarness,
+        piHarnessEnabled,
+      ),
     );
-  }, [flagsLoaded, lastUsedAgentRuntime, piHarnessEnabled, settingsHydrated]);
+  }, [
+    flagsLoaded,
+    lastUsedAgentRuntime,
+    piHarnessEnabled,
+    defaultHarness,
+    settingsHydrated,
+  ]);
 
   const { workspaceMode, setWorkspaceMode, overrideWorkspaceMode } =
     useResolvedWorkspaceMode({


### PR DESCRIPTION
## Problem

New PostHog Desktop tasks default to the ACP harness (Claude/Codex). Pi should become the default for everyone, but the default needs a remote off switch that does not require a release, and a user who deliberately switches back to Claude/Codex must keep that choice.

## Changes

- `TaskInput` and `ChannelHomeComposer` now resolve the composer's harness through `resolveAgentRuntime(savedRuntime, defaultHarness, piHarnessEnabled)`: an explicit saved choice wins over the default, and the existing `pi-harness` kill switch wins over both.
- `defaultHarness` reads a new remote-config flag, `posthog-code-default-harness` (payload `"pi"`, 100% rollout) via the new `useDefaultAgentHarness` hook — the default can move back to `"acp"` without shipping a build.
- The settings store's persisted `lastUsedAgentRuntime` becomes nullable (`null` = no explicit choice yet), with a `v2` migration: a pre-existing `"acp"` is cleared, because before this change it was indistinguishable from "never touched"; a pre-existing `"pi"` is kept, since reaching it always required an explicit switch.
- Mechanical: added `PI_HARNESS_FLAG` / `DEFAULT_HARNESS_FLAG` constants, `AGENT_RUNTIMES`-based `isAgentRuntime` / `DEFAULT_AGENT_RUNTIME` helpers.

## How did you test this code?

- `pnpm --filter @posthog/core test` and `pnpm --filter @posthog/ui test` (full suites) — all passing, including new cases in `configOptions.test.ts` (resolveAgentRuntime, parameterized), `useDefaultAgentHarness.test.ts` (new hook), and two new `settingsStore.test.ts` cases covering the v2 migration and the fresh-profile default.
- `pnpm --filter @posthog/core --filter @posthog/ui --filter @posthog/shared typecheck` — clean (pre-existing unrelated `@posthog/agent` / `workspace-server` errors confirmed present on `master` too, via `git stash`).
- `hogli ci:preflight` — 0 failures.
- Did not manually exercise the running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe harness defaults.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Desktop's agent (Pi runtime), this session.
- Skills invoked: `/writing-ui-components`, `/writing-tests`, `/writing-pr-descriptions`.
- Decision: kept the Pi capability kill switch (`pi-harness`) and the new default-harness flag as two independent levers, rather than overloading one flag, so the default can roll back without touching Pi's availability. Recorded as a wiki decision.
- No customer or internal material informed this change; all committed content is original to this session.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
