### PR TITLE
fix(flags): respect variant order in has_hash_dependent_variants

### DIFF
--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -1435,6 +1435,54 @@ mod tests {
     }
 
     #[test]
+    fn test_has_hash_dependent_variants_all_zero() {
+        // No variant is ever selected, so the hash decides nothing. The old rule called this
+        // hash dependent because nothing sat at 100.
+        let mut flag = mock!(FeatureFlag);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: Some("Control".to_string()),
+                    rollout_percentage: 0.0,
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: Some("Test".to_string()),
+                    rollout_percentage: 0.0,
+                },
+            ],
+        });
+        assert!(!flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_hash_dependent_variants_100_percent_in_the_middle() {
+        // The third variant is unreachable, but the first two still split on the hash.
+        let mut flag = mock!(FeatureFlag);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "a".to_string(),
+                    name: Some("A".to_string()),
+                    rollout_percentage: 30.0,
+                },
+                MultivariateFlagVariant {
+                    key: "b".to_string(),
+                    name: Some("B".to_string()),
+                    rollout_percentage: 100.0,
+                },
+                MultivariateFlagVariant {
+                    key: "c".to_string(),
+                    name: Some("C".to_string()),
+                    rollout_percentage: 50.0,
+                },
+            ],
+        });
+        assert!(flag.has_hash_dependent_variants());
+    }
+
+    #[test]
     fn test_needs_hash_key_override_partial_before_100_percent() {
         let mut flag = mock!(FeatureFlag);
         flag.ensure_experience_continuity = Some(true);

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -52,24 +52,33 @@ impl FeatureFlag {
 
     /// Returns true if the flag has multivariate variants that depend on hashing.
     ///
-    /// A flag with no variants or any variant at 100% is effectively not multivariate,
-    /// since the variant assignment doesn't depend on hashing. When any variant has
-    /// 100% rollout, that variant wins for everyone regardless of their hash bucket.
+    /// `get_matching_variant` walks the variants in order accumulating percentages and returns
+    /// the first whose running total passes the hash, so a variant is reachable only while the
+    /// total before it is still under 100 and its own share is non-zero. Hashing decides nothing
+    /// when at most one variant is reachable.
+    ///
+    /// Note this is about position, not just presence of a 100: `[100, 40]` is not hash
+    /// dependent because the first variant already takes everyone, while `[40, 100]` is,
+    /// because hashes below 0.40 still select the first.
     pub fn has_hash_dependent_variants(&self) -> bool {
         match &self.filters.multivariate {
             None => false,
             Some(multivariate) => {
-                let variants = &multivariate.variants;
-                // No variants = not multivariate
-                if variants.is_empty() {
-                    return false;
+                let mut cumulative = 0.0;
+                let mut reachable = 0;
+                for variant in &multivariate.variants {
+                    if cumulative >= 100.0 {
+                        break;
+                    }
+                    if variant.rollout_percentage > 0.0 {
+                        reachable += 1;
+                        if reachable > 1 {
+                            return true;
+                        }
+                    }
+                    cumulative += variant.rollout_percentage;
                 }
-                // Any variant at 100% wins for everyone, making hashing irrelevant
-                if variants.iter().any(|v| v.rollout_percentage >= 100.0) {
-                    return false;
-                }
-                // Multiple variants with partial rollouts = truly multivariate
-                true
+                false
             }
         }
     }
@@ -1359,6 +1368,91 @@ mod tests {
         });
         // When any variant is at 100%, hashing doesn't matter - that variant always wins
         assert!(!flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_hash_dependent_variants_partial_before_100_percent() {
+        // The old rule saw the 100 and returned false, but hashes below 0.40 select "control",
+        // so assignment does depend on the hash and continuity lookups must not be skipped.
+        let mut flag = mock!(FeatureFlag);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: Some("Control".to_string()),
+                    rollout_percentage: 40.0,
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: Some("Test".to_string()),
+                    rollout_percentage: 100.0,
+                },
+            ],
+        });
+        assert!(flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_hash_dependent_variants_zero_before_100_percent() {
+        // A zero-share variant is never selected, so the 100 still takes everyone.
+        let mut flag = mock!(FeatureFlag);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: Some("Control".to_string()),
+                    rollout_percentage: 0.0,
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: Some("Test".to_string()),
+                    rollout_percentage: 100.0,
+                },
+            ],
+        });
+        assert!(!flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_has_hash_dependent_variants_first_variant_over_100_percent() {
+        // The first variant already covers the whole range, so later ones are unreachable.
+        let mut flag = mock!(FeatureFlag);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: Some("Control".to_string()),
+                    rollout_percentage: 150.0,
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: Some("Test".to_string()),
+                    rollout_percentage: 10.0,
+                },
+            ],
+        });
+        assert!(!flag.has_hash_dependent_variants());
+    }
+
+    #[test]
+    fn test_needs_hash_key_override_partial_before_100_percent() {
+        let mut flag = mock!(FeatureFlag);
+        flag.ensure_experience_continuity = Some(true);
+        flag.filters.multivariate = Some(MultivariateFlagOptions {
+            variants: vec![
+                MultivariateFlagVariant {
+                    key: "control".to_string(),
+                    name: Some("Control".to_string()),
+                    rollout_percentage: 40.0,
+                },
+                MultivariateFlagVariant {
+                    key: "test".to_string(),
+                    name: Some("Test".to_string()),
+                    rollout_percentage: 100.0,
+                },
+            ],
+        });
+        assert!(flag.needs_hash_key_override());
     }
 
     #[test]

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -1372,8 +1372,8 @@ mod tests {
 
     #[test]
     fn test_has_hash_dependent_variants_partial_before_100_percent() {
-        // The old rule saw the 100 and returned false, but hashes below 0.40 select "control",
-        // so assignment does depend on the hash and continuity lookups must not be skipped.
+        // Hashes below 0.40 select "control", so assignment depends on the hash and
+        // continuity lookups must not be skipped.
         let mut flag = mock!(FeatureFlag);
         flag.filters.multivariate = Some(MultivariateFlagOptions {
             variants: vec![
@@ -1436,8 +1436,7 @@ mod tests {
 
     #[test]
     fn test_has_hash_dependent_variants_all_zero() {
-        // No variant is ever selected, so the hash decides nothing. The old rule called this
-        // hash dependent because nothing sat at 100.
+        // No variant is ever selected, so the hash decides nothing.
         let mut flag = mock!(FeatureFlag);
         flag.filters.multivariate = Some(MultivariateFlagOptions {
             variants: vec![


### PR DESCRIPTION
`has_hash_dependent_variants` returned false whenever any variant sat at 100, but `get_matching_variant` walks the variants in order, so an earlier smaller variant still takes the low hashes. On a `[40, 100]` flag the first variant serves every hash below 0.40, which means assignment does depend on the hash while the optimizer said it did not.

**What that breaks today**

`needs_hash_key_override` uses this to decide whether to look up the experience continuity override. For those flags it skips the lookup, so bucketing falls back to the current `distinct_id` instead of the stored one. A user whose `distinct_id` changes, which is exactly what continuity exists to handle, can be moved to a different variant.

It only bites when `optimize_experience_continuity_lookups` is on, since the legacy path always does the lookup.

**The fix**

Count reachable variants rather than looking for a 100 anywhere: a variant is reachable while the running total before it is under 100 and its own share is non-zero, and hashing decides nothing when at most one is. Position is what matters, not presence:

| variants | before | after |
|---|---|---|
| `[40, 100]` | not hash dependent | **hash dependent** |
| `[30, 100, 50]` | not hash dependent | **hash dependent** |
| `[0, 0]` | hash dependent | **not hash dependent** |
| `[100, 40]` | not hash dependent | unchanged |
| `[0, 100]` | not hash dependent | unchanged |
| `[150, 10]` | not hash dependent | unchanged |
| `[50, 50]` | hash dependent | unchanged |

The `[0, 0]` row is a second correction that came out of the rewrite: no variant is ever selected there, so the hash decides nothing and the lookup can be skipped. Harmless either way, but worth naming rather than leaving it to be discovered.

**Scope**

Found while writing a migration that clamps rollout sums over 100. That migration guards these flags itself rather than depending on this fix, so the two are independent. In production 12 flags in prod-us and 2 in prod-eu have the shape; none currently have continuity enabled, so nothing is mis-bucketed right now, but any of them could be by turning it on.

**Tests**

Six new cases covering every row above, plus a `needs_hash_key_override` case for `[40, 100]` with continuity on. The existing `[100, 0]` test still passes unchanged, since the corrected rule agrees with the old one there. Verified the new `[40, 100]` test fails against the old rule.
