### PR TITLE
fix(data-warehouse): label Trino SQL connections correctly

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.test.ts
@@ -45,6 +45,16 @@ describe('connectionSelectorLogic', () => {
                 supports_hogql: true,
                 is_builtin_managed_warehouse: false,
             },
+            {
+                id: 'conn-trino',
+                description: 'Managed Warehouse Trino',
+                prefix: 'trino',
+                engine: 'trino',
+                source_type: 'Trino',
+                access_method: 'direct',
+                supports_hogql: false,
+                is_builtin_managed_warehouse: false,
+            },
         ])
     })
 
@@ -82,6 +92,11 @@ describe('connectionSelectorLogic', () => {
                     value: 'conn-456',
                     label: 'prod (MySQL · synced)',
                     managementUrl: urls.dataWarehouseSource('managed-conn-456'),
+                }),
+                expect.objectContaining({
+                    value: 'conn-trino',
+                    label: 'Managed Warehouse Trino (Trino)',
+                    managementUrl: urls.dataWarehouseSource('managed-conn-trino'),
                 }),
             ])
         )

--- a/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.ts
@@ -12,6 +12,7 @@ import IconMySQL from 'public/services/mysql.png'
 import IconPostgres from 'public/services/postgres.png'
 import IconRedshift from 'public/services/redshift.png'
 import IconSnowflake from 'public/services/snowflake.png'
+import IconTrino from 'public/services/trino.svg'
 
 import { sourcesDataLogic } from 'products/data_warehouse/frontend/shared/logics/sourcesDataLogic'
 import {
@@ -47,7 +48,15 @@ export interface ConnectionSelectOptionGroup {
     options: ConnectionSelectOption[]
 }
 
-type ConnectionEngine = 'duckdb' | 'postgres' | 'mysql' | 'snowflake' | 'redshift' | 'clickhouse' | 'motherduck'
+type ConnectionEngine =
+    | 'duckdb'
+    | 'postgres'
+    | 'mysql'
+    | 'snowflake'
+    | 'redshift'
+    | 'clickhouse'
+    | 'motherduck'
+    | 'trino'
 
 const ENGINE_LABELS: Record<ConnectionEngine, string> = {
     duckdb: 'DuckDB',
@@ -57,6 +66,7 @@ const ENGINE_LABELS: Record<ConnectionEngine, string> = {
     redshift: 'Redshift',
     clickhouse: 'ClickHouse',
     motherduck: 'MotherDuck',
+    trino: 'Trino',
 }
 
 const ENGINE_ICONS: Record<ConnectionEngine, string> = {
@@ -67,6 +77,7 @@ const ENGINE_ICONS: Record<ConnectionEngine, string> = {
     redshift: IconRedshift,
     clickhouse: IconClickHouse,
     motherduck: IconMotherDuck,
+    trino: IconTrino,
 }
 
 function getConnectionEngine(
@@ -78,7 +89,8 @@ function getConnectionEngine(
         source.engine === 'snowflake' ||
         source.engine === 'redshift' ||
         source.engine === 'clickhouse' ||
-        source.engine === 'motherduck'
+        source.engine === 'motherduck' ||
+        source.engine === 'trino'
     ) {
         return source.engine
     }


### PR DESCRIPTION
## Problem

Trino users see their SQL editor connection labeled as Postgres, which makes the selected engine look incorrect.

The frontend engine allowlist omitted Trino and used Postgres as its fallback.

## Changes

- Trino connections now display the Trino label and icon in the SQL editor picker.
- The regression test covers a raw-only direct Trino connection and its exact selector label.
- Screenshots are omitted because no sanitized Trino connection is available in local development.

## How did you test this code?

- The focused selector test catches Trino connections falling back to Postgres.
- Frontend formatting, TypeScript checks, and scoped `ci:preflight` completed.
- Manual browser testing was not run because local development has no sanitized Trino connection.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. This PR corrects an existing SQL editor label.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex authored the change with terminal and GitHub CLI tools.
- Skills: /writing-ui-components, /writing-user-facing-copy, /writing-tests, /running-ci-preflight, and /writing-pr-descriptions.
- The public diff contains no customer data, private operational details, or copied source material.
