### PR TITLE
feat(dashboards): improve shared dashboard settings

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2005,25 +2005,25 @@ snapshots:
     components-sentencelist--two-actions--light:
         hash: v1.k794b7964.8fb241615dd5f20c152148d0a0ad4bd11b4f4a76bfd74e58c4b3701c68441881.G4Z4X-nRXDxQ2ZzlDzXZHB02uqXVRhq4q1a-4EpwC2I
     components-sharing--dashboard-sharing--dark:
-        hash: v1.k794b7964.48b0440d955a806acc5cf6d360a7bb396442b1697f596eb0ed4f1843a9624bb9.VdN-sOxbVOHqZD1QCGQOmKeiSq-6UvjmKIDgphMXC6A
+        hash: v1.k794b7964.42b2167baffbb4da178379d6dbe27bbb7651426118c87f7d2b6706f0703bd120.gRTvJNnd-Lf8NsrLnLtIBM7HC8PjGtjmfbWs-Ddw7SA
     components-sharing--dashboard-sharing--light:
-        hash: v1.k794b7964.1c2d50b70fc0f1c2c6595a20cfbf2539c752cdf15eff6e87c87495fef7563d28.SaUrdz4Yns_un2QKcGSaVjEHfxAbGjKDo8ha7b1_4to
+        hash: v1.k794b7964.5f6110ca74b9cbcd8533e6ef7a27d21e39dffb7fb47badd98eff9558696edaf1.v90RMIq4sZEsfHeUnh6tMkn9f5XfqrCH773D16M3HGY
     components-sharing--dashboard-sharing-licensed--dark:
-        hash: v1.k794b7964.0b6d3071a3b6e7032f6d7e63af0c9ee9b21f331c8b91693c011a8a059b55edf0.BBLiwWTW3L3qOm38-MFRr_d9dkmgdWiR0yVgSU10_L4
+        hash: v1.k794b7964.9d3da1f1746d52609577029a3d7b1bf67f1b0b98391b3c8dfb2a20c07c47f488.wBaXiHe7YLaaxopy_GhVeH9o-Py90L85aD9JVlD_9ok
     components-sharing--dashboard-sharing-licensed--light:
-        hash: v1.k794b7964.1541383ab6c520372d99be6b1383d3f5ce02dd83c18e0ae3c03fb5b09f8e77c2.0kAiAeDJzNXcaC8lnURofJDA86_PBoCf4Jv01EsonTk
+        hash: v1.k794b7964.602614952b8ab439849b70033b416c94828b627b572fa161876dfb63545e9ae6.-GqCyQSw3lzGYAAPLRft0Rdz6otSvGD9pnw_AMrhMu4
     components-sharing--insight-sharing--dark:
-        hash: v1.k794b7964.856fe5379f54c6a9a2e3f92f692798dce1d3c2fc6f8c4a02bd75b67a99e6b461.SKTeSzTqQVxKOrNIFGz4tvTUVav7J8iCZ6wYRVdRKEg
+        hash: v1.k794b7964.ced9828e7edacbe1c75ff3dd4c892daeb996fe0292bb61ddcea340f361bc3db6.80MnXjKdeTtupehXi3tzvr1Ov5DwPMgCfxj3TfhRrCQ
     components-sharing--insight-sharing--light:
-        hash: v1.k794b7964.28211b3f26fd085d9e3dcb13324d8c89a797aea23ed1a3e9524a9dd2d0dffb2e.nmQrx6G7cWdaym_hSGzSe148r_F02b7orPzBcs8QLM0
+        hash: v1.k794b7964.04c10d4e86935ff2f17de0fc08f5ce695f7c16148c92b2445a9549fdba8a7d4f.w2bWqOIHkYQQWQWdOEiJX2y8DYts0Sj378nmb7Kwd3k
     components-sharing--insight-sharing-licensed--dark:
-        hash: v1.k794b7964.0a9f59e7eae1002fdf9ef1c89984ce6052400213975e1f88d2b360ad6528db3a.sLiHw5kfDMNRueNH4JkyjxP0pP0wIFgJAne34D13kwU
+        hash: v1.k794b7964.fd0442e5fa5b4e73dcaa6a371531b562e76109d7796afd1e7872cac2ed0c69ed.KenKN_Ir-gZzX0BjE9weo1vznK2j8ucP3byfh-arl7k
     components-sharing--insight-sharing-licensed--light:
-        hash: v1.k794b7964.9ae9694b6c9138154a16d4aa0fd3249f93fce1c5fbbded2401c06be6f2bcb4e1.SuPRcpXJ5dacuoxlWtWmSgwlE-Fj6CYD0w8x7QUQnck
+        hash: v1.k794b7964.3da9301ea63a20be20cb9107226dc69f219372ce6e39f90ef5f9e560c9412540.-vdFnOau7-g5ZDEN2MDixSVpz6KuYQtV6aIdtGKTmmc
     components-sharing--recording-sharing-licensed--dark:
-        hash: v1.k794b7964.50a5102fcd24dd52bb07a41a78e6685486895d9ed86923b857de67a2bf0cfa25.yhotsOneF2mgB_iFToEVdcMfHQf58lr7yldfNN-ZYbU
+        hash: v1.k794b7964.9a607e1c8b67aa4caf736f532eae8f04172a08b1519a5b233caed383cd61ac2e.oJJ1rz584k526jS3YRjmGoRSSlONVnNRC_gh0BpAWDw
     components-sharing--recording-sharing-licensed--light:
-        hash: v1.k794b7964.887ed3d23b03515cab22e56f2258a1f1f7be9b7b69c1b5f3e17db17b6c05b4db.XWPlz4WofkRpUrTptzJ_y3K-quE1bDXIBkc2F5gq2wk
+        hash: v1.k794b7964.e5e8a1004d1628fd8a6a6f29a9071a59f3664ca9535cc757db079dde1241cecb.52undskkRbk3x7FpaxFiwDs9NNQWavdegSSi5D8JiRI
     components-skillpicker--default--dark:
         hash: v1.k794b7964.42e480d1854fa4e855c514aa6cb4e0adebde88d01cccd1b802b6a2acba0ccfd3.zWHBN45jGiaWgIUoC6ZoTFd9RLQ9LxAZ5x5szvvO2aE
     components-skillpicker--default--light:
@@ -5821,9 +5821,9 @@ snapshots:
     replay-sharing--private-link--light:
         hash: v1.k794b7964.e7f626d45c31884c47c75c166dedcd70fc857ebb972f02943426e2791790f26b.fR5sTtsvpwxEWF_MSNWpKGkxjsRmj7edgxu0tZX6Pbo
     replay-sharing--public-link--dark:
-        hash: v1.k794b7964.41ab601dc06c3e5dbe0c91d6cb2f9e1fea76982849ec929482d8d2b7950bf390.jEpWX2V7Die-vkh5vydzpl4JYNh-U0hCHRrO9QCVYr0
+        hash: v1.k794b7964.35bc5c57b5eb5e334a309cddd09c88050fee8cf24e7316ba334cd58c8e2327a7.1LUq387MHCKJqGF7JcxUBfBpaVe9NenU68aWt70JVTM
     replay-sharing--public-link--light:
-        hash: v1.k794b7964.d91ab7adfa4ff899dd17edeaa6e5d969b1825cb00be6dc628f9c5d53dc170cb7.jJaRbKyICbUgqqyyBsVfxQw0_z-jptaoZWBTf9yrPV8
+        hash: v1.k794b7964.ddfd8254ca69a6fc3cb638c1bcec9cd839fda06322c538d5b077f979d563e246.rsWbpqFKkbOOKpotVfWuctA8mHs1X9zPI8bkJU0TVQg
     replay-tabs-collections--recordings-play-lists--dark:
         hash: v1.k794b7964.967afbceab74b989f44a0e43654fc8bc219dfb858ba11a2e5ab9c00edb7a13ad.DhL8CprkQ7KvkxODyhe-4lv_TYdMdx-Or1aYK5SdE8M
     replay-tabs-collections--recordings-play-lists--light:
@@ -8852,6 +8852,10 @@ snapshots:
         hash: v1.k794b7964.074d7d64c384134bfd4c223d57cd339854d39bc4283b7d9b239d4c83d78e30fb._jPmYLjyiEistYmpwqii497iwY6LHQ1WQ4nzk9aMTDs
     scenes-app-workflows-createaitaskconnectors--unavailable-connector--light:
         hash: v1.k794b7964.c4fdab3ab5190ace67d354d7010b49cbd37e9ec72feaa3fab9760d1f1010c8b0.S5qBDGrQNUo7qygcV1_MG_nu9RWeaMnoOFrYdhnV97E
+    scenes-dashboards-customize-breakdown-colors--customize-breakdown-colors--dark:
+        hash: v1.k794b7964.cf89a12669d5221b2441fbfb4439b8b1b38191943438a2c1a220444148329954.B4ew6uW3gZCbPU_3vTOggsOyHojRlyvuXxh5FZnlO-0
+    scenes-dashboards-customize-breakdown-colors--customize-breakdown-colors--light:
+        hash: v1.k794b7964.441dbd7e00749f71e50c7b8c7b123485c1bc2da25498c43381bd12b2581f3034.ddH2Si9PeHnZaq2SataU1dDaQdDTMxWiJkhDaPlJypM
     scenes-inbox-scout-tags--editor-and-filter--dark:
         hash: v1.k794b7964.b76b173ee1dc78112e700af267b53d59959164f8ebbc814df2b5f4a3811bcd49.2hfIhAW_k3BdFlo9jtUoJhOyZhS1uQmgafcdvh_CGmg
     scenes-inbox-scout-tags--editor-and-filter--light:

