### PR TITLE
fix: batch get_actors to avoid pg timeouts during large exports

### DIFF
--- a/posthog/queries/actor_base_query.py
+++ b/posthog/queries/actor_base_query.py
@@ -293,7 +293,7 @@ def get_serialized_people(
     team: Team, people_ids: list[Any], value_per_actor_id: Optional[dict[str, float]] = None, distinct_id_limit=1000
 ) -> list[SerializedPerson]:
     persons_dict = PersonStrategy(team, ActorsQuery(), HogQLHasMorePaginator()).get_actors(
-        people_ids, order_by="created_at DESC, uuid"
+        people_ids, sort_by_created_at_descending=True
     )
     from posthog.api.person import get_person_name_helper
 


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

When exporting a csv with thousands of persons from an insight, the pg query will timeout with the following error. 

client error log - `django.db.utils.OperationalError: consuming input failed: server closed the connection unexpectedly`
From https://grafana.prod-us.posthog.dev/goto/JRIggfZDR?orgId=1

pgbouncer error - `2025-11-28 01:05:46.755 UTC [1] WARNING C-0xaaab0ccbf060: d25vf5hht9th9v/posthog-query-django-pgbouncer-persons@10.32.6.30:46538 pooler error: query timeout`
From https://grafana.prod-us.posthog.dev/goto/JeAgRBZDR?orgId=1

