### PR TITLE
feat(logs): derive log patterns from each team's configured message keys

### DIFF
--- a/docs/published/docs/logs/logs-config.mdx
+++ b/docs/published/docs/logs/logs-config.mdx
@@ -48,10 +48,12 @@ When a log body is a JSON object, PostHog looks up these keys in order and uses 
 
 If no key matches, the pattern is built from the object's set of top-level key names instead, so records with the same shape group together.
 
-An empty list turns message extraction off. Every JSON body then groups by its key set.
+An empty list turns message extraction off. Every JSON body then groups by its key set. A project without a logs configuration uses the default keys instead.
 
 This setting changes only how patterns are derived. The stored log body is never changed.
 
 ## Propagation
 
-A change reaches log ingestion within a few minutes. Records ingested in that window keep the patterns derived from the previous configuration.
+Ingestion caches pattern message keys for 30 seconds per consumer. Changes apply to newly ingested records when the cache refreshes; stored patterns are not recalculated. The existing pattern-ingestion rollout must be enabled for the project.
+
+If a configuration lookup fails, ingestion keeps the last successfully loaded keys, or the default keys if none have been loaded. It waits 30 seconds before retrying. Logs continue to ingest during the failure.

--- a/nodejs/src/logs/log-pattern-mask.test.ts
+++ b/nodejs/src/logs/log-pattern-mask.test.ts
@@ -6,7 +6,6 @@ import {
     KEY_SET_MAX_KEYS,
     type LogPatternResult,
     MASK_RULES,
-    MESSAGE_KEYS,
     PATTERN_CAPS,
     PATTERN_VERSION,
     buildLogPattern,
@@ -14,7 +13,12 @@ import {
 } from './log-pattern-mask'
 
 describe('log-pattern-mask', () => {
-    const patternResult = (body: string | null | undefined): LogPatternResult => buildLogPattern(body, MESSAGE_KEYS)
+    // The list is per team in production, so no single list is a global shape input. The ratchet
+    // below pins this one so the digest keeps covering the masker and the selection mechanism, and
+    // makes no claim about any team's configured list.
+    const TEST_MESSAGE_KEYS: readonly string[] = ['message', 'msg', 'event']
+    const patternResult = (body: string | null | undefined): LogPatternResult =>
+        buildLogPattern(body, TEST_MESSAGE_KEYS)
 
     describe('maskString', () => {
         it.each([
@@ -351,9 +355,9 @@ describe('log-pattern-mask', () => {
          * Bodies chosen to reach every branch that decides a pattern's shape: each mask rule, the
          * message keys, the key-set and array forms, both caps, and the order of parse and cap.
          *
-         * The message-key bodies are derived from `MESSAGE_KEYS` so a new key joins the corpus, and
-         * moves the digest, on arrival. Mask rules cannot be derived that way, so a coverage test
-         * below holds the equivalent line for them.
+         * The message-key bodies are derived from `TEST_MESSAGE_KEYS`, the fixed list the ratchet is
+         * pinned to. Mask rules cannot be derived that way, so a coverage test below holds the
+         * equivalent line for them.
          */
         const CORPUS: (string | null)[] = [
             null,
@@ -370,7 +374,7 @@ describe('log-pattern-mask', () => {
             'built sha a3f9c1d2 from 1724495000',
             'charging cus_Qz4WmTb7Kx9pLr for org_01ABCDEF23GHJK45MNPQRS67',
             '{"10.0.0.1":1,"10.0.0.2":2}',
-            ...MESSAGE_KEYS.map((key) => JSON.stringify({ [key]: 'served 3 requests', level: 'info' })),
+            ...TEST_MESSAGE_KEYS.map((key) => JSON.stringify({ [key]: 'served 3 requests', level: 'info' })),
             '{"msg":"loses 2","message":"wins 1"}',
             // Reach `extractJsonMessage` itself, not just the keys it reads. Widening it to accept a
             // number, or trimming what it returns, reshapes real bodies while leaving every other
@@ -417,7 +421,7 @@ describe('log-pattern-mask', () => {
         const SHAPE_INPUTS = JSON.stringify({
             rules: MASK_RULES.map((rule) => [rule.name, rule.pattern, rule.replacement]),
             caps: PATTERN_CAPS,
-            messageKeys: MESSAGE_KEYS,
+            messageKeys: TEST_MESSAGE_KEYS,
             keySetMaxKeys: KEY_SET_MAX_KEYS,
             jsonArray: JSON_ARRAY,
         })

--- a/nodejs/src/logs/log-pattern-mask.ts
+++ b/nodejs/src/logs/log-pattern-mask.ts
@@ -226,8 +226,6 @@ export type LogPatternResult = {
     ruleFires: number[]
 }
 
-export const MESSAGE_KEYS = ['message', 'msg', 'event'] as const
-
 function extractJsonMessage(value: object, messageKeys: readonly string[]): string | null {
     if (Array.isArray(value)) {
         return null

--- a/nodejs/src/logs/log-pattern-stage.test.ts
+++ b/nodejs/src/logs/log-pattern-stage.test.ts
@@ -41,7 +41,7 @@ describe('log-pattern-stage', () => {
     }
 
     it('tallies body kinds, rule fires, and input caps across a batch without touching the body', async () => {
-        const stage = makePatternMaskingStage()
+        const stage = makePatternMaskingStage(['message'])
         const records = [
             makeRecord(null),
             makeRecord('plain 5'),
@@ -71,7 +71,7 @@ describe('log-pattern-stage', () => {
         ['a plain body', 'retry 5', 'retry <N>'],
         ['an empty body, which must still carry a version or it reads as written before masking', null, ''],
     ])('stamps pattern and version onto the record: %s', async (_name, body, expected) => {
-        const stage = makePatternMaskingStage()
+        const stage = makePatternMaskingStage(['message'])
         const record = makeRecord(body)
 
         await stage.run([record])
@@ -80,7 +80,7 @@ describe('log-pattern-stage', () => {
     })
 
     it('keeps the batch when masking throws, so a measurement fault cannot DLQ customer logs', async () => {
-        const stage = makePatternMaskingStage()
+        const stage = makePatternMaskingStage(['message'])
         const record = makeRecord(null)
         Object.defineProperty(record, 'body', {
             get: () => {

--- a/nodejs/src/logs/log-pattern-stage.ts
+++ b/nodejs/src/logs/log-pattern-stage.ts
@@ -1,7 +1,7 @@
 import { performance } from 'node:perf_hooks'
 import { Counter, Histogram } from 'prom-client'
 
-import { MASK_RULES, MESSAGE_KEYS, PATTERN_VERSION, buildLogPattern, zeroRuleFires } from './log-pattern-mask'
+import { MASK_RULES, PATTERN_VERSION, buildLogPattern, zeroRuleFires } from './log-pattern-mask'
 import type { LogRecord } from './log-record-avro'
 import type { PipelineStage } from './pipeline/log-processing-pipeline'
 
@@ -51,13 +51,13 @@ export const logsPatternStageErrorCounter = new Counter({
     help: 'Batches where the pattern masking stage threw. The records survive. Any record the throw came before keeps its stamp, and the rest stay unstamped, which reads as version 0.',
 })
 
-export function makePatternMaskingStage(): PipelineStage {
+export function makePatternMaskingStage(messageKeys: readonly string[]): PipelineStage {
     return {
         kind: 'mutate',
         name: 'pattern_masking',
         run: (records) => {
             try {
-                stampBatch(records)
+                stampBatch(records, messageKeys)
             } catch {
                 logsPatternStageErrorCounter.inc()
             }
@@ -65,14 +65,14 @@ export function makePatternMaskingStage(): PipelineStage {
     }
 }
 
-function stampBatch(records: LogRecord[]): void {
+function stampBatch(records: LogRecord[], messageKeys: readonly string[]): void {
     const kindCounts = new Map<string, number>()
     const ruleFires: number[] = zeroRuleFires()
     let inputCapped = 0
 
     for (const record of records) {
         const start = performance.now()
-        const result = buildLogPattern(record.body, MESSAGE_KEYS)
+        const result = buildLogPattern(record.body, messageKeys)
         record.pattern = result.pattern
         record.pattern_version = PATTERN_VERSION
         logsPatternMaskingDurationHistogram.observe((performance.now() - start) / 1000)

--- a/nodejs/src/logs/logs-config-cache.test.ts
+++ b/nodejs/src/logs/logs-config-cache.test.ts
@@ -1,0 +1,73 @@
+import { PostgresRouter } from '~/common/utils/db/postgres'
+
+import { LogsConfigCache } from './logs-config-cache'
+
+describe('LogsConfigCache', () => {
+    let query: jest.Mock
+    let cache: LogsConfigCache
+
+    beforeEach(() => {
+        jest.useFakeTimers()
+        query = jest.fn()
+        cache = new LogsConfigCache({ query } as unknown as PostgresRouter)
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+        jest.restoreAllMocks()
+    })
+
+    it.each([
+        ['stored ordered keys', [{ logs_pattern_message_keys: ['text', 'msg'] }], ['text', 'msg']],
+        ['an explicitly empty list', [{ logs_pattern_message_keys: [] }], []],
+        ['no config row', [], ['message', 'msg', 'event']],
+    ])('uses %s without confusing missing configuration with disabled extraction', async (_name, rows, expected) => {
+        query.mockResolvedValueOnce({ rows })
+        expect(await cache.getPatternMessageKeys(1)).toEqual(expected)
+    })
+
+    it('coalesces concurrent refreshes per team and reloads changed settings after the TTL', async () => {
+        let resolveFirstTeam!: (result: { rows: { logs_pattern_message_keys: string[] }[] }) => void
+        query.mockReturnValueOnce(new Promise((resolve) => (resolveFirstTeam = resolve)))
+        query.mockResolvedValueOnce({ rows: [{ logs_pattern_message_keys: ['other'] }] })
+
+        const first = cache.getPatternMessageKeys(1)
+        const concurrent = cache.getPatternMessageKeys(1)
+        expect(await cache.getPatternMessageKeys(2)).toEqual(['other'])
+        expect(query).toHaveBeenCalledTimes(2)
+
+        resolveFirstTeam({ rows: [{ logs_pattern_message_keys: ['text'] }] })
+        expect(await Promise.all([first, concurrent])).toEqual([['text'], ['text']])
+        jest.advanceTimersByTime(29_999)
+        expect(await cache.getPatternMessageKeys(1)).toEqual(['text'])
+        expect(query).toHaveBeenCalledTimes(2)
+
+        jest.advanceTimersByTime(1)
+        query.mockResolvedValueOnce({ rows: [{ logs_pattern_message_keys: [] }] })
+        expect(await Promise.all([cache.getPatternMessageKeys(1), cache.getPatternMessageKeys(1)])).toEqual([[], []])
+        expect(query).toHaveBeenCalledTimes(3)
+    })
+
+    it.each([undefined, [], ['text']])('backs off after a failed refresh with cached keys %j', async (storedKeys) => {
+        if (storedKeys !== undefined) {
+            query.mockResolvedValueOnce({ rows: [{ logs_pattern_message_keys: storedKeys }] })
+            await cache.getPatternMessageKeys(1)
+            jest.advanceTimersByTime(30_000)
+        }
+        query.mockClear()
+        query.mockRejectedValueOnce(new Error('pg down'))
+        const expected = storedKeys ?? ['message', 'msg', 'event']
+        expect(await Promise.all([cache.getPatternMessageKeys(1), cache.getPatternMessageKeys(1)])).toEqual([
+            expected,
+            expected,
+        ])
+        jest.advanceTimersByTime(29_999)
+        expect(await cache.getPatternMessageKeys(1)).toEqual(expected)
+        expect(query).toHaveBeenCalledTimes(1)
+
+        jest.advanceTimersByTime(1)
+        query.mockResolvedValueOnce({ rows: [{ logs_pattern_message_keys: ['recovered'] }] })
+        expect(await cache.getPatternMessageKeys(1)).toEqual(['recovered'])
+        expect(query).toHaveBeenCalledTimes(2)
+    })
+})

--- a/nodejs/src/logs/logs-config-cache.ts
+++ b/nodejs/src/logs/logs-config-cache.ts
@@ -1,0 +1,60 @@
+import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
+import { logger } from '~/common/utils/logger'
+
+export const DEFAULT_LOGS_PATTERN_MESSAGE_KEYS: readonly string[] = Object.freeze(['message', 'msg', 'event'])
+
+const REFRESH_MS = 30_000
+
+type CacheEntry = {
+    patternMessageKeys: readonly string[]
+    fetchedAtMs: number
+}
+
+export class LogsConfigCache {
+    private cache = new Map<number, CacheEntry>()
+    private inFlight = new Map<number, Promise<readonly string[]>>()
+
+    constructor(private postgres: PostgresRouter) {}
+
+    public async getPatternMessageKeys(teamId: number): Promise<readonly string[]> {
+        const existing = this.cache.get(teamId)
+        if (existing && Date.now() - existing.fetchedAtMs < REFRESH_MS) {
+            return existing.patternMessageKeys
+        }
+        const pending = this.inFlight.get(teamId)
+        if (pending) {
+            return pending
+        }
+        const refresh = this.refreshPatternMessageKeys(teamId)
+        this.inFlight.set(teamId, refresh)
+        try {
+            return await refresh
+        } finally {
+            this.inFlight.delete(teamId)
+        }
+    }
+
+    private async refreshPatternMessageKeys(teamId: number): Promise<readonly string[]> {
+        let keys: readonly string[]
+        try {
+            keys = await this.fetchPatternMessageKeys(teamId)
+        } catch (error) {
+            logger.warn('[logs-config] fetch failed — falling back', { teamId, error: String(error) })
+            keys = this.cache.get(teamId)?.patternMessageKeys ?? DEFAULT_LOGS_PATTERN_MESSAGE_KEYS
+        }
+        this.cache.set(teamId, { patternMessageKeys: keys, fetchedAtMs: Date.now() })
+        return keys
+    }
+
+    private async fetchPatternMessageKeys(teamId: number): Promise<readonly string[]> {
+        const res = await this.postgres.query<{ logs_pattern_message_keys: string[] | null }>(
+            PostgresUse.COMMON_READ,
+            `SELECT logs_pattern_message_keys
+             FROM logs_teamlogsconfig
+             WHERE team_id = $1`,
+            [teamId],
+            'logs-config-fetch'
+        )
+        return res.rows[0]?.logs_pattern_message_keys ?? DEFAULT_LOGS_PATTERN_MESSAGE_KEYS
+    }
+}

--- a/nodejs/src/logs/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.test.ts
@@ -30,6 +30,7 @@ import * as otelMetrics from './ingestion-otel-metrics'
 import { resetLogsIngestionInstrumentsForTests } from './ingestion-otel-metrics'
 import { logsPatternBodyKindCounter } from './log-pattern-stage'
 import { LogRecord, decodeLogRecords, encodeLogRecords } from './log-record-avro'
+import { LogsConfigCache } from './logs-config-cache'
 import {
     DEFAULT_LOGS_RETENTION_DAYS,
     LogsIngestionConsumer,
@@ -110,6 +111,8 @@ const createKafkaMessage = async (logData: any, headers: Record<string, string> 
             { name: 'instrumentation_scope', type: ['null', 'string'] },
             { name: 'event_name', type: ['null', 'string'] },
             { name: 'attributes', type: ['null', { type: 'map', values: 'string' }] },
+            { name: 'pattern', type: ['null', 'string'], default: null },
+            { name: 'pattern_version', type: ['null', 'int'], default: null },
         ],
     })
 
@@ -158,6 +161,8 @@ const createMultiRecordKafkaMessage = async (
             { name: 'instrumentation_scope', type: ['null', 'string'] },
             { name: 'event_name', type: ['null', 'string'] },
             { name: 'attributes', type: ['null', { type: 'map', values: 'string' }] },
+            { name: 'pattern', type: ['null', 'string'], default: null },
+            { name: 'pattern_version', type: ['null', 'int'], default: null },
         ],
     })
 
@@ -209,7 +214,7 @@ describe('LogsIngestionConsumer', () => {
         depsPartial: Partial<
             Pick<
                 LogsIngestionConsumerDeps,
-                'samplingRulesCache' | 'metricRulesCache' | 'metricsEmitter' | 'logsTransformer'
+                'samplingRulesCache' | 'metricRulesCache' | 'metricsEmitter' | 'logsTransformer' | 'logsConfigCache'
             >
         > = {}
     ) => {
@@ -2431,6 +2436,63 @@ describe('LogsIngestionConsumer', () => {
                 expect(bodyKindIncSpy).toHaveBeenCalled()
             } else {
                 expect(bodyKindIncSpy).not.toHaveBeenCalled()
+            }
+        })
+
+        // The fixture encodes the whole log object as the body, so its top-level keys are
+        // `level`, `message`, `service`, `timestamp`.
+        it.each([
+            ["the team's configured keys pick the message", ['service'], 'served <N> requests'],
+            ['configured key order takes precedence', ['message', 'service'], 'ignored <N>'],
+            ['an explicitly empty list disables extraction', [], '<JSON:level,message,service,timestamp>'],
+            ['a missing config row preserves default extraction', null, 'ignored <N>'],
+            ['a missing config cache preserves default extraction', undefined, 'ignored <N>'],
+        ])('%s', async (_name, keys, expectedPattern) => {
+            if (keys !== undefined && keys !== null) {
+                await hub.postgres.query(
+                    PostgresUse.COMMON_WRITE,
+                    `INSERT INTO logs_teamlogsconfig (team_id, logs_pattern_message_keys)
+                     VALUES ($1, $2)
+                     ON CONFLICT (team_id) DO UPDATE SET logs_pattern_message_keys = EXCLUDED.logs_pattern_message_keys`,
+                    [team.id, keys],
+                    'test-set-logs-config'
+                )
+            }
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `INSERT INTO logs_teamlogsconfig (team_id, logs_pattern_message_keys) VALUES ($1, $2)`,
+                [team2.id, ['service']],
+                'test-set-other-team-logs-config'
+            )
+            const logsConfigCache = keys !== undefined ? new LogsConfigCache(hub.postgres) : undefined
+            maskingConsumer = await createLogsIngestionConsumer(
+                hub,
+                { LOGS_PATTERN_MASKING_ENABLED_TEAMS: '*' },
+                { logsConfigCache }
+            )
+
+            const logData = createLogMessage({ message: 'ignored 9', service: 'served 5 requests' })
+            const messages = [
+                ...(await createKafkaMessages([logData], { token: team.api_token })),
+                ...(await createKafkaMessages([logData], { token: team2.api_token })),
+            ]
+            await waitForBackgroundTasks(maskingConsumer.processKafkaBatch(messages))
+
+            const logsMessages = getProducedKafkaMessages().filter((m) => m.topic === 'clickhouse_logs_test')
+            expect(logsMessages).toHaveLength(2)
+            for (const message of logsMessages) {
+                const [, , records] = await decodeLogRecords(message.value as Buffer)
+                const expected =
+                    message.headers?.team_id === team.id.toString()
+                        ? expectedPattern
+                        : keys !== undefined
+                          ? 'served <N> requests'
+                          : 'ignored <N>'
+                expect(records[0].pattern).toBe(expected)
+                expect(parseJSON(records[0].body!)).toMatchObject({
+                    message: 'ignored 9',
+                    service: 'served 5 requests',
+                })
             }
         })
     })

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -37,6 +37,7 @@ import {
     bufferProcessingMode,
     processLogMessageBuffer,
 } from './log-record-avro'
+import { DEFAULT_LOGS_PATTERN_MESSAGE_KEYS, LogsConfigCache } from './logs-config-cache'
 import type { CompiledMetricRule } from './metrics-rules/compile-metric-rules'
 import { MetricRulesCache } from './metrics-rules/metric-rules-cache'
 import { LogsMetricsEmitter } from './metrics-rules/metrics-emitter'
@@ -67,6 +68,7 @@ export interface LogsIngestionConsumerDeps {
     logsTransformer?: LogsTransformerService
     /** When set, enabled teams stamp per-row retention from retention rules before produce. */
     retentionRulesCache?: RetentionRulesCache
+    logsConfigCache?: LogsConfigCache
     /**
      * Resolved outputs registry — must include `LOGS_OUTPUT`, `LOGS_DLQ_OUTPUT`,
      * and `APP_METRICS_OUTPUT`. The producer + topic for each is wired by the
@@ -362,7 +364,6 @@ export class LogsIngestionConsumer {
     private readonly retentionEnabledTeamsRaw: string
     private readonly retentionKillswitch: boolean
     private readonly patternMaskingEnabledTeamsRaw: string
-    private readonly patternMaskingStage: PipelineStage
 
     protected groupId: string
     protected topic: string
@@ -413,7 +414,6 @@ export class LogsIngestionConsumer {
         this.retentionEnabledTeamsRaw = mergedConfig.LOGS_RETENTION_ENABLED_TEAMS
         this.retentionKillswitch = mergedConfig.LOGS_RETENTION_KILLSWITCH
         this.patternMaskingEnabledTeamsRaw = mergedConfig.LOGS_PATTERN_MASKING_ENABLED_TEAMS
-        this.patternMaskingStage = makePatternMaskingStage()
     }
 
     private isSamplingEvalEnabledForTeam(teamId: number): boolean {
@@ -549,7 +549,10 @@ export class LogsIngestionConsumer {
             if (modeWithoutMasking !== 'decode_and_reencode') {
                 logsPatternForcedDecodeCounter.inc({ from: modeWithoutMasking })
             }
-            stages.push(this.patternMaskingStage)
+            const messageKeys =
+                (await this.deps.logsConfigCache?.getPatternMessageKeys(message.teamId)) ??
+                DEFAULT_LOGS_PATTERN_MESSAGE_KEYS
+            stages.push(makePatternMaskingStage(messageKeys))
         }
 
         trace.getActiveSpan()?.setAttributes({

--- a/nodejs/src/servers/ingestion-logs-server.ts
+++ b/nodejs/src/servers/ingestion-logs-server.ts
@@ -14,6 +14,7 @@ import {
     LogsIngestionOutputsConfig,
     getDefaultLogsIngestionOutputsConfig,
 } from '~/logs/config'
+import { LogsConfigCache } from '~/logs/logs-config-cache'
 import { LogsIngestionConsumer } from '~/logs/logs-ingestion-consumer'
 import { MetricRulesCache } from '~/logs/metrics-rules/metric-rules-cache'
 import { LogsMetricsEmitter } from '~/logs/metrics-rules/metrics-emitter'
@@ -130,6 +131,7 @@ export class IngestionLogsServer implements NodeServer {
             ? new LogsMetricsEmitter(this.config.LOGS_METRICS_RULES_EXPORT_URL)
             : undefined
         const retentionRulesCache = new RetentionRulesCache(this.postgres)
+        const logsConfigCache = new LogsConfigCache(this.postgres)
 
         // 2. Resolve outputs (topic + producer per logical name, env-controlled)
         const outputs = createLogsOutputsRegistry().build(this.producerRegistry, this.config)
@@ -170,6 +172,7 @@ export class IngestionLogsServer implements NodeServer {
                 metricsEmitter,
                 logsTransformer,
                 retentionRulesCache,
+                logsConfigCache,
                 usageBatch,
             })
             await consumer.start()


### PR DESCRIPTION
## Problem

Changing pattern message keys through the project API has no effect on ingested patterns.

**Why:** ingestion must honor the project configuration already exposed by [#93585](https://github.com/PostHog/posthog/pull/93585) and supported by the masker since [#92777](https://github.com/PostHog/posthog/pull/92777).

## Changes

- Ingestion uses each project's stored keys in order, behind the existing pattern-ingestion rollout.
- Missing configuration preserves the default keys. An explicitly empty list disables message extraction.
- Settings refresh after a 30-second cache TTL. Concurrent requests share one refresh per project.
- Lookup failures retain cached keys, or defaults on a cold cache, and wait 30 seconds before retrying.

Mechanical: the masking stage accepts the resolved keys; the shape ratchet pins its existing test keys.

The settings UI and its screenshot moved to the separate draft [#96735](https://github.com/PostHog/posthog/pull/96735).

**Before**
```mermaid
flowchart LR
  Defaults[Hardcoded keys] --> Stage[Pattern ingestion]
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  class Defaults phGray;
  class Stage phBlue;
```

**After**
```mermaid
flowchart LR
  Settings[Project settings] --> Cache[Per-project cache] --> Stage[Pattern ingestion]
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  class Settings phGray;
  class Cache,Stage phBlue;
```

Raw bodies, query-time mining, and masking rules remain unchanged. Empty-string selection behavior is unchanged; this PR only connects configuration.

## How did you test this code?

- Database-backed consumer cases cover project isolation, key priority, explicit empty lists, missing configuration, and preserved bodies.
- Cache cases cover refresh expiry, concurrent lookups, failure backoff, and recovery.
- Before the split: cache, masker, stage, and full consumer tests, ESLint, and `hogli ci:preflight --fix` passed.
- The split restores the exact previously tested ingestion commit tree. Remaining Node.js suites and production rollout verification remain outstanding.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

Updated the logs configuration page with defaults, cache propagation, and lookup-failure behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Codex separated the UI into its own draft and restored the ingestion-only changes here. Query-time mining stays out of scope.

Skills: writing-tests, writing-code-comments, writing-user-facing-copy, writing-pr-descriptions. Tools: GitHub CLI, Jest, ESLint, hogli, and signed Git tools.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*
