### PR TITLE
fix(data-modeling): reconcile dags that hold no tiers yet

### DIFF
--- a/products/data_modeling/backend/logic/schedule_reconcile.py
+++ b/products/data_modeling/backend/logic/schedule_reconcile.py
@@ -539,7 +539,11 @@ async def _apply_reconciliation(
 
     temporal = await async_connect()
     existing_ids = await _list_execute_dag_schedule_ids(temporal, dag_id)
-    if require_tiered and not any(is_tier_schedule_id(schedule_id) for schedule_id in existing_ids):
+    # `require_tiered` protects a DAG that still holds legacy (non-tier) schedules: tiering only
+    # the seeded nodes would delete the whole-DAG schedule and leave the unseeded ones with no
+    # scheduler. A DAG holding no schedule at all carries no such risk and has no scheduler to
+    # lose, so it reconciles: that is a DAG whose views were all paused and one re-enabled.
+    if require_tiered and existing_ids and not any(is_tier_schedule_id(schedule_id) for schedule_id in existing_ids):
         logger.debug("DAG not converted to cadence tiers yet, skipping reconcile", dag_id=dag_id)
         return False
     # An empty tier set on a DAG that still has only legacy (non-tier) schedules means an unseeded

--- a/products/data_modeling/backend/test/test_schedule_reconcile.py
+++ b/products/data_modeling/backend/test/test_schedule_reconcile.py
@@ -428,8 +428,8 @@ class TestMaybeReconcileDag(BaseTest):
         return temporal
 
     def test_untiered_dag_is_left_alone(self):
-        # a legacy single-schedule DAG converts only via the conversion command; a mutation
-        # trigger must neither unschedule it nor create tiers next to live v1 schedules
+        # a legacy single-schedule DAG converts only via the conversion command: tiering the
+        # seeded nodes here would delete the whole-DAG schedule the unseeded ones still ride
         dag = self._dag_with_target()
         with (
             mock.patch(
@@ -443,6 +443,19 @@ class TestMaybeReconcileDag(BaseTest):
                 maybe_reconcile_dag(dag)
         create.assert_not_called()
         update.assert_not_called()
+        delete.assert_not_called()
+
+    def test_dag_with_no_schedule_regains_a_tier(self):
+        dag = self._dag_with_target()
+        with (
+            mock.patch(f"{RECONCILE}.async_connect", new=mock.AsyncMock(return_value=self._temporal_listing([]))),
+            mock.patch(f"{RECONCILE}.a_create_schedule", new=mock.AsyncMock()) as create,
+            mock.patch(f"{RECONCILE}.a_delete_schedule", new=mock.AsyncMock()) as delete,
+        ):
+            with self.captureOnCommitCallbacks(execute=True):
+                maybe_reconcile_dag(dag)
+        create.assert_called_once()
+        self.assertEqual(create.call_args.kwargs["id"], tier_schedule_id(str(dag.id), M15))
         delete.assert_not_called()
 
     def test_tiered_dag_reconciles_after_commit(self):


### PR DESCRIPTION
## Problem

A team that pauses every materialized view, then re-enables one, gets a view that never refreshes.

Setting a view's cadence to "never" clears its freshness target, and once the last target is gone the DAG's cadence tiers are torn down. Re-enabling a view writes the target back, but the reconcile that turns targets into schedules skips a DAG holding no tier — so nothing is ever created. No error is raised, and the picker reports the cadence it just stored.

## Changes

- A DAG holding no schedule at all now reconciles instead of being skipped, so the re-enabled view gets a tier.
- A DAG still holding a legacy whole-DAG schedule stays protected, unchanged: tiering only its seeded nodes would delete the schedule the unseeded ones ride on.
- Both cases were one `require_tiered` bool. The guard now asks the second question separately.

Management commands pass `require_tiered=True` and keep it. They gain the same no-schedule behavior, which is the outcome they already want.

## How did you test this code?

`test_dag_with_no_schedule_regains_a_tier` is new and fails on master. `test_untiered_dag_is_left_alone` is unchanged and passes on both sides, pinning the legacy protection.

645 tests pass across `products/data_modeling/backend/test/`. `hogli ci:preflight --strict` reports 0 failures.

Not exercised against a live Temporal instance.

## 🤖 Agent context

Human-driven (agent-assisted). The reviewer should check the guard split at `_apply_reconciliation`: empty `existing_ids` means no scheduler at all, legacy-only means unconverted, and only the first is now allowed through.

An earlier revision of this PR dropped `require_tiered` at the hook instead. Review feedback pointed out that partial seeding on a legacy DAG would then delete the whole-DAG schedule and leave unseeded nodes dark, so the change was narrowed to the guard.
