### PR TITLE
fix(ci): unparallelize action-downloading steps

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -835,21 +835,23 @@ jobs:
             # Depot shadow: canonical threads a setup-action app token into both
             # pnpm-install and setup-python; mint stripped here (secret not
             # available on Depot), so setup-python keeps the bot PAT.
-            - parallel:
-                  - name: Install pnpm dependencies
-                    uses: ./.depot/actions/pnpm-install
-                    with:
-                        install-command: pnpm install --frozen-lockfile --filter=@posthog/root
-                  - name: Set up Python
-                    uses: ./.depot/actions/setup-python-cached
-                    with:
-                        python-version: 3.13.13
-                        token: ${{ secrets.POSTHOG_BOT_PAT }}
-                  - name: Install Rust
-                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-                    with:
-                        toolchain: 1.91.1
-                        components: cargo
+            # Don't wrap these in a `parallel:` block: two branches that each download an
+            # action corrupt the runner's action registry and kill the job during setup.
+            # See docs/internal/ci-things-already-tried.md.
+            - name: Install pnpm dependencies
+              uses: ./.depot/actions/pnpm-install
+              with:
+                  install-command: pnpm install --frozen-lockfile --filter=@posthog/root
+            - name: Set up Python
+              uses: ./.depot/actions/setup-python-cached
+              with:
+                  python-version: 3.13.13
+                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -1868,25 +1870,26 @@ jobs:
             # Tool cache steps inlined rather than the setup-python-cached composite:
             # this job checks out the PR head ref, which cannot resolve a local
             # action that only exists on master until the branch rebases. The
-            # restore sits before the parallel block so the tool cache is warm
-            # when setup-python starts.
+            # restore sits before setup-python so the tool cache is warm when it runs.
             - name: Restore Python tool cache
               id: python-toolcache
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               with:
                   path: ${{ runner.tool_cache }}/Python/${{ matrix.python-version }}
                   key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
-            - parallel:
-                  - name: Set up Python
-                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-                    with:
-                        python-version: ${{ matrix.python-version }}
-                  - name: Install Rust
-                    if: needs.changes.outputs.backend == 'true'
-                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-                    with:
-                        toolchain: 1.91.1
-                        components: cargo
+            # Don't wrap these in a `parallel:` block: two branches that each download an
+            # action corrupt the runner's action registry and kill the job during setup.
+            # See docs/internal/ci-things-already-tried.md.
+            - name: Set up Python
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version: ${{ matrix.python-version }}
+            - name: Install Rust
+              if: needs.changes.outputs.backend == 'true'
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
             - name: Save Python tool cache
               if: github.ref == 'refs/heads/master' && steps.python-toolcache.outputs.cache-hit != 'true'
               uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -357,6 +357,11 @@ jobs:
                   fi
                   echo "version=$version" >> "$GITHUB_OUTPUT"
 
+            # Parallel branches that each download an action can corrupt the runner's action
+            # registry and kill the job during setup, so setup steps elsewhere run in order.
+            # These branches stay parallel: they are Depot image builds, and running three
+            # multi-platform builds one at a time costs more than the crash has ever cost here.
+            # See docs/internal/ci-things-already-tried.md.
             - parallel:
                   - name: Build and push container image (base)
                     id: build

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -806,24 +806,26 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
                   skip-token-revoke: true
 
-            - parallel:
-                  - name: Install pnpm dependencies
-                    uses: ./.github/actions/pnpm-install
-                    with:
-                        install-command: pnpm install --frozen-lockfile --filter=@posthog/root
-                        token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+            # Don't wrap these in a `parallel:` block: two branches that each download an
+            # action corrupt the runner's action registry and kill the job during setup.
+            # See docs/internal/ci-things-already-tried.md.
+            - name: Install pnpm dependencies
+              uses: ./.github/actions/pnpm-install
+              with:
+                  install-command: pnpm install --frozen-lockfile --filter=@posthog/root
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
-                  - name: Set up Python
-                    uses: ./.github/actions/setup-python-cached
-                    with:
-                        python-version: 3.13.13
-                        token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+            - name: Set up Python
+              uses: ./.github/actions/setup-python-cached
+              with:
+                  python-version: 3.13.13
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
-                  - name: Install Rust
-                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-                    with:
-                        toolchain: 1.91.1
-                        components: cargo
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
 
             - name: Install uv
               id: setup-uv
