### PR TITLE
fix(surveys): stop approval policies blocking every survey save

### DIFF
--- a/products/approvals/backend/decorators.py
+++ b/products/approvals/backend/decorators.py
@@ -17,6 +17,7 @@ from posthog.models import Team
 
 from products.approvals.backend.actions.registry import get_action
 from products.approvals.backend.exceptions import ApprovalRequired, PolicyConflict
+from products.approvals.backend.exemptions import is_exempt_write
 from products.approvals.backend.models import ChangeRequest, ChangeRequestState
 from products.approvals.backend.notifications import send_approval_requested_notification
 from products.approvals.backend.policies import PolicyDecision, PolicyEngine
@@ -486,27 +487,22 @@ def approval_gate(action_refs: Union[type, str, list]):
             if not actions:
                 return method(self, *args, **kwargs)
 
-            # The approved change is applied through this same serializer; re-gating it
-            # here would block (or duplicate) a change that is already approved.
-            if isinstance(getattr(self, "context", None), dict) and self.context.get("approval_apply"):
-                return method(self, *args, **kwargs)
-
             is_serializer = hasattr(self, "context") and isinstance(self.context, dict) and "request" in self.context
 
             if is_serializer:
-                request, team, organization = _extract_context(self)
+                request = self.context.get("request")
             else:
                 request = args[0] if args else kwargs.get("request")
-                _, team, organization = _extract_context(self, request)
 
-            # System writes (facade calls from tasks or service code) bypass the gate:
-            # approval policies target human-driven changes, and a ChangeRequest cannot
-            # exist without a requester to attribute it to. Only a request explicitly
-            # declaring itself a system write takes this path (`is True` so mocks and
-            # attribute-forwarding proxies can't) — a merely user-less request, e.g. a
-            # pre-auth HttpRequest, still engages the gate.
-            if getattr(request, "is_system", False) is True:
+            # is_exempt_write owns every reason a write skips the gate. Ask it before resolving
+            # team and organization, so an exempt write costs no queries.
+            if is_exempt_write(self, request):
                 return method(self, *args, **kwargs)
