### PR TITLE
feat: Don't Label Users as Quota Limited for N Days After They Exceed Their Quota

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -1,7 +1,16 @@
 import copy
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import Enum
-from typing import Dict, List, Mapping, Optional, Sequence, TypedDict, cast
+from typing import (
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    TypedDict,
+    cast,
+)
 
 import dateutil.parser
 import posthoganalytics
@@ -22,7 +31,11 @@ from posthog.tasks.usage_report import (
 )
 from posthog.utils import get_current_day
 
-QUOTA_LIMITER_CACHE_KEY = "@posthog/quota-limits/"
+# We are updating the quota limiting behavior so we retain data for DAYS_RETAIN_DATA days before
+# permanently dropping it. This will allow us to recover data in the case of incidents
+# where usage may have inadvertently exceeded a billing limit.
+# Ref: INC-144
+DAYS_RETAIN_DATA = 3
 
 QUOTA_LIMIT_DATA_RETENTION_FLAG = "retain-data-past-quota-limit"
 
@@ -33,6 +46,11 @@ class QuotaResource(Enum):
     ROWS_SYNCED = "rows_synced"
 
 
+class QuotaLimitingRedisCaches(Enum):
+    QUOTA_OVERAGE_RETENTION_CACHE_KEY = "@posthog/quota-overage-retention/"
+    QUOTA_LIMITER_CACHE_KEY = "@posthog/quota-limits/"
+
+
 OVERAGE_BUFFER = {
     QuotaResource.EVENTS: 0,
     QuotaResource.RECORDINGS: 1000,
@@ -40,29 +58,33 @@ OVERAGE_BUFFER = {
 }
 
 
-def replace_limited_team_tokens(resource: QuotaResource, tokens: Mapping[str, int]) -> None:
+def replace_limited_team_tokens(
+    resource: QuotaResource, tokens: Mapping[str, int], cache_key: QuotaLimitingRedisCaches
+) -> None:
     pipe = get_client().pipeline()
-    pipe.delete(f"{QUOTA_LIMITER_CACHE_KEY}{resource.value}")
+    pipe.delete(f"{cache_key}{resource.value}")
     if tokens:
-        pipe.zadd(f"{QUOTA_LIMITER_CACHE_KEY}{resource.value}", tokens)  # type: ignore # (zadd takes a Mapping[str, int] but the derived Union type is wrong)
+        pipe.zadd(f"{cache_key}{resource.value}", tokens)  # type: ignore # (zadd takes a Mapping[str, int] but the derived Union type is wrong)
     pipe.execute()
 
 
-def add_limited_team_tokens(resource: QuotaResource, tokens: Mapping[str, int]) -> None:
+def add_limited_team_tokens(
+    resource: QuotaResource, tokens: Mapping[str, int], cache_key: QuotaLimitingRedisCaches
+) -> None:
     redis_client = get_client()
-    redis_client.zadd(f"{QUOTA_LIMITER_CACHE_KEY}{resource.value}", tokens)  # type: ignore # (zadd takes a Mapping[str, int] but the derived Union type is wrong)
+    redis_client.zadd(f"{cache_key}{resource.value}", tokens)  # type: ignore # (zadd takes a Mapping[str, int] but the derived Union type is wrong)
 
 
-def remove_limited_team_tokens(resource: QuotaResource, tokens: List[str]) -> None:
+def remove_limited_team_tokens(resource: QuotaResource, tokens: List[str], cache_key: QuotaLimitingRedisCaches) -> None:
     redis_client = get_client()
-    redis_client.zrem(f"{QUOTA_LIMITER_CACHE_KEY}{resource.value}", *tokens)
+    redis_client.zrem(f"{cache_key}{resource.value}", *tokens)
 
 
 @cache_for(timedelta(seconds=30), background_refresh=True)
-def list_limited_team_attributes(resource: QuotaResource) -> List[str]:
+def list_limited_team_attributes(resource: QuotaResource, cache_key: QuotaLimitingRedisCaches) -> List[str]:
     now = timezone.now()
     redis_client = get_client()
-    results = redis_client.zrangebyscore(f"{QUOTA_LIMITER_CACHE_KEY}{resource.value}", min=now.timestamp(), max="+inf")
+    results = redis_client.zrangebyscore(f"{cache_key}{resource.value}", min=now.timestamp(), max="+inf")
     return [x.decode("utf-8") for x in results]
 
 
@@ -72,7 +94,16 @@ class UsageCounters(TypedDict):
     rows_synced: int
 
 
-def org_quota_limited_until(organization: Organization, resource: QuotaResource) -> Optional[int]:
+class QuotaLimitingTracker(TypedDict):
+    data_retained_until: Optional[int]  # timestamp
+    quota_limited_until: Optional[int]  # timestamp
+    needs_save: Optional[bool]
+
+
+def determine_org_quota_limit_or_data_retention(
+    organization: Organization, resource: QuotaResource
+) -> Optional[QuotaLimitingTracker]:
+    today, _ = get_current_day()
     if not organization.usage:
         return None
 
@@ -81,18 +112,30 @@ def org_quota_limited_until(organization: Organization, resource: QuotaResource)
         return None
     usage = summary.get("usage", 0)
     todays_usage = summary.get("todays_usage", 0)
+    data_retained_until = summary.get("retained_period_end", None)
     limit = summary.get("limit")
+    needs_save = False
 
     if limit is None:
         return None
 
     is_quota_limited = usage + todays_usage >= limit + OVERAGE_BUFFER[resource]
+    billing_period_start = round(dateutil.parser.isoparse(organization.usage["period"][0]).timestamp())
     billing_period_end = round(dateutil.parser.isoparse(organization.usage["period"][1]).timestamp())
 
-    if is_quota_limited and organization.never_drop_data:
+    if not is_quota_limited:
+        # Reset data retention
+        if data_retained_until:
+            data_retained_until = None
+            del summary["retained_period_end"]
+            needs_save = True
+            return {"quota_limited_until": None, "data_retained_until": None, "needs_save": needs_save}
         return None
 
-    if is_quota_limited and posthoganalytics.feature_enabled(
+    if organization.never_drop_data:
+        return None
+
+    if posthoganalytics.feature_enabled(
         QUOTA_LIMIT_DATA_RETENTION_FLAG,
         organization.id,
         groups={"organization": str(organization.id)},
@@ -105,8 +148,22 @@ def org_quota_limited_until(organization: Organization, resource: QuotaResource)
         )
         return None
 
-    if is_quota_limited and billing_period_end:
-        return billing_period_end
+    # Either wasn't set or was set in the previous biling period
+    if (
+        not data_retained_until
+        or round((datetime.fromtimestamp(data_retained_until) - timedelta(days=DAYS_RETAIN_DATA)).timestamp())
+        < billing_period_start
+    ):
+        data_retained_until = round((today + timedelta(days=DAYS_RETAIN_DATA)).timestamp())
+        summary["retained_period_end"] = data_retained_until
+        needs_save = True
+
+    if billing_period_end:
+        return {
+            "quota_limited_until": billing_period_end,
+            "data_retained_until": data_retained_until,
+            "needs_save": needs_save,
+        }
 
     return None
 
@@ -115,14 +172,35 @@ def sync_org_quota_limits(organization: Organization):
     if not organization.usage:
         return None
 
+    today_start, _ = get_current_day()
     for resource in [QuotaResource.EVENTS, QuotaResource.RECORDINGS, QuotaResource.ROWS_SYNCED]:
         team_attributes = get_team_attribute_by_quota_resource(organization, resource)
-        quota_limited_until = org_quota_limited_until(organization, resource)
+        result = determine_org_quota_limit_or_data_retention(organization, resource)
+        if result:
+            quota_limited_until = result.get("quota_limited_until")
+            data_retained_until = result.get("data_retained_until")
+            needs_save = result.get("needs_save")
 
-        if quota_limited_until:
-            add_limited_team_tokens(resource, {x: quota_limited_until for x in team_attributes})
-        else:
-            remove_limited_team_tokens(resource, team_attributes)
+            if needs_save:
+                organization.save()
+            if quota_limited_until and (data_retained_until and data_retained_until < round(today_start.timestamp())):
+                add_limited_team_tokens(
+                    resource,
+                    {x: quota_limited_until for x in team_attributes},
+                    QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY,
+                )
+                continue
+            elif data_retained_until and data_retained_until >= today_start.timestamp():
+                add_limited_team_tokens(
+                    resource,
+                    {x: data_retained_until for x in team_attributes},
+                    QuotaLimitingRedisCaches.QUOTA_OVERAGE_RETENTION_CACHE_KEY,
+                )
+                continue
+        remove_limited_team_tokens(resource, team_attributes, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY)
+        remove_limited_team_tokens(
+            resource, team_attributes, QuotaLimitingRedisCaches.QUOTA_OVERAGE_RETENTION_CACHE_KEY
+        )
 
 
 def get_team_attribute_by_quota_resource(organization: Organization, resource: QuotaResource):
@@ -182,7 +260,7 @@ def set_org_usage_summary(
     return has_changed
 
 
-def update_all_org_billing_quotas(dry_run: bool = False) -> Dict[str, Dict[str, int]]:
+def update_all_org_billing_quotas(dry_run: bool = False) -> Tuple[Dict[str, Dict[str, int]], Dict[str, Dict[str, int]]]:
     period = get_current_day()
     period_start, period_end = period
 
@@ -233,7 +311,8 @@ def update_all_org_billing_quotas(dry_run: bool = False) -> Dict[str, Dict[str, 
             for field in team_report:
                 org_report[field] += team_report[field]  # type: ignore
 
-    quota_limited_orgs: Dict[str, Dict[str, int]] = {"events": {}, "recordings": {}, "rows_synced": {}}
+    quota_limited_orgs: Dict[str, Dict[str, int]] = {key.value: {} for key in QuotaResource}
+    data_retained_orgs: Dict[str, Dict[str, int]] = {key.value: {} for key in QuotaResource}
 
     # We find all orgs that should be rate limited
     for org_id, todays_report in todays_usage_report.items():
@@ -246,24 +325,35 @@ def update_all_org_billing_quotas(dry_run: bool = False) -> Dict[str, Dict[str, 
                 org.save(update_fields=["usage"])
 
             for field in ["events", "recordings", "rows_synced"]:
-                quota_limited_until = org_quota_limited_until(org, QuotaResource(field))
+                result = determine_org_quota_limit_or_data_retention(org, QuotaResource(field))
+                if result:
+                    quota_limited_until = result.get("quota_limited_until")
+                    data_retained_until = result.get("data_retained_until")
+                    needs_save = result.get("needs_save")
 
-                if quota_limited_until:
-                    # TODO: Set this rate limit to the end of the billing period
-                    quota_limited_orgs[field][org_id] = quota_limited_until
+                    if needs_save:
+                        org.save(update_fields=["usage"])
 
-    # Get the current quota limits so we can track to poshog if it changes
+                    if data_retained_until and data_retained_until >= period_start.timestamp():
+                        data_retained_orgs[field][org_id] = data_retained_until
+                    elif quota_limited_until:
+                        quota_limited_orgs[field][org_id] = quota_limited_until
+
+    # Get the current quota limits so we can track to posthog if it changes
     orgs_with_changes = set()
-    previously_quota_limited_team_tokens: Dict[str, Dict[str, int]] = {
-        "events": {},
-        "recordings": {},
-        "rows_synced": {},
-    }
+    previously_quota_limited_team_tokens: Dict[str, Dict[str, int]] = {key.value: {} for key in QuotaResource}
+    previously_data_retained_teams: Dict[str, Dict[str, int]] = {key.value: {} for key in QuotaResource}
 
     for field in quota_limited_orgs:
-        previously_quota_limited_team_tokens[field] = list_limited_team_attributes(QuotaResource(field))
+        previously_quota_limited_team_tokens[field] = list_limited_team_attributes(
+            QuotaResource(field), QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+        )
+        previously_data_retained_teams[field] = list_limited_team_attributes(
+            QuotaResource(field), QuotaLimitingRedisCaches.QUOTA_OVERAGE_RETENTION_CACHE_KEY
+        )
 
-    quota_limited_teams: Dict[str, Dict[str, int]] = {"events": {}, "recordings": {}, "rows_synced": {}}
+    quota_limited_teams: Dict[str, Dict[str, int]] = {key.value: {} for key in QuotaResource}
+    data_retained_teams: Dict[str, Dict[str, int]] = {key.value: {} for key in QuotaResource}
 
     # Convert the org ids to team tokens
     for team in teams:
@@ -275,9 +365,14 @@ def update_all_org_billing_quotas(dry_run: bool = False) -> Dict[str, Dict[str, 
                 # If the team was not previously quota limited, we add it to the list of orgs that were added
                 if team.api_token not in previously_quota_limited_team_tokens[field]:
                     orgs_with_changes.add(org_id)
+            elif org_id in data_retained_orgs[field]:
+                data_retained_teams[field][team.api_token] = data_retained_orgs[field][org_id]
             else:
                 # If the team was previously quota limited, we add it to the list of orgs that were removed
-                if team.api_token in previously_quota_limited_team_tokens[field]:
+                if (
+                    team.api_token in previously_quota_limited_team_tokens[field]
+                    or team.api_token in previously_data_retained_teams[field]
+                ):
                     orgs_with_changes.add(org_id)
 
     for org_id in orgs_with_changes:
@@ -295,7 +390,15 @@ def update_all_org_billing_quotas(dry_run: bool = False) -> Dict[str, Dict[str, 
         )
 
     if not dry_run:
+        for field in data_retained_teams:
+            replace_limited_team_tokens(
+                QuotaResource(field),
+                data_retained_teams[field],
+                QuotaLimitingRedisCaches.QUOTA_OVERAGE_RETENTION_CACHE_KEY,
+            )
         for field in quota_limited_teams:
-            replace_limited_team_tokens(QuotaResource(field), quota_limited_teams[field])
+            replace_limited_team_tokens(
+                QuotaResource(field), quota_limited_teams[field], QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+            )
 
-    return quota_limited_orgs
+    return quota_limited_orgs, data_retained_orgs

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -9,10 +9,10 @@ from freezegun import freeze_time
 
 from ee.billing.quota_limiting import (
     QUOTA_LIMIT_DATA_RETENTION_FLAG,
-    QUOTA_LIMITER_CACHE_KEY,
+    QuotaLimitingRedisCaches,
     QuotaResource,
+    determine_org_quota_limit_or_data_retention,
     list_limited_team_attributes,
-    org_quota_limited_until,
     replace_limited_team_tokens,
     set_org_usage_summary,
     sync_org_quota_limits,
@@ -29,6 +29,12 @@ class TestQuotaLimiting(BaseTest):
     def setUp(self) -> None:
         super().setUp()
         self.redis_client = get_client()
+        self.redis_client.delete("@posthog/quota-overage-retention/events")
+        self.redis_client.delete("@posthog/quota-overage-retention/recordings")
+        self.redis_client.delete("@posthog/quota-overage-retention/rows_synced")
+        self.redis_client.delete("@posthog/quota-limits/events")
+        self.redis_client.delete("@posthog/quota-limits/recordings")
+        self.redis_client.delete("@posthog/quota-limits/rows_synced")
 
     @patch("posthoganalytics.capture")
     @patch("posthoganalytics.feature_enabled", return_value=True)
@@ -45,7 +51,6 @@ class TestQuotaLimiting(BaseTest):
             distinct_id = str(uuid4())
 
             # add a bunch of events so that the organization is over the limit
-            # Because the feature flag is enabled
             for _ in range(0, 10):
                 _create_event(
                     distinct_id=distinct_id,
@@ -55,8 +60,7 @@ class TestQuotaLimiting(BaseTest):
                     team=self.team,
                 )
         time.sleep(1)
-
-        result = update_all_org_billing_quotas()
+        quota_limited_orgs, data_retained_orgs = update_all_org_billing_quotas()
         patch_feature_enabled.assert_called_with(
             QUOTA_LIMIT_DATA_RETENTION_FLAG,
             self.organization.id,
@@ -69,13 +73,17 @@ class TestQuotaLimiting(BaseTest):
             properties={"current_usage": 109},
             groups={"instance": "http://localhost:8000", "organization": str(self.organization.id)},
         )
-        assert result["events"] == {}
-        assert result["recordings"] == {}
-        assert result["rows_synced"] == {}
+        # Not limited because the feature flag is enabled.
+        assert data_retained_orgs["events"] == {}
+        assert data_retained_orgs["recordings"] == {}
+        assert data_retained_orgs["rows_synced"] == {}
+        assert quota_limited_orgs["events"] == {}
+        assert quota_limited_orgs["recordings"] == {}
+        assert quota_limited_orgs["rows_synced"] == {}
 
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
 
     @patch("posthoganalytics.capture")
     @patch("posthoganalytics.feature_enabled", return_value=True)
@@ -90,18 +98,20 @@ class TestQuotaLimiting(BaseTest):
         self.organization.save()
 
         time.sleep(1)
-        with self.assertNumQueries(2):
-            result = update_all_org_billing_quotas()
+        quota_limited_orgs, data_retained_orgs = update_all_org_billing_quotas()
         # Shouldn't be called due to lazy evaluation of the conditional
         patch_feature_enabled.assert_not_called()
         patch_capture.assert_not_called()
-        assert result["events"] == {}
-        assert result["recordings"] == {}
-        assert result["rows_synced"] == {}
+        assert data_retained_orgs["events"] == {}
+        assert data_retained_orgs["recordings"] == {}
+        assert data_retained_orgs["rows_synced"] == {}
+        assert quota_limited_orgs["events"] == {}
+        assert quota_limited_orgs["recordings"] == {}
+        assert quota_limited_orgs["rows_synced"] == {}
 
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
 
     def test_billing_rate_limit_not_set_if_missing_org_usage(self) -> None:
         with self.settings(USE_TZ=False):
@@ -121,18 +131,20 @@ class TestQuotaLimiting(BaseTest):
                     team=self.team,
                 )
 
-        result = update_all_org_billing_quotas()
-        assert result["events"] == {}
-        assert result["recordings"] == {}
-        assert result["rows_synced"] == {}
+        quota_limited_orgs, data_retained_orgs = update_all_org_billing_quotas()
+        assert data_retained_orgs["events"] == {}
+        assert data_retained_orgs["recordings"] == {}
+        assert data_retained_orgs["rows_synced"] == {}
+        assert quota_limited_orgs["events"] == {}
+        assert quota_limited_orgs["recordings"] == {}
+        assert quota_limited_orgs["rows_synced"] == {}
 
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+        assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
 
-    @patch("posthoganalytics.capture")
-    def test_billing_rate_limit(self, patch_capture) -> None:
-        with self.settings(USE_TZ=False):
+    def test_billing_rate_limit(self) -> None:
+        with self.settings(USE_TZ=False), freeze_time("2021-01-25T22:09:14.252Z"):
             self.organization.usage = {
                 "events": {"usage": 99, "limit": 100},
                 "recordings": {"usage": 1, "limit": 100},
@@ -154,36 +166,126 @@ class TestQuotaLimiting(BaseTest):
                     team=self.team,
                 )
         time.sleep(1)
-        result = update_all_org_billing_quotas()
         org_id = str(self.organization.id)
-        assert result["events"] == {org_id: 1612137599}
-        assert result["recordings"] == {}
-        assert result["rows_synced"] == {}
 
-        patch_capture.assert_called_once_with(
-            org_id,
-            "organization quota limits changed",
-            properties={
-                "quota_limited_events": 1612137599,
-                "quota_limited_recordings": 1612137599,
-                "quota_limited_rows_synced": None,
-            },
-            groups={"instance": "http://localhost:8000", "organization": org_id},
-        )
+        with freeze_time("2021-01-25T22:09:14.252Z"):
+            # Should be data_retained until Jan 28 2021
+            quota_limited_orgs, data_retained_orgs = update_all_org_billing_quotas()
+            assert data_retained_orgs["events"] == {org_id: 1611792000}
+            assert quota_limited_orgs["events"] == {}
+            assert quota_limited_orgs["recordings"] == {}
+            assert quota_limited_orgs["rows_synced"] == {}
 
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == [
-            self.team.api_token.encode("UTF-8")
-        ]
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
-        assert self.redis_client.zrange(f"{QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
+            assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
+            assert (
+                self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+            )
+            assert (
+                self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
+            )
 
-        self.organization.refresh_from_db()
-        assert self.organization.usage == {
-            "events": {"usage": 99, "limit": 100, "todays_usage": 10},
-            "recordings": {"usage": 1, "limit": 100, "todays_usage": 0},
-            "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 0},
-            "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
-        }
+            self.organization.refresh_from_db()
+            assert self.organization.usage == {
+                "events": {"usage": 99, "limit": 100, "todays_usage": 10, "retained_period_end": 1611792000},
+                "recordings": {"usage": 1, "limit": 100, "todays_usage": 0},
+                "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 0},
+                "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
+            }
+
+        with freeze_time("2021-01-27T22:09:14.252Z"):
+            self.organization.usage = {
+                "events": {"usage": 109, "limit": 100, "retained_period_end": 1611792000},
+                "recordings": {"usage": 1, "limit": 100},
+                "rows_synced": {"usage": 5, "limit": 100},
+                "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
+            }
+            self.organization.save()
+            # Fast forward two days and should still be data retained until Jan 28 2021
+            quota_limited_orgs, data_retained_orgs = update_all_org_billing_quotas()
+            assert data_retained_orgs["events"] == {org_id: 1611792000}
+            assert quota_limited_orgs["events"] == {}
+            assert quota_limited_orgs["recordings"] == {}
+            assert quota_limited_orgs["rows_synced"] == {}
+
+            assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
+            assert (
+                self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+            )
+            assert (
+                self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
+            )
+
+            self.organization.refresh_from_db()
+            assert self.organization.usage == {
+                "events": {"usage": 109, "limit": 100, "todays_usage": 0, "retained_period_end": 1611792000},
+                "recordings": {"usage": 1, "limit": 100, "todays_usage": 0},
+                "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 0},
+                "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
+            }
+
+        with freeze_time("2021-02-2T22:09:14.252Z"):
+            self.organization.usage = {
+                "events": {"usage": 109, "limit": 100, "retained_period_end": 1611792000},
+                "recordings": {"usage": 1, "limit": 100},
+                "rows_synced": {"usage": 5, "limit": 100},
+                "period": ["2021-01-05T00:00:00Z", "2021-02-05T23:59:59Z"],
+            }
+            self.organization.save()
+            # Fast forward eight days and should no longer be data retained, still in same billing period
+            quota_limited_orgs, data_retained_orgs = update_all_org_billing_quotas()
+            assert data_retained_orgs["events"] == {}
+            assert quota_limited_orgs["events"] == {org_id: 1612569599}
+            assert quota_limited_orgs["recordings"] == {}
+            assert quota_limited_orgs["rows_synced"] == {}
+
+            assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == [
+                self.team.api_token.encode("UTF-8")
+            ]
+            assert (
+                self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+            )
+            assert (
+                self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
+            )
+
+            self.organization.refresh_from_db()
+            assert self.organization.usage == {
+                "events": {"usage": 109, "limit": 100, "todays_usage": 0, "retained_period_end": 1611792000},
+                "recordings": {"usage": 1, "limit": 100, "todays_usage": 0},
+                "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 0},
+                "period": ["2021-01-05T00:00:00Z", "2021-02-05T23:59:59Z"],
+            }
+
+        with freeze_time("2021-02-2T22:09:14.252Z"):
+            self.organization.usage = {
+                "events": {"usage": 109, "limit": 100, "retained_period_end": 1612137600},
+                "recordings": {"usage": 1, "limit": 100},
+                "rows_synced": {"usage": 5, "limit": 100},
+                "period": ["2021-02-01T00:00:00Z", "2021-02-28T23:59:59Z"],
+            }
+            self.organization.save()
+            # Fast forward two days and should still be data retained but with updated retention end because of new biling period
+            quota_limited_orgs, data_retained_orgs = update_all_org_billing_quotas()
+            assert data_retained_orgs["events"] == {org_id: 1612483200}
+            assert quota_limited_orgs["events"] == {}
+            assert quota_limited_orgs["recordings"] == {}
+            assert quota_limited_orgs["rows_synced"] == {}
+
+            assert self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}events", 0, -1) == []
+            assert (
+                self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}recordings", 0, -1) == []
+            )
+            assert (
+                self.redis_client.zrange(f"{QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY}rows_synced", 0, -1) == []
+            )
+
+            self.organization.refresh_from_db()
+            assert self.organization.usage == {
+                "events": {"usage": 109, "limit": 100, "todays_usage": 0, "retained_period_end": 1612483200},
+                "recordings": {"usage": 1, "limit": 100, "todays_usage": 0},
+                "rows_synced": {"usage": 5, "limit": 100, "todays_usage": 0},
+                "period": ["2021-02-01T00:00:00Z", "2021-02-28T23:59:59Z"],
+            }
 
     def test_set_org_usage_summary_updates_correctly(self):
         self.organization.usage = {
@@ -261,9 +363,10 @@ class TestQuotaLimiting(BaseTest):
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
         }
 
+    @freeze_time("2021-01-25T22:09:14.252Z")
     def test_org_quota_limited_until(self):
         self.organization.usage = None
-        assert org_quota_limited_until(self.organization, QuotaResource.EVENTS) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.EVENTS) is None
 
         self.organization.usage = {
             "events": {"usage": 99, "limit": 100},
@@ -272,32 +375,49 @@ class TestQuotaLimiting(BaseTest):
             "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
         }
 
-        assert org_quota_limited_until(self.organization, QuotaResource.EVENTS) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.EVENTS) is None
 
         self.organization.usage["events"]["usage"] = 120
-        assert org_quota_limited_until(self.organization, QuotaResource.EVENTS) == 1612137599
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.EVENTS) == {
+            "data_retained_until": 1611792000,
+            "needs_save": True,
+            "quota_limited_until": 1612137599,
+        }
 
         self.organization.usage["events"]["usage"] = 90
         self.organization.usage["events"]["todays_usage"] = 10
-        assert org_quota_limited_until(self.organization, QuotaResource.EVENTS) == 1612137599
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.EVENTS) == {
+            "data_retained_until": 1611792000,
+            "needs_save": False,
+            "quota_limited_until": 1612137599,
+        }
 
         self.organization.usage["events"]["limit"] = None
-        assert org_quota_limited_until(self.organization, QuotaResource.EVENTS) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.EVENTS) is None
 
         self.organization.usage["recordings"]["usage"] = 1099  # Under limit + buffer
-        assert org_quota_limited_until(self.organization, QuotaResource.RECORDINGS) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.RECORDINGS) is None
 
         self.organization.usage["recordings"]["usage"] = 1100  # Over limit + buffer
-        assert org_quota_limited_until(self.organization, QuotaResource.RECORDINGS) == 1612137599
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.RECORDINGS) == {
+            "data_retained_until": 1611792000,
+            "needs_save": True,
+            "quota_limited_until": 1612137599,
+        }
 
-        assert org_quota_limited_until(self.organization, QuotaResource.ROWS_SYNCED) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.ROWS_SYNCED) is None
 
         self.organization.usage["rows_synced"]["usage"] = 101
-        assert org_quota_limited_until(self.organization, QuotaResource.ROWS_SYNCED) == 1612137599
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.ROWS_SYNCED) == {
+            "data_retained_until": 1611792000,
+            "needs_save": True,
+            "quota_limited_until": 1612137599,
+        }
 
