### PR TITLE
feat(workflows): migrate conversion windows onto the duration-string field

### DIFF
--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -1940,7 +1940,7 @@ MAX_CONVERSION_WINDOW_MINUTES = 365 * 24 * 60
 MAX_LEGACY_WINDOW_MINUTES = 90 * 24 * 60
 
 
-def _duration_minutes(value: str) -> float:
+def duration_to_minutes(value: str) -> float:
     return float(value[:-1]) * _MINUTES_PER_DURATION_UNIT[value[-1]]
 
 

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -1940,7 +1940,7 @@ MAX_CONVERSION_WINDOW_MINUTES = 365 * 24 * 60
 MAX_LEGACY_WINDOW_MINUTES = 90 * 24 * 60
 
 
-def duration_to_minutes(value: str) -> float:
+def _duration_minutes(value: str) -> float:
     return float(value[:-1]) * _MINUTES_PER_DURATION_UNIT[value[-1]]
 
 

--- a/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
@@ -5,6 +5,7 @@ from django.db import transaction
 
 from products.workflows.backend.api.hog_flow import MAX_LEGACY_WINDOW_MINUTES
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
+from products.workflows.backend.models.hog_flow_revision import HogFlowRevision
 from products.workflows.backend.services.timing_reschedule import parse_delay_duration_seconds
 
 MINUTES_PER_DAY = 1440
@@ -36,6 +37,7 @@ class Command(BaseCommand):
             self.stdout.write(f"Filtering to team_id={team_id}")
 
         converted = 0
+        drafts_with_rows = 0
         needs_review = []
         for flow in flows.iterator():
             conversion = flow.conversion or {}
@@ -64,19 +66,84 @@ class Command(BaseCommand):
                 )
                 continue
 
-            locked_minutes, window = result
+            locked_minutes, window, draft_converted = result
+            drafts_with_rows += 1 if draft_converted else 0
             self.stdout.write(
                 f"  Converting flow id={flow.id} team_id={flow.team_id} status={flow.status}: "
                 f"window_minutes={locked_minutes} -> window={window}"
             )
             converted += 1
 
+        drafts = drafts_with_rows + self.convert_drafts(live_run, team_id)
+        revisions = self.convert_revisions(live_run, team_id)
+
         self.report_needs_review(needs_review)
 
         verb = "converted" if live_run else "to convert"
         self.stdout.write(self.style.SUCCESS(f"Completed ({mode}): {converted} flow(s) {verb}"))
+        self.stdout.write(self.style.SUCCESS(f"  plus {drafts} draft(s) and {revisions} revision snapshot(s)"))
 
-    def convert_locked(self, pk: uuid.UUID) -> tuple[int, str] | None:
+    def convert_drafts(self, live_run: bool, team_id: int | None) -> int:
+        """Drafts whose live conversion needed no change of its own. The pass above already rewrote a
+        draft alongside its row; this catches the rest, where only the draft carries the old field."""
+        flows = HogFlow.objects.filter(draft__isnull=False)
+        if team_id:
+            flows = flows.filter(team_id=team_id)
+
+        count = 0
+        for flow in flows.iterator():
+            draft = flow.draft
+            if not isinstance(draft, dict):
+                continue
+            rewritten = converted_conversion(draft.get("conversion"))
+            if rewritten is None:
+                continue
+            self.stdout.write(
+                f"  {'Converting' if live_run else 'Would convert'} draft on flow id={flow.id} "
+                f"team_id={flow.team_id}: window={rewritten['window']}"
+            )
+            if live_run:
+                with transaction.atomic():
+                    locked = HogFlow.objects.select_for_update().get(pk=flow.pk)
+                    locked_draft = locked.draft
+                    if not isinstance(locked_draft, dict):
+                        continue
+                    fresh = converted_conversion(locked_draft.get("conversion"))
+                    if fresh is None:
+                        continue
+                    HogFlow.objects.filter(pk=flow.pk).update(draft={**locked_draft, "conversion": fresh})
+            count += 1
+        return count
+
+    def convert_revisions(self, live_run: bool, team_id: int | None) -> int:
+        """Snapshots a rollback copies back into the draft. Rewriting one keeps a restore from putting
+        the deprecated field back. The value is unchanged, only how it is spelled, so the snapshot still
+        records the same window it always did."""
+        # Fail-closed manager: one team goes through for_team, and a whole-instance backfill is the
+        # cross-team access unscoped() exists for.
+        revisions = HogFlowRevision.objects.for_team(team_id) if team_id else HogFlowRevision.objects.unscoped().all()
+
+        count = 0
+        for revision in revisions.iterator():
+            content = revision.content
+            if not isinstance(content, dict):
+                continue
+            rewritten = converted_conversion(content.get("conversion"))
+            if rewritten is None:
+                continue
+            self.stdout.write(
+                f"  {'Converting' if live_run else 'Would convert'} revision id={revision.id} "
+                f"flow={revision.hog_flow_id} v{revision.version}: window={rewritten['window']}"
+            )
+            if live_run:
+                # Append-only in practice — nothing edits a published snapshot — so no lock is needed.
+                HogFlowRevision.objects.for_team(revision.team_id).filter(pk=revision.pk).update(
+                    content={**content, "conversion": rewritten}
+                )
+            count += 1
+        return count
+
+    def convert_locked(self, pk: uuid.UUID) -> tuple[int, str, bool] | None:
         # Re-read the row under a lock and convert the value it holds now, not the one the scan read.
         # A customer saving the workflow between the scan and this write would otherwise lose that edit
         # to the stale conversion this command is holding, the lost write the API save path and the
