### PR TITLE
refactor(security): validate destination hosts with the shared SSRF validator

### DIFF
--- a/posthog/models/integration/postgres.py
+++ b/posthog/models/integration/postgres.py
@@ -3,7 +3,7 @@
 from typing import ClassVar, Literal, NamedTuple
 
 from posthog.models.user import User
-from posthog.security.url_validation import resolve_and_validate_host
+from posthog.security.url_validation import validate_external_host
 
 from . import common, model
 
@@ -78,7 +78,7 @@ class PostgreSQLServerIntegration:
     ) -> model.Integration:
         host = common._return_non_empty_str_from_config(config, "host", friendly_name="Host", kind=cls.integration_kind)
         try:
-            resolve_and_validate_host(host)
+            validate_external_host(host)
         except ValueError:
             raise common.IntegrationError(f"Provided host '{host}' is not valid")
 

--- a/posthog/models/integration/postgres.py
+++ b/posthog/models/integration/postgres.py
@@ -80,7 +80,12 @@ class PostgreSQLServerIntegration:
         try:
             validate_external_host(host)
         except ValueError:
-            raise common.IntegrationError(f"Provided host '{host}' is not valid")
+            # One message for every reason. The value can be a pasted connection string
+            # carrying a password, so it is not echoed, and reporting whether a host resolved
+            # internally would answer that question for someone probing the network.
+            raise common.IntegrationError(
+                "Invalid host. Enter a hostname or IP address without credentials, scheme, or path."
+            )
 
         port = config.get("port", None)
         try:

--- a/posthog/models/integration/postgres.py
+++ b/posthog/models/integration/postgres.py
@@ -6,7 +6,7 @@ from posthog.models.user import User
 from posthog.security.url_validation import (
     INVALID_HOST_MESSAGE,
     UNREACHABLE_HOST_MESSAGE,
-    HostShapeError,
+    ShapeError,
     validate_external_host,
 )
 
@@ -84,7 +84,7 @@ class PostgreSQLServerIntegration:
         host = common._return_non_empty_str_from_config(config, "host", friendly_name="Host", kind=cls.integration_kind)
         try:
             validate_external_host(host)
-        except HostShapeError:
+        except ShapeError:
             # Decided from the form alone, so it names what to fix without saying anything
             # about our network. The value itself is never echoed: it can be a pasted
             # connection string carrying a password.

--- a/posthog/models/integration/postgres.py
+++ b/posthog/models/integration/postgres.py
@@ -3,7 +3,12 @@
 from typing import ClassVar, Literal, NamedTuple
 
 from posthog.models.user import User
-from posthog.security.url_validation import validate_external_host
+from posthog.security.url_validation import (
+    INVALID_HOST_MESSAGE,
+    UNREACHABLE_HOST_MESSAGE,
+    HostShapeError,
+    validate_external_host,
+)
 
 from . import common, model
 
@@ -79,13 +84,15 @@ class PostgreSQLServerIntegration:
         host = common._return_non_empty_str_from_config(config, "host", friendly_name="Host", kind=cls.integration_kind)
         try:
             validate_external_host(host)
+        except HostShapeError:
+            # Decided from the form alone, so it names what to fix without saying anything
+            # about our network. The value itself is never echoed: it can be a pasted
+            # connection string carrying a password.
+            raise common.IntegrationError(INVALID_HOST_MESSAGE)
         except ValueError:
-            # One message for every reason. The value can be a pasted connection string
-            # carrying a password, so it is not echoed, and reporting whether a host resolved
-            # internally would answer that question for someone probing the network.
-            raise common.IntegrationError(
-                "Invalid host. Enter a hostname or IP address without credentials, scheme, or path."
-            )
+            # One message for a host that does not resolve and for one that resolves inside
+            # our network, so the error cannot be used to map it.
+            raise common.IntegrationError(UNREACHABLE_HOST_MESSAGE)
 
         port = config.get("port", None)
         try:

--- a/posthog/models/integration/postgres.py
+++ b/posthog/models/integration/postgres.py
@@ -85,13 +85,8 @@ class PostgreSQLServerIntegration:
         try:
             validate_external_host(host)
         except ShapeError:
-            # Decided from the form alone, so it names what to fix without saying anything
-            # about our network. The value itself is never echoed: it can be a pasted
-            # connection string carrying a password.
             raise common.IntegrationError(INVALID_HOST_MESSAGE)
         except ValueError:
-            # One message for a host that does not resolve and for one that resolves inside
-            # our network, so the error cannot be used to map it.
             raise common.IntegrationError(UNREACHABLE_HOST_MESSAGE)
 
         port = config.get("port", None)

--- a/posthog/security/test/test_url_validation.py
+++ b/posthog/security/test/test_url_validation.py
@@ -225,6 +225,26 @@ class TestUrlValidation:
         with pytest.raises(ValueError):
             validate(value)
 
+    @pytest.mark.parametrize(
+        "host, usable",
+        [
+            ("db.example.com", True),
+            ("8.8.8.8", True),
+            ("2001:db8::1", True),  # a bare IPv6 literal is a host, and its colons are not a path
+            ("db.example.com.", True),  # the root dot of an absolute FQDN
+            ("db.acme.com:5432", False),
+            ("user@db.acme.com", False),
+            ("http://db.acme.com", False),
+        ],
+    )
+    def test_host_field_takes_a_hostname_or_ip_only(self, enforce_destination_validation, monkeypatch, host, usable):
+        monkeypatch.setattr(uv, "resolve_host_ips", lambda _host: {ipaddress.ip_address("93.184.216.34")})
+        if usable:
+            uv.validate_external_host(host)
+        else:
+            with pytest.raises(ValueError, match="hostname or IP address"):
+                uv.validate_external_host(host)
+
     @pytest.mark.parametrize("value", [None, 123])
     def test_non_string_target_is_a_client_error(self, value):
         # A non-string has to read as bad input rather than surface as a TypeError

--- a/posthog/security/test/test_url_validation.py
+++ b/posthog/security/test/test_url_validation.py
@@ -13,6 +13,13 @@ def force_prod(monkeypatch):
     monkeypatch.setattr(uv, "is_dev_mode", lambda: False)
 
 
+@pytest.fixture
+def enforce_destination_validation(settings):
+    # By default, we bypass URL and host validation in tests. We want to test the validation
+    # logic, so we opt back in.
+    settings.FORCE_URL_VALIDATION = True
+
+
 class TestUrlValidation:
     def test_resolve_host_ips_uses_bounded_lifetime(self, monkeypatch):
         class Answers:
@@ -117,6 +124,114 @@ class TestUrlValidation:
         settings.FORCE_URL_VALIDATION = False
         ok, err = uv.is_url_allowed("http://localhost")
         assert ok and err is None
