### PR TITLE
feat(cdp): add beehiiv realtime destination

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/beehiiv/beehiiv.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/beehiiv/beehiiv.template.test.ts
@@ -1,0 +1,212 @@
+import { parseJSON } from '~/common/utils/json-parse'
+
+import { TemplateTester } from '../../test/test-helpers'
+import { template } from './beehiiv.template'
+
+const PUBLICATION_ID = 'pub_00000000-0000-0000-0000-000000000000'
+const EMAIL = 'max+newsletter@posthog.com'
+const COLLECTION_URL = `https://api.beehiiv.com/v2/publications/${PUBLICATION_ID}/subscriptions`
+const SUBSCRIPTION_URL = `${COLLECTION_URL}/by_email/max%2Bnewsletter%40posthog.com`
+
+const EXPECTED_HEADERS = {
+    Authorization: 'Bearer API_KEY',
+    'Content-Type': 'application/json',
+}
+
+const defaultInputs = {
+    apiKey: 'API_KEY',
+    publicationId: PUBLICATION_ID,
+    email: EMAIL,
+    customFields: {
+        'First Name': 'Max',
+        'Last Name': 'AI',
+        Empty: '',
+    },
+    sendWelcomeEmail: false,
+    reactivateExisting: false,
+    utmSource: 'posthog',
+    utmMedium: 'product',
+    utmCampaign: 'newsletter-launch',
+    utmTerm: 'product-analytics',
+    utmContent: 'upgrade-cta',
+    referringSite: 'https://posthog.com/blog',
+}
+
+const parseBody = (invocation: any): Record<string, any> => {
+    return parseJSON(invocation.queueParameters.body)
+}
+
+describe('beehiiv template', () => {
+    const tester = new TemplateTester(template)
+
+    beforeEach(async () => {
+        await tester.beforeEach()
+    })
+
+    it('creates a subscriber when no subscription matches the email', async () => {
+        const lookupRequest = await tester.invoke(defaultInputs, {})
+
+        expect(lookupRequest.error).toBeUndefined()
+        expect(lookupRequest.finished).toBe(false)
+        expect(lookupRequest.invocation.queueParameters).toEqual({
+            type: 'fetch',
+            url: SUBSCRIPTION_URL,
+            method: 'GET',
+            headers: EXPECTED_HEADERS,
+        })
+
+        const createRequest = await tester.invokeFetchResponse(lookupRequest.invocation, {
+            status: 404,
+            body: { errors: [{ message: 'Subscription not found' }] },
+        })
+
+        expect(createRequest.finished).toBe(false)
+        expect(createRequest.invocation.queueParameters).toMatchObject({
+            type: 'fetch',
+            url: COLLECTION_URL,
+            method: 'POST',
+            headers: EXPECTED_HEADERS,
+        })
+        expect(parseBody(createRequest.invocation)).toEqual({
+            email: EMAIL,
+            reactivate_existing: false,
+            send_welcome_email: false,
+            utm_source: 'posthog',
+            utm_medium: 'product',
+            utm_campaign: 'newsletter-launch',
+            utm_term: 'product-analytics',
+            utm_content: 'upgrade-cta',
+            referring_site: 'https://posthog.com/blog',
+            custom_fields: [
+                { name: 'First Name', value: 'Max' },
+                { name: 'Last Name', value: 'AI' },
+            ],
+        })
+
+        const done = await tester.invokeFetchResponse(createRequest.invocation, {
+            status: 200,
+            body: { data: { id: 'sub_123', email: EMAIL } },
+        })
+
+        expect(done.error).toBeUndefined()
+        expect(done.finished).toBe(true)
+        expect(done.logs.some((log) => log.message.includes(`Successfully created beehiiv subscription ${EMAIL}`))).toBe(
+            true
+        )
+    })
+
+    it('updates custom fields for an existing subscriber', async () => {
+        const lookupRequest = await tester.invoke(defaultInputs, {})
+        const updateRequest = await tester.invokeFetchResponse(lookupRequest.invocation, {
+            status: 200,
+            body: { data: { id: 'sub_123', email: EMAIL, status: 'active' } },
+        })
+
+        expect(updateRequest.finished).toBe(false)
+        expect(updateRequest.invocation.queueParameters).toMatchObject({
+            type: 'fetch',
+            url: SUBSCRIPTION_URL,
+            method: 'PUT',
+            headers: EXPECTED_HEADERS,
+        })
+        expect(parseBody(updateRequest.invocation)).toEqual({
+            custom_fields: [
+                { name: 'First Name', value: 'Max' },
+                { name: 'Last Name', value: 'AI' },
+            ],
+        })
+
+        const done = await tester.invokeFetchResponse(updateRequest.invocation, {
+            status: 200,
+            body: { data: { id: 'sub_123', email: EMAIL } },
+        })
+
+        expect(done.error).toBeUndefined()
+        expect(done.finished).toBe(true)
+    })
+
+    it('requests reactivation for existing and newly created subscribers only when enabled', async () => {
+        const inputs = { ...defaultInputs, reactivateExisting: true }
+        const lookupRequest = await tester.invoke(inputs, {})
+        const updateRequest = await tester.invokeFetchResponse(lookupRequest.invocation, {
+            status: 200,
+            body: { data: { id: 'sub_123', email: EMAIL, status: 'inactive' } },
+        })
+
+        expect(parseBody(updateRequest.invocation)).toMatchObject({ unsubscribe: false })
+
+        const missingLookupRequest = await tester.invoke(inputs, {})
+        const createRequest = await tester.invokeFetchResponse(missingLookupRequest.invocation, {
+            status: 404,
+            body: {},
+        })
+        expect(parseBody(createRequest.invocation)).toMatchObject({ reactivate_existing: true })
+    })
+
+    it('skips an existing subscriber when there are no fields to update', async () => {
+        const lookupRequest = await tester.invoke({ ...defaultInputs, customFields: {} }, {})
+        const response = await tester.invokeFetchResponse(lookupRequest.invocation, {
+            status: 200,
+            body: { data: { id: 'sub_123', email: EMAIL, status: 'active' } },
+        })
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.invocation.queueParameters).toBeFalsy()
+        expect(
+            response.logs.some((log) =>
+                log.message.includes('Subscription already exists and there are no fields to update. Skipping...')
+            )
+        ).toBe(true)
+    })
+
+    it('skips when email is empty', async () => {
+        const response = await tester.invoke({ ...defaultInputs, email: '' }, {})
+
+        expect(response.error).toBeUndefined()
+        expect(response.finished).toBe(true)
+        expect(response.invocation.queueParameters).toBeFalsy()
+        expect(response.logs.some((log) => log.message.includes('No email set. Skipping...'))).toBe(true)
+    })
+
+    it('throws when the subscriber lookup fails', async () => {
+        const lookupRequest = await tester.invoke(defaultInputs, {})
+        const errorResponse = await tester.invokeFetchResponse(lookupRequest.invocation, {
+            status: 401,
+            body: { errors: [{ message: 'Unauthorized' }] },
+        })
+
+        expect(errorResponse.finished).toBe(true)
+        expect(errorResponse.error).toMatch('Error looking up beehiiv subscription (status 401)')
+    })
+
+    it('throws when subscriber creation fails', async () => {
+        const lookupRequest = await tester.invoke(defaultInputs, {})
+        const createRequest = await tester.invokeFetchResponse(lookupRequest.invocation, {
+            status: 404,
+            body: {},
+        })
+        const errorResponse = await tester.invokeFetchResponse(createRequest.invocation, {
+            status: 400,
+            body: { errors: [{ message: 'Invalid email' }] },
+        })
+
+        expect(errorResponse.finished).toBe(true)
+        expect(errorResponse.error).toMatch('Error creating beehiiv subscription (status 400)')
+    })
+
+    it('throws when subscriber update fails', async () => {
+        const lookupRequest = await tester.invoke(defaultInputs, {})
+        const updateRequest = await tester.invokeFetchResponse(lookupRequest.invocation, {
+            status: 200,
+            body: { data: { id: 'sub_123', email: EMAIL } },
+        })
+        const errorResponse = await tester.invokeFetchResponse(updateRequest.invocation, {
+            status: 429,
+            body: { errors: [{ message: 'Rate limit exceeded' }] },
+        })
+
+        expect(errorResponse.finished).toBe(true)
+        expect(errorResponse.error).toMatch('Error updating beehiiv subscription (status 429)')
+    })
+})