You can reproduce this error by clicking on the persons modal in this funnel (https://us.posthog.com/project/2/insights/Tlzcv6X0) and then clicking `Download CSV`. The 7k persons will sometimes fail, but the 200k ones will reliably fail from my testing. 

The persons reader query timeout is 8s set here https://github.com/PostHog/charts/blob/main/argocd/posthog/values/posthog-query-django/values.prod-us.yaml#L120 

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Batch the query to avoid hitting the timeout. 

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

- Added unit test. 
- Verified locally export still works
- I ran the batched `get_actors` code against 300k random actor_ids for team 2 in prod and these were the results
```
  | Metric         | Value                          |
  |----------------|--------------------------------|
  | Total time     | 196.48s                        |
  | Time per batch | 0.655s (well under 8s timeout) |
  | Persons found  | 145,830                        |
  | Distinct IDs   | 2,763,388                      |

```

<details>
<summary>Script</summary>

``` Python
import time
import orjson as json
from django.db import connections
from posthog.models import Team
from posthog.models.person import Person, PersonDistinctId
from posthog.person_db_router import PERSONS_DB_FOR_READ
from posthog.clickhouse.client import sync_execute

TEAM_ID = 2
TOTAL_UUIDS = 300000
BATCH_SIZE = 1000


def get_real_person_uuids(team_id: int, limit: int) -> list[str]:
    """Get real person UUIDs from ClickHouse."""
    print(f"Fetching {limit} real person UUIDs from ClickHouse...")
    start = time.perf_counter()
    results = sync_execute(
        """
        SELECT DISTINCT person_id
        FROM events
        WHERE team_id = %(team_id)s
        AND timestamp > now() - INTERVAL 30 DAY
        AND person_id != '00000000-0000-0000-0000-000000000000'
        LIMIT %(limit)s
        """,
        {"team_id": team_id, "limit": limit},
    )
    elapsed = time.perf_counter() - start
    uuids = [str(row[0]) for row in results]
    print(f"Got {len(uuids)} UUIDs in {elapsed:.2f}s")
    return uuids


def get_actors_batched(team, actor_ids):
    """Batched get_actors implementation."""
    person_table = Person._meta.db_table
    pdi_table = PersonDistinctId._meta.db_table
    conn = connections[PERSONS_DB_FOR_READ]

    actor_ids_list = list(actor_ids)
    all_people = []
    all_distinct_ids = []

    with conn.cursor() as cursor:
        for i in range(0, len(actor_ids_list), BATCH_SIZE):
            batch = actor_ids_list[i : i + BATCH_SIZE]
            cursor.execute(
                f"""SELECT {person_table}.id, {person_table}.uuid, {person_table}.properties,
                           {person_table}.is_identified, {person_table}.created_at
                    FROM {person_table}
                    WHERE {person_table}.uuid = ANY(%(uuids)s)
                    AND {person_table}.team_id = %(team_id)s""",
                {"uuids": batch, "team_id": team.pk},
            )
            all_people.extend(cursor.fetchall())

        person_ids = [x[0] for x in all_people]
        for i in range(0, len(person_ids), BATCH_SIZE):
            batch = person_ids[i : i + BATCH_SIZE]
            cursor.execute(
                f"""SELECT {pdi_table}.person_id, {pdi_table}.distinct_id
                    FROM {pdi_table}
                    WHERE {pdi_table}.person_id = ANY(%(people_ids)s)
                    AND {pdi_table}.team_id = %(team_id)s""",
                {"people_ids": batch, "team_id": team.pk},
            )
            all_distinct_ids.extend(cursor.fetchall())

    person_id_to_raw = {person[0]: (person, []) for person in all_people}
    for pdid in all_distinct_ids:
        if pdid[0] in person_id_to_raw:
            person_id_to_raw[pdid[0]][1].append(pdid[1])

    return {
        str(person[1]): {
            "id": person[1],
            "properties": json.loads(person[2]),
            "is_identified": person[3],
            "created_at": person[4],
            "distinct_ids": dids,
        }
        for person, dids in person_id_to_raw.values()
    }, len(all_distinct_ids)


def run_benchmark():
    """Main benchmark runner."""
    print("=" * 80)
    print(f"Benchmark: Batched PostgreSQL get_actors with {TOTAL_UUIDS} real UUIDs")
    print(f"Batch size: {BATCH_SIZE}")
    print("=" * 80)

    team = Team.objects.get(pk=TEAM_ID)
    print(f"Team: {team.name} (ID: {team.pk})")

    test_uuids = get_real_person_uuids(TEAM_ID, TOTAL_UUIDS)

    num_batches = (len(test_uuids) + BATCH_SIZE - 1) // BATCH_SIZE
    print(f"\nRunning get_actors with {len(test_uuids)} UUIDs in {num_batches} batches...")

    start = time.perf_counter()
    result, pdi_count = get_actors_batched(team, test_uuids)
    elapsed = time.perf_counter() - start

    print(f"\nResults:")
    print(f"    Total time: {elapsed:.2f}s")
    print(f"    Time per batch: {elapsed / num_batches:.3f}s")
    print(f"    Persons found: {len(result)}")
    print(f"    Distinct IDs found: {pdi_count}")

    print("\n" + "=" * 80)
    print("SUCCESS: Batched queries completed without timeout!")


run_benchmark()
```
Run on prod pod:
```
cat /Users/andyzhao/repos/posthog/posthog/hogql_queries/benchmark_batched_get_actors.py | kubectl exec -i -n posthog posthog-query-django-69fdf46f87-2djxb -- python manage.py shell 2>&1 | grep -v
   "^I1202\|^{\"event\"\|site-packages\|^\s*$"

```
</details>

## Why not used ClickHouse persons and pid tables isntead? 
CH is only faster for large sets of actor_is so we would need to maintain two query paths here, CH for exports and PG for interactive queries. Because the two data sources are eventually consistent, there may be a difference between the export and interactive query, leading to some confusion on the customer's end. I also think the extra code path makes this code harder to maintain and isn't worth it just to save time on large exports. 

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Docs reminder: If this change requires updated docs, please do that! Engineers are the primary people responsible for their documentation. 🙌 -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Changelog: (features only) Is this feature complete?

<!-- Yes if this is okay to go in the changelog. No if it's still hidden behind a feature flag, or part of a feature that's not complete yet, etc.  -->
<!-- Removing this section does not mean the changelog bot won't pick it up, because *some people* like to not use the template, so we can't rely on it existing. -->