+    @freeze_time("2021-01-25T22:09:14.252Z")
     def test_over_quota_but_not_dropped_org(self):
         self.organization.usage = None
-        assert org_quota_limited_until(self.organization, QuotaResource.EVENTS) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.EVENTS) is None
 
         self.organization.usage = {
             "events": {"usage": 100, "limit": 90},
@@ -307,9 +427,9 @@ class TestQuotaLimiting(BaseTest):
         }
         self.organization.never_drop_data = True
 
-        assert org_quota_limited_until(self.organization, QuotaResource.EVENTS) is None
-        assert org_quota_limited_until(self.organization, QuotaResource.RECORDINGS) is None
-        assert org_quota_limited_until(self.organization, QuotaResource.ROWS_SYNCED) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.EVENTS) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.RECORDINGS) is None
+        assert determine_org_quota_limit_or_data_retention(self.organization, QuotaResource.ROWS_SYNCED) is None
 
         # reset for subsequent tests
         self.organization.never_drop_data = False
@@ -320,8 +440,12 @@ class TestQuotaLimiting(BaseTest):
 
             now = timezone.now().timestamp()
 
-            replace_limited_team_tokens(QuotaResource.EVENTS, {"1234": now + 10000})
-            replace_limited_team_tokens(QuotaResource.ROWS_SYNCED, {"1337": now + 10000})
+            replace_limited_team_tokens(
+                QuotaResource.EVENTS, {"1234": now + 10000}, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+            )
+            replace_limited_team_tokens(
+                QuotaResource.ROWS_SYNCED, {"1337": now + 10000}, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+            )
             self.organization.usage = {
                 "events": {"usage": 99, "limit": 100},
                 "recordings": {"usage": 1, "limit": 100},
@@ -330,23 +454,68 @@ class TestQuotaLimiting(BaseTest):
             }
 
             sync_org_quota_limits(self.organization)
