### PR TITLE
fix(ci): decide mcp builds from state not the push diff

### DIFF
--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -7,17 +7,14 @@
 name: MCP Container Image CD
 
 on:
+    # No paths filter on master. GitHub derives the push diff from its own record of
+    # how master advanced, and that record sometimes omits an update, which makes the
+    # diff empty and skips the build for code that is on master. The changes job below
+    # decides from repository state instead, so a dropped push event costs one commit
+    # of latency rather than an unbuilt image.
     push:
         branches:
             - master
-        paths:
-            - 'services/mcp/**'
-            - '.github/workflows/cd-mcp-image.yml'
-            # Bundled into the MCP image at build time (copy-instructions.ts `shared/` copy +
-            # shared parser sources) — without these paths an edit there never rebuilds the
-            # image and the bundle goes stale.
-            - 'products/ai_observability/backend/prompts/parser_recipe_examples.yaml'
-            - 'packages/llm-normalizer/**'
     # paths mirror the push trigger; the build-mcp-image label only forces a
     # build on PRs touching these paths, use workflow_dispatch otherwise.
     pull_request:
@@ -29,12 +26,65 @@ on:
             - 'packages/llm-normalizer/**'
     workflow_dispatch:
 
+# Master pushes group per SHA so two of them never cancel each other's deploy dispatch.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+    changes:
+        name: Check build paths against the last build
+        runs-on: ubuntu-24.04
+        timeout-minutes: 5
+        permissions:
+            contents: read
+            actions: read
+        outputs:
+            build: ${{ steps.check.outputs.result }}
+        steps:
+            - name: Compare against the last successful master build
+              id: check
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              with:
+                  result-encoding: string
+                  # Keep BUILD_PATHS in sync with the pull_request paths filter below.
+                  script: |
+                      if (context.eventName !== 'push') return 'true';
+                      const BUILD_PATHS = [
+                        'services/mcp/',
+                        '.github/workflows/cd-mcp-image.yml',
+                        'products/ai_observability/backend/prompts/parser_recipe_examples.yaml',
+                        'packages/llm-normalizer/',
+                      ];
+                      const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        workflow_id: 'cd-mcp-image.yml',
+                        branch: 'master',
+                        event: 'push',
+                        status: 'success',
+                        per_page: 1,
+                      });
+                      const base = runs.workflow_runs[0]?.head_sha;
+                      if (!base) return 'true';
+                      if (base === context.sha) return 'false';
+                      const { data: cmp } = await github.rest.repos.compareCommitsWithBasehead({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        basehead: `${base}...${context.sha}`,
+                      });
+                      // compareCommits caps files at 300, so a wider window cannot be ruled out.
+                      if (cmp.status === 'diverged' || !cmp.files || cmp.files.length >= 300) return 'true';
+                      const changed = cmp.files.some((f) => BUILD_PATHS.some((p) => f.filename.startsWith(p)));
+                      core.info(`base=${base} commits=${cmp.total_commits} files=${cmp.files.length} build=${changed}`);
+                      return String(changed);
+
     build:
         name: Build and push container image
+        needs: changes
         if: |
             github.repository_owner == 'PostHog' && (
-                github.event_name == 'push' ||
+                (github.event_name == 'push' && needs.changes.outputs.build == 'true') ||
                 github.event_name == 'workflow_dispatch' ||
                 contains(github.event.pull_request.labels.*.name, 'build-mcp-image')
             )

--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -118,6 +118,26 @@ jobs:
                       const labels = pulls.flatMap(pr => pr.labels.map(l => l.name));
                       return JSON.stringify([...new Set(labels)]);
 
+            - name: Resolve deployed commit
+              id: commit
+              # head_commit is null on workflow_dispatch, and charts/state-update.yml reads
+              # the empty timestamp that produces as midnight UTC, then skips the deploy.
+              uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              with:
+                  script: |
+                      const { data: commit } = await github.rest.repos.getCommit({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        ref: context.sha,
+                      });
+                      return {
+                        id: commit.sha,
+                        message: commit.commit.message,
+                        author: { username: commit.author?.login },
+                        committer: { username: commit.committer?.login },
+                        timestamp: commit.commit.committer.date,
+                      };
+
             - name: Trigger MCP deployment
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
               with:
@@ -132,8 +152,8 @@ jobs:
                           }
                         },
                         "release": "mcp",
-                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "commit": ${{ steps.commit.outputs.result }},
                         "repository": ${{ toJson(github.repository) }},
                         "labels": ${{ steps.labels.outputs.result }},
-                        "timestamp": "${{ github.event.head_commit.timestamp }}"
+                        "timestamp": "${{ fromJson(steps.commit.outputs.result).timestamp }}"
                       }


### PR DESCRIPTION
## Problem

- The MCP image silently skips a build when GitHub loses a master push event, and the fix ships only when an unrelated PR happens to touch `services/mcp` later.
- GitHub occasionally advances master without recording the update, so the next push reports an empty diff and every `paths`-filtered workflow correctly skips.
- Over the last year master took 31,108 commits and GitHub recorded 30,931 ref updates. Nine commits landed with no push event and no push-triggered run.
- Two of the nine changed `services/mcp`, so the image was stale until an unrelated commit rebuilt it:

| commit | date | mcp files | rebuilt after |
|---|---|---|---|
| `26322a7ad` | 2026-06-30 | 3 | 28 min |
| `e37024b87` | 2026-09-02 | 148 | 57 min |

- Neither commit is the head SHA of any workflow run, and neither has a check suite.
- A manual rebuild does not recover either case. `github.event.head_commit` is null on `workflow_dispatch`, so the charts dispatch sends `"timestamp": ""`, `state-update.yml` reads that as midnight UTC, and its staleness guard skips the update and exits 0. See [this dispatch](https://github.com/PostHog/posthog/actions/runs/33644956632) and the [charts run](https://github.com/PostHog/charts/actions/runs/33645258958) it triggered.

## Changes

- A dropped push event now costs one commit of latency instead of an unbuilt image.
- The master `push` trigger loses its `paths` filter, so the workflow no longer trusts GitHub's push diff.
- A new `changes` job compares the last successful master build against `github.sha` and builds only when a build path changed. It builds when it cannot rule the window out: no prior build, a diverged base, or 300 files.
- A manual rebuild deploys again. The dispatch payload reads the commit for `context.sha` from the API instead of `github.event.head_commit`, so push and dispatch share one path.
- The workflow gains the canonical per-SHA push concurrency group, since master pushes now dispatch a run each.
- `pull_request` behavior is unchanged.

> [!NOTE]
> This drops a trigger-level `paths` filter, which `/authoring-ci-workflows` prefers, so the workflow now dispatches a run per master push. That filter is the unreliable input this PR is removing. The `changes` job makes two API calls and no checkout.

## How did you test this code?

- Replayed the `changes` job against both incidents using the real compare API. Each would have built on the next master push:
  - 2026-06-30: base `f74f4f67fb5`, head `772e1743540`, 3 files under `services/mcp`.
  - 2026-09-02: base `1eca205dde`, head `e0217f3b298`, 148 files under `services/mcp`.
- Not run: a live master push or `workflow_dispatch`, which need this merged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5). Skills invoked: `/authoring-ci-workflows`, `/gating-production-deploys`, `/writing-code-comments`, `/writing-pr-descriptions`.
- The nine orphaned commits come from walking the master activity API for a year and asserting each ref update's `before` equals the previous `after`. A commit that is never an `after` but is some child's `before` had its push event dropped.
- Rejected: an hourly cron rebuild. It bounds staleness but wastes builds, reports nothing, and leaves the workflow trusting the push diff.
- Rejected: defaulting the empty timestamp in `charts/state-update.yml`. One line and it fixes all ten dispatchers, but `client_payload.commit` stays null, so the state file records `sha: null`.
- Nine other CD workflows carry the same `head_commit` bug. `container-images-cd.yml` covers 30 releases including `posthog` and `ingestion`. Left for a follow-up.

https://claude.ai/code/session_01HPCok7a4RYbvHYRDCbQ83a