--- a/nodejs/src/cdp/templates/_destinations/beehiiv/beehiiv.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/beehiiv/beehiiv.template.ts
@@ -1,0 +1,217 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+export const template: HogFunctionTemplate = {
+    status: 'alpha',
+    free: false,
+    type: 'destination',
+    id: 'template-beehiiv',
+    name: 'beehiiv',
+    description: 'Sync PostHog persons to beehiiv as subscribers',
+    icon_url: '/static/services/beehiiv.png',
+    category: ['User Engagement Platforms'],
+    code_language: 'hog',
+    code: `
+if (empty(inputs.email)) {
+    print('No email set. Skipping...')
+    return
+}
+
+let headers := {
+    'Authorization': f'Bearer {inputs.apiKey}',
+    'Content-Type': 'application/json'
+}
+
+let customFields := []
+for (let name, value in inputs.customFields) {
+    if (not empty(name) and not empty(value)) {
+        customFields := arrayPushBack(customFields, {
+            'name': name,
+            'value': value
+        })
+    }
+}
+
+let encodedEmail := encodeURLComponent(inputs.email)
+let subscriptionUrl := f'https://api.beehiiv.com/v2/publications/{inputs.publicationId}/subscriptions/by_email/{encodedEmail}'
+let getRes := fetch(subscriptionUrl, {
+    'method': 'GET',
+    'headers': headers
+})
+
+if (getRes.status == 404) {
+    let createBody := {
+        'email': inputs.email,
+        'reactivate_existing': inputs.reactivateExisting,
+        'send_welcome_email': inputs.sendWelcomeEmail
+    }
+
+    if (not empty(inputs.utmSource)) createBody.utm_source := inputs.utmSource
+    if (not empty(inputs.utmMedium)) createBody.utm_medium := inputs.utmMedium
+    if (not empty(inputs.utmCampaign)) createBody.utm_campaign := inputs.utmCampaign
+    if (not empty(inputs.utmTerm)) createBody.utm_term := inputs.utmTerm
+    if (not empty(inputs.utmContent)) createBody.utm_content := inputs.utmContent
+    if (not empty(inputs.referringSite)) createBody.referring_site := inputs.referringSite
+    if (not empty(customFields)) createBody.custom_fields := customFields
+
+    let createRes := fetch(f'https://api.beehiiv.com/v2/publications/{inputs.publicationId}/subscriptions', {
+        'method': 'POST',
+        'headers': headers,
+        'body': createBody
+    })
+
+    if (createRes.status >= 400) {
+        throw Error(f'Error creating beehiiv subscription (status {createRes.status}): {createRes.body}')
+    }
+
+    print(f'Successfully created beehiiv subscription {inputs.email}')
+    return
+}
+
+if (getRes.status >= 400) {
+    throw Error(f'Error looking up beehiiv subscription (status {getRes.status}): {getRes.body}')
+}
+
+let updateBody := {}
+if (not empty(customFields)) updateBody.custom_fields := customFields
+if (inputs.reactivateExisting) updateBody.unsubscribe := false
+
+if (empty(updateBody)) {
+    print('Subscription already exists and there are no fields to update. Skipping...')
+    return
+}
+
+let updateRes := fetch(subscriptionUrl, {
+    'method': 'PUT',
+    'headers': headers,
+    'body': updateBody
+})
+
+if (updateRes.status >= 400) {
+    throw Error(f'Error updating beehiiv subscription (status {updateRes.status}): {updateRes.body}')
+}
+
+print(f'Successfully updated beehiiv subscription {inputs.email}')
+`,
+    inputs_schema: [
+        {
+            key: 'apiKey',
+            type: 'string',
+            label: 'API key',
+            description:
+                'Create an API key in beehiiv under Settings > Workspace Settings > API. The key must have access to the selected publication.',
+            secret: true,
+            required: true,
+        },
+        {
+            key: 'publicationId',
+            type: 'string',
+            label: 'Publication ID',
+            description: 'The beehiiv publication ID, beginning with `pub_`.',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'email',
+            type: 'string',
+            label: 'Email',
+            description: 'Email address used to find, create, or update the beehiiv subscription.',
+            default: '{person.properties.email ?? event.properties.email}',
+            secret: false,
+            required: true,
+        },
+        {
+            key: 'customFields',
+            type: 'dictionary',
+            label: 'Custom field mapping',
+            description:
+                'Map existing beehiiv custom field names to PostHog values. Unknown beehiiv custom fields are ignored by the beehiiv API.',
+            default: {
+                'First Name': '{person.properties.first_name}',
+                'Last Name': '{person.properties.last_name}',
+            },
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'sendWelcomeEmail',
+            type: 'boolean',
+            label: 'Send welcome email',
+            description: 'Send the publication welcome email when a new subscription is created.',
+            default: false,
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'reactivateExisting',
+            type: 'boolean',
+            label: 'Reactivate existing subscription',
+            description:
+                'Reactivate a previously unsubscribed subscriber. Enable this only when the person has knowingly requested to resubscribe.',
+            default: false,
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'utmSource',
+            type: 'string',
+            label: 'UTM source',
+            description: 'Acquisition source applied when a subscription is first created.',
+            default: 'posthog',
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'utmMedium',
+            type: 'string',
+            label: 'UTM medium',
+            description: 'Acquisition medium applied when a subscription is first created.',
+            default: '{event.properties.utm_medium}',
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'utmCampaign',
+            type: 'string',
+            label: 'UTM campaign',
+            description: 'Acquisition campaign applied when a subscription is first created.',
+            default: '{event.properties.utm_campaign}',
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'utmTerm',
+            type: 'string',
+            label: 'UTM term',
+            description: 'Acquisition term applied when a subscription is first created.',
+            default: '{event.properties.utm_term}',
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'utmContent',
+            type: 'string',
+            label: 'UTM content',
+            description: 'Acquisition content applied when a subscription is first created.',
+            default: '{event.properties.utm_content}',
+            secret: false,
+            required: false,
+        },
+        {
+            key: 'referringSite',
+            type: 'string',
+            label: 'Referring site',
+            description: 'Referring URL applied when a subscription is first created.',
+            default: '{event.properties.$referrer}',
+            secret: false,
+            required: false,
+        },
+    ],
+    filters: {
+        events: [
+            { id: '$identify', name: '$identify', type: 'events', order: 0 },
+            { id: '$set', name: '$set', type: 'events', order: 1 },
+        ],
+        actions: [],
+        filter_test_accounts: true,
+    },
+}

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -3,6 +3,7 @@ import { SEGMENT_DESTINATIONS } from '../segment/segment-templates'
 import { HogFunctionTemplate, NativeTemplate } from '../types'
 import { template as accoilTemplate } from './_destinations/accoil/accoil.template'
 import { template as appcuesTemplate } from './_destinations/appcues/appcues.template'
