### PR TITLE
chore: exclude exception event and props

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -251,6 +251,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                             exclude_hidden: true,
                             ordering: eventOrdering ?? undefined,
                         }).url,
+                        excludedProperties: excludedProperties?.[TaxonomicFilterGroupType.Events],
                         getName: (eventDefinition: Record<string, any>) => eventDefinition.name,
                         getValue: (eventDefinition: Record<string, any>) =>
                             // Use the property's "name" when available, or "value" if a local option

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFilters.tsx
@@ -4,7 +4,7 @@ import { id } from 'chartjs-plugin-trendline'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
-import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { ExcludedProperties, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { useMemo } from 'react'
@@ -71,6 +71,23 @@ export function HogFunctionFilters({
     const isLegacyPlugin = configuration?.template?.id?.startsWith('plugin-')
     const isTransformation = type === 'transformation'
     const cdpPersonUpdatesEnabled = useFeatureFlag('CDP_PERSON_UPDATES')
+
+    const excludedProperties: ExcludedProperties = {
+        [TaxonomicFilterGroupType.EventProperties]: [
+            '$exception_types',
+            '$exception_functions',
+            '$exception_values',
+            '$exception_sources',
+            '$exception_list',
+            '$exception_type',
+            '$exception_level',
+            '$exception_message',
+        ],
+    }
+
+    if (type === 'transformation') {
+        excludedProperties[TaxonomicFilterGroupType.Events] = ['$exception']
+    }
 
     const taxonomicGroupTypes = useMemo(() => {
         const types = [
@@ -188,6 +205,7 @@ export function HogFunctionFilters({
                                     onChange(newValue as CyclotronJobFiltersType)
                                 }}
                                 pageKey={`HogFunctionPropertyFilters.${id}`}
+                                excludedProperties={excludedProperties}
                             />
 
                             {showEventMatchers ? (
@@ -227,6 +245,7 @@ export function HogFunctionFilters({
                                             type: EntityTypes.EVENTS,
                                         }}
                                         buttonCopy="Add event matcher"
+                                        excludedProperties={excludedProperties}
                                     />
                                 </>
                             ) : null}

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilter.tsx
@@ -27,6 +27,7 @@ import {
 import { teamLogic } from '../../../teamLogic'
 import { ActionFilterRow, MathAvailability } from './ActionFilterRow/ActionFilterRow'
 import { entityFilterLogic, LocalFilter, toFilters } from './entityFilterLogic'
+import { TaxonomicPopoverProps } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 
 export interface ActionFilterProps {
     setFilters: (filters: FilterType) => void
@@ -94,6 +95,8 @@ export interface ActionFilterProps {
     filtersLeftPadding?: boolean
     /** Doc link to show in the tooltip of the New Filter button */
     addFilterDocLink?: string
+    /** Properties to exclude from the properties filter */
+    excludedProperties?: TaxonomicPopoverProps['excludedProperties']
 }
 
 export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(function ActionFilter(
@@ -128,6 +131,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         dataWarehousePopoverFields,
         filtersLeftPadding,
         addFilterDocLink,
+        excludedProperties,
     },
     ref
 ): JSX.Element {
@@ -190,6 +194,7 @@ export const ActionFilter = React.forwardRef<HTMLDivElement, ActionFilterProps>(
         dataWarehousePopoverFields,
         filtersLeftPadding,
         addFilterDocLink,
+        excludedProperties,
     }
 
     const reachedLimit: boolean = Boolean(entitiesLimit && localFilters.length >= entitiesLimit)

--- a/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
+++ b/frontend/src/scenes/insights/filters/ActionFilter/ActionFilterRow/ActionFilterRow.tsx
@@ -20,7 +20,11 @@ import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
 import { SeriesGlyph, SeriesLetter } from 'lib/components/SeriesGlyph'
 import { defaultDataWarehousePopoverFields } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import { DataWarehousePopoverField, TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { TaxonomicPopover, TaxonomicStringPopover } from 'lib/components/TaxonomicPopover/TaxonomicPopover'
+import {
+    TaxonomicPopover,
+    TaxonomicPopoverProps,
+    TaxonomicStringPopover,
+} from 'lib/components/TaxonomicPopover/TaxonomicPopover'
 import { IconWithCount, SortableDragIcon } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
@@ -175,7 +179,8 @@ export function ActionFilterRow({
     dataWarehousePopoverFields = defaultDataWarehousePopoverFields,
     filtersLeftPadding = false,
     addFilterDocLink,
-}: ActionFilterRowProps): JSX.Element {
+    excludedProperties,
+}: ActionFilterRowProps & Pick<TaxonomicPopoverProps, 'excludedProperties'>): JSX.Element {
     const { entityFilterVisible } = useValues(logic)
     const {
         updateFilter,
@@ -323,6 +328,7 @@ export function ActionFilterRow({
             disabled={disabled || readOnly}
             showNumericalPropsOnly={showNumericalPropsOnly}
             dataWarehousePopoverFields={dataWarehousePopoverFields}
+            excludedProperties={excludedProperties}
         />
     )
 
@@ -665,6 +671,7 @@ export function ActionFilterRow({
                                 : []
                         }
                         addFilterDocLink={addFilterDocLink}
+                        excludedProperties={excludedProperties}
                     />
                 </div>
             )}

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Literal, cast, Optional
 
 from django.db.models import Manager
@@ -160,6 +161,12 @@ class EventDefinitionViewSet(
         exclude_hidden = self.request.GET.get("exclude_hidden", "false").lower() == "true"
         if exclude_hidden and is_enterprise:
             search_query = search_query + " AND (hidden IS NULL OR hidden = false)"
+
+        excluded_properties = self.request.GET.get("excluded_properties")
+
+        if excluded_properties:
+            excluded_list = list(set(json.loads(excluded_properties)))
+            search_query = search_query + f" AND NOT name = ANY(ARRAY{excluded_list})"
 
         sql = create_event_definitions_sql(
             event_type,


### PR DESCRIPTION
## Problem

Exception events do not go through the regular pipeline so we need to make some changes to make sure that they're correctly handled in CDP land

## Changes

- Do not allow exception events or associated properties to be used in transformations. This required implementing property exclusion on the `event_definitions` API endpoint
- Fixes a bug where the plugin server HogVM was throwing an `Unsupported function call: JSONExtract` when using string allow properties