@@ -88,15 +155,25 @@ class Command(BaseCommand):
             locked = HogFlow.objects.select_for_update().get(pk=pk)
             conversion = locked.conversion or {}
             minutes = conversion.get("window_minutes")
-            if conversion.get("window") or not isinstance(minutes, int) or isinstance(minutes, bool) or minutes <= 0:
+            rewritten = converted_conversion(conversion)
+            if rewritten is None:
                 return None
-            if minutes > MAX_LEGACY_WINDOW_MINUTES:
-                return None
-            window = duration_string(minutes)
-            new_conversion = {k: v for k, v in conversion.items() if k != "window_minutes"}
-            new_conversion["window"] = window
-            HogFlow.objects.filter(pk=pk).update(conversion=new_conversion)
-        return minutes, window
+            # converted_conversion only returns a dict once it has established both of these, but it
+            # hands back the whole conversion, so narrow them here rather than assert.
+            minutes = int(minutes)
+            window = str(rewritten["window"])
+            fields: dict[str, object] = {"conversion": rewritten}
+            draft_converted = False
+            # The draft holds its own copy of conversion, so leaving it behind would put the
+            # deprecated field back on the live row the moment the draft is published.
+            draft = locked.draft
+            if isinstance(draft, dict):
+                draft_conversion = converted_conversion(draft.get("conversion"))
+                if draft_conversion is not None:
+                    fields["draft"] = {**draft, "conversion": draft_conversion}
+                    draft_converted = True
+            HogFlow.objects.filter(pk=pk).update(**fields)
+        return minutes, window, draft_converted
 
     def report_needs_review(self, needs_review):
         if not needs_review:
@@ -115,6 +192,21 @@ class Command(BaseCommand):
             "  Read it as whichever column sits closest to the workflow's own delay steps. A value that "
             "only makes sense as seconds was written by someone who meant that many days."
         )
+
+
+def converted_conversion(conversion: object) -> dict | None:
+    """The same conversion with window_minutes spelled as a duration string, or None when it must not
+    be touched: already migrated, no usable value, or above the ceiling where the reading is in doubt."""
+    if not isinstance(conversion, dict):
+        return None
+    minutes = conversion.get("window_minutes")
+    if conversion.get("window") or not isinstance(minutes, int) or isinstance(minutes, bool) or minutes <= 0:
+        return None
+    if minutes > MAX_LEGACY_WINDOW_MINUTES:
+        return None
+    rewritten = {k: v for k, v in conversion.items() if k != "window_minutes"}
+    rewritten["window"] = duration_string(minutes)
+    return rewritten
 
 
 def duration_string(minutes: int) -> str:

--- a/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
@@ -1,0 +1,106 @@
+import re
+
+from django.core.management.base import BaseCommand
+
+from products.workflows.backend.api.hog_flow import MAX_LEGACY_WINDOW_MINUTES, duration_to_minutes
+from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
+
+DURATION_RE = re.compile(r"^\d*\.?\d+[dhms]$")
+
+MINUTES_PER_DAY = 1440
+
+
+class Command(BaseCommand):
+    help = (
+        "Move conversion.window_minutes onto conversion.window, the duration-string form. "
+        "Only converts values the matcher already honors in full (at or under the legacy ceiling of "
+        f"{MAX_LEGACY_WINDOW_MINUTES} minutes), which is a representation change with no effect on any "
+        "conversion rate. A larger value is reported and left alone: those are minutes fields holding "
+        "second counts, so converting one either way changes what the workflow measures, and which "
+        "reading is right needs a person. Default dry-run; pass --live-run to apply."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", default=None, type=int, help="Limit to a specific team ID")
+        parser.add_argument("--live-run", action="store_true", help="Apply changes (default is dry-run)")
+
+    def handle(self, *args, **options):
+        live_run = options.get("live_run", False)
+        team_id = options.get("team_id")
+        mode = "LIVE RUN" if live_run else "DRY RUN"
+        self.stdout.write(f"Starting migrate_conversion_window_to_duration ({mode})")
+
+        flows = HogFlow.objects.filter(conversion__isnull=False)
+        if team_id:
+            flows = flows.filter(team_id=team_id)
+            self.stdout.write(f"Filtering to team_id={team_id}")
+
+        converted = 0
+        needs_review = []
+        for flow in flows.iterator():
+            conversion = flow.conversion or {}
+            minutes = conversion.get("window_minutes")
+            # A row that already carries a window was written by a client that knows the new field.
+            if conversion.get("window") or not isinstance(minutes, int) or isinstance(minutes, bool) or minutes <= 0:
+                continue
+
+            if minutes > MAX_LEGACY_WINDOW_MINUTES:
+                needs_review.append((flow, minutes))
+                continue
+
+            window = duration_string(minutes)
+            new_conversion = {k: v for k, v in conversion.items() if k != "window_minutes"}
+            new_conversion["window"] = window
+
+            self.stdout.write(
+                f"  {'Converting' if live_run else 'Would convert'} flow id={flow.id} team_id={flow.team_id} "
+                f"status={flow.status}: window_minutes={minutes} -> window={window}"
+            )
+            if live_run:
+                # .update() avoids bumping updated_at / firing save signals for a backfill.
+                HogFlow.objects.filter(pk=flow.pk).update(conversion=new_conversion)
+            converted += 1
+
+        self.report_needs_review(needs_review)
+
+        verb = "converted" if live_run else "to convert"
+        self.stdout.write(self.style.SUCCESS(f"Completed ({mode}): {converted} flow(s) {verb}"))
+
+    def report_needs_review(self, needs_review):
+        if not needs_review:
+            return
+        self.stdout.write("")
+        self.stdout.write(self.style.WARNING(f"{len(needs_review)} flow(s) left alone, each needs a person:"))
+        self.stdout.write("  team_id  window_minutes  as minutes  as seconds  own delay steps  name")
+        for flow, minutes in sorted(needs_review, key=lambda pair: pair[0].team_id):
+            span = flow_span_days(flow)
+            span_label = f"{span:.1f}d" if span else "none"
+            self.stdout.write(
+                f"  {flow.team_id:<7}  {minutes:<14}  {minutes / MINUTES_PER_DAY:>7.1f}d  "
+                f"{minutes / (MINUTES_PER_DAY * 60):>8.1f}d  {span_label:>15}  {flow.name}"
+            )
+        self.stdout.write(
+            "  Read it as whichever column sits closest to the workflow's own delay steps. A value that "
+            "only makes sense as seconds was written by someone who meant that many days."
+        )
+
+
+def duration_string(minutes: int) -> str:
+    """The shortest exact duration string for a whole number of minutes."""
+    if minutes % MINUTES_PER_DAY == 0:
+        return f"{minutes // MINUTES_PER_DAY}d"
+    if minutes % 60 == 0:
+        return f"{minutes // 60}h"
+    return f"{minutes}m"
+
+
+def flow_span_days(flow: HogFlow) -> float:
+    """How long the workflow's own delay steps run, which is what says whether a window is plausible."""
+    total = 0.0
+    for action in flow.actions or []:
+        if not isinstance(action, dict):
+            continue
+        duration = (action.get("config") or {}).get("delay_duration")
+        if isinstance(duration, str) and DURATION_RE.match(duration):
+            total += duration_to_minutes(duration)
+    return total / MINUTES_PER_DAY

--- a/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
@@ -71,12 +71,12 @@ class Command(BaseCommand):
             return
         self.stdout.write("")
         self.stdout.write(self.style.WARNING(f"{len(needs_review)} flow(s) left alone, each needs a person:"))
-        self.stdout.write("  team_id  window_minutes  as minutes  as seconds  own delay steps  name")
+        self.stdout.write(f"  {'id':<36}  team_id  window_minutes  as minutes  as seconds  own delay steps  name")
         for flow, minutes in sorted(needs_review, key=lambda pair: pair[0].team_id):
             span = flow_span_days(flow)
             span_label = f"{span:.1f}d" if span else "none"
             self.stdout.write(
-                f"  {flow.team_id:<7}  {minutes:<14}  {minutes / MINUTES_PER_DAY:>7.1f}d  "
+                f"  {str(flow.id):<36}  {flow.team_id:<7}  {minutes:<14}  {minutes / MINUTES_PER_DAY:>7.1f}d  "
                 f"{minutes / (MINUTES_PER_DAY * 60):>8.1f}d  {span_label:>15}  {flow.name}"
             )
         self.stdout.write(

--- a/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
@@ -3,12 +3,32 @@ import uuid
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
+from posthog.dataclasses import frozen
+
 from products.workflows.backend.api.hog_flow import MAX_LEGACY_WINDOW_MINUTES
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
 from products.workflows.backend.models.hog_flow_revision import HogFlowRevision
 from products.workflows.backend.services.timing_reschedule import parse_delay_duration_seconds
 
 MINUTES_PER_DAY = 1440
+
+
+@frozen
+class RewrittenWindow:
+    """A conversion whose window_minutes has been respelled as a duration string."""
+
+    conversion: dict
+    window: str
+    minutes: int
+
+
+@frozen
+class ConvertedFlow:
+    """What one locked row's conversion turned into, and whether its draft moved with it."""
+
+    window: str
+    minutes: int
+    draft_converted: bool
 
 
 class Command(BaseCommand):
@@ -66,11 +86,10 @@ class Command(BaseCommand):
                 )
                 continue
 
-            locked_minutes, window, draft_converted = result
-            drafts_with_rows += 1 if draft_converted else 0
+            drafts_with_rows += 1 if result.draft_converted else 0
             self.stdout.write(
                 f"  Converting flow id={flow.id} team_id={flow.team_id} status={flow.status}: "
-                f"window_minutes={locked_minutes} -> window={window}"
+                f"window_minutes={result.minutes} -> window={result.window}"
             )
             converted += 1
 
@@ -100,7 +119,7 @@ class Command(BaseCommand):
                 continue
             self.stdout.write(
                 f"  {'Converting' if live_run else 'Would convert'} draft on flow id={flow.id} "
-                f"team_id={flow.team_id}: window={rewritten['window']}"
+                f"team_id={flow.team_id}: window={rewritten.window}"
             )
             if live_run:
                 with transaction.atomic():
@@ -111,7 +130,7 @@ class Command(BaseCommand):
                     fresh = converted_conversion(locked_draft.get("conversion"))
                     if fresh is None:
                         continue
-                    HogFlow.objects.filter(pk=flow.pk).update(draft={**locked_draft, "conversion": fresh})
+                    HogFlow.objects.filter(pk=flow.pk).update(draft={**locked_draft, "conversion": fresh.conversion})
             count += 1
         return count
 
@@ -133,17 +152,17 @@ class Command(BaseCommand):
                 continue
             self.stdout.write(
                 f"  {'Converting' if live_run else 'Would convert'} revision id={revision.id} "
-                f"flow={revision.hog_flow_id} v{revision.version}: window={rewritten['window']}"
+                f"flow={revision.hog_flow_id} v{revision.version}: window={rewritten.window}"
             )
             if live_run:
                 # Append-only in practice — nothing edits a published snapshot — so no lock is needed.
                 HogFlowRevision.objects.for_team(revision.team_id).filter(pk=revision.pk).update(
-                    content={**content, "conversion": rewritten}
+                    content={**content, "conversion": rewritten.conversion}
                 )
             count += 1
         return count
 
-    def convert_locked(self, pk: uuid.UUID) -> tuple[int, str, bool] | None:
+    def convert_locked(self, pk: uuid.UUID) -> ConvertedFlow | None:
         # Re-read the row under a lock and convert the value it holds now, not the one the scan read.
         # A customer saving the workflow between the scan and this write would otherwise lose that edit
         # to the stale conversion this command is holding, the lost write the API save path and the
@@ -153,16 +172,10 @@ class Command(BaseCommand):
         # editor's next save or re-sort untouched flows to the top.
         with transaction.atomic():
             locked = HogFlow.objects.select_for_update().get(pk=pk)
-            conversion = locked.conversion or {}
-            minutes = conversion.get("window_minutes")
-            rewritten = converted_conversion(conversion)
+            rewritten = converted_conversion(locked.conversion or {})
             if rewritten is None:
                 return None
-            # converted_conversion only returns a dict once it has established both of these, but it
-            # hands back the whole conversion, so narrow them here rather than assert.
-            minutes = int(minutes)
-            window = str(rewritten["window"])
-            fields: dict[str, object] = {"conversion": rewritten}
+            fields: dict[str, object] = {"conversion": rewritten.conversion}
             draft_converted = False
             # The draft holds its own copy of conversion, so leaving it behind would put the
             # deprecated field back on the live row the moment the draft is published.
@@ -170,10 +183,10 @@ class Command(BaseCommand):
             if isinstance(draft, dict):
                 draft_conversion = converted_conversion(draft.get("conversion"))
                 if draft_conversion is not None:
-                    fields["draft"] = {**draft, "conversion": draft_conversion}
+                    fields["draft"] = {**draft, "conversion": draft_conversion.conversion}
                     draft_converted = True
             HogFlow.objects.filter(pk=pk).update(**fields)
-        return minutes, window, draft_converted
+        return ConvertedFlow(window=rewritten.window, minutes=rewritten.minutes, draft_converted=draft_converted)
 
     def report_needs_review(self, needs_review):
         if not needs_review:
@@ -194,7 +207,7 @@ class Command(BaseCommand):
         )
 
 
