### PR TITLE
fix(data-imports): stamp the full-run marker on a zero-batch v3 run

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -1,5 +1,6 @@
 import time
 import asyncio
+import datetime
 from typing import TYPE_CHECKING, Any, Generic
 
 import pyarrow as pa
@@ -62,7 +63,6 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.sin
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.table_stats import record_source_item_stats
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.typings import PipelineResult
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import update_last_synced_at
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.metrics import (
     get_batches_produced_metric,
     get_pipeline_run_duration_metric,
@@ -503,18 +503,25 @@ class PipelineV3(Generic[ResumableData]):
             str(self._job.id), self._job.team_id, self._schema.id, pa_table.num_rows, self._logger
         )
 
-    async def _record_checked_without_extracting(self) -> None:
-        """Mark the schema as checked after a run that produced no batches.
+    async def _stamp_full_run(self) -> None:
+        """Record that this run took the full extraction path, for the fast-return valve.
+
+        Writes only `last_full_run_at`, which `_fast_return_eligible` is the sole reader of.
+        `last_synced_at` is deliberately left alone: it feeds data freshness, the schemas UI and
+        the signals watermark (`partition_field > last_synced_at`), so moving it on a run that
+        loaded nothing would narrow the next run's signal window.
 
         Best-effort: a bookkeeping failure must not fail an otherwise successful sync, which is
         how the observed-columns write above treats the same risk.
         """
         try:
-            await update_last_synced_at(
-                job_id=str(self._job.id), schema_id=str(self._schema.id), team_id=self._job.team_id
+            await database_sync_to_async_pool(update_sync_type_config_keys)(
+                self._schema.id,
+                self._job.team_id,
+                updates={"last_full_run_at": datetime.datetime.now(datetime.UTC).isoformat()},
             )
         except Exception:
-            await self._logger.aexception("V3 Pipeline: Failed to record a zero-batch run as synced")
+            await self._logger.aexception("V3 Pipeline: Failed to stamp last_full_run_at")
 
     async def _finalize(self, row_count: int) -> None:
         # Column-picker bookkeeping — a failure here must not fail an otherwise successful sync.
@@ -532,12 +539,11 @@ class PipelineV3(Generic[ResumableData]):
         total_batches = len(self._batch_results)
 
         if total_batches == 0:
-            # A run that extracted nothing still checked the source, so it owes the same
-            # bookkeeping every other path gets from post-load. Post-load never runs here:
-            # with no batches the load consumer is never notified, so nothing downstream
-            # writes `last_synced_at` and the schema reads as stale for as long as the source
-            # stays quiet. The v2 pipeline already writes it on its own zero-row path.
-            await self._record_checked_without_extracting()
+            # A zero-batch run still ran the full extraction, which is what the fast-return
+            # valve counts. Post-load stamps this on every other path but never runs here: with
+            # no batches the load consumer is never notified. Without this a v3 schema whose
+            # source stays quiet could never satisfy `_fast_return_eligible`.
+            await self._stamp_full_run()
             self._logger.debug("V3 Pipeline: No batches extracted, skipping finalization")
             return
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -62,6 +62,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.sin
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.table_stats import record_source_item_stats
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.typings import PipelineResult
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import update_last_synced_at
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.metrics import (
     get_batches_produced_metric,
     get_pipeline_run_duration_metric,
@@ -502,6 +503,19 @@ class PipelineV3(Generic[ResumableData]):
             str(self._job.id), self._job.team_id, self._schema.id, pa_table.num_rows, self._logger
         )
 
+    async def _record_checked_without_extracting(self) -> None:
+        """Mark the schema as checked after a run that produced no batches.
+
+        Best-effort: a bookkeeping failure must not fail an otherwise successful sync, which is
+        how the observed-columns write above treats the same risk.
+        """
+        try:
+            await update_last_synced_at(
+                job_id=str(self._job.id), schema_id=str(self._schema.id), team_id=self._job.team_id
+            )
+        except Exception:
+            await self._logger.aexception("V3 Pipeline: Failed to record a zero-batch run as synced")
+
     async def _finalize(self, row_count: int) -> None:
         # Column-picker bookkeeping — a failure here must not fail an otherwise successful sync.
         if self._observed_columns:
@@ -518,6 +532,12 @@ class PipelineV3(Generic[ResumableData]):
         total_batches = len(self._batch_results)
 
         if total_batches == 0:
+            # A run that extracted nothing still checked the source, so it owes the same
+            # bookkeeping every other path gets from post-load. Post-load never runs here:
+            # with no batches the load consumer is never notified, so nothing downstream
+            # writes `last_synced_at` and the schema reads as stale for as long as the source
+            # stays quiet. The v2 pipeline already writes it on its own zero-row path.
+            await self._record_checked_without_extracting()
             self._logger.debug("V3 Pipeline: No batches extracted, skipping finalization")
             return
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/test_pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/test_pipeline.py
@@ -312,20 +312,21 @@ class TestCDCSeqProvenanceSurvivesStaging:
         assert has_engine_seq(pq.read_table(buf))
 
 
-class TestZeroBatchRunIsRecordedAsSynced:
+class TestZeroBatchRunStampsTheFullRunMarker:
     @pytest.mark.asyncio
-    async def test_a_run_that_extracted_nothing_is_still_recorded_as_synced(self) -> None:
+    async def test_a_run_that_extracted_nothing_still_counts_as_a_full_run(self) -> None:
         pipeline = _make_pipeline()
         pipeline._batch_results = []
 
         with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.pipeline.update_last_synced_at",
-            new=AsyncMock(),
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.pipeline.update_sync_type_config_keys",
+            new=MagicMock(),
         ) as update:
             await pipeline._finalize(row_count=0)
 
-        update.assert_awaited_once()
-        assert update.await_args.kwargs["schema_id"] == str(pipeline._schema.id)
+        update.assert_called_once()
+        assert "last_full_run_at" in update.call_args.kwargs["updates"]
+        assert "extra_model_fields" not in update.call_args.kwargs
 
     @pytest.mark.asyncio
     async def test_a_bookkeeping_failure_does_not_fail_the_sync(self) -> None:
@@ -333,7 +334,7 @@ class TestZeroBatchRunIsRecordedAsSynced:
         pipeline._batch_results = []
 
         with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.pipeline.update_last_synced_at",
-            new=AsyncMock(side_effect=RuntimeError("pooler is down")),
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.pipeline.update_sync_type_config_keys",
+            new=MagicMock(side_effect=RuntimeError("pooler is down")),
         ):
             await pipeline._finalize(row_count=0)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/test_pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/test_pipeline.py
@@ -15,6 +15,7 @@ def _make_logger() -> MagicMock:
     logger.ainfo = AsyncMock()
     logger.awarning = AsyncMock()
     logger.aerror = AsyncMock()
+    logger.aexception = AsyncMock()
     logger.exception = MagicMock()
     return logger
 
@@ -309,3 +310,30 @@ class TestCDCSeqProvenanceSurvivesStaging:
         buf.seek(0)
 
         assert has_engine_seq(pq.read_table(buf))
+
+
+class TestZeroBatchRunIsRecordedAsSynced:
+    @pytest.mark.asyncio
+    async def test_a_run_that_extracted_nothing_is_still_recorded_as_synced(self) -> None:
+        pipeline = _make_pipeline()
+        pipeline._batch_results = []
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.pipeline.update_last_synced_at",
+            new=AsyncMock(),
+        ) as update:
+            await pipeline._finalize(row_count=0)
+
+        update.assert_awaited_once()
+        assert update.await_args.kwargs["schema_id"] == str(pipeline._schema.id)
+
+    @pytest.mark.asyncio
+    async def test_a_bookkeeping_failure_does_not_fail_the_sync(self) -> None:
+        pipeline = _make_pipeline()
+        pipeline._batch_results = []
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.pipeline.update_last_synced_at",
+            new=AsyncMock(side_effect=RuntimeError("pooler is down")),
+        ):
+            await pipeline._finalize(row_count=0)


### PR DESCRIPTION
## Problem

- A warehouse schema on the v3 pipeline can never qualify for fast return ([#86729](https://github.com/PostHog/posthog/pull/86729)), so its no-op syncs keep paying full cost.
- Eligibility requires `last_full_run_at`, stamped by post-load on every run that reaches it.
- A v3 extraction that produces no batches never notifies the load consumer, so post-load never runs and the marker is never written.
- The schemas fast return targets are exactly the quiet ones, so on v3 the gate stays shut for the whole population it was built for.

Measured on the dogfood replica over a 3-hour window: v3 carried the marker on 1 schema out of roughly 4,000 completed runs, against 783 v2 schemas that took it while every run in the window returned zero rows.

Neon runs entirely on v3, and a slice of Postgres does too, so both are excluded until this lands.

## Changes

- A v3 run that produces no batches now stamps `last_full_run_at`, so a quiet v3 schema can become eligible for fast return.
- The write sits on the branch in `_finalize` that already returns early when there are no batches. That branch is the one point which knows the extraction ran and produced nothing.
- The call is best-effort: a bookkeeping failure must not fail an otherwise successful sync, matching the observed-columns write directly above it.

> [!NOTE]
> The write is deliberately limited to `last_full_run_at`, whose only reader is `_fast_return_eligible`. Post-load's equivalent also moves `last_synced_at`, which was rejected here: that field feeds data freshness, the schemas UI, HogQL system tables and the signals watermark (`partition_field > last_synced_at`). Advancing it on a run that loaded nothing would narrow the next run's signal window, so a late-arriving record could be skipped for signal emission.

Nothing user-visible changes, on any pipeline version.

## How did you test this code?

- Two cases in `pipeline_v3/test_pipeline.py`: a zero-batch run stamps the marker and touches nothing else, and a failing write leaves the sync successful. The first catches the gate staying shut on v3, which no existing test covered; it also asserts `extra_model_fields` is absent, so a future change cannot quietly start moving `last_synced_at` here.
- Ran the v3 pipeline suite locally.
- Not verified in production: the fix needs a deploy to observe. The numbers above come from reading the replica, not from running this branch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no user-facing behavior, API, or config change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Implemented with Claude Code while validating [#86729](https://github.com/PostHog/posthog/pull/86729) after deploy.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
- Found by chasing a rollout gate that would not open on v3 schemas. The first theory was an incomplete deploy; splitting marker coverage by pipeline version showed v3 at zero even for runs that did extract rows, which pointed at the zero-batch path instead.
- The first revision called post-load's `update_last_synced_at`, which writes both fields. Review of every consumer of `last_synced_at` turned up the signals watermark, so the write was narrowed to the one field this PR needs. A separate observation, that quiet v3 schemas never refresh `last_synced_at` and so report stale in data freshness, is left for its own PR rather than bundled here.
