### PR TITLE
fix(llma): return all spans for a trace, regardless of duration

### DIFF
--- a/posthog/hogql_queries/ai/test/__snapshots__/test_trace_query_runner.ambr
+++ b/posthog/hogql_queries/ai/test/__snapshots__/test_trace_query_runner.ambr
@@ -1,35 +1,20 @@
 # serializer version: 1
 # name: TestTraceQueryRunner.test_event_property_filters
   '''
-  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '') AS id,
-         any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_session_id'), ''), 'null'), '^"|"$', '')) AS ai_session_id,
-         min(toTimeZone(events.timestamp, 'UTC')) AS first_timestamp,
-         max(toTimeZone(events.timestamp, 'UTC')) AS last_timestamp,
-         ifNull(nullIf(argMinIf(events.distinct_id, toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), ''), argMin(events.distinct_id, toTimeZone(events.timestamp, 'UTC'))) AS first_distinct_id,
-         round(if(and(ifNull(equals(countIf(and(ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0), notEquals(events.event, '$ai_generation'))), 0), 0), ifNull(greater(countIf(and(ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0), equals(events.event, '$ai_generation'))), 0), 0)), sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), and(equals(events.event, '$ai_generation'), ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0))), sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', ''))
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')))))), 2) AS total_latency,
-         nullIf(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_tokens'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_tokens'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_total_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
-         arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(events.uuid, events.event, toTimeZone(events.timestamp, 'UTC'), events.properties, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_choices'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_state'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_tools'), ''), 'null'), '^"|"$', '')), notEquals(events.event, '$ai_trace')))) AS events,
-         argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS input_state,
-         argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS output_state,
-         ifNull(argMinIf(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), argMin(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'))) AS trace_name
+  SELECT min(toTimeZone(events.timestamp, 'UTC')) AS min_ts,
+         max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'bar'), 0)))
-  GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')
-  LIMIT 1 SETTINGS readonly=2,
-                   max_execution_time=60,
-                   allow_experimental_object_type=1,
-                   max_ast_elements=4000000,
-                   max_expanded_ast_elements=4000000,
-                   max_bytes_before_external_group_by=0,
-                   transform_null_in=1,
-                   optimize_min_equality_disjunction_chain_length=4294967295,
-                   allow_experimental_join_condition=1,
-                   use_hive_partitioning=0
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
   '''
 # ---
 # name: TestTraceQueryRunner.test_event_property_filters.1
@@ -51,7 +36,7 @@
          argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS output_state,
          ifNull(argMinIf(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), argMin(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'))) AS trace_name
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'baz'), 0)))
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:59:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('2024-12-01 00:01:00.000000', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'bar'), 0)))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')
   LIMIT 1 SETTINGS readonly=2,
                    max_execution_time=60,
@@ -67,6 +52,24 @@
 # ---
 # name: TestTraceQueryRunner.test_event_property_filters.2
   '''
+  SELECT min(toTimeZone(events.timestamp, 'UTC')) AS min_ts,
+         max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
+  FROM events
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestTraceQueryRunner.test_event_property_filters.3
+  '''
   SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '') AS id,
          any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_session_id'), ''), 'null'), '^"|"$', '')) AS ai_session_id,
          min(toTimeZone(events.timestamp, 'UTC')) AS first_timestamp,
