### PR TITLE
fix(clickhouse): drop sweep partitions on a leader replica

### DIFF
--- a/posthog/dags/clickhouse_cleanup.py
+++ b/posthog/dags/clickhouse_cleanup.py
@@ -37,6 +37,7 @@ from posthog.clickhouse.cleanup_snapshots import (
 from posthog.clickhouse.client.connection import ClickHouseCredentials, ClickHouseUser, get_clickhouse_creds
 from posthog.clickhouse.cluster import ClickhouseCluster, LightweightDeleteMutationRunner, MutationWaiter, NodeRole
 from posthog.clickhouse.custom_metrics import MetricsClient
+from posthog.clickhouse.workload import Workload
 from posthog.dags.common import JobOwners
 from posthog.dags.common.common import settings_with_log_comment
 from posthog.dags.common.dictionaries import Dictionary
@@ -1141,9 +1142,10 @@ def drop_snapshot_assets(
     for dictionary in (run.orphaned_dictionary, run.persons_dictionary):
         cluster.map_all_hosts(dictionary.drop).result()
     # The TTL would reap these anyway. Clearing them now keeps the shared tables small enough that
-    # a run's own rows stay cheap to read.
+    # a run's own rows stay cheap to read. Replicated DROP PARTITION must run on a leader-capable
+    # replica, and only online replicas can become leaders, so the drop is routed to one.
     for table in run.all_tables:
-        cluster.any_host_by_role(table.drop_run_partition, NodeRole.DATA).result()
+        cluster.any_host_by_role(table.drop_run_partition, NodeRole.DATA, Workload.ONLINE).result()
 
 
 def _drop_dictionary(client: Client, qualified_name: str) -> None:


### PR DESCRIPTION
## Problem

- The weekly ClickHouse deletion sweep can fail at its final cleanup step after every delete already succeeded, stranding the run as FAILED. The first prod-US dry run ([`d107298b`](https://posthog.dagster.plus/prod-us/runs/d107298b-d981-41b9-b01f-ce368b7496db)) hit this.
- `drop_snapshot_assets` clears each run's snapshot partition on an arbitrary data host.
- Replicated `DROP PARTITION` requires a leader-capable replica; it throws `NOT_A_LEADER` (code 529) elsewhere.
- Both prod regions keep a third of their data replicas in an offline pool that can never become leader, so each of the four drops rolled a ~1-in-3 die. The earlier EU run passed by host-pick luck.

## Changes

- The partition drop now routes to an online replica (`Workload.ONLINE` on the `any_host_by_role` call). Online replicas are the leader pool in both prod regions (verified via `system.replicas`: `hostClusterType=online` maps exactly to `is_leader=1`).
- No dev/test branch is needed: every dev and CI ClickHouse host is typed `online` (`docker/clickhouse/config.d/*.xml`), so the tested path is the shipped path.
- The rest is mechanical: one import and one comment line.
- A failed run needs no manual cleanup either way: the failure hook drops the dictionaries, and the snapshot tables' 14-day TTL reaps the rows.

## How did you test this code?

- The full sweep and shared-dictionary suites pass locally; the dev stack's hosts carry `hostClusterType=online`, so they exercise the changed call exactly as shipped.
- No new test: the regression (removing the workload argument) is only observable on a cluster with a non-leader replica pool, which the single-host test stack cannot stand up.
- Prod proof planned: rerun the US dry run after deploy and confirm the run ends green with its rows and dictionaries cleared.

## 🤖 Agent context

Authored with Claude Code in an interactive session with Eli. Root-caused from the failed run's Dagster debug payload (single exception: `NOT_A_LEADER` from `StorageReplicatedMergeTree::dropPartition`) and prod topology queried via Metabase in both regions. Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`, `/writing-tests`. Alternatives rejected: retry-on-529 (more code, no repo precedent) and `ON CLUSTER` (different DDL semantics).
