### PR TITLE
chore(ci): experiment with pytest gc, allocator and runner settings

### DIFF
--- a/.depot/workflows/gc-experiment.yml
+++ b/.depot/workflows/gc-experiment.yml
@@ -1,0 +1,489 @@
+name: '[experiment] GC settings on Depot CI'
+
+# Throwaway experiment. Repeats the garbage collector, allocator, and Postgres sweep from
+# .github/workflows/ci-backend-gc-experiment.yml on Depot CI, whose runners are reported to
+# give two threads per core where the GitHub Actions runners give one. Collector frequency
+# is sensitive to shared-cache contention, so a variant that did nothing on one thread per
+# core can still matter here. The design is unchanged so the two sets of numbers compare:
+# every variant runs back to back on one runner, the order rotates per block, and each block
+# runs the baseline twice to measure its own noise floor.
+#
+# Dispatch only. Nothing here runs on a push or a pull request.
+
+on:
+    workflow_dispatch:
+        inputs:
+            splits:
+                description: Number of pytest-split shards the Core suite is cut into
+                default: '60'
+                type: string
+            group:
+                description: Which of those shards to run
+                default: '7'
+                type: string
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+    actions: read
+
+env:
+    SCHEMA_CACHE_EPOCH: v2
+    HYPOTHESIS_CONSTANTS_EPOCH: v1
+    SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
+    DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+    REDIS_URL: 'redis://localhost'
+    CLICKHOUSE_HOST: 'localhost'
+    CLICKHOUSE_SECURE: 'False'
+    CLICKHOUSE_VERIFY: 'False'
+    CLICKHOUSE_TEST_CLUSTER_HOST: 'localhost'
+    CLICKHOUSE_TEST_CLUSTER_DATABASE: 'posthog_test'
+    CLICKHOUSE_TEST_CLUSTER_USER: 'autoresearch'
+    CLICKHOUSE_TEST_CLUSTER_PASSWORD: 'autoresearchpass'
+    CLICKHOUSE_TEST_CLUSTER_SECURE: 'False'
+    CLICKHOUSE_TEST_CLUSTER_VERIFY: 'False'
+    TEST: 1
+    OBJECT_STORAGE_ENABLED: 'True'
+    OBJECT_STORAGE_ENDPOINT: 'http://localhost:19000'
+    OBJECT_STORAGE_ACCESS_KEY_ID: 'object_storage_root_user'
+    OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
+    UV_HTTP_TIMEOUT: 120
+    DISPLAY: ':99.0'
+    OIDC_RSA_PRIVATE_KEY: ${{ vars.OIDC_RSA_FAKE_PRIVATE_KEY }}
+    SANDBOX_JWT_PRIVATE_KEY: ${{ vars.OIDC_RSA_FAKE_PRIVATE_KEY }}
+    SPLITS: ${{ github.event.inputs.splits || '60' }}
+    GROUP: ${{ github.event.inputs.group || '7' }}
+
+jobs:
+    plan:
+        name: Pin sharding plan
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - name: Restore test durations from cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .test_durations
+                  key: posthog-test-durations-${{ github.run_id }}
+                  restore-keys: |
+                      posthog-test-durations-
+
+            - name: Fall back to the last published durations
+              if: ${{ hashFiles('.test_durations') == '' }}
+              continue-on-error: true
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow ci-backend-update-test-timing.yml \
+                      --branch master --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+                  if [ -z "$run_id" ]; then
+                      echo "::warning::No successful timing run to fall back to, sharding without durations"
+                      exit 0
+                  fi
+                  gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name test-durations --dir . \
+                      || echo "::warning::Timing artifact of run $run_id unavailable, sharding without durations"
+
+            - name: Publish the plan every variant will shard from
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: gc-experiment-durations
+                  path: .test_durations
+                  if-no-files-found: warn
+                  retention-days: 3
+
+    test:
+        name: GC block ${{ matrix.block }}
+        needs: plan
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 90
+        strategy:
+            fail-fast: false
+            matrix:
+                # Each block is one runner that executes every variant in sequence.
+                block: [1, 2, 3, 4, 5, 6]
+        env:
+            DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
+            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+            COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+            COMPOSE_PROFILES: temporal,azure
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 1
+                  lfs: true
+
+            - name: Install signal-fanout
+              shell: bash
+              run: sudo install -m 0755 .github/scripts/signal-fanout /usr/local/bin/signal-fanout
+
+            - name: Log in to Docker Hub
+              continue-on-error: true
+              if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+              with:
+                  username: ${{ vars.DOCKERHUB_USER }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Resolve the ClickHouse image
+              shell: bash
+              run: echo "CLICKHOUSE_SERVER_IMAGE=$(jq -r .oldest_supported .github/clickhouse-versions.json)" >> "$GITHUB_ENV"
+
+            - name: Stop/Start stack with Docker Compose
+              shell: bash
+              env:
+                  WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3
+                  WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 5
+              run: |
+                  cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
+                  bin/ci-wait-for-docker launch --background --down-all-profiles
+
+            - name: Add service hostnames to /etc/hosts
+              shell: bash
+              run: echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
+
+            - name: Set up Python
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version: 3.13.13
+
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
+
+            - name: Install uv
+              id: setup-uv-tests
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: true
+                  cache-dependency-glob: uv.lock
+                  save-cache: false
+
+            - name: Install SAML (python3-saml) dependencies
+              shell: bash
+              run: sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+            - name: Install sqlx-cli
+              uses: ./.depot/actions/setup-sqlx-cli
+
+            - name: Cache and install Qt libraries
+              uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+              with:
+                  packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0
+                  version: 1.0
+
+            - name: Install Python dependencies
+              shell: bash
+              run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+
+            - name: Set up needed files
+              shell: bash
+              run: |
+                  mkdir -p frontend/dist
+                  touch frontend/dist/index.html
+                  touch frontend/dist/layout.html
+                  touch frontend/dist/exporter.html
+                  ./bin/download-mmdb
+
+            - name: Wait for Docker services
+              shell: bash
+              run: bin/ci-wait-for-docker wait
+
+            - name: Restore schema cache from master
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: schema.sql.gz
+                  key: posthog-schema-master-${{ github.event.pull_request.base.sha || github.sha }}
+                  restore-keys: |
+                      posthog-schema-mig-${{ env.SCHEMA_CACHE_EPOCH }}-
+                      posthog-schema-master-
+
+            - name: Prime test_posthog from cached schema
+              id: prime-schema
+              shell: bash
+              run: |
+                  echo "restored=false" >> "$GITHUB_OUTPUT"
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss; the migrate step will build test_posthog"
+                      exit 0
+                  fi
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  if ./bin/hogli db:restore-test-db; then
+                      echo "restored=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "::warning::Schema restore failed (stale/incompatible cached dump?); the migrate step will build test_posthog"
+                  fi
+
+            - name: Migrate test_posthog from scratch
+              if: ${{ steps.prime-schema.outputs.restored != 'true' }}
+              shell: bash
+              env:
+                  DATABASE_URL: postgres://posthog:posthog@localhost:5432/test_posthog
+              run: |
+                  admin_psql() { docker compose -f docker-compose.dev.yml exec -T db psql -U posthog postgres "$@"; }
+                  if ! admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" -c "CREATE DATABASE test_posthog;"; then
+                      echo "::warning::Could not recreate test_posthog; pytest --reuse-db will run the full migrate itself"
+                      exit 0
+                  fi
+                  if ! python manage.py migrate; then
+                      echo "::warning::Out-of-process migrate failed; pytest --reuse-db will run the full migrate itself"
+                      admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" || true
+                  fi
+
+            - name: Download the pinned sharding plan
+              continue-on-error: true
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: gc-experiment-durations
+                  path: .
+
+            - name: Compute hypothesis constants cache key
+              id: hyp-constants-key
+              shell: bash
+              run: |
+                  hyp_version=$(python -c "import hypothesis; print(hypothesis.__version__)")
+                  prefix="posthog-hypothesis-constants-${hyp_version}-${HYPOTHESIS_CONSTANTS_EPOCH}-"
+                  {
+                      echo "key=${prefix}$(date -u +%G-%V)"
+                      echo "restore_prefix=${prefix}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Restore hypothesis constants cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .hypothesis/constants
+                  key: ${{ steps.hyp-constants-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.hyp-constants-key.outputs.restore_prefix }}
+
+            - name: Record the runner topology
+              shell: bash
+              run: |
+                  mkdir -p results
+                  lscpu > results/lscpu.txt 2>&1 || true
+                  {
+                      echo "runner=${RUNNER_NAME:-unknown}"
+                      echo "nproc=$(nproc)"
+                      echo "threads_per_core=$(lscpu | awk -F: '/Thread\(s\) per core/{gsub(/ /,"",$2); print $2}')"
+                      echo "cores_per_socket=$(lscpu | awk -F: '/Core\(s\) per socket/{gsub(/ /,"",$2); print $2}')"
+                      echo "model=$(lscpu | awk -F: '/Model name/{sub(/^ +/,"",$2); print $2}')"
+                      echo "l3=$(lscpu | awk -F: '/L3 cache/{gsub(/ /,"",$2); print $2}')"
+                      echo "mem_gb=$(free -g | awk '/^Mem:/{print $2}')"
+                  } | tee results/topology.txt
+
+            - name: Install jemalloc
+              shell: bash
+              run: sudo apt-get install -y -qq libjemalloc2
+
+            - name: Run every variant on this runner
+              id: run
+              continue-on-error: true
+              env:
+                  BLOCK: ${{ matrix.block }}
+                  PERSON_ON_EVENTS_V2_ENABLED: 'true'
+                  CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA: 'false'
+              shell: 'signal-fanout bash --noprofile --norc -eo pipefail {0}'
+              run: |
+                  mkdir -p results
+                  # baseline appears twice: the gap between the two measures how much this
+                  # runner drifts across the block, which is the noise floor every other
+                  # comparison is read against.
+                  SEQUENCE=(baseline hashseed0 malloc_arena2 jemalloc high_thresholds no_gc baseline_late)
+                  # Rotate by block so a variant never keeps the same position in the sequence.
+                  rotate=$(( (BLOCK - 1) % ${#SEQUENCE[@]} ))
+                  ORDERED=("${SEQUENCE[@]:$rotate}" "${SEQUENCE[@]:0:$rotate}")
+                  echo "Block $BLOCK order: ${ORDERED[*]}"
+
+                  run_variant() {
+                      local variant="$1" position="$2" stack="$3"
+                      local result="results/${variant}.json"
+                      (
+                          case "$variant" in
+                              hashseed0) export PYTHONHASHSEED=0 ;;
+                              malloc_arena2) export MALLOC_ARENA_MAX=2 ;;
+                              jemalloc) export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 ;;
+                          esac
+                          # baseline_late and pg_nofsync run the baseline collector settings.
+                          case "$variant" in
+                              baseline_late|pg_nofsync) export GC_EXPERIMENT=baseline ;;
+                              *) export GC_EXPERIMENT="$variant" ;;
+                          esac
+                          export GC_EXPERIMENT_RESULT="$result"
+                          set +e
+                          pytest --tb=line -q --reuse-db -p pytest_gc_experiment posthog ee/ -m "not async_migrations" \
+                              --ignore=posthog/temporal \
+                              --ignore=posthog/dags \
+                              --ignore=common/hogvm/python/test \
+                              --ignore=posthog/test/repo_invariants \
+                              --splits "$SPLITS" --group "$GROUP" \
+                              --splitting-algorithm=optimal_chunks --split-granularity=file \
+                              --snapshot-warn-unused \
+                              -p no:cacheprovider
+                          local exit_code=$?
+                          set -e
+                          if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 5 ]; then
+                              echo "::warning::pytest exited $exit_code for $variant in block $BLOCK"
+                          fi
+                          python - "$variant" "$position" "$stack" "$exit_code" "$result" <<'PY'
+                  import json
+                  import os
+                  import sys
+
+                  variant, position, stack, exit_code, path = sys.argv[1:6]
+                  data = json.load(open(path)) if os.path.exists(path) else {}
+                  data.update(
+                      variant=variant,
+                      block=int(os.environ["BLOCK"]),
+                      position=int(position),
+                      stack=stack,
+                      pytest_exit_code=int(exit_code),
+                      runner=os.environ.get("RUNNER_NAME"),
+                  )
+                  json.dump(data, open(path, "w"), indent=2)
+                  print(json.dumps({k: data.get(k) for k in ("variant", "block", "position", "stack", "test_phase_wall_s", "gc_seconds_total", "max_rss_mb", "tests")}))
+                  PY
+                      )
+                  }
+
+                  position=0
+                  for variant in "${ORDERED[@]}"; do
+                      position=$((position + 1))
+                      echo "::group::block $BLOCK position $position: $variant"
+                      run_variant "$variant" "$position" normal || echo "::warning::$variant did not finish cleanly in block $BLOCK"
+                      echo "::endgroup::"
+                  done
+
+                  # Postgres durability is a stack setting, so it needs its own container.
+                  # The named volume keeps the migrated test_posthog across the recreate.
+                  echo "::group::block $BLOCK position $((position + 1)): pg_nofsync"
+                  COMPOSE_FILE="$COMPOSE_FILE:docker-compose.gc-experiment-pg.yml" \
+                      docker compose up -d --force-recreate db
+                  for _ in $(seq 1 30); do
+                      if docker compose exec -T db pg_isready -U posthog > /dev/null 2>&1; then break; fi
+                      sleep 2
+                  done
+                  echo "Postgres settings now in force:"
+                  docker compose exec -T db psql -U posthog -c "show fsync" -c "show synchronous_commit" -c "show full_page_writes"
+                  run_variant pg_nofsync "$((position + 1))" nofsync || echo "::warning::pg_nofsync did not finish cleanly in block $BLOCK"
+                  echo "::endgroup::"
+
+            - name: Upload the block's results
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: gc-experiment-depot-block-${{ matrix.block }}
+                  path: |
+                      results/*.json
+                      results/topology.txt
+                      results/lscpu.txt
+                  if-no-files-found: warn
+                  retention-days: 14
+
+    summarize:
+        name: Tabulate variants
+        needs: test
+        if: always()
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Download every result
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  pattern: gc-experiment-depot-block-*
+                  path: results
+
+            - name: Write the comparison table
+              shell: bash
+              run: |
+                  python3 - <<'PY' | tee /dev/stderr
+                  import glob
+                  import json
+                  import os
+                  import statistics
+
+                  rows = [json.load(open(p)) for p in sorted(glob.glob("results/**/*.json", recursive=True))]
+                  rows = [r for r in rows if "test_phase_wall_s" in r and r.get("block")]
+
+                  by_block: dict[int, dict[str, dict]] = {}
+                  for row in rows:
+                      by_block.setdefault(row["block"], {})[row["variant"]] = row
+
+                  # Each block is one runner. A variant is scored against the baseline that ran
+                  # on that same runner, so machine-to-machine variance cancels.
+                  deltas: dict[str, list[float]] = {}
+                  for block, runs in by_block.items():
+                      anchors = [runs[v]["test_phase_wall_s"] for v in ("baseline", "baseline_late") if v in runs]
+                      if not anchors:
+                          continue
+                      anchor = statistics.fmean(anchors)
+                      for variant, row in runs.items():
+                          deltas.setdefault(variant, []).append((row["test_phase_wall_s"] - anchor) / anchor * 100)
+
+                  def agg(variant, key):
+                      values = [b[variant][key] for b in by_block.values() if variant in b]
+                      return statistics.fmean(values) if values else float("nan")
+
+                  lines = [
+                      "### Paired comparison (each variant against the baseline on its own runner)",
+                      "",
+                      "| variant | blocks | delta vs same-runner baseline | spread of that delta | wall s | gc s | gen0 | peak RSS MB |",
+                      "|---|---|---|---|---|---|---|---|",
+                  ]
+                  for variant, values in sorted(deltas.items(), key=lambda kv: statistics.fmean(kv[1])):
+                      mean = statistics.fmean(values)
+                      sd = statistics.pstdev(values) if len(values) > 1 else 0.0
+                      gen0 = statistics.fmean([b[variant]["gc_runs"][0] for b in by_block.values() if variant in b])
+                      lines.append(
+                          f"| {variant} | {len(values)} | {mean:+.1f}% | +/- {sd:.1f} | {agg(variant, 'test_phase_wall_s'):.0f} "
+                          f"| {agg(variant, 'gc_seconds_total'):.1f} | {gen0:.0f} "
+                          f"| {agg(variant, 'max_rss_mb'):.0f} |"
+                      )
+
+                  floor = [
+                      (b, runs["baseline"]["test_phase_wall_s"], runs["baseline_late"]["test_phase_wall_s"])
+                      for b, runs in sorted(by_block.items())
+                      if "baseline" in runs and "baseline_late" in runs
+                  ]
+                  if floor:
+                      lines += [
+                          "",
+                          "### Noise floor: the same config twice on the same runner",
+                          "",
+                          "| block | first baseline s | second baseline s | gap |",
+                          "|---|---|---|---|",
+                      ]
+                      for b, first, second in floor:
+                          lines.append(f"| {b} | {first:.0f} | {second:.0f} | {(second - first) / first * 100:+.1f}% |")
+
+                  walls = [r["test_phase_wall_s"] for r in rows]
+                  cpus = [r["test_phase_cpu_s"] for r in rows]
+                  lines += [
+                      "",
+                      f"All {len(rows)} runs: wall {statistics.fmean(walls):.0f}s "
+                      f"(cv {statistics.pstdev(walls) / statistics.fmean(walls) * 100:.1f}%), "
+                      f"cpu {statistics.fmean(cpus):.0f}s "
+                      f"(cv {statistics.pstdev(cpus) / statistics.fmean(cpus) * 100:.1f}%). "
+                      f"CPU is {statistics.fmean(cpus) / statistics.fmean(walls) * 100:.0f}% of wall.",
+                  ]
+
+                  lines += ["", "### Every run", "", "| block | position | variant | stack | wall s | gc s | gen0/gen1/gen2 | peak RSS MB | tests | runner |", "|---|---|---|---|---|---|---|---|---|---|"]
+                  for row in sorted(rows, key=lambda r: (r["block"], r["position"])):
+                      g = row["gc_runs"]
+                      lines.append(
+                          f"| {row['block']} | {row['position']} | {row['variant']} | {row['stack']} | {row['test_phase_wall_s']:.0f} "
+                          f"| {row['gc_seconds_total']:.1f} | {g[0]}/{g[1]}/{g[2]} | {row['max_rss_mb']:.0f} | {row['tests']} | {row.get('runner')} |"
+                      )
+
+                  table = "\n".join(lines)
+                  print(table)
+                  path = os.environ.get("GITHUB_STEP_SUMMARY")
+                  if path:
+                      with open(path, "a") as summary:
+                          summary.write("## GC experiment on Depot CI\n\n" + table + "\n")
+                  PY
+