@@ -84,7 +87,58 @@
          argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS output_state,
          ifNull(argMinIf(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), argMin(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'))) AS trace_name
   FROM events
-  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'barz'), 0)))
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:59:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('2024-12-01 00:01:00.000000', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'baz'), 0)))
+  GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestTraceQueryRunner.test_event_property_filters.4
+  '''
+  SELECT min(toTimeZone(events.timestamp, 'UTC')) AS min_ts,
+         max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
+  FROM events
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestTraceQueryRunner.test_event_property_filters.5
+  '''
+  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '') AS id,
+         any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_session_id'), ''), 'null'), '^"|"$', '')) AS ai_session_id,
+         min(toTimeZone(events.timestamp, 'UTC')) AS first_timestamp,
+         max(toTimeZone(events.timestamp, 'UTC')) AS last_timestamp,
+         ifNull(nullIf(argMinIf(events.distinct_id, toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), ''), argMin(events.distinct_id, toTimeZone(events.timestamp, 'UTC'))) AS first_distinct_id,
+         round(if(and(ifNull(equals(countIf(and(ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0), notEquals(events.event, '$ai_generation'))), 0), 0), ifNull(greater(countIf(and(ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0), equals(events.event, '$ai_generation'))), 0), 0)), sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), and(equals(events.event, '$ai_generation'), ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0))), sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')))))), 2) AS total_latency,
+         nullIf(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_tokens'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
+         nullIf(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_tokens'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
+         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
+         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
+         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_total_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(events.uuid, events.event, toTimeZone(events.timestamp, 'UTC'), events.properties, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_choices'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_state'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_tools'), ''), 'null'), '^"|"$', '')), notEquals(events.event, '$ai_trace')))) AS events,
+         argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS input_state,
+         argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS output_state,
+         ifNull(argMinIf(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), argMin(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'))) AS trace_name
+  FROM events
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:59:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('2024-12-01 00:01:00.000000', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'foo'), ''), 'null'), '^"|"$', ''), 'barz'), 0)))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')
   LIMIT 1 SETTINGS readonly=2,
                    max_execution_time=60,
@@ -100,52 +154,20 @@
 # ---
 # name: TestTraceQueryRunner.test_person_property_filters
   '''
-  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '') AS id,
-         any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_session_id'), ''), 'null'), '^"|"$', '')) AS ai_session_id,
-         min(toTimeZone(events.timestamp, 'UTC')) AS first_timestamp,
-         max(toTimeZone(events.timestamp, 'UTC')) AS last_timestamp,
-         ifNull(nullIf(argMinIf(events.distinct_id, toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), ''), argMin(events.distinct_id, toTimeZone(events.timestamp, 'UTC'))) AS first_distinct_id,
-         round(if(and(ifNull(equals(countIf(and(ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0), notEquals(events.event, '$ai_generation'))), 0), 0), ifNull(greater(countIf(and(ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0), equals(events.event, '$ai_generation'))), 0), 0)), sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), and(equals(events.event, '$ai_generation'), ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0))), sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', ''))
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')))))), 2) AS total_latency,
-         nullIf(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_tokens'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
-         nullIf(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_tokens'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
-         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
-         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
-         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_total_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
-         arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(events.uuid, events.event, toTimeZone(events.timestamp, 'UTC'), events.properties, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_choices'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_state'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_tools'), ''), 'null'), '^"|"$', '')), notEquals(events.event, '$ai_trace')))) AS events,
-         argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS input_state,
-         argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS output_state,
-         ifNull(argMinIf(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), argMin(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'))) AS trace_name
+  SELECT min(toTimeZone(events.timestamp, 'UTC')) AS min_ts,
+         max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
   FROM events
-  LEFT OUTER JOIN
-    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
-            person_distinct_id_overrides.distinct_id AS distinct_id
-     FROM person_distinct_id_overrides
-     WHERE equals(person_distinct_id_overrides.team_id, 99999)
-     GROUP BY person_distinct_id_overrides.distinct_id
-     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-  LEFT JOIN
-    (SELECT person.id AS id,
-            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'bar'), ''), 'null'), '^"|"$', '') AS properties___bar
-     FROM person
-     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                   (SELECT person.id AS id, max(person.version) AS version
-                                                    FROM person
-                                                    WHERE equals(person.team_id, 99999)
-                                                    GROUP BY person.id
-                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(events__person.properties___bar, 'baz'), 0)))
-  GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')
-  LIMIT 1 SETTINGS readonly=2,
-                   max_execution_time=60,
-                   allow_experimental_object_type=1,
-                   max_ast_elements=4000000,
-                   max_expanded_ast_elements=4000000,
-                   max_bytes_before_external_group_by=0,
-                   transform_null_in=1,
-                   optimize_min_equality_disjunction_chain_length=4294967295,
-                   allow_experimental_join_condition=1,
-                   use_hive_partitioning=0
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
   '''
 # ---
 # name: TestTraceQueryRunner.test_person_property_filters.1
@@ -184,7 +206,75 @@
                                                     WHERE equals(person.team_id, 99999)
                                                     GROUP BY person.id
                                                     HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
