### PR TITLE
feat(rbac): start new orgs on most-specific access resolution

### DIFF
--- a/posthog/models/organization.py
+++ b/posthog/models/organization.py
@@ -110,6 +110,9 @@ class OrganizationManager(models.Manager):
             kwargs["default_anonymize_ips"] = default_anonymize_ips()
         if "is_ai_training_opted_in" not in kwargs:
             kwargs["is_ai_training_opted_in"] = default_is_ai_training_opted_in()
+        # New organizations start on the most-specific resolution. Existing ones opt in.
+        if "uses_most_specific_access_resolution" not in kwargs:
+            kwargs["uses_most_specific_access_resolution"] = True
         return create_with_slug(super().create, *args, **kwargs)
 
     def bootstrap(

--- a/posthog/models/test/test_organization_model.py
+++ b/posthog/models/test/test_organization_model.py
@@ -31,6 +31,13 @@ class TestOrganization(BaseTest):
         super().setUp()
         cache.clear()
 
+    def test_new_organizations_start_on_most_specific_access_resolution(self):
+        organization = Organization.objects.create(name="Fresh org")
+        self.assertTrue(organization.uses_most_specific_access_resolution)
+
+        opted_out = Organization.objects.create(name="Opted out org", uses_most_specific_access_resolution=False)
+        self.assertFalse(opted_out.uses_most_specific_access_resolution)
+
     def test_organization_active_invites(self):
         self.assertEqual(self.organization.invites.count(), 0)
         self.assertEqual(self.organization.active_invites.count(), 0)

--- a/products/access_control/backend/tests/test_most_specific_resolution.py
+++ b/products/access_control/backend/tests/test_most_specific_resolution.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 from posthog.models.organization import OrganizationMembership
 
 from products.access_control.backend.facade.subject_access_control import SubjectAccessControl
+from products.access_control.backend.facade.user_access_control import UserAccessControl
 from products.access_control.backend.tests.test_user_access_control import BaseUserAccessControlTest
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSource
@@ -160,6 +161,13 @@ class TestResolveResourceAccess(BaseMostSpecificResolutionTest):
 
 @pytest.mark.ee
 class TestShadowDivergenceTelemetry(BaseMostSpecificResolutionTest):
+    def setUp(self):
+        super().setUp()
+        # The shadow only runs, and only diverges, for an org still on the legacy resolution
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
+
     @patch("products.access_control.backend.facade.user_access_control.posthoganalytics.capture")
     def test_enforcement_keeps_the_enforced_answer_and_reports_the_divergence(self, mock_capture):
         self._apply({"member": "none", "role_a": "editor"})

--- a/products/access_control/backend/tests/test_resolution_preview.py
+++ b/products/access_control/backend/tests/test_resolution_preview.py
@@ -17,6 +17,10 @@ from products.dashboards.backend.models.dashboard import Dashboard
 class TestBuildResolutionPreview(BaseUserAccessControlTest):
     def setUp(self):
         super().setUp()
+        # The preview compares the enforced legacy resolution against the most-specific one,
+        # so it is only meaningful for an org still on the legacy resolution
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
         self.other_membership = OrganizationMembership.objects.get(user=self.other_user, organization=self.organization)
         self.dashboard = Dashboard.objects.create(team=self.team, created_by=self.user, name="Growth KPIs")
 
@@ -159,6 +163,10 @@ class TestBuildResolutionPreview(BaseUserAccessControlTest):
 class TestResolutionPreviewAPI(BaseUserAccessControlTest):
     def setUp(self):
         super().setUp()
+        # The preview compares the enforced legacy resolution against the most-specific one,
+        # so it is only meaningful for an org still on the legacy resolution
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
         self.dashboard = Dashboard.objects.create(team=self.team, created_by=self.other_user, name="Growth KPIs")
         self._create_access_control(resource="dashboard", resource_id=str(self.dashboard.id), access_level="viewer")
         self._create_access_control(resource="dashboard", access_level="editor")

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -639,6 +639,9 @@ class TestUserAccessControlSerializer(BaseUserAccessControlTest):
 
     def test_resource_level_takes_priority(self):
         # Legacy resolution: resource-level rules beat the object's own default rule
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
         self._create_access_control(resource="dashboard", resource_id=None, access_level="editor")
         self._create_access_control(resource="dashboard", resource_id=str(self.dashboard.id), access_level="viewer")
         serializer = self.Serializer(self.dashboard, context={"user_access_control": self.user_access_control})
@@ -926,6 +929,9 @@ class TestUserAccessControlGetUserAccessLevel(BaseUserAccessControlTest):
             role=self.role_a,
         )
 
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
         access_level = self.user_access_control.get_user_access_level(self.other_dashboard)
         assert access_level == "editor"  # Legacy resolution: higher level wins across member and role rows
 

