### PR TITLE
fix(person-frontend): fix person query showing split distinct_ids

### DIFF
--- a/frontend/src/scenes/persons/personsLogic.tsx
+++ b/frontend/src/scenes/persons/personsLogic.tsx
@@ -165,7 +165,7 @@ export const personsLogic = kea<personsLogicType>([
                 },
                 loadPersonUUID: async ({ uuid }): Promise<PersonType | null> => {
                     const response = await hogqlQuery(
-                        hogql`select id, groupArray(101)(pdi2.distinct_id) as distinct_ids, properties, is_identified, created_at from persons LEFT JOIN (SELECT argMax(pdi2.person_id, pdi2.version) AS person_id, pdi2.distinct_id AS distinct_id FROM raw_person_distinct_ids as pdi2 WHERE pdi2.person_id = {id} GROUP BY pdi2.distinct_id HAVING ifNull(equals(argMax(pdi2.is_deleted, pdi2.version), 0), 0)) as pdi2 ON pdi2.person_id=persons.id where id={id} group by id, properties, is_identified, created_at`,
+                        hogql`select id, groupArray(101)(pdi2.distinct_id) as distinct_ids, properties, is_identified, created_at from persons LEFT JOIN (SELECT person_id, distinct_id FROM (SELECT argMax(pdi2.person_id, pdi2.version) AS person_id, pdi2.distinct_id AS distinct_id, argMax(pdi2.is_deleted, pdi2.version) AS is_deleted FROM raw_person_distinct_ids as pdi2 GROUP BY pdi2.distinct_id) WHERE person_id = {id} AND ifNull(equals(is_deleted, 0), 0)) as pdi2 ON pdi2.person_id=persons.id where id={id} group by id, properties, is_identified, created_at`,
                         { id: uuid },
                         'blocking'
                     )


### PR DESCRIPTION
## Problem

When persons are split, the split operation creates new person entries with separate distinct_ids. However, the query that fetches a person's distinct ids was incorrectly showing all distinct ids that were ever associated with it, not just the ones currently associated, since it filtered by `person_id` before applying an `argMax(version)`, causing all historical versions to be considered.

This impacts the page `https://us.posthog.com/project/:project_id/persons/:person_uuid`

## Changes

```sql
# Before:
  SELECT argMax(pdi2.person_id, pdi2.version) AS person_id, pdi2.distinct_id
  FROM raw_person_distinct_ids as pdi2
  WHERE pdi2.person_id = {id} 
  GROUP BY pdi2.distinct_id

# After:
  SELECT person_id, distinct_id
  FROM (
      SELECT
          argMax(pdi2.person_id, pdi2.version) AS person_id,
          pdi2.distinct_id AS distinct_id,
          argMax(pdi2.is_deleted, pdi2.version) AS is_deleted
      FROM raw_person_distinct_ids as pdi2
      GROUP BY pdi2.distinct_id  -- Apply argMax first to get latest mapping
  )
  WHERE person_id = {id} AND ifNull(equals(is_deleted, 0), 0)  -- Filter after argMax
```


## How did you test this code?

- Manually tested 
  - Created 3 persons with distinct ids user_001, user_002, user_003
  - Merged all 3 into a single person (user_001) -> verified it showed all 3 distinct ids
  - Split the merged person back into 3 separate persons
    - Before the fix, user_001 showed all 3 distinct ids
    - After the fix, user_001 only showed user_001 distinct id. 