--- a/.github/workflows/ci-backend-gc-experiment.yml
+++ b/.github/workflows/ci-backend-gc-experiment.yml
@@ -34,6 +34,7 @@ on:
                 options:
                     - saturation
                     - variants
+                    - flakiness
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -485,7 +486,7 @@ jobs:
     saturation:
         name: Runner saturation and xdist sweep
         needs: plan
-        if: ${{ github.event.inputs.phase != 'variants' }}
+        if: ${{ github.event.inputs.phase == 'saturation' }}
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 90
         env:
@@ -780,3 +781,360 @@ jobs:
                   path: results/*.json
                   if-no-files-found: warn
                   retention-days: 14
+
+    flakiness:
+        name: Flakiness sweep shard ${{ matrix.group }}
+        needs: plan
+        if: ${{ github.event.inputs.phase == '' || github.event.inputs.phase == 'flakiness' }}
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 90
+        strategy:
+            fail-fast: false
+            matrix:
+                # Ten shards spread across the Core suite, so the sweep sees ClickHouse-heavy
+                # work and not only the light shard the saturation run happened to pick.
+                group: [1, 4, 7, 10, 13, 16, 19, 22, 25, 28]
+        env:
+            DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
+            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+            COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+            COMPOSE_PROFILES: temporal,azure
+            GROUP: ${{ matrix.group }}
+            # 30 splits keeps each shard close to the size a real Core shard runs,
+            # so contention here resembles contention in production CI.
+            SPLITS: '30'
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 1
+                  lfs: true
+
+            - name: Install signal-fanout
+              shell: bash
+              run: sudo install -m 0755 .github/scripts/signal-fanout /usr/local/bin/signal-fanout
+
+            - name: Log in to Docker Hub
+              continue-on-error: true
+              if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+              with:
+                  username: ${{ vars.DOCKERHUB_USER }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Resolve the ClickHouse image
+              shell: bash
+              run: echo "CLICKHOUSE_SERVER_IMAGE=$(jq -r .oldest_supported .github/clickhouse-versions.json)" >> "$GITHUB_ENV"
+
+            - name: Stop/Start stack with Docker Compose
+              shell: bash
+              env:
+                  WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3
+                  WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 5
+              run: |
+                  cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
+                  bin/ci-wait-for-docker launch --background --down-all-profiles
+
+            - name: Add service hostnames to /etc/hosts
+              shell: bash
+              run: echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
+
+            - name: Set up Python
+              uses: ./.github/actions/setup-python-cached
+              with:
+                  python-version: 3.13.13
+                  token: ${{ github.token }}
+
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
+
+            - name: Install uv
+              id: setup-uv-tests
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: true
+                  cache-dependency-glob: uv.lock
+                  save-cache: false
+
+            - name: Install SAML (python3-saml) dependencies
+              shell: bash
+              run: sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+            - name: Install sqlx-cli
+              uses: ./.github/actions/setup-sqlx-cli
+
+            - name: Cache and install Qt libraries
+              uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+              with:
+                  packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0
+                  version: 1.0
+
+            - name: Install Python dependencies
+              shell: bash
+              run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+
+            - name: Set up needed files
+              shell: bash
+              run: |
+                  mkdir -p frontend/dist
+                  touch frontend/dist/index.html
+                  touch frontend/dist/layout.html
+                  touch frontend/dist/exporter.html
+                  ./bin/download-mmdb
+
+            - name: Wait for Docker services
+              shell: bash
+              run: bin/ci-wait-for-docker wait
+
+            - name: Restore schema cache from master
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: schema.sql.gz
+                  key: posthog-schema-master-${{ github.event.pull_request.base.sha || github.sha }}
+                  restore-keys: |
+                      posthog-schema-mig-${{ env.SCHEMA_CACHE_EPOCH }}-
+                      posthog-schema-master-
+
+            - name: Prime test_posthog from cached schema
+              id: prime-schema
+              shell: bash
+              run: |
+                  echo "restored=false" >> "$GITHUB_OUTPUT"
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss; the migrate step will build test_posthog"
+                      exit 0
+                  fi
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  if ./bin/hogli db:restore-test-db; then
+                      echo "restored=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "::warning::Schema restore failed (stale/incompatible cached dump?); the migrate step will build test_posthog"
+                  fi
+
+            - name: Migrate test_posthog from scratch
+              if: ${{ steps.prime-schema.outputs.restored != 'true' }}
+              shell: bash
+              env:
+                  DATABASE_URL: postgres://posthog:posthog@localhost:5432/test_posthog
+              run: |
+                  admin_psql() { docker compose -f docker-compose.dev.yml exec -T db psql -U posthog postgres "$@"; }
+                  if ! admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" -c "CREATE DATABASE test_posthog;"; then
+                      echo "::warning::Could not recreate test_posthog; pytest --reuse-db will run the full migrate itself"
+                      exit 0
+                  fi
+                  if ! python manage.py migrate; then
+                      echo "::warning::Out-of-process migrate failed; pytest --reuse-db will run the full migrate itself"
+                      admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" || true
+                  fi
+
+            - name: Download the pinned sharding plan
+              continue-on-error: true
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: gc-experiment-durations
+                  path: .
+
+            - name: Compute hypothesis constants cache key
+              id: hyp-constants-key
+              shell: bash
+              run: |
+                  hyp_version=$(python -c "import hypothesis; print(hypothesis.__version__)")
+                  prefix="posthog-hypothesis-constants-${hyp_version}-${HYPOTHESIS_CONSTANTS_EPOCH}-"
+                  {
+                      echo "key=${prefix}$(date -u +%G-%V)"
+                      echo "restore_prefix=${prefix}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Restore hypothesis constants cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .hypothesis/constants
+                  key: ${{ steps.hyp-constants-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.hyp-constants-key.outputs.restore_prefix }}
+
+            - name: Compare one and two workers on this shard
+              id: sweep
+              continue-on-error: true
+              env:
+                  PERSON_ON_EVENTS_V2_ENABLED: 'true'
+                  CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA: 'false'
+                  PGPASSWORD: posthog
+              shell: 'signal-fanout bash --noprofile --norc -eo pipefail {0}'
+              run: |
+                  mkdir -p results
+                  cores=$(nproc)
+
+                  cpu_snapshot() {
+                      awk '/^cpu /{busy=$2+$3+$4+$7+$8+$9; idle=$5+$6; print busy, idle}' /proc/stat
+                  }
+
+                  run_once() {
+                      local workers="$1" round="$2"
+                      local label="g${GROUP}-n${workers}-r${round}"
+                      local xdist=()
+                      if [ "$workers" -gt 1 ]; then
+                          # Clone before every parallel run so a previous failure cannot
+                          # leave a worker database dirty and charge that to xdist.
+                          ./bin/clone-test-db-for-xdist "$workers" > /dev/null
+                          xdist=(-n "$workers" --dist worksteal)
+                      fi
+                      read -r busy_before idle_before <<< "$(cpu_snapshot)"
+                      local start
+                      start=$(date +%s.%N)
+                      set +e
+                      pytest --tb=no -q --reuse-db posthog ee/ -m "not async_migrations" \
+                          --ignore=posthog/temporal \
+                          --ignore=posthog/dags \
+                          --ignore=common/hogvm/python/test \
+                          --ignore=posthog/test/repo_invariants \
+                          --splits "$SPLITS" --group "$GROUP" \
+                          --splitting-algorithm=optimal_chunks --split-granularity=file \
+                          --snapshot-warn-unused \
+                          -p no:cacheprovider \
+                          "${xdist[@]}" \
+                          --junitxml="results/junit-${label}.xml"
+                      local exit_code=$?
+                      set -e
+                      local wall
+                      wall=$(echo "$(date +%s.%N) - $start" | bc)
+                      read -r busy_after idle_after <<< "$(cpu_snapshot)"
+                      python3 - "$label" "$workers" "$round" "$exit_code" "$wall" "$busy_before" "$idle_before" "$busy_after" "$idle_after" "$cores" "$GROUP" <<'PY'
+                  import json
+                  import sys
+                  import xml.etree.ElementTree as ET
+
+                  label, workers, round_, exit_code, wall, bb, ib, ba, ia, cores, group = sys.argv[1:12]
+                  busy, idle = int(ba) - int(bb), int(ia) - int(ib)
+                  used = busy / (busy + idle) * int(cores) if busy + idle else 0.0
+                  tests = 0
+                  failed = []
+                  try:
+                      root = ET.parse(f"results/junit-{label}.xml").getroot()
+                      for case in root.iter("testcase"):
+                          tests += 1
+                          if case.find("failure") is not None or case.find("error") is not None:
+                              failed.append(f"{case.get('classname')}::{case.get('name')}")
+                  except Exception as exc:
+                      print(f"could not parse junit: {exc}")
+                  result = {
+                      "label": label,
+                      "group": int(group),
+                      "workers": int(workers),
+                      "round": int(round_),
+                      "wall_s": round(float(wall), 1),
+                      "cores_used": round(used, 2),
+                      "runner_cores": int(cores),
+                      "exit_code": int(exit_code),
+                      "tests": tests,
+                      "failures": len(failed),
+                      "failed_tests": sorted(failed)[:40],
+                  }
+                  json.dump(result, open(f"results/{label}.json", "w"), indent=2)
+                  print(json.dumps({k: result[k] for k in ("label", "wall_s", "cores_used", "tests", "failures")}))
+                  print("FAILED:", *result["failed_tests"], sep="\n  ")
+                  PY
+                  }
+
+                  # Alternating and mirrored, so neither worker count owns the early or late
+                  # half of the job. Two observations each is the minimum that can separate a
+                  # test that always fails under xdist from one that fails intermittently.
+                  run_once 1 1 || echo "::warning::shard $GROUP n=1 r1 did not finish cleanly"
+                  run_once 2 1 || echo "::warning::shard $GROUP n=2 r1 did not finish cleanly"
+                  run_once 2 2 || echo "::warning::shard $GROUP n=2 r2 did not finish cleanly"
+                  run_once 1 2 || echo "::warning::shard $GROUP n=1 r2 did not finish cleanly"
+
+            - name: Upload this shard's results
+              if: always()
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: gc-experiment-flakiness-${{ matrix.group }}
+                  path: results/*.json
+                  if-no-files-found: warn
+                  retention-days: 14
+
+    flakiness-summary:
+        name: Tabulate flakiness
+        needs: flakiness
+        if: ${{ always() && (github.event.inputs.phase == '' || github.event.inputs.phase == 'flakiness') }}
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  pattern: gc-experiment-flakiness-*
+                  path: results
+
+            - name: Write the flakiness table
+              shell: bash
+              run: |
+                  python3 - <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+                  import glob
+                  import json
+                  import statistics
+                  from collections import defaultdict
+
+                  rows = [json.load(open(p)) for p in sorted(glob.glob("results/**/*.json", recursive=True))]
+                  rows = [r for r in rows if "wall_s" in r]
+
+                  print("## xdist flakiness sweep")
+                  print()
+                  print("### Failures, which is the question")
+                  print()
+                  print("| workers | runs | total tests | runs with a failure | distinct failing tests |")
+                  print("|---|---|---|---|---|")
+                  seen = defaultdict(set)
+                  for workers in (1, 2):
+                      runs = [r for r in rows if r["workers"] == workers]
+                      for r in runs:
+                          seen[workers].update(r["failed_tests"])
+                      dirty = sum(1 for r in runs if r["failures"])
+                      print(
+                          f"| {workers} | {len(runs)} | {sum(r['tests'] for r in runs)} | {dirty} | {len(seen[workers])} |"
+                      )
+
+                  only_parallel = sorted(seen[2] - seen[1])
+                  print()
+                  print(f"Tests that failed only with two workers: {len(only_parallel)}")
+                  for name in only_parallel[:40]:
+                      print(f"- `{name}`")
+                  both = sorted(seen[2] & seen[1])
+                  if both:
+                      print()
+                      print(f"Tests that failed at both worker counts, so not caused by xdist: {len(both)}")
+                      for name in both[:20]:
+                          print(f"- `{name}`")
+
+                  print()
+                  print("### Wall time per shard")
+                  print()
+                  print("| shard | 1 worker s | 2 workers s | change | cores used at 1 | cores used at 2 | failures at 2 |")
+                  print("|---|---|---|---|---|---|---|")
+                  by_group = defaultdict(lambda: defaultdict(list))
+                  for r in rows:
+                      by_group[r["group"]][r["workers"]].append(r)
+                  totals = {1: [], 2: []}
+                  for group in sorted(by_group):
+                      one, two = by_group[group].get(1, []), by_group[group].get(2, [])
+                      if not one or not two:
+                          continue
+                      w1 = statistics.fmean([r["wall_s"] for r in one])
+                      w2 = statistics.fmean([r["wall_s"] for r in two])
+                      totals[1].append(w1)
+                      totals[2].append(w2)
+                      print(
+                          f"| {group} | {w1:.0f} | {w2:.0f} | {(w2 - w1) / w1 * 100:+.1f}% "
+                          f"| {statistics.fmean([r['cores_used'] for r in one]):.2f} "
+                          f"| {statistics.fmean([r['cores_used'] for r in two]):.2f} "
+                          f"| {sum(r['failures'] for r in two)} |"
+                      )
+                  if totals[1]:
+                      m1, m2 = statistics.fmean(totals[1]), statistics.fmean(totals[2])
+                      print(f"| **mean** | **{m1:.0f}** | **{m2:.0f}** | **{(m2 - m1) / m1 * 100:+.1f}%** | | | |")
+                      print()
+                      print("Runner size does not change between the columns, so the wall change is also the cost change.")
+                  PY

