### PR TITLE
chore(warehouse-sources): deflake the parent snapshot pin test

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_warehouse_parent.py
@@ -1,3 +1,4 @@
+import os
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -77,6 +78,17 @@ def _patched_resolve(uri: str, snapshot_timestamp=None, row_filter=None):
         patch.object(warehouse_parent, "_snapshot_pin_as_of", return_value=snapshot_timestamp),
     ):
         return resolve_parent_table_ref(1, "00000000-0000-0000-0000-000000000000", "issues", row_filter=row_filter)
+
+
+# Delta time travel resolves a timestamp against each commit file's modification time, not the
+# `commitInfo` timestamp the file carries. Restamp both, so a test that pins between two commits
+# does not depend on how coarsely the runner's clock stamped them.
+def _stamp_commit(commit_file: Path, at: datetime) -> None:
+    entries = commit_file.read_text().splitlines()
+    commit = json.loads(entries[0])
+    commit["commitInfo"]["timestamp"] = int(at.timestamp() * 1000)
+    commit_file.write_text("\n".join([json.dumps(commit), *entries[1:]]) + "\n")
+    os.utime(commit_file, (at.timestamp(), at.timestamp()))
 
 
 def test_resolve_parent_table_ref_raises_when_parent_schema_missing() -> None:
@@ -177,19 +189,17 @@ def test_resolve_raises_when_parent_has_no_synced_table(tmp_path: Path) -> None:
 
 def test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing(tmp_path: Path) -> None:
     uri = _write_parent_table(tmp_path)
-    v0_table = deltalake.DeltaTable(uri)
-    v0 = v0_table.version()
-    v0_timestamp = datetime.fromtimestamp(v0_table.history()[0]["timestamp"] / 1000, tz=UTC)
+    v0 = deltalake.DeltaTable(uri).version()
 
     # An in-flight full refresh has already committed a partial overwrite on top of v0.
     deltalake.write_deltalake(uri, pa.table({"id": ["partial"], "last_seen": ["x"], "title": ["y"]}), mode="overwrite")
-    partial_refresh_log = Path(uri) / "_delta_log" / "00000000000000000001.json"
-    entries = partial_refresh_log.read_text().splitlines()
-    partial_refresh_commit = json.loads(entries[0])
-    partial_refresh_commit["commitInfo"]["timestamp"] = int(v0_timestamp.timestamp() * 1000) + 1
-    partial_refresh_log.write_text("\n".join([json.dumps(partial_refresh_commit), *entries[1:]]) + "\n")
 
-    pinned = _patched_resolve(uri, snapshot_timestamp=v0_timestamp)
+    delta_log = Path(uri) / "_delta_log"
+    pin = datetime.now(tz=UTC)
+    _stamp_commit(delta_log / "00000000000000000000.json", pin - timedelta(minutes=1))
+    _stamp_commit(delta_log / "00000000000000000001.json", pin + timedelta(minutes=1))
+
+    pinned = _patched_resolve(uri, snapshot_timestamp=pin)
 
     assert pinned.version == v0
 


### PR DESCRIPTION
## Problem

Anyone whose PR runs the full product test matrix can be blocked by `test_resolve_pins_to_last_completed_snapshot_while_parent_is_syncing` failing with `assert 1 == 0`, even when their change is nowhere near warehouse sources.
It surfaced on [#93181](https://github.com/PostHog/posthog/pull/93181), which only touches tasks and desktop, and reproduced on a rerun.

The test builds a Delta table at v0, commits an in-flight partial overwrite as v1, and pins to a timestamp that should resolve back to v0.
It separated the two commits by rewriting `commitInfo.timestamp` on v1 to v0 + 1 ms.
Delta time travel does not read that field — it resolves a timestamp against each commit file's modification time.
So the pin was decided by whatever mtime the filesystem happened to stamp, and a runner whose clock granularity exceeds the 1 ms margin resolves to v1.

## Changes

- The pin test no longer depends on runner timing, so it passes or fails on the behavior it is meant to guard.
- Both commits are now stamped explicitly, `commitInfo` and mtime together, a minute either side of the pin. Mechanical: a `_stamp_commit` helper replaces the inline log rewrite.

