### PR TITLE
fix(aio): cap hdbscan cluster size so runs stop collapsing into two clusters

### DIFF
--- a/posthog/temporal/ai_observability/evaluation_clustering/activities.py
+++ b/posthog/temporal/ai_observability/evaluation_clustering/activities.py
@@ -292,6 +292,9 @@ def _compute_sync(inputs: EvaluationClusteringComputeInputs) -> EvaluationCluste
             "min_cluster_size_fraction", trace_constants.DEFAULT_MIN_CLUSTER_SIZE_FRACTION
         ),
         min_samples=params.get("min_samples", trace_constants.DEFAULT_HDBSCAN_MIN_SAMPLES),
+        max_cluster_size_fraction=params.get(
+            "max_cluster_size_fraction", trace_constants.DEFAULT_MAX_CLUSTER_SIZE_FRACTION
+        ),
     )
     labels_array = np.array(hdbscan_result.labels)
     centroids_array = (

--- a/posthog/temporal/ai_observability/trace_clustering/activities.py
+++ b/posthog/temporal/ai_observability/trace_clustering/activities.py
@@ -230,10 +230,14 @@ def _perform_clustering_compute(inputs: ClusteringActivityInputs) -> ClusteringC
             "min_cluster_size_fraction", constants.DEFAULT_MIN_CLUSTER_SIZE_FRACTION
         )
         min_samples = clustering_params.get("min_samples", constants.DEFAULT_HDBSCAN_MIN_SAMPLES)