-            assert list_limited_team_attributes(QuotaResource.EVENTS) == ["1234"]
-            assert list_limited_team_attributes(QuotaResource.ROWS_SYNCED) == ["1337"]
+            assert list_limited_team_attributes(
+                QuotaResource.EVENTS, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+            ) == ["1234"]
+            assert list_limited_team_attributes(
+                QuotaResource.ROWS_SYNCED, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+            ) == ["1337"]
 
             self.organization.usage["events"]["usage"] = 120
             self.organization.usage["rows_synced"]["usage"] = 120
             sync_org_quota_limits(self.organization)
-            assert sorted(list_limited_team_attributes(QuotaResource.EVENTS)) == sorted(
-                ["1234", self.team.api_token, other_team.api_token]
-            )
+            # Org will be data retained.
+            assert self.organization.usage == {
+                "events": {"usage": 120, "limit": 100, "retained_period_end": 1609718400},
+                "recordings": {"usage": 1, "limit": 100},
+                "rows_synced": {"limit": 100, "retained_period_end": 1609718400, "usage": 120},
+                "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
+            }
+            assert sorted(
+                list_limited_team_attributes(
+                    QuotaResource.EVENTS, QuotaLimitingRedisCaches.QUOTA_OVERAGE_RETENTION_CACHE_KEY
+                )
+            ) == sorted([self.team.api_token, other_team.api_token])
+            assert sorted(
+                list_limited_team_attributes(QuotaResource.EVENTS, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY)
+            ) == sorted(["1234"])
 
             # rows_synced uses teams, not tokens
