### PR TITLE
fix(experiments): dismiss confidence interval tooltip on scroll

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -620,6 +620,22 @@ export function MetricRowGroup({
         }
     }, [])
 
+    // The tooltip is fixed-positioned from coordinates captured on hover, so it
+    // doesn't track the page on scroll — dismiss it instead, like native tooltips.
+    useEffect(() => {
+        if (!tooltipState.isVisible) {
+            return
+        }
+        const handleScroll = (): void => {
+            clearTooltipCloseTimer()
+            hideTooltipState()
+        }
+        // Capture phase so scrolls of any ancestor scroll container are caught, not just the window
+        window.addEventListener('scroll', handleScroll, { capture: true, passive: true })
+        return () => window.removeEventListener('scroll', handleScroll, { capture: true })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tooltipState.isVisible])
+
     const scale = useAxisScale(axisRange, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
 
     const { reportExperimentTimeseriesViewed, retryPrimaryMetric, retrySecondaryMetric, refreshExperimentResults } =


### PR DESCRIPTION
## Problem

Hovering a metric row on the experiment results table shows the confidence interval tooltip. Scrolling then moves the page but not the tooltip, so it hangs misplaced over unrelated content.

The tooltip is a fixed-positioned div, placed once from coordinates captured on hover, and nothing dismissed it on scroll.

## Changes

- The tooltip now closes as soon as the user scrolls, matching how other tooltips behave.
- A scroll listener is active only while the tooltip is visible. It uses the capture phase because the page scrolls inside a nested container, not the window.

## How did you test this code?

Frontend typecheck and oxlint pass. Not verified in the running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /wt, /writing-pr-descriptions.