-  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-11-30 23:50:00', 'UTC'))), lessOrEquals(events.timestamp, assumeNotNull(toDateTime('2024-12-01 00:20:00', 'UTC'))), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(events__person.properties___bar, 'foo'), 0)))
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(events__person.properties___bar, 'baz'), 0)))
+  GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestTraceQueryRunner.test_person_property_filters.2
+  '''
+  SELECT min(toTimeZone(events.timestamp, 'UTC')) AS min_ts,
+         max(toTimeZone(events.timestamp, 'UTC')) AS max_ts
+  FROM events
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('2024-11-30 23:50:00.000000', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('today', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0)))
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestTraceQueryRunner.test_person_property_filters.3
+  '''
+  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '') AS id,
+         any(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_session_id'), ''), 'null'), '^"|"$', '')) AS ai_session_id,
+         min(toTimeZone(events.timestamp, 'UTC')) AS first_timestamp,
+         max(toTimeZone(events.timestamp, 'UTC')) AS last_timestamp,
+         ifNull(nullIf(argMinIf(events.distinct_id, toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), ''), argMin(events.distinct_id, toTimeZone(events.timestamp, 'UTC'))) AS first_distinct_id,
+         round(if(and(ifNull(equals(countIf(and(ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0), notEquals(events.event, '$ai_generation'))), 0), 0), ifNull(greater(countIf(and(ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0), equals(events.event, '$ai_generation'))), 0), 0)), sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), and(equals(events.event, '$ai_generation'), ifNull(greater(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), 0), 0))), sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_latency'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), or(isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', '')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')), isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_parent_id'), ''), 'null'), '^"|"$', ''))
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          and isNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')))))), 2) AS total_latency,
+         nullIf(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_tokens'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS input_tokens,
+         nullIf(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_tokens'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 0) AS output_tokens,
+         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS input_cost,
+         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS output_cost,
+         nullIf(round(sumIf(accurateCastOrNull(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_total_cost_usd'), ''), 'null'), '^"|"$', ''), 'Float64'), 'Float64'), in(events.event, tuple('$ai_generation', '$ai_embedding'))), 10), 0) AS total_cost,
+         arrayDistinct(arraySort(x -> x.3, groupArrayIf(tuple(events.uuid, events.event, toTimeZone(events.timestamp, 'UTC'), events.properties, replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_choices'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_state'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_tools'), ''), 'null'), '^"|"$', '')), notEquals(events.event, '$ai_trace')))) AS events,
+         argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_input_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS input_state,
+         argMinIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_output_state'), ''), 'null'), '^"|"$', ''), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')) AS output_state,
+         ifNull(argMinIf(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$ai_trace')), argMin(ifNull(nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_span_name'), ''), 'null'), '^"|"$', ''), ''), nullIf(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_name'), ''), 'null'), '^"|"$', ''), '')), toTimeZone(events.timestamp, 'UTC'))) AS trace_name
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING ifNull(equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  LEFT JOIN
+    (SELECT person.id AS id,
+            replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'bar'), ''), 'null'), '^"|"$', '') AS properties___bar
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                    FROM person
+                                                    WHERE equals(person.team_id, 99999)
+                                                    GROUP BY person.id
+                                                    HAVING and(ifNull(equals(argMax(person.is_deleted, person.version), 0), 0), ifNull(less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))), 0))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+  WHERE and(equals(events.team_id, 99999), in(events.event, tuple('$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace')), and(greaterOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', ''), 'trace1'), 0), ifNull(equals(events__person.properties___bar, 'foo'), 0)))
   GROUP BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, '$ai_trace_id'), ''), 'null'), '^"|"$', '')
   LIMIT 1 SETTINGS readonly=2,
                    max_execution_time=60,

--- a/posthog/hogql_queries/ai/test/test_trace_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_trace_query_runner.py
@@ -448,6 +448,7 @@ class TestTraceQueryRunner(ClickhouseTestMixin, BaseTest):
         ).calculate()
         self.assertEqual(len(response.results), 0)
 
+    @freeze_time("2024-12-02T00:00:00Z")
     def test_capture_range(self):
         """Test the capture range window includes events before and well after the trace start."""
         _create_person(distinct_ids=["person1"], team=self.team)

