### PR TITLE
fix(experiments): hide running time calculator noise in history

### DIFF
--- a/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
+++ b/frontend/src/scenes/experiments/activity-descriptions/experimentChangeDescription.tsx
@@ -68,6 +68,17 @@ function withoutRunningTimeCalculationKeys(value: unknown): Record<string, unkno
     )
 }
 
+const DERIVED_RUNNING_TIME_KEYS = ['recommended_running_time', 'recommended_sample_size']
+
+/** Strip the derived calculator outputs so only deliberate input edits (MDE, exposure estimate) count. */
+function withoutDerivedRunningTimeKeys(value: unknown): Record<string, unknown> {
+    return Object.fromEntries(
+        Object.entries((value as Record<string, unknown> | null) ?? {}).filter(
+            ([key]) => !DERIVED_RUNNING_TIME_KEYS.includes(key)
+        )
+    )
+}
+
 function describeExcludedVariantsChange(before: string[] | undefined, after: string[] | undefined): string | null {
     const beforeSet = new Set(before ?? [])
     const afterSet = new Set(after ?? [])
@@ -283,7 +294,12 @@ export const getExperimentChangeDescription = (
             }
             return 'updated parameters'
         })
-        .with({ field: 'running_time_calculation' }, () => {
+        .with({ field: 'running_time_calculation' }, ({ before, after }) => {
+            // Opening the calculator re-saves the recomputed outputs, so they drift as exposure
+            // data changes — a row only earns its place when a calculator input was edited.
+            if (equal(withoutDerivedRunningTimeKeys(before), withoutDerivedRunningTimeKeys(after))) {
+                return null
+            }
             return 'updated the running time calculation'
         })
         .with({ field: 'excluded_variants' }, () => {

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
@@ -257,5 +257,73 @@ describe('experimentActivityDescriber', () => {
             )
             expect(textOf(result)).not.toContain('updated parameters')
         })
+
+        it.each([
+            {
+                name: 'recomputed outputs drifted',
+                action: 'changed' as const,
+                before: { recommended_sample_size: 5442, recommended_running_time: 10 },
+                after: { recommended_sample_size: 21781, recommended_running_time: 127 },
+            },
+            {
+                name: 'first save only stored recomputed outputs',
+                action: 'created' as const,
+                before: null,
+                after: { recommended_sample_size: 7307, recommended_running_time: 13 },
+            },
+        ])('drops the row when no calculator input was edited: $name', ({ action, before, after }) => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity: 'updated',
+                    detail: {
+                        name: 'Checkout funnel',
+                        changes: [
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action,
+                                field: 'running_time_calculation',
+                                before,
+                                after,
+                            },
+                        ],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            expect(result.description).toBeNull()
+        })
+
+        it('keeps the row when output drift accompanies a real change', () => {
+            const result = experimentActivityDescriber(
+                baseLogItem({
+                    activity: 'updated',
+                    detail: {
+                        name: 'Checkout funnel',
+                        changes: [
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'created',
+                                field: 'start_date',
+                                before: null,
+                                after: '2026-06-18T14:25:34Z',
+                            },
+                            {
+                                type: ActivityScope.EXPERIMENT,
+                                action: 'changed',
+                                field: 'running_time_calculation',
+                                before: { recommended_sample_size: 5442 },
+                                after: { recommended_sample_size: 21781 },
+                            },
+                        ],
+                        merge: null,
+                        trigger: null,
+                    },
+                })
+            )
+            const text = textOf(result)
+            expect(text).toContain('launched experiment')
+            expect(text).not.toContain('running time calculation')
+        })
     })
 })

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -320,6 +320,11 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                     .filter((part): part is string | JSX.Element => part !== null)
             }
 
+            if (isExperiment && changes.length > 0 && listParts.length === 0) {
+                // Every change described to null (e.g. only derived values drifted) — drop the row.
+                return { description: null }
+            }
+
             if (isExperiment && changes.length > 0 && listParts.length > 0) {
                 const lastIndex = listParts.length - 1
                 listParts[lastIndex] = appendPreposition(listParts[lastIndex])

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -321,7 +321,7 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
             }
 
             if (isExperiment && changes.length > 0 && listParts.length === 0) {
-                // Every change described to null (e.g. only derived values drifted) — drop the row.
+                // humanize() skips log items with a null description
                 return { description: null }
             }
 


### PR DESCRIPTION
## Problem

Opening the running time calculator re-saves its recomputed outputs, so the experiment History tab fills with "updated the running time calculation" rows from people who edited nothing. On one sample experiment that was 7 of 17 entries.

## Changes

- Describe a running time calculation change only when a calculator input changed (minimum detectable effect, exposure estimate config), not when the recomputed sample size or running time drifted.
- Drop a history entry entirely when all of its changes describe to nothing, instead of rendering a broken sentence.

Filtering happens in the frontend describer, so already-logged noise disappears from the feed too.

## How did you test this code?

New jest cases: a drift-only entry is dropped, and a launch entry that also carries drift still renders "launched experiment" (guards against over-dropping). Ran the describer suites and the frontend typecheck.