-def converted_conversion(conversion: object) -> dict | None:
+def converted_conversion(conversion: object) -> RewrittenWindow | None:
     """The same conversion with window_minutes spelled as a duration string, or None when it must not
     be touched: already migrated, no usable value, or above the ceiling where the reading is in doubt."""
     if not isinstance(conversion, dict):
@@ -204,9 +217,10 @@ def converted_conversion(conversion: object) -> dict | None:
         return None
     if minutes > MAX_LEGACY_WINDOW_MINUTES:
         return None
+    window = duration_string(minutes)
     rewritten = {k: v for k, v in conversion.items() if k != "window_minutes"}
-    rewritten["window"] = duration_string(minutes)
-    return rewritten
+    rewritten["window"] = window
+    return RewrittenWindow(conversion=rewritten, window=window, minutes=minutes)
 
 
 def duration_string(minutes: int) -> str:

--- a/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
@@ -1,6 +1,8 @@
 import re
+import uuid
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 
 from products.workflows.backend.api.hog_flow import MAX_LEGACY_WINDOW_MINUTES, duration_to_minutes
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
@@ -48,23 +50,55 @@ class Command(BaseCommand):
                 needs_review.append((flow, minutes))
                 continue
 
-            window = duration_string(minutes)
-            new_conversion = {k: v for k, v in conversion.items() if k != "window_minutes"}
-            new_conversion["window"] = window
+            if not live_run:
+                self.stdout.write(
+                    f"  Would convert flow id={flow.id} team_id={flow.team_id} status={flow.status}: "
+                    f"window_minutes={minutes} -> window={duration_string(minutes)}"
+                )
+                converted += 1
+                continue
 