--- a/.github/workflows/ci-backend-gc-experiment.yml
+++ b/.github/workflows/ci-backend-gc-experiment.yml
@@ -27,6 +27,13 @@ on:
                 description: How many runners each run the whole variant sequence
                 default: '6'
                 type: string
+            phase:
+                description: Which experiment to run
+                default: saturation
+                type: choice
+                options:
+                    - saturation
+                    - variants
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -103,6 +110,7 @@ jobs:
     test:
         name: block ${{ matrix.block }}
         needs: plan
+        if: ${{ github.event.inputs.phase == 'variants' }}
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 90
         strategy:
@@ -376,7 +384,7 @@ jobs:
     summarize:
         name: Tabulate variants
         needs: test
-        if: always()
+        if: ${{ always() && github.event.inputs.phase == 'variants' }}
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
@@ -414,7 +422,7 @@ jobs:
                           deltas.setdefault(variant, []).append((row["test_phase_wall_s"] - anchor) / anchor * 100)
 
                   def agg(variant, key):
-                      values = [r[key] for b in by_block.values() if variant in b for r in [b[variant]]]
+                      values = [b[variant][key] for b in by_block.values() if variant in b]
                       return statistics.fmean(values) if values else float("nan")
 
                   lines = [
@@ -426,12 +434,39 @@ jobs:
                   for variant, values in sorted(deltas.items(), key=lambda kv: statistics.fmean(kv[1])):
                       mean = statistics.fmean(values)
                       sd = statistics.pstdev(values) if len(values) > 1 else 0.0
-                      gen0 = agg(variant, "gc_runs")
+                      gen0 = statistics.fmean([b[variant]["gc_runs"][0] for b in by_block.values() if variant in b])
                       lines.append(
                           f"| {variant} | {len(values)} | {mean:+.1f}% | +/- {sd:.1f} | {agg(variant, 'test_phase_wall_s'):.0f} "
-                          f"| {agg(variant, 'gc_seconds_total'):.1f} | {by_block[min(by_block)][variant]['gc_runs'][0] if variant in by_block[min(by_block)] else 0} "
+                          f"| {agg(variant, 'gc_seconds_total'):.1f} | {gen0:.0f} "
                           f"| {agg(variant, 'max_rss_mb'):.0f} |"
                       )
+
+                  floor = [
+                      (b, runs["baseline"]["test_phase_wall_s"], runs["baseline_late"]["test_phase_wall_s"])
+                      for b, runs in sorted(by_block.items())
+                      if "baseline" in runs and "baseline_late" in runs
+                  ]
+                  if floor:
+                      lines += [
+                          "",
+                          "### Noise floor: the same config twice on the same runner",
+                          "",
+                          "| block | first baseline s | second baseline s | gap |",
+                          "|---|---|---|---|",
+                      ]
+                      for b, first, second in floor:
+                          lines.append(f"| {b} | {first:.0f} | {second:.0f} | {(second - first) / first * 100:+.1f}% |")
+
+                  walls = [r["test_phase_wall_s"] for r in rows]
+                  cpus = [r["test_phase_cpu_s"] for r in rows]
+                  lines += [
+                      "",
+                      f"All {len(rows)} runs: wall {statistics.fmean(walls):.0f}s "
+                      f"(cv {statistics.pstdev(walls) / statistics.fmean(walls) * 100:.1f}%), "
+                      f"cpu {statistics.fmean(cpus):.0f}s "
+                      f"(cv {statistics.pstdev(cpus) / statistics.fmean(cpus) * 100:.1f}%). "
+                      f"CPU is {statistics.fmean(cpus) / statistics.fmean(walls) * 100:.0f}% of wall.",
+                  ]
 
                   lines += ["", "### Every run", "", "| block | position | variant | stack | wall s | gc s | gen0/gen1/gen2 | peak RSS MB | tests | runner |", "|---|---|---|---|---|---|---|---|---|---|"]
                   for row in sorted(rows, key=lambda r: (r["block"], r["position"])):
@@ -446,3 +481,284 @@ jobs:
                   with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
                       summary.write("## GC experiment\n\n" + table + "\n")
                   PY
+
+    saturation:
+        name: Runner saturation and xdist sweep
+        needs: plan
+        if: ${{ github.event.inputs.phase != 'variants' }}
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 90
+        env:
+            DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
+            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+            COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
+            COMPOSE_PROFILES: temporal,azure
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 1
+                  lfs: true
+
+            - name: Install signal-fanout
+              shell: bash
+              run: sudo install -m 0755 .github/scripts/signal-fanout /usr/local/bin/signal-fanout
+
+            - name: Log in to Docker Hub
+              continue-on-error: true
+              if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+              with:
+                  username: ${{ vars.DOCKERHUB_USER }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Resolve the ClickHouse image
+              shell: bash
+              run: echo "CLICKHOUSE_SERVER_IMAGE=$(jq -r .oldest_supported .github/clickhouse-versions.json)" >> "$GITHUB_ENV"
+
+            - name: Stop/Start stack with Docker Compose
+              shell: bash
+              env:
+                  WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3
+                  WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 5
+              run: |
+                  cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
+                  bin/ci-wait-for-docker launch --background --down-all-profiles
+
+            - name: Add service hostnames to /etc/hosts
+              shell: bash
+              run: echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
+
+            - name: Set up Python
+              uses: ./.github/actions/setup-python-cached
+              with:
+                  python-version: 3.13.13
+                  token: ${{ github.token }}
+
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
+
+            - name: Install uv
+              id: setup-uv-tests
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: true
+                  cache-dependency-glob: uv.lock
+                  save-cache: false
+
+            - name: Install SAML (python3-saml) dependencies
+              shell: bash
+              run: sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+            - name: Install sqlx-cli
+              uses: ./.github/actions/setup-sqlx-cli
+
+            - name: Cache and install Qt libraries
+              uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+              with:
+                  packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0
+                  version: 1.0
+
+            - name: Install Python dependencies
+              shell: bash
+              run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+
+            - name: Set up needed files
+              shell: bash
+              run: |
+                  mkdir -p frontend/dist
+                  touch frontend/dist/index.html
+                  touch frontend/dist/layout.html
+                  touch frontend/dist/exporter.html
+                  ./bin/download-mmdb
+
+            - name: Wait for Docker services
+              shell: bash
+              run: bin/ci-wait-for-docker wait
+
+            - name: Restore schema cache from master
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: schema.sql.gz
+                  key: posthog-schema-master-${{ github.event.pull_request.base.sha || github.sha }}
+                  restore-keys: |
+                      posthog-schema-mig-${{ env.SCHEMA_CACHE_EPOCH }}-
+                      posthog-schema-master-
+
+            - name: Prime test_posthog from cached schema
+              id: prime-schema
+              shell: bash
+              run: |
+                  echo "restored=false" >> "$GITHUB_OUTPUT"
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss; the migrate step will build test_posthog"
+                      exit 0
+                  fi
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  if ./bin/hogli db:restore-test-db; then
+                      echo "restored=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "::warning::Schema restore failed (stale/incompatible cached dump?); the migrate step will build test_posthog"
+                  fi
+
+            - name: Migrate test_posthog from scratch
+              if: ${{ steps.prime-schema.outputs.restored != 'true' }}
+              shell: bash
+              env:
+                  DATABASE_URL: postgres://posthog:posthog@localhost:5432/test_posthog
+              run: |
+                  admin_psql() { docker compose -f docker-compose.dev.yml exec -T db psql -U posthog postgres "$@"; }
+                  if ! admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" -c "CREATE DATABASE test_posthog;"; then
+                      echo "::warning::Could not recreate test_posthog; pytest --reuse-db will run the full migrate itself"
+                      exit 0
+                  fi
+                  if ! python manage.py migrate; then
+                      echo "::warning::Out-of-process migrate failed; pytest --reuse-db will run the full migrate itself"
+                      admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" || true
+                  fi
+
+            - name: Download the pinned sharding plan
+              continue-on-error: true
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: gc-experiment-durations
+                  path: .
+
+            - name: Compute hypothesis constants cache key
+              id: hyp-constants-key
+              shell: bash
+              run: |
+                  hyp_version=$(python -c "import hypothesis; print(hypothesis.__version__)")
+                  prefix="posthog-hypothesis-constants-${hyp_version}-${HYPOTHESIS_CONSTANTS_EPOCH}-"
+                  {
+                      echo "key=${prefix}$(date -u +%G-%V)"
+                      echo "restore_prefix=${prefix}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Restore hypothesis constants cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .hypothesis/constants
+                  key: ${{ steps.hyp-constants-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.hyp-constants-key.outputs.restore_prefix }}
+
+            - name: Run the shard at several worker counts
+              id: sweep
+              continue-on-error: true
+              env:
+                  PERSON_ON_EVENTS_V2_ENABLED: 'true'
+                  CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA: 'false'
+                  PGPASSWORD: posthog
+              shell: 'signal-fanout bash --noprofile --norc -eo pipefail {0}'
+              run: |
+                  mkdir -p results
+                  cores=$(nproc)
+                  echo "Runner has $cores cores and $(free -g | awk '/^Mem:/{print $2}') GB"
+
+                  # /proc/stat counts every process on the box, so this covers the
+                  # service containers too, not just pytest. That is the whole point:
+                  # a shard can look idle in-process while Postgres and ClickHouse
+                  # saturate the runner.
+                  cpu_snapshot() {
+                      awk '/^cpu /{busy=$2+$3+$4+$7+$8+$9; idle=$5+$6; print busy, idle}' /proc/stat
+                  }
+
+                  run_sweep() {
+                      local workers="$1"
+                      local label="n${workers}"
+                      local xdist=()
+                      if [ "$workers" -gt 1 ]; then
+                          ./bin/clone-test-db-for-xdist "$workers"
+                          xdist=(-n "$workers" --dist worksteal)
+                      fi
+                      read -r busy_before idle_before <<< "$(cpu_snapshot)"
+                      local start
+                      start=$(date +%s.%N)
+                      set +e
+                      pytest --tb=line -q --reuse-db posthog ee/ -m "not async_migrations" \
+                          --ignore=posthog/temporal \
+                          --ignore=posthog/dags \
+                          --ignore=common/hogvm/python/test \
+                          --ignore=posthog/test/repo_invariants \
+                          --splits "$SPLITS" --group "$GROUP" \
+                          --splitting-algorithm=optimal_chunks --split-granularity=file \
+                          --snapshot-warn-unused \
+                          -p no:cacheprovider \
+                          "${xdist[@]}" \
+                          --junitxml="results/junit-${label}.xml"
+                      local exit_code=$?
+                      set -e
+                      local wall
+                      wall=$(echo "$(date +%s.%N) - $start" | bc)
+                      read -r busy_after idle_after <<< "$(cpu_snapshot)"
+                      python3 - "$label" "$workers" "$exit_code" "$wall" "$busy_before" "$idle_before" "$busy_after" "$idle_after" "$cores" <<'PY'
+                  import json
+                  import sys
+                  import xml.etree.ElementTree as ET
+
+                  label, workers, exit_code, wall, bb, ib, ba, ia, cores = sys.argv[1:10]
+                  busy = int(ba) - int(bb)
+                  idle = int(ia) - int(ib)
+                  used = busy / (busy + idle) * int(cores) if busy + idle else 0.0
+                  tests = failures = 0
+                  try:
+                      root = ET.parse(f"results/junit-{label}.xml").getroot()
+                      for suite in root.iter("testsuite"):
+                          tests += int(suite.get("tests", 0))
+                          failures += int(suite.get("failures", 0)) + int(suite.get("errors", 0))
+                  except Exception:
+                      pass
+                  result = {
+                      "label": label,
+                      "workers": int(workers),
+                      "wall_s": round(float(wall), 1),
+                      "cores_used": round(used, 2),
+                      "runner_cores": int(cores),
+                      "saturation_pct": round(used / int(cores) * 100, 1),
+                      "exit_code": int(exit_code),
+                      "tests": tests,
+                      "failures": failures,
+                  }
+                  json.dump(result, open(f"results/{label}.json", "w"), indent=2)
+                  print(json.dumps(result))
+                  PY
+                  }
+
+                  for workers in 1 2 3; do
+                      echo "::group::pytest with $workers worker(s)"
+                      run_sweep "$workers" || echo "::warning::sweep n=$workers did not finish cleanly"
+                      echo "::endgroup::"
+                  done
+
+                  echo "## Runner saturation and xdist sweep" >> "$GITHUB_STEP_SUMMARY"
+                  python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+                  import glob
+                  import json
+
+                  rows = [json.load(open(p)) for p in sorted(glob.glob("results/n*.json"))]
+                  base = next((r["wall_s"] for r in rows if r["workers"] == 1), None)
+                  print()
+                  print("| workers | wall s | vs 1 worker | cores used | runner saturation | tests | failures |")
+                  print("|---|---|---|---|---|---|---|")
+                  for r in rows:
+                      delta = f"{(r['wall_s'] - base) / base * 100:+.1f}%" if base else "n/a"
+                      print(
+                          f"| {r['workers']} | {r['wall_s']:.0f} | {delta} | {r['cores_used']:.2f} of {r['runner_cores']} "
+                          f"| {r['saturation_pct']:.0f}% | {r['tests']} | {r['failures']} |"
+                      )
+                  print()
+                  print("Cost tracks wall time here: every row runs on the same runner size, so a shorter row is also a cheaper row.")
+                  PY
+
+            - name: Upload the sweep results
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: gc-experiment-saturation
+                  path: results/*.json
+                  if-no-files-found: warn
+                  retention-days: 14

--- a/.github/workflows/ci-backend-gc-experiment.yml
+++ b/.github/workflows/ci-backend-gc-experiment.yml
@@ -669,8 +669,8 @@ jobs:
                   }
 
                   run_sweep() {
-                      local workers="$1"
-                      local label="n${workers}"
+                      local workers="$1" round="$2"
+                      local label="n${workers}-r${round}"
                       local xdist=()
                       if [ "$workers" -gt 1 ]; then
                           ./bin/clone-test-db-for-xdist "$workers"
@@ -696,12 +696,12 @@ jobs:
                       local wall
                       wall=$(echo "$(date +%s.%N) - $start" | bc)
                       read -r busy_after idle_after <<< "$(cpu_snapshot)"
-                      python3 - "$label" "$workers" "$exit_code" "$wall" "$busy_before" "$idle_before" "$busy_after" "$idle_after" "$cores" <<'PY'
+                      python3 - "$label" "$workers" "$exit_code" "$wall" "$busy_before" "$idle_before" "$busy_after" "$idle_after" "$cores" "$round" <<'PY'
                   import json
                   import sys
                   import xml.etree.ElementTree as ET
 
-                  label, workers, exit_code, wall, bb, ib, ba, ia, cores = sys.argv[1:10]
+                  label, workers, exit_code, wall, bb, ib, ba, ia, cores, round_ = sys.argv[1:11]
                   busy = int(ba) - int(bb)
                   idle = int(ia) - int(ib)
                   used = busy / (busy + idle) * int(cores) if busy + idle else 0.0
@@ -716,6 +716,7 @@ jobs:
                   result = {
                       "label": label,
                       "workers": int(workers),
+                      "round": int(round_),
                       "wall_s": round(float(wall), 1),
                       "cores_used": round(used, 2),
                       "runner_cores": int(cores),
@@ -729,10 +730,14 @@ jobs:
                   PY
                   }
 
-                  for workers in 1 2 3; do
-                      echo "::group::pytest with $workers worker(s)"
-                      run_sweep "$workers" || echo "::warning::sweep n=$workers did not finish cleanly"
-                      echo "::endgroup::"
+                  # Three interleaved rounds: a worker count is never measured only at one
+                  # point in the job, so drift across the job cannot masquerade as an effect.
+                  for round in 1 2 3; do
+                      for workers in 1 2 3; do
+                          echo "::group::round $round, pytest with $workers worker(s)"
+                          run_sweep "$workers" "$round" || echo "::warning::round $round sweep n=$workers did not finish cleanly"
+                          echo "::endgroup::"
+                      done
                   done
 
                   echo "## Runner saturation and xdist sweep" >> "$GITHUB_STEP_SUMMARY"
@@ -740,17 +745,30 @@ jobs:
                   import glob
                   import json
 
+                  import statistics
+
                   rows = [json.load(open(p)) for p in sorted(glob.glob("results/n*.json"))]
-                  base = next((r["wall_s"] for r in rows if r["workers"] == 1), None)
+                  by_workers: dict[int, list[dict]] = {}
+                  for row in rows:
+                      by_workers.setdefault(row["workers"], []).append(row)
+                  base = statistics.fmean([r["wall_s"] for r in by_workers.get(1, [])]) if by_workers.get(1) else None
                   print()
-                  print("| workers | wall s | vs 1 worker | cores used | runner saturation | tests | failures |")
-                  print("|---|---|---|---|---|---|---|")
-                  for r in rows:
-                      delta = f"{(r['wall_s'] - base) / base * 100:+.1f}%" if base else "n/a"
+                  print("| workers | rounds | wall s | vs 1 worker | cores used | runner saturation | tests | failures |")
+                  print("|---|---|---|---|---|---|---|---|")
+                  for workers, runs in sorted(by_workers.items()):
+                      wall = statistics.fmean([r["wall_s"] for r in runs])
+                      delta = f"{(wall - base) / base * 100:+.1f}%" if base else "n/a"
                       print(
-                          f"| {r['workers']} | {r['wall_s']:.0f} | {delta} | {r['cores_used']:.2f} of {r['runner_cores']} "
-                          f"| {r['saturation_pct']:.0f}% | {r['tests']} | {r['failures']} |"
+                          f"| {workers} | {len(runs)} | {wall:.0f} | {delta} "
+                          f"| {statistics.fmean([r['cores_used'] for r in runs]):.2f} of {runs[0]['runner_cores']} "
+                          f"| {statistics.fmean([r['saturation_pct'] for r in runs]):.0f}% | {runs[0]['tests']} "
+                          f"| {sum(r['failures'] for r in runs)} |"
                       )
+                  print()
+                  print("| workers | round | wall s | cores used | failures |")
+                  print("|---|---|---|---|---|")
+                  for r in sorted(rows, key=lambda r: (r["workers"], r["round"])):
+                      print(f"| {r['workers']} | {r['round']} | {r['wall_s']:.0f} | {r['cores_used']:.2f} | {r['failures']} |")
                   print()
                   print("Cost tracks wall time here: every row runs on the same runner size, so a shorter row is also a cheaper row.")
                   PY

--- a/.github/workflows/ci-backend-gc-experiment.yml
+++ b/.github/workflows/ci-backend-gc-experiment.yml
@@ -1,0 +1,409 @@
+name: CI backend GC experiment
+
+# Throwaway experiment: runs one fixed pytest-split shard of the Core Django suite under
+# several garbage collector, allocator, and Postgres configurations, several repetitions
+# each, and tabulates test-phase wall time, collector time, and peak RSS per variant.
+# The setup steps mirror the "Django tests" job of ci-backend.yml so the numbers transfer.
+
+on:
+    pull_request:
+        paths:
+            - .github/workflows/ci-backend-gc-experiment.yml
+            - pytest_gc_experiment.py
+            - docker-compose.gc-experiment-pg.yml
+    workflow_dispatch:
+        inputs:
+            splits:
+                description: Number of pytest-split shards the Core suite is cut into
+                default: '30'
+                type: string
+            group:
+                description: Which of those shards to run
+                default: '7'
+                type: string
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+    contents: read
+    actions: read
+
+env:
+    SCHEMA_CACHE_EPOCH: v2
+    HYPOTHESIS_CONSTANTS_EPOCH: v1
+    SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
+    DATABASE_URL: 'postgres://posthog:posthog@localhost:5432/posthog'
+    REDIS_URL: 'redis://localhost'
+    CLICKHOUSE_HOST: 'localhost'
+    CLICKHOUSE_SECURE: 'False'
+    CLICKHOUSE_VERIFY: 'False'
+    CLICKHOUSE_TEST_CLUSTER_HOST: 'localhost'
+    CLICKHOUSE_TEST_CLUSTER_DATABASE: 'posthog_test'
+    CLICKHOUSE_TEST_CLUSTER_USER: 'autoresearch'
+    CLICKHOUSE_TEST_CLUSTER_PASSWORD: 'autoresearchpass'
+    CLICKHOUSE_TEST_CLUSTER_SECURE: 'False'
+    CLICKHOUSE_TEST_CLUSTER_VERIFY: 'False'
+    TEST: 1
+    OBJECT_STORAGE_ENABLED: 'True'
+    OBJECT_STORAGE_ENDPOINT: 'http://localhost:19000'
+    OBJECT_STORAGE_ACCESS_KEY_ID: 'object_storage_root_user'
+    OBJECT_STORAGE_SECRET_ACCESS_KEY: 'object_storage_root_password'
+    UV_HTTP_TIMEOUT: 120
+    DISPLAY: ':99.0'
+    OIDC_RSA_PRIVATE_KEY: ${{ vars.OIDC_RSA_FAKE_PRIVATE_KEY }}
+    SANDBOX_JWT_PRIVATE_KEY: ${{ vars.OIDC_RSA_FAKE_PRIVATE_KEY }}
+    SPLITS: ${{ github.event.inputs.splits || '30' }}
+    GROUP: ${{ github.event.inputs.group || '7' }}
+
+jobs:
+    plan:
+        name: Pin sharding plan
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 5
+        steps:
+            - name: Restore test durations from cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .test_durations
+                  key: posthog-test-durations-${{ github.run_id }}
+                  restore-keys: |
+                      posthog-test-durations-
+
+            - name: Fall back to the last published durations
+              if: ${{ hashFiles('.test_durations') == '' }}
+              continue-on-error: true
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  run_id=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow ci-backend-update-test-timing.yml \
+                      --branch master --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+                  if [ -z "$run_id" ]; then
+                      echo "::warning::No successful timing run to fall back to, sharding without durations"
+                      exit 0
+                  fi
+                  gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name test-durations --dir . \
+                      || echo "::warning::Timing artifact of run $run_id unavailable, sharding without durations"
+
+            - name: Publish the plan every variant will shard from
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: gc-experiment-durations
+                  path: .test_durations
+                  if-no-files-found: warn
+                  retention-days: 3
+
+    test:
+        name: ${{ matrix.variant }} (rep ${{ matrix.rep }})
+        needs: plan
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 60
+        strategy:
+            fail-fast: false
+            matrix:
+                variant:
+                    - baseline # what master runs: boot window, freeze, thresholds (50000, 20, 20)
+                    - stock_gc # interpreter defaults, no boot window, no freeze: the pre-June setup
+                    - freeze_stock_thresholds # boot window + freeze, thresholds back to the 3.13 defaults (2000, 10, 10)
+                    - high_thresholds # boot window + freeze, thresholds (200000, 50, 50)
+                    - no_gc # boot window + freeze, collector off for the whole test phase
+                    - hashseed0 # baseline + PYTHONHASHSEED=0
+                    - malloc_arena2 # baseline + MALLOC_ARENA_MAX=2
+                    - jemalloc # baseline + libjemalloc via LD_PRELOAD
+                    - pg_nofsync # baseline + Postgres fsync/synchronous_commit/full_page_writes off
+                rep: [1, 2, 3]
+                include:
+                    - variant: baseline
+                      rep: 4
+                    - variant: baseline
+                      rep: 5
+        env:
+            DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
+            DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+            COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml${{ matrix.variant == 'pg_nofsync' && ':docker-compose.gc-experiment-pg.yml' || '' }}
+            COMPOSE_PROFILES: temporal,azure
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  fetch-depth: 1
+                  lfs: true
+
+            - name: Install signal-fanout
+              shell: bash
+              run: sudo install -m 0755 .github/scripts/signal-fanout /usr/local/bin/signal-fanout
+
+            - name: Log in to Docker Hub
+              continue-on-error: true
+              if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+              uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+              with:
+                  username: ${{ vars.DOCKERHUB_USER }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Resolve the ClickHouse image
+              shell: bash
+              run: echo "CLICKHOUSE_SERVER_IMAGE=$(jq -r .oldest_supported .github/clickhouse-versions.json)" >> "$GITHUB_ENV"
+
+            - name: Stop/Start stack with Docker Compose
+              shell: bash
+              env:
+                  WAIT_FOR_DOCKER_LAUNCH_RETRIES: 3
+                  WAIT_FOR_DOCKER_LAUNCH_RETRY_DELAY: 5
+              run: |
+                  cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
+                  bin/ci-wait-for-docker launch --background --down-all-profiles
+
+            - name: Add service hostnames to /etc/hosts
+              shell: bash
+              run: echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
+
+            - name: Set up Python
+              uses: ./.github/actions/setup-python-cached
+              with:
+                  python-version: 3.13.13
+                  token: ${{ github.token }}
+
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
+
+            - name: Install uv
+              id: setup-uv-tests
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: true
+                  cache-dependency-glob: uv.lock
+                  save-cache: false
+
+            - name: Install SAML (python3-saml) dependencies
+              shell: bash
+              run: sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+            - name: Install sqlx-cli
+              uses: ./.github/actions/setup-sqlx-cli
+
+            - name: Cache and install Qt libraries
+              uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+              with:
+                  packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0
+                  version: 1.0
+
+            - name: Install Python dependencies
+              shell: bash
+              run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+
+            - name: Set up needed files
+              shell: bash
+              run: |
+                  mkdir -p frontend/dist
+                  touch frontend/dist/index.html
+                  touch frontend/dist/layout.html
+                  touch frontend/dist/exporter.html
+                  ./bin/download-mmdb
+
+            - name: Wait for Docker services
+              shell: bash
+              run: bin/ci-wait-for-docker wait
+
+            - name: Restore schema cache from master
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: schema.sql.gz
+                  key: posthog-schema-master-${{ github.event.pull_request.base.sha || github.sha }}
+                  restore-keys: |
+                      posthog-schema-mig-${{ env.SCHEMA_CACHE_EPOCH }}-
+                      posthog-schema-master-
+
+            - name: Prime test_posthog from cached schema
+              id: prime-schema
+              shell: bash
+              run: |
+                  echo "restored=false" >> "$GITHUB_OUTPUT"
+                  if [ ! -f schema.sql.gz ]; then
+                      echo "::notice::Schema cache miss; the migrate step will build test_posthog"
+                      exit 0
+                  fi
+                  mkdir -p .postgres-backups
+                  mv schema.sql.gz .postgres-backups/schema-latest.sql.gz
+                  if ./bin/hogli db:restore-test-db; then
+                      echo "restored=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "::warning::Schema restore failed (stale/incompatible cached dump?); the migrate step will build test_posthog"
+                  fi
+
+            - name: Migrate test_posthog from scratch
+              if: ${{ steps.prime-schema.outputs.restored != 'true' }}
+              shell: bash
+              env:
+                  DATABASE_URL: postgres://posthog:posthog@localhost:5432/test_posthog
+              run: |
+                  admin_psql() { docker compose -f docker-compose.dev.yml exec -T db psql -U posthog postgres "$@"; }
+                  if ! admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" -c "CREATE DATABASE test_posthog;"; then
+                      echo "::warning::Could not recreate test_posthog; pytest --reuse-db will run the full migrate itself"
+                      exit 0
+                  fi
+                  if ! python manage.py migrate; then
+                      echo "::warning::Out-of-process migrate failed; pytest --reuse-db will run the full migrate itself"
+                      admin_psql -c "DROP DATABASE IF EXISTS test_posthog;" || true
+                  fi
+
+            - name: Download the pinned sharding plan
+              continue-on-error: true
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: gc-experiment-durations
+                  path: .
+
+            - name: Compute hypothesis constants cache key
+              id: hyp-constants-key
+              shell: bash
+              run: |
+                  hyp_version=$(python -c "import hypothesis; print(hypothesis.__version__)")
+                  prefix="posthog-hypothesis-constants-${hyp_version}-${HYPOTHESIS_CONSTANTS_EPOCH}-"
+                  {
+                      echo "key=${prefix}$(date -u +%G-%V)"
+                      echo "restore_prefix=${prefix}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Restore hypothesis constants cache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .hypothesis/constants
+                  key: ${{ steps.hyp-constants-key.outputs.key }}
+                  restore-keys: |
+                      ${{ steps.hyp-constants-key.outputs.restore_prefix }}
+
+            - name: Run the shard under the variant
+              id: run
+              continue-on-error: true
+              env:
+                  VARIANT: ${{ matrix.variant }}
+                  REP: ${{ matrix.rep }}
+                  PERSON_ON_EVENTS_V2_ENABLED: 'true'
+                  CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA: 'false'
+                  GC_EXPERIMENT: ${{ matrix.variant }}
+                  GC_EXPERIMENT_RESULT: gc-experiment-result.json
+              shell: 'signal-fanout bash --noprofile --norc -eo pipefail {0}'
+              run: |
+                  case "$VARIANT" in
+                      hashseed0) export PYTHONHASHSEED=0 ;;
+                      malloc_arena2) export MALLOC_ARENA_MAX=2 ;;
+                      jemalloc)
+                          sudo apt-get install -y -qq libjemalloc2
+                          export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+                          ;;
+                  esac
+                  if [ ! -f .test_durations ]; then
+                      echo "::warning::No durations file, the shard is cut by test count instead"
+                  fi
+                  set +e
+                  start=$(date +%s.%N)
+                  pytest -v --tb=short --reuse-db -p pytest_gc_experiment posthog ee/ -m "not async_migrations" \
+                      --ignore=posthog/temporal \
+                      --ignore=posthog/dags \
+                      --ignore=common/hogvm/python/test \
+                      --ignore=posthog/test/repo_invariants \
+                      --splits "$SPLITS" --group "$GROUP" \
+                      --splitting-algorithm=optimal_chunks --split-granularity=file \
+                      -r fEsxX \
+                      --junitxml=junit-gc-experiment.xml
+                  exit_code=$?
+                  step_wall=$(echo "$(date +%s.%N) - $start" | bc)
+                  set -e
+                  python - "$VARIANT" "$REP" "$exit_code" "$step_wall" <<'PY'
+                  import json
+                  import os
+                  import sys
+
+                  path = "gc-experiment-result.json"
+                  data = json.load(open(path)) if os.path.exists(path) else {"variant": sys.argv[1]}
+                  data.update(
+                      rep=int(sys.argv[2]),
+                      pytest_exit_code=int(sys.argv[3]),
+                      step_wall_s=round(float(sys.argv[4]), 1),
+                      runner=os.environ.get("RUNNER_NAME"),
+                      run_attempt=os.environ.get("GITHUB_RUN_ATTEMPT"),
+                  )
+                  json.dump(data, open(path, "w"), indent=2)
+                  print(json.dumps(data))
+                  PY
+                  if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 5 ]; then
+                      echo "::warning::pytest exited $exit_code for $VARIANT rep $REP; the timing is still recorded"
+                  fi
+
+            - name: Upload the result
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: gc-experiment-result-${{ matrix.variant }}-${{ matrix.rep }}
+                  path: gc-experiment-result.json
+                  if-no-files-found: warn
+                  retention-days: 14
+
+    summarize:
+        name: Tabulate variants
+        needs: test
+        if: always()
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Download every result
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  pattern: gc-experiment-result-*
+                  path: results
+                  merge-multiple: false
+
+            - name: Write the comparison table
+              shell: bash
+              run: |
+                  python3 - <<'PY'
+                  import glob
+                  import json
+                  import os
+                  import statistics
+
+                  rows = [json.load(open(p)) for p in sorted(glob.glob("results/**/*.json", recursive=True))]
+                  rows = [r for r in rows if "test_phase_wall_s" in r]
+                  groups: dict[str, list[dict]] = {}
+                  for row in rows:
+                      groups.setdefault(row["variant"], []).append(row)
+
+                  def mean(values):
+                      return statistics.fmean(values) if values else float("nan")
+
+                  def spread(values):
+                      return statistics.pstdev(values) / mean(values) * 100 if len(values) > 1 else 0.0
+
+                  base = mean([r["test_phase_wall_s"] for r in groups.get("baseline", [])])
+                  header = (
+                      "| variant | n | test wall s mean | min | max | cv % | vs baseline | cpu s | gc s | gc runs g0/g1/g2 | max RSS MB | tests | failed |\n"
+                      "|---|---|---|---|---|---|---|---|---|---|---|---|---|"
+                  )
+                  lines = [header]
+                  for variant, runs in sorted(groups.items(), key=lambda kv: mean([r["test_phase_wall_s"] for r in kv[1]])):
+                      walls = [r["test_phase_wall_s"] for r in runs]
+                      m = mean(walls)
+                      delta = f"{(m - base) / base * 100:+.1f}%" if base == base and base else "n/a"
+                      gc_runs = [mean([r["gc_runs"][g] for r in runs]) for g in range(3)]
+                      lines.append(
+                          f"| {variant} | {len(runs)} | {m:.0f} | {min(walls):.0f} | {max(walls):.0f} | {spread(walls):.1f} | {delta} "
+                          f"| {mean([r['test_phase_cpu_s'] for r in runs]):.0f} | {mean([r['gc_seconds_total'] for r in runs]):.1f} "
+                          f"| {gc_runs[0]:.0f}/{gc_runs[1]:.0f}/{gc_runs[2]:.0f} | {mean([r['max_rss_mb'] for r in runs]):.0f} "
+                          f"| {runs[0]['tests']} | {max(r['failed'] for r in runs)} |"
+                      )
+                  lines += ["", "| variant | rep | test wall s | step wall s | cpu s | gc s | max RSS MB | exit | runner |", "|---|---|---|---|---|---|---|---|---|"]
+                  for row in sorted(rows, key=lambda r: (r["variant"], r.get("rep", 0))):
+                      lines.append(
+                          f"| {row['variant']} | {row.get('rep')} | {row['test_phase_wall_s']:.0f} | {row.get('step_wall_s', 0):.0f} "
+                          f"| {row['test_phase_cpu_s']:.0f} | {row['gc_seconds_total']:.1f} | {row['max_rss_mb']:.0f} "
+                          f"| {row.get('pytest_exit_code')} | {row.get('runner')} |"
+                      )
+                  table = "\n".join(lines)
+                  print(table)
+                  with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+                      summary.write("## GC experiment\n\n" + table + "\n")
+                  PY

--- a/.github/workflows/ci-backend-gc-experiment.yml
+++ b/.github/workflows/ci-backend-gc-experiment.yml
@@ -1,8 +1,10 @@
 name: CI backend GC experiment
 
-# Throwaway experiment: runs one fixed pytest-split shard of the Core Django suite under
-# several garbage collector, allocator, and Postgres configurations, several repetitions
-# each, and tabulates test-phase wall time, collector time, and peak RSS per variant.
+# Throwaway experiment: measures how garbage collector, allocator, and Postgres settings
+# change backend test time. Every variant runs back to back on the same runner, so a
+# variant is compared against a baseline that saw the same machine, and machine-to-machine
+# variance becomes a blocking factor instead of a confounder. Each block rotates the order
+# so a variant cannot alias with its position in the sequence.
 # The setup steps mirror the "Django tests" job of ci-backend.yml so the numbers transfer.
 
 on:
@@ -15,11 +17,15 @@ on:
         inputs:
             splits:
                 description: Number of pytest-split shards the Core suite is cut into
-                default: '30'
+                default: '60'
                 type: string
             group:
                 description: Which of those shards to run
                 default: '7'
+                type: string
+            blocks:
+                description: How many runners each run the whole variant sequence
+                default: '6'
                 type: string
 
 concurrency:
@@ -54,7 +60,7 @@ env:
     DISPLAY: ':99.0'
     OIDC_RSA_PRIVATE_KEY: ${{ vars.OIDC_RSA_FAKE_PRIVATE_KEY }}
     SANDBOX_JWT_PRIVATE_KEY: ${{ vars.OIDC_RSA_FAKE_PRIVATE_KEY }}
-    SPLITS: ${{ github.event.inputs.splits || '30' }}
+    SPLITS: ${{ github.event.inputs.splits || '60' }}
     GROUP: ${{ github.event.inputs.group || '7' }}
 
 jobs:
@@ -95,33 +101,19 @@ jobs:
                   retention-days: 3
 
     test:
-        name: ${{ matrix.variant }} (rep ${{ matrix.rep }})
+        name: block ${{ matrix.block }}
         needs: plan
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 60
+        timeout-minutes: 90
         strategy:
             fail-fast: false
             matrix:
-                variant:
-                    - baseline # what master runs: boot window, freeze, thresholds (50000, 20, 20)
-                    - stock_gc # interpreter defaults, no boot window, no freeze: the pre-June setup
-                    - freeze_stock_thresholds # boot window + freeze, thresholds back to the 3.13 defaults (2000, 10, 10)
-                    - high_thresholds # boot window + freeze, thresholds (200000, 50, 50)
-                    - no_gc # boot window + freeze, collector off for the whole test phase
-                    - hashseed0 # baseline + PYTHONHASHSEED=0
-                    - malloc_arena2 # baseline + MALLOC_ARENA_MAX=2
-                    - jemalloc # baseline + libjemalloc via LD_PRELOAD
-                    - pg_nofsync # baseline + Postgres fsync/synchronous_commit/full_page_writes off
-                rep: [1, 2, 3]
-                include:
-                    - variant: baseline
-                      rep: 4
-                    - variant: baseline
-                      rep: 5
+                # Each block is one runner that executes every variant in sequence.
+                block: [1, 2, 3, 4, 5, 6]
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-            COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml${{ matrix.variant == 'pg_nofsync' && ':docker-compose.gc-experiment-pg.yml' || '' }}
+            COMPOSE_FILE: docker-compose.dev.yml:docker-compose.profiles.yml
             COMPOSE_PROFILES: temporal,azure
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -277,69 +269,107 @@ jobs:
                   restore-keys: |
                       ${{ steps.hyp-constants-key.outputs.restore_prefix }}
 
-            - name: Run the shard under the variant
+            - name: Install jemalloc
+              shell: bash
+              run: sudo apt-get install -y -qq libjemalloc2
+
+            - name: Run every variant on this runner
               id: run
               continue-on-error: true
               env:
-                  VARIANT: ${{ matrix.variant }}
-                  REP: ${{ matrix.rep }}
+                  BLOCK: ${{ matrix.block }}
                   PERSON_ON_EVENTS_V2_ENABLED: 'true'
                   CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA: 'false'
-                  GC_EXPERIMENT: ${{ matrix.variant }}
-                  GC_EXPERIMENT_RESULT: gc-experiment-result.json
               shell: 'signal-fanout bash --noprofile --norc -eo pipefail {0}'
               run: |
-                  case "$VARIANT" in
-                      hashseed0) export PYTHONHASHSEED=0 ;;
-                      malloc_arena2) export MALLOC_ARENA_MAX=2 ;;
-                      jemalloc)
-                          sudo apt-get install -y -qq libjemalloc2
-                          export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
-                          ;;
-                  esac
-                  if [ ! -f .test_durations ]; then
-                      echo "::warning::No durations file, the shard is cut by test count instead"
-                  fi
-                  set +e
-                  start=$(date +%s.%N)
-                  pytest -v --tb=short --reuse-db -p pytest_gc_experiment posthog ee/ -m "not async_migrations" \
-                      --ignore=posthog/temporal \
-                      --ignore=posthog/dags \
-                      --ignore=common/hogvm/python/test \
-                      --ignore=posthog/test/repo_invariants \
-                      --splits "$SPLITS" --group "$GROUP" \
-                      --splitting-algorithm=optimal_chunks --split-granularity=file \
-                      -r fEsxX \
-                      --junitxml=junit-gc-experiment.xml
-                  exit_code=$?
-                  step_wall=$(echo "$(date +%s.%N) - $start" | bc)
-                  set -e
-                  python - "$VARIANT" "$REP" "$exit_code" "$step_wall" <<'PY'
+                  mkdir -p results
+                  # baseline appears twice: the gap between the two measures how much this
+                  # runner drifts across the block, which is the noise floor every other
+                  # comparison is read against.
+                  SEQUENCE=(baseline hashseed0 malloc_arena2 jemalloc high_thresholds no_gc baseline_late)
+                  # Rotate by block so a variant never keeps the same position in the sequence.
+                  rotate=$(( (BLOCK - 1) % ${#SEQUENCE[@]} ))
+                  ORDERED=("${SEQUENCE[@]:$rotate}" "${SEQUENCE[@]:0:$rotate}")
+                  echo "Block $BLOCK order: ${ORDERED[*]}"
+
+                  run_variant() {
+                      local variant="$1" position="$2" stack="$3"
+                      local result="results/${variant}.json"
+                      (
+                          case "$variant" in
+                              hashseed0) export PYTHONHASHSEED=0 ;;
+                              malloc_arena2) export MALLOC_ARENA_MAX=2 ;;
+                              jemalloc) export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 ;;
+                          esac
+                          # baseline_late and pg_nofsync run the baseline collector settings.
+                          case "$variant" in
+                              baseline_late|pg_nofsync) export GC_EXPERIMENT=baseline ;;
+                              *) export GC_EXPERIMENT="$variant" ;;
+                          esac
+                          export GC_EXPERIMENT_RESULT="$result"
+                          set +e
+                          pytest --tb=line -q --reuse-db -p pytest_gc_experiment posthog ee/ -m "not async_migrations" \
+                              --ignore=posthog/temporal \
+                              --ignore=posthog/dags \
+                              --ignore=common/hogvm/python/test \
+                              --ignore=posthog/test/repo_invariants \
+                              --splits "$SPLITS" --group "$GROUP" \
+                              --splitting-algorithm=optimal_chunks --split-granularity=file \
+                              --snapshot-warn-unused \
+                              -p no:cacheprovider
+                          local exit_code=$?
+                          set -e
+                          if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 5 ]; then
+                              echo "::warning::pytest exited $exit_code for $variant in block $BLOCK"
+                          fi
+                          python - "$variant" "$position" "$stack" "$exit_code" "$result" <<'PY'
                   import json
                   import os
                   import sys
 