--- a/frontend/src/lib/components/Sharing/SharingModal.test.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 
 import { cleanup, render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { expectLogic } from 'kea-test-utils'
 
 import { themeLogic } from 'lib/logic/themeLogic'
@@ -112,9 +113,23 @@ describe('SharingModal (dashboard)', () => {
         expect(screen.getByText('Access control')).toBeInTheDocument()
 
         // Dashboard options smoke checks
-        expect(screen.getByText(/Show PostHog branding/i)).toBeInTheDocument()
-        expect(screen.getByText('Theme')).toBeInTheDocument()
+        expect(screen.getByText(/Show branding/i)).toBeInTheDocument()
+        expect(screen.getByText('Public sharing')).toBeInTheDocument()
+        expect(screen.getByText('Shared dashboard appearance')).toBeInTheDocument()
+        expect(screen.getByText('Choose how the shared dashboard appears to viewers.')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /System/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Light/i })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Dark/i })).toBeInTheDocument()
         expect(screen.queryByText(/Show insight details/i)).toBeNull()
+    })
+
+    it('updates the shared dashboard theme', async () => {
+        const user = userEvent.setup()
+        render(<DashboardSharingModalWrapper />)
+
+        await user.click(await screen.findByRole('button', { name: /Dark/i }))
+
+        expect(sharingLogic({ dashboardId }).values.sharingSettings.theme).toBe('dark')
     })
 
     it('calls onSharingEnabledChange after the dashboard sharing switch update succeeds', async () => {
@@ -197,6 +212,8 @@ describe('SharingModal (insight)', () => {
 
         // Insight option: Show title and description (insight-specific toggle)
         expect(await screen.findByText(/Show title and description/i)).toBeInTheDocument()
+        expect(screen.getByText('Shared insight appearance')).toBeInTheDocument()
+        expect(screen.getByText('Choose how the shared insight appears to viewers.')).toBeInTheDocument()
 
         // Dashboard-only options should not be present
         const modalTitle = await screen.findByText('Insight permissions & sharing')

--- a/frontend/src/lib/components/Sharing/SharingModal.test.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.test.tsx
@@ -106,20 +106,15 @@ describe('SharingModal (dashboard)', () => {
     it('renders sharing options when sharing is enabled', async () => {
         render(<DashboardSharingModalWrapper />)
 
-        // Sharing section label
-        expect(await screen.findByText('Sharing')).toBeInTheDocument()
-
-        // Access control section
         expect(screen.getByText('Access control')).toBeInTheDocument()
+        expect(await screen.findByText('Shared dashboard appearance')).toBeInTheDocument()
 
-        // Dashboard options smoke checks
         expect(screen.getByText(/Show branding/i)).toBeInTheDocument()
         expect(screen.getByText('Public sharing')).toBeInTheDocument()
-        expect(screen.getByText('Shared dashboard appearance')).toBeInTheDocument()
         expect(screen.getByText('Choose how the shared dashboard appears to viewers.')).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: /System/i })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: /Light/i })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: /Dark/i })).toBeInTheDocument()
+        expect(document.querySelector('[data-attr="sharing-theme-system"]')).toBeInTheDocument()
+        expect(document.querySelector('[data-attr="sharing-theme-light"]')).toBeInTheDocument()
+        expect(document.querySelector('[data-attr="sharing-theme-dark"]')).toBeInTheDocument()
         expect(screen.queryByText(/Show insight details/i)).toBeNull()
     })
 
@@ -127,7 +122,7 @@ describe('SharingModal (dashboard)', () => {
         const user = userEvent.setup()
         render(<DashboardSharingModalWrapper />)
 
-        await user.click(await screen.findByRole('button', { name: /Dark/i }))
+        await user.click(await screen.findByTestId('sharing-theme-dark'))
 
         expect(sharingLogic({ dashboardId }).values.sharingSettings.theme).toBe('dark')
     })

--- a/frontend/src/lib/components/Sharing/SharingModal.tsx
+++ b/frontend/src/lib/components/Sharing/SharingModal.tsx
@@ -4,13 +4,13 @@ import { router } from 'kea-router'
 import posthog from 'posthog-js'
 import { ReactNode, useEffect, useState } from 'react'
 
-import { IconCollapse, IconExpand, IconInfo, IconLock } from '@posthog/icons'
+import { IconCollapse, IconDay, IconExpand, IconInfo, IconLaptop, IconLock, IconNight } from '@posthog/icons'
 import {
     LemonBanner,
     LemonButton,
     LemonDivider,
     LemonModal,
-    LemonSelect,
+    LemonSegmentedButton,
     LemonSkeleton,
     LemonSwitch,
 } from '@posthog/lemon-ui'