-            assert sorted(list_limited_team_attributes(QuotaResource.ROWS_SYNCED)) == sorted(
-                ["1337", str(self.team.pk), str(other_team.pk)]
-            )
+            assert sorted(
+                list_limited_team_attributes(
+                    QuotaResource.ROWS_SYNCED, QuotaLimitingRedisCaches.QUOTA_OVERAGE_RETENTION_CACHE_KEY
+                )
+            ) == sorted([str(self.team.pk), str(other_team.pk)])
+            assert sorted(
+                list_limited_team_attributes(
+                    QuotaResource.ROWS_SYNCED, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+                )
+            ) == sorted(["1337"])
 
             self.organization.usage["events"]["usage"] = 80
             self.organization.usage["rows_synced"]["usage"] = 36
             sync_org_quota_limits(self.organization)
-            assert sorted(list_limited_team_attributes(QuotaResource.EVENTS)) == sorted(["1234"])
-            assert sorted(list_limited_team_attributes(QuotaResource.ROWS_SYNCED)) == sorted(["1337"])
+            assert self.organization.usage == {
+                "events": {"usage": 80, "limit": 100},
+                "recordings": {"usage": 1, "limit": 100},
+                "rows_synced": {"limit": 100, "usage": 36},
+                "period": ["2021-01-01T00:00:00Z", "2021-01-31T23:59:59Z"],
+            }
+            assert sorted(
+                list_limited_team_attributes(QuotaResource.EVENTS, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY)
+            ) == sorted(["1234"])
+            assert sorted(
+                list_limited_team_attributes(
+                    QuotaResource.EVENTS, QuotaLimitingRedisCaches.QUOTA_OVERAGE_RETENTION_CACHE_KEY
+                )
+            ) == sorted([])
+            assert sorted(
+                list_limited_team_attributes(
+                    QuotaResource.ROWS_SYNCED, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+                )
+            ) == sorted(["1337"])
+            assert sorted(
+                list_limited_team_attributes(
+                    QuotaResource.ROWS_SYNCED, QuotaLimitingRedisCaches.QUOTA_OVERAGE_RETENTION_CACHE_KEY
+                )
+            ) == sorted([])

