### PR TITLE
chore: delete the facade helpers the vision actions migration used

### DIFF
--- a/products/feature_flags/backend/facade/api.py
+++ b/products/feature_flags/backend/facade/api.py
@@ -287,33 +287,3 @@ def serialize_flags(flags: Any, *, context: dict) -> Any:
     access-control-derived fields, so it can only be built for a real request.
     """
     return FeatureFlagSerializer(flags, many=True, context=context).data
-
-
-def add_group_to_flag_targeting(*, team: Team, key: str, group_key: str) -> bool:
-    """Add one group key to a flag's group-targeting condition, for a product rolling itself out.
-
-    A product that migrates its own data organization by organization needs to widen the flag as
-    each one lands, and it should not have to know how release conditions are stored to do it.
-    Returns False when no such flag exists on the team, or when its conditions carry no
-    `$group_key` filter to widen — both mean the caller's rollout assumption no longer holds, so
-    they are reported rather than silently repaired.
-    """
-    flag = FeatureFlag.objects.filter(team=team, key=key, deleted=False).first()
-    if flag is None:
-        return False
-    conditions = [
-        prop
-        for group in (flag.filters or {}).get("groups") or []
-        for prop in group.get("properties", [])
-        if prop.get("key") == "$group_key"
-    ]
-    if not conditions:
-        return False
-    condition = conditions[0]
-    values = condition.get("value")
-    if not isinstance(values, list):
-        return False
-    if group_key not in values:
-        values.append(group_key)
-        flag.save(update_fields=["filters"])
-    return True

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -963,69 +963,6 @@ def scout_reports_for_source(
     return reports
 
 
-@frozen
-class ScoutSummary:
-    """One scout standing on another product's object, in the shape that product needs to render
-    or manage it without reaching into scout tables."""
-
-    config_id: str
-    skill_name: str
-    source_id: str | None
-    enabled: bool
-    run_cron_schedule: str | None
-    run_interval_minutes: int
-    output_destinations: dict[str, Any]
-    description: str
-    created_at: datetime
-    created_by_id: int | None
-    last_run_at: datetime | None
-
-
-def list_scouts_for_source(
-    team_id: int, source_product: str, source_ids: list[str] | None = None
-) -> list[ScoutSummary]:
-    """The scouts a product stood up on its own objects, oldest first.
-
-    `(source_product, source_id)` was recorded at creation and is not user-editable, so the rows
-    returned are exactly the ones the calling product owns. Descriptions come from the live skill;
-    a scout whose skill was archived comes back with an empty description, matching the scout UI.
-    """
-    # Imported inside the call for the same reason as `create_scout_for_source`: keeps the skills
-    # API surface off the facade's import path.
-    from products.skills.backend.models.skills import (
-        LLMSkill,  # noqa: PLC0415 — keeps the API surface off the import path
-    )
-
-    configs_qs = SignalScoutConfig.objects.for_team(team_id).filter(source_product=source_product)
-    if source_ids is not None:
-        configs_qs = configs_qs.filter(source_id__in=source_ids)
-    configs = list(configs_qs.order_by("created_at"))
-    descriptions = dict(
-        LLMSkill.objects.filter(
-            team_id=team_id,
-            name__in=[config.skill_name for config in configs],
-            is_latest=True,
-            deleted=False,
-        ).values_list("name", "description")
-    )
-    return [
-        ScoutSummary(
-            config_id=str(config.id),
-            skill_name=config.skill_name,
-            source_id=config.source_id,
-            enabled=config.enabled,
-            run_cron_schedule=config.run_cron_schedule,
-            run_interval_minutes=config.run_interval_minutes,
-            output_destinations=config.output_destinations or {},
-            description=descriptions.get(config.skill_name, ""),
-            created_at=config.created_at,
-            created_by_id=config.created_by_id,
-            last_run_at=config.last_run_at,
-        )
-        for config in configs
-    ]
-
-
 def update_scout_for_source(
     team_id: int,
     source_product: str,


### PR DESCRIPTION
## Problem

Nobody sees a difference. #92983 removed the legacy Replay Vision vision actions, and it took the last caller of three facade helpers with it. A reviewer flagged them there as a non-blocking follow-up.

## Changes

- Deletes `ScoutSummary` and `list_scouts_for_source` from the signals facade.
- Deletes `add_group_to_flag_targeting` from the feature flags facade. Its docstring described the org-by-org rollout the migration command performed, which has now run in both regions.
- The whole diff is 93 deleted lines and nothing else.

Every deletion is callerless on master: the only remaining `ScoutSummary` hits are the unrelated React component `ScoutSummaryRow`, and `create_scout_for_source` (which Replay Vision still calls) is untouched.

## How did you test this code?

- `products/signals/backend/test` and `products/feature_flags/backend`: 4555 passed.
- `hogli lint:tach` validates every module; ruff clean.
- The pre-existing unused-ignore warning in `test_agentic_report_activity.py` reproduces on master too, so it is not from this change.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code in Tue's session as the first follow-up to #92983.
- Callerless status verified with `git grep` over `origin/master` across Python and TypeScript before deleting.