+
+    @pytest.mark.parametrize(
+        "resolved_ips, expected_error",
+        [
+            ({ipaddress.ip_address("10.0.0.1")}, "internal IP"),
+            (set(), "Could not resolve"),
+            ({ipaddress.ip_address("93.184.216.34")}, None),
+        ],
+    )
+    def test_validate_external_host_enforced(
+        self, monkeypatch, enforce_destination_validation, resolved_ips, expected_error
+    ):
+        # This path resolves and judges IPs itself rather than calling is_url_allowed, so the
+        # cases above do not cover it. A host that resolves to no IPs is rejected, because
+        # there is then nothing to judge it by.
+        monkeypatch.setattr(uv, "resolve_host_ips", lambda host: resolved_ips)
+        if expected_error is None:
+            uv.validate_external_host("db.example.com")
+        else:
+            with pytest.raises(ValueError, match=expected_error):
+                uv.validate_external_host("db.example.com")
+
+    @pytest.mark.parametrize(
+        "url, resolved_ip, should_raise",
+        [
+            ("http://127.0.0.1", None, True),
+            ("https://example.com", "93.184.216.34", False),
+        ],
+    )
+    def test_validate_external_url_enforced(
+        self, monkeypatch, enforce_destination_validation, url, resolved_ip, should_raise
+    ):
+        # This path takes its rules from is_url_allowed, so what is under test is the
+        # translation of its verdict: a blocked one has to raise, an allowed one has to return.
+        if resolved_ip is not None:
+            monkeypatch.setattr(uv, "resolve_host_ips", lambda host: {ipaddress.ip_address(resolved_ip)})
+        if should_raise:
+            with pytest.raises(ValueError):
+                uv.validate_external_url(url)
+        else:
+            uv.validate_external_url(url)
+
+    @pytest.mark.parametrize(
+        "dev_mode, test_mode, force, bypassed",
+        [
+            (True, False, False, True),  # local dev
+            (False, True, False, True),  # in tests
+            (False, True, True, False),  # override using FORCE_URL_VALIDATION
+            (False, False, False, False),  # production
+        ],
+    )
+    def test_validate_external_url_and_host_bypass_validation_only_in_dev_and_test(
+        self, monkeypatch, settings, dev_mode, test_mode, force, bypassed
+    ):
+        monkeypatch.setattr(uv, "is_dev_mode", lambda: dev_mode)
+        settings.TEST = test_mode
+        settings.FORCE_URL_VALIDATION = force
+
+        if bypassed:
+            uv.validate_external_host("10.0.0.1")
+            uv.validate_external_url("http://localhost:9000")
+        else:
+            with pytest.raises(ValueError):
+                uv.validate_external_host("10.0.0.1")
+            with pytest.raises(ValueError):
+                uv.validate_external_url("http://localhost:9000")
+
+    @pytest.mark.parametrize(
+        "host, expected_reason",
+        [
+            ("db.corp", "Internal domain pattern blocked"),  # the suffix loop
+            ("metadata.google.internal", "Local/metadata host"),  # exact match, a separate branch
+            ("DB.CORP", "Internal domain pattern blocked"),  # matching is case sensitive
+            ("db.corp.", "Internal domain pattern blocked"),  # a root dot must not hide a suffix
+            ("localhost.", "Local/Loopback host not allowed"),  # nor an exact match
+        ],
+    )
+    def test_host_and_url_paths_agree_on_internal_names(self, enforce_destination_validation, host, expected_reason):
+        with pytest.raises(ValueError, match=expected_reason):
+            uv.validate_external_host(host)
+        allowed, reason = uv.is_url_allowed(f"https://{host}")
+        assert not allowed
+        assert expected_reason in (reason or "")
+
+    @pytest.mark.parametrize(
+        "validate, value",
+        [
+            (uv.validate_external_url, "not-a-url"),
+            (uv.validate_external_url, "javascript:alert(1)"),
+            (uv.validate_external_url, "ftp://internal"),
+            (uv.validate_external_url, "https://"),
+            (uv.validate_external_host, ""),
+            (uv.validate_external_host, "   "),
+        ],
+    )
+    def test_malformed_target_is_rejected_even_where_validation_is_bypassed(self, validate, value):
+        # No enforce_destination_validation here on purpose; the form of a target does not
+        # depend on the environment.
+        with pytest.raises(ValueError):
+            validate(value)
+
+    @pytest.mark.parametrize("value", [None, 123])
+    def test_non_string_target_is_a_client_error(self, value):
+        # A non-string has to read as bad input rather than surface as a TypeError
+        with pytest.raises(ValueError):
+            uv.validate_external_host(value)
+        with pytest.raises(ValueError):
+            uv.validate_external_url(value)
 
     @pytest.mark.parametrize(
         "resolved_ip",

--- a/posthog/security/test/test_url_validation.py
+++ b/posthog/security/test/test_url_validation.py
@@ -229,7 +229,8 @@ class TestUrlValidation:
         [
             ("db.corp", "Internal domain pattern blocked"),  # the suffix loop
             ("metadata.google.internal", "Local/metadata host"),  # exact match, a separate branch
-            ("DB.CORP", "Internal domain pattern blocked"),  # matching is case sensitive
+            # The suffix match is case sensitive, and canonicalization lowercases first.
+            ("DB.CORP", "Internal domain pattern blocked"),
             ("db.corp.", "Internal domain pattern blocked"),  # a root dot must not hide a suffix
             ("localhost.", "Local/Loopback host not allowed"),  # nor an exact match
             # The whole of 127.0.0.0/8 is loopback, not just 127.0.0.1. Caught by parsing the

--- a/posthog/security/test/test_url_validation.py
+++ b/posthog/security/test/test_url_validation.py
@@ -116,8 +116,6 @@ class TestUrlValidation:
         "url",
         [
             "javascript:alert(1)",
-            # urlparse reads no scheme at all here, which used to end the reason at a colon and
-            # tell the reader nothing.
             "not-a-url",
         ],
     )

--- a/posthog/security/test/test_url_validation.py
+++ b/posthog/security/test/test_url_validation.py
@@ -235,6 +235,10 @@ class TestUrlValidation:
             # The whole of 127.0.0.0/8 is loopback, not just 127.0.0.1. Caught by parsing the
             # address, so no DNS lookup happens and every long form is caught the same way.
             ("127.0.0.2", "Private IP address not allowed"),
+            # IDNA maps fullwidth characters onto ASCII ones, so this is the resolver's
+            # "evil.corp". The name checks have to see the form the resolver will query.
+            ("ｅｖｉｌ．ｃｏｒｐ", "Internal domain pattern blocked"),
+            ("ｌｏｃａｌｈｏｓｔ", "Local/Loopback host not allowed"),
         ],
     )
     def test_host_and_url_paths_agree_on_internal_names(self, enforce_destination_validation, host, expected_reason):

--- a/posthog/security/test/test_url_validation.py
+++ b/posthog/security/test/test_url_validation.py
@@ -36,6 +36,27 @@ class TestUrlValidation:
 
         assert uv.resolve_host_ips("example.com") == {ipaddress.ip_address("93.184.216.34")}
 
+    def test_resolve_host_ips_resolves_an_idn_host_but_not_a_url(self, monkeypatch):
+        # Every other test replaces resolve_host_ips itself, so nothing else runs a real host
+        # string through its shape gate. The gate has to admit an internationalized name, whose
+        # punycode form is a hostname, while still keeping a URL away from the resolver.
+        queried: list[str] = []
+
+        class Answers:
+            def addresses(self):
+                return iter(["93.184.216.34"])
+
+        class Resolver:
+            def resolve_name(self, host, *, lifetime):
+                queried.append(host)
+                return Answers()
+
+        monkeypatch.setattr(uv.dns.resolver, "Resolver", Resolver)
+
+        assert uv.resolve_host_ips("münchen.de") == {ipaddress.ip_address("93.184.216.34")}
+        assert uv.resolve_host_ips("postgresql://db.example.com:5432/analytics") == set()
+        assert queried == ["münchen.de"]
+
     def test_resolve_url_hosts_ips_deduplicates_hosts(self, monkeypatch):
         def fake_resolve_hosts_ips(hosts):
             assert hosts == {"shared.example.com"}
@@ -91,9 +112,19 @@ class TestUrlValidation:
 
         assert uv.resolve_hosts_ips({"busy.example.com"}) == {"busy.example.com": set()}
 
-    def test_is_url_allowed_disallowed_scheme(self):
-        ok, err = uv.is_url_allowed("javascript:alert(1)")
-        assert not ok and "scheme" in (err or "")
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "javascript:alert(1)",
+            # urlparse reads no scheme at all here, which used to end the reason at a colon and
+            # tell the reader nothing.
+            "not-a-url",
+        ],
+    )
+    def test_is_url_allowed_rejects_anything_that_is_not_http(self, url):
+        ok, err = uv.is_url_allowed(url)
+        assert not ok
+        assert "must start with http" in (err or "")
 
     def test_is_url_allowed_localhost(self):
         ok, err = uv.is_url_allowed("http://localhost")

--- a/posthog/security/test/test_url_validation.py
+++ b/posthog/security/test/test_url_validation.py
@@ -128,8 +128,10 @@ class TestUrlValidation:
     @pytest.mark.parametrize(
         "resolved_ips, expected_error",
         [
-            ({ipaddress.ip_address("10.0.0.1")}, "internal IP"),
-            (set(), "Could not resolve"),
+            # An internal IP and a host that does not resolve report the same thing on purpose,
+            # so the error cannot be used to find which addresses exist inside our network.
+            ({ipaddress.ip_address("10.0.0.1")}, "does not resolve to a valid IP address"),
+            (set(), "does not resolve to a valid IP address"),
             ({ipaddress.ip_address("93.184.216.34")}, None),
         ],
     )
@@ -199,6 +201,9 @@ class TestUrlValidation:
             ("DB.CORP", "Internal domain pattern blocked"),  # matching is case sensitive
             ("db.corp.", "Internal domain pattern blocked"),  # a root dot must not hide a suffix
             ("localhost.", "Local/Loopback host not allowed"),  # nor an exact match
+            # The whole of 127.0.0.0/8 is loopback, not just 127.0.0.1. Caught by parsing the
+            # address, so no DNS lookup happens and every long form is caught the same way.
+            ("127.0.0.2", "Private IP address not allowed"),
         ],
     )
     def test_host_and_url_paths_agree_on_internal_names(self, enforce_destination_validation, host, expected_reason):