-                  path = "gc-experiment-result.json"
-                  data = json.load(open(path)) if os.path.exists(path) else {"variant": sys.argv[1]}
+                  variant, position, stack, exit_code, path = sys.argv[1:6]
+                  data = json.load(open(path)) if os.path.exists(path) else {}
                   data.update(
-                      rep=int(sys.argv[2]),
-                      pytest_exit_code=int(sys.argv[3]),
-                      step_wall_s=round(float(sys.argv[4]), 1),
+                      variant=variant,
+                      block=int(os.environ["BLOCK"]),
+                      position=int(position),
+                      stack=stack,
+                      pytest_exit_code=int(exit_code),
                       runner=os.environ.get("RUNNER_NAME"),
-                      run_attempt=os.environ.get("GITHUB_RUN_ATTEMPT"),
                   )
                   json.dump(data, open(path, "w"), indent=2)
-                  print(json.dumps(data))
+                  print(json.dumps({k: data.get(k) for k in ("variant", "block", "position", "stack", "test_phase_wall_s", "gc_seconds_total", "max_rss_mb", "tests")}))
                   PY
-                  if [ "$exit_code" -ne 0 ] && [ "$exit_code" -ne 5 ]; then
-                      echo "::warning::pytest exited $exit_code for $VARIANT rep $REP; the timing is still recorded"
-                  fi
+                      )
+                  }
 
