### PR TITLE
fix(llma): keep a vendor's own promotion at the served price

### DIFF
--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
@@ -27,6 +27,7 @@ import {
     finalizeTotals,
     foldModelIntoTotals,
     isFirstPartyRoute,
+    isSoleVendorModel,
     isVendorPromotion,
     parseDiscountRate,
     readEndpointsFromOpenRouter,
@@ -50,6 +51,7 @@ const candidate = (key: string, promptPrice: string, discount: number, vendorPro
     cost: cost(promptPrice, discount)!,
     discount,
     vendorPromotion,
+    soleVendor: false,
 })
 
 /** An endpoints-payload entry shaped the way OpenRouter serves it. */
@@ -165,6 +167,9 @@ describe('isFirstPartyRoute()', () => {
         { description: 'the vendor of a different model', model: 'qwen/qwen-plus', key: 'qwen', expected: false },
         { description: 'a reseller sharing the vendor prefix', model: 'openai/o5', key: 'openaint', expected: false },
         { description: 'an id with no namespace', model: 'gpt-5.6-luna', key: 'openai', expected: false },
+        // Without the separator guard the whole id is read as its own vendor, and
+        // this is the shape where that returns true instead of false.
+        { description: 'a slug-only id that looks like a vendor', model: 'openai-x', key: 'openai', expected: false },
     ])('$description', ({ model, key, expected }) => {
         expect(isFirstPartyRoute(model, key)).toBe(expected)
     })
@@ -177,10 +182,33 @@ describe('isFirstPartyRoute()', () => {
             expect(normalizeProviderKey(vendor)).toBe(vendor)
         }
     })
+
+    it('maps every alias onto a provider key that serves that namespace', () => {
+        // Binds the table to the price book rather than to itself: a stale or
+        // typo'd vendor matches no route and silently reverts to de-discounting.
+        const book: Array<{ model: string; cost: Record<string, unknown> }> = parseJSON(
+            fs.readFileSync(path.join(__dirname, '../providers/llm-costs.json'), 'utf8')
+        )
+
+        for (const [namespace, vendor] of Object.entries(MODEL_NAMESPACE_VENDORS)) {
+            const keys = book
+                .filter((row) => row.model.startsWith(`${namespace}/`))
+                .flatMap((row) => Object.keys(row.cost))
+            expect(keys.length).toBeGreaterThan(0)
+            expect(keys.filter((key) => key === vendor || key.startsWith(`${vendor}-`))).not.toHaveLength(0)
+        }
+    })
 })
 
 describe('isVendorPromotion()', () => {
-    const route = (discount: number, firstParty: boolean) => ({ discount, firstParty })
+    // Prices default well clear of any list price a case builds, so a case only
+    // exercises the price refutation when it sets them.
+    const route = (discount: number, firstParty: boolean, servedPrompt = 7e-7): RouteRate => ({
+        discount,
+        firstParty,
+        servedPrompt,
+        listPrompt: discount === 0 ? servedPrompt : parseFloat((servedPrompt / (1 - discount)).toPrecision(10)),
+    })
 
     it.each<{ description: string; subject: RouteRate; routes: RouteRate[]; expected: boolean }>([
         {
@@ -202,19 +230,43 @@ describe('isVendorPromotion()', () => {
             expected: true,
         },
         {
+            description: 'fails when de-discounting lands on an undiscounted price',
+            // minimax-m2 live: the vendor's 0.15 divides out to exactly what two
+            // undiscounted hosts charge, so the rate is a markdown off a real list.
+            subject: route(0.15, true, 2.55e-7),
+            routes: [route(0.15, true, 2.55e-7), route(0, false, 3e-7)],
+            expected: false,
+        },
+        {
+            description: 'ignores an undiscounted host at a different price',
+            subject: route(0.15, true, 2.55e-7),
+            routes: [route(0.15, true, 2.55e-7), route(0, false, 9e-7)],
+            expected: true,
+        },
+        {
             description: 'never holds for a reseller route',
             subject: route(0.5, false),
             routes: [route(0.5, false)],
             expected: false,
         },
         {
+            // Sole route on purpose: a second route would refute this on its own.
             description: 'never holds without a rate',
             subject: route(0, true),
-            routes: [route(0, true), route(0, false)],
+            routes: [route(0, true)],
             expected: false,
         },
     ])('$description', ({ subject, routes, expected }) => {
         expect(isVendorPromotion(subject, routes)).toBe(expected)
+    })
+
+    it('holds on a vendor-only model, where nothing can refute it', () => {
+        // gemini-3.7-flash is this shape: every route is Google's, so both
+        // refutations scan an empty set. `isSoleVendorModel` marks it in the report.
+        const routes = [route(0.5, true), route(0.5, true, 3.5e-7)]
+        expect(isVendorPromotion(routes[0], routes)).toBe(true)
+        expect(isSoleVendorModel(routes)).toBe(true)
+        expect(isSoleVendorModel([route(0.5, true), route(0, false)])).toBe(false)
     })
 })
 
@@ -432,7 +484,15 @@ describe('buildModelRow()', () => {
         ])
         expect(built!.discount).toEqual({
             model: 'openai/gpt-5.6-luna',
-            endpoints: [{ key: 'novita-fp8', discount: 0.5, confirmation: 'confirmed' as const }],
+            endpoints: [
+                {
+                    key: 'novita-fp8',
+                    discount: 0.5,
+                    confirmation: 'confirmed' as const,
+                    vendorPromotion: false,
+                    soleVendor: false,
+                },
+            ],
         })
     })
 
