### PR TITLE
fix(desktop): surface BYOS errors and login info (orgs)

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.test.ts
@@ -6,18 +6,50 @@ import type {
   SDKAssistantMessage,
   SDKModelRefusalFallbackMessage,
   SDKPartialAssistantMessage,
+  SDKResultMessage,
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { describe, expect, it } from "vitest";
 import { Logger } from "../../../utils/logger";
 import type { Session } from "../types";
 import {
+  handleResultMessage,
   handleStreamEvent,
   handleSystemMessage,
   handleUserAssistantMessage,
   type MessageHandlerContext,
   stripMarkerTags,
 } from "./sdk-to-acp";
+
+describe("handleResultMessage error text", () => {
+  it("shows a subscription usage-limit result as-is, without an 'Internal error:' prefix", () => {
+    const message = {
+      subtype: "success",
+      is_error: true,
+      result: "Claude AI usage limit reached. Your limit will reset at 3pm.",
+    } as unknown as SDKResultMessage;
+
+    const { error } = handleResultMessage(message);
+
+    expect(error?.message).toBe(
+      "Claude AI usage limit reached. Your limit will reset at 3pm.",
+    );
+  });
+
+  it("keeps the 'Internal error:' prefix for other agent errors", () => {
+    const message = {
+      subtype: "success",
+      is_error: true,
+      result: "API Error: 500 something broke",
+    } as unknown as SDKResultMessage;
+
+    const { error } = handleResultMessage(message);
+
+    expect(error?.message).toBe(
+      "Internal error: API Error: 500 something broke",
+    );
+  });
+});
 
 describe("stripMarkerTags", () => {
   it("strips a single marker and keeps surrounding prose", () => {

--- a/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/conversion/sdk-to-acp.ts
@@ -48,6 +48,8 @@ import {
   toolUpdateFromToolResult,
 } from "./tool-use-to-acp";
 
+const ACP_INTERNAL_ERROR_CODE = -32603;
+
 type AnthropicContentChunk =
   | ContentBlockParam
   | BetaContentBlock
@@ -919,14 +921,19 @@ export function handleResultMessage(
       }
       if (message.is_error) {
         const classification = classifyAgentError(message.result);
-        return {
-          shouldStop: true,
-          error: RequestError.internalError(
-            { classification, result: message.result },
-            message.result,
-          ),
-          usage,
-        };
+        // A subscription usage-limit hit already carries a clear, specific
+        // reason from the CLI (and often a reset time) — show it as-is
+        // instead of burying it under a generic "Internal error:" prefix.
+        const error =
+          classification === "subscription_usage_limit"
+            ? new RequestError(ACP_INTERNAL_ERROR_CODE, message.result, {
+                classification,
+              })
+            : RequestError.internalError(
+                { classification, result: message.result },
+                message.result,
+              );
+        return { shouldStop: true, error, usage };
       }
       return { shouldStop: true, stopReason: "end_turn", usage };
     }

--- a/products/desktop/packages/agent/src/adapters/claude/subscription-login.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/subscription-login.test.ts
@@ -38,8 +38,12 @@ const STRIPPED_KEYS = [
   "CLAUDE_CODE_USE_MANTLE",
 ] as const;
 
-function statusJson(loggedIn: boolean, authMethod: string): string {
-  return JSON.stringify({ loggedIn, authMethod });
+function statusJson(
+  loggedIn: boolean,
+  authMethod: string,
+  extra?: Record<string, unknown>,
+): string {
+  return JSON.stringify({ loggedIn, authMethod, ...extra });
 }
 
 describe("hasClaudeLogin", () => {
@@ -87,7 +91,7 @@ describe("hasClaudeLogin", () => {
       machineAuth: {},
     });
     emitStdout(statusJson(true, "claude.ai"));
-    await expect(result).resolves.toBe("logged-in");
+    await expect(result).resolves.toEqual({ state: "logged-in" });
   });
 
   it("reports logged in for an oauth_token subscription", async () => {
@@ -96,7 +100,27 @@ describe("hasClaudeLogin", () => {
       machineAuth: {},
     });
     emitStdout(statusJson(true, "oauth_token"));
-    await expect(result).resolves.toBe("logged-in");
+    await expect(result).resolves.toEqual({ state: "logged-in" });
+  });
+
+  it("surfaces the connected account's email, org, and plan", async () => {
+    const result = hasClaudeLogin({
+      claudeCliPath: "/bundled/claude",
+      machineAuth: {},
+    });
+    emitStdout(
+      statusJson(true, "claude.ai", {
+        email: "user@posthog.com",
+        orgName: "PostHog",
+        subscriptionType: "team",
+      }),
+    );
+    await expect(result).resolves.toEqual({
+      state: "logged-in",
+      email: "user@posthog.com",
+      organization: "PostHog",
+      subscriptionType: "team",
+    });
   });
 
   it("reports logged out for a third-party Bedrock provider", async () => {
@@ -105,7 +129,7 @@ describe("hasClaudeLogin", () => {
       machineAuth: {},
     });
     emitStdout(statusJson(true, "third_party"));
-    await expect(result).resolves.toBe("logged-out");
+    await expect(result).resolves.toEqual({ state: "logged-out" });
   });
 
   it("reports logged out for an api_key auth method", async () => {
@@ -114,7 +138,7 @@ describe("hasClaudeLogin", () => {
       machineAuth: {},
     });
     emitStdout(statusJson(true, "api_key"));
-    await expect(result).resolves.toBe("logged-out");
+    await expect(result).resolves.toEqual({ state: "logged-out" });
   });
 
   it("reports logged out when the CLI confirms no login", async () => {
@@ -123,7 +147,7 @@ describe("hasClaudeLogin", () => {
       machineAuth: {},
     });
     emitStdout(statusJson(false, "none"));
-    await expect(result).resolves.toBe("logged-out");
+    await expect(result).resolves.toEqual({ state: "logged-out" });
   });
 
   it("reports unknown when the CLI exits non-zero with no JSON", async () => {
@@ -132,7 +156,7 @@ describe("hasClaudeLogin", () => {
       machineAuth: {},
     });
     exit(1);
-    await expect(result).resolves.toBe("unknown");
+    await expect(result).resolves.toEqual({ state: "unknown" });
   });
 
   it("reports unknown when the CLI cannot start", async () => {
@@ -141,14 +165,14 @@ describe("hasClaudeLogin", () => {
       machineAuth: {},
     });
     queueMicrotask(() => child.emit("error", new Error("spawn failed")));
-    await expect(result).resolves.toBe("unknown");
+    await expect(result).resolves.toEqual({ state: "unknown" });
   });
 
   it("reports unknown when the bundled binary is missing", async () => {
     vi.mocked(existsSync).mockReturnValue(false);
     await expect(
       hasClaudeLogin({ claudeCliPath: "/bundled/claude", machineAuth: {} }),
-    ).resolves.toBe("unknown");
+    ).resolves.toEqual({ state: "unknown" });
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -233,7 +257,7 @@ describe("hasClaudeLogin", () => {
           timeoutMs: 100,
         });
         vi.advanceTimersByTime(200);
-        await expect(result).resolves.toBe("unknown");
+        await expect(result).resolves.toEqual({ state: "unknown" });
         expect(child.kill).toHaveBeenCalledWith("SIGTERM");
         if (exitsAfterTerm) child.emit("exit", null);
         vi.advanceTimersByTime(5000);

--- a/products/desktop/packages/agent/src/adapters/claude/subscription-login.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/subscription-login.ts
@@ -53,17 +53,40 @@ export interface ClaudeLoginCheckOptions {
 
 export type ClaudeLoginResult = "logged-in" | "logged-out" | "unknown";
 
+export interface ClaudeLoginStatus {
+  state: ClaudeLoginResult;
+  email?: string;
+  organization?: string;
+  subscriptionType?: string;
+}
+
 interface ClaudeAuthStatusJson {
   loggedIn?: unknown;
   authMethod?: unknown;
   apiProvider?: unknown;
   subscriptionType?: unknown;
+  email?: unknown;
+  orgName?: unknown;
 }
 
 function isSubscriptionLogin(status: ClaudeAuthStatusJson): boolean {
   if (status.loggedIn !== true) return false;
   const method = status.authMethod;
   return method === "claude.ai" || method === "oauth_token";
+}
+
+function accountFieldsFromStatus(
+  status: ClaudeAuthStatusJson,
+): Pick<ClaudeLoginStatus, "email" | "organization" | "subscriptionType"> {
+  return {
+    email: typeof status.email === "string" ? status.email : undefined,
+    organization:
+      typeof status.orgName === "string" ? status.orgName : undefined,
+    subscriptionType:
+      typeof status.subscriptionType === "string"
+        ? status.subscriptionType
+        : undefined,
+  };
 }
 
 function parseAuthStatusJson(stdout: string): ClaudeAuthStatusJson | null {
@@ -80,12 +103,12 @@ function parseAuthStatusJson(stdout: string): ClaudeAuthStatusJson | null {
 
 export async function hasClaudeLogin(
   options: ClaudeLoginCheckOptions,
-): Promise<ClaudeLoginResult> {
+): Promise<ClaudeLoginStatus> {
   if (!existsSync(options.claudeCliPath)) {
     options.logger?.debug("Claude CLI not found, reporting unknown", {
       claudeCliPath: options.claudeCliPath,
     });
-    return "unknown";
+    return { state: "unknown" };
   }
 
   const isLegacyJs = options.claudeCliPath.endsWith(".js");
@@ -100,9 +123,9 @@ export async function hasClaudeLogin(
     env.ELECTRON_RUN_AS_NODE = "1";
   }
 
-  return new Promise<ClaudeLoginResult>((resolve) => {
+  return new Promise<ClaudeLoginStatus>((resolve) => {
     let settled = false;
-    const finish = (result: ClaudeLoginResult): void => {
+    const finish = (result: ClaudeLoginStatus): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -121,7 +144,7 @@ export async function hasClaudeLogin(
         STATUS_KILL_GRACE_MS,
       );
       child.once("exit", () => clearTimeout(killTimer));
-      finish("unknown");
+      finish({ state: "unknown" });
     }, options.timeoutMs ?? STATUS_TIMEOUT_MS);
 
     let stdout = "";
@@ -136,7 +159,7 @@ export async function hasClaudeLogin(
       options.logger?.debug("Failed to run claude auth status", {
         error: error.message,
       });
-      finish("unknown");
+      finish({ state: "unknown" });
     });
     child.on("exit", (code) => {
       const status = parseAuthStatusJson(stdout);
@@ -147,14 +170,14 @@ export async function hasClaudeLogin(
         stderr: stderr.slice(0, 500),
       });
       if (status && isSubscriptionLogin(status)) {
-        finish("logged-in");
+        finish({ state: "logged-in", ...accountFieldsFromStatus(status) });
         return;
       }
       if (status || code === 0) {
-        finish("logged-out");
+        finish({ state: "logged-out" });
         return;
       }
-      finish("unknown");
+      finish({ state: "unknown" });
     });
   });
 }

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.test.ts
@@ -2353,6 +2353,44 @@ describe("CodexAppServerAgent", () => {
     });
   });
 
+  it("renders ChatGPT's own usage-limit message instead of the generic fallback", async () => {
+    const stub = makeStubRpc({ "thread/start": { thread: { id: "t" } } });
+    const { client, sessionUpdates } = makeFakeClient();
+    const agent = new CodexAppServerAgent(client, {
+      processOptions: { binaryPath: "/x/codex" },
+      rpcFactory: stub.factory,
+    });
+
+    await agent.newSession({ cwd: "/r" } as unknown as NewSessionRequest);
+    const done = agent.prompt({
+      sessionId: "t",
+      prompt: [{ type: "text", text: "go" }],
+    } as unknown as PromptRequest);
+    stub.emit("error", {
+      willRetry: false,
+      error: {
+        message:
+          "You've hit your usage limit. To continue using Codex and get access to GPT-5.3-Codex, start a free trial of Plus today (https://chatgpt.com/explore/plus), or try again at Oct 2nd, 2026 9:53 AM.",
+        codexErrorInfo: "usageLimitExceeded",
+      },
+    });
+    stub.emit("turn/completed", {
+      turn: { id: "turn_1", status: "failed" },
+    });
+
+    expect((await done).stopReason).toBe("refusal");
+    expect(sessionUpdates).toContainEqual({
+      sessionId: "t",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "You've hit your usage limit. To continue using Codex and get access to GPT-5.3-Codex, start a free trial of Plus today (https://chatgpt.com/explore/plus), or try again at Oct 2nd, 2026 9:53 AM.",
+        },
+      },
+    });
+  });
+
   it("renders a policy error after the turn already completed", async () => {
     const stub = makeStubRpc({
       "thread/start": { thread: { id: "t" } },

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -1753,6 +1753,13 @@ export class CodexAppServerAgent extends BaseAcpAgent {
           void this.refuseTurnWithMessage(policyErrorMessage);
           return;
         }
+        // ChatGPT's own usage limit, not a PostHog gateway denial — show the
+        // account's real reason (it already includes a reset time) instead
+        // of the generic fallback below.
+        if (codexErrorInfo === "usageLimitExceeded" && message) {
+          void this.refuseTurnWithMessage(message);
+          return;
+        }
         void this.failTurn(
           new RequestError(
             ACP_INTERNAL_ERROR_CODE,

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/subscription-login.test.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/subscription-login.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { APP_SERVER_METHODS, APP_SERVER_NOTIFICATIONS } from "./protocol";
 
 const state = vi.hoisted(() => ({
-  account: null as { type: string } | null,
+  account: null as { type: string; email?: string; planType?: string } | null,
   failLogout: false,
   kill: vi.fn(),
   onExit: undefined as (() => void) | undefined,
@@ -88,11 +88,29 @@ describe("Codex account", () => {
   it("uses the normal machine login and accepts only ChatGPT accounts", async () => {
     state.account = { type: "chatgpt" };
 
-    await expect(hasCodexChatgptLogin(options)).resolves.toBe(true);
+    await expect(hasCodexChatgptLogin(options)).resolves.toMatchObject({
+      loggedIn: true,
+    });
     expect(state.spawnOptions?.useMachineAuth).toBe(true);
 
     state.account = { type: "apiKey" };
-    await expect(hasCodexChatgptLogin(options)).resolves.toBe(false);
+    await expect(hasCodexChatgptLogin(options)).resolves.toMatchObject({
+      loggedIn: false,
+    });
+  });
+
+  it("surfaces the connected account's email and plan", async () => {
+    state.account = {
+      type: "chatgpt",
+      email: "user@posthog.com",
+      planType: "team",
+    };
+
+    await expect(hasCodexChatgptLogin(options)).resolves.toEqual({
+      loggedIn: true,
+      email: "user@posthog.com",
+      planType: "team",
+    });
   });
 
   it("finishes login from the app-server notification", async () => {

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/subscription-login.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/subscription-login.ts
@@ -36,16 +36,26 @@ export interface CodexLoginSession {
   cancel: () => Promise<void>;
 }
 
+export interface CodexLoginStatus {
+  loggedIn: boolean;
+  email?: string;
+  planType?: string;
+}
+
 export async function hasCodexChatgptLogin(
   options: CodexAccountOptions,
-): Promise<boolean> {
+): Promise<CodexLoginStatus> {
   const client = openCodexAccountClient(options);
   try {
     await initialize(client.rpc);
     const result = await requestWithTimeout<{
-      account?: { type?: string } | null;
+      account?: { type?: string; email?: string; planType?: string } | null;
     }>(client.rpc, APP_SERVER_METHODS.ACCOUNT_READ, { refreshToken: false });
-    return result.account?.type === "chatgpt";
+    return {
+      loggedIn: result.account?.type === "chatgpt",
+      email: result.account?.email,
+      planType: result.account?.planType,
+    };
   } finally {
     client.close();
   }

--- a/products/desktop/packages/agent/src/adapters/error-classification.test.ts
+++ b/products/desktop/packages/agent/src/adapters/error-classification.test.ts
@@ -38,6 +38,10 @@ describe("classifyAgentError", () => {
       "[ede_diagnostic] result_type=assistant last_content_type=text stop_reason=null",
       "agent_error",
     ],
+    [
+      "Claude AI usage limit reached. Your limit will reset at 3pm.",
+      "subscription_usage_limit",
+    ],
     ["API Error: 400 invalid request", "agent_error"],
     // 413 is a hard client rejection, never a transient upstream failure.
     ["API Error: 413 Payload Too Large", "agent_error"],

--- a/products/desktop/packages/agent/src/adapters/error-classification.ts
+++ b/products/desktop/packages/agent/src/adapters/error-classification.ts
@@ -7,11 +7,17 @@ export type AgentErrorClassification =
   | "upstream_provider_failure"
   | "content_block_rejection"
   | "turn_ended_without_response"
+  | "subscription_usage_limit"
   | "agent_error";
 
 const UPSTREAM_PROVIDER_ERROR_STATUS_PATTERN = /API Error:\s*(?:429|5\d\d)\b/i;
 const TURN_ENDED_WITHOUT_RESPONSE_PATTERN =
   /\[ede_diagnostic\]\s+result_type=user\b/i;
+// Anthropic's exact CLI wording for a Claude Pro/Max own-subscription limit
+// isn't pinned anywhere we can check offline, so this matches the phrase
+// loosely rather than a fixed string. Update this if the real wording turns
+// out to differ.
+const SUBSCRIPTION_USAGE_LIMIT_PATTERN = /usage limit/i;
 
 /**
  * Classify error strings surfaced by agent adapters. Transient upstream
@@ -59,6 +65,9 @@ export function classifyAgentError(
   }
   if (TURN_ENDED_WITHOUT_RESPONSE_PATTERN.test(text)) {
     return "turn_ended_without_response";
+  }
+  if (SUBSCRIPTION_USAGE_LIMIT_PATTERN.test(text)) {
+    return "subscription_usage_limit";
   }
   return "agent_error";
 }

--- a/products/desktop/packages/ui/src/features/settings/adapterSubscription.ts
+++ b/products/desktop/packages/ui/src/features/settings/adapterSubscription.ts
@@ -18,6 +18,9 @@ import { useQuery } from "@tanstack/react-query";
 
 export interface SubscriptionStatus {
   loginState: "logged-in" | "logged-out" | "unknown";
+  email?: string;
+  organization?: string;
+  subscriptionType?: string;
 }
 
 export type WorkspaceModeForAccess = "local" | "worktree" | "cloud";
@@ -154,8 +157,14 @@ export function useAdapterSubscription(adapter: Adapter): AdapterSubscription {
   const modelAccess = useSettingsStore(spec.readAccess);
   const { localWorkspaces } = useHostCapabilities();
   const hostTRPC = useHostTRPC();
-  const { data: status } = useQuery({
-    ...hostTRPC.agent[spec.statusProcedure].queryOptions(),
+  // Both procedures share the same output shape (SubscriptionStatus), but
+  // indexing the tRPC router by a union of procedure names produces a union
+  // of `queryOptions` functions TS won't call — the two procedures never
+  // actually differ at runtime, so `any` here is safe.
+  // biome-ignore lint/suspicious/noExplicitAny: dynamic procedure lookup, see comment above
+  const statusProcedure = hostTRPC.agent[spec.statusProcedure] as any;
+  const { data: status } = useQuery<SubscriptionStatus>({
+    ...statusProcedure.queryOptions(),
     enabled: flagEnabled && localWorkspaces,
     staleTime: 30_000,
   });

--- a/products/desktop/packages/ui/src/features/settings/sections/ClaudeSubscriptionSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/ClaudeSubscriptionSettings.tsx
@@ -14,6 +14,27 @@ import {
   ClaudeAuthTerminalDialog,
 } from "./ClaudeAuthTerminalDialog";
 
+interface ClaudeAccountStatus {
+  email?: string;
+  organization?: string;
+  subscriptionType?: string;
+}
+
+function connectedAccountLabel(
+  status: ClaudeAccountStatus | undefined,
+): string {
+  if (!status?.email) return "Claude Code logged in";
+  const details = [
+    status.organization,
+    status.subscriptionType && `${status.subscriptionType} plan`,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  return details
+    ? `Logged in as ${status.email} (${details})`
+    : `Logged in as ${status.email}`;
+}
+
 export function ClaudeSubscriptionSettings(): ReactElement | null {
   const subscription = useAdapterSubscription("claude");
   const hostTRPC = useHostTRPC();
@@ -86,7 +107,7 @@ export function ClaudeSubscriptionSettings(): ReactElement | null {
       return { color: "bg-(--amber-9)", label: "Could not check the login" };
     }
     if (loggedIn) {
-      return { color: "bg-(--green-9)", label: "Claude Code logged in" };
+      return { color: "bg-(--green-9)", label: connectedAccountLabel(status) };
     }
     return { color: "bg-(--red-9)", label: "Not logged in" };
   })();

--- a/products/desktop/packages/ui/src/features/settings/sections/CodexSubscriptionSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/CodexSubscriptionSettings.tsx
@@ -18,6 +18,19 @@ import { type ReactElement, useEffect, useState } from "react";
 const SIGN_IN_POLL_TIMEOUT_MS = 10 * 60_000 + 15_000;
 const SIGN_IN_LAUNCH_FEEDBACK_MS = 4_000;
 
+interface CodexAccountStatus {
+  email?: string;
+  subscriptionType?: string;
+}
+
+function connectedAccountLabel(status: CodexAccountStatus | undefined): string {
+  if (!status?.email) return "ChatGPT account connected";
+  const plan = status.subscriptionType
+    ? ` (${status.subscriptionType} plan)`
+    : "";
+  return `Connected as ${status.email}${plan}`;
+}
+
 export function CodexSubscriptionSettings(): ReactElement | null {
   const subscription = useAdapterSubscription("codex");
   const hostTRPC = useHostTRPC();
@@ -152,7 +165,7 @@ export function CodexSubscriptionSettings(): ReactElement | null {
               className="inline-block h-1.5 w-1.5 rounded-full bg-(--green-9)"
               aria-hidden
             />
-            ChatGPT account connected
+            {connectedAccountLabel(status)}
             <span aria-hidden>&middot;</span>
             <button
               type="button"

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -537,19 +537,27 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
 
   async getCodexSubscriptionStatus(): Promise<CodexSubscriptionStatus> {
     if (this.codexLogin) return { loginState: "logged-out" };
-    const loggedIn = await hasCodexChatgptLogin({
+    const status = await hasCodexChatgptLogin({
       binaryPath: this.getCodexBinaryPath(),
     });
-    return { loginState: loggedIn ? "logged-in" : "logged-out" };
+    return {
+      loginState: status.loggedIn ? "logged-in" : "logged-out",
+      email: status.email,
+      subscriptionType: status.planType,
+    };
   }
 
   async getClaudeSubscriptionStatus(): Promise<ClaudeSubscriptionStatus> {
+    const status = await hasClaudeLogin({
+      claudeCliPath: this.getClaudeCliPath(),
+      machineAuth: machineClaudeAuth(),
+      logger: this.log,
+    });
     return {
-      loginState: await hasClaudeLogin({
-        claudeCliPath: this.getClaudeCliPath(),
-        machineAuth: machineClaudeAuth(),
-        logger: this.log,
-      }),
+      loginState: status.state,
+      email: status.email,
+      organization: status.organization,
+      subscriptionType: status.subscriptionType,
     };
   }
 
@@ -1006,7 +1014,7 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
       let claudeSubscription =
         adapter === "claude" && config.claudeModelAccess === "own-subscription";
       if (claudeSubscription) {
-        const loginState = await hasClaudeLogin({
+        const { state: loginState } = await hasClaudeLogin({
           claudeCliPath: this.getClaudeCliPath(),
           machineAuth: machineClaudeAuth(),
           logger: this.log,

--- a/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/schemas.ts
@@ -253,6 +253,8 @@ export type RtkStatus = z.infer<typeof rtkStatusOutput>;
 
 export const codexSubscriptionStatusOutput = z.object({
   loginState: z.enum(["logged-in", "logged-out", "unknown"]),
+  email: z.string().optional(),
+  subscriptionType: z.string().optional(),
 });
 
 export type CodexSubscriptionStatus = z.infer<
@@ -261,6 +263,9 @@ export type CodexSubscriptionStatus = z.infer<
 
 export const claudeSubscriptionStatusOutput = z.object({
   loginState: z.enum(["logged-in", "logged-out", "unknown"]),
+  email: z.string().optional(),
+  organization: z.string().optional(),
+  subscriptionType: z.string().optional(),
 });
 
 export type ClaudeSubscriptionStatus = z.infer<


### PR DESCRIPTION
## Problem

A Codex own-subscription session that hits the user's own ChatGPT usage limit shows "The agent stopped before completing this request. Please try again.", hiding the real reason and when it resets. Claude's equivalent case shows the reason, but wrapped in a raw "Internal error:" string. Settings only shows connected or not connected, with no way to check which account or plan is actually linked.

## Changes

- Codex now shows OpenAI's own usage-limit message, which already names the reset time, instead of the generic fallback.
- Claude's usage-limit message drops the "Internal error:" wrapper it was leaking through.
- Settings shows the connected account's email and plan for both the Claude and Codex subscription rows (screenshot below).
- Mechanical: the status endpoints and their schemas now carry email, organization and plan fields that the underlying CLI and RPC calls already returned but the code discarded.

![Harness settings showing the connected account and plan for both adapters](https://github.com/user-attachments/assets/1ee78997-e60c-497d-829f-518310422ca2)

## How did you test this code?

- `codex-app-server-agent.test.ts`: new case locks in that the real usage-limit message renders instead of the generic fallback.
- `sdk-to-acp.test.ts`: new case locks in that Claude's usage-limit message has no "Internal error:" prefix; a second case guards that other errors keep it.
- `error-classification.test.ts`: new row for the usage-limit pattern.
- `subscription-login.test.ts` (both adapters): new cases lock in that email, organization and plan pass through.
- Verified live in a running dev build of the desktop app, signed into a real Claude and ChatGPT account (see screenshot).
- Not run: a real usage-limit hit end to end, since that needs an account that is actually at its limit.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code investigated the desktop app's own-subscription code paths from a bug report, then implemented and verified the fix in this session. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

While investigating, live checks against the real `claude` CLI and `codex app-server` binaries showed both already return the account's email and plan, which the desktop code was discarding. That replaced an earlier plan to call the heavier Claude Agent SDK `accountInfo()` session-control method.

No customer, incident or Slack content is included; test fixtures use invented emails.