### PR TITLE
fix(insights): validate each value of a multi-value regex filter

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.test.tsx
@@ -1,0 +1,27 @@
+import { PropertyOperator } from '~/types'
+
+import { getValidationError } from './OperatorValueSelect'
+
+describe('getValidationError', () => {
+    it('validates every pattern of a multi-value regex filter without crashing on the array', () => {
+        // A visited_page filter ORs several regex values, so the value is an array. RE2JS.compile
+        // used to receive the array directly and throw "this.str.codePointAt is not a function",
+        // surfacing that internal error to the user in the filter editor.
+        const value = ['/project/[^/]+/replay/home', '/project/[^/]+/replay/playlists']
+
+        expect(getValidationError(PropertyOperator.Regex, value)).toBeNull()
+    })
+
+    it('reports the first invalid pattern in a multi-value regex filter', () => {
+        const value = ['/valid/path', '/bad(unclosed']
+
+        const error = getValidationError(PropertyOperator.Regex, value)
+
+        expect(error).not.toBeNull()
+        expect(error).not.toContain('codePointAt')
+    })
+
+    it('still reports an invalid single-value regex', () => {
+        expect(getValidationError(PropertyOperator.Regex, '(unclosed')).not.toBeNull()
+    })
+})

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -157,17 +157,24 @@ interface OperatorSelectProps extends Omit<LemonSelectProps<any>, 'options'> {
 }
 
 function getRegexValidationError(operator: PropertyOperator, value: any): string | null {
-    if (isOperatorRegex(operator)) {
+    if (!isOperatorRegex(operator)) {
+        return null
+    }
+    // A regex operator can hold several values (e.g. a multi-value `visited_page` filter), so the
+    // value is an array. RE2JS.compile expects a single string and crashes on an array, so validate
+    // each pattern and surface the first that fails.
+    const patterns: unknown[] = Array.isArray(value) ? value : [value]
+    for (const pattern of patterns) {
         try {
-            RE2JS.compile(value)
+            RE2JS.compile(String(pattern))
         } catch (error) {
-            return formatRE2Error(error as Error, value)
+            return formatRE2Error(error as Error, String(pattern))
         }
     }
     return null
 }
 
-function getValidationError(operator: PropertyOperator, value: any, property?: string): string | null {
+export function getValidationError(operator: PropertyOperator, value: any, property?: string): string | null {
     const regexErrorMessage = getRegexValidationError(operator, value)
     if (regexErrorMessage != null) {
         return regexErrorMessage


### PR DESCRIPTION
## Problem

Editing a regex property filter that holds several values showed a yellow validation error reading **\`this.str.codePointAt is not a function\`**.

A \`visited_page\` filter ORs its regex values, so its \`value\` is an array. The regex validator called \`RE2JS.compile(value)\`, which expects a single string. Given an array, RE2JS builds a string iterator over it and \`array.codePointAt\` does not exist, so it threw, and the raw internal error was shown to the user.

This surfaced when editing an AI-drafted Replay Vision scanner (the drafter emits multi-value \`regex\` \`visited_page\` filters), but it affects any multi-value regex filter in the app. Pre-existing on master; not introduced by the drafter.

## Changes

- \`getRegexValidationError\` now normalizes the value to a list and compiles each pattern, returning the first that fails. A valid multi-value regex filter validates cleanly; an invalid one reports a real regex error instead of the internal \`codePointAt\` message.
- Exported \`getValidationError\` so the pure validation logic has a unit test.

## How did you test this code?

- `OperatorValueSelect.test.tsx` (new): a valid multi-value regex array validates without error; an array with one bad pattern reports a real error and never the \`codePointAt\` message; a single invalid regex still errors (no regression). 3 tests pass.
- TypeScript check and lint pass on the changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by editing an AI-drafted scanner's page filters. Written with Claude Code. No customer conversation, ticket, or log shaped this change.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*