+            result = self.convert_locked(flow.pk)
+            if result is None:
+                self.stdout.write(
+                    f"  Skipped flow id={flow.id} team_id={flow.team_id}: conversion changed since the "
+                    "scan, leaving it for a rerun"
+                )
+                continue
+
+            locked_minutes, window = result
             self.stdout.write(
-                f"  {'Converting' if live_run else 'Would convert'} flow id={flow.id} team_id={flow.team_id} "
-                f"status={flow.status}: window_minutes={minutes} -> window={window}"
+                f"  Converting flow id={flow.id} team_id={flow.team_id} status={flow.status}: "
+                f"window_minutes={locked_minutes} -> window={window}"
             )
-            if live_run:
-                # .update() avoids bumping updated_at / firing save signals for a backfill.
-                HogFlow.objects.filter(pk=flow.pk).update(conversion=new_conversion)
             converted += 1
 
         self.report_needs_review(needs_review)
 
         verb = "converted" if live_run else "to convert"
         self.stdout.write(self.style.SUCCESS(f"Completed ({mode}): {converted} flow(s) {verb}"))
+
+    def convert_locked(self, pk: uuid.UUID) -> tuple[int, str] | None:
+        # Re-read the row under a lock and convert the value it holds now, not the one the scan read.
+        # A customer saving the workflow between the scan and this write would otherwise lose that edit
+        # to the stale conversion this command is holding, the lost write the API save path and the
+        # sibling backfills guard against. A locked row that no longer qualifies (a save added a window
+        # or pushed the value above the ceiling) is left for a rerun. .update() keeps updated_at
+        # untouched: this is a representation change, not a user edit, so it must not fail an open
+        # editor's next save or re-sort untouched flows to the top.
+        with transaction.atomic():
+            locked = HogFlow.objects.select_for_update().get(pk=pk)
+            conversion = locked.conversion or {}
+            minutes = conversion.get("window_minutes")
+            if conversion.get("window") or not isinstance(minutes, int) or isinstance(minutes, bool) or minutes <= 0:
+                return None
+            if minutes > MAX_LEGACY_WINDOW_MINUTES:
+                return None
+            window = duration_string(minutes)
+            new_conversion = {k: v for k, v in conversion.items() if k != "window_minutes"}
+            new_conversion["window"] = window
+            HogFlow.objects.filter(pk=pk).update(conversion=new_conversion)
+        return minutes, window
 
     def report_needs_review(self, needs_review):
         if not needs_review:

--- a/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
@@ -1,13 +1,11 @@
-import re
 import uuid
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from products.workflows.backend.api.hog_flow import MAX_LEGACY_WINDOW_MINUTES, duration_to_minutes
+from products.workflows.backend.api.hog_flow import MAX_LEGACY_WINDOW_MINUTES
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
-
-DURATION_RE = re.compile(r"^\d*\.?\d+[dhms]$")
+from products.workflows.backend.services.timing_reschedule import parse_delay_duration_seconds
 
 MINUTES_PER_DAY = 1440
 
