### PR TITLE
feat(logs): allow wide windows for below-threshold absence alerts

### DIFF
--- a/products/logs/backend/alert_destinations.py
+++ b/products/logs/backend/alert_destinations.py
@@ -33,19 +33,22 @@ _BROKEN_ERRORED_BASE_DATA: dict[str, str] = {
     "alert_url": "{project.url}/logs/alerts/{event.properties.alert_id}",
 }
 
+# A below-threshold alert with zero matching logs is an absence check, so it reads
+# better as "no logs for N minutes" than as "0 logs (threshold: below 1)".
+_FIRING_DETAIL = (
+    "{if(event.properties.result_count = 0 and event.properties.threshold_operator = 'below',"
+    " concat('No matching logs for ', event.properties.window_minutes, ' minutes'),"
+    " concat(event.properties.result_count, ' logs in ', event.properties.window_minutes, 'm (threshold: ',"
+    " event.properties.threshold_operator, ' ', event.properties.threshold_count, ')'))}"
+)
+
 
 EVENT_KIND_CONFIG: dict[EventKind, EventKindSpec] = {
     "firing": EventKindSpec(
         event_id="$logs_alert_firing",
         display_kind="firing",
         header="🔴 Log alert '{event.properties.alert_name}' is firing",
-        details=(
-            (
-                "Threshold breached",
-                "{event.properties.result_count} logs in {event.properties.window_minutes}m "
-                "(threshold: {event.properties.threshold_operator} {event.properties.threshold_count})",
-            ),
-        ),
+        details=(("Threshold breached", _FIRING_DETAIL),),
         primary_action_url="{project.url}/logs?{event.properties.logs_url_params}",
         primary_action_label="View logs",
         webhook_body={

--- a/products/logs/backend/presentation/views/alerts_api.py
+++ b/products/logs/backend/presentation/views/alerts_api.py
@@ -78,6 +78,10 @@ from products.logs.backend.pattern_alert_check_query import (
 from products.logs.backend.pattern_alert_evaluator import DEFAULT_SEED_LOOKBACK_DAYS, MAX_SEED_LOOKBACK_DAYS
 
 ALLOWED_WINDOW_MINUTES = {5, 10, 15, 30, 60}
+# Extra window sizes allowed only for threshold_operator=below, where a wide window
+# means "alert when nothing matching has logged for this long" (an absence check).
+# Widening this for "above" too would mostly just delay a real spike being noticed.
+BELOW_ONLY_WINDOW_MINUTES = {120, 360, 720, 1440}
 MAX_ALERTS_PER_TEAM = 20
 LOGS_ALERT_EVENT_IDS: Final = tuple(spec.event_id for spec in EVENT_KIND_CONFIG.values())
 # Comma-separated team IDs that bypass MAX_ALERTS_PER_TEAM. Configured via
@@ -284,7 +288,8 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
     )
     window_minutes = serializers.IntegerField(
         default=5,
-        help_text="Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60.",
+        help_text="Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, "
+        "and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent).",
     )
     check_interval_minutes = serializers.IntegerField(
         read_only=True,
@@ -562,8 +567,13 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
             _validate_filters(filters)
 
         window = attrs.get("window_minutes", getattr(self.instance, "window_minutes", None))
-        if window is not None and window not in ALLOWED_WINDOW_MINUTES:
-            raise ValidationError({"window_minutes": f"Must be one of {sorted(ALLOWED_WINDOW_MINUTES)}."})
+        operator = attrs.get(
+            "threshold_operator",
+            getattr(self.instance, "threshold_operator", LogsAlertConfiguration.ThresholdOperator.ABOVE),
+        )
+        allowed_windows = _allowed_window_minutes(operator)
+        if window is not None and window not in allowed_windows:
+            raise ValidationError({"window_minutes": f"Must be one of {sorted(allowed_windows)}."})
 
         trigger_type = attrs.get(
             "trigger_type", getattr(self.instance, "trigger_type", LogsAlertConfiguration.TriggerType.COUNT)
@@ -703,6 +713,12 @@ class LogsAlertConfigurationSerializer(serializers.ModelSerializer):
                     schedule_restriction=schedule_restriction,
                 )
             return super().create(validated_data)
+
+
+def _allowed_window_minutes(threshold_operator: str) -> set[int]:
+    if threshold_operator == LogsAlertConfiguration.ThresholdOperator.BELOW:
+        return ALLOWED_WINDOW_MINUTES | BELOW_ONLY_WINDOW_MINUTES
+    return ALLOWED_WINDOW_MINUTES
 
 
 def _validate_filters(filters: dict) -> None:
@@ -890,12 +906,10 @@ class LogsAlertSimulateRequestSerializer(serializers.Serializer):
             raise ValidationError(f"date_from cannot be more than {MAX_SIMULATE_LOOKBACK_DAYS} days in the past.")
         return value
 
-    def validate_window_minutes(self, value: int) -> int:
-        if value not in ALLOWED_WINDOW_MINUTES:
-            raise ValidationError(f"Must be one of {sorted(ALLOWED_WINDOW_MINUTES)}.")
-        return value
-
     def validate(self, attrs: dict) -> dict:
+        allowed_windows = _allowed_window_minutes(attrs["threshold_operator"])
+        if attrs["window_minutes"] not in allowed_windows:
+            raise ValidationError({"window_minutes": f"Must be one of {sorted(allowed_windows)}."})
         if (
             attrs.get("trigger_type", LogsAlertConfiguration.TriggerType.COUNT)
             != LogsAlertConfiguration.TriggerType.COUNT

--- a/products/logs/backend/test/test_alerts_api.py
+++ b/products/logs/backend/test/test_alerts_api.py
@@ -25,6 +25,7 @@ from products.logs.backend.alert_utils import compute_shard_offset_seconds
 from products.logs.backend.models import LogsAlertConfiguration, LogsAlertEvent
 from products.logs.backend.presentation.views.alerts_api import (
     ALLOWED_WINDOW_MINUTES,
+    BELOW_ONLY_WINDOW_MINUTES,
     LOGS_ALERT_EVENT_IDS,
     MAX_ALERTS_PER_TEAM,
     MAX_DESTINATION_IDS_PER_DELETE_REQUEST,
@@ -534,6 +535,39 @@ class TestLogsAlertAPI(APIBaseTest):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == "window_minutes"
+
+    @parameterized.expand([(w,) for w in sorted(BELOW_ONLY_WINDOW_MINUTES)])
+    def test_create_accepts_wide_window_for_below_operator(self, window):
+        response = self.client.post(
+            self.base_url,
+            self._valid_payload(window_minutes=window, threshold_operator="below"),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.json()
+
+    @parameterized.expand([(w,) for w in sorted(BELOW_ONLY_WINDOW_MINUTES)])
+    def test_create_rejects_wide_window_for_above_operator(self, window):
+        response = self.client.post(
+            self.base_url,
+            self._valid_payload(window_minutes=window, threshold_operator="above"),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["attr"] == "window_minutes"
+
+    def test_switching_an_above_alert_with_a_wide_window_to_below_is_allowed(self):
+        created = self.client.post(
+            self.base_url,
+            self._valid_payload(window_minutes=60, threshold_operator="above"),
+            format="json",
+        ).json()
+
+        response = self.client.patch(
+            f"{self.base_url}{created['id']}/",
+            {"window_minutes": 1440, "threshold_operator": "below"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK, response.json()
 
     # --- Validation: N-of-M ---
 
@@ -1953,6 +1987,15 @@ class TestLogsAlertAPI(APIBaseTest):
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_simulate_rejects_wide_window_for_above_operator(self):
+        response = self.client.post(
+            self._simulate_url(),
+            self._simulate_payload(window_minutes=1440, threshold_operator="above"),
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["attr"] == "window_minutes"
 
     def test_simulate_rejects_n_greater_than_m(self):
         response = self.client.post(

--- a/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
+++ b/products/logs/frontend/components/LogsAlerting/LogsAlertForm.tsx
@@ -35,6 +35,15 @@ const WINDOW_OPTIONS = [
     { value: 60, label: '60 minutes' },
 ]
 
+// Only valid with threshold_operator=below: a wide window turns the alert into an
+// absence check ("nothing matched for this long"), which above doesn't support.
+const BELOW_ONLY_WINDOW_OPTIONS = [
+    { value: 120, label: '2 hours' },
+    { value: 360, label: '6 hours' },
+    { value: 720, label: '12 hours' },
+    { value: 1440, label: '24 hours' },
+]
+
 const taxonomicFilterLogicKey = 'logs-alert'
 const taxonomicGroupTypes = [
     TaxonomicFilterGroupType.Logs,
@@ -315,11 +324,24 @@ function LogsAlertTriggerRow(): JSX.Element {
         )
     }
 
+    const isBelow = alertForm.thresholdOperator === LogsAlertThresholdOperatorEnumApi.Below
+    const windowOptions = isBelow ? [...WINDOW_OPTIONS, ...BELOW_ONLY_WINDOW_OPTIONS] : WINDOW_OPTIONS
+
     return (
         <AlertDefinitionRow label="Alert if count goes">
             <LemonSegmentedButton
                 value={alertForm.thresholdOperator}
-                onChange={(value) => setAlertFormValue('thresholdOperator', value)}
+                onChange={(value) => {
+                    setAlertFormValue('thresholdOperator', value)
+                    // A wide window is only valid for "below". Reset it so switching to
+                    // "above" doesn't leave the form holding a value the API will reject.
+                    if (
+                        value === LogsAlertThresholdOperatorEnumApi.Above &&
+                        BELOW_ONLY_WINDOW_OPTIONS.some((o) => o.value === alertForm.windowMinutes)
+                    ) {
+                        setAlertFormValue('windowMinutes', 10)
+                    }
+                }}
                 options={[
                     { value: LogsAlertThresholdOperatorEnumApi.Above, label: 'above' },
                     { value: LogsAlertThresholdOperatorEnumApi.Below, label: 'below' },
@@ -339,7 +361,7 @@ function LogsAlertTriggerRow(): JSX.Element {
             <LemonSelect
                 value={alertForm.windowMinutes}
                 onChange={(value) => setAlertFormValue('windowMinutes', value ?? 10)}
-                options={WINDOW_OPTIONS}
+                options={windowOptions}
                 size="small"
             />
         </AlertDefinitionRow>

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -577,7 +577,7 @@ export interface LogsAlertConfigurationApi {
      * * `above` - Above
      * * `below` - Below */
     threshold_operator?: LogsAlertThresholdOperatorEnumApi
-    /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
+    /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent). */
     window_minutes?: number
     /** How often the alert is evaluated, in minutes. Server-managed. */
     readonly check_interval_minutes: number
@@ -714,7 +714,7 @@ export interface LogsAlertConfigurationDetailApi {
      * * `above` - Above
      * * `below` - Below */
     threshold_operator?: LogsAlertThresholdOperatorEnumApi
-    /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
+    /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent). */
     window_minutes?: number
     /** How often the alert is evaluated, in minutes. Server-managed. */
     readonly check_interval_minutes: number
@@ -824,7 +824,7 @@ export interface PatchedLogsAlertConfigurationApi {
      * * `above` - Above
      * * `below` - Below */
     threshold_operator?: LogsAlertThresholdOperatorEnumApi
-    /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
+    /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent). */
     window_minutes?: number
     /** How often the alert is evaluated, in minutes. Server-managed. */
     readonly check_interval_minutes?: number

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -108,7 +108,9 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
     window_minutes: zod
         .number()
         .default(logsAlertsCreateBodyWindowMinutesDefault)
-        .describe('Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60.'),
+        .describe(
+            'Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent).'
+        ),
     evaluation_periods: zod
         .number()
         .min(1)
@@ -259,7 +261,9 @@ export const LogsAlertsUpdateBody = /* @__PURE__ */ zod.object({
     window_minutes: zod
         .number()
         .default(logsAlertsUpdateBodyWindowMinutesDefault)
-        .describe('Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60.'),
+        .describe(
+            'Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent).'
+        ),
     evaluation_periods: zod
         .number()
         .min(1)
@@ -410,7 +414,9 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
     window_minutes: zod
         .number()
         .default(logsAlertsPartialUpdateBodyWindowMinutesDefault)
-        .describe('Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60.'),
+        .describe(
+            'Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent).'
+        ),
     evaluation_periods: zod
         .number()
         .min(1)

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -47967,7 +47967,7 @@ export namespace Schemas {
        * * `above` - Above
        * * `below` - Below */
       threshold_operator?: LogsAlertThresholdOperatorEnum;
-      /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
+      /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent). */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes: number;
@@ -48095,7 +48095,7 @@ export namespace Schemas {
        * * `above` - Above
        * * `below` - Below */
       threshold_operator?: LogsAlertThresholdOperatorEnum;
-      /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
+      /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent). */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes: number;
@@ -63571,7 +63571,7 @@ export namespace Schemas {
        * * `above` - Above
        * * `below` - Below */
       threshold_operator?: LogsAlertThresholdOperatorEnum;
-      /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60. */
+      /** Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent). */
       window_minutes?: number;
       /** How often the alert is evaluated, in minutes. Server-managed. */
       readonly check_interval_minutes?: number;

--- a/services/mcp/src/generated/logs/api.ts
+++ b/services/mcp/src/generated/logs/api.ts
@@ -1781,7 +1781,9 @@ export const LogsAlertsCreateBody = /* @__PURE__ */ zod.object({
     window_minutes: zod
         .number()
         .default(logsAlertsCreateBodyWindowMinutesDefault)
-        .describe('Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60.'),
+        .describe(
+            'Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent).'
+        ),
     evaluation_periods: zod
         .number()
         .min(1)
@@ -3594,7 +3596,9 @@ export const LogsAlertsPartialUpdateBody = /* @__PURE__ */ zod.object({
     window_minutes: zod
         .number()
         .optional()
-        .describe('Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60.'),
+        .describe(
+            'Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent).'
+        ),
     evaluation_periods: zod
         .number()
         .min(1)

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-create.json
@@ -2924,7 +2924,7 @@
         },
         "threshold_count": {
             "default": 100,
-            "description": "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.",
+            "description": "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.",
             "minimum": 0,
             "type": "number"
         },
@@ -2934,9 +2934,35 @@
             "enum": ["above", "below"],
             "type": "string"
         },
+        "trigger_config": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "seed_lookback_days": {
+                            "default": 7,
+                            "description": "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire.",
+                            "maximum": 30,
+                            "minimum": 1,
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Trigger-specific settings. Only used with trigger_type=new_pattern."
+        },
+        "trigger_type": {
+            "default": "count",
+            "description": "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n* `count` - Count threshold\n* `new_pattern` - New pattern\n* `pattern_threshold` - Pattern threshold",
+            "enum": ["count", "new_pattern", "pattern_threshold"],
+            "type": "string"
+        },
         "window_minutes": {
             "default": 5,
-            "description": "Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60.",
+            "description": "Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent).",
             "type": "number"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-partial-update.json
@@ -2923,7 +2923,7 @@
             "description": "ISO 8601 timestamp until which the alert is snoozed. Set to null to unsnooze."
         },
         "threshold_count": {
-            "description": "Number of matching log entries that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any matching log.",
+            "description": "Number of matching log entries (or, for a pattern trigger, occurrences of one error shape) that constitutes a threshold breach within the evaluation window. Defaults to 100. Use 0 with the 'above' operator to fire on any match.",
             "minimum": 0,
             "type": "number"
         },
@@ -2932,8 +2932,33 @@
             "enum": ["above", "below"],
             "type": "string"
         },
+        "trigger_config": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "seed_lookback_days": {
+                            "default": 7,
+                            "description": "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire.",
+                            "maximum": 30,
+                            "minimum": 1,
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Trigger-specific settings. Only used with trigger_type=new_pattern."
+        },
+        "trigger_type": {
+            "description": "What the alert evaluates. 'count': threshold_count matching logs in the window (the default). 'new_pattern': the first time a distinct (service, pattern) error shape appears. 'pattern_threshold': a single error shape reaching threshold_count occurrences in the window. The pattern trigger types require log pattern stamping to be enabled for this team, and force evaluation_periods and datapoints_to_alarm to 1.\n\n* `count` - Count threshold\n* `new_pattern` - New pattern\n* `pattern_threshold` - Pattern threshold",
+            "enum": ["count", "new_pattern", "pattern_threshold"],
+            "type": "string"
+        },
         "window_minutes": {
-            "description": "Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60.",
+            "description": "Time window in minutes over which log entries are counted. Allowed values: 5, 10, 15, 30, 60, and, only with threshold_operator=below, also 120, 360, 720, 1440 (for detecting a service gone silent).",
             "type": "number"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-simulate-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/logs-alerts-simulate-create.json
@@ -2888,6 +2888,32 @@
             "enum": ["above", "below"],
             "type": "string"
         },
+        "trigger_config": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "seed_lookback_days": {
+                            "default": 7,
+                            "description": "Only used with trigger_type=new_pattern. Days of history the alert's first check scans to seed its seen-set before it starts alerting, so pre-existing error shapes never fire.",
+                            "maximum": 30,
+                            "minimum": 1,
+                            "type": "number"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Same meaning as LogsAlertConfiguration.trigger_config. Only used with trigger_type=new_pattern."
+        },
+        "trigger_type": {
+            "default": "count",
+            "description": "Same meaning as LogsAlertConfiguration.trigger_type. Forces evaluation_periods and datapoints_to_alarm to 1 for a pattern trigger.\n\n* `count` - Count threshold\n* `new_pattern` - New pattern\n* `pattern_threshold` - Pattern threshold",
+            "enum": ["count", "new_pattern", "pattern_threshold"],
+            "type": "string"
+        },
         "window_minutes": {
             "description": "Window size in minutes — determines bucket interval.",
             "type": "number"


### PR DESCRIPTION
## Problem

A `below`-threshold logs alert already fires on silence (a count of 0 is below any positive threshold), but `window_minutes` tops out at 60. A team that wants to know "this service has logged nothing for 6 hours" has no way to configure that window today, only "nothing in the last hour."

## Changes

- `window_minutes` accepts four more values (120, 360, 720, 1440 minutes) when `threshold_operator` is `below`. `above` alerts are unaffected: a wide window there would mostly just delay a real spike being noticed, so it stays capped at 60.
- Switching an alert's operator from `below` back to `above` in the form resets a wide window back to a valid one, instead of leaving the form holding a value the API would reject on save.
- A fired notification that breached because nothing matched at all (`result_count` is 0, on a `below` alert) now reads "No matching logs for N minutes" instead of the generic "0 logs in Nm (threshold: below 1)".
- Mechanical: regenerates OpenAPI/frontend/MCP types for the updated `window_minutes` help text.

## How did you test this code?

- Added `test_create_accepts_wide_window_for_below_operator` / `test_create_rejects_wide_window_for_above_operator` (parameterized over the four new values) and `test_switching_an_above_alert_with_a_wide_window_to_below_is_allowed` in `test_alerts_api.py`, plus `test_simulate_rejects_wide_window_for_above_operator` for the simulate endpoint, which shares the same validation helper.
- Ran the full `products/logs/backend/test/` suite (1437 tests) and `uv run mypy --cache-fine-grained .` (repo-wide, 19547 files): both clean.
- The notification copy change is a Hog template string (`{if(...)}`), the same pattern the existing `_SEVERITY_SERVICE_CONTEXT` template already uses. There is no test harness in this codebase that evaluates a Hog expression's logic directly; the existing `TestSlackBody`/`TestTeamsText` parameterized tests, which iterate over every event kind including `firing`, confirm the new template still renders as valid markdown, and I did not add a test that would only re-assert the string itself.
- `pnpm --filter=@posthog/frontend typescript:check`: clean, no errors in any touched file.
- Not run: manual or browser verification, for the same reason as the frontend layer PR in this stack. The dev environment wasn't running in this sandbox.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no documented workflow describes `window_minutes`' allowed values today.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Last of a four-layer stack: model/evaluator ([#92982](https://github.com/PostHog/posthog/pull/92982)), API ([#93029](https://github.com/PostHog/posthog/pull/93029)), frontend ([#93607](https://github.com/PostHog/posthog/pull/93607)), and this rider. Unlike the other three layers, this one has no code dependency on the pattern-trigger work: it only touches the existing count-threshold path, so it can land or be reviewed independently of the rest of the stack.

Skills invoked: `/improving-drf-endpoints`, `/writing-ui-components`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, `/writing-code-comments`, `/stacking-prs`.

Public artifact: nothing in this PR carries material from the agent session that is not already public. No customer conversation, ticket, or internal thread informed any file, fixture, or comment.
