### PR TITLE
fix(desktop): use "Enter API key" placeholder in MCP gateway key fields

### DIFF
--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
@@ -165,7 +165,7 @@ export function GatewayAddServer({
                 value={values.apiKey}
                 onChange={(e) => set("apiKey", e.target.value)}
                 type={showKey ? "text" : "password"}
-                placeholder="sk-…"
+                placeholder="Enter API key"
                 spellCheck={false}
                 className="font-mono"
               >

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayConnectDialog.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayConnectDialog.test.tsx
@@ -53,7 +53,7 @@ describe("GatewayConnectDialog", () => {
         "This server uses an API key. Enter your own key to connect.",
       ),
     ).toBeInTheDocument();
-    await user.type(screen.getByPlaceholderText("sk-…"), "sk-mine");
+    await user.type(screen.getByPlaceholderText("Enter API key"), "sk-mine");
     await user.click(screen.getByRole("button", { name: "Connect" }));
 
     expect(onSubmit).toHaveBeenCalledWith({
@@ -102,7 +102,7 @@ describe("GatewayConnectDialog", () => {
     const connect = screen.getByRole("button", { name: "Connect" });
     expect(connect).toBeDisabled();
 
-    await user.type(screen.getByPlaceholderText("sk-…"), "sk-secret");
+    await user.type(screen.getByPlaceholderText("Enter API key"), "sk-secret");
     await user.click(connect);
 
     expect(onSubmit).toHaveBeenCalledWith({

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayConnectDialog.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayConnectDialog.tsx
@@ -106,7 +106,7 @@ export function GatewayConnectDialog({
                   value={values.apiKey}
                   onChange={(e) => set("apiKey", e.target.value)}
                   type={showKey ? "text" : "password"}
-                  placeholder="sk-…"
+                  placeholder="Enter API key"
                   spellCheck={false}
                   autoFocus
                   className="font-mono"


### PR DESCRIPTION
## Problem

The API key fields in the desktop MCP gateway dialogs show `sk-…` as the placeholder. This text looks like a real key prefix. It can make a person think the field only accepts keys that start with `sk-`. The web UI for the same flow already uses `Enter API key`.

**Why:** the placeholder was noticed in the screenshot on [#93430](https://github.com/PostHog/posthog/pull/93430). This PR targets that branch so the fix lands with the feature.

## Changes

- The API key field in the connect dialog and in the add-server form now shows `Enter API key`.
- The connect dialog test now finds the field by the new placeholder text. Mechanical.

## How did you test this code?

- `pnpm vitest run src/features/mcp-gateway/components/parts/GatewayConnectDialog.test.tsx` in `products/desktop/packages/ui` passes.
- No manual test of the desktop app.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tools: PostHog Desktop agent (Claude Code). Skills: `writing-simplified-technical-english`.
- The change is a text replacement in two components and one test. No other files changed.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