@@ -129,12 +127,16 @@ def duration_string(minutes: int) -> str:
 
 
 def flow_span_days(flow: HogFlow) -> float:
-    """How long the workflow's own delay steps run, which is what says whether a window is plausible."""
-    total = 0.0
+    """Rough timescale of the workflow's fixed delay steps, each clamped per unit the way the worker
+    clamps a delay before it waits, so a step written 90d counts the 30 days it actually waits. This
+    is only a sanity signal for the review table. It sums fixed delays without following branches, so
+    mutually exclusive delays are added together, and it counts neither date-based delays nor
+    condition-wait deadlines. Treat it as approximate, not the exact span any one run follows."""
+    total_seconds = 0.0
     for action in flow.actions or []:
         if not isinstance(action, dict):
             continue
-        duration = (action.get("config") or {}).get("delay_duration")
-        if isinstance(duration, str) and DURATION_RE.match(duration):
-            total += duration_to_minutes(duration)
-    return total / MINUTES_PER_DAY
+        seconds = parse_delay_duration_seconds((action.get("config") or {}).get("delay_duration"))
+        if seconds is not None:
+            total_seconds += seconds
+    return total_seconds / (MINUTES_PER_DAY * 60)

--- a/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 
 from django.core.management.base import BaseCommand
 from django.db import transaction
@@ -41,11 +42,11 @@ class Command(BaseCommand):
         "which one is right needs a person. Default dry-run; pass --live-run to apply."
     )
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: Any) -> None:
         parser.add_argument("--team-id", default=None, type=int, help="Limit to a specific team ID")
         parser.add_argument("--live-run", action="store_true", help="Apply changes (default is dry-run)")
 
-    def handle(self, *args, **options):
+    def handle(self, *args: Any, **options: Any) -> None:
         live_run = options.get("live_run", False)
         team_id = options.get("team_id")
         mode = "LIVE RUN" if live_run else "DRY RUN"
@@ -169,7 +170,10 @@ class Command(BaseCommand):
         # sibling backfills guard against. A locked row that no longer qualifies (a save added a window
         # or pushed the value above the ceiling) is left for a rerun. .update() keeps updated_at
         # untouched: this is a representation change, not a user edit, so it must not fail an open
-        # editor's next save or re-sort untouched flows to the top.
+        # editor's next save or re-sort untouched flows to the top. The cost is that an editor which loaded
+        # the workflow before the run and saves after it writes its stale conversion back, returning that
+        # one row to window_minutes. The value it restores is under the ceiling and still honored, and a
+        # rerun converts it again, so this is the cheaper side of the trade.
         with transaction.atomic():
             locked = HogFlow.objects.select_for_update().get(pk=pk)
             rewritten = converted_conversion(locked.conversion or {})
@@ -188,7 +192,7 @@ class Command(BaseCommand):
             HogFlow.objects.filter(pk=pk).update(**fields)
         return ConvertedFlow(window=rewritten.window, minutes=rewritten.minutes, draft_converted=draft_converted)
 
-    def report_needs_review(self, needs_review):
+    def report_needs_review(self, needs_review: list[tuple[HogFlow, int]]) -> None:
         if not needs_review:
             return
         self.stdout.write("")

--- a/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/management/commands/migrate_conversion_window_to_duration.py
@@ -15,9 +15,9 @@ class Command(BaseCommand):
         "Move conversion.window_minutes onto conversion.window, the duration-string form. "
         "Only converts values the matcher already honors in full (at or under the legacy ceiling of "
         f"{MAX_LEGACY_WINDOW_MINUTES} minutes), which is a representation change with no effect on any "
-        "conversion rate. A larger value is reported and left alone: those are minutes fields holding "
-        "second counts, so converting one either way changes what the workflow measures, and which "
-        "reading is right needs a person. Default dry-run; pass --live-run to apply."
+        "conversion rate. A larger value is reported and left alone: it can be a real minute count or a "
+        "seconds count in a minutes field, and either reading changes what the workflow measures, so "
+        "which one is right needs a person. Default dry-run; pass --live-run to apply."
     )
 
     def add_arguments(self, parser):

--- a/products/workflows/backend/test/test_migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/test/test_migrate_conversion_window_to_duration.py
@@ -4,13 +4,14 @@ from django.core.management import call_command
 
 from parameterized import parameterized
 
+from posthog.models import Team
 from posthog.models.scoping import team_scope
 
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
 from products.workflows.backend.models.hog_flow_revision import HogFlowRevision
 
 