@@ -2816,8 +2818,7 @@ jobs:
             # Tool cache steps inlined rather than the setup-python-cached composite:
             # this job checks out the PR head ref, which cannot resolve a local
             # action that only exists on master until the branch rebases. The
-            # restore sits before the parallel block so the tool cache is warm
-            # when setup-python starts.
+            # restore sits before setup-python so the tool cache is warm when it runs.
             - name: Restore Python tool cache
               id: python-toolcache
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -2825,19 +2826,21 @@ jobs:
                   path: ${{ runner.tool_cache }}/Python/${{ matrix.python-version }}
                   key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
 
-            - parallel:
-                  - name: Set up Python
-                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-                    with:
-                        python-version: ${{ matrix.python-version }}
-                        token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+            # Don't wrap these in a `parallel:` block: two branches that each download an
+            # action corrupt the runner's action registry and kill the job during setup.
+            # See docs/internal/ci-things-already-tried.md.
+            - name: Set up Python
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
-                  - name: Install Rust
-                    if: needs.changes.outputs.backend == 'true'
-                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-                    with:
-                        toolchain: 1.91.1
-                        components: cargo
+            - name: Install Rust
+              if: needs.changes.outputs.backend == 'true'
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: cargo
 
             - name: Save Python tool cache
               if: github.ref == 'refs/heads/master' && steps.python-toolcache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-deltalite-python.yml
+++ b/.github/workflows/ci-deltalite-python.yml
@@ -49,17 +49,19 @@ jobs:
                   sparse-checkout-cone-mode: false
                   clean: false
 
-            - parallel:
-                  - name: Install rust
-                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-                    with:
-                        toolchain: 1.91.1
-                        components: clippy,rustfmt
+            # Don't wrap these in a `parallel:` block: two branches that each download an
+            # action corrupt the runner's action registry and kill the job during setup.
+            # See docs/internal/ci-things-already-tried.md.
+            - name: Install rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: clippy,rustfmt
 
-                  - name: Set up Python
-                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-                    with:
-                        python-version: '3.13'
+            - name: Set up Python
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version: '3.13'
 
             - name: Cache Rust dependencies
               uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -275,20 +275,22 @@ jobs:
                   sparse-checkout-cone-mode: false
                   clean: false
 