-            - name: Upload the result
+                  position=0
+                  for variant in "${ORDERED[@]}"; do
+                      position=$((position + 1))
+                      echo "::group::block $BLOCK position $position: $variant"
+                      run_variant "$variant" "$position" normal || echo "::warning::$variant did not finish cleanly in block $BLOCK"
+                      echo "::endgroup::"
+                  done
+
+                  # Postgres durability is a stack setting, so it needs its own container.
+                  # The named volume keeps the migrated test_posthog across the recreate.
+                  echo "::group::block $BLOCK position $((position + 1)): pg_nofsync"
+                  COMPOSE_FILE="$COMPOSE_FILE:docker-compose.gc-experiment-pg.yml" \
+                      docker compose up -d --force-recreate db
+                  for _ in $(seq 1 30); do
+                      if docker compose exec -T db pg_isready -U posthog > /dev/null 2>&1; then break; fi
+                      sleep 2
+                  done
+                  echo "Postgres settings now in force:"
+                  docker compose exec -T db psql -U posthog -c "show fsync" -c "show synchronous_commit" -c "show full_page_writes"
+                  run_variant pg_nofsync "$((position + 1))" nofsync || echo "::warning::pg_nofsync did not finish cleanly in block $BLOCK"
+                  echo "::endgroup::"
+
+            - name: Upload the block's results
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
-                  name: gc-experiment-result-${{ matrix.variant }}-${{ matrix.rep }}
-                  path: gc-experiment-result.json
+                  name: gc-experiment-result-block-${{ matrix.block }}
+                  path: results/*.json
                   if-no-files-found: warn
                   retention-days: 14
 
@@ -353,9 +383,8 @@ jobs:
             - name: Download every result
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
-                  pattern: gc-experiment-result-*
+                  pattern: gc-experiment-result-block-*
                   path: results
-                  merge-multiple: false
 
             - name: Write the comparison table
               shell: bash
@@ -367,41 +396,51 @@ jobs:
                   import statistics
 
                   rows = [json.load(open(p)) for p in sorted(glob.glob("results/**/*.json", recursive=True))]