@@ -480,6 +540,25 @@ describe('buildModelRow()', () => {
         expect(built!.cost['z-ai-fp8'].prompt_token).toBe(1.5e-7)
         expect(built!.cost['novita-fp8'].prompt_token).toBe(1.5e-7)
         expect(built!.discount?.endpoints[0].confirmation).toBe('confirmed')
+    })
+
+    it('de-discounts a vendor route whose recovered price an undiscounted host charges', () => {
+        // minimax-m2 live: 0.15 off 2.55e-7 recovers 3e-7, which two undiscounted
+        // hosts charge outright, so the rate is a markdown and not MiniMax's promo.
+        const built = buildModelRow('minimax/minimax-m2', listPricing, [
+            endpoint('minimax-fp8', '0.000000255', 0.15),
+            endpoint('novita-fp8', '0.0000003'),
+        ])
+        expect(built!.cost['minimax-fp8'].prompt_token).toBe(3e-7)
+        expect(built!.discount?.endpoints[0].confirmation).toBe('confirmed')
+    })
+
+    it('marks a vendor-only model as having nothing that could refute it', () => {
+        const built = buildModelRow('google/gemini-3.7-flash', listPricing, [
+            endpoint('google-ai-studio', '0.0000005', 0.5),
+        ])
+        expect(built!.cost['google-ai-studio'].prompt_token).toBe(0.0000005)
+        expect(built!.discount?.endpoints[0].soleVendor).toBe(true)
     })
 
     it('keeps a vendor promotion when a reseller runs a different rate', () => {
@@ -566,12 +645,14 @@ describe('confirmDiscountAgainstSiblings()', () => {
             cost: buildModelCost({ prompt: '0.0000005', completion: '0.000009', discount: 0.5 })!,
             discount: 0.5,
             vendorPromotion: false,
+            soleVendor: false,
         }
         const sibling: EndpointCandidate = {
             key: 'azure',
             cost: buildModelCost({ prompt: '0.000001', completion: '0.000002' })!,
             discount: 0,
             vendorPromotion: false,
+            soleVendor: false,
         }
         expect(confirmDiscountAgainstSiblings(discounted, [discounted, sibling])).toBe('confirmed')
     })
@@ -614,7 +695,15 @@ describe('sanitizeReportCell()', () => {
 describe('renderDiscountReport()', () => {
     const entry = (over: Partial<DiscountReportEntry> = {}): DiscountReportEntry => ({
         model: 'openai/gpt-5.6-luna',
-        endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'confirmed' as const }],
+        endpoints: [
+            {
+                key: 'openai',
+                discount: 0.5,
+                confirmation: 'confirmed' as const,
+                vendorPromotion: false,
+                soleVendor: false,
+            },
+        ],
         ...over,
     })
 
@@ -654,13 +743,33 @@ describe('renderDiscountReport()', () => {
             entry(),
             entry({
                 model: 'aaa/unconfirmed',
-                endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'unconfirmed' as const }],
+                endpoints: [
+                    {
+                        key: 'openai',
+                        discount: 0.5,
+                        confirmation: 'unconfirmed' as const,
+                        vendorPromotion: false,
+                        soleVendor: false,
+                    },
+                ],
             }),
             entry({
                 model: 'qwen/qwen-plus',
                 endpoints: [
-                    { key: 'alibaba-fp8', discount: 0.35, confirmation: 'not-checkable' as const },
-                    { key: 'streamlake', discount: 0.4, confirmation: 'not-checkable' as const },
+                    {
+                        key: 'alibaba-fp8',
+                        discount: 0.35,
+                        confirmation: 'not-checkable' as const,
+                        vendorPromotion: false,
+                        soleVendor: false,
+                    },
+                    {
+                        key: 'streamlake',
+                        discount: 0.4,
+                        confirmation: 'not-checkable' as const,
+                        vendorPromotion: false,
+                        soleVendor: false,
+                    },
                 ],
             }),
         ])
@@ -669,10 +778,52 @@ describe('renderDiscountReport()', () => {
         expect(report).toContain('1/2 checkable')
     })
 
+    it('attributes a kept promotion to the vendor, not to OpenRouter', () => {
+        // Without the vendorPromotion filters the headline claims 3 endpoints on
+        // 2 models and the ratio reads 1/2, crediting routes nothing corroborated.
+        const report = renderDiscountReport([
+            entry(),
+            entry({
+                model: 'google/gemini-3.7-flash',
+                endpoints: [
+                    {
+                        key: 'google-ai-studio',
+                        discount: 0.5,
+                        confirmation: 'not-applicable' as const,
+                        vendorPromotion: true,
+                        soleVendor: true,
+                    },
+                    {
+                        key: 'google-vertex-global',
+                        discount: 0.5,
+                        confirmation: 'not-applicable' as const,
+                        vendorPromotion: true,
+                        soleVendor: false,
+                    },
+                ],
+            }),
+        ])
+        expect(report).toContain('**1 endpoint(s)**')
+        expect(report).toContain('**1 model(s)**')
+        expect(report).toContain('1/1 checkable')
+        expect(report).toContain('**2 endpoint(s)**')
+        expect(report).toContain('**1** of those sit on models with no route outside the')
+        expect(report).toContain('| `google-ai-studio` | 50% | served (sole) | not-applicable |')
+        expect(report).toContain('| `google-vertex-global` | 50% | served | not-applicable |')
+    })
+
     it('puts the confirmation verdict on the row it belongs to', () => {
         const report = renderDiscountReport([
             entry({
-                endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'unconfirmed' as const }],
+                endpoints: [
+                    {
+                        key: 'openai',
+                        discount: 0.5,
+                        confirmation: 'unconfirmed' as const,
+                        vendorPromotion: false,
+                        soleVendor: false,
+                    },
+                ],
             }),
         ])
         expect(report).toContain('| unconfirmed |')
@@ -682,8 +833,20 @@ describe('renderDiscountReport()', () => {
         const report = renderDiscountReport([
             entry({
                 endpoints: [
-                    { key: 'openai', discount: 0.5, confirmation: 'confirmed' as const },
-                    { key: 'openai-flex', discount: 0.5, confirmation: 'confirmed' as const },
+                    {
+                        key: 'openai',
+                        discount: 0.5,
+                        confirmation: 'confirmed' as const,
+                        vendorPromotion: false,
+                        soleVendor: false,
+                    },
+                    {
+                        key: 'openai-flex',
+                        discount: 0.5,
+                        confirmation: 'confirmed' as const,
+                        vendorPromotion: false,
+                        soleVendor: false,
+                    },
                 ],
             }),
         ])
@@ -711,6 +874,8 @@ describe('renderDiscountReport()', () => {
                     key: `k${e}`,
                     discount: 0.5,
                     confirmation: 'confirmed' as const,
+                    vendorPromotion: false,
+                    soleVendor: false,
                 })),
             })
         )
@@ -754,6 +919,8 @@ describe('renderDiscountReport()', () => {
                         key: 'a|b\n| pwned | 9 | 9 |',
                         discount: 0.5,
                         confirmation: 'confirmed' as const,
+                        vendorPromotion: false,
+                        soleVendor: false,
                     },
                 ],
             }),
@@ -784,7 +951,15 @@ describe('accumulateModelRow()', () => {
     it('collects a discount entry when the row reports one', () => {
         const discount = {
             model: 'm',
-            endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'confirmed' as const }],
+            endpoints: [
+                {
+                    key: 'openai',
+                    discount: 0.5,
+                    confirmation: 'confirmed' as const,
+                    vendorPromotion: false,
+                    soleVendor: false,
+                },
+            ],
         }
         expect(accumulateModelRow(built({ discount }), 'm', totals()).discounts).toStrictEqual([discount])
     })
@@ -807,7 +982,9 @@ describe('accumulateModelRow()', () => {
         const base = totals()
         const discount: DiscountReportEntry = {
             model: 'a',
-            endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'confirmed' }],
+            endpoints: [
+                { key: 'openai', discount: 0.5, confirmation: 'confirmed', vendorPromotion: false, soleVendor: false },
+            ],
         }
         accumulateModelRow(built({ checked: false, discount }), 'a', base)
         expect(base.models).toHaveLength(0)
@@ -1115,7 +1292,9 @@ describe('writeOutputs()', () => {
         const writes = captureWrites()
         const promo: DiscountReportEntry = {
             model: 'openai/gpt-5.6-luna',
-            endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'confirmed' }],
+            endpoints: [
+                { key: 'openai', discount: 0.5, confirmation: 'confirmed', vendorPromotion: false, soleVendor: false },
+            ],
         }
 
         writeOutputs([{ model: 'm', cost: { default: cost('0.000001')! } }], [promo], 0)

--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
@@ -26,8 +26,8 @@ import {
     fetchOpenRouterCosts,
     finalizeTotals,
     foldModelIntoTotals,
+    hasNoRefuter,
     isFirstPartyRoute,
-    isSoleVendorModel,
     isVendorPromotion,
     parseDiscountRate,
     readEndpointsFromOpenRouter,
@@ -51,7 +51,9 @@ const candidate = (key: string, promptPrice: string, discount: number, vendorPro
     cost: cost(promptPrice, discount)!,
     discount,
     vendorPromotion,
-    soleVendor: false,
+    unrefutable: false,
+    servedPrompt: undefined,
+    listPrompt: undefined,
 })
 
 /** An endpoints-payload entry shaped the way OpenRouter serves it. */
@@ -183,20 +185,29 @@ describe('isFirstPartyRoute()', () => {
         }
     })
 
-    it('maps every alias onto a provider key that serves that namespace', () => {
-        // Binds the table to the price book rather than to itself: a stale or
-        // typo'd vendor matches no route and silently reverts to de-discounting.
+    it('maps every alias onto a vendor that hosts most of its own namespace', () => {
+        // Binds the table to the price book rather than to itself. Mere presence
+        // is too weak: resellers appear on other vendors' namespaces too, and
+        // `qwen: 'together'` would pass that. A vendor hosts the bulk of its own
+        // models (80-100% live) where a reseller reaches a third at most.
         const book: Array<{ model: string; cost: Record<string, unknown> }> = parseJSON(
             fs.readFileSync(path.join(__dirname, '../providers/llm-costs.json'), 'utf8')
         )
 
+        let checked = 0
         for (const [namespace, vendor] of Object.entries(MODEL_NAMESPACE_VENDORS)) {
-            const keys = book
-                .filter((row) => row.model.startsWith(`${namespace}/`))
-                .flatMap((row) => Object.keys(row.cost))
-            expect(keys.length).toBeGreaterThan(0)
-            expect(keys.filter((key) => key === vendor || key.startsWith(`${vendor}-`))).not.toHaveLength(0)
+            const models = book.filter((row) => row.model.startsWith(`${namespace}/`))
+            // A namespace the catalogue drops makes its entry inert, not wrong.
+            if (models.length === 0) {
+                continue
+            }
+            const hosted = models.filter((row) =>
+                Object.keys(row.cost).some((key) => key === vendor || key.startsWith(`${vendor}-`))
+            )
+            expect(hosted.length / models.length).toBeGreaterThan(0.5)
+            checked += 1
         }
+        expect(checked).toBeGreaterThan(0)
     })
 })
 