+import { template as beehiivTemplate } from './_destinations/beehiiv/beehiiv.template'
 import { template as clickupTemplate } from './_destinations/clickup/clickup.template'
 import { template as closeTemplate } from './_destinations/close/close.template'
 import { allComingSoonTemplates } from './_destinations/coming-soon/coming-soon-destinations.template'
@@ -86,6 +87,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     googleTagManagerTemplate,
     emailTemplate,
     pushTemplate,
+    beehiivTemplate,
     clickupTemplate,
     posthogCaptureTemplate,
     posthogGroupIdentifyTemplate,


### PR DESCRIPTION
## Problem

PostHog users cannot create or update beehiiv subscribers from person events with a first-party realtime destination.

## Changes

- Users can send `$identify` and `$set` events to beehiiv.
- The destination creates missing subscribers and updates existing custom fields.
- Reactivation stays off unless a user explicitly enables it for people who requested resubscription.
- Welcome emails and creation-time attribution are configurable.
- The template registration is mechanical.

Before:

```mermaid
flowchart LR
    A[PostHog person event] --> B[Custom integration]
    B --> C[beehiiv API]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
    class C phRed;
```

After:

```mermaid
flowchart LR
    A[PostHog person event] --> B[beehiiv destination]
    B --> C[beehiiv API]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
    class C phRed;
```

## How did you test this code?

- Added focused `TemplateTester` cases for create, update, reactivation, URL encoding, skip, and API failure paths.
- `git diff --check` passed.
- Not run: Jest and repository formatting. The checkout lacks dependencies, and the standalone formatter excluded these paths.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Companion documentation PR: https://github.com/PostHog/posthog.com/pull/19915

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi applied a user-provided contribution package and registered the template against current `master`.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.

The committed examples use placeholder values and contain no customer or session data.
