### PR TITLE
fix(slo): only send SLO events from cloud deployments

### DIFF
--- a/posthog/slo/events.py
+++ b/posthog/slo/events.py
@@ -1,8 +1,10 @@
 from collections.abc import Callable
+from typing import Any
 
 import posthoganalytics
 from prometheus_client import Counter, Histogram
 
+from posthog.cloud_utils import is_cloud
 from posthog.exceptions_capture import capture_exception
 from posthog.git import get_git_commit_short
 from posthog.slo.types import SloCompletedProperties, SloStartedProperties
@@ -70,6 +72,14 @@ def _capture_emit_exception(
         pass
 
 
+def _send(capture: Callable | None, **event: Any) -> None:
+    # The module-level client carries PostHog's own project token in every non-debug run mode, so without this
+    # guard a self-hosted instance reports its SLO events into PostHog's internal project, with no region.
+    if capture is None and not is_cloud():
+        return
+    (capture or posthoganalytics.capture)(**event)
+
+
 def emit_slo_started(
     distinct_id: str,
     properties: SloStartedProperties,
@@ -86,12 +96,7 @@ def emit_slo_started(
         if sample_rate < 1.0:
             all_properties["sample_rate"] = sample_rate
 
-        _capture = capture or posthoganalytics.capture
-        _capture(
-            distinct_id=distinct_id,
-            event="slo_operation_started",
-            properties=all_properties,
-        )
+        _send(capture, distinct_id=distinct_id, event="slo_operation_started", properties=all_properties)
         OPERATION_STARTED_COUNTER.labels(
             area=properties.area,
             operation=properties.operation,
@@ -122,12 +127,7 @@ def emit_slo_completed(
         if sample_rate < 1.0:
             all_properties["sample_rate"] = sample_rate
 
-        _capture = capture or posthoganalytics.capture
-        _capture(
-            distinct_id=distinct_id,
-            event="slo_operation_completed",
-            properties=all_properties,
-        )
+        _send(capture, distinct_id=distinct_id, event="slo_operation_completed", properties=all_properties)
         OPERATION_COMPLETED_COUNTER.labels(
             area=properties.area,
             operation=properties.operation,

--- a/posthog/slo/events.py
+++ b/posthog/slo/events.py
@@ -1,10 +1,12 @@
 from collections.abc import Callable
 from typing import Any
 
+from django.conf import settings
+
 import posthoganalytics
 from prometheus_client import Counter, Histogram
 
-from posthog.cloud_utils import is_cloud
+from posthog.cloud_utils import is_hobby
 from posthog.exceptions_capture import capture_exception
 from posthog.git import get_git_commit_short
 from posthog.slo.types import SloCompletedProperties, SloStartedProperties
@@ -73,9 +75,10 @@ def _capture_emit_exception(
 
 
 def _send(capture: Callable | None, *, distinct_id: str, event: str, properties: dict[str, Any]) -> None:
-    # The module-level client carries PostHog's own project token in every non-debug run mode, so without this
-    # guard a self-hosted instance reports its SLO events into PostHog's internal project, with no region.
-    if capture is None and not is_cloud():
+    # The module-level client carries PostHog's own project token on self-hosted installs too, so without this
+    # guard they report SLO events into PostHog's internal project, with no region. Tests run in hobby mode with
+    # that client patched, so they keep observing emission.
+    if capture is None and is_hobby() and not settings.TEST:
         return
     (capture or posthoganalytics.capture)(distinct_id=distinct_id, event=event, properties=properties)
 

--- a/posthog/slo/events.py
+++ b/posthog/slo/events.py
@@ -72,12 +72,12 @@ def _capture_emit_exception(
         pass
 
 
-def _send(capture: Callable | None, **event: Any) -> None:
+def _send(capture: Callable | None, *, distinct_id: str, event: str, properties: dict[str, Any]) -> None:
     # The module-level client carries PostHog's own project token in every non-debug run mode, so without this
     # guard a self-hosted instance reports its SLO events into PostHog's internal project, with no region.
     if capture is None and not is_cloud():
         return
-    (capture or posthoganalytics.capture)(**event)
+    (capture or posthoganalytics.capture)(distinct_id=distinct_id, event=event, properties=properties)
 
 
 def emit_slo_started(

--- a/posthog/slo/test/test_events.py
+++ b/posthog/slo/test/test_events.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from parameterized import parameterized
+
+from posthog.slo.events import emit_slo_completed, emit_slo_started
+from posthog.slo.types import SloArea, SloCompletedProperties, SloOperation, SloOutcome, SloStartedProperties
+
+STARTED = SloStartedProperties(area=SloArea.ANALYTIC_PLATFORM, operation=SloOperation.EXPORT, team_id=1)
+COMPLETED = SloCompletedProperties(
+    area=SloArea.ANALYTIC_PLATFORM, operation=SloOperation.EXPORT, team_id=1, outcome=SloOutcome.SUCCESS
+)
+
+
+@parameterized.expand(
+    [
+        ("started_on_cloud", emit_slo_started, STARTED, "US", True),
+        ("started_self_hosted", emit_slo_started, STARTED, None, False),
+        ("completed_on_cloud", emit_slo_completed, COMPLETED, "EU", True),
+        ("completed_self_hosted", emit_slo_completed, COMPLETED, None, False),
+    ]
+)
+def test_slo_events_only_reach_posthog_from_cloud(_name, emit, properties, cloud_deployment, expected_sent) -> None:
+    with (
+        override_settings(CLOUD_DEPLOYMENT=cloud_deployment),
+        patch("posthog.slo.events.posthoganalytics.capture") as capture,
+    ):
+        emit("distinct-id", properties)
+
+    assert capture.called is expected_sent

--- a/posthog/slo/test/test_slo_events.py
+++ b/posthog/slo/test/test_slo_events.py
@@ -15,23 +15,29 @@ COMPLETED = SloCompletedProperties(
 )
 
 
+CLOUD = {"CLOUD_DEPLOYMENT": "US", "DEBUG": False, "TEST": False}
+LOCAL_DEV = {"CLOUD_DEPLOYMENT": None, "DEBUG": True, "TEST": False}
+SELF_HOSTED = {"CLOUD_DEPLOYMENT": None, "DEBUG": False, "TEST": False}
+
+
 @parameterized.expand(
     [
-        ("started_on_cloud", emit_slo_started, STARTED, "US", True),
-        ("started_self_hosted", emit_slo_started, STARTED, None, False),
-        ("completed_on_cloud", emit_slo_completed, COMPLETED, "EU", True),
-        ("completed_self_hosted", emit_slo_completed, COMPLETED, None, False),
+        ("started_on_cloud", emit_slo_started, STARTED, CLOUD, True),
+        ("started_in_local_dev", emit_slo_started, STARTED, LOCAL_DEV, True),
+        ("started_self_hosted", emit_slo_started, STARTED, SELF_HOSTED, False),
+        ("completed_on_cloud", emit_slo_completed, COMPLETED, CLOUD, True),
+        ("completed_self_hosted", emit_slo_completed, COMPLETED, SELF_HOSTED, False),
     ]
 )
-def test_slo_events_only_reach_posthog_from_cloud(
+def test_slo_events_never_reach_posthog_from_self_hosted(
     _name: str,
     emit: Callable[..., None],
     properties: SloStartedProperties | SloCompletedProperties,
-    cloud_deployment: str | None,
+    run_mode_settings: dict[str, object],
     expected_sent: bool,
 ) -> None:
     with (
-        override_settings(CLOUD_DEPLOYMENT=cloud_deployment),
+        override_settings(**run_mode_settings),
         patch("posthog.slo.events.posthoganalytics.capture") as capture,
     ):
         emit("distinct-id", properties)

--- a/posthog/slo/test/test_slo_events.py
+++ b/posthog/slo/test/test_slo_events.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from unittest.mock import patch
 
 from django.test import override_settings
@@ -21,7 +23,13 @@ COMPLETED = SloCompletedProperties(
         ("completed_self_hosted", emit_slo_completed, COMPLETED, None, False),
     ]
 )
-def test_slo_events_only_reach_posthog_from_cloud(_name, emit, properties, cloud_deployment, expected_sent) -> None:
+def test_slo_events_only_reach_posthog_from_cloud(
+    _name: str,
+    emit: Callable[..., None],
+    properties: SloStartedProperties | SloCompletedProperties,
+    cloud_deployment: str | None,
+    expected_sent: bool,
+) -> None:
     with (
         override_settings(CLOUD_DEPLOYMENT=cloud_deployment),
         patch("posthog.slo.events.posthoganalytics.capture") as capture,


### PR DESCRIPTION
## Problem

Self-hosted PostHog instances report their SLO telemetry (`slo_operation_started`, `slo_operation_completed`) into PostHog's own internal project, with `region`, `service` and `environment` unset. On internal dashboards that break down by region this shows up as a "None (no value)" series next to US and EU, and several self-hosted instances have been doing it.

- The emitters in `posthog/slo/events.py` use the module-level `posthoganalytics` client, which `posthog/apps.py` points at the internal project in every run mode except debug, test and E2E.
- `ph_scoped_capture` already refuses to capture off cloud. The SLO path had no such guard.

## Changes

- Self-hosted instances no longer send SLO events to PostHog: `emit_slo_started` and `emit_slo_completed` skip the capture in hobby mode (neither cloud nor local dev) when no explicit `capture` callable was passed. Cloud keeps emitting, local dev keeps its self-capture, and tests keep observing the patched client. Prometheus counters and histograms still update everywhere.
- Mechanical: both emitters share one `_send` helper instead of building the capture call twice.

## How did you test this code?

New `posthog/slo/test/test_slo_events.py`, five parameterized cases covering the cloud, local dev and self-hosted run modes per emitter. It catches the guard being dropped, widened to local dev, or moved in front of the explicit `capture` path. The existing `test_slo_context.py` is unchanged and passing.

Not checked: a real self-hosted deployment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, session linked below. Found while investigating an unexpected region on the events-retention sync dashboard, where the region-less series traced back to a self-hosted instance. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The first version gated on `is_cloud()`. That silenced about 35 existing tests across alerts, exports, subscriptions and the persons API that observe SLO emission through the patched module client, since tests run in hobby mode. Rather than switch those tests to cloud mode, the guard now targets hobby mode and exempts `TEST`, which also keeps local dev's self-capture working.

Public artifact: self-hosted instances are described only in aggregate; no identifiers from the session appear here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuyL4asmxXmXTab7VhcZc
