### PR TITLE
fix(mcp): point dev oauth at the dev instance

### DIFF
--- a/services/mcp/src/lib/oauth-constants.ts
+++ b/services/mcp/src/lib/oauth-constants.ts
@@ -89,7 +89,23 @@ export const isCloudApi = (): boolean => {
 
 export const isLocalApi = (): boolean => !!getCustomApiBaseUrl()?.includes('localhost')
 
+const isCloudHost = (url: string): boolean => {
+    try {
+        return CLOUD_HOSTS.has(new URL(url).hostname)
+    } catch {
+        return false
+    }
+}
+
 export const resolveAuthorizationServerUrl = (): string => {
+    // Every k8s deployment shares a cluster-internal `POSTHOG_API_BASE_URL` that a browser
+    // cannot reach, so it cannot double as the authorization server. Cloud sends clients to
+    // the region proxy, which only knows US and EU. Non-cloud environments (dev) authorize
+    // against their own public instance instead, named by `POSTHOG_PUBLIC_URL`.
+    const publicUrl = env.POSTHOG_PUBLIC_URL
+    if (publicUrl && !isCloudHost(publicUrl)) {
+        return publicUrl
+    }
     if (isCloudApi()) {
         return OAUTH_PROXY_URL
     }

--- a/services/mcp/tests/unit/oauth-region.test.ts
+++ b/services/mcp/tests/unit/oauth-region.test.ts
@@ -136,6 +136,20 @@ describe('OAuth Region Routing', () => {
             delete process.env.POSTHOG_API_BASE_URL
             expect(getAuthorizationServerUrl()).toBe('https://oauth.posthog.com')
         })
+
+        it.each([
+            {
+                name: 'dev',
+                publicUrl: 'https://app.dev.posthog.dev',
+                expected: 'https://app.dev.posthog.dev',
+            },
+            { name: 'prod-us', publicUrl: 'https://us.posthog.com', expected: 'https://oauth.posthog.com' },
+            { name: 'prod-eu', publicUrl: 'https://eu.posthog.com', expected: 'https://oauth.posthog.com' },
+        ])('returns $expected for the $name cluster deployment', ({ publicUrl, expected }) => {
+            process.env.POSTHOG_API_BASE_URL = 'http://posthog-web-django.posthog.svc.cluster.local:8000'
+            process.env.POSTHOG_PUBLIC_URL = publicUrl
+            expect(getAuthorizationServerUrl()).toBe(expected)
+        })
     })
 
     describe('401 Response Metadata URL (RFC 9728)', () => {


### PR DESCRIPTION
## Problem

Nobody can log in to the dev MCP server at `mcp.dev.posthog.dev`.
The OAuth flow offers only prod US and prod EU, so a developer testing MCP against dev has no way to finish it.

- Dev advertises `https://oauth.posthog.com` as its authorization server, and that proxy knows two regions ([`Region = 'us' | 'eu'`](https://github.com/PostHog/posthog/blob/master/services/oauth-proxy/src/lib/constants.ts#L1)).
- All three k8s deployments share one cluster-internal `POSTHOG_API_BASE_URL`, which `isCloudApi()` treats as cloud.
- A cluster-internal host is not browser-reachable, so it cannot double as the authorization server. Routing it to the prod proxy was the right call for prod and caught dev with it.
- Picking a prod region does not help either: a prod token fails introspection against the dev database.

## Changes

- The dev MCP server now sends clients to `https://app.dev.posthog.dev` to authorize, and the login completes.
- `resolveAuthorizationServerUrl` prefers `POSTHOG_PUBLIC_URL` when it names a non-cloud host.

That variable already exists on every deployment for clickable links, so this needs no charts change and no new setting:

| Deployment | `POSTHOG_PUBLIC_URL` | Authorization server |
| --- | --- | --- |
| dev | `https://app.dev.posthog.dev` | `https://app.dev.posthog.dev` (was the prod proxy) |
| prod-us, prod-eu | `us`/`eu.posthog.com` | `https://oauth.posthog.com`, unchanged |
| local, self-hosted | unset | falls back to `POSTHOG_API_BASE_URL`, unchanged |

The function reads `env.POSTHOG_PUBLIC_URL` rather than the `getPublicBaseUrl()` helper.
That helper falls back to `POSTHOG_API_BASE_URL`, which would make prod's cluster-internal host look like a valid authorization server.

Nothing user-visible changes in prod. Both entry points, the Cloudflare worker and Hono, resolve through this one function.

## How did you test this code?

The new parameterized case in `tests/unit/oauth-region.test.ts` covers all three cluster deployments.
No existing test set `POSTHOG_PUBLIC_URL` alongside a cluster-internal API base, so nothing caught dev resolving to the prod proxy, and nothing pinned prod against a regression in the other direction.

Dev Django is a working authorization server: its [metadata](https://app.dev.posthog.dev/.well-known/oauth-authorization-server) reports `issuer: https://app.dev.posthog.dev` and lists a registration endpoint.

Not checked: the login flow itself. That needs the fix deployed to dev, and this sandbox cannot deploy.
`typecheck` reports 83 errors on this branch, all pre-existing and all downstream of the unbuilt `@posthog/quill` workspace in `src/ui-apps/**`. None sit in the changed files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The dev MCP server is internal and undocumented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) investigated a report that the dev MCP server's OAuth flow only offered prod regions, then wrote the fix.
Skills invoked: `/writing-pr-descriptions`.

The session started as a diagnosis rather than a change request.
Reading `oauth-constants.ts` gave the mechanism; probing `mcp.dev.posthog.dev/.well-known/oauth-protected-resource` confirmed it advertises the prod proxy; the values files in the charts repo confirmed dev already sets `POSTHOG_PUBLIC_URL`, which is what made the one-function fix possible.
An earlier sketch used the `getPublicBaseUrl()` helper, which passes prod's cluster-internal host through as an authorization server. The existing prod tests do not set `POSTHOG_PUBLIC_URL`, so they would not have caught it.

A personal API key works as a bearer token in the meantime, which unblocks dev MCP access without OAuth.