@@ -23,7 +23,6 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { IconLink } from 'lib/lemon-ui/icons'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonField } from 'lib/lemon-ui/LemonField'
-import { LemonLabel } from 'lib/lemon-ui/LemonLabel/LemonLabel'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -73,7 +72,7 @@ function getResourceType(
     return AccessControlResourceType.Project
 }
 
-export const SHARING_MODAL_WIDTH = 600
+export const SHARING_MODAL_WIDTH = 640
 
 export interface SharingModalBaseProps {
     dashboardId?: number
@@ -234,14 +233,16 @@ export function SharingModalContent({
                 </>
             ) : undefined}
 
-            <div className="deprecated-space-y-2">
+            <div className="flex flex-col gap-4">
                 {!sharingConfiguration && sharingConfigurationLoading ? (
                     <LemonSkeleton.Row repeat={3} />
                 ) : !sharingConfiguration ? (
                     <p>Something went wrong...</p>
                 ) : (
-                    <>
-                        <h3>Sharing</h3>
+                    <div>
+                        <h4 className="mb-3 text-xs font-semibold uppercase tracking-wide text-secondary">
+                            Public sharing
+                        </h4>
                         {!sharingAllowed ? (
                             <LemonBanner type="warning">Public sharing is disabled for this organization.</LemonBanner>
                         ) : (
@@ -259,224 +260,244 @@ export function SharingModalContent({
                         )}
 
                         {sharingAllowed && sharingConfiguration.enabled && sharingConfiguration.access_token ? (
-                            <>
-                                <div className="deprecated-space-y-2">
-                                    {passwordProtectedSharesEnabled && (
-                                        <div className="LemonSwitch LemonSwitch--medium LemonSwitch--bordered LemonSwitch--full-width flex-col py-1.5">
+                            <div className="mt-2 flex flex-col gap-2">
+                                {passwordProtectedSharesEnabled && (
+                                    <div className="LemonSwitch LemonSwitch--medium LemonSwitch--bordered LemonSwitch--full-width flex-col py-1.5">
+                                        <LemonSwitch
+                                            className="px-0"
+                                            fullWidth
+                                            label={
+                                                <div className="flex items-center">
+                                                    Password protect
+                                                    {!accessControlAvailable && (
+                                                        <Tooltip title="This is a premium feature, click to learn more.">
+                                                            <IconLock className="ml-1.5 text-muted text-lg" />
+                                                        </Tooltip>
+                                                    )}
+                                                </div>
+                                            }
+                                            onChange={(passwordRequired: boolean) => {
+                                                if (passwordRequired) {
+                                                    guardAvailableFeature(AvailableFeature.ACCESS_CONTROL, () =>
+                                                        setPasswordRequired(passwordRequired)
+                                                    )
+                                                } else {
+                                                    setPasswordRequired(passwordRequired)
+                                                }
+                                            }}
+                                            checked={sharingConfiguration.password_required}
+                                            disabledReason={sharingManageDisabledReason}
+                                        />
+                                        {sharingConfiguration.password_required && (
+                                            <div className="mt-1 w-full">
+                                                <SharePasswordsTable
+                                                    dashboardId={dashboardId}
+                                                    insightId={insight?.id}
+                                                    recordingId={recordingId}
+                                                    notebookShortId={notebookShortId}
+                                                    disabledReason={sharingManageDisabledReason}
+                                                />
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+                                <LemonButton
+                                    data-attr="sharing-link-button"
+                                    type="primary"
+                                    onClick={() => {
+                                        // TRICKY: there's a chance this was sending useless errors to error tracking
+                                        // even when it succeeded, so we're explicitly ignoring the promise success
+                                        // and naming the error when reported to error tracking - @pauldambra
+                                        copyToClipboard(shareLink, shareLink).catch((e) =>
+                                            posthog.captureException(
+                                                new Error('unexpected sharing modal clipboard error: ' + e.message)
+                                            )
+                                        )
+                                    }}
+                                    icon={<IconLink />}
+                                    className="ml-auto"
+                                >
+                                    Copy public link
+                                </LemonButton>
+                                {recordingLinkTimeForm}
+                            </div>
+                        ) : null}
+                    </div>
+                )}
+                {sharingAllowed &&
+                sharingConfiguration?.enabled &&
+                sharingConfiguration.access_token &&
+                hasEditAccess ? (
+                    <>
+                        <LemonDivider />
+                        <div>
+                            <div>
+                                <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-secondary">
+                                    Shared {resource} appearance
+                                </h4>
+                                <p className="mb-0 text-sm text-secondary">
+                                    Choose how the shared {resource} appears to viewers.
+                                </p>
+                            </div>
+                            <Form
+                                logic={sharingLogic}
+                                props={logicProps}
+                                formKey="sharingSettings"
+                                className="mt-4 deprecated-space-y-2"
+                            >
+                                <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+                                    {insight && (
+                                        <LemonField name="noHeader">
+                                            {({ value, onChange }) => (
+                                                <LemonSwitch
+                                                    fullWidth
+                                                    bordered
+                                                    label={<div>Show title and description</div>}
+                                                    onChange={() => onChange(!value)}
+                                                    checked={!value}
+                                                />
+                                            )}
+                                        </LemonField>
+                                    )}
+                                    <LemonField name="whitelabel">
+                                        {({ value }) => (
                                             <LemonSwitch
-                                                className="px-0"
                                                 fullWidth
+                                                bordered
                                                 label={
                                                     <div className="flex items-center">
-                                                        Password protect
-                                                        {!accessControlAvailable && (
+                                                        <span>Show branding</span>
+                                                        {!whitelabelAvailable && (
                                                             <Tooltip title="This is a premium feature, click to learn more.">
-                                                                <IconLock className="ml-1.5 text-muted text-lg" />
+                                                                <IconLock className="ml-1.5 text-secondary text-lg" />
                                                             </Tooltip>
                                                         )}
                                                     </div>
                                                 }
-                                                onChange={(passwordRequired: boolean) => {
-                                                    if (passwordRequired) {
-                                                        guardAvailableFeature(AvailableFeature.ACCESS_CONTROL, () =>
-                                                            setPasswordRequired(passwordRequired)
+                                                onChange={(showBranding: boolean) => {
+                                                    const newWhitelabelValue = !showBranding
+                                                    if (newWhitelabelValue) {
+                                                        guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () =>
+                                                            setSharingSettingsValue('whitelabel', newWhitelabelValue)
                                                         )
                                                     } else {
-                                                        setPasswordRequired(passwordRequired)
+                                                        setSharingSettingsValue('whitelabel', newWhitelabelValue)
                                                     }
                                                 }}
-                                                checked={sharingConfiguration.password_required}
-                                                disabledReason={sharingManageDisabledReason}
+                                                checked={!value}
                                             />
-                                            {sharingConfiguration.password_required && (
-                                                <div className="mt-1 w-full">
-                                                    <SharePasswordsTable
-                                                        dashboardId={dashboardId}
-                                                        insightId={insight?.id}
-                                                        recordingId={recordingId}
-                                                        notebookShortId={notebookShortId}
-                                                        disabledReason={sharingManageDisabledReason}
-                                                    />
-                                                </div>
+                                        )}
+                                    </LemonField>
+
+                                    {isInsightVizNode(insight?.query) &&
+                                        insightShortId && (
+                                            // These options are only valid for `InsightVizNode`s, and they rely on `insightVizDataLogic`
+                                            <>
+                                                <LegendCheckbox insightShortId={insightShortId} />
+                                                <DetailedResultsCheckbox insightShortId={insightShortId} />
+                                            </>
+                                        )}
+
+                                    {recordingId && (
+                                        <LemonField name="showInspector">
+                                            {({ value, onChange }) => (
+                                                <LemonSwitch
+                                                    fullWidth
+                                                    bordered
+                                                    label={<div>Show inspector panel</div>}
+                                                    onChange={onChange}
+                                                    checked={value}
+                                                />
                                             )}
-                                        </div>
+                                        </LemonField>
                                     )}
-                                    <LemonButton
-                                        data-attr="sharing-link-button"
-                                        type="primary"
-                                        onClick={() => {
-                                            // TRICKY: there's a chance this was sending useless errors to error tracking
-                                            // even when it succeeded, so we're explicitly ignoring the promise success
-                                            // and naming the error when reported to error tracking - @pauldambra
-                                            copyToClipboard(shareLink, shareLink).catch((e) =>
-                                                posthog.captureException(
-                                                    new Error('unexpected sharing modal clipboard error: ' + e.message)
-                                                )
-                                            )
-                                        }}
-                                        icon={<IconLink />}
-                                        className="ml-auto mb-4"
-                                    >
-                                        Copy public link
-                                    </LemonButton>
-                                    {hasEditAccess && (
-                                        <Form
-                                            logic={sharingLogic}
-                                            props={logicProps}
-                                            formKey="sharingSettings"
-                                            className="deprecated-space-y-2"
-                                        >
-                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-                                                {insight && (
-                                                    <LemonField name="noHeader">
-                                                        {({ value, onChange }) => (
-                                                            <LemonSwitch
-                                                                fullWidth
-                                                                bordered
-                                                                label={<div>Show title and description</div>}
-                                                                onChange={() => onChange(!value)}
-                                                                checked={!value}
-                                                            />
-                                                        )}
-                                                    </LemonField>
-                                                )}
-                                                <LemonField name="whitelabel">
-                                                    {({ value }) => (
-                                                        <LemonSwitch
-                                                            fullWidth
-                                                            bordered
-                                                            label={
-                                                                <div className="flex items-center">
-                                                                    <span>Show PostHog branding</span>
-                                                                    {!whitelabelAvailable && (
-                                                                        <Tooltip title="This is a premium feature, click to learn more.">
-                                                                            <IconLock className="ml-1.5 text-secondary text-lg" />
-                                                                        </Tooltip>
-                                                                    )}
-                                                                </div>
-                                                            }
-                                                            onChange={(showBranding: boolean) => {
-                                                                const newWhitelabelValue = !showBranding
-                                                                if (newWhitelabelValue) {
-                                                                    guardAvailableFeature(
-                                                                        AvailableFeature.WHITE_LABELLING,
-                                                                        () =>
-                                                                            setSharingSettingsValue(
-                                                                                'whitelabel',
-                                                                                newWhitelabelValue
-                                                                            )
-                                                                    )
-                                                                } else {
-                                                                    setSharingSettingsValue(
-                                                                        'whitelabel',
-                                                                        newWhitelabelValue
-                                                                    )
-                                                                }
-                                                            }}
-                                                            checked={!value}
-                                                        />
-                                                    )}
-                                                </LemonField>
 
-                                                {isInsightVizNode(insight?.query) &&
-                                                    insightShortId && (
-                                                        // These options are only valid for `InsightVizNode`s, and they rely on `insightVizDataLogic`
-                                                        <>
-                                                            <LegendCheckbox insightShortId={insightShortId} />
-                                                            <DetailedResultsCheckbox insightShortId={insightShortId} />
-                                                        </>
-                                                    )}
-
-                                                {recordingId && (
-                                                    <LemonField name="showInspector">
-                                                        {({ value, onChange }) => (
-                                                            <LemonSwitch
-                                                                fullWidth
-                                                                bordered
-                                                                label={<div>Show inspector panel</div>}
-                                                                onChange={onChange}
-                                                                checked={value}
-                                                            />
-                                                        )}
-                                                    </LemonField>
-                                                )}
-
-                                                {dashboardId && (
-                                                    <LemonField
-                                                        name="theme"
-                                                        inline
-                                                        className="items-center justify-between col-span-2"
-                                                    >
-                                                        {({ value, onChange }) => (
-                                                            <>
-                                                                <LemonLabel htmlFor="sharing-theme-select">
-                                                                    Theme
-                                                                </LemonLabel>
-                                                                <LemonSelect
-                                                                    id="sharing-theme-select"
-                                                                    value={value ?? 'system'}
-                                                                    onSelect={(theme) => onChange(theme)}
-                                                                    options={[
-                                                                        { value: 'system', label: 'System' },
-                                                                        { value: 'light', label: 'Light' },
-                                                                        { value: 'dark', label: 'Dark' },
-                                                                    ]}
-                                                                />
-                                                            </>
-                                                        )}
-                                                    </LemonField>
-                                                )}
-                                            </div>
-
-                                            {previewIframe && (
-                                                <div className="rounded border">
-                                                    <LemonButton
+                                    {dashboardId && (
+                                        <LemonField name="theme" className="col-span-2">
+                                            {({ value, onChange }) => (
+                                                <fieldset>
+                                                    <legend className="mb-2 text-sm font-semibold">Color theme</legend>
+                                                    <LemonSegmentedButton
+                                                        value={value ?? 'system'}
+                                                        onChange={onChange}
                                                         fullWidth
-                                                        sideIcon={showPreview ? <IconCollapse /> : <IconExpand />}
-                                                        onClick={togglePreview}
-                                                    >
-                                                        Preview
-                                                        {showPreview && !iframeLoaded ? (
-                                                            <Spinner className="ml-2" />
-                                                        ) : null}
-                                                    </LemonButton>
-                                                    {showPreview && (
-                                                        <div className="SharingPreview border-t">
-                                                            <iframe
-                                                                className="block"
-                                                                {...iframeProperties}
-                                                                title="Shared insight preview"
-                                                                onLoad={() => setIframeLoaded(true)}
-                                                                sandbox="allow-scripts allow-same-origin allow-popups"
-                                                            />
-                                                        </div>
-                                                    )}
-                                                </div>
+                                                        options={[
+                                                            {
+                                                                value: 'system',
+                                                                label: 'System',
+                                                                icon: <IconLaptop />,
+                                                                tooltip: 'Match the viewer’s system setting',
+                                                                'data-attr': 'sharing-theme-system',
+                                                            },
+                                                            {
+                                                                value: 'light',
+                                                                label: 'Light',
+                                                                icon: <IconDay />,
+                                                                'data-attr': 'sharing-theme-light',
+                                                            },
+                                                            {
+                                                                value: 'dark',
+                                                                label: 'Dark',
+                                                                icon: <IconNight />,
+                                                                'data-attr': 'sharing-theme-dark',
+                                                            },
+                                                        ]}
+                                                    />
+                                                </fieldset>
                                             )}
-                                        </Form>
+                                        </LemonField>
                                     )}
-                                    {recordingLinkTimeForm}
                                 </div>
-                            </>
-                        ) : null}
+
+                                {previewIframe && (
+                                    <div className="rounded border">
+                                        <LemonButton
+                                            fullWidth
+                                            sideIcon={showPreview ? <IconCollapse /> : <IconExpand />}
+                                            onClick={togglePreview}
+                                        >
+                                            Preview
+                                            {showPreview && !iframeLoaded ? <Spinner className="ml-2" /> : null}
+                                        </LemonButton>
+                                        {showPreview && (
+                                            <div className="SharingPreview border-t">
+                                                <iframe
+                                                    className="block"
+                                                    {...iframeProperties}
+                                                    title="Shared insight preview"
+                                                    onLoad={() => setIframeLoaded(true)}
+                                                    sandbox="allow-scripts allow-same-origin allow-popups"
+                                                />
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+                            </Form>
+                        </div>
                     </>
-                )}
+                ) : null}
+                {sharingAllowed && sharingConfiguration?.enabled && sharingConfiguration.access_token && embedCode ? (
+                    <>
+                        <LemonDivider />
+                        <div>
+                            <TitleWithIcon
+                                icon={
+                                    <Tooltip
+                                        title={`Use the HTML snippet below to embed the ${resource} on your website`}
+                                    >
+                                        <IconInfo />
+                                    </Tooltip>
+                                }
+                            >
+                                <h4 className="mb-3 text-xs font-semibold uppercase tracking-wide text-secondary">
+                                    Embed {resource}
+                                </h4>
+                            </TitleWithIcon>
+                            <CodeSnippet language={Language.HTML}>{embedCode}</CodeSnippet>
+                        </div>
+                    </>
+                ) : null}
             </div>
-            {sharingConfiguration?.enabled && embedCode && (
-                <>
-                    <LemonDivider />
-                    <TitleWithIcon
-                        icon={
-                            <Tooltip title={`Use the HTML snippet below to embed the ${resource} on your website`}>
-                                <IconInfo />
-                            </Tooltip>
-                        }
-                    >
-                        <b>Embed {resource}</b>
-                    </TitleWithIcon>
-                    <CodeSnippet language={Language.HTML}>{embedCode}</CodeSnippet>
-                </>
-            )}
             {insight?.query && (
                 <>
                     <LemonDivider />

--- a/frontend/src/scenes/dashboard/DashboardInsightColorsModal.stories.tsx
+++ b/frontend/src/scenes/dashboard/DashboardInsightColorsModal.stories.tsx
@@ -1,0 +1,56 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { BindLogic, useActions, useMountedLogic } from 'kea'
+
+import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
+import dashboardFixture from 'scenes/dashboard/__mocks__/dashboard.json'
+import { DashboardInsightColorsModal } from 'scenes/dashboard/DashboardInsightColorsModal'
+import { dashboardInsightColorsModalLogic } from 'scenes/dashboard/dashboardInsightColorsModalLogic'
+import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
+
+import { useStorybookMocks } from '~/mocks/browser'
+import { DashboardType, QueryBasedInsightModel } from '~/types'
+
+const DASHBOARD_ID = 5
+
+const dashboard = {
+    ...dashboardFixture,
+    id: DASHBOARD_ID,
+    tiles: dashboardFixture.tiles.map((tile, index) => ({ ...tile, id: index + 1 })),
+} as unknown as DashboardType<QueryBasedInsightModel>
+
+const meta: Meta = {
+    title: 'Scenes/Dashboards/Customize breakdown colors',
+    component: DashboardInsightColorsModal,
+    parameters: {
+        layout: 'fullscreen',
+        mockDate: '2023-07-01',
+    },
+    render: () => (
+        <BindLogic logic={dashboardLogic} props={{ id: DASHBOARD_ID }}>
+            <StoryCanvas />
+        </BindLogic>
+    ),
+}
+
+function StoryCanvas(): JSX.Element {
+    useMountedLogic(dashboardLogic)
+    useMountedLogic(dashboardInsightColorsModalLogic)
+    const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
+
+    useStorybookMocks({
+        get: {
+            [`/api/environments/:team_id/dashboards/${DASHBOARD_ID}/`]: dashboard,
+        },
+    })
+
+    useOnMountEffect(() => {
+        showInsightColorsModal(DASHBOARD_ID)
+    })
+
+    return <DashboardInsightColorsModal />
+}
+
+export default meta
+type Story = StoryObj
+
+export const CustomizeBreakdownColors: Story = {}

--- a/frontend/src/scenes/dashboard/DashboardInsightColorsModal.tsx
+++ b/frontend/src/scenes/dashboard/DashboardInsightColorsModal.tsx
@@ -1,7 +1,15 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonLabel, LemonModal, LemonSelect, LemonTag } from '@posthog/lemon-ui'
-import { LemonButton, LemonColorPicker, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonColorPicker,
+    LemonLabel,
+    LemonModal,
+    LemonSkeleton,
+    LemonTag,
+    LemonTable,
+    LemonTableColumns,
+} from '@posthog/lemon-ui'
 
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
 import stringWithWBR from 'lib/utils/stringWithWBR'
@@ -12,7 +20,7 @@ import { dataColorThemesLogic } from 'scenes/settings/environment/dataColorTheme
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { BreakdownFilter } from '~/queries/schema/schema-general'
-import { DashboardMode } from '~/types'
+import { DashboardMode, DataColorThemeModel } from '~/types'
 
 import {
     BreakdownColorConfig,
@@ -26,6 +34,21 @@ import { dashboardInsightColorsModalLogic } from './dashboardInsightColorsModalL
 import { dashboardLogic } from './dashboardLogic'
 
 type BreakdownColorRow = BreakdownColorConfig & { pinnedConfig?: BreakdownColorConfig }
+
+function ThemeSwatches({ theme }: { theme: DataColorThemeModel }): JSX.Element {
+    return (
+        <span className="flex shrink-0 items-center gap-0.5">
+            {theme.colors.slice(0, 6).map((color, index) => (
+                <span
+                    key={index}
+                    className="h-4 w-1.5 rounded-full"
+                    // eslint-disable-next-line react/forbid-dom-props
+                    style={{ backgroundColor: color }}
+                />
+            ))}
+        </span>
+    )
+}
 
 function BreakdownPropertyGroupTitle({ breakdownProperty }: { breakdownProperty?: string }): JSX.Element {
     if (breakdownProperty == null) {
@@ -192,20 +215,50 @@ export function DashboardInsightColorsModal(): JSX.Element {
                 </>
             }
         >
-            <LemonLabel info="Select a color theme for all insights on this dashboard. If a theme is selected, it will be applied to all series and breakdowns.">
+            <LemonLabel info="Pick a theme to set the colors every insight on this dashboard uses. Anyone who views or shares the dashboard sees the same colors, so series stay recognizable outside PostHog.">
                 Color theme
             </LemonLabel>
-            <LemonSelect
-                className="mt-2"
-                value={dataColorThemeId || null}
-                placeholder="Defined by insight"
-                onChange={(id) => {
-                    ensureEditMode()
-                    setDataColorThemeId(id)
-                }}
-                loading={themesLoading}
-                options={themes.map((theme) => ({ value: theme.id, label: theme.name }))}
-            />
+            <div className="mt-2 flex flex-col gap-1">
+                {themesLoading ? (
+                    <>
+                        <LemonSkeleton.Button className="w-full" />
+                        <LemonSkeleton.Button className="w-full" />
+                    </>
+                ) : (
+                    <>
+                        <LemonButton
+                            type="secondary"
+                            fullWidth
+                            active={dataColorThemeId == null}
+                            onClick={() => {
+                                ensureEditMode()
+                                setDataColorThemeId(null)
+                            }}
+                            data-attr="dashboard-colors-theme-none"
+                        >
+                            Defined by insight
+                        </LemonButton>
+                        {themes.map((theme) => (
+                            <LemonButton
+                                key={theme.id}
+                                type="secondary"
+                                fullWidth
+                                active={dataColorThemeId === theme.id}
+                                onClick={() => {
+                                    ensureEditMode()
+                                    setDataColorThemeId(theme.id)
+                                }}
+                                data-attr={`dashboard-colors-theme-${theme.id}`}
+                            >
+                                <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
+                                    <span className="truncate">{theme.name}</span>
+                                    <ThemeSwatches theme={theme} />
+                                </span>
+                            </LemonButton>
+                        ))}
+                    </>
+                )}
+            </div>
 
             <LemonLabel
                 className="mt-4 mb-2"


### PR DESCRIPTION
## Problem

- Dashboard owners manage sharing, appearance, and embedding in a dense settings modal. Theme selection is easy to miss.

## Changes

- Dashboard owners now choose System, Light, or Dark with labeled icon buttons.
- The modal separates access control, public sharing, shared appearance, and embedding with clear section labels and dividers.
- The shared appearance labels now name the resource being shared.

![Shared dashboard settings](https://raw.githubusercontent.com/PostHog/pr-assets/7663f4d980600d2a2baa4502b25859db613c6cde/2026/09/bc2c3c5d-b7da-42a6-ba51-e481b2841330.png)

## How did you test this code?

- The sharing-modal test covers dashboard theme selection and resource-aware appearance copy.
- TypeScript and frontend formatting checks pass.
- Not run: browser-based visual QA after the final spacing changes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Used `writing-ui-components`, `writing-user-facing-copy`, `writing-pr-descriptions`, and `qa-team`.
- Applied the QA findings for resource-aware copy and semantic theme-group labeling.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*