--- a/posthog/api/capture.py
+++ b/posthog/api/capture.py
@@ -20,19 +20,17 @@ from sentry_sdk.api import capture_exception, start_span
 from statshog.defaults.django import statsd
 from token_bucket import Limiter, MemoryStorage
 
+from ee.billing.quota_limiting import QuotaLimitingRedisCaches
 from posthog.api.utils import get_data, get_token, safe_clickhouse_string
 from posthog.exceptions import generate_exception_response
-from posthog.kafka_client.client import (
-    KafkaProducer,
-    sessionRecordingKafkaProducer,
-)
+from posthog.kafka_client.client import KafkaProducer, sessionRecordingKafkaProducer
 from posthog.kafka_client.topics import (
     KAFKA_EVENTS_PLUGIN_INGESTION_HISTORICAL,
     KAFKA_SESSION_RECORDING_EVENTS,
     KAFKA_SESSION_RECORDING_SNAPSHOT_ITEM_EVENTS,
 )
 from posthog.logging.timing import timed
-from posthog.metrics import LABEL_RESOURCE_TYPE, KLUDGES_COUNTER
+from posthog.metrics import KLUDGES_COUNTER, LABEL_RESOURCE_TYPE
 from posthog.models.utils import UUIDT
 from posthog.session_recordings.session_recording_helpers import (
     preprocess_replay_events_for_blob_ingestion,
@@ -268,8 +266,12 @@ def drop_events_over_quota(token: str, events: List[Any]) -> List[Any]:
     from ee.billing.quota_limiting import QuotaResource, list_limited_team_attributes
 
     results = []
-    limited_tokens_events = list_limited_team_attributes(QuotaResource.EVENTS)
-    limited_tokens_recordings = list_limited_team_attributes(QuotaResource.RECORDINGS)
+    limited_tokens_events = list_limited_team_attributes(
+        QuotaResource.EVENTS, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+    )
+    limited_tokens_recordings = list_limited_team_attributes(
+        QuotaResource.RECORDINGS, QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY
+    )
 
     for event in events:
         if event.get("event") in SESSION_RECORDING_EVENT_NAMES:

--- a/posthog/api/test/test_capture.py
+++ b/posthog/api/test/test_capture.py
@@ -12,11 +12,12 @@ from typing import Any, Dict, List, Union, cast
 from unittest import mock
 from unittest.mock import ANY, MagicMock, call, patch
 from urllib.parse import quote
+
 import lzstring
 import pytest
 import structlog
 from django.http import HttpResponse
-from django.test.client import Client, MULTIPART_CONTENT
+from django.test.client import MULTIPART_CONTENT, Client
 from django.utils import timezone
 from freezegun import freeze_time
 from kafka.errors import KafkaError
@@ -27,6 +28,7 @@ from prance import ResolvingParser
 from rest_framework import status
 from token_bucket import Limiter, MemoryStorage
 
+from ee.billing.quota_limiting import QuotaLimitingRedisCaches
 from posthog.api import capture
 from posthog.api.capture import (
     LIKELY_ANONYMOUS_IDS,
@@ -1721,10 +1723,12 @@ class TestCapture(BaseTest):
         replace_limited_team_tokens(
             QuotaResource.RECORDINGS,
             {self.team.api_token: timezone.now().timestamp() + 10000},
+            QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY,
         )
         replace_limited_team_tokens(
             QuotaResource.EVENTS,
             {self.team.api_token: timezone.now().timestamp() + 10000},
+            QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY,
         )
         self._send_august_2023_version_session_recording_event()
         self.assertEqual(kafka_produce.call_count, 1)
@@ -1776,6 +1780,7 @@ class TestCapture(BaseTest):
             replace_limited_team_tokens(
                 QuotaResource.EVENTS,
                 {self.team.api_token: timezone.now().timestamp() + 10000},
+                QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY,
             )
             _produce_events()
             self.assertEqual(kafka_produce.call_count, 1)  # Only the recording event
@@ -1783,6 +1788,7 @@ class TestCapture(BaseTest):
             replace_limited_team_tokens(
                 QuotaResource.RECORDINGS,
                 {self.team.api_token: timezone.now().timestamp() + 10000},
+                QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY,
             )
             _produce_events()
             self.assertEqual(kafka_produce.call_count, 0)  # No events
@@ -1790,10 +1796,12 @@ class TestCapture(BaseTest):
             replace_limited_team_tokens(
                 QuotaResource.RECORDINGS,
                 {self.team.api_token: timezone.now().timestamp() - 10000},
+                QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY,
             )
             replace_limited_team_tokens(
                 QuotaResource.EVENTS,
                 {self.team.api_token: timezone.now().timestamp() - 10000},
+                QuotaLimitingRedisCaches.QUOTA_LIMITER_CACHE_KEY,
             )
             _produce_events()
             self.assertEqual(kafka_produce.call_count, 3)  # All events as limit-until timestamp is in the past

--- a/posthog/management/commands/update_billing_quotas.py
+++ b/posthog/management/commands/update_billing_quotas.py
@@ -15,16 +15,19 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
 
-        results = update_all_org_billing_quotas(dry_run)
+        quota_limited_orgs, data_retained_orgs = update_all_org_billing_quotas(dry_run)
 
         if options["print_reports"]:
-            print("")  # noqa T201
-            pprint.pprint(results)  # noqa T203
-            print("")  # noqa T201
+            print("Quota Limited Orgs")  # noqa T201
+            pprint.pprint(quota_limited_orgs)  # noqa T203
+            print("Quota Limiting Suspended Orgs")  # noqa T201
+            pprint.pprint(data_retained_orgs)  # noqa T203
 
         if dry_run:
             print("Dry run so not stored.")  # noqa T201
         else:
-            print(f"{len(results['events'])} orgs rate limited for events")  # noqa T201
-            print(f"{len(results['recordings'])} orgs rate limited for recordings")  # noqa T201
+            print(f"{len(quota_limited_orgs['events'])} orgs rate limited for events")  # noqa T201
+            print(f"{len(data_retained_orgs['events'])} orgs quota limiting suspended for events")  # noqa T201
+            print(f"{len(quota_limited_orgs['recordings'])} orgs rate limited for recordings")  # noqa T201
+            print(f"{len(data_retained_orgs['recordings'])} orgs quota limiting suspended for recordings")  # noqa T201
             print("Done!")  # noqa T201

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -160,13 +160,13 @@ def get_current_day(at: Optional[datetime.datetime] = None) -> Tuple[datetime.da
         at,
         datetime.time.max,
         tzinfo=ZoneInfo("UTC"),
-    )  # very end of the reference day
+    )  # end of the reference day
 
     period_start: datetime.datetime = datetime.datetime.combine(
         period_end,
         datetime.time.min,
         tzinfo=ZoneInfo("UTC"),
-    )  # very start of the reference day
+    )  # start of the reference day
 
     return (period_start, period_end)
 


### PR DESCRIPTION
## Problem

N = 7. We had discussed making N = 3 because 7 might just be too many days. 

We would like to keep users' data for N days after they start to exceed their usage quotas. This will allow us to recover in a case where billing limits inadvertently become lower than current usage ([INC-144](https://posthog.slack.com/archives/C06E3RC442V)). This PR introduces a new redis cache and additional metadata on the cached usage dict in posthog to record this temporary state. 

Working on tests 🔨 

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

👉 *Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review.*

## How did you test this code?

<!-- Briefly describe the steps you took. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