--- a/posthog/hogql_queries/ai/test/test_trace_query_runner.py
+++ b/posthog/hogql_queries/ai/test/test_trace_query_runner.py
@@ -449,7 +449,7 @@ class TestTraceQueryRunner(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(response.results), 0)
 
     def test_capture_range(self):
-        """Test the 10-minute capture range window."""
+        """Test the capture range window includes events before and well after the trace start."""
         _create_person(distinct_ids=["person1"], team=self.team)
         _create_ai_generation_event(
             distinct_id="person1",
@@ -463,8 +463,14 @@ class TestTraceQueryRunner(ClickhouseTestMixin, BaseTest):
             team=self.team,
             timestamp=datetime(2024, 12, 1, 0, 10),
         )
+        # Late-arriving span hours after the trace started — must still be captured.
+        _create_ai_generation_event(
+            distinct_id="person1",
+            trace_id="trace1",
+            team=self.team,
+            timestamp=datetime(2024, 12, 1, 5, 0),
+        )
 
-        # Events within 10 minutes should be included
         response = TraceQueryRunner(
             team=self.team,
             query=TraceQuery(
@@ -473,7 +479,7 @@ class TestTraceQueryRunner(ClickhouseTestMixin, BaseTest):
             ),
         ).calculate()
         self.assertEqual(len(response.results), 1)
-        self.assertEqual(len(response.results[0].events), 2)
+        self.assertEqual(len(response.results[0].events), 3)
 
     def test_overlap_semantics_trace_started_before_window(self):
         _create_person(distinct_ids=["person1"], team=self.team)

--- a/posthog/hogql_queries/ai/trace_query_runner.py
+++ b/posthog/hogql_queries/ai/trace_query_runner.py
@@ -41,35 +41,42 @@ TRACE_FIELDS_MAPPING: dict[str, str] = {
 }
 
 
-class TraceQueryDateRange(QueryDateRange):
-    """
-    Extends the QueryDateRange to include a capture range of 10 minutes before and after the date range.
-    It's a naive assumption that a trace finishes generating within 10 minutes of the first event so we can apply the date filters.
-    """
-
-    CAPTURE_RANGE_MINUTES = 10
-
-    def date_from_for_filtering(self) -> datetime:
-        return super().date_from()
-
-    def date_to_for_filtering(self) -> datetime:
-        return super().date_to()
-
-    def date_from(self) -> datetime:
-        return super().date_from() - timedelta(minutes=self.CAPTURE_RANGE_MINUTES)
-
-    def date_to(self) -> datetime:
-        return super().date_to() + timedelta(minutes=self.CAPTURE_RANGE_MINUTES)
-
-
 class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
+    """
+    Returns a single trace and its events.
+
+    Runs in two stages so the trace detail view shows the same spans the user
+    sees by expanding the trace from the sessions view. A single-stage time
+    filter, no matter how wide, will eventually miss long-running traces or
+    late-arriving spans; the resulting span-count mismatch reads as cache
+    staleness and has been a recurring source of confusion. Stage one finds
+    the trace's actual timestamp bounds; stage two fetches all events using
+    those exact bounds.
+    """
+
+    BOUNDS_BACKWARD_BUFFER_MINUTES = 10
+    EVENTS_BUFFER_MINUTES = 1
+
     query: TraceQuery
     cached_response: CachedTraceQueryResponse
+    _trace_bounds: tuple[datetime, datetime] | None = None
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
     def _calculate(self):
+        bounds = self._discover_trace_bounds()
+        if bounds is None:
+            return TraceQueryResponse(
+                columns=[],
+                results=[],
+                timings=self.timings.to_list(),
+                hogql="",
+                modifiers=self.modifiers,
+            )
+
+        self._trace_bounds = bounds
+
         query_result = execute_with_ai_events_fallback(
             query=self._build_query(),
             placeholders={"filter_conditions": self._get_where_clause()},
@@ -90,6 +97,37 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
             hogql=query_result.hogql,
             modifiers=self.modifiers,
         )