@@ -230,7 +235,10 @@ class TestUrlValidation:
         [
             ("db.example.com", True),
             ("8.8.8.8", True),
-            ("2001:db8::1", True),  # a bare IPv6 literal is a host, and its colons are not a path
+            # A bare IPv6 literal is a host, and its colons are not a path. It has to be a
+            # globally routable one, because the name check rejects every internal address.
+            ("2606:4700:4700::1111", True),
+            ("10.example.com", True),  # a name that starts like a private range is still a name
             ("db.example.com.", True),  # the root dot of an absolute FQDN
             ("db.acme.com:5432", False),
             ("user@db.acme.com", False),

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -64,6 +64,12 @@ INTERNAL_DOMAIN_PATTERNS = (
 
 def resolve_host_ips(host: str) -> ResolvedIPs:
     """Resolve a hostname to its IP addresses."""
+    # Resolving a value that is not a host would put it in the warning below, and dnspython
+    # repeats the queried name in its error text, so both fields would carry whatever the
+    # caller passed. Callers reject this shape first; this keeps a new one from leaking.
+    if _host_shape_error(host) is not None:
+        return set()
+
     try:
         return {ipaddress.ip_address(host)}
     except ValueError:
@@ -172,6 +178,36 @@ def _is_private_ip_literal(host: str) -> bool:
         or host.startswith("172.30.")
         or host.startswith("172.31.")
     )
+
+
+# Labels joined by dots, with an optional root dot. Underscores are not valid in a hostname
+# under RFC 1123, but they resolve in practice, so the pattern keeps them: the job here is to
+# reject the parts of a URL, not to enforce the RFC.
+_HOSTNAME_LABEL = r"[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?"
+_BARE_HOSTNAME = re.compile(rf"{_HOSTNAME_LABEL}(?:\.{_HOSTNAME_LABEL})*\.?", re.ASCII)
+_MAX_HOSTNAME_LENGTH = 253
+
+
+def _host_shape_error(host: object) -> str | None:
+    """Reason to reject a host on its form alone, or None when the form is usable.
+
+    A host field takes a hostname or an IP address. Customers paste whole connection strings
+    into it, so anything carrying credentials, a scheme, a port or a path is rejected before
+    it reaches DNS or a log line. Takes ``object`` because callers read the value out of
+    untyped config.
+    """
+    if not isinstance(host, str):
+        return "Host must be a string"
+    if not host.strip():
+        return "Host is empty"
+    try:
+        ipaddress.ip_address(host)
+        return None
+    except ValueError:
+        pass
+    if len(host) > _MAX_HOSTNAME_LENGTH or not _BARE_HOSTNAME.fullmatch(host):
+        return "Host must be a hostname or IP address"
+    return None
 
 
 def _url_shape_error(raw_url: str) -> str | None:
@@ -464,10 +500,9 @@ def validate_external_host(host: str) -> None:
     cannot drift apart. Bypassed in local dev and in tests, unless the
     ``FORCE_URL_VALIDATION`` setting is true.
     """
-    if not isinstance(host, str):
-        raise ValueError("Host must be a string")
-    if not host.strip():
-        raise ValueError("Host is empty")
+    shape_reason = _host_shape_error(host)
+    if shape_reason is not None:
+        raise ValueError(shape_reason)
 
     if _dev_bypass_enabled() or _test_bypass_enabled():
         return

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -474,10 +474,10 @@ def validate_external_host(host: str) -> None:
 
     name_reason = _blocked_host_reason(host)
     if name_reason is not None:
-        raise ValueError(f"{name_reason}: {host}")
+        raise ValueError(name_reason)
 
     ips = resolve_host_ips(host)
     if not ips:
-        raise ValueError(f"Could not resolve host: {host}")
+        raise ValueError("Could not resolve host")
     if any(_is_internal_ip(ip) for ip in ips):
-        raise ValueError(f"Host resolves to an internal IP: {host}")
+        raise ValueError("Host resolves to an internal IP")

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -1,5 +1,4 @@
 import re
-import socket
 import ipaddress
 import urllib.parse as urlparse
 from collections.abc import Iterable, Mapping
@@ -175,6 +174,45 @@ def _is_private_ip_literal(host: str) -> bool:
     )
 
 
+def _url_shape_error(raw_url: str) -> str | None:
+    """Reason to reject a URL on its form alone, or None when the form is usable."""
+    if has_authority_bypass_chars(raw_url):
+        return "Invalid URL: ambiguous authority"
+    try:
+        parsed = urlparse.urlparse(raw_url)
+    except Exception:
+        return "Invalid URL"
+    if parsed.scheme not in {"http", "https"} or parsed.scheme in DISALLOWED_SCHEMES:
+        return f"Disallowed scheme: {parsed.scheme}"
+    if not parsed.netloc:
+        return "Missing host"
+    return None
+
+
+def _blocked_host_reason(host: str) -> str | None:
+    """Reason to reject a host on its name alone, or None when the name is acceptable.
+
+    These checks run before resolution, so they also catch a name that resolves to a public
+    IP: split-horizon DNS, and a registered domain shaped like an internal one.
+
+    Normalizes the host itself rather than trusting the caller to. Matching below is exact
+    or by suffix, so an un-normalized host fails these checks open.
+    """
+    # An absolute FQDN carries the DNS root dot ("db.corp."), which every client accepts and
+    # resolves to the same target. Without this, suffix and exact matching both miss it.
+    host = host.lower().rstrip(".")
+    if host in METADATA_HOSTS:
+        return "Local/metadata host"
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return "Local/Loopback host not allowed"
+    for pattern in INTERNAL_DOMAIN_PATTERNS:
+        if host.endswith(pattern):
+            return f"Internal domain pattern blocked: {pattern}"
+    if _is_private_ip_literal(host):
+        return "Private IP address not allowed"
+    return None
+
+
 def has_ambiguous_authority(url: str) -> bool:
     """
     Reject a URL whose authority any client could read differently than ``urlparse`` does.
@@ -311,13 +349,11 @@ def resolve_url_hosts_ips(raw_urls: Iterable[str]) -> dict[str, ResolvedIPs]:
             host = (parsed_url.hostname or "").lower()
         except Exception:
             continue
+        # Skip what the validator will reject anyway. This shares the rule rather than restating it.
         if (
             parsed_url.scheme not in {"http", "https"}
             or not parsed_url.netloc
-            or host in METADATA_HOSTS
-            or host in {"localhost", "127.0.0.1", "::1"}
-            or any(host.endswith(pattern) for pattern in INTERNAL_DOMAIN_PATTERNS)
-            or _is_private_ip_literal(host)
+            or _blocked_host_reason(host) is not None
         ):
             continue
         hosts.add(host)
@@ -366,30 +402,14 @@ def _validate_url_with_ips(
         logger.warning("url_validation.blocked", reason=reason, **log_kwargs)
         return PinnedUrlVerdict(allowed=False, reason=reason, pinned_ips=empty)
 
-    if has_authority_bypass_chars(raw_url):
-        return _blocked("Invalid URL: ambiguous authority")
-    try:
-        u = urlparse.urlparse(raw_url)
-    except Exception:
-        return _blocked("Invalid URL")
-    if u.scheme not in {"http", "https"} or u.scheme in DISALLOWED_SCHEMES:
-        return _blocked("Disallowed scheme", scheme=u.scheme)
-    if not u.netloc:
-        return _blocked("Missing host")
+    shape_reason = _url_shape_error(raw_url)
+    if shape_reason is not None:
+        return _blocked(shape_reason)
+    u = urlparse.urlparse(raw_url)
     host = (u.hostname or "").lower()
-    if host in METADATA_HOSTS:
-        return _blocked("Local/metadata host", host=host)
-    if host in {"localhost", "127.0.0.1", "::1"}:
-        return _blocked("Local/Loopback host not allowed", host=host)
-
-    # Check internal domain patterns
-    for pattern in INTERNAL_DOMAIN_PATTERNS:
-        if host.endswith(pattern):
-            return _blocked(f"Internal domain pattern blocked: {pattern}", host=host, pattern=pattern)
-
-    # Quick check for private IP literals (avoids DNS lookup)
-    if _is_private_ip_literal(host):
-        return _blocked("Private IP address not allowed", host=host)
+    name_reason = _blocked_host_reason(host)
+    if name_reason is not None:
+        return _blocked(name_reason, host=host)
 
     ips = resolve_host_ips(host) if resolved_ips_by_host is None else resolved_ips_by_host.get(host, empty)
     if not ips:
@@ -410,78 +430,54 @@ def should_block_url(u: str) -> bool:
     return not allowed
 
 
-# The destination-host check below guards a batch export or warehouse-import target that a
-# customer supplies and our servers later connect to. It duplicates the concern the rest of
-# this module already covers, with its own ranges and its own resolver, and it is kept
-# unchanged here only so the move carries no behavior change. Unifying it with
-# `is_url_allowed` changes what we reject, so that lands separately.
-
-INTERNAL_NETWORKS = (
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("0.0.0.0/8"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
-    ipaddress.ip_network("fe80::/10"),
-)
+def _test_bypass_enabled() -> bool:
+    return settings.TEST and not settings.FORCE_URL_VALIDATION
 
 
-def is_ip_internal(ip: str) -> bool:
-    """Check if IP belongs to an internal network."""
-    try:
-        addr = ipaddress.ip_address(ip)
-    except ValueError:
-        raise ValueError("Could not parse IP")
+def validate_external_url(url: str) -> None:
+    """Raise ``ValueError`` unless ``url`` is safe for our servers to reach.
 
-    if any(addr in network for network in INTERNAL_NETWORKS):
-        return True
-    return False
+    SSRF guard for a stored URL a destination later fetches (an S3-compatible endpoint,
+    a webhook). Bypassed in local dev and in tests, unless the
+    ``FORCE_URL_VALIDATION`` setting is true.
+    """
 
+    if not isinstance(url, str):
+        raise ValueError("URL must be a string")
+    shape_reason = _url_shape_error(url)
+    if shape_reason is not None:
+        raise ValueError(shape_reason)
 
-def resolve_and_validate_url(url: str) -> None:
-    """Ensure provided url point to a non-internal IP."""
-    try:
-        parsed = urlparse.urlparse(url)
-    except Exception as e:
-        raise ValueError(f"Invalid URL'{url}': {e}") from e
-
-    host = parsed.hostname
-    if not host:
-        raise ValueError("URL has no hostname")
-
-    resolve_and_validate_host(host)
-
-
-def is_local_dev_or_test() -> bool:
-    return settings.DEBUG or settings.TEST
-
-
-def resolve_and_validate_host(host: str) -> None:
-    """Ensure provided host resolves to a non-internal IP."""
-    if host == "localhost" and is_local_dev_or_test():
+    if _dev_bypass_enabled() or _test_bypass_enabled():
         return
 
-    # Host may already be an IP literal
-    try:
-        if is_ip_internal(host) and not is_local_dev_or_test():
-            raise ValueError("Host resolved to internal IP")
+    allowed, reason = is_url_allowed(url)
+    if not allowed:
+        raise ValueError(reason or "URL is not allowed")
+
+
+def validate_external_host(host: str) -> None:
+    """Raise ``ValueError`` unless ``host`` is safe for our servers to reach.
+
+    SSRF guard for a destination that stores a bare host rather than a URL (Postgres,
+    Redshift). Applies the same name and IP rules as ``validate_external_url``, so the two
+    cannot drift apart. Bypassed in local dev and in tests, unless the
+    ``FORCE_URL_VALIDATION`` setting is true.
+    """
+    if not isinstance(host, str):
+        raise ValueError("Host must be a string")
+    if not host.strip():
+        raise ValueError("Host is empty")
+
+    if _dev_bypass_enabled() or _test_bypass_enabled():
         return
-    except ValueError:
-        # Not an IP literal, requires DNS
-        pass
 
-    try:
-        # getaddrinfo supports both ipv4 and ipv6
-        results = socket.getaddrinfo(host, None)
-    except socket.gaierror as e:
-        raise ValueError(f"Could not resolve '{host}': {e}") from e
+    name_reason = _blocked_host_reason(host)
+    if name_reason is not None:
+        raise ValueError(f"{name_reason}: {host}")
 
-    # Keeps only unique ips from the result tuple
-    resolved_ips = {str(r[4][0]) for r in results}
-
-    for ip in resolved_ips:
-        if is_ip_internal(ip) and not is_local_dev_or_test():
-            raise ValueError("Host resolved to internal IP")
+    ips = resolve_host_ips(host)
+    if not ips:
+        raise ValueError(f"Could not resolve host: {host}")
+    if any(_is_internal_ip(ip) for ip in ips):
+        raise ValueError(f"Host resolves to an internal IP: {host}")

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -530,9 +530,9 @@ class ShapeError(ValueError):
     """
 
 
-# Both destination forms show these, so they live here rather than in either one. A shape
-# error is safe to describe; every other reason shares one message, so an error cannot be used
-# to find which addresses exist inside our network. Neither echoes the value it rejected.
+# A shape error is safe to describe. Every other reason shares one message, so an error cannot
+# be used to find which addresses exist inside our network. Neither echoes the value it
+# rejected.
 INVALID_HOST_MESSAGE = "Invalid host. Enter a hostname or IP address without credentials, scheme, or path."
 UNREACHABLE_HOST_MESSAGE = (
     "Could not reach this host. Check that the hostname is correct and reachable from the internet."

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -35,9 +35,6 @@ _dns_resolution_executor = ThreadPoolExecutor(
 )
 _dns_resolution_capacity = BoundedSemaphore(DNS_RESOLUTION_MAX_WORKERS)
 
-# Schemes that should never be allowed for external URLs
-DISALLOWED_SCHEMES = {"file", "ftp", "gopher", "ws", "wss", "data", "javascript"}
-
 # Cloud metadata service hosts that should be blocked to prevent SSRF
 METADATA_HOSTS = {"169.254.169.254", "metadata.google.internal"}
 
@@ -168,34 +165,30 @@ def _is_internal_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
 
 
 def _is_internal_ip_literal(host: str) -> bool:
-    """True when the host is written as an IP address we must not reach, so DNS is not needed.
-
-    Parses the address rather than matching text prefixes. A prefix match misses the whole of
-    127.0.0.0/8 except 127.0.0.1, and every long form of an IPv6 address, and it blocks an
-    ordinary name such as 10.example.com because the text happens to start with "10.".
-    """
+    """True when the host is written as an IP address we must not reach, so DNS is not needed."""
     ip = _parse_ip_literal(host)
     return ip is not None and _is_internal_ip(ip)
 
 
-# Labels joined by dots, with an optional root dot. Underscores are not valid in a hostname
-# under RFC 1123, but they resolve in practice, so the pattern keeps them: the job here is to
-# reject the parts of a URL, not to enforce the RFC.
+# Labels joined by dots, with an optional root dot. The character class is ASCII on purpose,
+# because _host_shape_error converts an internationalized name to its punycode form before it
+# matches here. Underscores are not valid in a hostname under RFC 1123, but they resolve in
+# practice, so the pattern keeps them: the job here is to reject the parts of a URL, not to
+# enforce the RFC.
 _HOSTNAME_LABEL = r"[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?"
-_BARE_HOSTNAME = re.compile(rf"{_HOSTNAME_LABEL}(?:\.{_HOSTNAME_LABEL})*\.?", re.ASCII)
+_BARE_HOSTNAME = re.compile(rf"{_HOSTNAME_LABEL}(?:\.{_HOSTNAME_LABEL})*\.?")
 _MAX_HOSTNAME_LENGTH = 253
+
+
+def _matches_hostname_pattern(host: str) -> bool:
+    return len(host) <= _MAX_HOSTNAME_LENGTH and _BARE_HOSTNAME.fullmatch(host) is not None
 
 
 def _canonicalize_host(host: str) -> str:
     """The one form every host check runs on.
 
-    Case and the DNS root dot do not change which server a client reaches, so they are
-    normalized once and each check below sees a single form. The root dot has to go, because
-    an absolute FQDN carries it ("db.corp.") and the block list matches exactly or by suffix,
-    so both would otherwise miss it.
-
-    Nothing else is repaired: a host is validated and then stored and connected to by the
-    caller, so whitespace or the parts of a URL have to be rejected rather than cleaned up.
+    We strip any trailing "." because an absolute FQDN carries the DNS root dot ("db.corp.").
+    The block list matches exactly or by suffix, so it would otherwise miss that form.
     """
     return host.lower().rstrip(".")
 
@@ -214,7 +207,17 @@ def _host_shape_error(host: str) -> str | None:
         return "Host is empty"
     if _parse_ip_literal(host) is not None:
         return None
-    if len(host) > _MAX_HOSTNAME_LENGTH or not _BARE_HOSTNAME.fullmatch(host):
+    if _matches_hostname_pattern(host):
+        return None
+
+    # An internationalized name is a hostname, and the pattern is ASCII, so judge its punycode
+    # form. A connection string does not slip through: the codec returns it unchanged, and the
+    # pattern rejects it either way.
+    try:
+        encoded = host.encode("idna").decode("ascii")
+    except ValueError:
+        return "Host must be a hostname or IP address"
+    if not _matches_hostname_pattern(encoded):
         return "Host must be a hostname or IP address"
     return None
 
@@ -227,8 +230,10 @@ def _url_shape_error(raw_url: str) -> str | None:
         parsed = urlparse.urlparse(raw_url)
     except Exception:
         return "Invalid URL"
-    if parsed.scheme not in {"http", "https"} or parsed.scheme in DISALLOWED_SCHEMES:
-        return f"Disallowed scheme: {parsed.scheme}"
+    # The scheme stays out of the message. It is caller-supplied text, and it is empty for
+    # anything urlparse does not read as a URL, which produced a reason ending in a colon.
+    if parsed.scheme not in {"http", "https"}:
+        return "URL must start with http:// or https://"
     if not parsed.netloc:
         return "Missing host"
     return None

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -224,6 +224,20 @@ def _host_shape_error(host: str) -> str | None:
     return None
 
 
+def _url_log_fields(raw_url: str) -> dict[str, str]:
+    """Discrete fields for a blocked-URL log line, so a query can group by them.
+
+    The reason string carries no scheme, and an investigation starts from the scheme more
+    often than from anything else. Neither field can hold a credential: ``hostname`` excludes
+    the userinfo, and a scheme is a short token before the colon.
+    """
+    try:
+        parsed = urlparse.urlsplit(raw_url)
+    except ValueError:
+        return {}
+    return {"scheme": parsed.scheme, "host": parsed.hostname or ""}
+
+
 def _url_shape_error(raw_url: str) -> str | None:
     """Reason to reject a URL on its form alone, or None when the form is usable."""
     if has_authority_bypass_chars(raw_url):
@@ -455,7 +469,7 @@ def _validate_url_with_ips(
 
     shape_reason = _url_shape_error(raw_url)
     if shape_reason is not None:
-        return _blocked(shape_reason)
+        return _blocked(shape_reason, **_url_log_fields(raw_url))
     u = urlparse.urlparse(raw_url)
     host = _canonicalize_host(u.hostname or "")
     name_reason = _blocked_host_reason(host)
@@ -508,6 +522,21 @@ def validate_external_url(url: str) -> None:
         raise ValueError(reason or "URL is not allowed")
 
 
+class HostShapeError(ValueError):
+    """The value cannot be a host, judged from its form alone before any lookup.
+
+    Separate from the other reasons because it is safe to report in detail: nothing about our
+    network went into the decision, and the user has something they can fix.
+    """
+
+
+# Both destination forms show these, so they live here rather than in either one.
+INVALID_HOST_MESSAGE = "Invalid host. Enter a hostname or IP address without credentials, scheme, or path."
+UNREACHABLE_HOST_MESSAGE = (
+    "Could not reach this host. Check that the hostname is correct and reachable from the internet."
+)
+
+
 def validate_external_host(host: str) -> None:
     """Raise ``ValueError`` unless ``host`` is safe for our servers to reach.
 
@@ -519,10 +548,10 @@ def validate_external_host(host: str) -> None:
 
     # The host could come from untyped config, so check its type first
     if not isinstance(host, str):
-        raise ValueError("Host must be a string")
+        raise HostShapeError("Host must be a string")
     shape_reason = _host_shape_error(host)
     if shape_reason is not None:
-        raise ValueError(shape_reason)
+        raise HostShapeError(shape_reason)
     host = _canonicalize_host(host)
 
     if _dev_bypass_enabled() or _test_bypass_enabled():

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -197,7 +197,7 @@ def _canonicalize_host(host: str) -> str:
     """
     try:
         host = host.encode("idna").decode("ascii")
-    except (ValueError, UnicodeError):
+    except ValueError:  # UnicodeError, which the codec raises, subclasses this
         pass
     return host.lower().rstrip(".")
 
@@ -211,22 +211,15 @@ def _host_shape_error(host: str) -> str | None:
 
     An IP address is accepted first because an IPv6 literal carries colons and so can never
     match the hostname pattern. An IPv4 literal matches it either way.
+
+    Everything else is judged in canonical form, which is the form the checks below and the
+    resolver use. Judging a different form from theirs is what let a fullwidth name through.
     """
     if not host.strip():
         return "Host is empty"
     if _parse_ip_literal(host) is not None:
         return None
-    if _matches_hostname_pattern(host):
-        return None
-
-    # An internationalized name is a hostname, and the pattern is ASCII, so judge its punycode
-    # form. A connection string does not slip through: the codec returns it unchanged, and the
-    # pattern rejects it either way.
-    try:
-        encoded = host.encode("idna").decode("ascii")
-    except ValueError:
-        return "Host must be a hostname or IP address"
-    if not _matches_hostname_pattern(encoded):
+    if not _matches_hostname_pattern(_canonicalize_host(host)):
         return "Host must be a hostname or IP address"
     return None
 

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -186,10 +186,10 @@ def _canonicalize_host(host: str) -> str:
     We strip any trailing "." because an absolute FQDN carries the DNS root dot ("db.corp.").
     The block list matches exactly or by suffix, so it would otherwise miss that form.
 
-    An internationalized name becomes the punycode form the resolver queries, because IDNA
-    maps characters such as fullwidth ones onto ASCII: a name left raw clears the block list
-    and then resolves to the host it spells. A name the codec rejects comes back unchanged,
-    for the shape check to refuse.
+    An internationalized name becomes the punycode form the resolver queries. IDNA maps some
+    characters onto ASCII ones, so "ｅｖｉｌ．ｃｏｒｐ" and "evil.corp" reach the same server. The
+    block list would recognize only the second. A name the codec rejects comes back unchanged,
+    and the shape check refuses it.
     """
     try:
         host = host.encode("idna").decode("ascii")

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -189,7 +189,16 @@ def _canonicalize_host(host: str) -> str:
 
     We strip any trailing "." because an absolute FQDN carries the DNS root dot ("db.corp.").
     The block list matches exactly or by suffix, so it would otherwise miss that form.
+
+    An internationalized name becomes the punycode form the resolver queries. IDNA maps
+    several characters onto ASCII ones, so without this a host written in fullwidth
+    characters passes every name check and then resolves to the host those checks exist to
+    block. A name the codec rejects is returned unchanged, for the shape check to refuse.
     """
+    try:
+        host = host.encode("idna").decode("ascii")
+    except (ValueError, UnicodeError):
+        pass
     return host.lower().rstrip(".")
 
 

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -65,9 +65,8 @@ def resolve_host_ips(host: str) -> ResolvedIPs:
     if ip is not None:
         return {ip}
 
-    # Resolving a value that is not a host would put it in the warning below, and dnspython
-    # repeats the queried name in its error text, so both fields would carry whatever the
-    # caller passed. Callers reject this shape first; this keeps a new one from leaking.
+    # dnspython repeats the queried name in its error text, so a value that is not a host
+    # would reach both the message and the host field of the warning below.
     if _host_shape_error(host) is not None:
         return set()
 
@@ -135,8 +134,7 @@ _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 def _parse_ip_literal(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
     """Parse a host written as an IP address, or None when it is a name."""
 
-    # ``ipaddress.ip_address`` also takes an integer, where 123 becomes 0.0.0.123, so reject
-    # non-string values first
+    # ``ipaddress.ip_address`` also takes an integer, where 123 becomes 0.0.0.123.
     if not isinstance(host, str):
         raise TypeError("host must be a string")
     try:
@@ -170,11 +168,9 @@ def _is_internal_ip_literal(host: str) -> bool:
     return ip is not None and _is_internal_ip(ip)
 
 
-# Labels joined by dots, with an optional root dot. The character class is ASCII on purpose,
-# because _host_shape_error converts an internationalized name to its punycode form before it
-# matches here. Underscores are not valid in a hostname under RFC 1123, but they resolve in
-# practice, so the pattern keeps them: the job here is to reject the parts of a URL, not to
-# enforce the RFC.
+# Labels joined by dots, with an optional root dot. ASCII on purpose, because callers match
+# the punycode form. Underscores are not valid under RFC 1123 but resolve in practice, so the
+# pattern keeps them: the job is to reject the parts of a URL, not to enforce the RFC.
 _HOSTNAME_LABEL = r"[A-Za-z0-9_](?:[A-Za-z0-9_-]{0,61}[A-Za-z0-9_])?"
 _BARE_HOSTNAME = re.compile(rf"{_HOSTNAME_LABEL}(?:\.{_HOSTNAME_LABEL})*\.?")
 _MAX_HOSTNAME_LENGTH = 253
@@ -190,10 +186,10 @@ def _canonicalize_host(host: str) -> str:
     We strip any trailing "." because an absolute FQDN carries the DNS root dot ("db.corp.").
     The block list matches exactly or by suffix, so it would otherwise miss that form.
 
-    An internationalized name becomes the punycode form the resolver queries. IDNA maps
-    several characters onto ASCII ones, so without this a host written in fullwidth
-    characters passes every name check and then resolves to the host those checks exist to
-    block. A name the codec rejects is returned unchanged, for the shape check to refuse.
+    An internationalized name becomes the punycode form the resolver queries, because IDNA
+    maps characters such as fullwidth ones onto ASCII: a name left raw clears the block list
+    and then resolves to the host it spells. A name the codec rejects comes back unchanged,
+    for the shape check to refuse.
     """
     try:
         host = host.encode("idna").decode("ascii")
@@ -205,15 +201,12 @@ def _canonicalize_host(host: str) -> str:
 def _host_shape_error(host: str) -> str | None:
     """Reason to reject a host on its form alone, or None when the form is usable.
 
-    A host field takes a hostname or an IP address. Customers could, in theory, paste whole
-    connection strings into it, so anything carrying credentials, a scheme, a port or a path is
-    rejected before it reaches DNS or a log line.
+    A host field takes a hostname or an IP address, so a pasted connection string is rejected
+    before its credentials reach DNS or a log line.
 
-    An IP address is accepted first because an IPv6 literal carries colons and so can never
-    match the hostname pattern. An IPv4 literal matches it either way.
-
-    Everything else is judged in canonical form, which is the form the checks below and the
-    resolver use. Judging a different form from theirs is what let a fullwidth name through.
+    An IP address is accepted first, because an IPv6 literal carries colons and can never match
+    the hostname pattern. Everything else is judged in canonical form, the one the checks below
+    and the resolver use.
     """
     if not host.strip():
         return "Host is empty"
@@ -246,8 +239,8 @@ def _url_shape_error(raw_url: str) -> str | None:
         parsed = urlparse.urlparse(raw_url)
     except Exception:
         return "Invalid URL"
-    # The scheme stays out of the message. It is caller-supplied text, and it is empty for
-    # anything urlparse does not read as a URL, which produced a reason ending in a colon.
+    # The scheme stays out of the message: it is caller-supplied text, and it is empty for
+    # anything urlparse does not read as a URL.
     if parsed.scheme not in {"http", "https"}:
         return "URL must start with http:// or https://"
     if not parsed.netloc:
@@ -259,9 +252,8 @@ def _url_shape_error(raw_url: str) -> str | None:
 class BlockedName:
     """Why a host name is blocked, and which internal pattern matched it.
 
-    The pattern rides alongside the reason rather than only inside it, so a log query can
-    group by it. Deriving it again at the log site would mean a second copy of the matching,
-    which is the shape that produced the fullwidth bypass.
+    The pattern travels beside the reason so a log query can group by it. Deriving it again at
+    the log site would mean a second copy of the matching.
     """
 
     reason: str
@@ -274,9 +266,8 @@ def _blocked_host_name(host: str) -> BlockedName | None:
     These checks run before resolution, so they also catch a name that resolves to a public
     IP: split-horizon DNS, and a registered domain shaped like an internal one.
 
-    Takes a canonical host. Every caller passes one, and it canonicalizes again anyway,
-    because matching below is exact or by suffix: an un-normalized host would fail these
-    checks open, which is the one failure mode worth paying a duplicate call to avoid.
+    Canonicalizes again although every caller does. Matching below is exact or by suffix, so
+    an un-normalized host would fail it open.
     """
     host = _canonicalize_host(host)
     if host in METADATA_HOSTS:
@@ -534,13 +525,14 @@ def validate_external_url(url: str) -> None:
 class ShapeError(ValueError):
     """The value cannot be a host or a URL, judged from its form alone before any lookup.
 
-    Separate from the other reasons because it is safe to report in detail: nothing about our
-    network went into the decision, and the user has something they can fix. Everything else a
-    validator raises has to stay behind one neutral message.
+    Safe to report in detail, because nothing about our network went into the decision and the
+    user has something they can fix.
     """
 
 
-# Both destination forms show these, so they live here rather than in either one.
+# Both destination forms show these, so they live here rather than in either one. A shape
+# error is safe to describe; every other reason shares one message, so an error cannot be used
+# to find which addresses exist inside our network. Neither echoes the value it rejected.
 INVALID_HOST_MESSAGE = "Invalid host. Enter a hostname or IP address without credentials, scheme, or path."
 UNREACHABLE_HOST_MESSAGE = (
     "Could not reach this host. Check that the hostname is correct and reachable from the internet."

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -63,17 +63,16 @@ INTERNAL_DOMAIN_PATTERNS = (
 
 
 def resolve_host_ips(host: str) -> ResolvedIPs:
-    """Resolve a hostname to its IP addresses."""
+    """Resolve a canonical hostname to its IP addresses."""
+    ip = _parse_ip_literal(host)
+    if ip is not None:
+        return {ip}
+
     # Resolving a value that is not a host would put it in the warning below, and dnspython
     # repeats the queried name in its error text, so both fields would carry whatever the
     # caller passed. Callers reject this shape first; this keeps a new one from leaking.
     if _host_shape_error(host) is not None:
         return set()
-
-    try:
-        return {ipaddress.ip_address(host)}
-    except ValueError:
-        pass
 
     try:
         answers = dns.resolver.Resolver().resolve_name(host, lifetime=DNS_RESOLUTION_LIFETIME_SECONDS)
@@ -136,6 +135,19 @@ def resolve_hosts_ips(hosts: Iterable[str]) -> dict[str, ResolvedIPs]:
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 
 
+def _parse_ip_literal(host: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Parse a host written as an IP address, or None when it is a name."""
+
+    # ``ipaddress.ip_address`` also takes an integer, where 123 becomes 0.0.0.123, so reject
+    # non-string values first
+    if not isinstance(host, str):
+        raise TypeError("host must be a string")
+    try:
+        return ipaddress.ip_address(host)
+    except ValueError:
+        return None
+
+
 def _is_internal_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Check if an IP address is internal/private and should be blocked."""
     # An IPv4-mapped IPv6 address (::ffff:a.b.c.d) reaches the IPv4 host it embeds, and
@@ -155,29 +167,15 @@ def _is_internal_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     )
 
 
-def _is_private_ip_literal(host: str) -> bool:
-    """Quick check for RFC1918 and link-local IP literals (avoids DNS lookup)."""
-    return (
-        host.startswith("10.")
-        or host.startswith("192.168.")
-        or host.startswith("169.254.")
-        or host.startswith("172.16.")
-        or host.startswith("172.17.")
-        or host.startswith("172.18.")
-        or host.startswith("172.19.")
-        or host.startswith("172.20.")
-        or host.startswith("172.21.")
-        or host.startswith("172.22.")
-        or host.startswith("172.23.")
-        or host.startswith("172.24.")
-        or host.startswith("172.25.")
-        or host.startswith("172.26.")
-        or host.startswith("172.27.")
-        or host.startswith("172.28.")
-        or host.startswith("172.29.")
-        or host.startswith("172.30.")
-        or host.startswith("172.31.")
-    )
+def _is_internal_ip_literal(host: str) -> bool:
+    """True when the host is written as an IP address we must not reach, so DNS is not needed.
+
+    Parses the address rather than matching text prefixes. A prefix match misses the whole of
+    127.0.0.0/8 except 127.0.0.1, and every long form of an IPv6 address, and it blocks an
+    ordinary name such as 10.example.com because the text happens to start with "10.".
+    """
+    ip = _parse_ip_literal(host)
+    return ip is not None and _is_internal_ip(ip)
 
 
 # Labels joined by dots, with an optional root dot. Underscores are not valid in a hostname
@@ -188,23 +186,34 @@ _BARE_HOSTNAME = re.compile(rf"{_HOSTNAME_LABEL}(?:\.{_HOSTNAME_LABEL})*\.?", re
 _MAX_HOSTNAME_LENGTH = 253
 
 
-def _host_shape_error(host: object) -> str | None:
+def _canonicalize_host(host: str) -> str:
+    """The one form every host check runs on.
+
+    Case and the DNS root dot do not change which server a client reaches, so they are
+    normalized once and each check below sees a single form. The root dot has to go, because
+    an absolute FQDN carries it ("db.corp.") and the block list matches exactly or by suffix,
+    so both would otherwise miss it.
+
+    Nothing else is repaired: a host is validated and then stored and connected to by the
+    caller, so whitespace or the parts of a URL have to be rejected rather than cleaned up.
+    """
+    return host.lower().rstrip(".")
+
+
+def _host_shape_error(host: str) -> str | None:
     """Reason to reject a host on its form alone, or None when the form is usable.
 
-    A host field takes a hostname or an IP address. Customers paste whole connection strings
-    into it, so anything carrying credentials, a scheme, a port or a path is rejected before
-    it reaches DNS or a log line. Takes ``object`` because callers read the value out of
-    untyped config.
+    A host field takes a hostname or an IP address. Customers could, in theory, paste whole
+    connection strings into it, so anything carrying credentials, a scheme, a port or a path is
+    rejected before it reaches DNS or a log line.
+
+    An IP address is accepted first because an IPv6 literal carries colons and so can never
+    match the hostname pattern. An IPv4 literal matches it either way.
     """
-    if not isinstance(host, str):
-        return "Host must be a string"
     if not host.strip():
         return "Host is empty"
-    try:
-        ipaddress.ip_address(host)
+    if _parse_ip_literal(host) is not None:
         return None
-    except ValueError:
-        pass
     if len(host) > _MAX_HOSTNAME_LENGTH or not _BARE_HOSTNAME.fullmatch(host):
         return "Host must be a hostname or IP address"
     return None
@@ -231,12 +240,11 @@ def _blocked_host_reason(host: str) -> str | None:
     These checks run before resolution, so they also catch a name that resolves to a public
     IP: split-horizon DNS, and a registered domain shaped like an internal one.
 
-    Normalizes the host itself rather than trusting the caller to. Matching below is exact
-    or by suffix, so an un-normalized host fails these checks open.
+    Takes a canonical host. Every caller passes one, and it canonicalizes again anyway,
+    because matching below is exact or by suffix: an un-normalized host would fail these
+    checks open, which is the one failure mode worth paying a duplicate call to avoid.
     """
-    # An absolute FQDN carries the DNS root dot ("db.corp."), which every client accepts and
-    # resolves to the same target. Without this, suffix and exact matching both miss it.
-    host = host.lower().rstrip(".")
+    host = _canonicalize_host(host)
     if host in METADATA_HOSTS:
         return "Local/metadata host"
     if host in {"localhost", "127.0.0.1", "::1"}:
@@ -244,7 +252,7 @@ def _blocked_host_reason(host: str) -> str | None:
     for pattern in INTERNAL_DOMAIN_PATTERNS:
         if host.endswith(pattern):
             return f"Internal domain pattern blocked: {pattern}"
-    if _is_private_ip_literal(host):
+    if _is_internal_ip_literal(host):
         return "Private IP address not allowed"
     return None
 
@@ -382,7 +390,7 @@ def resolve_url_hosts_ips(raw_urls: Iterable[str]) -> dict[str, ResolvedIPs]:
             continue
         try:
             parsed_url = urlparse.urlparse(raw_url)
-            host = (parsed_url.hostname or "").lower()
+            host = _canonicalize_host(parsed_url.hostname or "")
         except Exception:
             continue
         # Skip what the validator will reject anyway. This shares the rule rather than restating it.
@@ -442,7 +450,7 @@ def _validate_url_with_ips(
     if shape_reason is not None:
         return _blocked(shape_reason)
     u = urlparse.urlparse(raw_url)
-    host = (u.hostname or "").lower()
+    host = _canonicalize_host(u.hostname or "")
     name_reason = _blocked_host_reason(host)
     if name_reason is not None:
         return _blocked(name_reason, host=host)
@@ -478,6 +486,7 @@ def validate_external_url(url: str) -> None:
     ``FORCE_URL_VALIDATION`` setting is true.
     """
 
+    # The URL could come from untyped config, so check its type first
     if not isinstance(url, str):
         raise ValueError("URL must be a string")
     shape_reason = _url_shape_error(url)
@@ -500,9 +509,14 @@ def validate_external_host(host: str) -> None:
     cannot drift apart. Bypassed in local dev and in tests, unless the
     ``FORCE_URL_VALIDATION`` setting is true.
     """
+
+    # The host could come from untyped config, so check its type first
+    if not isinstance(host, str):
+        raise ValueError("Host must be a string")
     shape_reason = _host_shape_error(host)
     if shape_reason is not None:
         raise ValueError(shape_reason)
+    host = _canonicalize_host(host)
 
     if _dev_bypass_enabled() or _test_bypass_enabled():
         return
@@ -511,8 +525,8 @@ def validate_external_host(host: str) -> None:
     if name_reason is not None:
         raise ValueError(name_reason)
 
+    # Return the same error message in both cases, to avoid exposing details of our internal
+    # network.
     ips = resolve_host_ips(host)
-    if not ips:
-        raise ValueError("Could not resolve host")
-    if any(_is_internal_ip(ip) for ip in ips):
-        raise ValueError("Host resolves to an internal IP")
+    if not ips or any(_is_internal_ip(ip) for ip in ips):
+        raise ValueError("Host does not resolve to a valid IP address")

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -255,8 +255,21 @@ def _url_shape_error(raw_url: str) -> str | None:
     return None
 
 
-def _blocked_host_reason(host: str) -> str | None:
-    """Reason to reject a host on its name alone, or None when the name is acceptable.
+@frozen
+class BlockedName:
+    """Why a host name is blocked, and which internal pattern matched it.
+
+    The pattern rides alongside the reason rather than only inside it, so a log query can
+    group by it. Deriving it again at the log site would mean a second copy of the matching,
+    which is the shape that produced the fullwidth bypass.
+    """
+
+    reason: str
+    pattern: str | None = None
+
+
+def _blocked_host_name(host: str) -> BlockedName | None:
+    """Why to reject a host on its name alone, or None when the name is acceptable.
 
     These checks run before resolution, so they also catch a name that resolves to a public
     IP: split-horizon DNS, and a registered domain shaped like an internal one.
@@ -267,14 +280,14 @@ def _blocked_host_reason(host: str) -> str | None:
     """
     host = _canonicalize_host(host)
     if host in METADATA_HOSTS:
-        return "Local/metadata host"
+        return BlockedName(reason="Local/metadata host")
     if host in {"localhost", "127.0.0.1", "::1"}:
-        return "Local/Loopback host not allowed"
+        return BlockedName(reason="Local/Loopback host not allowed")
     for pattern in INTERNAL_DOMAIN_PATTERNS:
         if host.endswith(pattern):
-            return f"Internal domain pattern blocked: {pattern}"
+            return BlockedName(reason=f"Internal domain pattern blocked: {pattern}", pattern=pattern)
     if _is_internal_ip_literal(host):
-        return "Private IP address not allowed"
+        return BlockedName(reason="Private IP address not allowed")
     return None
 
 
@@ -415,11 +428,7 @@ def resolve_url_hosts_ips(raw_urls: Iterable[str]) -> dict[str, ResolvedIPs]:
         except Exception:
             continue
         # Skip what the validator will reject anyway. This shares the rule rather than restating it.
-        if (
-            parsed_url.scheme not in {"http", "https"}
-            or not parsed_url.netloc
-            or _blocked_host_reason(host) is not None
-        ):
+        if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc or _blocked_host_name(host) is not None:
             continue
         hosts.add(host)
     return resolve_hosts_ips(hosts)
@@ -472,9 +481,9 @@ def _validate_url_with_ips(
         return _blocked(shape_reason, **_url_log_fields(raw_url))
     u = urlparse.urlparse(raw_url)
     host = _canonicalize_host(u.hostname or "")
-    name_reason = _blocked_host_reason(host)
-    if name_reason is not None:
-        return _blocked(name_reason, host=host)
+    blocked_name = _blocked_host_name(host)
+    if blocked_name is not None:
+        return _blocked(blocked_name.reason, host=host, pattern=blocked_name.pattern)
 
     ips = resolve_host_ips(host) if resolved_ips_by_host is None else resolved_ips_by_host.get(host, empty)
     if not ips:
@@ -509,10 +518,10 @@ def validate_external_url(url: str) -> None:
 
     # The URL could come from untyped config, so check its type first
     if not isinstance(url, str):
-        raise ValueError("URL must be a string")
+        raise ShapeError("URL must be a string")
     shape_reason = _url_shape_error(url)
     if shape_reason is not None:
-        raise ValueError(shape_reason)
+        raise ShapeError(shape_reason)
 
     if _dev_bypass_enabled() or _test_bypass_enabled():
         return
@@ -522,11 +531,12 @@ def validate_external_url(url: str) -> None:
         raise ValueError(reason or "URL is not allowed")
 
 
-class HostShapeError(ValueError):
-    """The value cannot be a host, judged from its form alone before any lookup.
+class ShapeError(ValueError):
+    """The value cannot be a host or a URL, judged from its form alone before any lookup.
 
     Separate from the other reasons because it is safe to report in detail: nothing about our
-    network went into the decision, and the user has something they can fix.
+    network went into the decision, and the user has something they can fix. Everything else a
+    validator raises has to stay behind one neutral message.
     """
 
 
@@ -548,18 +558,18 @@ def validate_external_host(host: str) -> None:
 
     # The host could come from untyped config, so check its type first
     if not isinstance(host, str):
-        raise HostShapeError("Host must be a string")
+        raise ShapeError("Host must be a string")
     shape_reason = _host_shape_error(host)
     if shape_reason is not None:
-        raise HostShapeError(shape_reason)
+        raise ShapeError(shape_reason)
     host = _canonicalize_host(host)
 
     if _dev_bypass_enabled() or _test_bypass_enabled():
         return
 
-    name_reason = _blocked_host_reason(host)
-    if name_reason is not None:
-        raise ValueError(name_reason)
+    blocked_name = _blocked_host_name(host)
+    if blocked_name is not None:
+        raise ValueError(blocked_name.reason)
 
     # Return the same error message in both cases, to avoid exposing details of our internal
     # network.

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -41,7 +41,7 @@ from posthog.models.integration import (
     DatabricksIntegrationError,
     Integration,
 )
-from posthog.security.url_validation import resolve_and_validate_host
+from posthog.security.url_validation import validate_external_host
 from posthog.temporal.common.client import sync_connect
 from posthog.utils import relative_date_parse, str_to_bool
 
@@ -1620,7 +1620,7 @@ class BatchExportSerializer(serializers.ModelSerializer):
 
             if host is not None:
                 try:
-                    resolve_and_validate_host(host)
+                    validate_external_host(host)
                 except ValueError:
                     raise serializers.ValidationError(INVALID_HOST_MESSAGE)
 

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -41,7 +41,12 @@ from posthog.models.integration import (
     DatabricksIntegrationError,
     Integration,
 )
-from posthog.security.url_validation import validate_external_host
+from posthog.security.url_validation import (
+    INVALID_HOST_MESSAGE,
+    UNREACHABLE_HOST_MESSAGE,
+    HostShapeError,
+    validate_external_host,
+)
 from posthog.temporal.common.client import sync_connect
 from posthog.utils import relative_date_parse, str_to_bool
 
@@ -1080,9 +1085,6 @@ class _DatabaseFieldFinder(TraversingVisitor):
         super().visit_field(node)
 
 
-INVALID_HOST_MESSAGE = "Invalid host. Enter a hostname or IP address without credentials, scheme, or path."
-
-
 class BatchExportSerializer(serializers.ModelSerializer):
     """Serializer for a BatchExport model."""
 
@@ -1621,8 +1623,10 @@ class BatchExportSerializer(serializers.ModelSerializer):
             if host is not None:
                 try:
                     validate_external_host(host)
-                except ValueError:
+                except HostShapeError:
                     raise serializers.ValidationError(INVALID_HOST_MESSAGE)
+                except ValueError:
+                    raise serializers.ValidationError(UNREACHABLE_HOST_MESSAGE)
 
         return destination_attrs
 

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -44,7 +44,7 @@ from posthog.models.integration import (
 from posthog.security.url_validation import (
     INVALID_HOST_MESSAGE,
     UNREACHABLE_HOST_MESSAGE,
-    HostShapeError,
+    ShapeError,
     validate_external_host,
 )
 from posthog.temporal.common.client import sync_connect
@@ -1623,7 +1623,7 @@ class BatchExportSerializer(serializers.ModelSerializer):
             if host is not None:
                 try:
                     validate_external_host(host)
-                except HostShapeError:
+                except ShapeError:
                     raise serializers.ValidationError(INVALID_HOST_MESSAGE)
                 except ValueError:
                     raise serializers.ValidationError(UNREACHABLE_HOST_MESSAGE)

--- a/products/batch_exports/backend/tests/api/test_create_postgres.py
+++ b/products/batch_exports/backend/tests/api/test_create_postgres.py
@@ -6,8 +6,8 @@ from django.test.client import Client as HttpClient
 from rest_framework import status
 
 from posthog.models.integration import Integration
+from posthog.security.url_validation import INVALID_HOST_MESSAGE, UNREACHABLE_HOST_MESSAGE
 
-from products.batch_exports.backend.api.batch_export import INVALID_HOST_MESSAGE
 from products.batch_exports.backend.tests.api.operations import create_batch_export
 
 pytestmark = [
@@ -72,17 +72,20 @@ def test_creating_postgres_batch_export_using_integration(client: HttpClient, te
 
 
 @pytest.mark.parametrize(
-    "host",
+    "host, expected_message",
     [
-        "169.254.169.254",
-        "127.0.0.1",
-        "10.0.0.1",
-        "192.168.1.1",
-        "postgres://alice:hunter2@db.example.com/app",
+        # A blocked name and a name that does not resolve report the same thing, so the error
+        # cannot be used to find which addresses exist inside our network.
+        ("169.254.169.254", UNREACHABLE_HOST_MESSAGE),
+        ("127.0.0.1", UNREACHABLE_HOST_MESSAGE),
+        ("10.0.0.1", UNREACHABLE_HOST_MESSAGE),
+        ("192.168.1.1", UNREACHABLE_HOST_MESSAGE),
+        # The form is wrong, which is settled before any lookup, so this one says what to fix.
+        ("postgres://alice:hunter2@db.example.com/app", INVALID_HOST_MESSAGE),
     ],
 )
 def test_creating_postgres_batch_export_validates_integration_host(
-    client: HttpClient, temporal, organization, team, user, host
+    client: HttpClient, temporal, organization, team, user, host, expected_message
 ):
     """Test that the integration's host is SSRF-validated when creating a Postgres batch export.
 
@@ -112,7 +115,7 @@ def test_creating_postgres_batch_export_validates_integration_host(
         response = create_batch_export(client, team.pk, batch_export_data)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert response.json()["detail"] == INVALID_HOST_MESSAGE
+    assert response.json()["detail"] == expected_message
     assert host not in response.content.decode()
     assert "hunter2" not in response.content.decode()
 

--- a/products/batch_exports/backend/tests/api/test_create_redshift.py
+++ b/products/batch_exports/backend/tests/api/test_create_redshift.py
@@ -6,8 +6,8 @@ from django.test.client import Client as HttpClient
 from rest_framework import status
 
 from posthog.models.integration import Integration
+from posthog.security.url_validation import INVALID_HOST_MESSAGE, UNREACHABLE_HOST_MESSAGE
 
-from products.batch_exports.backend.api.batch_export import INVALID_HOST_MESSAGE
 from products.batch_exports.backend.tests.api.fixtures import create_organization, create_team, create_user
 from products.batch_exports.backend.tests.api.operations import create_batch_export, get_batch_export_ok
 
@@ -201,19 +201,23 @@ def test_create_redshift_batch_export_rejects_invalid_authorization_type(
 
 
 @pytest.mark.parametrize(
-    "host",
+    "host, expected_message",
     [
-        "192.168.1.1",
-        "127.0.0.1",
-        "[::1]",
-        "10.0.0.1",
-        "169.254.0.0",
-        "localhost",
-        "postgres://alice:hunter2@db.example.com/app",
+        # A blocked name and a name that does not resolve report the same thing, so the error
+        # cannot be used to find which addresses exist inside our network.
+        ("192.168.1.1", UNREACHABLE_HOST_MESSAGE),
+        ("127.0.0.1", UNREACHABLE_HOST_MESSAGE),
+        ("10.0.0.1", UNREACHABLE_HOST_MESSAGE),
+        ("169.254.0.0", UNREACHABLE_HOST_MESSAGE),
+        ("localhost", UNREACHABLE_HOST_MESSAGE),
+        # These two are settled by form before any lookup, so they say what to fix. A bare
+        # IPv6 literal is a host, but the brackets a URL wraps it in are not.
+        ("[::1]", INVALID_HOST_MESSAGE),
+        ("postgres://alice:hunter2@db.example.com/app", INVALID_HOST_MESSAGE),
     ],
 )
 def test_create_redshift_batch_export_fails_with_invalid_host(
-    client: HttpClient, temporal, organization, team, user, host, aws_redshift_integration
+    client: HttpClient, temporal, organization, team, user, host, expected_message, aws_redshift_integration
 ):
     """Test creating a BatchExport with a Redshift destination rejects an internal host.
 
@@ -248,7 +252,7 @@ def test_create_redshift_batch_export_fails_with_invalid_host(
         )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
-    assert response.json()["detail"] == INVALID_HOST_MESSAGE
+    assert response.json()["detail"] == expected_message
     assert host not in response.content.decode()
     assert "hunter2" not in response.content.decode()
 

--- a/products/data_warehouse/backend/tests/api/test_table.py
+++ b/products/data_warehouse/backend/tests/api/test_table.py
@@ -52,8 +52,9 @@ class TestTable(APIBaseTest):
             ("localhost", "https://localhost/path/*.csv", "Local/Loopback host not allowed"),
             ("literal_ipv4_loopback", "https://127.0.0.1/path/*.csv", "Local/Loopback host not allowed"),
             ("literal_ipv4_linklocal", "https://169.254.169.254/path/*.csv", "Local/metadata host"),
-            ("literal_ipv6_mapped_loopback", "https://[::ffff:127.0.0.1]/path/*.csv", "Disallowed target IP"),
-            ("literal_ipv6_6to4_loopback", "https://[2002:7f00:1::]/path/*.csv", "Disallowed target IP"),
+            # Both are IP literals, so the address is parsed and judged without a DNS lookup.
+            ("literal_ipv6_mapped_loopback", "https://[::ffff:127.0.0.1]/path/*.csv", "Private IP address not allowed"),
+            ("literal_ipv6_6to4_loopback", "https://[2002:7f00:1::]/path/*.csv", "Private IP address not allowed"),
         ]
     )
     def test_create_columns_blocks_unsafe_url_patterns(self, _: str, url_pattern: str, expected_error: str):
@@ -89,12 +90,12 @@ class TestTable(APIBaseTest):
                 "Disallowed target IP",
             ),
             (
-                # The hostname string itself starts with "169.254." (a link-local prefix), so this
-                # is blocked by the literal-prefix check before resolve_host_ips is ever called.
+                # The hostname is a name rather than an address, so it is judged by what it
+                # resolves to, like every other wildcard-DNS name in this list.
                 "sslip_io_linklocal",
                 "https://169.254.169.254.sslip.io/latest/meta-data/",
                 {ipaddress.ip_address("169.254.169.254")},
-                "Private IP address not allowed",
+                "Disallowed target IP",
             ),
             (
                 "custom_dns_rebinding",

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -24,7 +24,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
-from posthog.security.url_validation import resolve_and_validate_url
+from posthog.security.url_validation import validate_external_url
 
 from products.managed_migrations.backend import trial_storage
 from products.managed_migrations.backend.models.batch_imports import (
@@ -123,7 +123,7 @@ class BatchImportSerializer(serializers.ModelSerializer):
         if not value or not value.strip():
             return None
         try:
-            resolve_and_validate_url(value)
+            validate_external_url(value)
         except ValueError:
             raise serializers.ValidationError(f"Invalid endpoint URL: '{value}'")
         return value

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -125,15 +125,12 @@ class BatchImportSerializer(serializers.ModelSerializer):
         try:
             validate_external_url(value)
         except ShapeError:
-            # Settled from the form alone, so it names what to fix. The value is never echoed:
-            # a URL carries its credentials in the userinfo, and this message reaches the
-            # response body, the request log and error tracking.
+            # The value is never echoed: a URL carries its credentials in the userinfo, and
+            # this message reaches the response body, the request log and error tracking.
             raise serializers.ValidationError(
                 "Invalid endpoint URL. Check that it starts with http:// or https:// and carries no credentials."
             )
         except ValueError:
-            # One message for a host that does not resolve and for one that resolves inside
-            # our network, so the error cannot be used to map it.
             raise serializers.ValidationError(UNREACHABLE_HOST_MESSAGE)
         return value
 

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -125,7 +125,11 @@ class BatchImportSerializer(serializers.ModelSerializer):
         try:
             validate_external_url(value)
         except ValueError:
-            raise serializers.ValidationError(f"Invalid endpoint URL: '{value}'")
+            # The value is not echoed. A URL carries its credentials in the userinfo, and this
+            # message reaches the response body, the request log and error tracking.
+            raise serializers.ValidationError(
+                "Invalid endpoint URL. Check that it starts with http:// or https:// and carries no credentials."
+            )
         return value
 
     def create(self, validated_data: dict) -> BatchImport:

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -24,7 +24,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
-from posthog.security.url_validation import validate_external_url
+from posthog.security.url_validation import UNREACHABLE_HOST_MESSAGE, ShapeError, validate_external_url
 
 from products.managed_migrations.backend import trial_storage
 from products.managed_migrations.backend.models.batch_imports import (
@@ -124,12 +124,17 @@ class BatchImportSerializer(serializers.ModelSerializer):
             return None
         try:
             validate_external_url(value)
-        except ValueError:
-            # The value is not echoed. A URL carries its credentials in the userinfo, and this
-            # message reaches the response body, the request log and error tracking.
+        except ShapeError:
+            # Settled from the form alone, so it names what to fix. The value is never echoed:
+            # a URL carries its credentials in the userinfo, and this message reaches the
+            # response body, the request log and error tracking.
             raise serializers.ValidationError(
                 "Invalid endpoint URL. Check that it starts with http:// or https:// and carries no credentials."
             )
+        except ValueError:
+            # One message for a host that does not resolve and for one that resolves inside
+            # our network, so the error cannot be used to map it.
+            raise serializers.ValidationError(UNREACHABLE_HOST_MESSAGE)
         return value
 
     def create(self, validated_data: dict) -> BatchImport:

--- a/products/managed_migrations/backend/api/test/test_batch_imports.py
+++ b/products/managed_migrations/backend/api/test/test_batch_imports.py
@@ -12,6 +12,8 @@ from django.test import RequestFactory, SimpleTestCase, override_settings
 
 from parameterized import parameterized
 
+from posthog.security.url_validation import UNREACHABLE_HOST_MESSAGE
+
 from products.managed_migrations.backend import trial_storage
 from products.managed_migrations.backend.admin.batch_imports import BatchImportAdmin
 from products.managed_migrations.backend.api.batch_imports import BatchImportS3SourceCreateSerializer
@@ -1124,6 +1126,30 @@ class TestBatchImportAPI(APIBaseTest):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["attr"], "endpoint_url")
+        self.assertIn("starts with http:// or https://", response.json()["detail"])
+
+    @override_settings(FORCE_URL_VALIDATION=True)
+    def test_s3_import_with_blocked_endpoint_url_returns_400(self):
+        # FORCE_URL_VALIDATION defeats both bypasses, which is what this needs: a blocked URL
+        # is well formed, so it only reaches this branch with the real check running. It must
+        # not be told to fix its scheme or drop credentials when it has neither problem.
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/managed_migrations",
+            {
+                "source_type": "s3",
+                "content_type": "captured",
+                "s3_bucket": "test-bucket",
+                "s3_region": "us-east-1",
+                "s3_prefix": "data/",
+                "access_key": "test-key",
+                "secret_key": "test-secret",
+                "endpoint_url": "http://10.0.0.1/",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["attr"], "endpoint_url")
+        self.assertEqual(response.json()["detail"], UNREACHABLE_HOST_MESSAGE)
 
     @override_settings(MANAGED_MIGRATIONS_IMPORT_ROLE_ARN="arn:aws:iam::999999999999:role/PostHogBatchImport")
     @patch("products.managed_migrations.backend.api.batch_imports.posthoganalytics.feature_enabled", return_value=True)


### PR DESCRIPTION
## Problem

- PR 2 in the stack
- A batch export or warehouse-import destination is checked against a weaker SSRF validator than the rest of PostHog uses.
- Let's use the same logic as we use elsewhere for consistency

## Changes

- Consolidate the URL and host validation with what we use elsewhere
- Take only a hostname or IP address in a host field. Customers paste whole connection strings in, and the value used to reach DNS as given, which put the password in the logs
- Answer with one message whatever makes a host invalid, so we don't tell someone whether their host resolved inside our network

## How did you test this code?

- Added cases in `posthog/security/test/test_url_validation.py`: the bypass truth table, the host and URL paths agreeing on internal-looking names, malformed input rejected while the bypass is on, and a host field taking only a hostname or IP.
- Ran the suites for every caller: security, integrations, batch exports API, and both managed_migrations test directories.
- Not measured: how many existing destinations would newly fail. Destination hosts live in the application database rather than in analytics, so there is no query for it. That is the main open risk. This risk should be fairly minimal though as it only affects when destinations are created or updated; it won't affect the execution of existing batch exports


## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Top layer of a two-PR stack. The layer below removes the cross-product coupling with no behavior change, leaving the policy change reviewable alone.
- Skills invoked: /writing-tests, /writing-pr-descriptions, /writing-code-comments, /writing-user-facing-copy, /stacking-prs, /isolating-product-facade-contracts.
- The security review found the host reaching DNS unparsed. Its suggested character check would have rejected bare IPv6, and the password was in the resolver's error text as well as the host field, so the fix is an allowlist ahead of resolution rather than a redacted log line.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