@@ -228,6 +239,22 @@ describe('isVendorPromotion()', () => {
             subject: route(0.5, true),
             routes: [route(0.5, true), route(0.2, false)],
             expected: true,
+        },
+        {
+            // 4e-8 / 0.2 is 2.0000000000000004e-7 in float, so this matches only
+            // because both sides round first. Pins that rounding.
+            description: 'refutes on a price whose division is inexact',
+            subject: route(0.8, true, 4e-8),
+            routes: [route(0.8, true, 4e-8), route(0, false, 2e-7)],
+            expected: false,
+        },
+        {
+            // A negative rate is a markup: the served price sits above list, and
+            // dividing it out is what recovers list.
+            description: 'never holds for a markup',
+            subject: route(-0.2, true),
+            routes: [route(-0.2, true)],
+            expected: false,
         },
         {
             description: 'fails when de-discounting lands on an undiscounted price',
@@ -262,11 +289,13 @@ describe('isVendorPromotion()', () => {
 
     it('holds on a vendor-only model, where nothing can refute it', () => {
         // gemini-3.7-flash is this shape: every route is Google's, so both
-        // refutations scan an empty set. `isSoleVendorModel` marks it in the report.
+        // refutations scan an empty set. `hasNoRefuter` marks it in the report.
         const routes = [route(0.5, true), route(0.5, true, 3.5e-7)]
         expect(isVendorPromotion(routes[0], routes)).toBe(true)
-        expect(isSoleVendorModel(routes)).toBe(true)
-        expect(isSoleVendorModel([route(0.5, true), route(0, false)])).toBe(false)
+        expect(hasNoRefuter(routes)).toBe(true)
+        // An undiscounted route could refute on price even when it is the vendor's own.
+        expect(hasNoRefuter([route(0.5, true), route(0, true)])).toBe(false)
+        expect(hasNoRefuter([route(0.5, true), route(0.5, false)])).toBe(false)
     })
 })
 
@@ -490,7 +519,9 @@ describe('buildModelRow()', () => {
                     discount: 0.5,
                     confirmation: 'confirmed' as const,
                     vendorPromotion: false,
-                    soleVendor: false,
+                    unrefutable: false,
+                    servedPrompt: 5e-7,
+                    listPrompt: 0.000001,
                 },
             ],
         })
@@ -558,7 +589,7 @@ describe('buildModelRow()', () => {
             endpoint('google-ai-studio', '0.0000005', 0.5),
         ])
         expect(built!.cost['google-ai-studio'].prompt_token).toBe(0.0000005)
-        expect(built!.discount?.endpoints[0].soleVendor).toBe(true)
+        expect(built!.discount?.endpoints[0].unrefutable).toBe(true)
     })
 
     it('keeps a vendor promotion when a reseller runs a different rate', () => {
@@ -645,14 +676,18 @@ describe('confirmDiscountAgainstSiblings()', () => {
             cost: buildModelCost({ prompt: '0.0000005', completion: '0.000009', discount: 0.5 })!,
             discount: 0.5,
             vendorPromotion: false,
-            soleVendor: false,
+            unrefutable: false,
+            servedPrompt: undefined,
+            listPrompt: undefined,
         }
         const sibling: EndpointCandidate = {
             key: 'azure',
             cost: buildModelCost({ prompt: '0.000001', completion: '0.000002' })!,
             discount: 0,
             vendorPromotion: false,
-            soleVendor: false,
+            unrefutable: false,
+            servedPrompt: undefined,
+            listPrompt: undefined,
         }
         expect(confirmDiscountAgainstSiblings(discounted, [discounted, sibling])).toBe('confirmed')
     })
@@ -701,7 +736,9 @@ describe('renderDiscountReport()', () => {
                 discount: 0.5,
                 confirmation: 'confirmed' as const,
                 vendorPromotion: false,
-                soleVendor: false,
+                unrefutable: false,
+                servedPrompt: undefined,
+                listPrompt: undefined,
             },
         ],
         ...over,
@@ -749,7 +786,9 @@ describe('renderDiscountReport()', () => {
                         discount: 0.5,
                         confirmation: 'unconfirmed' as const,
                         vendorPromotion: false,
-                        soleVendor: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
                     },
                 ],
             }),
@@ -761,14 +800,18 @@ describe('renderDiscountReport()', () => {
                         discount: 0.35,
                         confirmation: 'not-checkable' as const,
                         vendorPromotion: false,
-                        soleVendor: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
                     },
                     {
                         key: 'streamlake',
                         discount: 0.4,
                         confirmation: 'not-checkable' as const,
                         vendorPromotion: false,
-                        soleVendor: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
                     },
                 ],
             }),
@@ -791,14 +834,18 @@ describe('renderDiscountReport()', () => {
                         discount: 0.5,
                         confirmation: 'not-applicable' as const,
                         vendorPromotion: true,
-                        soleVendor: true,
+                        unrefutable: true,
+                        servedPrompt: 7.5e-7,
+                        listPrompt: 1.5e-6,
                     },
                     {
                         key: 'google-vertex-global',
                         discount: 0.5,
                         confirmation: 'not-applicable' as const,
                         vendorPromotion: true,
-                        soleVendor: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
                     },
                 ],
             }),
@@ -807,9 +854,31 @@ describe('renderDiscountReport()', () => {
         expect(report).toContain('**1 model(s)**')
         expect(report).toContain('1/1 checkable')
         expect(report).toContain('**2 endpoint(s)**')
-        expect(report).toContain('**1** of those sit on models with no route outside the')
-        expect(report).toContain('| `google-ai-studio` | 50% | served (sole) | not-applicable |')
-        expect(report).toContain('| `google-vertex-global` | 50% | served | not-applicable |')
+        expect(report).toContain('**1** of those had no route that could have refuted')
+        expect(report).toContain('| `google-ai-studio` | 50% | served (unrefuted) | $0.75 vs $1.5 | not-applicable |')
+        expect(report).toContain('| `google-vertex-global` | 50% | served |  | not-applicable |')
+    })
+
+    it('reads what was stored off the flag, not off the verdict', () => {
+        // The two agree in production. Held apart here so a regression back to
+        // deriving `Stored` from the enum cannot pass.
+        const report = renderDiscountReport([
+            entry({
+                endpoints: [
+                    {
+                        key: 'openai',
+                        discount: 0.5,
+                        confirmation: 'not-applicable' as const,
+                        vendorPromotion: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
+                    },
+                ],
+            }),
+        ])
+        expect(report).toContain('| 50% | list |')
+        expect(report).toContain('**1 endpoint(s)**')
     })
 
     it('puts the confirmation verdict on the row it belongs to', () => {
@@ -821,7 +890,9 @@ describe('renderDiscountReport()', () => {
                         discount: 0.5,
                         confirmation: 'unconfirmed' as const,
                         vendorPromotion: false,
-                        soleVendor: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
                     },
                 ],
             }),
@@ -838,14 +909,18 @@ describe('renderDiscountReport()', () => {
                         discount: 0.5,
                         confirmation: 'confirmed' as const,
                         vendorPromotion: false,
-                        soleVendor: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
                     },
                     {
                         key: 'openai-flex',
                         discount: 0.5,
                         confirmation: 'confirmed' as const,
                         vendorPromotion: false,
-                        soleVendor: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
                     },
                 ],
             }),
@@ -875,7 +950,9 @@ describe('renderDiscountReport()', () => {
                     discount: 0.5,
                     confirmation: 'confirmed' as const,
                     vendorPromotion: false,
-                    soleVendor: false,
+                    unrefutable: false,
+                    servedPrompt: undefined,
+                    listPrompt: undefined,
                 })),
             })
         )
@@ -920,7 +997,9 @@ describe('renderDiscountReport()', () => {
                         discount: 0.5,
                         confirmation: 'confirmed' as const,
                         vendorPromotion: false,
-                        soleVendor: false,
+                        unrefutable: false,
+                        servedPrompt: undefined,
+                        listPrompt: undefined,
                     },
                 ],
             }),
@@ -957,7 +1036,9 @@ describe('accumulateModelRow()', () => {
                     discount: 0.5,
                     confirmation: 'confirmed' as const,
                     vendorPromotion: false,
-                    soleVendor: false,
+                    unrefutable: false,
+                    servedPrompt: undefined,
+                    listPrompt: undefined,
                 },
             ],
         }