-                  rows = [r for r in rows if "test_phase_wall_s" in r]
-                  groups: dict[str, list[dict]] = {}
-                  for row in rows:
-                      groups.setdefault(row["variant"], []).append(row)
+                  rows = [r for r in rows if "test_phase_wall_s" in r and r.get("block")]
 
-                  def mean(values):
+                  by_block: dict[int, dict[str, dict]] = {}
+                  for row in rows:
+                      by_block.setdefault(row["block"], {})[row["variant"]] = row
+
+                  # Each block is one runner. A variant is scored against the baseline that ran
+                  # on that same runner, so machine-to-machine variance cancels.
+                  deltas: dict[str, list[float]] = {}
+                  for block, runs in by_block.items():
+                      anchors = [runs[v]["test_phase_wall_s"] for v in ("baseline", "baseline_late") if v in runs]
+                      if not anchors:
+                          continue
+                      anchor = statistics.fmean(anchors)
+                      for variant, row in runs.items():
+                          deltas.setdefault(variant, []).append((row["test_phase_wall_s"] - anchor) / anchor * 100)
+
+                  def agg(variant, key):
+                      values = [r[key] for b in by_block.values() if variant in b for r in [b[variant]]]
                       return statistics.fmean(values) if values else float("nan")
 
-                  def spread(values):
-                      return statistics.pstdev(values) / mean(values) * 100 if len(values) > 1 else 0.0
+                  lines = [
+                      "### Paired comparison (each variant against the baseline on its own runner)",
+                      "",
+                      "| variant | blocks | delta vs same-runner baseline | spread of that delta | wall s | gc s | gen0 | peak RSS MB |",
+                      "|---|---|---|---|---|---|---|---|",
+                  ]
+                  for variant, values in sorted(deltas.items(), key=lambda kv: statistics.fmean(kv[1])):
+                      mean = statistics.fmean(values)
+                      sd = statistics.pstdev(values) if len(values) > 1 else 0.0
+                      gen0 = agg(variant, "gc_runs")
+                      lines.append(
+                          f"| {variant} | {len(values)} | {mean:+.1f}% | +/- {sd:.1f} | {agg(variant, 'test_phase_wall_s'):.0f} "
+                          f"| {agg(variant, 'gc_seconds_total'):.1f} | {by_block[min(by_block)][variant]['gc_runs'][0] if variant in by_block[min(by_block)] else 0} "
+                          f"| {agg(variant, 'max_rss_mb'):.0f} |"
+                      )
 