+
+            if is_serializer:
+                _, team, organization = _extract_context(self)
+            else:
+                _, team, organization = _extract_context(self, request)
 
             if not team or not organization:
                 logger.warning(

--- a/products/approvals/backend/exemptions.py
+++ b/products/approvals/backend/exemptions.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+# Set by the apply path, when an approved change request replays its own change.
+APPROVAL_APPLY_KEY = "approval_apply"
+
+# Set by a product, to declare a write as its own internal plumbing.
+INTERNAL_WRITE_KEY = "approval_internal_write"
+
+
+def internal_write_context() -> dict[str, bool]:
+    """Mark a resource write as product-internal plumbing, which approval policies ignore.
+
+    Merge the result into the serializer context of the write:
+
+        FeatureFlagSerializer(data=..., context={**self.context, **internal_write_context()})
+
+    Use this only for a resource that the product generates and owns, and that no person
+    authored. An example is the feature flag a survey mints to track who dismissed it. Product
+    code supplies every value in such a resource, so an approver has no human decision to
+    review, and gating it only blocks the parent write.
+
+    This is not a system write. The acting user still owns the row, and activity logging still
+    attributes the change to them. Declare ``is_system`` instead when no user acts at all, such
+    as in a Celery task — see ``posthog.api.utils.ServiceRequest``.
+
+    Merge into a copy of the context. Never mutate the caller's dict: the same request can also
+    carry a user-authored write, and that write must still reach the gate.
+    """
+    return {INTERNAL_WRITE_KEY: True}
+
+
+def is_exempt_write(view_or_serializer: Any, request: Any) -> bool:
+    """Decide whether a write skips the approval gate.
+
+    This is the one place that answers that question. ``approval_gate`` calls it before it
+    resolves a team, an organization, or a policy, so an exempt write costs no queries.
+    """
+    context = getattr(view_or_serializer, "context", None)
+    if isinstance(context, dict):
+        # An approver already accepted this change, and the apply path replays it through this
+        # same serializer. A second gate here would block or duplicate it.
+        if context.get(APPROVAL_APPLY_KEY):
+            return True
+        # `is True` so that a mock, or an attribute-forwarding proxy, cannot claim the exemption.
+        if context.get(INTERNAL_WRITE_KEY) is True:
+            return True
+
+    # A system write has no acting user, and a change request needs a requester to attribute it
+    # to. Only a request that declares itself takes this path — a merely user-less request, such
+    # as a pre-auth HttpRequest, still engages the gate.
+    if getattr(request, "is_system", False) is True:
+        return True
+
+    return False

--- a/products/approvals/backend/tests/test_exemptions.py
+++ b/products/approvals/backend/tests/test_exemptions.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from products.approvals.backend.exemptions import (
+    APPROVAL_APPLY_KEY,
+    INTERNAL_WRITE_KEY,
+    internal_write_context,
+    is_exempt_write,
+)
+
+USER_REQUEST = SimpleNamespace(user="a-user")
+SYSTEM_REQUEST = SimpleNamespace(is_system=True)
+# A mock forwards any attribute as a truthy Mock, so a loose check would exempt every mocked write.
+PROXY_REQUEST = SimpleNamespace(is_system=MagicMock())
+
+
+class TestIsExemptWrite(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("apply path replays an approved change", {APPROVAL_APPLY_KEY: True}, USER_REQUEST, True),
+            ("product-internal write", {INTERNAL_WRITE_KEY: True}, USER_REQUEST, True),
+            ("internal marker must be exactly True", {INTERNAL_WRITE_KEY: MagicMock()}, USER_REQUEST, False),
+            ("system request", {}, SYSTEM_REQUEST, True),
+            ("is_system must be exactly True", {}, PROXY_REQUEST, False),
+            ("user-authored write is gated", {}, USER_REQUEST, False),
+            ("viewset has no context but a system request", None, SYSTEM_REQUEST, True),
+            ("viewset has no context and a user request", None, USER_REQUEST, False),
+        ]
+    )
+    def test_exemption(self, _name, context, request, expected):
+        assert is_exempt_write(SimpleNamespace(context=context), request) is expected
+
+    def test_internal_write_context_does_not_alias_the_caller_context(self):
+        caller_context = {"request": USER_REQUEST}
+
+        merged = {**caller_context, **internal_write_context()}
+
+        assert is_exempt_write(SimpleNamespace(context=merged), USER_REQUEST) is True
+        # The same request can still carry a user-authored write, which must reach the gate.
+        assert is_exempt_write(SimpleNamespace(context=caller_context), USER_REQUEST) is False

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -68,6 +68,8 @@ from products.access_control.backend.presentation.access_control import (
 )
 from products.actions.backend.api.action import ActionSerializer, ActionStepJSONSerializer
 from products.actions.backend.models.action import Action
+from products.approvals.backend.exemptions import internal_write_context
+from products.approvals.backend.mixins import ApprovalHandlingMixin
 from products.feature_flags.backend.api.feature_flag import (
     BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
     FeatureFlagSerializer,
@@ -1830,7 +1832,12 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
         }
 
         instance.internal_response_sampling_flag = self._create_or_update_targeting_flag(
-            None, sampling_filters, instance.name, bool(instance.start_date), flag_name_suffix="-sampling"
+            None,
+            sampling_filters,
+            instance.name,
+            bool(instance.start_date),
+            flag_name_suffix="-sampling",
+            internal=True,
         )
         instance.save()
 
@@ -1931,7 +1938,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
             serialized_data_filters = {**existing_targeting_flag.filters, **user_submitted_dismissed_filter}
 
             internal_targeting_flag = self._create_or_update_targeting_flag(
-                instance.internal_targeting_flag, serialized_data_filters, flag_name_suffix="-custom"
+                instance.internal_targeting_flag, serialized_data_filters, flag_name_suffix="-custom", internal=True
             )
 
             internal_targeting_flag.active = should_flag_be_active