--- a/products/access_control/backend/tests/test_user_access_control.py
+++ b/products/access_control/backend/tests/test_user_access_control.py
@@ -298,7 +298,10 @@ class TestUserAccessControl(BaseUserAccessControlTest):
         assert ac_user in matching_acs
         assert ac_role in matching_acs
         assert ac_role_2 in matching_acs
-        # the matching one should be the highest level
+        # Legacy resolution: the highest matching row decides
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
         assert self.user_access_control.access_level_for_object(self.team) == "admin"
 
     def test_org_admin_always_has_access(self):
@@ -1160,8 +1163,11 @@ class TestUserAccessControlSpecificAccessLevelForObject(BaseUserAccessControlTes
             role=self.role_a,
         )
 
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
         access_level = self.user_access_control.specific_access_level_for_object(self.other_dashboard)
-        assert access_level == "editor"  # Higher level wins
+        assert access_level == "editor"  # Legacy resolution: higher level wins
 
     def test_mixed_member_and_role_controls(self):
         """Test that both member and role controls are considered"""
@@ -1180,8 +1186,11 @@ class TestUserAccessControlSpecificAccessLevelForObject(BaseUserAccessControlTes
             role=self.role_a,
         )
 
+        self.organization.uses_most_specific_access_resolution = False
+        self.organization.save()
+        self.user_access_control = UserAccessControl(self.user, self.team)
         access_level = self.user_access_control.specific_access_level_for_object(self.other_dashboard)
-        assert access_level == "manager"  # Role control with higher level wins
+        assert access_level == "manager"  # Legacy resolution: role control with higher level wins
 
     def test_project_specific_access_control(self):
         """Test project-specific access controls"""
@@ -1195,12 +1204,11 @@ class TestUserAccessControlSpecificAccessLevelForObject(BaseUserAccessControlTes
         access_level = self.user_access_control.specific_access_level_for_object(self.team)
         assert access_level == "admin"
 
-    def test_organization_specific_access_control(self):
-        """Test organization-specific access controls"""
+    def test_organization_has_no_specific_access_control(self):
+        # Organization access comes from the membership level, never from an object row
         uac = UserAccessControl(user=self.user, organization_id=self.organization.id)
 
-        access_level = uac.specific_access_level_for_object(self.organization)
-        assert access_level == "member"
+        assert uac.specific_access_level_for_object(self.organization) is None
 
     def test_feature_flag_specific_access_control(self):
         """Test feature flag-specific access controls"""

--- a/products/access_control/backend/tests/test_user_access_control_pbt.py
+++ b/products/access_control/backend/tests/test_user_access_control_pbt.py
@@ -528,6 +528,8 @@ class BaseAccessControlPropertyTest(HypothesisDjangoTestCase, BaseTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
+        # The oracles in this suite model the legacy resolution, so the org must stay on it
+        cls.organization.uses_most_specific_access_resolution = False
         cls.organization.available_product_features = [
             {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
             {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
@@ -541,7 +543,9 @@ class BaseAccessControlPropertyTest(HypothesisDjangoTestCase, BaseTest):
         RoleMembership.objects.create(user=cls.other_user, role=cls.role_b)
 
         # A second organization self.user also belongs to, holding a role there
-        cls.other_organization = Organization.objects.create(name="PBT other organization")
+        cls.other_organization = Organization.objects.create(
+            name="PBT other organization", uses_most_specific_access_resolution=False
+        )
         cls.other_organization_membership = OrganizationMembership.objects.create(
             organization=cls.other_organization, user=cls.user, level=OrganizationMembership.Level.MEMBER
         )


### PR DESCRIPTION
## Problem

The new most-specific access control can be enabled for new organizations. They have no access control rows yet that can resolve differently. 

I checked the divergence logs, the resolution works as expected.

## Changes

- New organizations start with `uses_most_specific_access_resolution` set to `True`. The manager sets the default when the caller does not pass a value. Existing organizations keep their current value.
- Test organizations go through the same manager, so the access control test suites run in the new mode by default.
- Tests that pin the legacy precedence set the organization to the legacy mode: the PBT oracle suite, the resolution preview suite, and two precedence tests.

## How did you test this code?

- A new organization model test pins that fresh organizations start with the setting on, and that an explicit `False` is respected. It catches a dropped manager default, which would put new organizations on the legacy precedence.
- Not run locally. CI is the check for the access-control suites and for other products' suites, which also run in the new mode through this default.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None yet. 