+
+    def _discover_trace_bounds(self) -> tuple[datetime, datetime] | None:
+        bounds_query = parse_select(
+            """
+            SELECT
+                min(timestamp) AS min_ts,
+                max(timestamp) AS max_ts
+            FROM posthog.ai_events AS ai_events
+            WHERE event IN (
+                '$ai_span', '$ai_generation', '$ai_embedding', '$ai_metric', '$ai_feedback', '$ai_trace'
+            )
+              AND {filter_conditions}
+            """,
+        )
+
+        result = execute_with_ai_events_fallback(
+            query=cast(ast.SelectQuery, bounds_query),
+            placeholders={"filter_conditions": self._get_bounds_where_clause()},
+            team=self.team,
+            query_type=f"{NodeKind.TRACE_QUERY}_bounds",
+            timings=self.timings,
+            modifiers=self.modifiers,
+            limit_context=self.limit_context,
+        )
+
+        if not result.results:
+            return None
+        min_ts, max_ts = result.results[0]
+        if min_ts is None or max_ts is None:
+            return None
+        return cast(datetime, min_ts), cast(datetime, max_ts)
 
     def to_query(self):
         return self._build_query()
@@ -184,13 +222,12 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
         return {
             **super().get_cache_payload(),
             # When the response schema changes, increment this version to invalidate the cache.
-            "schema_version": 5,
+            "schema_version": 6,
         }
 
     @cached_property
     def _date_range(self):
-        # Minute-level precision for 10m capture range
-        return TraceQueryDateRange(self.query.dateRange, self.team, IntervalType.MINUTE, datetime.now())
+        return QueryDateRange(self.query.dateRange, self.team, IntervalType.MINUTE, datetime.now())
 
     def cache_target_age(self, last_refresh: Optional[datetime], lazy: bool = False) -> Optional[datetime]:
         if last_refresh is None:
@@ -198,27 +235,58 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
 
         return last_refresh + timedelta(minutes=1)
 
-    def _get_where_clause(self) -> ast.Expr:
+    def _get_bounds_where_clause(self) -> ast.Expr:
+        # The user-provided date range is just a hint to narrow ClickHouse
+        # partition scans during bounds discovery; we extend forward to "now"
+        # so the trace detail page still finds late-arriving spans even when
+        # the URL timestamp window only covers the first few minutes of a
+        # long-running trace.
+        date_from = self._date_range.date_from() - timedelta(minutes=self.BOUNDS_BACKWARD_BUFFER_MINUTES)
+        date_to = max(self._date_range.date_to(), self._date_range.now_with_timezone)
+
         where_exprs: list[ast.Expr] = [
             ast.CompareOperation(
                 op=ast.CompareOperationOp.GtEq,
                 left=ast.Field(chain=["ai_events", "timestamp"]),
-                right=self._date_range.date_from_as_hogql(),
+                right=ast.Constant(value=date_from),
             ),
             ast.CompareOperation(
                 op=ast.CompareOperationOp.LtEq,
                 left=ast.Field(chain=["ai_events", "timestamp"]),
-                right=self._date_range.date_to_as_hogql(),
+                right=ast.Constant(value=date_to),
             ),
-        ]
-
-        where_exprs.append(
             ast.CompareOperation(
                 left=ast.Field(chain=["trace_id"]),
                 op=ast.CompareOperationOp.Eq,
                 right=ast.Constant(value=self.query.traceId),
             ),
-        )
+        ]
+
+        return ast.And(exprs=where_exprs)
+
+    def _get_where_clause(self) -> ast.Expr:
+        # Stage two scopes the timestamp filter to the exact bounds discovered
+        # by stage one, plus a one-minute buffer to absorb any precision drift.
+        assert self._trace_bounds is not None, "Stage one must populate trace bounds before stage two runs"
+        min_ts, max_ts = self._trace_bounds
+
+        where_exprs: list[ast.Expr] = [
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.GtEq,
+                left=ast.Field(chain=["ai_events", "timestamp"]),
+                right=ast.Constant(value=min_ts - timedelta(minutes=self.EVENTS_BUFFER_MINUTES)),
+            ),
+            ast.CompareOperation(
+                op=ast.CompareOperationOp.LtEq,
+                left=ast.Field(chain=["ai_events", "timestamp"]),
+                right=ast.Constant(value=max_ts + timedelta(minutes=self.EVENTS_BUFFER_MINUTES)),
+            ),
+            ast.CompareOperation(
+                left=ast.Field(chain=["trace_id"]),
+                op=ast.CompareOperationOp.Eq,
+                right=ast.Constant(value=self.query.traceId),
+            ),
+        ]
 
         if self.query.properties:
             with self.timings.measure("property_filters"):