@@ -1947,13 +1954,19 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 instance.name,
                 should_flag_be_active,
                 flag_name_suffix="-custom",
+                internal=True,
             )
             instance.internal_targeting_flag_id = new_flag.id
             instance.save()
 
     def _create_or_update_targeting_flag(
-        self, existing_flag=None, filters=None, name=None, active=False, flag_name_suffix=None
+        self, existing_flag=None, filters=None, name=None, active=False, flag_name_suffix=None, internal=False
     ):
+        # A survey mints three flags. Only `targeting_flag` carries filters that a person wrote,
+        # so only it reaches the approval gate. The dismissal and sampling flags are product
+        # plumbing that always rolls out at 100%. approvals owns what that distinction means.
+        context = {**self.context, **internal_write_context()} if internal else self.context
+
         with create_flag_with_survey_errors():
             # Ensure the request method is set correctly for validation
             if existing_flag:
@@ -1962,7 +1975,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                     existing_flag,
                     data={"filters": filters},
                     partial=True,
-                    context=self.context,
+                    context=context,
                 )
                 existing_flag_serializer.is_valid(raise_exception=True)
                 return existing_flag_serializer.save()
@@ -1978,7 +1991,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                         "active": active,
                         "creation_context": "surveys",
                     },
-                    context=self.context,
+                    context=context,
                 )
 
                 feature_flag_serializer.is_valid(raise_exception=True)
@@ -2133,7 +2146,16 @@ class SurveyFilterSet(FilterSet):
         ],
     ),
 )
