### PR TITLE
chore(desktop): stop requesting the vision_action oauth scope

### DIFF
--- a/products/desktop/packages/shared/src/oauth.test.ts
+++ b/products/desktop/packages/shared/src/oauth.test.ts
@@ -20,9 +20,9 @@ describe("OAUTH_SCOPES guard", () => {
       fingerprint,
     }).toMatchInlineSnapshot(`
       {
-        "fingerprint": -237404099,
-        "scopeCount": 206,
-        "scopeVersion": 7,
+        "fingerprint": -2100722726,
+        "scopeCount": 204,
+        "scopeVersion": 8,
       }
     `);
   });

--- a/products/desktop/packages/shared/src/oauth.ts
+++ b/products/desktop/packages/shared/src/oauth.ts
@@ -217,8 +217,6 @@ export const OAUTH_SCOPES = [
   "user:write",
   "user_interview:read",
   "user_interview:write",
-  "vision_action:read",
-  "vision_action:write",
   "visual_review:read",
   "visual_review:write",
   "warehouse_objects:read",
@@ -244,7 +242,7 @@ export const OAUTH_SCOPES = [
 // applies to every future server-side scope addition the app relies on, even when
 // OAUTH_SCOPES itself is unchanged.
 // v7: "*" replaced with the explicit list above.
-export const OAUTH_SCOPE_VERSION = 7;
+export const OAUTH_SCOPE_VERSION = 8;
 
 export function getOauthClientIdFromRegion(region: CloudRegion): string {
   switch (region) {


### PR DESCRIPTION
## Problem

Nobody sees a difference today. #92983 deleted the Replay Vision vision actions, so `vision_action:read` / `vision_action:write` now grant access to endpoints that no longer exist, and the desktop app still asks for both at `/authorize`.

The server keeps advertising the scope only because these installed clients request it: dropping an advertised scope rejects the client's whole authorize request. This PR is the half that has to ship first, so the scope itself can go once a release carrying it is out.

## Changes

- Desktop stops requesting `vision_action:read` and `vision_action:write`, taking the requested set from 206 scopes to 204.
- `OAUTH_SCOPE_VERSION` goes to 8, so existing installs re-authorize against the smaller set.
- The `OAUTH_SCOPES` guard snapshot records the new count, fingerprint, and version. That guard is what forced the version bump.

Requesting fewer scopes is always safe, so this ships on its own. The reverse order is the one that breaks login, as #3411 did.

## How did you test this code?

- `products/desktop/packages/shared`: 909 passed across 37 files.
- Not run: a real `/authorize` round trip against prod; the guard test covers the contract this PR changes.

## Automatic notifications

- [ ] Publish changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code in Tue's session as a follow-up to #92983.
- Kept out of #92983 on purpose: mixing desktop and backend changes trips the desktop coupling guard, and desktop releases auto-update outside the backend deploy.
- Removing `vision_action` from `posthog/scopes.py` is the next step and waits on a desktop release that carries this.