@@ -263,19 +331,4 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
 
     def _map_results(self, columns: list[str], query_results: list) -> list[LLMTrace]:
         mapped_results = [dict(zip(columns, value)) for value in query_results]
-        traces = []
-
-        date_from = self._date_range.date_from_for_filtering()
-        date_to = self._date_range.date_to_for_filtering()
-
-        for result in mapped_results:
-            # Overlap semantics: match sessions list behavior where a trace
-            # is counted if ANY of its events fall in the date window.
-            first_timestamp = cast(datetime, result["first_timestamp"])
-            last_timestamp = cast(datetime, result["last_timestamp"])
-            if first_timestamp > date_to or last_timestamp < date_from:
-                continue
-
-            traces.append(self._map_trace(result, first_timestamp))
-
-        return traces
+        return [self._map_trace(result, cast(datetime, result["first_timestamp"])) for result in mapped_results]

--- a/posthog/hogql_queries/ai/trace_query_runner.py
+++ b/posthog/hogql_queries/ai/trace_query_runner.py
@@ -59,10 +59,10 @@ class TraceQueryRunner(AnalyticsQueryRunner[TraceQueryResponse]):
 
     query: TraceQuery
     cached_response: CachedTraceQueryResponse
-    _trace_bounds: tuple[datetime, datetime] | None = None
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
+        self._trace_bounds: tuple[datetime, datetime] | None = None
 
     def _calculate(self):
         bounds = self._discover_trace_bounds()


### PR DESCRIPTION
## Problem

The trace detail page (`/llm-analytics/traces/<id>`) and the same trace expanded from `/llm-analytics/sessions` could show different sets of spans for the same `trace_id`. The detail page applied a tight ~30 minute window around the URL `timestamp` parameter (frontend `+10 min` on `date_to`, backend `±10 min` buffer), while sessions expansion sent no `dateRange` and got the 7 day default. Long-running agent traces and late-arriving spans got cut off on the detail page only.

To customers this read as cache staleness — refreshing didn't help, because the date filter applied on every request — and a recent support escalation called this out explicitly.

## Changes

`TraceQueryRunner` now runs in two stages:

1. **Stage one** (`_discover_trace_bounds`) — `SELECT min(timestamp), max(timestamp) FROM ai_events WHERE trace_id = ?` over a generous hint window (user's `date_from − 10 min`, upper end extended to "now") so partition pruning still helps but late-arriving spans aren't cut off.
2. **Stage two** — the existing aggregation query, scoped to the exact bounds discovered in stage one (`min_ts ± 1 min`).

This mirrors the pattern already used by `TracesQueryRunner` for the list view, removes the `TraceQueryDateRange` wrapper and its now-meaningless overlap filter in `_map_results`, and bumps `schema_version` to 6 to invalidate caches that may still hold truncated event lists.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests:

- Updated `test_capture_range` in `posthog/hogql_queries/ai/test/test_trace_query_runner.py` to add a span emitted 5 hours after the trace start and assert it's returned. Other existing tests in this file (date-range filtering, property filters, person filters, embedding/trace-name behaviour) cover the unchanged paths.
- Locally ran `ruff check` and `ruff format` — clean. `lint-staged` ran `bin/hogli lint:python:fix`, `bin/hogli format:python`, and `uv run ty check` on the staged files at commit time, all green.

I have **not** manually clicked through the trace detail page in a browser.

## Publish to changelog?

no

## Docs update

n/a

## 🤖 Agent context

- Agent: PostHog Code (Claude Opus 4.7)
- Triggered by support ticket bc1a522d-2c83-4fa5-a92f-35129e54d19e (LLM analytics — "extremely stale data")
- Key decision: chose two-stage query over widening the single-stage window. The two-stage approach matches `TracesQueryRunner` and guarantees parity with sessions regardless of trace duration; widening the window would still leave a worst-case timeout for very long agents.
- Cache invalidation handled via `schema_version` bump (5 → 6).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*