-def _flow(team, name: str, conversion: dict) -> HogFlow:
+def _flow(team: Team, name: str, conversion: dict) -> HogFlow:
     return HogFlow.objects.create(
         team=team,
         name=name,

--- a/products/workflows/backend/test/test_migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/test/test_migrate_conversion_window_to_duration.py
@@ -4,7 +4,10 @@ from django.core.management import call_command
 
 from parameterized import parameterized
 
+from posthog.models.scoping import team_scope
+
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
+from products.workflows.backend.models.hog_flow_revision import HogFlowRevision
 
 
 def _flow(team, name: str, conversion: dict) -> HogFlow:
@@ -62,3 +65,49 @@ class TestMigrateConversionWindowToDuration(BaseTest):
 
         flow.refresh_from_db()
         assert flow.conversion == {"filters": [], "window": "7d"}
+
+    def test_converts_the_draft_copy_of_a_conversion(self):
+        # A draft carries its own conversion, so leaving it behind puts the deprecated field back on
+        # the live row the moment someone publishes.
+        flow = _flow(self.team, "with draft", {"filters": [], "window_minutes": 60})
+        flow.draft = {"conversion": {"filters": [], "window_minutes": 1440}}
+        flow.save()
+
+        call_command("migrate_conversion_window_to_duration", team_id=self.team.pk, live_run=True)
+
+        flow.refresh_from_db()
+        assert flow.conversion == {"filters": [], "window": "1h"}
+        assert flow.draft == {"conversion": {"filters": [], "window": "1d"}}
+
+    def test_converts_a_revision_snapshot(self):
+        # Restoring a snapshot copies it back into the draft, so an unmigrated one reintroduces the field.
+        flow = _flow(self.team, "with revision", {"filters": [], "window": "7d"})
+        with team_scope(self.team.id):
+            revision = HogFlowRevision.objects.create(
+                team=self.team,
+                hog_flow=flow,
+                version=1,
+                content={"conversion": {"filters": [], "window_minutes": 1440}},
+            )
+
+        call_command("migrate_conversion_window_to_duration", team_id=self.team.pk, live_run=True)
+
+        with team_scope(self.team.id):
+            revision.refresh_from_db()
+        assert revision.content == {"conversion": {"filters": [], "window": "1d"}}
+
+    def test_leaves_an_ambiguous_revision_snapshot_alone(self):
+        flow = _flow(self.team, "ambiguous revision", {"filters": [], "window": "7d"})
+        with team_scope(self.team.id):
+            revision = HogFlowRevision.objects.create(
+                team=self.team,
+                hog_flow=flow,
+                version=1,
+                content={"conversion": {"filters": [], "window_minutes": 604800}},
+            )
+
+        call_command("migrate_conversion_window_to_duration", team_id=self.team.pk, live_run=True)
+
+        with team_scope(self.team.id):
+            revision.refresh_from_db()
+        assert revision.content == {"conversion": {"filters": [], "window_minutes": 604800}}

--- a/products/workflows/backend/test/test_migrate_conversion_window_to_duration.py
+++ b/products/workflows/backend/test/test_migrate_conversion_window_to_duration.py
@@ -1,0 +1,64 @@
+from posthog.test.base import BaseTest
+
+from django.core.management import call_command
+
+from parameterized import parameterized
+
+from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
+
+
+def _flow(team, name: str, conversion: dict) -> HogFlow:
+    return HogFlow.objects.create(
+        team=team,
+        name=name,
+        status="active",
+        trigger={"type": "event", "filters": {}},
+        exit_condition="exit_only_at_end",
+        conversion=conversion,
+        actions=[],
+        edges=[],
+    )
+
+
+class TestMigrateConversionWindowToDuration(BaseTest):
+    @parameterized.expand(
+        [
+            ("a whole number of days", 129600, "90d"),
+            ("a whole number of hours", 60, "1h"),
+            ("neither", 90, "90m"),
+        ]
+    )
+    def test_converts_a_window_the_matcher_already_honors(self, _name, minutes, expected):
+        flow = _flow(self.team, "convertible", {"filters": [], "window_minutes": minutes})
+
+        call_command("migrate_conversion_window_to_duration", team_id=self.team.pk, live_run=True)
+
+        flow.refresh_from_db()
+        assert flow.conversion == {"filters": [], "window": expected}
+
+    @parameterized.expand([("seven days in seconds", 604800), ("thirty days in seconds", 2592000)])
+    def test_leaves_a_window_above_the_legacy_ceiling_alone(self, _name, minutes):
+        # Converting one of these either way changes what the workflow measures, and which reading is
+        # right needs a person. Touching it silently is the failure this guards.
+        flow = _flow(self.team, "ambiguous", {"filters": [], "window_minutes": minutes})
+
+        call_command("migrate_conversion_window_to_duration", team_id=self.team.pk, live_run=True)
+
+        flow.refresh_from_db()
+        assert flow.conversion == {"filters": [], "window_minutes": minutes}
+
+    def test_dry_run_writes_nothing(self):
+        flow = _flow(self.team, "untouched", {"filters": [], "window_minutes": 60})
+
+        call_command("migrate_conversion_window_to_duration", team_id=self.team.pk)
+
+        flow.refresh_from_db()
+        assert flow.conversion == {"filters": [], "window_minutes": 60}
+
+    def test_leaves_a_flow_that_already_has_a_window_alone(self):
+        flow = _flow(self.team, "already migrated", {"filters": [], "window": "7d"})
+
+        call_command("migrate_conversion_window_to_duration", team_id=self.team.pk, live_run=True)
+
+        flow.refresh_from_db()
+        assert flow.conversion == {"filters": [], "window": "7d"}


### PR DESCRIPTION
## Problem

Every workflow that set a conversion window before #93258 still holds it as `window_minutes`, a bare integer whose unit lives only in the field name. Until those rows move, the deprecated field cannot be removed and the ambiguity stays.

Most of them are unambiguous. A minority are not, and those are the ones holding second counts.

## Changes

- A management command moves `conversion.window_minutes` onto `conversion.window`, the duration-string form. Dry-run by default, `--live-run` to apply, `--team-id` to scope it, and safe to rerun.
- It converts only values the matcher already honors in full, at or under the 90-day legacy ceiling. Those are pure representation changes: `129600` becomes `"90d"` and measures exactly what it measured yesterday. No conversion rate moves.
- It converts the stored copies too. A workflow's draft carries its own `conversion`, and a revision snapshot is copied back on rollback, so leaving either behind puts the deprecated field back on the live row the moment someone publishes or restores.
- Anything above the ceiling is left alone and reported, with the value read both ways beside the workflow's own delay steps:

```
  id                                    team_id  window_minutes  as minutes  as seconds  own delay steps  name
  019...                                1        604800            420.0d       7.0d             6.0d  seven days in seconds
  019...                                1        259200            180.0d       3.0d           180.0d  a real 180-day window
  019...                                1        604800            420.0d       7.0d             none  no steps to judge by
```

Read the column that sits closest to the delay steps. The command does not guess, because either reading changes what the workflow measures and only its owner knows which was meant.

The live row and its draft are rewritten under one `select_for_update`, so a customer saving between the scan and the write does not lose that edit. `HogFlowRevision` sits on a fail-closed manager, so reads go through `for_team` when scoped and `unscoped()` for a whole-instance backfill, and writes always through `for_team`.

> [!NOTE]
> This leaves the deprecated field populated on the flows that need a person, so the removal PR cannot land until those are resolved with their teams.

Stacked on #93258.

## How did you test this code?

Ran the command against workflows seeded locally in the shapes production holds.

- Values at or under the ceiling converted to the shortest exact string: `129600` to `"90d"`, `86400` to `"60d"`, `57600` to `"40d"`, `46080` to `"32d"`, `60` to `"1h"`.
- Seven values above the ceiling were held back and printed with both readings. The `259200` on a workflow whose own steps run 180 days lines up as minutes; the `604800` on a six-day workflow only as seconds; three with no delay steps show `none`.
- Stored copies: seeded a live row carrying a draft, a draft-only row, and a revision snapshot. The first run converted 1 flow, 2 drafts and 1 revision; a second run converted 0 of each.
- Read the results back from Postgres. The live row, both drafts and the snapshot carry duration strings, and the `604800` flow keeps `window_minutes` in all three places.
- `--dry-run` wrote nothing.
- Full chain with the CDP worker running this branch: created a workflow through the API with `window_minutes: 86400`, ran the command against it, and enrolled a person through capture. The watcher expires in 60.00 days, so the worker reads the migrated field.

The ten command tests cover the property that matters: a value above the ceiling is never touched, in the live row, the draft or the snapshot. A regression there would silently change somebody's attribution window, and no other test would notice.

Not checked: running against production data. The classification was exercised against locally seeded copies of the shapes, not the rows themselves.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this. Skills invoked: `/announcing-behavior-changes`, `/writing-pr-descriptions`.

An earlier design classified the ambiguous values automatically, using the workflow's delay steps to pick a reading. It was dropped: the heuristic disagreed with itself on a workflow whose steps run 40 days and whose value reads as 7 days either way, and a wrong call there changes a customer's conversion rate without anyone noticing. Reporting beats guessing when the cost of a wrong guess is silent.

The draft and revision passes came from a review finding that stored copies of `conversion` would reintroduce the deprecated field after migration.

Per `/announcing-behavior-changes`, the flows left for review will move a visible metric when they are eventually converted. With roughly two dozen workflows across a small number of teams, direct outreach is more proportionate than an in-app notice, and only the backend can tell which flows were touched.

No customer conversation, ticket, or log fed this PR. The seeded workflows and events were invented for the session.

