### PR TITLE
refactor(security): move the destination host check out of batch_exports

### DIFF
--- a/posthog/models/integration/postgres.py
+++ b/posthog/models/integration/postgres.py
@@ -3,6 +3,7 @@
 from typing import ClassVar, Literal, NamedTuple
 
 from posthog.models.user import User
+from posthog.security.url_validation import resolve_and_validate_host
 
 from . import common, model
 
@@ -75,8 +76,6 @@ class PostgreSQLServerIntegration:
         created_by: User | None = None,
         **config,
     ) -> model.Integration:
-        from products.batch_exports.backend.api.batch_export import resolve_and_validate_host
-
         host = common._return_non_empty_str_from_config(config, "host", friendly_name="Host", kind=cls.integration_kind)
         try:
             resolve_and_validate_host(host)

--- a/posthog/security/url_validation.py
+++ b/posthog/security/url_validation.py
@@ -1,4 +1,5 @@
 import re
+import socket
 import ipaddress
 import urllib.parse as urlparse
 from collections.abc import Iterable, Mapping
@@ -407,3 +408,80 @@ def should_block_url(u: str) -> bool:
     """
     allowed, _ = is_url_allowed(u)
     return not allowed
+
+
+# The destination-host check below guards a batch export or warehouse-import target that a
+# customer supplies and our servers later connect to. It duplicates the concern the rest of
+# this module already covers, with its own ranges and its own resolver, and it is kept
+# unchanged here only so the move carries no behavior change. Unifying it with
+# `is_url_allowed` changes what we reject, so that lands separately.
+
+INTERNAL_NETWORKS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+)
+
+
+def is_ip_internal(ip: str) -> bool:
+    """Check if IP belongs to an internal network."""
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        raise ValueError("Could not parse IP")
+
+    if any(addr in network for network in INTERNAL_NETWORKS):
+        return True
+    return False
+
+
+def resolve_and_validate_url(url: str) -> None:
+    """Ensure provided url point to a non-internal IP."""
+    try:
+        parsed = urlparse.urlparse(url)
+    except Exception as e:
+        raise ValueError(f"Invalid URL'{url}': {e}") from e
+
+    host = parsed.hostname
+    if not host:
+        raise ValueError("URL has no hostname")
+
+    resolve_and_validate_host(host)
+
+
+def is_local_dev_or_test() -> bool:
+    return settings.DEBUG or settings.TEST
+
+
+def resolve_and_validate_host(host: str) -> None:
+    """Ensure provided host resolves to a non-internal IP."""
+    if host == "localhost" and is_local_dev_or_test():
+        return
+
+    # Host may already be an IP literal
+    try:
+        if is_ip_internal(host) and not is_local_dev_or_test():
+            raise ValueError("Host resolved to internal IP")
+        return
+    except ValueError:
+        # Not an IP literal, requires DNS
+        pass
+
+    try:
+        # getaddrinfo supports both ipv4 and ipv6
+        results = socket.getaddrinfo(host, None)
+    except socket.gaierror as e:
+        raise ValueError(f"Could not resolve '{host}': {e}") from e
+
+    # Keeps only unique ips from the result tuple
+    resolved_ips = {str(r[4][0]) for r in results}
+
+    for ip in resolved_ips:
+        if is_ip_internal(ip) and not is_local_dev_or_test():
+            raise ValueError("Host resolved to internal IP")

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -1,14 +1,11 @@
 import uuid
-import socket
 import typing
 import builtins
 import datetime as dt
-import ipaddress
 import dataclasses
 import collections.abc
 from dataclasses import dataclass
 from typing import Any, TypedDict, cast
-from urllib.parse import urlparse
 
 from django.conf import settings
 from django.db import models, transaction
@@ -44,6 +41,7 @@ from posthog.models.integration import (
     DatabricksIntegrationError,
     Integration,
 )
+from posthog.security.url_validation import resolve_and_validate_host
 from posthog.temporal.common.client import sync_connect
 from posthog.utils import relative_date_parse, str_to_bool
 
@@ -1082,78 +1080,7 @@ class _DatabaseFieldFinder(TraversingVisitor):
         super().visit_field(node)
 
 
-INTERNAL_NETWORKS = (
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("0.0.0.0/8"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
-    ipaddress.ip_network("fe80::/10"),
-)
-
-
-def is_ip_internal(ip: str) -> bool:
-    """Check if IP belongs to an internal network."""
-    try:
-        addr = ipaddress.ip_address(ip)
-    except ValueError:
-        raise ValueError("Could not parse IP")
-
-    if any(addr in network for network in INTERNAL_NETWORKS):
-        return True
-    return False
-
-
-def resolve_and_validate_url(url: str) -> None:
-    """Ensure provided url point to a non-internal IP."""
-    try:
-        parsed = urlparse(url)
-    except Exception as e:
-        raise ValueError(f"Invalid URL'{url}': {e}") from e
-
-    host = parsed.hostname
-    if not host:
-        raise ValueError("URL has no hostname")
-
-    resolve_and_validate_host(host)
-
-
-def is_local_dev_or_test() -> bool:
-    return settings.DEBUG or settings.TEST
-
-
 INVALID_HOST_MESSAGE = "Invalid host. Enter a hostname or IP address without credentials, scheme, or path."
-
-
-def resolve_and_validate_host(host: str) -> None:
-    """Ensure provided host resolves to a non-internal IP."""
-    if host == "localhost" and is_local_dev_or_test():
-        return
-
-    # Host may already be an IP literal
-    try:
-        if is_ip_internal(host) and not is_local_dev_or_test():
-            raise ValueError("Host resolved to internal IP")
-        return
-    except ValueError:
-        # Not an IP literal, requires DNS
-        pass
-
-    try:
-        # getaddrinfo supports both ipv4 and ipv6
-        results = socket.getaddrinfo(host, None)
-    except socket.gaierror as e:
-        raise ValueError(f"Could not resolve '{host}': {e}") from e
-
-    # Keeps only unique ips from the result tuple
-    resolved_ips = {str(r[4][0]) for r in results}
-
-    for ip in resolved_ips:
-        if is_ip_internal(ip) and not is_local_dev_or_test():
-            raise ValueError("Host resolved to internal IP")
 
 
 class BatchExportSerializer(serializers.ModelSerializer):

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -24,6 +24,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
+from posthog.security.url_validation import resolve_and_validate_url
 
 from products.managed_migrations.backend import trial_storage
 from products.managed_migrations.backend.models.batch_imports import (
@@ -121,10 +122,6 @@ class BatchImportSerializer(serializers.ModelSerializer):
     def validate_endpoint_url(self, value: str | None) -> str | None:
         if not value or not value.strip():
             return None
-        # Deferred: batch_export pulls the batch-export Temporal framework, which has no
-        # business on this module's import path.
-        from products.batch_exports.backend.api.batch_export import resolve_and_validate_url  # noqa: PLC0415
-
         try:
             resolve_and_validate_url(value)
         except ValueError:


### PR DESCRIPTION
## Problem

- Background context: we want to isolate the batch exports codebase to reduce the amount of tests that need to run in CI
- Isolating batch_exports behind a facade requires that nothing outside the product import its internals. Two callers still did.
- `posthog/models/integration/postgres.py` and `products/managed_migrations/backend/api/batch_imports.py` imported batch_exports' SSRF check to validate a customer-supplied destination host or URL.
- The check guards an outbound connection, so it is a core security concern rather than a batch-export one.

## Changes

**Note: this is PR 1 in a stack of 2. This PR just moves the code into a shared location, the follow-up PR consolidates the logic.**

- Nothing changes for a person using PostHog. The same hosts and URLs are accepted and rejected as before.
- `resolve_and_validate_host`, `resolve_and_validate_url`, `is_ip_internal`, `is_local_dev_or_test` and `INTERNAL_NETWORKS` move into `posthog/security/url_validation.py`.
- The three callers now import them from there, and managed_migrations drops the deferred import it only needed to avoid pulling in the Temporal framework.
- Mechanical: the bodies move unchanged. The one edit is `urlparse(url)` to `urlparse.urlparse(url)`, because the destination module imports `urllib.parse` under that alias.

The moved check still duplicates the concern `is_url_allowed` covers in the same module, with its own ranges and its own resolver. Unifying them changes what we reject, so that lands in the PR above this one rather than here.

## How did you test this code?

- Diffed the moved block against the original at the base commit: identical except the `urlparse` alias.
- No new tests. This PR adds no behavior to cover, and the existing suites already exercise both entry points.
- Ran locally and green: the batch export create suites (Postgres, S3, and the main suite), the Postgres integration tests, and the url_validation unit tests.
- Not run: the full backend suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No docs cover this internal validation path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Bottom layer of a two-PR stack, and a prerequisite for isolating batch_exports behind a facade to cut CI time.
- The stack exists to separate risk. This layer removes the cross-product coupling and cannot change behavior. The layer above tightens the policy and swaps the resolver, which is a customer-facing change that earns its own review.
- Skills invoked: /stacking-prs, /writing-pr-descriptions, /isolating-product-facade-contracts (planning).
- Tools: PostHog Desktop agent.
- Public artifact: nothing in this PR carries non-public session material.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