@@ -983,7 +1064,15 @@ describe('accumulateModelRow()', () => {
         const discount: DiscountReportEntry = {
             model: 'a',
             endpoints: [
-                { key: 'openai', discount: 0.5, confirmation: 'confirmed', vendorPromotion: false, soleVendor: false },
+                {
+                    key: 'openai',
+                    discount: 0.5,
+                    confirmation: 'confirmed',
+                    vendorPromotion: false,
+                    unrefutable: false,
+                    servedPrompt: undefined,
+                    listPrompt: undefined,
+                },
             ],
         }
         accumulateModelRow(built({ checked: false, discount }), 'a', base)
@@ -1293,7 +1382,15 @@ describe('writeOutputs()', () => {
         const promo: DiscountReportEntry = {
             model: 'openai/gpt-5.6-luna',
             endpoints: [
-                { key: 'openai', discount: 0.5, confirmation: 'confirmed', vendorPromotion: false, soleVendor: false },
+                {
+                    key: 'openai',
+                    discount: 0.5,
+                    confirmation: 'confirmed',
+                    vendorPromotion: false,
+                    unrefutable: false,
+                    servedPrompt: undefined,
+                    listPrompt: undefined,
+                },
             ],
         }
 

--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { parseJSON } from '~/common/utils/json-parse'
+import { normalizeProviderKey } from '~/ingestion/pipelines/ai/costs/provider-matching'
 import type { ModelCost } from '~/ingestion/pipelines/ai/costs/providers/types'
 
 import {
@@ -11,18 +12,22 @@ import {
     type DiscountReportEntry,
     type EndpointCandidate,
     FLAT_FEE_FIELDS,
+    MODEL_NAMESPACE_VENDORS,
     OPTIONAL_PRICING_FIELDS,
+    type RouteRate,
     type RunTotals,
     UNCHECKED_WARN_FRACTION,
     accumulateModelRow,
-    buildDefaultCost,
     buildModelCost,
     buildModelRow,
+    buildServedCost,
     collectModelRows,
     confirmDiscountAgainstSiblings,
     fetchOpenRouterCosts,
     finalizeTotals,
     foldModelIntoTotals,
+    isFirstPartyRoute,
+    isVendorPromotion,
     parseDiscountRate,
     readEndpointsFromOpenRouter,
     renderDiscountReport,
@@ -40,10 +45,11 @@ const cost = (promptPrice: string, discount = 0, completion = promptPrice): Retu
     return built
 }
 
-const candidate = (key: string, promptPrice: string, discount: number): EndpointCandidate => ({
+const candidate = (key: string, promptPrice: string, discount: number, vendorPromotion = false): EndpointCandidate => ({
     key,
     cost: cost(promptPrice, discount)!,
     discount,
+    vendorPromotion,
 })
 
 /** An endpoints-payload entry shaped the way OpenRouter serves it. */
@@ -137,15 +143,90 @@ describe('withoutDiscount()', () => {
     })
 })
 
-describe('buildDefaultCost()', () => {
+describe('isFirstPartyRoute()', () => {
+    it.each<{ description: string; model: string; key: string; expected: boolean }>([
+        { description: 'the vendor route itself', model: 'openai/gpt-5.6-luna', key: 'openai', expected: true },
+        { description: 'a vendor service tier', model: 'openai/gpt-5.6-luna', key: 'openai-flex', expected: true },
+        {
+            description: "the vendor's other hosting arm",
+            model: 'google/gemini-3.7-flash',
+            key: 'google-vertex-global',
+            expected: true,
+        },
+        {
+            description: 'a batch variant of the model',
+            model: 'google/x:batch',
+            key: 'google-ai-studio',
+            expected: true,
+        },
+        { description: 'a vendor aliased to another name', model: 'qwen/qwen-plus', key: 'alibaba', expected: true },
+        { description: 'a hyphenated vendor alias', model: 'x-ai/grok-5', key: 'xai-priority', expected: true },
+        { description: 'a reseller', model: 'google/gemini-3.7-flash', key: 'novita-fp8', expected: false },
+        { description: 'the vendor of a different model', model: 'qwen/qwen-plus', key: 'qwen', expected: false },
+        { description: 'a reseller sharing the vendor prefix', model: 'openai/o5', key: 'openaint', expected: false },
+        { description: 'an id with no namespace', model: 'gpt-5.6-luna', key: 'openai', expected: false },
+    ])('$description', ({ model, key, expected }) => {
+        expect(isFirstPartyRoute(model, key)).toBe(expected)
+    })
+
+    it('holds the alias table already normalized on both sides', () => {
+        // Neither side is normalized on lookup, so an entry that is not already
+        // in key form never matches and reverts that vendor to de-discounting.
+        for (const [namespace, vendor] of Object.entries(MODEL_NAMESPACE_VENDORS)) {
+            expect(normalizeProviderKey(namespace)).toBe(namespace)
+            expect(normalizeProviderKey(vendor)).toBe(vendor)
+        }
+    })
+})
+
+describe('isVendorPromotion()', () => {
+    const route = (discount: number, firstParty: boolean) => ({ discount, firstParty })
+
+    it.each<{ description: string; subject: RouteRate; routes: RouteRate[]; expected: boolean }>([
+        {
+            description: 'holds when only the vendor runs the rate',
+            subject: route(0.5, true),
+            routes: [route(0.5, true), route(0, false)],
+            expected: true,
+        },
+        {
+            description: 'fails when an unrelated host runs the same rate',
+            subject: route(0.5, true),
+            routes: [route(0.5, true), route(0.5, false)],
+            expected: false,
+        },
+        {
+            description: 'ignores an unrelated host on a different rate',
+            subject: route(0.5, true),
+            routes: [route(0.5, true), route(0.2, false)],
+            expected: true,
+        },
+        {
+            description: 'never holds for a reseller route',
+            subject: route(0.5, false),
+            routes: [route(0.5, false)],
+            expected: false,
+        },
+        {
+            description: 'never holds without a rate',
+            subject: route(0, true),
+            routes: [route(0, true), route(0, false)],
+            expected: false,
+        },
+    ])('$description', ({ subject, routes, expected }) => {
+        expect(isVendorPromotion(subject, routes)).toBe(expected)
+    })
+})
+
+describe('buildServedCost()', () => {
     it('keeps the served price when the list payload carries a rate', () => {
-        expect(buildDefaultCost({ prompt: '0.0000005', completion: '0.000003', discount: 0.5 })!.prompt_token).toBe(
+        expect(buildServedCost({ prompt: '0.0000005', completion: '0.000003', discount: 0.5 })!.prompt_token).toBe(
             0.0000005
         )
     })
 
     it('behaves like the plain builder when there is no rate', () => {
-        expect(buildDefaultCost({ prompt: '0.000001', completion: '0.000006' })).toEqual({
+        expect(buildServedCost({ prompt: '0.000001', completion: '0.000006' })).toEqual({
             prompt_token: 0.000001,
             completion_token: 0.000006,
         })
@@ -326,13 +407,13 @@ describe('buildModelRow()', () => {
         expect(Object.keys(built!.cost)).toStrictEqual(['default'])
     })
 
-    it('stores each endpoint at its de-discounted list price', () => {
+    it('stores each reseller endpoint at its de-discounted list price', () => {
         const built = buildModelRow('openai/gpt-5.6-luna', listPricing, [
-            endpoint('openai', '0.0000005', 0.5),
+            endpoint('novita-fp8', '0.0000005', 0.5),
             endpoint('azure', '0.000001'),
         ])
         expect(built!.checked).toBe(true)
-        expect(built!.cost.openai.prompt_token).toBe(0.000001)
+        expect(built!.cost['novita-fp8'].prompt_token).toBe(0.000001)
         expect(built!.cost.azure.prompt_token).toBe(0.000001)
     })
 
@@ -346,12 +427,12 @@ describe('buildModelRow()', () => {
 
     it('reports the discounted endpoints and the confirmation verdict', () => {
         const built = buildModelRow('openai/gpt-5.6-luna', listPricing, [
-            endpoint('openai', '0.0000005', 0.5),
+            endpoint('novita-fp8', '0.0000005', 0.5),
             endpoint('azure', '0.000001'),
         ])
         expect(built!.discount).toEqual({
             model: 'openai/gpt-5.6-luna',
-            endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'confirmed' as const }],
+            endpoints: [{ key: 'novita-fp8', discount: 0.5, confirmation: 'confirmed' as const }],
         })
     })
 
@@ -369,9 +450,45 @@ describe('buildModelRow()', () => {
     })
 
     it('reports not-checkable when no undiscounted sibling exists', () => {
-        // Every Qwen model: Alibaba is the only route, so nothing corroborates it.
-        const built = buildModelRow('qwen/qwen-plus', listPricing, [endpoint('alibaba-fp8', '0.000000169', 0.35)])
+        // Reseller tag on purpose: a vendor route would keep its promotion instead.
+        const built = buildModelRow('qwen/qwen-plus', listPricing, [endpoint('novita-fp8', '0.000000169', 0.35)])
         expect(built!.discount?.endpoints[0].confirmation).toBe('not-checkable')
+    })
+
+    it('leaves a vendor-run promotion at the price the vendor serves', () => {
+        const built = buildModelRow('google/gemini-3.7-flash', listPricing, [
+            endpoint('google-ai-studio', '0.0000005', 0.5),
+            endpoint('google-vertex-global', '0.0000005', 0.5),
+        ])
+        expect(built!.cost['google-ai-studio'].prompt_token).toBe(0.0000005)
+        expect(built!.cost['google-vertex-global'].prompt_token).toBe(0.0000005)
+        expect(built!.discount?.endpoints.map((e) => [e.key, e.confirmation])).toEqual([
+            ['google-ai-studio', 'not-applicable'],
+            ['google-vertex-global', 'not-applicable'],
+        ])
+    })
+
+    it('de-discounts a vendor route when unrelated hosts run the same rate', () => {
+        // One rate across unrelated hosts is OpenRouter promoting the model, so
+        // the vendor's route goes to list with the rest.
+        const built = buildModelRow('z-ai/glm-5.3-flash', listPricing, [
+            endpoint('z-ai-fp8', '0.000000075', 0.5),
+            endpoint('novita-fp8', '0.000000075', 0.5),
+            endpoint('deepinfra-fp8', '0.000000075', 0.5),
+            endpoint('together', '0.00000015'),
+        ])
+        expect(built!.cost['z-ai-fp8'].prompt_token).toBe(1.5e-7)
+        expect(built!.cost['novita-fp8'].prompt_token).toBe(1.5e-7)
+        expect(built!.discount?.endpoints[0].confirmation).toBe('confirmed')
+    })
+
+    it('keeps a vendor promotion when a reseller runs a different rate', () => {
+        const built = buildModelRow('openai/gpt-5.6-luna', listPricing, [
+            endpoint('openai', '0.0000005', 0.5),
+            endpoint('novita-fp8', '0.0000008', 0.2),
+        ])
+        expect(built!.cost.openai.prompt_token).toBe(0.0000005)
+        expect(built!.cost['novita-fp8'].prompt_token).toBe(0.000001)
     })
 
     it('warns once, naming the model, on an out-of-range rate', () => {
@@ -420,6 +537,15 @@ describe('confirmDiscountAgainstSiblings()', () => {
         expect(confirmDiscountAgainstSiblings(openai, [openai, candidate('azure', '0.000001', 0)])).toBe('confirmed')
     })
 
+    it('has nothing to corroborate for a route that kept its promotion', () => {
+        // The matching sibling stays: without the guard it reads as corroborating
+        // a division that never ran.
+        const openai = candidate('openai', '0.0000005', 0.5, true)
+        expect(confirmDiscountAgainstSiblings(openai, [openai, candidate('azure', '0.000001', 0)])).toBe(
+            'not-applicable'
+        )
+    })
+
     it('reports unconfirmed when the recovered price matches no sibling', () => {
         const openai = candidate('openai', '0.0000005', 0.5)
         expect(confirmDiscountAgainstSiblings(openai, [openai, candidate('azure', '0.000009', 0)])).toBe('unconfirmed')
@@ -439,11 +565,13 @@ describe('confirmDiscountAgainstSiblings()', () => {
             key: 'openai',
             cost: buildModelCost({ prompt: '0.0000005', completion: '0.000009', discount: 0.5 })!,
             discount: 0.5,
+            vendorPromotion: false,
         }
         const sibling: EndpointCandidate = {
             key: 'azure',
             cost: buildModelCost({ prompt: '0.000001', completion: '0.000002' })!,
             discount: 0,
+            vendorPromotion: false,
         }
         expect(confirmDiscountAgainstSiblings(discounted, [discounted, sibling])).toBe('confirmed')
     })
@@ -543,7 +671,9 @@ describe('renderDiscountReport()', () => {
 
     it('puts the confirmation verdict on the row it belongs to', () => {
         const report = renderDiscountReport([
-            entry({ endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'unconfirmed' as const }] }),
+            entry({
+                endpoints: [{ key: 'openai', discount: 0.5, confirmation: 'unconfirmed' as const }],
+            }),
         ])
         expect(report).toContain('| unconfirmed |')
     })
@@ -619,7 +749,13 @@ describe('renderDiscountReport()', () => {
         // Sanitized separately from the model id, so it needs its own input.
         const report = renderDiscountReport([
             entry({
-                endpoints: [{ key: 'a|b\n| pwned | 9 | 9 |', discount: 0.5, confirmation: 'confirmed' as const }],
+                endpoints: [
+                    {
+                        key: 'a|b\n| pwned | 9 | 9 |',
+                        discount: 0.5,
+                        confirmation: 'confirmed' as const,
+                    },
+                ],
             }),
         ])
         expect(report).not.toContain('pwned | 9 | 9 |')

--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
@@ -129,15 +129,39 @@ export const isFirstPartyRoute = (modelId: string, providerKey: string): boolean
 export interface RouteRate {
     discount: number
     firstParty: boolean
+    /** Prompt price as served, and where dividing the rate out would put it.
+     * Undefined when the feed's price does not parse, which corroborates nothing. */
+    servedPrompt: number | undefined
+    listPrompt: number | undefined
 }
 
+/** Where dividing a rate out puts a price. Shared with `buildModelCost` so a
+ * corroboration check compares against the number that actually gets stored. */
+const toListPrice = (value: number, discount: number): number =>
+    discount === 0 ? value : parseFloat((value / (1 - discount)).toPrecision(10))
+
 /** True when a rate is the vendor's own promotion, which its direct callers pay
- * too, so the route keeps the served price. A rate an unrelated operator also
- * runs is OpenRouter's promotion against a list the vendor still charges. */
-export const isVendorPromotion = (route: RouteRate, routes: RouteRate[]): boolean =>
-    route.firstParty &&
-    route.discount > 0 &&
-    !routes.some((other) => !other.firstParty && other.discount === route.discount)
+ * too, so the route keeps the served price. Two things refute it: an unrelated
+ * operator on the same rate, which makes the promotion OpenRouter's; and a
+ * de-discounted price landing on an undiscounted route, which proves the
+ * division recovers a list price somebody still charges. */
+export const isVendorPromotion = (route: RouteRate, routes: RouteRate[]): boolean => {
+    if (!route.firstParty || route.discount <= 0) {
+        return false
+    }
+
+    if (routes.some((other) => !other.firstParty && other.discount === route.discount)) {
+        return false
+    }
+
+    return !routes.some(
+        (other) => other.discount === 0 && other.servedPrompt !== undefined && other.servedPrompt === route.listPrompt
+    )
+}
+
+/** True when no route outside the model's vendor exists, so neither refutation
+ * above had anything to search. The verdict stands on the vendor's word. */
+export const isSoleVendorModel = (routes: RouteRate[]): boolean => !routes.some((route) => !route.firstParty)
 
 /** Keeps a cost at the price OpenRouter serves, promotion included. */
 export const buildServedCost = (
@@ -158,18 +182,16 @@ export const buildModelCost = (pricing: Record<string, unknown> | undefined, con
     }
 
     const discount = parseDiscountRate(pricing, context)
-    const toListPrice = (value: number): number =>
-        discount === 0 ? value : parseFloat((value / (1 - discount)).toPrecision(10))
 
     const cost: ModelCost = {
-        prompt_token: toListPrice(promptToken),
-        completion_token: toListPrice(completionToken),
+        prompt_token: toListPrice(promptToken, discount),
+        completion_token: toListPrice(completionToken, discount),
     }
 
     for (const [targetField, sourceField] of OPTIONAL_PRICING_FIELDS) {
         const parsedValue = parsePricingNumber(pricing[sourceField])
         if (parsedValue !== undefined && parsedValue !== 0) {
-            cost[targetField] = FLAT_FEE_FIELDS.has(targetField) ? parsedValue : toListPrice(parsedValue)
+            cost[targetField] = FLAT_FEE_FIELDS.has(targetField) ? parsedValue : toListPrice(parsedValue, discount)
         }
     }
 
@@ -181,6 +203,9 @@ export interface EndpointCandidate {
     cost: ModelCost
     discount: number
     vendorPromotion: boolean
+    /** True when the model has no route outside its vendor, so nothing could
+     * have refuted `vendorPromotion`. */
+    soleVendor: boolean
 }
 
 /*
@@ -218,12 +243,16 @@ export const confirmDiscountAgainstSiblings = (
 
 export interface DiscountReportEntry {
     model: string
-    endpoints: Array<{ key: string; discount: number; confirmation: DiscountConfirmation }>
+    endpoints: Array<{
+        key: string
+        discount: number
+        confirmation: DiscountConfirmation
+        /** What was stored, carried rather than read back off the verdict: the
+         * report is the only audit surface for these prices. */
+        vendorPromotion: boolean
+        soleVendor: boolean
+    }>
 }
-
-/** `not-applicable` is the only verdict a route stored at its served price can
- * carry, so it doubles as the marker for one. */
-const keptPromotion = (confirmation: DiscountConfirmation): boolean => confirmation === 'not-applicable'
 
 /** Share of the catalogue that may go unchecked before the run says so loudly. */
 export const UNCHECKED_WARN_FRACTION = 0.1
@@ -255,10 +284,16 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
     const rows = [...entries].sort((a, b) => a.model.localeCompare(b.model))
     // Routes that kept their promotion would pad the denominator with nothing
     // reconstructed.
-    const verdicts = rows.map((row) => row.endpoints.map((e) => e.confirmation).filter((c) => !keptPromotion(c)))
+    const verdicts = rows.map((row) => row.endpoints.filter((e) => !e.vendorPromotion).map((e) => e.confirmation))
     const confirmed = verdicts.filter((v) => v.includes('confirmed')).length
     const checkable = verdicts.filter((v) => v.some((c) => c !== 'not-checkable')).length
-    const endpointCount = rows.reduce((total, row) => total + row.endpoints.length, 0)
+
+    const allEndpoints = rows.flatMap((row) => row.endpoints)
+    const kept = allEndpoints.filter((e) => e.vendorPromotion)
+    // The platform's own promotions: a vendor's is not OpenRouter running one.
+    const endpointCount = allEndpoints.length - kept.length
+    const modelCount = rows.filter((row) => row.endpoints.some((e) => !e.vendorPromotion)).length
+    const unrefutable = kept.filter((e) => e.soleVendor).length
 
     const flatFeeList = [...FLAT_FEE_FIELDS]
         .sort()
@@ -268,15 +303,19 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
     const lines = [
         '## Discounts',
         '',
-        `OpenRouter is running a promotion on **${endpointCount} endpoint(s)** across **${rows.length} model(s)**.`,
+        `OpenRouter is running a promotion on **${endpointCount} endpoint(s)** across **${modelCount} model(s)**.`,
         'Reseller keys below are stored at list rate, with the promotion divided back',
         'out, so a provider key keeps meaning what that provider charges a direct caller.',
         `Per-call fees (${flatFeeList}) carry across untouched: promotional routes in`,
         'the feed serve `web_search` at the same fee as their undiscounted siblings,',
         'and every other per-call fee follows the same policy.',
-        'The `default` key is left as OpenRouter serves it, and so is any route marked',
-        '`served` below: the model vendor runs that route and no unrelated operator is on',
-        "the same rate, so the promotion is the vendor's and its direct callers pay it too.",
+        '',
+        `The \`default\` key is left as OpenRouter serves it, and so are **${kept.length} endpoint(s)**`,
+        'marked `served` below, where the model vendor runs the route and neither an',
+        'unrelated operator on the same rate nor an undiscounted sibling price',
+        `contradicts it. **${unrefutable}** of those sit on models with no route outside the`,
+        'vendor, so nothing could have contradicted them: check those against the',
+        "vendor's own pricing page before trusting a large rate.",
         '',
         `Independently confirmed against an undiscounted sibling route: ${confirmed}/${checkable} checkable model(s).`,
         unchecked,
@@ -296,7 +335,7 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
         for (const [index, endpoint] of row.endpoints.entries()) {
             const model = index === 0 ? sanitizeReportCell(row.model) : ''
             const confirmation = endpoint.confirmation
-            const stored = keptPromotion(confirmation) ? 'served' : 'list'
+            const stored = endpoint.vendorPromotion ? (endpoint.soleVendor ? 'served (sole)' : 'served') : 'list'
             lines.push(
                 `| ${model} | \`${sanitizeReportCell(endpoint.key)}\` | ${Math.round(endpoint.discount * 100)}% | ${stored} | ${confirmation} |`
             )
@@ -348,15 +387,21 @@ export const buildModelRow = (
                 ? providerKey
                 : `provider-${normalizeProviderKey(endpoint.provider_name ?? 'unknown') || 'unknown'}`
         const context = `${modelId} (${endpoint.tag ?? '?'})`
+        // Silent here; the builder below warns on whatever it is handed.
+        const discount = parseDiscountRate(endpoint.pricing ?? {}, context, false)
+        const servedPrompt = parsePricingNumber(endpoint.pricing?.prompt)
         return {
             endpoint,
             key,
             context,
-            // Silent here; the builder below warns on whatever it is handed.
-            discount: parseDiscountRate(endpoint.pricing ?? {}, context, false),
+            discount,
             firstParty: isFirstPartyRoute(modelId, key),
+            servedPrompt,
+            listPrompt: servedPrompt === undefined ? undefined : toListPrice(servedPrompt, discount),
         }
     })
+
+    const soleVendor = isSoleVendorModel(routes)
 
     for (const route of routes) {
         const vendorPromotion = isVendorPromotion(route, routes)
@@ -368,7 +413,13 @@ export const buildModelRow = (
         }
 
         cost[route.key] = endpointCost
-        candidates.push({ key: route.key, cost: endpointCost, discount: route.discount, vendorPromotion })
+        candidates.push({
+            key: route.key,
+            cost: endpointCost,
+            discount: route.discount,
+            vendorPromotion,
+            soleVendor,
+        })
     }
 
     // Keyed on parsed candidates rather than the raw endpoint count: a payload
@@ -389,6 +440,8 @@ export const buildModelRow = (
                           key: candidate.key,
                           discount: candidate.discount,
                           confirmation: confirmDiscountAgainstSiblings(candidate, candidates),
+                          vendorPromotion: candidate.vendorPromotion,
+                          soleVendor: candidate.soleVendor,
                       })),
                   }
                 : undefined,

--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
@@ -159,9 +159,11 @@ export const isVendorPromotion = (route: RouteRate, routes: RouteRate[]): boolea
     )
 }
 
-/** True when no route outside the model's vendor exists, so neither refutation
- * above had anything to search. The verdict stands on the vendor's word. */
-export const isSoleVendorModel = (routes: RouteRate[]): boolean => !routes.some((route) => !route.firstParty)
+/** True when no route could have satisfied either refutation above: none outside
+ * the vendor to carry the rate, and none undiscounted to carry the price. The
+ * verdict then stands on the vendor's word alone. */
+export const hasNoRefuter = (routes: RouteRate[]): boolean =>
+    !routes.some((route) => !route.firstParty || route.discount === 0)
 
 /** Keeps a cost at the price OpenRouter serves, promotion included. */
 export const buildServedCost = (
@@ -203,9 +205,12 @@ export interface EndpointCandidate {
     cost: ModelCost
     discount: number
     vendorPromotion: boolean
-    /** True when the model has no route outside its vendor, so nothing could
-     * have refuted `vendorPromotion`. */
-    soleVendor: boolean
+    /** True when nothing in the model could have refuted `vendorPromotion`. */
+    unrefutable: boolean
+    /** Served price and where dividing the rate out would put it, carried so the
+     * report can show a reader the spread it asks them to check. */
+    servedPrompt: number | undefined
+    listPrompt: number | undefined
 }
 
 /*
@@ -250,7 +255,9 @@ export interface DiscountReportEntry {
         /** What was stored, carried rather than read back off the verdict: the
          * report is the only audit surface for these prices. */
         vendorPromotion: boolean
-        soleVendor: boolean
+        unrefutable: boolean
+        servedPrompt: number | undefined
+        listPrompt: number | undefined
     }>
 }
 
@@ -259,6 +266,16 @@ export const UNCHECKED_WARN_FRACTION = 0.1
 
 /** Table rows rendered before the remainder collapses into a count line. */
 export const DISCOUNT_REPORT_ROW_LIMIT = 200
+
+/** Served price against the one dividing the rate out recovers, per million
+ * tokens. Only kept routes get it: the reader has to judge those by hand. */
+const renderSpread = (endpoint: DiscountReportEntry['endpoints'][number]): string => {
+    if (!endpoint.vendorPromotion || endpoint.servedPrompt === undefined || endpoint.listPrompt === undefined) {
+        return ''
+    }
+    const perMillion = (value: number): string => `$${parseFloat((value * 1e6).toPrecision(6))}`
+    return `${perMillion(endpoint.servedPrompt)} vs ${perMillion(endpoint.listPrompt)}`
+}
 
 /** Confines a third-party string to inert text in one table cell. An allowlist,
  * because a denylist has to anticipate every markdown construct that renders. */
@@ -293,7 +310,7 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
     // The platform's own promotions: a vendor's is not OpenRouter running one.
     const endpointCount = allEndpoints.length - kept.length
     const modelCount = rows.filter((row) => row.endpoints.some((e) => !e.vendorPromotion)).length
-    const unrefutable = kept.filter((e) => e.soleVendor).length
+    const unrefuted = kept.filter((e) => e.unrefutable).length
 
     const flatFeeList = [...FLAT_FEE_FIELDS]
         .sort()
@@ -313,14 +330,14 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
         `The \`default\` key is left as OpenRouter serves it, and so are **${kept.length} endpoint(s)**`,
         'marked `served` below, where the model vendor runs the route and neither an',
         'unrelated operator on the same rate nor an undiscounted sibling price',
-        `contradicts it. **${unrefutable}** of those sit on models with no route outside the`,
-        'vendor, so nothing could have contradicted them: check those against the',
-        "vendor's own pricing page before trusting a large rate.",
+        `contradicts it. **${unrefuted}** of those had no route that could have refuted`,
+        "either way, so they stand on the vendor's word: the spread column gives the",
+        'served and recovered prices to check against the vendor’s own pricing page.',
         '',
         `Independently confirmed against an undiscounted sibling route: ${confirmed}/${checkable} checkable model(s).`,
         unchecked,
-        '| Model | Endpoint | Rate | Stored | Confirmed |',
-        '| --- | --- | --- | --- | --- |',
+        '| Model | Endpoint | Rate | Stored | Spread /1M | Confirmed |',
+        '| --- | --- | --- | --- | --- | --- |',
     ]
 
     // Bounded on emitted rows, not models: the widest model carries 32 endpoints,
@@ -335,9 +352,9 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
         for (const [index, endpoint] of row.endpoints.entries()) {
             const model = index === 0 ? sanitizeReportCell(row.model) : ''
             const confirmation = endpoint.confirmation
-            const stored = endpoint.vendorPromotion ? (endpoint.soleVendor ? 'served (sole)' : 'served') : 'list'
+            const stored = endpoint.vendorPromotion ? (endpoint.unrefutable ? 'served (unrefuted)' : 'served') : 'list'
             lines.push(
-                `| ${model} | \`${sanitizeReportCell(endpoint.key)}\` | ${Math.round(endpoint.discount * 100)}% | ${stored} | ${confirmation} |`
+                `| ${model} | \`${sanitizeReportCell(endpoint.key)}\` | ${Math.round(endpoint.discount * 100)}% | ${stored} | ${renderSpread(endpoint)} | ${confirmation} |`
             )
         }
         emitted += row.endpoints.length
@@ -401,7 +418,7 @@ export const buildModelRow = (
         }
     })
 
-    const soleVendor = isSoleVendorModel(routes)
+    const unrefutable = hasNoRefuter(routes)
 
     for (const route of routes) {
         const vendorPromotion = isVendorPromotion(route, routes)
@@ -418,7 +435,9 @@ export const buildModelRow = (
             cost: endpointCost,
             discount: route.discount,
             vendorPromotion,
-            soleVendor,
+            unrefutable,
+            servedPrompt: route.servedPrompt,
+            listPrompt: route.listPrompt,
         })
     }
 
@@ -441,7 +460,9 @@ export const buildModelRow = (
                           discount: candidate.discount,
                           confirmation: confirmDiscountAgainstSiblings(candidate, candidates),
                           vendorPromotion: candidate.vendorPromotion,
-                          soleVendor: candidate.soleVendor,
+                          unrefutable: candidate.unrefutable,
+                          servedPrompt: candidate.servedPrompt,
+                          listPrompt: candidate.listPrompt,
                       })),
                   }
                 : undefined,

--- a/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts
@@ -100,8 +100,47 @@ export const withoutDiscount = (pricing: Record<string, unknown> | undefined): R
     return rest
 }
 
-/** `default` must stay at the served price whatever the list payload carries. */
-export const buildDefaultCost = (
+/** Route vendors OpenRouter names differently from the namespace it files their
+ * models under; a namespace absent here matches its own name. Not
+ * `PROVIDER_ALIASES`: that resolves `$ai_provider` onto one canonical key, where
+ * `google` means `google-ai-studio` and would miss `google-vertex-*`. */
+export const MODEL_NAMESPACE_VENDORS: Record<string, string> = {
+    'bytedance-seed': 'seed',
+    mistralai: 'mistral',
+    qwen: 'alibaba',
+    rekaai: 'reka',
+    'x-ai': 'xai',
+}
+
+/** True when the model's own vendor operates the route. */
+export const isFirstPartyRoute = (modelId: string, providerKey: string): boolean => {
+    const separator = modelId.indexOf('/')
+    if (separator < 0) {
+        return false
+    }
+
+    const vendor = normalizeProviderKey(modelId.slice(0, separator))
+    const routeVendor = MODEL_NAMESPACE_VENDORS[vendor] ?? vendor
+    // Hyphen-anchored, so `google` claims `google-vertex` but `openai` cannot
+    // claim a reseller that merely starts with those letters.
+    return providerKey === routeVendor || providerKey.startsWith(`${routeVendor}-`)
+}
+
+export interface RouteRate {
+    discount: number
+    firstParty: boolean
+}
+
+/** True when a rate is the vendor's own promotion, which its direct callers pay
+ * too, so the route keeps the served price. A rate an unrelated operator also
+ * runs is OpenRouter's promotion against a list the vendor still charges. */
+export const isVendorPromotion = (route: RouteRate, routes: RouteRate[]): boolean =>
+    route.firstParty &&
+    route.discount > 0 &&
+    !routes.some((other) => !other.firstParty && other.discount === route.discount)
+
+/** Keeps a cost at the price OpenRouter serves, promotion included. */
+export const buildServedCost = (
     modelPricing: Record<string, unknown> | undefined,
     context?: string
 ): ModelCost | null => buildModelCost(withoutDiscount(modelPricing), context)
@@ -141,6 +180,7 @@ export interface EndpointCandidate {
     key: string
     cost: ModelCost
     discount: number
+    vendorPromotion: boolean
 }
 
 /*
@@ -150,7 +190,7 @@ export interface EndpointCandidate {
  * two readers needs an `openrouter` key in `CanonicalProvider` first.
  */
 
-export type DiscountConfirmation = 'confirmed' | 'unconfirmed' | 'not-checkable'
+export type DiscountConfirmation = 'confirmed' | 'unconfirmed' | 'not-checkable' | 'not-applicable'
 
 /** Corroborates one route's de-discount against an undiscounted sibling. Per
  * route, or a verdict rolled up across a model's routes gets displayed against
@@ -160,6 +200,11 @@ export const confirmDiscountAgainstSiblings = (
     candidate: EndpointCandidate,
     candidates: EndpointCandidate[]
 ): DiscountConfirmation => {
+    // A route stored at its served price had nothing divided out to corroborate.
+    if (candidate.vendorPromotion) {
+        return 'not-applicable'
+    }
+
     const undiscounted = candidates.filter((other) => other.discount === 0)
     if (candidate.discount === 0 || undiscounted.length === 0) {
         return 'not-checkable'
@@ -175,6 +220,10 @@ export interface DiscountReportEntry {
     model: string
     endpoints: Array<{ key: string; discount: number; confirmation: DiscountConfirmation }>
 }
+
+/** `not-applicable` is the only verdict a route stored at its served price can
+ * carry, so it doubles as the marker for one. */
+const keptPromotion = (confirmation: DiscountConfirmation): boolean => confirmation === 'not-applicable'
 
 /** Share of the catalogue that may go unchecked before the run says so loudly. */
 export const UNCHECKED_WARN_FRACTION = 0.1
@@ -204,7 +253,9 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
     }
 
     const rows = [...entries].sort((a, b) => a.model.localeCompare(b.model))
-    const verdicts = rows.map((row) => row.endpoints.map((e) => e.confirmation))
+    // Routes that kept their promotion would pad the denominator with nothing
+    // reconstructed.
+    const verdicts = rows.map((row) => row.endpoints.map((e) => e.confirmation).filter((c) => !keptPromotion(c)))
     const confirmed = verdicts.filter((v) => v.includes('confirmed')).length
     const checkable = verdicts.filter((v) => v.some((c) => c !== 'not-checkable')).length
     const endpointCount = rows.reduce((total, row) => total + row.endpoints.length, 0)
@@ -218,17 +269,19 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
         '## Discounts',
         '',
         `OpenRouter is running a promotion on **${endpointCount} endpoint(s)** across **${rows.length} model(s)**.`,
-        'Per-provider keys below are stored at list rate, with the promotion divided back',
+        'Reseller keys below are stored at list rate, with the promotion divided back',
         'out, so a provider key keeps meaning what that provider charges a direct caller.',
         `Per-call fees (${flatFeeList}) carry across untouched: promotional routes in`,
         'the feed serve `web_search` at the same fee as their undiscounted siblings,',
         'and every other per-call fee follows the same policy.',
-        'The `default` key is left as OpenRouter serves it.',
+        'The `default` key is left as OpenRouter serves it, and so is any route marked',
+        '`served` below: the model vendor runs that route and no unrelated operator is on',
+        "the same rate, so the promotion is the vendor's and its direct callers pay it too.",
         '',
         `Independently confirmed against an undiscounted sibling route: ${confirmed}/${checkable} checkable model(s).`,
         unchecked,
-        '| Model | Endpoint | Rate | Confirmed |',
-        '| --- | --- | --- | --- |',
+        '| Model | Endpoint | Rate | Stored | Confirmed |',
+        '| --- | --- | --- | --- | --- |',
     ]
 
     // Bounded on emitted rows, not models: the widest model carries 32 endpoints,
@@ -243,8 +296,9 @@ export const renderDiscountReport = (entries: DiscountReportEntry[], uncheckedMo
         for (const [index, endpoint] of row.endpoints.entries()) {
             const model = index === 0 ? sanitizeReportCell(row.model) : ''
             const confirmation = endpoint.confirmation
+            const stored = keptPromotion(confirmation) ? 'served' : 'list'
             lines.push(
-                `| ${model} | \`${sanitizeReportCell(endpoint.key)}\` | ${Math.round(endpoint.discount * 100)}% | ${confirmation} |`
+                `| ${model} | \`${sanitizeReportCell(endpoint.key)}\` | ${Math.round(endpoint.discount * 100)}% | ${stored} | ${confirmation} |`
             )
         }
         emitted += row.endpoints.length
@@ -275,35 +329,46 @@ export const buildModelRow = (
     modelPricing: Record<string, unknown> | undefined,
     endpoints: unknown[]
 ): BuiltModelRow | null => {
-    const defaultCost = buildDefaultCost(modelPricing, modelId)
+    const defaultCost = buildServedCost(modelPricing, modelId)
     if (!defaultCost) {
         return null
     }
     const cost: Record<string, ModelCost> = { default: defaultCost }
     const candidates: EndpointCandidate[] = []
 
-    for (const raw of endpoints) {
+    // Rates are read across every route before any cost is built: whether a
+    // vendor's own rate is its promotion depends on who else is running it.
+    const routes = endpoints.map((raw) => {
         const endpoint = (raw ?? {}) as { tag?: string; provider_name?: string; pricing?: Record<string, unknown> }
+        const providerKey = endpointProviderKey(endpoint)
+        // Normalized too: every key here is interpolated into canonical-providers.ts
+        // as a string literal, so it must be [a-z0-9-] by construction.
+        const key =
+            providerKey && providerKey !== 'default'
+                ? providerKey
+                : `provider-${normalizeProviderKey(endpoint.provider_name ?? 'unknown') || 'unknown'}`
         const context = `${modelId} (${endpoint.tag ?? '?'})`
-        const endpointCost = buildModelCost(endpoint.pricing, context)
+        return {
+            endpoint,
+            key,
+            context,
+            // Silent here; the builder below warns on whatever it is handed.
+            discount: parseDiscountRate(endpoint.pricing ?? {}, context, false),
+            firstParty: isFirstPartyRoute(modelId, key),
+        }
+    })
+
+    for (const route of routes) {
+        const vendorPromotion = isVendorPromotion(route, routes)
+        const endpointCost = vendorPromotion
+            ? buildServedCost(route.endpoint.pricing, route.context)
+            : buildModelCost(route.endpoint.pricing, route.context)
         if (!endpointCost) {
             continue
         }
 
-        const providerKey = endpointProviderKey(endpoint)
-        // Normalized too: every key here is interpolated into canonical-providers.ts
-        // as a string literal, so it must be [a-z0-9-] by construction.
-        const safeProviderKey =
-            providerKey && providerKey !== 'default'
-                ? providerKey
-                : `provider-${normalizeProviderKey(endpoint.provider_name ?? 'unknown') || 'unknown'}`
-
-        cost[safeProviderKey] = endpointCost
-        candidates.push({
-            key: safeProviderKey,
-            cost: endpointCost,
-            discount: parseDiscountRate(endpoint.pricing ?? {}, context, false),
-        })
+        cost[route.key] = endpointCost
+        candidates.push({ key: route.key, cost: endpointCost, discount: route.discount, vendorPromotion })
     }
 
     // Keyed on parsed candidates rather than the raw endpoint count: a payload


### PR DESCRIPTION
## Problem

LLM analytics reports roughly double the real spend on any model whose vendor is running a promotion on its own API. Google charges **$0.75/M** input for `gemini-3.7-flash` through the end of 2026; the price book stores $1.50/M, which is its January 2027 rate.

The generator divides OpenRouter's per-endpoint `discount` back out of every provider key, so a key keeps meaning "what that provider charges a direct caller". That inverts when the vendor runs the promotion itself.

## Changes

A route keeps the price OpenRouter serves when the promotion is the vendor's own, and everything else is de-discounted as before.

- **`isVendorPromotion()`** keeps the served price only when the route is the model vendor's and two refutations both come up empty: no unrelated operator on the same rate, and no undiscounted route already charging what dividing the rate out would recover. The second refutation is load-bearing. `minimax/minimax-m2` serves its vendor route at $0.255/M on a 0.15 rate, which divides out to exactly the $0.30/M two undiscounted hosts charge, so that rate is a markdown off a real list and the route de-discounts.
- `isFirstPartyRoute()` matches a model's namespace against the route key by exact-or-hyphen-prefix, with **`MODEL_NAMESPACE_VENDORS`** covering the five vendors OpenRouter names differently from the namespace it files their models under, such as `qwen` models served by `alibaba`.
- The report gains **`Stored`** (`served`, `served (unrefuted)`, or `list`) and a **spread** column. Routes marked unrefuted had nothing in the model that could contradict them, so the spread prints served against recovered price for a human to check: `upstage/solar-pro4` reads `$0.03 vs $0.30` at a 0.9 rate. Headline counts no longer attribute a vendor's promotion to OpenRouter.
- `llm-costs.json` is not in this diff; the daily job regenerates it. Mechanical: `buildDefaultCost` becomes `buildServedCost`.

## How did you test this code?

Automated tests, plus a scripted run of `buildModelRow` over live OpenRouter payloads. No manual QA of the ingestion path.

- New cases pin what nothing caught before: a vendor promotion keeps its served price; a shared rate or an undiscounted host's matching price refutes it; a ratio that divides inexactly holds the rounding both sides depend on; a markup is never a promotion. The alias table is bound to the price book by the share of its own namespace each vendor hosts, which mere presence would not catch.
- Swept both refutations over every discounted model in the live catalogue: the rate check demotes one route (`z-ai/glm-5.3-flash`), the price check demotes one more (`minimax/minimax-m2`), and 27 routes keep their promotion.
- Live payloads: `gemini-3.7-flash` stores `google-ai-studio` at $0.75/$3.75, matching Google's published rate; `gpt-5.6-sol` keeps `openai` at its served $2/$10 while `azure` and `amazon-bedrock` stay at $5/$30 and $4.40/$22; `minimax-fp8` moves to $0.30 and reports `confirmed`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 5); requires human review. Skills invoked: `/simplify`, `/code-comments`, `/pr-descriptions`, `/branch-review`. The review found one high (the price refutation) and its fixes were reviewed again as new code.