-                  base = mean([r["test_phase_wall_s"] for r in groups.get("baseline", [])])
-                  header = (
-                      "| variant | n | test wall s mean | min | max | cv % | vs baseline | cpu s | gc s | gc runs g0/g1/g2 | max RSS MB | tests | failed |\n"
-                      "|---|---|---|---|---|---|---|---|---|---|---|---|---|"
-                  )
-                  lines = [header]
-                  for variant, runs in sorted(groups.items(), key=lambda kv: mean([r["test_phase_wall_s"] for r in kv[1]])):
-                      walls = [r["test_phase_wall_s"] for r in runs]
-                      m = mean(walls)
-                      delta = f"{(m - base) / base * 100:+.1f}%" if base == base and base else "n/a"
-                      gc_runs = [mean([r["gc_runs"][g] for r in runs]) for g in range(3)]
+                  lines += ["", "### Every run", "", "| block | position | variant | stack | wall s | gc s | gen0/gen1/gen2 | peak RSS MB | tests | runner |", "|---|---|---|---|---|---|---|---|---|---|"]
+                  for row in sorted(rows, key=lambda r: (r["block"], r["position"])):
+                      g = row["gc_runs"]
                       lines.append(
-                          f"| {variant} | {len(runs)} | {m:.0f} | {min(walls):.0f} | {max(walls):.0f} | {spread(walls):.1f} | {delta} "
-                          f"| {mean([r['test_phase_cpu_s'] for r in runs]):.0f} | {mean([r['gc_seconds_total'] for r in runs]):.1f} "
-                          f"| {gc_runs[0]:.0f}/{gc_runs[1]:.0f}/{gc_runs[2]:.0f} | {mean([r['max_rss_mb'] for r in runs]):.0f} "
-                          f"| {runs[0]['tests']} | {max(r['failed'] for r in runs)} |"
+                          f"| {row['block']} | {row['position']} | {row['variant']} | {row['stack']} | {row['test_phase_wall_s']:.0f} "
+                          f"| {row['gc_seconds_total']:.1f} | {g[0]}/{g[1]}/{g[2]} | {row['max_rss_mb']:.0f} | {row['tests']} | {row.get('runner')} |"
                       )
-                  lines += ["", "| variant | rep | test wall s | step wall s | cpu s | gc s | max RSS MB | exit | runner |", "|---|---|---|---|---|---|---|---|---|"]
-                  for row in sorted(rows, key=lambda r: (r["variant"], r.get("rep", 0))):
-                      lines.append(
-                          f"| {row['variant']} | {row.get('rep')} | {row['test_phase_wall_s']:.0f} | {row.get('step_wall_s', 0):.0f} "
-                          f"| {row['test_phase_cpu_s']:.0f} | {row['gc_seconds_total']:.1f} | {row['max_rss_mb']:.0f} "
-                          f"| {row.get('pytest_exit_code')} | {row.get('runner')} |"
-                      )
+
                   table = "\n".join(lines)
                   print(table)
                   with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:

--- a/bin/clone-test-db-for-xdist
+++ b/bin/clone-test-db-for-xdist
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Clone the migrated test databases into per-worker copies for pytest-xdist.
+# pytest-django suffixes each worker's DB as <name>_gwN, and posthog/conftest.py
+# derives the persons DB as <name>_gwN_persons; cloning both via
+# CREATE DATABASE ... TEMPLATE skips re-running Django + sqlx migrations per
+# worker, so `pytest -n N --reuse-db` starts instantly on every worker.
+#
+# Usage: bin/clone-test-db-for-xdist <num_workers> [source_db]
+set -euo pipefail
+
+WORKERS="${1:?usage: clone-test-db-for-xdist <num_workers> [source_db]}"
+SOURCE_DB="${2:-test_posthog}"
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-posthog}"
+export PGPASSWORD="${PGPASSWORD:-posthog}"
+
+psql_admin() {
+    psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d postgres -v ON_ERROR_STOP=1 -qAt -c "$1"
+}
+
+clone() {
+    local src="$1" dest="$2"
+    # TEMPLATE requires no active connections on the source DB.
+    psql_admin "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${src}' AND pid <> pg_backend_pid();" > /dev/null
+    psql_admin "DROP DATABASE IF EXISTS ${dest};" > /dev/null
+    psql_admin "CREATE DATABASE ${dest} TEMPLATE ${src};" > /dev/null
+    echo "cloned ${src} -> ${dest}"
+}
+
+for i in $(seq 0 $((WORKERS - 1))); do
+    clone "${SOURCE_DB}" "${SOURCE_DB}_gw${i}"
+    if psql_admin "SELECT 1 FROM pg_database WHERE datname = '${SOURCE_DB}_persons'" | grep -q 1; then
+        clone "${SOURCE_DB}_persons" "${SOURCE_DB}_gw${i}_persons"
+    fi
+done

--- a/docker-compose.gc-experiment-pg.yml
+++ b/docker-compose.gc-experiment-pg.yml
@@ -1,0 +1,5 @@
+# Experiment-only override: the dev Postgres without WAL durability. Appended to
+# COMPOSE_FILE by ci-backend-gc-experiment.yml for the pg_nofsync variant.
+services:
+    db:
+        command: postgres -c max_connections=1000 -c idle_in_transaction_session_timeout=300000 -c max_prepared_transactions=10 -c fsync=off -c synchronous_commit=off -c full_page_writes=off

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1253,3 +1253,7 @@ environment:
         bin_script: report-jest-timings
         description: 'Render a Jest test-speed report from timing artifacts'
         hidden: true
+    clone:test:db:for:xdist:
+        bin_script: clone-test-db-for-xdist
+        description: 'TODO: add description for clone-test-db-for-xdist'
+        hidden: true

--- a/pytest_gc_experiment.py
+++ b/pytest_gc_experiment.py
@@ -1,0 +1,126 @@
+"""Experiment-only pytest plugin that applies one GC configuration and reports its cost.
+
+Loaded explicitly with `-p pytest_gc_experiment` by ci-backend-gc-experiment.yml; nothing
+in pytest.ini references it. GC_EXPERIMENT names the configuration to apply once the root
+conftest has closed the boot GC window. Unknown names keep the repo's current setup, so
+allocator and environment variants can carry a label without changing the collector.
+
+At session end the plugin writes GC_EXPERIMENT_RESULT (default gc-experiment-result.json)
+with wall and CPU time of the test phase, time spent inside the collector per generation,
+and peak RSS.
+"""
+
+import gc
+import os
+import sys
+import json
+import time
+import resource
+from typing import Any
+
+import pytest
+
+VARIANT = os.environ.get("GC_EXPERIMENT", "baseline")
+RESULT_PATH = os.environ.get("GC_EXPERIMENT_RESULT", "gc-experiment-result.json")
+
+_gc_seconds = [0.0, 0.0, 0.0]
+_gc_runs = [0, 0, 0]
+_gc_collected = [0, 0, 0]
+_gc_started: dict[int, float] = {}
+_phase: dict[str, Any] = {}
+
+
+def _track_gc(phase: str, info: dict[str, int]) -> None:
+    generation = info["generation"]
+    if phase == "start":
+        _gc_started[generation] = time.perf_counter()
+        return
+    started = _gc_started.pop(generation, None)
+    if started is not None:
+        _gc_seconds[generation] += time.perf_counter() - started
+    _gc_runs[generation] += 1
+    _gc_collected[generation] += info["collected"]
+
+
+gc.callbacks.append(_track_gc)
+
+# stock_gc reproduces the interpreter defaults from before the boot window existed:
+# pytest_boot_gc has already disabled the collector by the time this module imports,
+# and django.setup() runs next.
+if VARIANT == "stock_gc":
+    gc.enable()
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    # The root conftest disables GC again at import time; collection must run with it on.
+    if VARIANT == "stock_gc":
+        gc.enable()
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_collection_finish(session: pytest.Session):
+    # With GC already enabled the root conftest's window close returns early:
+    # no freeze, thresholds stay at (700, 10, 10).
+    if VARIANT == "stock_gc":
+        gc.enable()
+    result = yield
+    if VARIANT == "freeze_stock_thresholds":
+        gc.set_threshold(2000, 10, 10)  # CPython 3.13 defaults
+    elif VARIANT == "high_thresholds":
+        gc.set_threshold(200_000, 50, 50)
+    elif VARIANT == "no_gc":
+        gc.disable()
+    return result
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtestloop(session: pytest.Session):
+    _phase["gc_enabled"] = gc.isenabled()
+    _phase["gc_threshold"] = gc.get_threshold()
+    _phase["gc_frozen"] = gc.get_freeze_count()
+    _phase["wall_start"] = time.perf_counter()
+    _phase["cpu_start"] = time.process_time()
+    result = yield
+    _phase["wall_s"] = time.perf_counter() - _phase["wall_start"]
+    _phase["cpu_s"] = time.process_time() - _phase["cpu_start"]
+    return result
+
+
+def _max_rss_mb() -> float:
+    max_rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    divisor = 1024 * 1024 if sys.platform == "darwin" else 1024
+    return round(max_rss / divisor, 1)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    final_collect_s = 0.0
+    if VARIANT == "no_gc":
+        started = time.perf_counter()
+        gc.collect()
+        final_collect_s = time.perf_counter() - started
+    result = {
+        "variant": VARIANT,
+        "python": sys.version.split()[0],
+        "pythonhashseed": os.environ.get("PYTHONHASHSEED"),
+        "malloc_arena_max": os.environ.get("MALLOC_ARENA_MAX"),
+        "ld_preload": os.environ.get("LD_PRELOAD"),
+        "gc_enabled": _phase.get("gc_enabled"),
+        "gc_threshold": _phase.get("gc_threshold"),
+        "gc_frozen": _phase.get("gc_frozen"),
+        "tests": session.testscollected,
+        "failed": session.testsfailed,
+        "exitstatus": int(exitstatus),
+        "test_phase_wall_s": round(_phase.get("wall_s", 0.0), 2),
+        "test_phase_cpu_s": round(_phase.get("cpu_s", 0.0), 2),
+        "gc_seconds": [round(s, 3) for s in _gc_seconds],
+        "gc_seconds_total": round(sum(_gc_seconds), 3),
+        "gc_runs": list(_gc_runs),
+        "gc_collected": list(_gc_collected),
+        "final_collect_s": round(final_collect_s, 3),
+        "max_rss_mb": _max_rss_mb(),
+    }
+    with open(RESULT_PATH, "w") as handle:
+        json.dump(result, handle, indent=2)
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_line(f"GC_EXPERIMENT_RESULT {json.dumps(result)}")


### PR DESCRIPTION
## Problem

- DevEx keeps hearing that Python garbage collector and memory settings would cut backend test time. The repo already tuned the collector between June and August, and nobody had measured what is left.
- A [Slack thread](https://posthog.slack.com/archives/C0457KENW2E/p1787050657221769?thread_ts=1784980358.603399) raised three claims: `PYTHONHASHSEED` stabilizes runtimes, the collector is sensitive to cache contention, and Postgres without fsync is faster. Those observations came from Depot CI, a different runner platform from the one our shards use.

## Changes

- Adds throwaway workflows that run one fixed Core shard under nine collector, allocator, and Postgres configurations, on both runner platforms.
- Every variant runs back to back on the same runner, the order rotates per block, and each block runs the baseline twice to measure its own noise floor.
- Not for merge. Neither workflow runs on a push, and the Depot one is dispatch-only.

## Results

**The tuning already in master is worth about 18%. There is nothing left to win.**

Between-runner run, 1446 tests, GitHub Actions runners:

| variant | n | vs baseline | collector s | gen0 collections |
|---|---|---|---|---|
| stock_gc (the pre-June setup) | 3 | +21.6% | 13.8 | 7327 |
| freeze_stock_thresholds | 3 | +6.4% | 9.4 | 6309 |
| no_gc | 3 | +3.1% | 3.9 | 205 |
| high_thresholds (200k) | 3 | +0.5% | 3.7 | 49 |
| baseline (what master runs) | 5 | 0.0% | 3.0 | 204 |

`gc.freeze()` carries about 15 points and the threshold raise about 6. Raising thresholds past the current 50000 gains nothing, and turning the collector off is worse than leaving it on. Stock settings cost 79 seconds of wall for 11 seconds of extra collector time, which matches the cache-contention explanation.

**Paired runs, every variant on the same runner, 6 blocks, 672 tests, both platforms:**

| variant | GitHub Actions | Depot CI | peak RSS MB |
|---|---|---|---|
| jemalloc | -5.3% | -0.8% | 1389 |
| malloc_arena2 | -3.6% | -2.7% | 1420 |
| high_thresholds | -0.4% | -1.6% | 1641 |
| pg_nofsync | -0.0% | +2.4% | 1628 |
| hashseed0 | +1.1% | -2.9% | 1628 |
| no_gc | +6.4% | -1.3% | 1630 |
| baseline | 0.0% | 0.0% | 1617 |

Every variant sits inside the noise. Running the same configuration twice on one runner differs by up to 11.7% on GitHub Actions and 12.6% on Depot CI. The rankings shuffle between platforms, which is what noise looks like.

- `PYTHONHASHSEED=0` neither speeds runs up nor stabilizes them on either platform.
- Postgres with fsync, synchronous_commit and full_page_writes off makes no difference. The job prints `show fsync` to prove the setting applied.
- **The Depot CI runners are not more cache-contended.** `lscpu` there reports 2 vCPU, one thread per core, AMD EPYC 9R45, 32 MiB L3, the same as the GitHub Actions runners.

**The two findings that are reproducible and worth keeping:**

- jemalloc and a capped malloc arena cut peak memory about 13% on both platforms. The wall-time gain is noise, but the memory result is consistent, which matters for shards that run near their memory limit.
- CPU is 40% of test-phase wall on GitHub Actions and 43% on Depot CI. The suite spends most of the test phase waiting on Postgres and ClickHouse, which is why interpreter and allocator settings cannot move it.

## How did you test this code?

- Three full runs: a [between-runner run](https://github.com/PostHog/posthog/actions/runs/33648362361) and a [paired run](https://github.com/PostHog/posthog/actions/runs/33650344314) on GitHub Actions, and a paired run on Depot CI (`depot ci run`, run `8zf8h0gmtb`).
- Result artifacts expire after 14 days. The tables above are the record.
- Not checked: whether the pre-June collector settings are even worse on Depot CI. The paired sequence has no stock_gc arm, so only the "is there more to win" question was asked there.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The durable home for this is `docs/internal/ci-things-already-tried.md`, which has no entry for collector, allocator, hash seed, or Postgres durability today.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code; skills invoked: /writing-pr-descriptions.
- The first run compared variants across separate runners, which confounded variant with machine. The second moved every variant onto one runner per block. The noise turned out to be within a machine rather than between machines, which is itself the useful result.
- The Depot CI run was added to test whether the original observations came from a more cache-contended platform. The measured topology says no.
- Python 3.13 raised the default gen0 threshold to 2000, so the stock-threshold variant uses that, not the 700 the conftest comment mentions.

https://claude.ai/code/session_018yEkBhpQFkw1rdCwRwKrdP
