### PR TITLE
feat(data-modeling): place managed Revenue Analytics views in their own DAG

### DIFF
--- a/products/data_modeling/backend/facade/models.py
+++ b/products/data_modeling/backend/facade/models.py
@@ -12,7 +12,7 @@ distinct resolver enum ``models.modeling.NodeType`` is exposed via ``facade.mode
 """
 
 from products.data_modeling.backend.graph import Graph
-from products.data_modeling.backend.models.dag import DAG, DEFAULT_DAG_NAME
+from products.data_modeling.backend.models.dag import DAG, DEFAULT_DAG_NAME, RESERVED_DAG_NAMES
 from products.data_modeling.backend.models.data_modeling_job import (
     DataModelingJob,
     DataModelingJobEngine,
@@ -33,6 +33,7 @@ from products.data_modeling.backend.models.node import Node, NodeType
 __all__ = [
     "DAG",
     "DEFAULT_DAG_NAME",
+    "RESERVED_DAG_NAMES",
     "DataModelingJob",
     "DataModelingJobEngine",
     "DataModelingJobStatus",

--- a/products/data_modeling/backend/facade/models.py
+++ b/products/data_modeling/backend/facade/models.py
@@ -12,7 +12,12 @@ distinct resolver enum ``models.modeling.NodeType`` is exposed via ``facade.mode
 """
 
 from products.data_modeling.backend.graph import Graph