-            - parallel:
-                  - name: Install system OpenSSL
-                    run: |
-                        sudo rm -f /etc/apt/sources.list.d/*twingate*
-                        sudo apt-get update
-                        sudo apt-get install -y libssl-dev pkg-config
+            # Don't wrap these in a `parallel:` block: two branches that each download an
+            # action corrupt the runner's action registry and kill the job during setup.
+            # See docs/internal/ci-things-already-tried.md.
+            - name: Install system OpenSSL
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/*twingate*
+                  sudo apt-get update
+                  sudo apt-get install -y libssl-dev pkg-config
 
-                  - name: Install protoc
-                    uses: ./.github/actions/setup-protoc
+            - name: Install protoc
+              uses: ./.github/actions/setup-protoc
 
-                  - name: Install rust
-                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-                    with:
-                        toolchain: 1.91.1
+            - name: Install rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
 
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
@@ -840,21 +842,23 @@ jobs:
                   sparse-checkout-cone-mode: false
                   clean: false
 
-            - parallel:
-                  - name: Install system OpenSSL
-                    run: |
-                        sudo rm -f /etc/apt/sources.list.d/*twingate*
-                        sudo apt-get update
-                        sudo apt-get install -y libssl-dev pkg-config
+            # Don't wrap these in a `parallel:` block: two branches that each download an
+            # action corrupt the runner's action registry and kill the job during setup.
+            # See docs/internal/ci-things-already-tried.md.
+            - name: Install system OpenSSL
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/*twingate*
+                  sudo apt-get update
+                  sudo apt-get install -y libssl-dev pkg-config
 
-                  - name: Install protoc
-                    uses: ./.github/actions/setup-protoc
+            - name: Install protoc
+              uses: ./.github/actions/setup-protoc
 
-                  - name: Install rust
-                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-                    with:
-                        toolchain: 1.91.1
-                        components: clippy,rustfmt
+            - name: Install rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+                  components: clippy,rustfmt
 
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"

--- a/docs/internal/ci-things-already-tried.md
+++ b/docs/internal/ci-things-already-tried.md
@@ -245,6 +245,23 @@ _Also asked as:_ Docker Hub rate limit in CI, unauthenticated pull limit, DOCKER
 
 ## CI orchestration
 
+### Run action-downloading steps in a `parallel:` block
+
+**Verdict: reverted** · Sep 2026
+
+`parallel:` steps run several setup branches at once, which shaves setup time off every job in a matrix.
+When two branches each resolve a step that downloads an action, the runner writes the same non-concurrent dictionary from both threads.
+It then fails the job with `Operations that change non-concurrent collections must have exclusive access`, or leaves `GITHUB_EVENT_PATH` empty so the next action crashes on `JSON.parse` with `SyntaxError: Unexpected end of JSON input`.
+The job dies during setup, before it runs a test, so the failure carries no findings and a rerun usually passes.
+
+Measured on 12 scheduled Backend CI runs: about 1 job in 100 died this way. The product-test matrix is around 46 jobs, so about a third of the nightly runs went red on it alone.
+Nested `uses:` inside a composite action resolve late, so a composite counts as several downloads.
+
+Blocks whose branches are all `run:` steps do not download anything and stay parallel.
+`cd-sandbox-base-image.yml` also stays parallel: its branches are Depot image builds, and serializing three multi-platform builds costs far more than the crash rate on a workflow that has never shown it.
+
+_Also asked as:_ parallel steps, run setup steps concurrently, speed up job setup, non-concurrent collection error, Unexpected end of JSON input in setup-node
+
 ### Move CI from the Depot runners to Blacksmith
 
 **Verdict: rejected** · Apr 2026 to May 2026 · [#54559](https://github.com/PostHog/posthog/pull/54559), removed by [#57991](https://github.com/PostHog/posthog/pull/57991)


### PR DESCRIPTION
## Problem

- Scheduled Backend CI runs go red with no test findings: a job dies during setup, and a rerun passes.
- The runner fails with `Operations that change non-concurrent collections must have exclusive access`, or leaves `GITHUB_EVENT_PATH` empty so the next action crashes on `SyntaxError: Unexpected end of JSON input`.
- Cause: `parallel:` step branches that each download an action write the runner's action registry from two threads.
- Sample of 12 scheduled runs: 4 went red on this alone ([16:32](https://github.com/PostHog/posthog/actions/runs/33655540472), [12:40](https://github.com/PostHog/posthog/actions/runs/33631282126), [11:28](https://github.com/PostHog/posthog/actions/runs/33624754406), [01:42](https://github.com/PostHog/posthog/actions/runs/33580413317)). The product-test matrix is ~46 jobs, so one bad job is enough.

## Changes

- Setup steps that were parallel now run in order, in the 3 workflows whose branches downloaded actions concurrently. Nothing else about them changes: every step keeps its `name`, `uses`, `with`, and `if` untouched.
- `parallel:` blocks whose branches are all `run:` steps keep the speedup. They download nothing.
- `cd-sandbox-base-image.yml` also keeps it, with a comment saying why: those branches are Depot image builds, and running three multi-platform builds one at a time costs more than the crash has ever cost there.
- Mirrored into `.depot/workflows/ci-backend.yml` to keep the shadow apples-to-apples.
- New entry in `docs/internal/ci-things-already-tried.md`, and a warning at each site, so the pattern is not reintroduced.

## How did you test this code?

- Parsed both revisions of every touched workflow and compared the step lists with the parallel blocks flattened. Identical in every job, so the change is nesting only.
- `bin/hogli lint:workflows`, `actionlint`, and `hogli ci:preflight` pass.
- The failure is a runner race, so I could not reproduce it locally or prove absence. The check is that CI still passes and the crash stops appearing on scheduled runs.
- The blocks came from [#76651](https://github.com/PostHog/posthog/pull/76651), which reported no before/after timings, so there is no measured win to weigh against this.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5), starting from a master-red alert in #alerts-devex.
- Skills invoked: `/authoring-ci-workflows`, `/code-review`, `/simplify`.
- The first draft also serialized `cd-sandbox-base-image.yml`. Review caught that those branches are image builds rather than setup steps, so they are left alone.
- Considered keeping `parallel:` and pre-warming the action downloads instead. Rejected: nested `uses:` inside a composite resolve lazily, so there is no reliable point to pre-warm them.
- Two other reds in the same window are separate and not addressed here: a `temporal.download` fetch failure, and a `warehouse-sources` snapshot-pin flake that [#93155](https://github.com/PostHog/posthog/pull/93155) already targets.

https://claude.ai/code/session_013SombsNtSjMRnGQPaSF55i