-class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.ModelViewSet):
+class SurveyViewSet(
+    # Converts the ApprovalRequired that FeatureFlagSerializer raises, when a policy gates the
+    # user-authored targeting flag, into a 409 carrying the pending change_request_id.
+    ApprovalHandlingMixin,
+    TeamAndOrgViewSetMixin,
+    AccessControlViewSetMixin,
+    viewsets.ModelViewSet,
+):
+    """Create, read, update, and manage surveys and their targeting."""
+
     scope_object = "survey"
     queryset = Survey.objects.select_related(
         "linked_flag", "linked_insight", "targeting_flag", "internal_targeting_flag"

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -32,6 +32,7 @@ from posthog.test.persons import create_person
 
 from products.access_control.backend.models.access_control import AccessControl
 from products.actions.backend.models.action import Action
+from products.approvals.backend.models import ApprovalPolicy, ChangeRequest
 from products.cohorts.backend.models.cohort import Cohort
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.product_analytics.backend.facade.models import Insight
@@ -7981,3 +7982,91 @@ class TestSurveyFeatureFlagScopeEnforcement(PersonalAPIKeysBaseTest, APIBaseTest
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+
+class TestSurveyApprovalGate(APIBaseTest):
+    ROLLOUT_CONDITION: dict[str, Any] = {
+        "type": "before_after",
+        "field": "rollout_percentage",
+        "operator": ">",
+        "value": 0,
+    }
+    TARGETING_FILTERS: dict[str, Any] = {"groups": [{"variant": None, "rollout_percentage": 50, "properties": []}]}
+
+    def setUp(self):
+        super().setUp()
+        patcher = patch("products.approvals.backend.decorators._is_approvals_enabled", return_value=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _policy(self, action_key: str, conditions: Optional[dict[str, Any]] = None) -> None:
+        ApprovalPolicy.objects.create(
+            organization=self.organization,
+            team=self.team,
+            action_key=action_key,
+            conditions=conditions or {},
+            approver_config={"quorum": 1, "users": [self.user.id]},
+            created_by=self.user,
+        )
+
+    @parameterized.expand(
+        [
+            ("rollout policy", "feature_flag.update", ROLLOUT_CONDITION, {}),
+            ("enable policy", "feature_flag.enable", None, {"start_date": "2026-01-01T00:00:00Z"}),
+        ]
+    )
+    def test_survey_create_is_unaffected_by_flag_policies(self, _name, action_key, conditions, extra):
+        self._policy(action_key, conditions)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={"name": "survey", "type": "popover", **extra},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        survey = Survey.objects.get(team=self.team, name="survey")
+        assert survey.internal_targeting_flag_id is not None
+
+    def test_repeated_survey_creates_are_unaffected(self):
+        self._policy("feature_flag.update", self.ROLLOUT_CONDITION)
+
+        for name in ("first", "second"):
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/surveys/",
+                data={"name": name, "type": "popover"},
+                format="json",
+            )
+            assert response.status_code == status.HTTP_201_CREATED
+
+    def test_user_authored_targeting_flag_still_requires_approval_on_create(self):
+        self._policy("feature_flag.update", self.ROLLOUT_CONDITION)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={"name": "targeted", "type": "popover", "targeting_flag_filters": self.TARGETING_FILTERS},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json()["code"] == "approval_required"
+        assert response.json()["change_request_id"]
+        assert not Survey.objects.filter(team=self.team, name="targeted").exists()
+
+    def test_user_authored_targeting_flag_still_requires_approval_on_update(self):
+        created = self.client.post(
+            f"/api/projects/{self.team.id}/surveys/",
+            data={"name": "later targeted", "type": "popover"},
+            format="json",
+        )
+        assert created.status_code == status.HTTP_201_CREATED
+        self._policy("feature_flag.update", self.ROLLOUT_CONDITION)
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{created.json()['id']}/",
+            data={"targeting_flag_filters": self.TARGETING_FILTERS},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert ChangeRequest.objects.filter(id=response.json()["change_request_id"]).exists()

--- a/products/surveys/frontend/generated/api.ts
+++ b/products/surveys/frontend/generated/api.ts
@@ -61,6 +61,9 @@ export const getSurveysListUrl = (projectId: string, params?: SurveysListParams)
         : `/api/projects/${projectId}/surveys/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysList = async (
     projectId: string,
     params?: SurveysListParams,
@@ -76,6 +79,9 @@ export const getSurveysCreateUrl = (projectId: string) => {
     return `/api/projects/${projectId}/surveys/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysCreate = async (
     projectId: string,
     surveySerializerCreateUpdateOnlySchemaApi: NonReadonly<SurveySerializerCreateUpdateOnlySchemaApi>,
@@ -93,6 +99,9 @@ export const getSurveysRetrieveUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/surveys/${id}/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<SurveyApi> => {
     return apiMutator<SurveyApi>(getSurveysRetrieveUrl(projectId, id), {
         ...options,
@@ -104,6 +113,9 @@ export const getSurveysUpdateUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/surveys/${id}/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysUpdate = async (
     projectId: string,
     id: string,
@@ -122,6 +134,9 @@ export const getSurveysPartialUpdateUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/surveys/${id}/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysPartialUpdate = async (
     projectId: string,
     id: string,
@@ -140,6 +155,9 @@ export const getSurveysDestroyUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/surveys/${id}/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getSurveysDestroyUrl(projectId, id), {
         ...options,
@@ -151,6 +169,9 @@ export const getSurveysActivityRetrieveUrl = (projectId: string, id: string) => 
     return `/api/projects/${projectId}/surveys/${id}/activity/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysActivityRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getSurveysActivityRetrieveUrl(projectId, id), {
         ...options,
@@ -207,6 +228,9 @@ export const getSurveysGenerateTranslationsCreateUrl = (projectId: string, id: s
     return `/api/projects/${projectId}/surveys/${id}/generate_translations/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysGenerateTranslationsCreate = async (
     projectId: string,
     id: string,
@@ -406,6 +430,9 @@ export const getSurveysSummaryHeadlineCreateUrl = (projectId: string, id: string
     return `/api/projects/${projectId}/surveys/${id}/summary_headline/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysSummaryHeadlineCreate = async (
     projectId: string,
     id: string,
@@ -424,6 +451,9 @@ export const getSurveysAllActivityRetrieveUrl = (projectId: string) => {
     return `/api/projects/${projectId}/surveys/activity/`
 }
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysAllActivityRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getSurveysAllActivityRetrieveUrl(projectId), {
         ...options,

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -9,6 +9,9 @@
  */
 import * as zod from 'zod'
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysCreateBodyNameMax = 400
 
 export const surveysCreateBodyTargetingFlagFiltersOneEarlyExitDefault = false
@@ -868,6 +871,9 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
     form_content: zod.unknown().optional(),
 })
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysUpdateBodyNameMax = 400
 
 export const surveysUpdateBodyResponsesLimitMin = 0
@@ -967,6 +973,9 @@ export const SurveysUpdateBody = /* @__PURE__ */ zod
     })
     .describe('Mixin for serializers to add user access control fields')
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysPartialUpdateBodyNameMax = 400
 
 export const surveysPartialUpdateBodyTargetingFlagFiltersOneEarlyExitDefault = false
@@ -1936,6 +1945,9 @@ export const SurveysDuplicateToProjectsCreateBody = /* @__PURE__ */ zod.object({
     form_content: zod.unknown().optional(),
 })
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysGenerateTranslationsCreateBodyOverwriteDefault = false
 
 export const SurveysGenerateTranslationsCreateBody = /* @__PURE__ */ zod.object({
@@ -2178,6 +2190,9 @@ export const SurveysSummarizeResponsesCreateBody = /* @__PURE__ */ zod.object({
         .describe('When true, bypass cached summaries and regenerate. Defaults to false.'),
 })
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const surveysSummaryHeadlineCreateBodyNameMax = 400
 
 export const surveysSummaryHeadlineCreateBodyResponsesLimitMin = 0

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -8,6 +8,9 @@
  */
 import * as zod from 'zod'
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const SurveysListParams = () => zod.object({
     project_id: zod
         .string()
@@ -42,6 +45,9 @@ export const SurveysListQueryParams = () => zod.object({
         ),
 })
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const SurveysCreateParams = () => zod.object({
     project_id: zod
         .string()
@@ -909,6 +915,9 @@ export const SurveysCreateBody = () => zod.object({
     form_content: zod.unknown().optional(),
 })
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const SurveysRetrieveParams = () => zod.object({
     id: zod.string().describe('A UUID string identifying this survey.'),
     project_id: zod
@@ -918,6 +927,9 @@ export const SurveysRetrieveParams = () => zod.object({
         ),
 })
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const SurveysPartialUpdateParams = () => zod.object({
     id: zod.string().describe('A UUID string identifying this survey.'),
     project_id: zod
@@ -1788,6 +1800,9 @@ export const SurveysPartialUpdateBody = () => zod.object({
     form_content: zod.unknown().optional(),
 })
 
+/**
+ * Create, read, update, and manage surveys and their targeting.
+ */
 export const SurveysDestroyParams = () => zod.object({
     id: zod.string().describe('A UUID string identifying this survey.'),
     project_id: zod

--- a/tach.toml
+++ b/tach.toml
@@ -808,6 +808,7 @@ depends_on = [
     "ee",
     "posthog",
     "products.actions",
+    "products.approvals",
     "products.feature_flags",
     "products.product_analytics",
     "products.product_tours", "products.access_control",


### PR DESCRIPTION
## Problem

A person in an organization with a feature flag approval policy cannot create a survey at all. Saving one returns a 500 and an HTML error page.

- Surveys mint three internal feature flags through `FeatureFlagSerializer`, which carries `@approval_gate`.
- Two of those flags are machine-generated and always roll out at 100%, so a rollout policy trips on every survey save, even one with no targeting.
- `ApprovalRequired` is a plain `Exception`, and `SurveyViewSet` had no handler for it, so it escaped as an unhandled 500.
- The survey row is written before the failing flag write, so the failed request still leaves a survey behind with no internal targeting flag.

Reported through error tracking, first seen after the feature flag approval gate rolled out.

## Changes

- A survey now saves normally under a feature flag approval policy, and still gets its internal flags.
- A survey whose targeting a person wrote still needs approval, and now returns 409 with the pending change request id instead of a 500.
- Every survey API endpoint now carries a real description in the generated types, instead of an internal mixin note.
- `products/approvals/backend/exemptions.py` holds one predicate, `is_exempt_write`, that decides whether any write skips the gate.
- The gate consults that predicate before it resolves a team, an organization, or a policy, so an exempt write costs no queries.
- Surveys declare only which of their flags is machine plumbing. Approvals decides what that declaration means.
- Mechanical: the `tach.toml` entry, and the regenerated OpenAPI types.

A narrower fix is to add `ApprovalHandlingMixin` and stop there. That turns the 500 into a 409, but a survey save still blocks on an approval nobody meant to request. The gate is meant for flag rollouts a person chose, and no person chose these.

The exemption is deliberately not `is_system`. A system write means no acting user, and it clears `created_by` and logs the change as system. A survey save has an acting user who should keep ownership of the flag.

No transaction wrapper is needed here. The gated write runs before the survey row is written on create, and after it on update, so an `ApprovalRequired` leaves nothing half-written and keeps the pending change request alive. Product tours needs `@transaction.atomic` on create for the opposite ordering.

> [!NOTE]
> Two pre-existing defects surfaced while testing this, both out of scope.
> The surveys UI swallows the 409: the page renders the rejected targeting as saved, with no error.
> Approving one of these change requests creates the flag but never links it to a survey, leaving an orphan. Product tours shares that path.

## How did you test this code?

Automated, both new:

- `test_exemptions.py` covers `is_exempt_write` as a pure function. The case that earns its place asserts the `is True` checks, so a mock or an attribute-forwarding proxy cannot claim an exemption and silently bypass approvals.
- `TestSurveyApprovalGate` covers the wiring the unit tests cannot: that the viewset actually reaches the predicate. It catches an over-broad fix that exempts every survey flag, and a regression to the 500.

Manual, on a devbox running this branch against a seeded org with the approvals feature and an enabled rollout policy. Toggled the fix with `git stash` to get both states:

| | Without the fix | With the fix |
| --- | --- | --- |
| Plain survey create | 500, HTML error page | 201 |
| Internal flag linked to the survey | no | yes |
| Create with targeting filters | 500 | 409 `approval_required` |

Also created a survey through the UI on that devbox, which saved as a draft and linked its internal flag.

Not checked: the survey Playwright suites, and any surface other than survey create and update.

No frontend source changed, so nothing looks different beyond the save succeeding.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) investigated a bug report, reproduced it, and wrote the fix under direction.

The session started as reproduction only. The reproduction confirmed the report and found two things it missed: the break needs no targeting filters at all, because every survey create writes a 100% rollout flag, and the failed request leaves a survey row behind.

The first recommendation was to bypass the gate for all survey flags. That was wrong, and changed after being pointed at how experiments handle approvals: stay gated, fail cleanly. The shipped design splits the difference along who authored the rollout, and the requirement to keep the decision inside the approvals module came from the reviewer.

Adding the mixin first in the base list made drf-spectacular publish the mixin's own docstring as the description of every survey endpoint. `SurveyViewSet` now has its own docstring, matching `ProductTourViewSet`. `EnterpriseExperimentsViewSet` still lacks one and leaks the same note into the experiments generated types, which this PR leaves alone.

Skills invoked: `/superpowers:systematic-debugging`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`, `/setting-up-devbox`.

The report behind this is an internal error tracking signal. Nothing from it reaches this PR: no customer names, no operational counts, and the test data is invented.