-from products.data_modeling.backend.models.dag import DAG, DEFAULT_DAG_NAME, RESERVED_DAG_NAMES
+from products.data_modeling.backend.models.dag import (
+    DAG,
+    DEFAULT_DAG_NAME,
+    RESERVED_DAG_NAMES,
+    REVENUE_ANALYTICS_DAG_NAME,
+)
 from products.data_modeling.backend.models.data_modeling_job import (
     DataModelingJob,
     DataModelingJobEngine,
@@ -34,6 +39,7 @@ __all__ = [
     "DAG",
     "DEFAULT_DAG_NAME",
     "RESERVED_DAG_NAMES",
+    "REVENUE_ANALYTICS_DAG_NAME",
     "DataModelingJob",
     "DataModelingJobEngine",
     "DataModelingJobStatus",

--- a/products/data_modeling/backend/logic/saved_query_dag_sync.py
+++ b/products/data_modeling/backend/logic/saved_query_dag_sync.py
@@ -97,10 +97,17 @@ def resolve_dependency_to_node(
     return node
 
 
+class ManagedDAGError(Exception):
+    """Raised when a user-initiated sync targets a system-managed DAG (e.g. Revenue Analytics)."""
+
+    pass
+
+
 def sync_saved_query_to_dag(
     saved_query: "DataWarehouseSavedQuery",
     extra_properties: dict | None = None,  # TODO(andrew): remove this after backfill
     dag: DAG | None = None,
+    allow_managed: bool = False,
 ) -> Node | None:
     """
     Create or update Node and Edges for a SavedQuery.
@@ -115,9 +122,13 @@ def sync_saved_query_to_dag(
         saved_query: The SavedQuery to sync to the DAG
         extra_properties: Optional dict of properties to merge into created nodes and edges
         dag: Optional DAG to use. If not provided, uses the default team DAG.
+        allow_managed: Whether placement into a system-managed DAG is permitted. Only the
+            internal managed-viewset sync passes this; user-initiated callers must not, so a
+            same-team user can't insert nodes/edges into a managed DAG via the saved-query API.
 
     Returns the Node for the SavedQuery, or None if query parsing fails.
     Raises QueryError or CycleDetectionError if the query would create an invalid DAG.
+    Raises ManagedDAGError if dag is system-managed and allow_managed is False.
     """
     from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 
@@ -125,6 +136,8 @@ def sync_saved_query_to_dag(
     team = saved_query.team
     if dag is None:
         dag = DAG.get_or_create_default(team)
+    if dag.is_managed and not allow_managed:
+        raise ManagedDAGError(f"Cannot sync saved query into system-managed DAG: dag_id={dag.id}")
     model_query = saved_query.query.get("query") if saved_query.query else None
     if not model_query:
         raise ValueError(f"DataWarehouseSavedQuery has no query: saved_query_id={saved_query.id}")

--- a/products/data_modeling/backend/models/__init__.py
+++ b/products/data_modeling/backend/models/__init__.py
@@ -1,4 +1,4 @@
-from .dag import DAG, DEFAULT_DAG_NAME
+from .dag import DAG, DEFAULT_DAG_NAME, REVENUE_ANALYTICS_DAG_NAME
 from .data_modeling_job import DataModelingJob, DataModelingJobEngine, DataModelingJobStatus
 from .datawarehouse_managed_viewset import DataWarehouseManagedViewSet
 from .datawarehouse_saved_query import DataWarehouseSavedQuery
@@ -13,6 +13,7 @@ from .node import Node, NodeType
 __all__ = [
     "DAG",
     "DEFAULT_DAG_NAME",
+    "REVENUE_ANALYTICS_DAG_NAME",
     "CycleDetectionError",
     "DAGMismatchError",
     "DataModelingEdgeManager",

--- a/products/data_modeling/backend/models/__init__.py
+++ b/products/data_modeling/backend/models/__init__.py
@@ -1,4 +1,4 @@
-from .dag import DAG, DEFAULT_DAG_NAME, REVENUE_ANALYTICS_DAG_NAME
+from .dag import DAG, DEFAULT_DAG_NAME, RESERVED_DAG_NAMES, REVENUE_ANALYTICS_DAG_NAME
 from .data_modeling_job import DataModelingJob, DataModelingJobEngine, DataModelingJobStatus
 from .datawarehouse_managed_viewset import DataWarehouseManagedViewSet
 from .datawarehouse_saved_query import DataWarehouseSavedQuery
@@ -13,6 +13,7 @@ from .node import Node, NodeType
 __all__ = [
     "DAG",
     "DEFAULT_DAG_NAME",
+    "RESERVED_DAG_NAMES",
     "REVENUE_ANALYTICS_DAG_NAME",
     "CycleDetectionError",
     "DAGMismatchError",

--- a/products/data_modeling/backend/models/dag.py
+++ b/products/data_modeling/backend/models/dag.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
 DEFAULT_DAG_NAME = "Default"
 REVENUE_ANALYTICS_DAG_NAME = "PostHog Revenue Analytics"
 
+# Names users may not claim via the API — they belong to system-controlled DAGs.
+RESERVED_DAG_NAMES = frozenset({DEFAULT_DAG_NAME, REVENUE_ANALYTICS_DAG_NAME})
+
 
 class DAG(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
     team = models.ForeignKey("posthog.Team", on_delete=models.CASCADE)

--- a/products/data_modeling/backend/models/dag.py
+++ b/products/data_modeling/backend/models/dag.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from posthog.models import Team
 
 DEFAULT_DAG_NAME = "Default"
+REVENUE_ANALYTICS_DAG_NAME = "PostHog Revenue Analytics"
 
 
 class DAG(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
@@ -27,6 +28,11 @@ class DAG(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
     @classmethod
     def get_or_create_default(cls, team: Team) -> DAG:
         dag, _ = cls.objects.get_or_create(team=team, name=DEFAULT_DAG_NAME)
+        return dag
+
+    @classmethod
+    def get_or_create_revenue_analytics(cls, team: Team) -> DAG:
+        dag, _ = cls.objects.get_or_create(team=team, name=REVENUE_ANALYTICS_DAG_NAME)
         return dag
 
     @property

--- a/products/data_modeling/backend/models/dag.py
+++ b/products/data_modeling/backend/models/dag.py
@@ -39,6 +39,11 @@ class DAG(UUIDModel, CreatedMetaFields, UpdatedMetaFields):
     def is_default(self) -> bool:
         return self.name == DEFAULT_DAG_NAME
 
+    @property
+    def is_managed(self) -> bool:
+        """System-managed DAGs (e.g. Revenue Analytics) cannot be renamed, edited, or deleted by users."""
+        return self.name == REVENUE_ANALYTICS_DAG_NAME
+
     class Meta:
         db_table = "posthog_datamodelingdag"
         constraints = [

--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -161,6 +161,32 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
                 self.saved_queries.exclude(name__in=expected_view_names).exclude(deleted=True)
             )
 
+        # Managed views get their own DAG (Revenue Analytics runs on a single 12h schedule), kept
+        # separate from the team's Default DAG so each DAG has exactly one sync frequency. Maintained
+        # on every sync — create, update, and resync — not just first creation. saved_queries_to_schedule
+        # is in expected_views order (dependencies first), so edges resolve in a single pass.
+        from products.data_modeling.backend.models.dag import DAG
+        from products.data_modeling.backend.models.node import Node
+        from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
+
+        managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+        for saved_query in saved_queries_to_schedule:
+            try:
+                sync_saved_query_to_dag(saved_query, dag=managed_dag)
+                # Drop any stale node left in another DAG (e.g. a legacy Default-DAG placement),
+                # unless something there still depends on it (don't orphan a dependent).
+                for stale in Node.objects.filter(team=self.team, saved_query=saved_query).exclude(dag=managed_dag):
+                    if not stale.outgoing_edges.exists():
+                        stale.delete()
+            except Exception as e:
+                capture_exception(e, {"managed_viewset_id": self.id, "view_name": saved_query.name})
+                logger.warning(
+                    "failed_to_sync_managed_view_to_dag",
+                    team_id=self.team_id,
+                    view_name=saved_query.name,
+                    error=str(e),
+                )
+
         for saved_query in saved_queries_to_schedule:
             try:
                 saved_query.schedule_materialization()

--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -20,9 +20,13 @@ from posthog.hogql.database.models import (
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 
+from products.data_modeling.backend.models.dag import DAG
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_modeling.backend.models.node import Node
+from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
 from products.revenue_analytics.backend.views.schemas import SCHEMAS as REVENUE_ANALYTICS_SCHEMAS
 from products.warehouse_sources.backend.facade.types import DataWarehouseManagedViewSetKind
+from products.warehouse_sources.backend.types import DataWarehouseManagedViewSetKind
 
 logger = structlog.get_logger(__name__)
 
@@ -163,29 +167,39 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
 
         # Managed views get their own DAG (Revenue Analytics runs on a single 12h schedule), kept
         # separate from the team's Default DAG so each DAG has exactly one sync frequency. Maintained
-        # on every sync — create, update, and resync — not just first creation. saved_queries_to_schedule
-        # is in expected_views order (dependencies first), so edges resolve in a single pass.
-        from products.data_modeling.backend.models.dag import DAG
-        from products.data_modeling.backend.models.node import Node
-        from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
-
-        managed_dag = DAG.get_or_create_revenue_analytics(self.team)
-        for saved_query in saved_queries_to_schedule:
-            try:
-                sync_saved_query_to_dag(saved_query, dag=managed_dag)
-                # Drop any stale node left in another DAG (e.g. a legacy Default-DAG placement),
-                # unless something there still depends on it (don't orphan a dependent).
-                for stale in Node.objects.filter(team=self.team, saved_query=saved_query).exclude(dag=managed_dag):
-                    if not stale.outgoing_edges.exists():
-                        stale.delete()
-            except Exception as e:
-                capture_exception(e, {"managed_viewset_id": self.id, "view_name": saved_query.name})
-                logger.warning(
-                    "failed_to_sync_managed_view_to_dag",
-                    team_id=self.team_id,
-                    view_name=saved_query.name,
-                    error=str(e),
-                )
+        # on every sync — create, update, and resync. saved_queries_to_schedule is in expected_views
+        # order (dependencies first), so edges resolve in a single pass.
+        #
+        # Serialize concurrent sync_views for this team+kind with a SESSION-level advisory lock so two
+        # calls can't race on node/edge placement (one call's edge delete-and-recreate wiping
+        # another's). Deliberately NOT wrapped in a transaction: sync_saved_query_to_dag parses HogQL
+        # (builds a Database context + resolves view dependencies), and holding a Postgres transaction
+        # open across that is what starves the data-modeling connection pool. Each call commits in
+        # autocommit and is idempotent; the lock is released in a finally so it never leaks.
+        lock_key = f"{self.team_id}_sync_views_{self.kind}"
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT pg_advisory_lock(hashtext(%s)::bigint)", [lock_key])
+        try:
+            managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+            for saved_query in saved_queries_to_schedule:
+                try:
+                    sync_saved_query_to_dag(saved_query, dag=managed_dag)
+                    # Drop any stale node left in another DAG (e.g. a legacy Default-DAG placement),
+                    # unless something there still depends on it (don't orphan a dependent).
+                    for stale in Node.objects.filter(team=self.team, saved_query=saved_query).exclude(dag=managed_dag):
+                        if not stale.outgoing_edges.exists():
+                            stale.delete()
+                except Exception as e:
+                    capture_exception(e, {"managed_viewset_id": self.id, "view_name": saved_query.name})
+                    logger.warning(
+                        "failed_to_sync_managed_view_to_dag",
+                        team_id=self.team_id,
+                        view_name=saved_query.name,
+                        error=str(e),
+                    )
+        finally:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT pg_advisory_unlock(hashtext(%s)::bigint)", [lock_key])
 
         for saved_query in saved_queries_to_schedule:
             try:

--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -182,7 +182,7 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
             managed_dag = DAG.get_or_create_revenue_analytics(self.team)
             for saved_query in saved_queries_to_schedule:
                 try:
-                    sync_saved_query_to_dag(saved_query, dag=managed_dag)
+                    sync_saved_query_to_dag(saved_query, dag=managed_dag, allow_managed=True)
                     # Drop any stale node left in another DAG (e.g. a legacy Default-DAG placement),
                     # unless something there still depends on it (don't orphan a dependent).
                     for stale in Node.objects.filter(team=self.team, saved_query=saved_query).exclude(dag=managed_dag):

--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -26,7 +26,6 @@ from products.data_modeling.backend.models.node import Node
 from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
 from products.revenue_analytics.backend.views.schemas import SCHEMAS as REVENUE_ANALYTICS_SCHEMAS
 from products.warehouse_sources.backend.facade.types import DataWarehouseManagedViewSetKind
-from products.warehouse_sources.backend.types import DataWarehouseManagedViewSetKind
 
 logger = structlog.get_logger(__name__)
 

--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -20,10 +20,10 @@ from posthog.hogql.database.models import (
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 
+from products.data_modeling.backend.logic.saved_query_dag_sync import sync_saved_query_to_dag
 from products.data_modeling.backend.models.dag import DAG
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_modeling.backend.models.node import Node
-from products.data_modeling.backend.services.saved_query_dag_sync import sync_saved_query_to_dag
 from products.revenue_analytics.backend.views.schemas import SCHEMAS as REVENUE_ANALYTICS_SCHEMAS
 from products.warehouse_sources.backend.facade.types import DataWarehouseManagedViewSetKind
 

--- a/products/data_modeling/backend/presentation/views/dag.py
+++ b/products/data_modeling/backend/presentation/views/dag.py
@@ -56,8 +56,11 @@ class DAGSerializer(serializers.ModelSerializer):
         return value
 
     def validate_name(self, value: str) -> str:
-        if self.instance is not None and self.instance.is_default and value != self.instance.name:
-            raise serializers.ValidationError("The default DAG cannot be renamed.")
+        if self.instance is not None and value != self.instance.name:
+            if self.instance.is_default:
+                raise serializers.ValidationError("The default DAG cannot be renamed.")
+            if self.instance.is_managed:
+                raise serializers.ValidationError("System-managed DAGs cannot be renamed.")
         return value
 
     def create(self, validated_data: dict) -> DAG:
@@ -68,6 +71,8 @@ class DAGSerializer(serializers.ModelSerializer):
         return super().create(validated_data)
 
     def update(self, instance: DAG, validated_data: dict) -> DAG:
+        if instance.is_managed:
+            raise serializers.ValidationError("System-managed DAGs cannot be edited.")
         sync_frequency = validated_data.pop("sync_frequency", None)
         if sync_frequency is not None:
             validated_data["sync_frequency_interval"] = sync_frequency_to_sync_frequency_interval(sync_frequency)
@@ -86,4 +91,6 @@ class DAGViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def perform_destroy(self, instance: DAG) -> None:
         if instance.is_default:
             raise ValidationError("The default DAG cannot be deleted.")
+        if instance.is_managed:
+            raise ValidationError("System-managed DAGs cannot be deleted.")
         instance.delete()

--- a/products/data_modeling/backend/presentation/views/dag.py
+++ b/products/data_modeling/backend/presentation/views/dag.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from django.db.models import Count
 
 from rest_framework import serializers, viewsets
@@ -58,9 +60,10 @@ class DAGSerializer(serializers.ModelSerializer):
     def validate_name(self, value: str) -> str:
         is_rename = self.instance is not None and value != self.instance.name
         if is_rename:
-            if self.instance.is_default:
+            instance = cast(DAG, self.instance)
+            if instance.is_default:
                 raise serializers.ValidationError("The default DAG cannot be renamed.")
-            if self.instance.is_managed:
+            if instance.is_managed:
                 raise serializers.ValidationError("System-managed DAGs cannot be renamed.")
         # Block users from claiming a reserved system name via create or rename.
         if value in RESERVED_DAG_NAMES and (self.instance is None or is_rename):

--- a/products/data_modeling/backend/presentation/views/dag.py
+++ b/products/data_modeling/backend/presentation/views/dag.py
@@ -5,7 +5,7 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
-from products.data_modeling.backend.facade.models import DAG
+from products.data_modeling.backend.facade.models import DAG, RESERVED_DAG_NAMES
 from products.warehouse_sources.backend.facade.models import (
     sync_frequency_interval_to_sync_frequency,
     sync_frequency_to_sync_frequency_interval,
@@ -56,11 +56,15 @@ class DAGSerializer(serializers.ModelSerializer):
         return value
 
     def validate_name(self, value: str) -> str:
-        if self.instance is not None and value != self.instance.name:
+        is_rename = self.instance is not None and value != self.instance.name
+        if is_rename:
             if self.instance.is_default:
                 raise serializers.ValidationError("The default DAG cannot be renamed.")
             if self.instance.is_managed:
                 raise serializers.ValidationError("System-managed DAGs cannot be renamed.")
+        # Block users from claiming a reserved system name via create or rename.
+        if value in RESERVED_DAG_NAMES and (self.instance is None or is_rename):
+            raise serializers.ValidationError("This name is reserved for system-managed DAGs.")
         return value
 
     def create(self, validated_data: dict) -> DAG:

--- a/products/data_modeling/backend/presentation/views/edge.py
+++ b/products/data_modeling/backend/presentation/views/edge.py
@@ -36,6 +36,17 @@ class EdgeSerializer(serializers.ModelSerializer):
     def get_dag_name(self, edge: Edge) -> str:
         return edge.dag.name
 
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        # System-managed DAGs (e.g. Revenue Analytics) own their edges; the internal sync path
+        # maintains them directly via the ORM and bypasses this serializer. Block users from
+        # editing managed edges or moving any edge into a managed DAG via the API.
+        if self.instance is not None and self.instance.dag.is_managed:
+            raise serializers.ValidationError("Edges belonging to a system-managed DAG cannot be modified.")
+        target_dag = attrs.get("dag")
+        if target_dag is not None and target_dag.is_managed:
+            raise serializers.ValidationError("Edges cannot be created in or moved into a system-managed DAG.")
+        return attrs
+
 
 class EdgePagination(PageNumberPagination):
     page_size = 5000
@@ -52,6 +63,11 @@ class EdgeViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def get_serializer_context(self) -> dict[str, Any]:
         return super().get_serializer_context()
+
+    def perform_destroy(self, instance: Edge) -> None:
+        if instance.dag.is_managed:
+            raise serializers.ValidationError("Edges belonging to a system-managed DAG cannot be deleted.")
+        instance.delete()
 
     def safely_get_queryset(self, queryset):
         qs = queryset.filter(team_id=self.team_id)

--- a/products/data_modeling/backend/presentation/views/node.py
+++ b/products/data_modeling/backend/presentation/views/node.py
@@ -94,6 +94,17 @@ class NodeSerializer(serializers.ModelSerializer):
     def get_dag_name(self, node: Node) -> str:
         return node.dag.name
 
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        # System-managed DAGs (e.g. Revenue Analytics) own their nodes; the internal sync path
+        # maintains them directly via the ORM and bypasses this serializer. Block users from
+        # editing managed nodes or moving any node into a managed DAG via the API.
+        if self.instance is not None and self.instance.dag.is_managed:
+            raise serializers.ValidationError("Nodes belonging to a system-managed DAG cannot be modified.")
+        target_dag = attrs.get("dag")
+        if target_dag is not None and target_dag.is_managed:
+            raise serializers.ValidationError("Nodes cannot be created in or moved into a system-managed DAG.")
+        return attrs
+
 
 class NodePagination(PageNumberPagination):
     page_size = 1000
@@ -188,6 +199,11 @@ class NodeViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def get_serializer_context(self) -> dict[str, Any]:
         return super().get_serializer_context()
+
+    def perform_destroy(self, instance: Node) -> None:
+        if instance.dag.is_managed:
+            raise serializers.ValidationError("Nodes belonging to a system-managed DAG cannot be deleted.")
+        instance.delete()
 
     def list(self, request, *args, **kwargs):
         from products.data_modeling.backend.facade.models import Graph

--- a/products/data_modeling/backend/test/test_saved_query_dag_sync.py
+++ b/products/data_modeling/backend/test/test_saved_query_dag_sync.py
@@ -7,6 +7,7 @@ from posthog.hogql.errors import QueryError
 
 from products.data_modeling.backend.logic.saved_query_dag_sync import (
     HasDependentsError,
+    ManagedDAGError,
     delete_node_from_dag,
     get_dag_id,
     get_dependent_saved_queries,
@@ -40,6 +41,32 @@ class TestSyncSavedQueryToDag(BaseTest):
 
         dag = DAG.objects.get(team=self.team, name=DEFAULT_DAG_NAME)
         self.assertEqual(dag.name, DEFAULT_DAG_NAME)
+
+    def test_sync_rejects_managed_dag_for_user_initiated_call(self):
+        managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            name="sneaky_view",
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+        )
+
+        with self.assertRaises(ManagedDAGError):
+            sync_saved_query_to_dag(saved_query, dag=managed_dag)
+
+        self.assertFalse(Node.objects.filter(team=self.team, dag=managed_dag).exists())
+
+    def test_sync_allows_managed_dag_for_internal_call(self):
+        managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            name="managed_view",
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+        )
+
+        node = sync_saved_query_to_dag(saved_query, dag=managed_dag, allow_managed=True)
+
+        assert node is not None
+        self.assertEqual(node.dag_id, managed_dag.id)
 
     def test_sync_reuses_existing_dag_model(self):
         existing_dag = DAG.objects.create(team=self.team, name=DEFAULT_DAG_NAME)

--- a/products/data_modeling/backend/tests/api/test_dag_api.py
+++ b/products/data_modeling/backend/tests/api/test_dag_api.py
@@ -110,6 +110,27 @@ class TestDAGViewSet(APIBaseTest):
         dag.refresh_from_db()
         self.assertEqual(dag.description, "")
 
+    def test_cannot_create_dag_with_reserved_name(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/data_modeling_dags/",
+            {"name": "PostHog Revenue Analytics"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(DAG.objects.filter(team=self.team, name="PostHog Revenue Analytics").exists())
+
+    def test_cannot_rename_dag_to_reserved_name(self):
+        dag = DAG.objects.create(team=self.team, name="my_dag")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
+            {"name": "PostHog Revenue Analytics"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        dag.refresh_from_db()
+        self.assertEqual(dag.name, "my_dag")
+
     def test_node_count_reflects_nodes(self):
         dag = DAG.objects.create(team=self.team, name="my_dag")
         Node.objects.create(team=self.team, dag=dag, name="events", type=NodeType.TABLE)

--- a/products/data_modeling/backend/tests/api/test_dag_api.py
+++ b/products/data_modeling/backend/tests/api/test_dag_api.py
@@ -78,6 +78,38 @@ class TestDAGViewSet(APIBaseTest):
         dag.refresh_from_db()
         self.assertEqual(dag.name, "Default")
 
+    def test_cannot_delete_managed_dag(self):
+        dag = DAG.get_or_create_revenue_analytics(self.team)
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(DAG.objects.filter(team=self.team, id=dag.id).exists())
+
+    def test_cannot_rename_managed_dag(self):
+        dag = DAG.get_or_create_revenue_analytics(self.team)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
+            {"name": "renamed"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        dag.refresh_from_db()
+        self.assertEqual(dag.name, "PostHog Revenue Analytics")
+
+    def test_cannot_edit_managed_dag(self):
+        dag = DAG.get_or_create_revenue_analytics(self.team)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
+            {"description": "updated description"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        dag.refresh_from_db()
+        self.assertEqual(dag.description, "")
+
     def test_node_count_reflects_nodes(self):
         dag = DAG.objects.create(team=self.team, name="my_dag")
         Node.objects.create(team=self.team, dag=dag, name="events", type=NodeType.TABLE)

--- a/products/data_modeling/backend/tests/api/test_node_api.py
+++ b/products/data_modeling/backend/tests/api/test_node_api.py
@@ -417,6 +417,59 @@ class TestNodeViewSet(APIBaseTest):
         self.assertEqual(self.view_node.saved_query_id, original_saved_query_id)
         self.assertNotEqual(self.view_node.name, foreign_sq.name)
 
+    def _create_managed_node(self) -> Node:
+        managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+        sq = DataWarehouseSavedQuery.objects.create(
+            name="managed_view", team=self.team, query={"query": "SELECT 1", "kind": "HogQLQuery"}
+        )
+        return Node.objects.create(
+            team=self.team, dag=managed_dag, saved_query=sq, type=NodeType.VIEW, description="orig"
+        )
+
+    def test_cannot_delete_node_in_managed_dag(self):
+        node = self._create_managed_node()
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/data_modeling_nodes/{node.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(Node.objects.filter(id=node.id).exists())
+
+    def test_cannot_patch_node_in_managed_dag(self):
+        node = self._create_managed_node()
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_nodes/{node.id}/",
+            data={"description": "changed"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        node.refresh_from_db()
+        self.assertEqual(node.description, "orig")
+
+    @parameterized.expand(["post", "patch"])
+    def test_cannot_add_or_move_node_into_managed_dag(self, method):
+        managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+
+        if method == "post":
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/data_modeling_nodes/",
+                data={"name": "sneaky", "type": NodeType.TABLE, "dag": str(managed_dag.id)},
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertFalse(Node.objects.filter(name="sneaky", dag=managed_dag).exists())
+            return
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_nodes/{self.view_node.id}/",
+            data={"dag": str(managed_dag.id)},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.view_node.refresh_from_db()
+        self.assertEqual(self.view_node.dag_id, self.dag.id)
+
 
 class TestEdgeViewSet(APIBaseTest):
     def setUp(self):
@@ -521,3 +574,33 @@ class TestEdgeViewSet(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
+
+    def _create_managed_edge(self) -> Edge:
+        managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+        source = Node.objects.create(team=self.team, dag=managed_dag, name="m_events", type=NodeType.TABLE)
+        sq = DataWarehouseSavedQuery.objects.create(
+            name="m_view", team=self.team, query={"query": "SELECT 1", "kind": "HogQLQuery"}
+        )
+        target = Node.objects.create(team=self.team, dag=managed_dag, saved_query=sq, type=NodeType.VIEW)
+        return Edge.objects.create(team=self.team, dag=managed_dag, source=source, target=target, properties={"a": 1})
+
+    def test_cannot_delete_edge_in_managed_dag(self):
+        edge = self._create_managed_edge()
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/data_modeling_edges/{edge.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(Edge.objects.filter(id=edge.id).exists())
+
+    def test_cannot_patch_edge_in_managed_dag(self):
+        edge = self._create_managed_edge()
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_edges/{edge.id}/",
+            data={"properties": {"a": 2}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        edge.refresh_from_db()
+        self.assertEqual(edge.properties, {"a": 1})

--- a/products/data_warehouse/backend/models/test/test_managed_viewset.py
+++ b/products/data_warehouse/backend/models/test/test_managed_viewset.py
@@ -6,6 +6,7 @@ from django.db import IntegrityError
 from posthog.schema import RevenueAnalyticsEventItem, RevenueCurrencyPropertyConfig
 
 from products.data_modeling.backend.facade.models import DataWarehouseManagedViewSet, DataWarehouseSavedQuery
+from products.data_modeling.backend.models import DAG, REVENUE_ANALYTICS_DAG_NAME, Node
 from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -133,6 +134,30 @@ class TestDataWarehouseManagedViewSetModel(BaseTest):
         self.assertNotEqual(saved_query.columns, old_columns)
         self.assertIsNotNone(saved_query.external_tables)  # Was unset, guarantee we've set it
         self.assertIn("HogQLQuery", saved_query.query.get("kind", ""))  # type: ignore
+
+    def test_sync_views_places_views_in_revenue_analytics_dag(self):
+        managed_viewset = DataWarehouseManagedViewSet.objects.create(
+            team=self.team,
+            kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS,
+        )
+        managed_viewset.sync_views()
+
+        ra_dag = DAG.objects.filter(team=self.team, name=REVENUE_ANALYTICS_DAG_NAME).first()
+        self.assertIsNotNone(ra_dag)
+
+        views = DataWarehouseSavedQuery.objects.filter(team=self.team, managed_viewset=managed_viewset).exclude(
+            deleted=True
+        )
+        node_sq_ids = set(
+            Node.objects.filter(team=self.team, dag=ra_dag, saved_query__isnull=False).values_list(
+                "saved_query_id", flat=True
+            )
+        )
+        # every managed view is represented by a node in the Revenue Analytics DAG, and nowhere else
+        for view in views:
+            self.assertIn(view.id, node_sq_ids)
+            other_dag_nodes = Node.objects.filter(team=self.team, saved_query=view).exclude(dag=ra_dag)
+            self.assertFalse(other_dag_nodes.exists())
 
     def test_delete_with_views(self):
         """Test that delete_with_views properly deletes the managed viewset and marks views as deleted"""

--- a/products/data_warehouse/backend/models/test/test_managed_viewset.py
+++ b/products/data_warehouse/backend/models/test/test_managed_viewset.py
@@ -6,7 +6,7 @@ from django.db import IntegrityError
 from posthog.schema import RevenueAnalyticsEventItem, RevenueCurrencyPropertyConfig
 
 from products.data_modeling.backend.facade.models import DataWarehouseManagedViewSet, DataWarehouseSavedQuery
-from products.data_modeling.backend.models import DAG, REVENUE_ANALYTICS_DAG_NAME, Node
+from products.data_modeling.backend.models import DAG, REVENUE_ANALYTICS_DAG_NAME, Edge, Node, NodeType
 from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -158,6 +158,58 @@ class TestDataWarehouseManagedViewSetModel(BaseTest):
             self.assertIn(view.id, node_sq_ids)
             other_dag_nodes = Node.objects.filter(team=self.team, saved_query=view).exclude(dag=ra_dag)
             self.assertFalse(other_dag_nodes.exists())
+
+    def test_sync_views_removes_stale_default_dag_node(self):
+        managed_viewset = DataWarehouseManagedViewSet.objects.create(
+            team=self.team,
+            kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS,
+        )
+        managed_viewset.sync_views()
+        sq = (
+            DataWarehouseSavedQuery.objects.filter(team=self.team, managed_viewset=managed_viewset)
+            .exclude(deleted=True)
+            .first()
+        )
+
+        # simulate a legacy placement of this managed view in the Default DAG
+        default_dag = DAG.get_or_create_default(self.team)
+        Node.objects.get_or_create(team=self.team, saved_query=sq, dag=default_dag, defaults={"type": NodeType.VIEW})
+
+        managed_viewset.sync_views()
+
+        ra_dag = DAG.objects.get(team=self.team, name=REVENUE_ANALYTICS_DAG_NAME)
+        self.assertTrue(Node.objects.filter(team=self.team, saved_query=sq, dag=ra_dag).exists())
+        self.assertFalse(Node.objects.filter(team=self.team, saved_query=sq, dag=default_dag).exists())
+
+    def test_sync_views_keeps_stale_node_with_dependent(self):
+        managed_viewset = DataWarehouseManagedViewSet.objects.create(
+            team=self.team,
+            kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS,
+        )
+        managed_viewset.sync_views()
+        sq = (
+            DataWarehouseSavedQuery.objects.filter(team=self.team, managed_viewset=managed_viewset)
+            .exclude(deleted=True)
+            .first()
+        )
+
+        default_dag = DAG.get_or_create_default(self.team)
+        stale_node, _ = Node.objects.get_or_create(
+            team=self.team, saved_query=sq, dag=default_dag, defaults={"type": NodeType.VIEW}
+        )
+        # a non-managed view in the Default DAG depends on the stale node (stale_node has an outgoing edge)
+        dependent_sq = DataWarehouseSavedQuery.objects.create(
+            team=self.team, name="dependent_view", query={"kind": "HogQLQuery", "query": "SELECT 1"}
+        )
+        dependent_node = Node.objects.create(
+            team=self.team, saved_query=dependent_sq, dag=default_dag, type=NodeType.VIEW
+        )
+        Edge.objects.create(team=self.team, dag=default_dag, source=stale_node, target=dependent_node)
+
+        managed_viewset.sync_views()
+
+        # the stale Default-DAG node is kept because a dependent still relies on it
+        self.assertTrue(Node.objects.filter(id=stale_node.id).exists())
 
     def test_delete_with_views(self):
         """Test that delete_with_views properly deletes the managed viewset and marks views as deleted"""

--- a/products/data_warehouse/backend/tests/api/test_external_data_schema.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_schema.py
@@ -24,6 +24,7 @@ from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.utils import generate_random_token_personal
 from posthog.temporal.common.schedule import describe_schedule
 
+from products.data_modeling.backend.models import Edge, Node
 from products.data_warehouse.backend.direct_postgres import DIRECT_POSTGRES_URL_PATTERN
 from products.data_warehouse.backend.logic.external_data_source.webhooks import WebhookHogFunctionCreateResult
 from products.data_warehouse.backend.tests.api.utils import create_external_data_source_ok
@@ -2000,6 +2001,11 @@ class TestUpdateExternalDataSchema:
 
         yield team
 
+        # Creating a source syncs managed Revenue Analytics views into a DAG, leaving Node rows whose
+        # saved_query FK is PROTECT. Team cascades to DataWarehouseSavedQuery, so the nodes/edges must
+        # go first — same ordering production relies on in delete_bulky_postgres_data.
+        Edge.objects.filter(team=team).delete()
+        Node.objects.filter(team=team).delete()
         team.delete()
 
     @pytest.fixture


### PR DESCRIPTION
## Problem

Managed Revenue Analytics views always materialize on a 12h cadence. Today they sync into the team's **Default** DAG, mixed with user views that run on other frequencies. A DAG with more than one sync frequency cannot be migrated to a single v2 `data-modeling-execute-dag` schedule, so these teams are stuck on the per-query v1 backend. New managed views also weren't being maintained in any DAG by `sync_views` at all.

## Changes

`DataWarehouseManagedViewSet.sync_views()` now syncs each managed view into a dedicated **"PostHog Revenue Analytics"** DAG (new `DAG.get_or_create_revenue_analytics` helper + `REVENUE_ANALYTICS_DAG_NAME` constant), separate from the Default DAG, so each DAG carries exactly one sync frequency and can move to v2 independently.

- Runs on **every** sync — create, update, and resync — not just first creation.
- `saved_queries_to_schedule` is already in dependency order (deps first), so a single pass resolves edges.
- A stale node left in another DAG (e.g. a legacy Default-DAG placement) is removed, unless something there still depends on it (don't orphan a dependent).

Scheduling is unchanged here: the per-view `schedule_materialization` call is already guarded against reviving v1 for queries whose DAG is on v2 (earlier PR in this stack).

## How did you test this code?

I'm an agent (Claude Code); no manual run. Added `test_sync_views_places_views_in_revenue_analytics_dag` asserting every managed view gets a node in the Revenue Analytics DAG and no node in any other DAG. The full `test_managed_viewset.py` suite (12 tests) passes; ran ruff check/format. (Local Temporal is down, so `schedule_materialization`'s RPC fails and is swallowed as designed — placement assertions are unaffected.)

## 🤖 Agent context

Authored with Claude Code (Opus 4.8). Third in a stack finishing the data modeling v1→v2 / DAG migration. Single-pass placement (rather than a two-pass node-then-edge helper) is safe because `sync_views` emits views dependency-ordered. The one-time migration of existing teams' RA nodes out of the Default DAG is handled by separate migration scripts; this change keeps the steady state correct going forward.

<!-- gg:stack-start -->
## gg stack

- **#63600 `andrew/revenue-analytics-dag` 👈 this PR**
<!-- gg:stack-end -->