+        max_cluster_size_fraction = clustering_params.get(
+            "max_cluster_size_fraction", constants.DEFAULT_MAX_CLUSTER_SIZE_FRACTION
+        )
         hdbscan_result = perform_hdbscan_clustering(
             clustering_embeddings,
             min_cluster_size_fraction=min_cluster_size_fraction,
             min_samples=min_samples,
+            max_cluster_size_fraction=max_cluster_size_fraction,
         )
         labels_array = np.array(hdbscan_result.labels)
         centroids_array = (

--- a/posthog/temporal/ai_observability/trace_clustering/clustering.py
+++ b/posthog/temporal/ai_observability/trace_clustering/clustering.py
@@ -275,6 +275,7 @@ def perform_hdbscan_clustering(
     embeddings: np.ndarray,
     min_cluster_size_fraction: float = 0.02,
     min_samples: int = 5,
+    max_cluster_size_fraction: float = 0.4,
 ) -> HDBSCANResult:
     """
     Perform HDBSCAN clustering on embeddings.
@@ -286,6 +287,9 @@ def perform_hdbscan_clustering(
         embeddings: Array of embedding vectors (ideally UMAP-reduced)
         min_cluster_size_fraction: Minimum cluster size as fraction of total samples
         min_samples: Minimum samples in neighborhood for core points
+        max_cluster_size_fraction: Maximum cluster size as fraction of total samples. A cluster
+            above this is not selected; its sub-clusters are selected instead, or its points
+            become noise when no sub-cluster reaches min_cluster_size.
 
     Returns:
         HDBSCANResult with labels, centroids, probabilities, and noise count
@@ -305,9 +309,13 @@ def perform_hdbscan_clustering(
             f"min_cluster_size_fraction must be between {MIN_CLUSTER_SIZE_FRACTION_MIN} and {MIN_CLUSTER_SIZE_FRACTION_MAX}"
         )
 
+    if not min_cluster_size_fraction <= max_cluster_size_fraction <= 1.0:
+        raise ValueError("max_cluster_size_fraction must be between min_cluster_size_fraction and 1.0")
+
     # Calculate min_cluster_size from fraction, with minimum of 5 but capped at n_samples
     # HDBSCAN requires min_cluster_size <= n_samples
     min_cluster_size = min(n_samples, max(5, int(n_samples * min_cluster_size_fraction)))
+    max_cluster_size = max(min_cluster_size, int(n_samples * max_cluster_size_fraction))
 
     # Adjust min_samples if needed
     effective_min_samples = min(min_samples, min_cluster_size)
@@ -315,6 +323,7 @@ def perform_hdbscan_clustering(
     clusterer = HDBSCAN(
         min_cluster_size=min_cluster_size,
         min_samples=effective_min_samples,
+        max_cluster_size=max_cluster_size,
         metric="euclidean",
         cluster_selection_method="eom",  # Excess of Mass - good for varying densities
     )

--- a/posthog/temporal/ai_observability/trace_clustering/clustering.py
+++ b/posthog/temporal/ai_observability/trace_clustering/clustering.py
@@ -275,7 +275,7 @@ def perform_hdbscan_clustering(
     embeddings: np.ndarray,
     min_cluster_size_fraction: float = 0.02,
     min_samples: int = 5,
-    max_cluster_size_fraction: float = 0.4,
+    max_cluster_size_fraction: float = 0.5,
 ) -> HDBSCANResult:
     """
     Perform HDBSCAN clustering on embeddings.

--- a/posthog/temporal/ai_observability/trace_clustering/constants.py
+++ b/posthog/temporal/ai_observability/trace_clustering/constants.py
@@ -127,6 +127,9 @@ DEFAULT_MIN_CLUSTER_SIZE_FRACTION = 0.02  # 2% of samples as minimum cluster siz
 MIN_CLUSTER_SIZE_FRACTION_MIN = 0.02  # Minimum allowed value for min_cluster_size_fraction
 MIN_CLUSTER_SIZE_FRACTION_MAX = 0.5  # Maximum allowed value for min_cluster_size_fraction
 DEFAULT_HDBSCAN_MIN_SAMPLES = 5  # Minimum samples in neighborhood for core points
+# Excess of Mass selection can stop at the root split and return one cluster that holds most of
+# the sample. A cluster above this fraction is refused, so selection descends into its sub-clusters.
+DEFAULT_MAX_CLUSTER_SIZE_FRACTION = 0.4
 DEFAULT_UMAP_N_COMPONENTS = 100  # Dimensionality for clustering (not visualization)
 DEFAULT_UMAP_N_NEIGHBORS = 15  # UMAP neighborhood size
 DEFAULT_UMAP_MIN_DIST = 0.0  # Tighter packing for clustering (vs 0.1 for visualization)

--- a/posthog/temporal/ai_observability/trace_clustering/constants.py
+++ b/posthog/temporal/ai_observability/trace_clustering/constants.py
@@ -129,7 +129,7 @@ MIN_CLUSTER_SIZE_FRACTION_MAX = 0.5  # Maximum allowed value for min_cluster_siz
 DEFAULT_HDBSCAN_MIN_SAMPLES = 5  # Minimum samples in neighborhood for core points
 # Excess of Mass selection can stop at the root split and return one cluster that holds most of
 # the sample. A cluster above this fraction is refused, so selection descends into its sub-clusters.
-DEFAULT_MAX_CLUSTER_SIZE_FRACTION = 0.4
+DEFAULT_MAX_CLUSTER_SIZE_FRACTION = 0.5
 DEFAULT_UMAP_N_COMPONENTS = 100  # Dimensionality for clustering (not visualization)
 DEFAULT_UMAP_N_NEIGHBORS = 15  # UMAP neighborhood size
 DEFAULT_UMAP_MIN_DIST = 0.0  # Tighter packing for clustering (vs 0.1 for visualization)

--- a/posthog/temporal/ai_observability/trace_clustering/models.py
+++ b/posthog/temporal/ai_observability/trace_clustering/models.py
@@ -43,7 +43,7 @@ class ClusteringWorkflowInputs:
     dimensionality_reduction_ndims: int = 100  # target dimensions for umap/pca (ignored if method is "none")
     run_label: str = ""  # optional label/tag for the clustering run (used as suffix in run_id for tracking experiments)
     clustering_method: str = "hdbscan"  # "hdbscan" or "kmeans"
-    # Method-specific params. For HDBSCAN: min_cluster_size_fraction, min_samples
+    # Method-specific params. For HDBSCAN: min_cluster_size_fraction, min_samples, max_cluster_size_fraction
     # For k-means: min_k, max_k (uses silhouette score to pick best k)
     clustering_method_params: dict[str, Any] = field(default_factory=dict)
     visualization_method: str = "umap"  # "umap", "pca", or "tsne" - method for 2D scatter plot visualization

--- a/posthog/temporal/ai_observability/trace_clustering/tests/test_clustering.py
+++ b/posthog/temporal/ai_observability/trace_clustering/tests/test_clustering.py
@@ -79,6 +79,35 @@ class TestPerformHDBSCANClustering:
         with pytest.raises(ValueError, match="Cannot cluster empty"):
             perform_hdbscan_clustering(np.array([]).reshape(0, 10))
 
+    def test_max_cluster_size_splits_root_level_clusters(self):
+        # Six sub-groups inside two macro groups. Without a cap, Excess of Mass keeps the two macro
+        # groups, which is the collapsed result seen on the clusters page.
+        np.random.seed(42)
+        sub_groups = []
+        for macro_offset in (0.0, 60.0):
+            for sub_offset in (0.0, 3.0, 6.0):
+                center = np.zeros(10)
+                center[0] = macro_offset + sub_offset
+                sub_groups.append(np.random.randn(40, 10) * 0.4 + center)
+        embeddings = np.vstack(sub_groups)
+
+        uncapped = perform_hdbscan_clustering(
+            embeddings, min_cluster_size_fraction=0.05, min_samples=5, max_cluster_size_fraction=1.0
+        )
+        capped = perform_hdbscan_clustering(
+            embeddings, min_cluster_size_fraction=0.05, min_samples=5, max_cluster_size_fraction=0.4
+        )
+
+        assert len(uncapped.centroids) == 2
+        assert len(capped.centroids) == 6
+        assert capped.num_noise_points == 0
+
+    def test_max_cluster_size_fraction_below_min_raises_error(self):
+        with pytest.raises(ValueError, match="max_cluster_size_fraction"):
+            perform_hdbscan_clustering(
+                np.random.randn(20, 5), min_cluster_size_fraction=0.2, max_cluster_size_fraction=0.1
+            )
+
 
 class TestCalculateTraceDistances:
     def test_distance_matrix_shape(self):

--- a/posthog/temporal/ai_observability/trace_clustering/tests/test_clustering.py
+++ b/posthog/temporal/ai_observability/trace_clustering/tests/test_clustering.py
@@ -80,12 +80,14 @@ class TestPerformHDBSCANClustering:
             perform_hdbscan_clustering(np.array([]).reshape(0, 10))
 
     def test_max_cluster_size_splits_root_level_clusters(self):
-        # Six sub-groups inside two macro groups. Without a cap, Excess of Mass keeps the two macro
-        # groups, which is the collapsed result seen on the clusters page.
+        # Two macro groups: one holds four sub-groups (two thirds of the items), the other two.
+        # Without a cap, Excess of Mass keeps the two macro groups, which is the collapsed result
+        # seen on the clusters page. The default cap refuses the large macro group and keeps
+        # its four sub-groups; the small macro group is under the cap and stays whole.
         np.random.seed(42)
         sub_groups = []
-        for macro_offset in (0.0, 60.0):
-            for sub_offset in (0.0, 3.0, 6.0):
+        for macro_offset, sub_offsets in ((0.0, (0.0, 3.0, 6.0, 9.0)), (60.0, (0.0, 3.0))):
+            for sub_offset in sub_offsets:
                 center = np.zeros(10)
                 center[0] = macro_offset + sub_offset
                 sub_groups.append(np.random.randn(40, 10) * 0.4 + center)
@@ -94,13 +96,10 @@ class TestPerformHDBSCANClustering:
         uncapped = perform_hdbscan_clustering(
             embeddings, min_cluster_size_fraction=0.05, min_samples=5, max_cluster_size_fraction=1.0
         )
-        capped = perform_hdbscan_clustering(
-            embeddings, min_cluster_size_fraction=0.05, min_samples=5, max_cluster_size_fraction=0.4
-        )
+        capped = perform_hdbscan_clustering(embeddings, min_cluster_size_fraction=0.05, min_samples=5)
 
         assert len(uncapped.centroids) == 2
-        assert len(capped.centroids) == 6
-        assert capped.num_noise_points == 0
+        assert len(capped.centroids) == 5
 
     def test_max_cluster_size_fraction_below_min_raises_error(self):
         with pytest.raises(ValueError, match="max_cluster_size_fraction"):

--- a/products/ai_observability/backend/api/clustering.py
+++ b/products/ai_observability/backend/api/clustering.py
@@ -21,6 +21,7 @@ from posthog.permissions import AccessControlPermission
 from posthog.temporal.ai_observability.trace_clustering.constants import (
     DEFAULT_HDBSCAN_MIN_SAMPLES,
     DEFAULT_LOOKBACK_DAYS,
+    DEFAULT_MAX_CLUSTER_SIZE_FRACTION,
     DEFAULT_MAX_SAMPLES,
     DEFAULT_MIN_CLUSTER_SIZE_FRACTION,
     DEFAULT_UMAP_N_COMPONENTS,
@@ -102,6 +103,13 @@ class ClusteringRunRequestSerializer(serializers.Serializer):
         max_value=100,
         help_text="HDBSCAN min_samples parameter (higher = more conservative clustering)",
     )
+    max_cluster_size_fraction = serializers.FloatField(
+        required=False,
+        default=DEFAULT_MAX_CLUSTER_SIZE_FRACTION,
+        min_value=MIN_CLUSTER_SIZE_FRACTION_MIN,
+        max_value=1.0,
+        help_text="Maximum cluster size as fraction of total samples (e.g., 0.5 = 50%). A cluster above this is split into its sub-clusters",
+    )
 
     # K-means parameters (used when clustering_method='kmeans')
     kmeans_min_k = serializers.IntegerField(
@@ -151,6 +159,16 @@ class ClusteringRunRequestSerializer(serializers.Serializer):
         allow_null=True,
         help_text="If provided, use this clustering job's analysis_level and event_filters instead of request params",
     )
+
+    def validate(self, attrs: dict) -> dict:
+        if (
+            attrs["clustering_method"] == "hdbscan"
+            and attrs["max_cluster_size_fraction"] < attrs["min_cluster_size_fraction"]
+        ):
+            raise serializers.ValidationError(
+                {"max_cluster_size_fraction": "Must be greater than or equal to min_cluster_size_fraction."}
+            )
+        return attrs
 
 
 class AIObservabilityClusteringRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
@@ -222,6 +240,7 @@ class AIObservabilityClusteringRunViewSet(TeamAndOrgViewSetMixin, viewsets.ViewS
             clustering_method_params = {
                 "min_cluster_size_fraction": serializer.validated_data["min_cluster_size_fraction"],
                 "min_samples": serializer.validated_data["hdbscan_min_samples"],
+                "max_cluster_size_fraction": serializer.validated_data["max_cluster_size_fraction"],
             }
         elif clustering_method == "kmeans":
             clustering_method_params = {

--- a/products/ai_observability/backend/api/test/test_clustering_run.py
+++ b/products/ai_observability/backend/api/test/test_clustering_run.py
@@ -1,0 +1,53 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+from rest_framework import status
+
+from products.ai_observability.backend.api.clustering import ClusteringRunRequestSerializer
+
+
+class TestClusteringRunRequestSerializer(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("cap_below_floor", 0.4, 0.2, False),
+            ("cap_equal_to_floor", 0.4, 0.4, True),
+            ("cap_above_floor", 0.02, 0.5, True),
+        ]
+    )
+    def test_max_cluster_size_fraction_must_not_undercut_min(
+        self, _name: str, min_fraction: float, max_fraction: float, expected_valid: bool
+    ) -> None:
+        serializer = ClusteringRunRequestSerializer(
+            data={
+                "clustering_method": "hdbscan",
+                "min_cluster_size_fraction": min_fraction,
+                "max_cluster_size_fraction": max_fraction,
+            }
+        )
+
+        assert serializer.is_valid() == expected_valid
+        if not expected_valid:
+            assert "max_cluster_size_fraction" in serializer.errors
+
+
+class TestClusteringRunViewSet(APIBaseTest):
+    @patch("products.ai_observability.backend.api.clustering.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.ai_observability.backend.api.clustering.sync_connect")
+    def test_max_cluster_size_fraction_reaches_the_workflow(
+        self, mock_sync_connect: MagicMock, _mock_feature_enabled: MagicMock
+    ) -> None:
+        mock_sync_connect.return_value = MagicMock(start_workflow=AsyncMock())
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/llm_analytics/clustering_runs/",
+            {"clustering_method": "hdbscan", "max_cluster_size_fraction": 0.3},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED, response.data
+        assert response.data["parameters"]["clustering_method_params"]["max_cluster_size_fraction"] == 0.3
+        workflow_inputs = mock_sync_connect.return_value.start_workflow.call_args.args[1]
+        assert workflow_inputs.clustering_method_params["max_cluster_size_fraction"] == 0.3

--- a/products/ai_observability/frontend/clusters/ClusteringAdminModal.tsx
+++ b/products/ai_observability/frontend/clusters/ClusteringAdminModal.tsx
@@ -265,6 +265,22 @@ export function ClusteringAdminModal(): JSX.Element {
                                 </div>
                             </div>
                             <div>
+                                <label className="text-sm font-medium mb-1 block">max_cluster_size_fraction</label>
+                                <LemonInput
+                                    type="number"
+                                    min={0.02}
+                                    max={1}
+                                    step={0.05}
+                                    value={params.max_cluster_size_fraction}
+                                    onChange={(value) => setParams({ max_cluster_size_fraction: Number(value) })}
+                                    fullWidth
+                                />
+                                <div className="text-xs text-muted mt-1">
+                                    Max cluster as % of samples, larger clusters get split (default:{' '}
+                                    {(DEFAULT_CLUSTERING_PARAMS.max_cluster_size_fraction * 100).toFixed(0)}%)
+                                </div>
+                            </div>
+                            <div>
                                 <label className="text-sm font-medium mb-1 block">min_samples</label>
                                 <LemonInput
                                     type="number"

--- a/products/ai_observability/frontend/clusters/clustersAdminLogic.ts
+++ b/products/ai_observability/frontend/clusters/clustersAdminLogic.ts
@@ -21,6 +21,7 @@ export interface ClusteringRunParams {
     clustering_method: 'hdbscan' | 'kmeans'
     // HDBSCAN params
     min_cluster_size_fraction: number
+    max_cluster_size_fraction: number
     hdbscan_min_samples: number
     // K-means params
     kmeans_min_k: number
@@ -47,6 +48,7 @@ export const DEFAULT_CLUSTERING_PARAMS: ClusteringRunParams = {
     dimensionality_reduction_ndims: 100,
     clustering_method: 'hdbscan',
     min_cluster_size_fraction: 0.02,
+    max_cluster_size_fraction: 0.5,
     hdbscan_min_samples: 5,
     kmeans_min_k: 2,
     kmeans_max_k: 10,

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -1404,6 +1404,12 @@ export interface ClusteringRunRequestApi {
      */
     hdbscan_min_samples?: number
     /**
+     * Maximum cluster size as fraction of total samples (e.g., 0.5 = 50%). A cluster above this is split into its sub-clusters
+     * @minimum 0.02
+     * @maximum 1
+     */
+    max_cluster_size_fraction?: number
+    /**
      * Minimum number of clusters to try for k-means
      * @minimum 2
      * @maximum 50

--- a/products/ai_observability/frontend/generated/api.zod.ts
+++ b/products/ai_observability/frontend/generated/api.zod.ts
@@ -1003,6 +1003,10 @@ export const llmAnalyticsClusteringRunsCreateBodyMinClusterSizeFractionMax = 0.5
 export const llmAnalyticsClusteringRunsCreateBodyHdbscanMinSamplesDefault = 5
 export const llmAnalyticsClusteringRunsCreateBodyHdbscanMinSamplesMax = 100
 
+export const llmAnalyticsClusteringRunsCreateBodyMaxClusterSizeFractionDefault = 0.5
+export const llmAnalyticsClusteringRunsCreateBodyMaxClusterSizeFractionMin = 0.02
+export const llmAnalyticsClusteringRunsCreateBodyMaxClusterSizeFractionMax = 1
+
 export const llmAnalyticsClusteringRunsCreateBodyKmeansMinKDefault = 2
 export const llmAnalyticsClusteringRunsCreateBodyKmeansMinKMin = 2
 export const llmAnalyticsClusteringRunsCreateBodyKmeansMinKMax = 50
@@ -1069,6 +1073,14 @@ export const LlmAnalyticsClusteringRunsCreateBody = /* @__PURE__ */ zod
             .max(llmAnalyticsClusteringRunsCreateBodyHdbscanMinSamplesMax)
             .default(llmAnalyticsClusteringRunsCreateBodyHdbscanMinSamplesDefault)
             .describe('HDBSCAN min_samples parameter (higher = more conservative clustering)'),
+        max_cluster_size_fraction: zod
+            .number()
+            .min(llmAnalyticsClusteringRunsCreateBodyMaxClusterSizeFractionMin)
+            .max(llmAnalyticsClusteringRunsCreateBodyMaxClusterSizeFractionMax)
+            .default(llmAnalyticsClusteringRunsCreateBodyMaxClusterSizeFractionDefault)
+            .describe(
+                'Maximum cluster size as fraction of total samples (e.g., 0.5 = 50%). A cluster above this is split into its sub-clusters'
+            ),
         kmeans_min_k: zod
             .number()
             .min(llmAnalyticsClusteringRunsCreateBodyKmeansMinKMin)

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -17802,6 +17802,12 @@ export namespace Schemas {
          */
       hdbscan_min_samples?: number;
       /**
+         * Maximum cluster size as fraction of total samples (e.g., 0.5 = 50%). A cluster above this is split into its sub-clusters
+         * @minimum 0.02
+         * @maximum 1
+         */
+      max_cluster_size_fraction?: number;
+      /**
          * Minimum number of clusters to try for k-means
          * @minimum 2
          * @maximum 50


### PR DESCRIPTION
## Problem

A person opening AI observability → Clusters sometimes finds two cluster cards where the same job showed a dozen the night before. The run is not empty and the page is not broken. The job returned a split with one cluster holding most of the sample and no noise points, so the cards say nothing about the traffic.

HDBSCAN's Excess of Mass selection causes this. When no sub-cluster is stable enough, it keeps the root split. Each run clusters a fresh random sample, so a job flips between a useful split and a collapsed one with no config change.

Across all US projects, about 11% of nightly clustering runs collapse this way, and the rate has not been below 10% since June. Full write-up with fleet-wide numbers: [AI clustering collapse notebook](https://us.posthog.com/project/2/notebooks/9IYWiSJj) (internal).

Alternative in flight: #93646 detects the collapsed shape after the fact and re-runs with leaf selection. This PR reaches for the HDBSCAN parameter built for the problem instead of adding a retry heuristic.

## Changes

- Clustering runs no longer return one cluster that holds most of the sample. HDBSCAN now gets `max_cluster_size` set to 50% of the sample, so selection refuses a cluster above that and descends into its sub-clusters.
- Trace, generation, and evaluation clustering all pass the cap through `perform_hdbscan_clustering`.
- A manual run can set `max_cluster_size_fraction` on the clustering run request, and the staff clustering admin modal exposes the knob next to `min_cluster_size_fraction`. The request is rejected when the cap sits below `min_cluster_size_fraction`.
- Scheduled runs always use the default. The coordinator builds workflow inputs without `clustering_method_params`, so no saved job can override the cap, the same as `min_cluster_size_fraction` today.
- Mechanical: a constant, a docstring, a comment on the params field, and a validation error when the cap is below the minimum fraction.

> [!WARNING]
> The cap changes more runs than the collapsed ones. Fleet-wide over the last 30 days, about 25% of runs had a largest cluster at 50% or more, of which about 10% were collapsed. The other 15% had 5 to 6 clusters with one dominant topic; that topic is now split into sub-topics. A 40% cap would have touched 37% of runs, which is why the default is 50%.

> [!WARNING]
> A cluster above the cap with no sub-cluster of at least `min_cluster_size` is dropped to noise, not kept. Confirmed against scikit-learn 1.7.2, where any node above `max_cluster_size` is deselected.

## How did you test this code?

Unit tests only. Not run against production embeddings, since that needs a worker and the embedding table. Before merging, someone with access should run the trace clustering workflow for the window that collapsed and check the cards.

New tests in `test_clustering.py`:

- Two macro groups, one holding four sub-groups and the other two: the uncapped run returns two clusters and the default cap returns five. No existing test covered a collapsed split.
- A cap below the minimum fraction raises a `ValueError`.

New tests in `test_clustering_run.py`, which had no existing counterpart:

- Serializer cases for a cap below, equal to, and above `min_cluster_size_fraction`. These guard the 400 on an inverted range.
- One endpoint case that asserts the cap reaches the workflow inputs. This guards the passthrough that made the parameter unreachable before.

The existing HDBSCAN tests still pass with the new default.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal clustering behavior, no documented setting changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code after a Slack thread about the clusters page showing two cards. The human chose the `max_cluster_size` parameter over the retry-with-leaf approach in #93646. The default started at 40%, then moved to 50% after a fleet-wide query showed how many non-collapsed runs each cap value would rewrite. No real embeddings or customer data were used. The test fixture is synthetic.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

https://claude.ai/code/session_01CtmKozWxdWrwQt7oXqYqY1

